### PR TITLE
upgrade to jetty 9

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -404,9 +404,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-maven-plugin</artifactId>
+            <version>9.2.6.v20141205</version>
              <dependencies>
               <!-- specify the dependent jdbc driver here -->
               <dependency>
@@ -420,7 +420,7 @@
           <stopPort>9966</stopPort>
           <stopKey>stop-jetty</stopKey>
           <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
+            <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
               <port>8080</port>
               <maxIdleTime>60000</maxIdleTime>
             </connector>


### PR DESCRIPTION
upgraded jetty from 6.1 to 9.2. The 6.1 branch was announced EOL a few weeks ago.

Signed-off-by: Laszlo Hornyak laszlo.hornyak@gmail.com
