### PR TITLE
CLOUDSTACK-8157: Add absolute schema references to support MySQL 5.6 better

### DIFF
--- a/setup/db/create-schema-premium.sql
+++ b/setup/db/create-schema-premium.sql
@@ -296,7 +296,7 @@ CREATE TABLE `cloud`.`netapp_volume` (
   `password` varchar(200) COMMENT 'password',
   `round_robin_marker` int COMMENT 'This marks the volume to be picked up for lun creation, RR fashion',
   PRIMARY KEY  (`id`),
-  CONSTRAINT `fk_netapp_volume__pool_id` FOREIGN KEY `fk_netapp_volume__pool_id` (`pool_id`) REFERENCES `netapp_pool` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_netapp_volume__pool_id` FOREIGN KEY `fk_netapp_volume__pool_id` (`pool_id`) REFERENCES `cloud`.`netapp_pool` (`id`) ON DELETE CASCADE,
   INDEX `i_netapp_volume__pool_id`(`pool_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -315,7 +315,7 @@ CREATE TABLE `cloud`.`netapp_lun` (
   `size` bigint NOT NULL COMMENT 'lun size',
   `volume_id` bigint unsigned NOT NULL COMMENT 'parent volume id',
   PRIMARY KEY (`id`),
-  CONSTRAINT `fk_netapp_lun__volume_id` FOREIGN KEY `fk_netapp_lun__volume_id` (`volume_id`) REFERENCES `netapp_volume` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_netapp_lun__volume_id` FOREIGN KEY `fk_netapp_lun__volume_id` (`volume_id`) REFERENCES `cloud`.`netapp_volume` (`id`) ON DELETE CASCADE,
   INDEX `i_netapp_lun__volume_id`(`volume_id`),
   INDEX `i_netapp_lun__lun_name`(`lun_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
This should fix the problem some people are seeing with cloudstack-setup-databases complaining about 'No database selected'