### PR TITLE
CLOUDSTACK-8262: Missing usage event on FollowAgentPowerOffReport (Instance shutdown from OS)

### DIFF
--- a/api/src/com/cloud/vm/VirtualMachine.java
+++ b/api/src/com/cloud/vm/VirtualMachine.java
@@ -142,7 +142,10 @@ public interface VirtualMachine extends RunningOn, ControlledEntity, Identity, I
         }
 
         public static boolean isVmStopped(State oldState, Event e, State newState) {
-            if (oldState == State.Stopping && newState == State.Stopped) {
+            if ((oldState == State.Stopping && newState == State.Stopped) ||
+                (oldState == State.Running &&
+                 newState == State.Stopped &&
+                 e == Event.FollowAgentPowerOffReport)) {
                 return true;
             }
             return false;


### PR DESCRIPTION
When shutting down an instance from the OS, no VM.STOP usage record is being inserted. From usage perspective, instance is still considered as running

https://issues.apache.org/jira/browse/CLOUDSTACK-8262