### PR TITLE
CLOUDSTACK-7929: Unhandled exception when setting negative value for throttling rate while creating network offering

### DIFF
--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3723,6 +3723,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             throw new InvalidParameterValueException("Invalid value for Availability. Supported types: " + Availability.Required + ", " + Availability.Optional);
         }
 
+        if (networkRate != null && networkRate < 0) {
+            networkRate = 0;
+        }
+
         Long serviceOfferingId = cmd.getServiceOfferingId();
 
         if (serviceOfferingId != null) {


### PR DESCRIPTION
To fix issue while creating network offering if one specifies negative value for network rate

then we will convert that value to 0 i.e. unlimited
