### PR TITLE
CLOUDSTACK-8299: Adding test case to test ingress rule for security group for specific IP set

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -1494,6 +1494,7 @@ test_data = {
                            },
                     "ostype": 'CentOS 5.3 (64-bit)',
                     "mode": 'HTTP_DOWNLOAD'
-        }
+        },
+     "setHostConfigurationForIngressRule": False
     }
 }


### PR DESCRIPTION
Adding test case to test ingress rules for specific IP sets (Not 0.0.0.0/0, e.g. 10.2.3.4/32) and also to test that VM is not accessed from outside the given IP range.