### PR TITLE
systemvm: correct sftp subsystem path of debian wheezy

### DIFF
--- a/systemvm/patches/debian/config/etc/ssh/sshd_config
+++ b/systemvm/patches/debian/config/etc/ssh/sshd_config
@@ -121,7 +121,7 @@ MaxSessions 1000
 #Banner /some/path
 
 # override default of no subsystems
-Subsystem	sftp	/usr/libexec/openssh/sftp-server
+Subsystem	sftp	/usr/lib/openssh/sftp-server
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs


### PR DESCRIPTION
The sftp subsystem path is `/usr/lib/openssh/sftp-server` according https://packages.debian.org/wheezy/amd64/openssh-server/filelist and checked with plain wheezy install.