### PR TITLE
Add Apache Kafka event-bus support - producing only.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -243,6 +243,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-mom-kafka</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-framework-ipc</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -1,0 +1,45 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cloud-mom-kafka</artifactId>
+  <name>Apache CloudStack Plugin - Kafka Event Bus</name>
+  <parent>
+    <groupId>org.apache.cloudstack</groupId>
+    <artifactId>cloudstack-plugins</artifactId>
+    <version>4.4.2</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <dependencies>
+    <dependency>
+    <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-framework-events</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>0.8.2.0</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <defaultGoal>install</defaultGoal>
+  </build>
+</project>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.4.2</version>
+    <version>4.6.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
+++ b/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
@@ -47,7 +47,10 @@ import com.cloud.utils.PropertiesUtil;
 @Local(value = EventBus.class)
 public class KafkaEventBus extends ManagerBase implements EventBus {
 
-    private final String _topic = "cloudstack";
+    public static final String DEFAULT_TOPIC = "cloudstack";
+    public static final String DEFAULT_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+
+    private String _topic = null;
     private Producer<String,String> _producer;
     private static final Logger s_logger = Logger.getLogger(KafkaEventBus.class);
 
@@ -58,7 +61,23 @@ public class KafkaEventBus extends ManagerBase implements EventBus {
 
         try {
             final FileInputStream is = new FileInputStream(PropertiesUtil.findConfigFile("kafka.producer.properties"));
+
             props.load(is);
+
+            _topic = (String)props.remove("topic");
+            if (_topic == null) {
+                _topic = DEFAULT_TOPIC;
+            }
+
+            if (!props.containsKey("key.serializer")) {
+                props.put("key.serializer", DEFAULT_SERIALIZER);
+            }
+
+            if (!props.containsKey("value.serializer")) {
+                props.put("value.serializer", DEFAULT_SERIALIZER);
+            }
+
+
             is.close();
         } catch (Exception e) {
             throw new ConfigurationException("Could not read kafka properties");

--- a/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
+++ b/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cloudstack.mom.kafka;
+
+import java.io.FileInputStream;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.Properties;
+
+import javax.ejb.Local;
+import javax.naming.ConfigurationException;
+
+import org.apache.log4j.Logger;
+
+import org.apache.cloudstack.framework.events.Event;
+import org.apache.cloudstack.framework.events.EventBus;
+import org.apache.cloudstack.framework.events.EventBusException;
+import org.apache.cloudstack.framework.events.EventSubscriber;
+import org.apache.cloudstack.framework.events.EventTopic;
+
+import com.cloud.utils.component.ManagerBase;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import com.cloud.utils.PropertiesUtil;
+
+@Local(value = EventBus.class)
+public class KafkaEventBus extends ManagerBase implements EventBus {
+
+    private final String _topic = "cloudstack";
+    private Producer<String,String> _producer;
+    private static final Logger s_logger = Logger.getLogger(KafkaEventBus.class);
+
+    @Override
+    public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
+
+        final Properties props = new Properties();
+
+        try {
+            final FileInputStream is = new FileInputStream(PropertiesUtil.findConfigFile("kafka.producer.properties"));
+            props.load(is);
+            is.close();
+        } catch (Exception e) {
+            throw new ConfigurationException("Could not read kafka properties");
+        }
+
+        _producer = new KafkaProducer<String,String>(props);
+        _name = name;
+
+        return true;
+    }
+
+    @Override
+    public void setName(String name) {
+        _name = name;
+    }
+
+    @Override
+    public UUID subscribe(EventTopic topic, EventSubscriber subscriber) throws EventBusException {
+        /* NOOP */
+        return UUID.randomUUID();
+    }
+
+    @Override
+    public void unsubscribe(UUID subscriberId, EventSubscriber subscriber) throws EventBusException {
+        /* NOOP */
+    }
+
+    @Override
+    public void publish(Event event) throws EventBusException {
+        ProducerRecord<String, String> record = new ProducerRecord<String,String>(_topic, event.getResourceUUID(), event.getDescription());
+        _producer.send(record);
+    }
+
+    @Override
+    public String getName() {
+        return _name;
+    }
+
+    @Override
+    public boolean start() {
+        return true;
+    }
+
+    @Override
+    public boolean stop() {
+        return true;
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -54,6 +54,7 @@
     <module>hypervisors/kvm</module>
     <module>event-bus/rabbitmq</module>
     <module>event-bus/inmemory</module>
+    <module>event-bus/kafka</module>
     <module>hypervisors/baremetal</module>
     <module>hypervisors/ucs</module>
     <module>hypervisors/hyperv</module>


### PR DESCRIPTION
This commit produces event bus messages to a "cloudstack" topic
in Apache Kafka. Configuration is expected to be found in
/etc/cloudstack/management/kafka.producer.properties and will
generally be of the form:

    topic=cloudstack
    bootstrap.servers=kafka-host1:9092,kafka-host2:9092

If topic is not provided, it will default to _cloudstack_.
Should you wish to use a different key or value serializer when producing, it can be provided in the config file with:

    key.serializer=classpath.to.serializer
    value.serializer=classpath.to.serializer

Both key and value serializers default to `org.apache.kafka.common.serialization.StringSerializer`

The consuming code is just place-holder. I think adding a consumer within cloudstack
is very debatable and likely not needed.