### PR TITLE
CLOUDSTACK-8307: UI not showing all Domains, if there are more than 24 domains then the last domain gets cut off on firefox and IE. 

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -7888,6 +7888,10 @@ label.error {
   overflow: auto;
 }
 
+.tree-view.overflowScroll {
+  overflow: scroll;
+}
+
 #browser .tree-view div.toolbar {
 }
 

--- a/ui/scripts/domains.js
+++ b/ui/scripts/domains.js
@@ -21,6 +21,7 @@
 
         // Domain tree
         treeView: {
+        	overflowScroll: true,
             // Details
             detailView: {
                 name: 'Domain details',

--- a/ui/scripts/ui/widgets/treeView.js
+++ b/ui/scripts/ui/widgets/treeView.js
@@ -83,6 +83,10 @@
         var treeViewArgs = args.treeView;
         var $browser = args.$browser;
 
+        if(treeViewArgs.overflowScroll) {
+            $treeView.addClass('overflowScroll');
+        }
+
         makeTreeList({
             $treeView: $treeView,
             parent: null,


### PR DESCRIPTION
Added a flag in treeview widget and based on the flag adding css class which will make overflow as scroll instead of the default auto.