### PR TITLE
add ip set interface up because in CentOS 7 the interface will not auto p

### DIFF
--- a/scripts/vm/network/vnet/modifyvlan.sh
+++ b/scripts/vm/network/vnet/modifyvlan.sh
@@ -34,6 +34,7 @@ addVlan() {
 	if [ ! -d /sys/class/net/$vlanDev ]
 	then
 		ip link add link $pif name $vlanDev type vlan id $vlanId > /dev/null
+		ip link set $vlanDev up
 		
 		if [ $? -gt 0 ]
 		then


### PR DESCRIPTION
When run "ip link add link $pif name $vlanDev type vlan id $vlanId > /dev/null",  the interface will not auto change to up status, so add "ip link set $vlanDev up", on CentOS 7.