### PR TITLE
Support all pythons from 2.6 up.

### DIFF
--- a/tools/apidoc/gen_toc.py
+++ b/tools/apidoc/gen_toc.py
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -131,7 +131,7 @@ known_categories = {
     'Project': 'Project',
     'Lun': 'Storage',
     'Pool': 'Pool',
-    'VPC': 'VPC', 
+    'VPC': 'VPC',
     'PrivateGateway': 'VPC',
     'Simulator': 'simulator',
     'StaticRoute': 'VPC',
@@ -177,7 +177,7 @@ categories = {}
 
 
 def choose_category(fn):
-    for k, v in known_categories.iteritems():
+    for k, v in known_categories.items():
         if k in fn:
             return v
     raise Exception('Need to add a category for %s to %s:known_categories' %
@@ -198,7 +198,8 @@ for f in sys.argv:
     if dirname.startswith('./'):
         dirname = dirname[2:]
     try:
-        dom = minidom.parse(file(f))
+        with open(f) as data:
+            dom = minidom.parse(data)
         name = dom.getElementsByTagName('name')[0].firstChild.data
         isAsync = dom.getElementsByTagName('isAsync')[0].firstChild.data
         category = choose_category(fn)
@@ -210,11 +211,11 @@ for f in sys.argv:
             'async': isAsync == 'true',
             'user': dirname_to_user[dirname],
             })
-    except ExpatError, e:
+    except ExpatError as e:
         pass
-    except IndexError, e:
-        print fn
-    
+    except IndexError as e:
+        print(fn)
+
 
 def xml_for(command):
     name = command['name']
@@ -227,9 +228,9 @@ def xml_for(command):
 
 
 def write_xml(out, user):
-    with file(out, 'w') as f:
+    with open(out, 'w') as f:
         cat_strings = []
-        
+
         for category in categories.keys():
             strings = []
             for command in categories[category]:
@@ -244,24 +245,24 @@ def write_xml(out, user):
         i = 0
         for _1, category, all_strings in cat_strings:
             if i == 0:
-                print >>f, '<div class="apismallsections">'
-            print >>f, '''<div class="apismallbullet_box">
+                f.write('<div class="apismallsections">\n')
+            f.write('''<div class="apismallbullet_box">
 <h5>%(category)s</h5>
 <ul>
 <xsl:for-each select="commands/command">
 %(all_strings)s
 </xsl:for-each>
-</ul>      
+</ul>
 </div>
 
-''' % locals()
+''' % locals())
             if i == 3:
-                print >>f, '</div>'
+                f.write('</div>\n')
                 i = 0
             else:
                 i += 1
         if i != 0:
-            print >>f, '</div>'
+            f.write('</div>\n')
 
 
 def java_for(command, user):
@@ -277,7 +278,7 @@ def java_for_user(user):
         for command in categories[category]:
             if command['user'] == user:
                 strings.append(java_for(command, user))
-    func = user_to_func[user]        
+    func = user_to_func[user]
     all_strings = ''.join(strings)
     return '''
     public void %(func)s() {
@@ -287,8 +288,8 @@ def java_for_user(user):
 
 
 def write_java(out):
-    with file(out, 'w') as f:
-        print >>f, '''/* Generated using gen_toc.py.  Do not edit. */
+    with open(out, 'w') as f:
+        f.write('''/* Generated using gen_toc.py.  Do not edit. */
 
 import java.util.HashSet;
 import java.util.Set;
@@ -299,14 +300,15 @@ public class XmlToHtmlConverterData {
 	Set<String> domainAdminCommandNames = new HashSet<String>();
 	Set<String> userCommandNames = new HashSet<String>();
 
-'''
-        print >>f, java_for_user(REGULAR_USER)
-        print >>f, java_for_user(ROOT_ADMIN)
-        print >>f, java_for_user(DOMAIN_ADMIN)
+''')
+        f.write(java_for_user(REGULAR_USER) + "\n");
+        f.write(java_for_user(ROOT_ADMIN) + "\n")
+        f.write(java_for_user(DOMAIN_ADMIN) + "\n")
 
-        print >>f, '''
+        f.write('''
 }
-'''
+
+''')
 
 
 write_xml('generatetocforuser_include.xsl', REGULAR_USER)


### PR DESCRIPTION
These small changes allow the build to succeed on all versions of python from 2.6 up (2.5 will break). This covers all serious candidate platforms for running cloudstack.