### PR TITLE
CLOUDSTACK-6900: Fixed if we download a volume and then migrate the same volume, then migration fails

### DIFF
--- a/engine/storage/src/org/apache/cloudstack/storage/image/db/VolumeDataStoreDaoImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/db/VolumeDataStoreDaoImpl.java
@@ -83,6 +83,7 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
         storeVolumeSearch.and("store_id", storeVolumeSearch.entity().getDataStoreId(), SearchCriteria.Op.EQ);
         storeVolumeSearch.and("volume_id", storeVolumeSearch.entity().getVolumeId(), SearchCriteria.Op.EQ);
         storeVolumeSearch.and("destroyed", storeVolumeSearch.entity().getDestroyed(), SearchCriteria.Op.EQ);
+        storeVolumeSearch.and("download_url", storeVolumeSearch.entity().getExtractUrl(), Op.NULL);
         storeVolumeSearch.done();
 
         updateStateSearch = this.createSearchBuilder();


### PR DESCRIPTION
In findByStoreVolume method of VolumeDataStoreDao now listing only those volumes whose download_url is not generated in volume_store_ref.

 This will not affect migrate operations as in that case download_url is never generated
 In case of download volume operation that is only set when volume reached to ready state
 in volume_store_ref table. After that this row is not listed through findByStoreVolume method
 so it will not affect in that case also.