### PR TITLE
debian: Fix changelog to use 4.4.1 release with snapshot in the version ...

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloudstack (4.4.1) unstable; urgency=low
+
+  * Update the version to 4.4.1
+
+ -- Rohit Yadav <rohit.yadav@shapeblue.com> Mon, 20 Oct 2014 15:30:00 +0530
+
 cloudstack (4.4.1-snapshot) unstable; urgency=low
 
   * Update the version to 4.4.1.snapshot


### PR DESCRIPTION
Both 4.4.0 and 4.4.1 tagged releases have -snapshot in debian/changelog resulting in debian package names which should be 4.4.0 or 4.4.1 and not 4.4.0-snapshot or 4.4.1-snapshot. This is not the case in case of 4.3.1/4.3.0 and past releases. Since 4.4.1 has already been tagged, we can keep it this way. Sending this pull request just in case there is time to fix it? cc @DaanHoogland

Regards.
