### PR TITLE
Fix the bug when build apidoc under windows crygwin environment.

### DIFF
--- a/tools/apidoc/build-apidoc.sh
+++ b/tools/apidoc/build-apidoc.sh
@@ -62,7 +62,18 @@ set -e
  sed -e 's,%API_HEADER%,Root Admin API,g' "$thisdir/generatetoc_header.xsl" >generatetocforadmin.xsl
  sed -e 's,%API_HEADER%,Domain Admin API,g' "$thisdir/generatetoc_header.xsl" >generatetocfordomainadmin.xsl
 
- python "$thisdir/gen_toc.py" $(find . -type f)
+ WINOS=`uname -s|grep -i WIN`
+ gen_toc_file=''
+ if [ "x$WINOS" != "x" ]; then
+ gen_toc_file="`cygpath -w $thisdir`\\gen_toc.py"
+ else
+ gen_toc_file="$thisdir/gen_toc.py"
+ fi
+ 
+ argfiles=`find . -type f`
+ for file in $argfiles;
+ 	do echo "Parse file $file";python $gen_toc_file $file;
+ done
 
  cat generatetocforuser_include.xsl >>generatetocforuser.xsl
  cat generatetocforadmin_include.xsl >>generatetocforadmin.xsl


### PR DESCRIPTION
Currently, when building apidoc under windows error occured caused by python can not understand the directory of gen_toc.py file.
Besides gen_toc.py can not receive large parameter.The commit works fine with 4.4.1 and 4.4.2 should works fine with other branches.