### PR TITLE
Fixed CLOUDSTACK-7242: Adding a securing config using configDepo doesnt ...

### DIFF
--- a/framework/config/src/org/apache/cloudstack/framework/config/dao/ConfigurationDaoImpl.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/dao/ConfigurationDaoImpl.java
@@ -210,9 +210,6 @@ public class ConfigurationDaoImpl extends GenericDaoBase<ConfigurationVO, String
                     update(name, category, initValue);
                 }
             } else {
-                if (category.equals("Hidden") || category.equals("Secure")) {
-                    initValue = DBEncryptionUtil.encrypt(initValue);
-                }
                 ConfigurationVO newConfig = new ConfigurationVO(category, "DEFAULT", "management-server", name, initValue, desc);
                 persist(newConfig);
             }

--- a/framework/config/src/org/apache/cloudstack/framework/config/impl/ConfigurationVO.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/impl/ConfigurationVO.java
@@ -73,8 +73,8 @@ public class ConfigurationVO implements Configuration {
         this.instance = instance;
         this.component = component;
         this.name = name;
-        this.value = value;
         this.description = description;
+        setValue(value);
     }
 
     public ConfigurationVO(String component, ConfigKey<?> key) {
@@ -122,11 +122,23 @@ public class ConfigurationVO implements Configuration {
 
     @Override
     public String getValue() {
-        return (("Hidden".equals(getCategory()) || "Secure".equals(getCategory())) ? DBEncryptionUtil.decrypt(value) : value);
+        if(isEncryptedConfig()) {
+            return DBEncryptionUtil.decrypt(value);
+        } else {
+            return value;
+        }
     }
 
     public void setValue(String value) {
-        this.value = value;
+        if(isEncryptedConfig()) {
+            this.value = DBEncryptionUtil.encrypt(value);
+        } else {
+            this.value = value;
+        }
+    }
+
+    private boolean isEncryptedConfig() {
+        return "Hidden".equals(getCategory()) || "Secure".equals(getCategory());
     }
 
     @Override

--- a/server/src/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/com/cloud/server/ConfigurationServerImpl.java
@@ -203,7 +203,6 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     String instance = "DEFAULT";
                     String component = c.getComponent();
                     String value = c.getDefaultValue();
-                    value = ("Hidden".equals(category) || "Secure".equals(category)) ? DBEncryptionUtil.encrypt(value) : value;
                     String description = c.getDescription();
                     ConfigurationVO configVO = new ConfigurationVO(category, instance, component, name, value, description);
                     configVO.setDefaultValue(value);
@@ -635,7 +634,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 }
                 String base64Keystore = getBase64Keystore(keystorePath);
                 ConfigurationVO configVO =
-                        new ConfigurationVO("Hidden", "DEFAULT", "management-server", "ssl.keystore", DBEncryptionUtil.encrypt(base64Keystore),
+                        new ConfigurationVO("Hidden", "DEFAULT", "management-server", "ssl.keystore", base64Keystore,
                                 "SSL Keystore for the management servers");
                 _configDao.persist(configVO);
                 s_logger.info("Stored SSL keystore to database.");


### PR DESCRIPTION
In ConfigurationVo, changed the setter to do the encryption if required
(like the getter). Called the setter in constructor as well.

Removed references of encryption check in different places.
