### PR TITLE
use directIO flags when dd'ing template

### DIFF
--- a/scripts/vm/hypervisor/xenserver/copy_vhd_from_secondarystorage.sh
+++ b/scripts/vm/hypervisor/xenserver/copy_vhd_from_secondarystorage.sh
@@ -104,7 +104,7 @@ copyvhd()
     exit 0
   fi
   if [ "${parent##*vhd has}" = " no parent" ]; then
-    dd if=$srcvhd of=$desvhd bs=2M     
+    dd if=$srcvhd of=$desvhd bs=2M oflag=direct iflag=direct
     if [ $? -ne 0 ]; then
       echo "31#failed to dd $srcvhd to $desvhd"
       cleanup


### PR DESCRIPTION
This makes sure dom0 in xenserver doesn't get hammered
when copying templates. It doesn't make sense to use
the cache of dom0 as the template does not fit in
memory. The directIO flags prevents it from trying.
