### PR TITLE
CLOUDSTACK-7703, CLOUDSTACK-7752: Fixed deployment planner stuck in infinite loop

### DIFF
--- a/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -31,7 +31,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import com.cloud.utils.fsm.StateMachine2;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.affinity.AffinityGroupProcessor;
@@ -121,6 +120,7 @@ import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.StateListener;
+import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.vm.DiskProfile;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
@@ -990,7 +990,10 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
 
         // if all hosts or all pools in the cluster are in avoid set after this
         // pass, then put the cluster in avoid set.
-        boolean avoidAllHosts = true, avoidAllPools = true;
+        boolean avoidAllHosts = true;
+        boolean avoidAllPools = true;
+        boolean avoidAllLocalPools = true;
+        boolean avoidAllSharedPools = true;
 
         List<HostVO> allhostsInCluster =
                 _hostDao.listAllUpAndEnabledNonHAHosts(Host.Type.Routing, clusterVO.getId(), clusterVO.getPodId(), clusterVO.getDataCenterId(), null);
@@ -1024,7 +1027,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 for (StoragePoolVO pool : allPoolsInCluster) {
                     if (!allocatorAvoidOutput.shouldAvoid(pool)) {
                         // there's some pool in the cluster that is not yet in avoid set
-                        avoidAllPools = false;
+                        avoidAllSharedPools = false;
                         break;
                     }
                 }
@@ -1038,10 +1041,18 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     if (!allocatorAvoidOutput.shouldAvoid(pool)) {
                         // there's some pool in the cluster that is not yet
                         // in avoid set
-                        avoidAllPools = false;
+                        avoidAllLocalPools = false;
                         break;
                     }
                 }
+            }
+
+            if (vmRequiresSharedStorage && vmRequiresLocalStorege) {
+                avoidAllPools = (avoidAllLocalPools || avoidAllSharedPools) ? true : false;
+            } else if (vmRequiresSharedStorage) {
+                avoidAllPools = avoidAllSharedPools;
+            } else if (vmRequiresLocalStorege) {
+                avoidAllPools = avoidAllLocalPools;
             }
         }
 


### PR DESCRIPTION
CLOUDSTACK-7703, CLOUDSTACK-7752: Fixed deployment planner stuck in infinite loop.

If we create VM with shared service offering and attach disk with local disk offering,
and one of storage pool is full(cannot be allocated) and other is not full then
we are not putting the cluster in avoid list which is causing this infinite loop.

Fixed by putting the cluster in avoid list even if one of the storage pool is full(cannot be allocated)
