### PR TITLE
CLOUDSTACK-8215: SAML changing date calculation

### DIFF
--- a/utils/src/org/apache/cloudstack/utils/auth/SAMLUtils.java
+++ b/utils/src/org/apache/cloudstack/utils/auth/SAMLUtils.java
@@ -89,6 +89,7 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
@@ -314,15 +315,22 @@ public class SAMLUtils {
     }
 
     public static X509Certificate generateRandomX509Certificate(KeyPair keyPair) throws NoSuchAlgorithmException, NoSuchProviderException, CertificateEncodingException, SignatureException, InvalidKeyException {
-        Date validityBeginDate = new Date(System.currentTimeMillis() - 24 * 60 * 60 * 1000);
-        Date validityEndDate = new Date(System.currentTimeMillis() + 3 * 365 * 24 * 60 * 60 * 1000);
+        Date referenceDate = new Date();
+        Calendar validityBeginDate = Calendar.getInstance();
+        validityBeginDate.setTime(referenceDate);
+        validityBeginDate.add(Calendar.DAY_OF_YEAR, -1);
+
+        Calendar validityEndDate = Calendar.getInstance();
+        validityEndDate.setTime(referenceDate);
+        validityEndDate.add(Calendar.YEAR, 3);
+
         X500Principal dnName = new X500Principal("CN=ApacheCloudStack");
         X509V1CertificateGenerator certGen = new X509V1CertificateGenerator();
         certGen.setSerialNumber(BigInteger.valueOf(System.currentTimeMillis()));
         certGen.setSubjectDN(dnName);
         certGen.setIssuerDN(dnName);
-        certGen.setNotBefore(validityBeginDate);
-        certGen.setNotAfter(validityEndDate);
+        certGen.setNotBefore(validityBeginDate.getTime());
+        certGen.setNotAfter(validityEndDate.getTime());
         certGen.setPublicKey(keyPair.getPublic());
         certGen.setSignatureAlgorithm("SHA256WithRSAEncryption");
 

--- a/utils/src/org/apache/cloudstack/utils/auth/SAMLUtils.java
+++ b/utils/src/org/apache/cloudstack/utils/auth/SAMLUtils.java
@@ -25,6 +25,7 @@ import org.apache.log4j.Logger;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.x509.X509V1CertificateGenerator;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.opensaml.Configuration;
 import org.opensaml.common.SAMLVersion;
 import org.opensaml.common.xml.SAMLConstants;
@@ -89,8 +90,6 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
@@ -315,25 +314,16 @@ public class SAMLUtils {
     }
 
     public static X509Certificate generateRandomX509Certificate(KeyPair keyPair) throws NoSuchAlgorithmException, NoSuchProviderException, CertificateEncodingException, SignatureException, InvalidKeyException {
-        Date referenceDate = new Date();
-        Calendar validityBeginDate = Calendar.getInstance();
-        validityBeginDate.setTime(referenceDate);
-        validityBeginDate.add(Calendar.DAY_OF_YEAR, -1);
-
-        Calendar validityEndDate = Calendar.getInstance();
-        validityEndDate.setTime(referenceDate);
-        validityEndDate.add(Calendar.YEAR, 3);
-
+        DateTime now = DateTime.now(DateTimeZone.UTC);
         X500Principal dnName = new X500Principal("CN=ApacheCloudStack");
         X509V1CertificateGenerator certGen = new X509V1CertificateGenerator();
         certGen.setSerialNumber(BigInteger.valueOf(System.currentTimeMillis()));
         certGen.setSubjectDN(dnName);
         certGen.setIssuerDN(dnName);
-        certGen.setNotBefore(validityBeginDate.getTime());
-        certGen.setNotAfter(validityEndDate.getTime());
+        certGen.setNotBefore(now.minusDays(1).toDate());
+        certGen.setNotAfter(now.plusYears(3).toDate());
         certGen.setPublicKey(keyPair.getPublic());
         certGen.setSignatureAlgorithm("SHA256WithRSAEncryption");
-
         return certGen.generate(keyPair.getPrivate(), "BC");
     }
 


### PR DESCRIPTION
Changed to java.util.Calendar which is a bit more straight forward to use.

Tested and verified that the new certificate is valid for 3 years