### PR TITLE
Fix CLOUDSTACK-7476: always pass along $JAVA_HOME

### DIFF
--- a/packaging/centos63/cloud-usage.rc
+++ b/packaging/centos63/cloud-usage.rc
@@ -96,7 +96,7 @@ start() {
 
     echo -n "Starting $PROGNAME" "$SHORTNAME"
 
-    if daemon --pidfile $PIDFILE $DAEMON -cp "$CLASSPATH" -pidfile "$PIDFILE" -user "$USER" \
+    if daemon --pidfile $PIDFILE $DAEMON -home "$JAVA_HOME" -cp "$CLASSPATH" -pidfile "$PIDFILE" -user "$USER" \
       -errfile $LOGDIR/cloudstack-usage.err -outfile $LOGDIR/cloudstack-usage.out -Dpid=$$ $CLASS
         RETVAL=$?
     then

--- a/packaging/debian/init/cloud-usage
+++ b/packaging/debian/init/cloud-usage
@@ -102,7 +102,7 @@ start() {
         exit 1
     fi
 
-    if start_daemon -p $PIDFILE $DAEMON -cp "$CLASSPATH" -pidfile "$PIDFILE" -outfile SYSLOG -errfile SYSLOG -Dpid=$$ $CLASS
+    if start_daemon -p $PIDFILE $DAEMON -home "$JAVA_HOME" -cp "$CLASSPATH" -pidfile "$PIDFILE" -outfile SYSLOG -errfile SYSLOG -Dpid=$$ $CLASS
         RETVAL=$?
     then
         rc=0


### PR DESCRIPTION
On a secured environment (selinux w/ env_reset enabled in sudoers), the
runuser command that is invoked by the daemon() function does not pass
along environment variables, so $JAVA_HOME is empty, and JSVC falls
back to its default behavior, which may not find java or may not find
the intended java.

This fix simply passes $JAVA_HOME explicitly using the -home argument to
JSVC.
