### PR TITLE
Add distribution fedora21 in packaging.sh and delete the agent dir in cloud.spec

### DIFF
--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -580,7 +580,6 @@ fi
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
-%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/agent
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/awsapi
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
 %config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -490,7 +490,6 @@ fi
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
-%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/agent
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/awsapi
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
 %config(noreplace) %{_sysconfdir}/sudoers.d/%{name}-management

--- a/packaging/fedora20/cloud.spec
+++ b/packaging/fedora20/cloud.spec
@@ -582,7 +582,6 @@ fi
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
-%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/agent
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/awsapi
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
 %config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties

--- a/packaging/fedora21/cloud.spec
+++ b/packaging/fedora21/cloud.spec
@@ -582,7 +582,6 @@ fi
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
-%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/agent
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/awsapi
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
 %config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -23,7 +23,7 @@ function usage() {
     echo "The commonly used Arguments are:"
     echo "-p|--pack oss|OSS             To package with only redistributable libraries (default)"
     echo "-p|--pack noredist|NOREDIST   To package with non-redistributable libraries"
-    echo "-d centos7|centos63|fedora20  To build a package for a distribution"
+    echo "-d centos7|centos63|fedora20|fedora21  To build a package for a distribution"
     echo "-s simulator|SIMULATOR        To build for Simulator"
     echo ""
     echo "Examples: ./package.sh -p|--pack oss|OSS"


### PR DESCRIPTION
Add distribution fedora21 in packaging/package.sh, help to build rpm for fedora21.
Fix cloud.spec for building management rpm, need not create agent dir but agetn rpm (kvm host agent). When user install management and agent in the same host, it causes yum problem about agent dir recover by another.