### PR TITLE
noncritical fixes on packaging script

### DIFF
--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -18,7 +18,7 @@
 
 function usage() {
     echo ""
-    echo "usage: ./package.sh [-p|--pack] [-h|--help] [-o|--operating-system] [ARGS]"
+    echo "usage: ./package.sh [-p|--pack] [-h|--help] [ARGS]"
     echo ""
     echo "The commonly used Arguments are:"
     echo "-p|--pack oss|OSS             To package with only redistributable libraries (default)"


### PR DESCRIPTION
fixed:
- a syntax issue, which was tolerated by bash
- removed an option from usage text
