### PR TITLE
Fix CID-1222222

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -477,7 +477,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
         Boolean.parseBoolean(value);
 
         value = _params.get("xenserver.check.hvm");
-        _checkHvm = false;
+        _checkHvm = Boolean.parseBoolean(value);
         _connPool = XenServerConnectionPool.getInstance();
 
         _agentMgr.registerForHostEvents(this, true, false, true);


### PR DESCRIPTION
Fixes 1222222 issue.

`xen.check.hvm` param was not being used.
