### PR TITLE
CLOUDSTACK-7951: Limit amount of memory used by cloudstack-agent jsvc

### DIFF
--- a/packaging/centos7/cloud-agent.rc
+++ b/packaging/centos7/cloud-agent.rc
@@ -64,7 +64,7 @@ export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/a
 start() {
     echo -n $"Starting $PROGNAME: "
     if hostname --fqdn >/dev/null 2>&1 ; then
-        $JSVC -cp "$CLASSPATH" -pidfile "$PIDFILE" \
+        $JSVC -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
             -errfile $LOGDIR/cloudstack-agent.err -outfile $LOGDIR/cloudstack-agent.out $CLASS
         RETVAL=$?
         echo


### PR DESCRIPTION
According https://issues.apache.org/jira/browse/CLOUDSTACK-7951, and https://git-wip-us.apache.org/repos/asf?p=cloudstack.git;h=207d465, also fix to centos7.