### PR TITLE
CLOUDSTACK-6212: Let vm_instance table's ID field be unique and auto_inc...

### DIFF
--- a/setup/db/db/schema-442to450.sql
+++ b/setup/db/db/schema-442to450.sql
@@ -35,7 +35,15 @@ CREATE VIEW `cloud`.`storage_tag_view` AS
 
 ALTER TABLE `cloud`.`volumes` ADD COLUMN `provisioning_type` VARCHAR(32) NOT NULL DEFAULT 'thin' COMMENT 'pre allocation setting of the volume';
 ALTER TABLE `cloud`.`disk_offering` ADD COLUMN `provisioning_type` VARCHAR(32) NOT NULL DEFAULT 'thin' COMMENT 'pre allocation setting of the volume';
-ALTER TABLE `cloud`.`vm_instance` MODIFY id bigint unsigned AUTO_INCREMENT UNIQUE NOT NULL;
+
+-- Have primary keys of following table AUTO_INCREMENT
+ALTER TABLE `cloud`.`region` MODIFY `id` int unsigned AUTO_INCREMENT UNIQUE NOT NULL;
+ALTER TABLE `cloud`.`vm_instance` MODIFY `id` bigint unsigned AUTO_INCREMENT UNIQUE NOT NULL;
+ALTER TABLE `cloud`.`user_vm` MODIFY `id` bigint unsigned AUTO_INCREMENT UNIQUE NOT NULL;
+ALTER TABLE `cloud`.`domain_router` MODIFY `id` bigint unsigned AUTO_INCREMENT UNIQUE NOT NULL;
+ALTER TABLE `cloud`.`service_offering` MODIFY `id` bigint unsigned AUTO_INCREMENT NOT NULL;
+ALTER TABLE `cloud`.`load_balancing_rules` MODIFY `id` bigint unsigned AUTO_INCREMENT NOT NULL;
+ALTER TABLE `cloud`.`port_forwarding_rules` MODIFY `id` bigint unsigned AUTO_INCREMENT NOT NULL;
 
 DROP VIEW IF EXISTS `cloud`.`disk_offering_view`;
 CREATE VIEW `cloud`.`disk_offering_view` AS


### PR DESCRIPTION
...rement

`vm_instance` table's id column is unique but does not auto_increment like other
resource tables. The fix simply alter the table's id column to have it
auto_increment which may avoid id conflicts in a multi-master mysql setup.

Signed-off-by: Rohit Yadav rohit.yadav@shapeblue.com
