### PR TITLE
CLOUDSTACK-8336: Adding tests for shared networks with basic operations related to network/router restart and acquire IP

### DIFF
--- a/test/integration/component/test_shared_networks.py
+++ b/test/integration/component/test_shared_networks.py
@@ -29,15 +29,17 @@ from marvin.lib.base import (Account,
                              StaticNATRule,
                              FireWallRule,
                              ServiceOffering,
-                             PublicIPAddress)
+                             PublicIPAddress,
+                             Router)
 from marvin.lib.utils import (cleanup_resources,
                               validateList)
 from marvin.lib.common import (get_domain,
                                get_zone,
                                get_template,
-                               wait_for_cleanup,
-                               get_free_vlan)
+                               get_free_vlan,
+			       wait_for_cleanup)
 from marvin.codes import PASS
+from ddt import ddt, data
 import random
 import netaddr
 
@@ -152,6 +154,7 @@ class Services:
         }
 
 
+@ddt
 class TestSharedNetworks(cloudstackTestCase):
 
     @classmethod
@@ -293,10 +296,12 @@ class TestSharedNetworks(cloudstackTestCase):
         #  5. delete the admin account
         # Validations,
         #  1. listAccounts name=admin-XABU1, state=enabled returns your account
-        #  2. listPhysicalNetworks should return at least one active physical network
-        #  3. listNetworkOfferings - name=mysharedoffering , should list offering in disabled state
-        # 4. listNetworkOfferings - name=mysharedoffering, should list enabled
-        # offering
+        #  2. listPhysicalNetworks should return at least one active physical
+        #     network
+        #  3. listNetworkOfferings - name=mysharedoffering , should list
+        #     offering in disabled state
+        # 4.  listNetworkOfferings - name=mysharedoffering, should list
+        #     enabled offering
 
         # Create an account
         self.account = Account.create(
@@ -432,9 +437,10 @@ class TestSharedNetworks(cloudstackTestCase):
         #  4. delete the admin account
         # Validations,
         #  1. listAccounts name=admin-XABU1, state=enabled returns your account
-        #  2. listPhysicalNetworks should return at least one active physical network
-        # 3. createNetworkOffering fails - vlan should be specified in advanced
-        # zone
+        #  2. listPhysicalNetworks should return at least one active physical
+        #     network
+        # 3.  createNetworkOffering fails - vlan should be specified in
+        #     advanced zone
 
         # Create an account
         self.account = Account.create(
@@ -502,10 +508,12 @@ class TestSharedNetworks(cloudstackTestCase):
                 conservemode=False
             )
             self.fail(
-                "Network offering got created with vlan as False in advance mode and shared guest type, which is invalid case.")
+                "Network offering got created with vlan as False in advance\
+                        mode and shared guest type, which is invalid case.")
         except Exception as e:
             self.debug(
-                "Network Offering creation failed with vlan as False in advance mode and shared guest type. Exception: %s" %
+                "Network Offering creation failed with vlan as False\
+                 in advance mode and shared guest type. Exception: %s" %
                 e)
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
@@ -525,9 +533,10 @@ class TestSharedNetworks(cloudstackTestCase):
         #  4. delete the admin account
         # Validations,
         #  1. listAccounts name=admin-XABU1, state=enabled returns your account
-        #  2. listPhysicalNetworks should return at least one active physical network
-        # 3. createNetworkOffering fails - ip ranges should be specified when
-        # creating shared network offering
+        #  2. listPhysicalNetworks should return at least one active physical
+        #     network
+        # 3.  createNetworkOffering fails - ip ranges should be specified when
+        #     creating shared network offering
 
         # Create an account
         self.account = Account.create(
@@ -595,12 +604,14 @@ class TestSharedNetworks(cloudstackTestCase):
                 conservemode=False
             )
             self.fail(
-                "Network offering got created with vlan as True and ip ranges as False in advance mode and with shared guest type, which is invalid case.")
+                "Network offering got created with vlan as True and ip ranges\
+                as False in advance mode and with shared guest type,\
+                which is invalid case.")
         except Exception as e:
             self.debug(
-                "Network Offering creation failed with vlan as true and ip ranges as False in advance mode and with shared guest type.\
-                        Exception : %s" %
-                e)
+                "Network Offering creation failed with vlan as true and ip\
+                 ranges as False in advance mode and with shared guest type.\
+                 Exception : %s" % e)
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_createSharedNetwork_All(self):
@@ -621,19 +632,27 @@ class TestSharedNetworks(cloudstackTestCase):
         #    - name = mysharednetwork, displaytext = mysharednetwork
         #    - vlan = 123 (say)
         #    - networkofferingid = <mysharedoffering>
-        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200, netmask=255.255.255.0
+        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200
+        #    - netmask=255.255.255.0
         #    - scope = all
         #  6. create User account - user-ASJDK
-        #  7. deployVirtualMachine in this account and in admin account & within networkid = <mysharednetwork>
+        #  7. deployVirtualMachine in this account and in admin account &
+        #     within networkid = <mysharednetwork>
         #  8. delete the admin account and the user account
         # Validations,
-        #  1. listAccounts name=admin-XABU1, state=enabled returns your account
-        #  2. listPhysicalNetworks should return at least one active physical network
-        #  3. listNetworkOfferings - name=mysharedoffering , should list offering in disabled state
-        #  4. listNetworkOfferings - name=mysharedoffering, should list enabled offering
-        #  5. listNetworks - name = mysharednetwork should list the successfully created network, verify the guestIp ranges and CIDR are as given in the createNetwork call
+        #  1. listAccounts name=admin-XABU1, state=enabled returns account
+        #  2. listPhysicalNetworks should return at least one active
+        #     physical network
+        #  3. listNetworkOfferings - name=mysharedoffering , should list
+        #     offering in disabled state
+        #  4. listNetworkOfferings - name=mysharedoffering, should list
+        #     enabled offering
+        #  5. listNetworks - name = mysharednetwork should list the
+        #     successfully created network, verify the guestIp ranges and
+        #     CIDR are as given in the createNetwork call
         #  6. No checks reqd
-        #  7. a. listVirtualMachines should show both VMs in running state in the user account and the admin account
+        #  7. a. listVirtualMachines should show both VMs in running state
+        #     in the user account and the admin account
         #     b. VM's IPs shoud be in the range of the shared network ip ranges
 
         # Create admin account
@@ -808,7 +827,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+                    set to False.")
 
         self.debug(
             "Shared Network created for scope domain: %s" %
@@ -850,7 +870,8 @@ class TestSharedNetworks(cloudstackTestCase):
                     self.services["network"]["endip"])))
         if netaddr.IPAddress(unicode(vms[0].nic[0].ipaddress)) not in ip_range:
             self.fail(
-                "Virtual machine ip should be from the ip range assigned to network created.")
+                "Virtual machine ip should be from the ip range assigned to\
+                        network created.")
 
         self.user_account_virtual_machine = VirtualMachine.create(
             self.api_client,
@@ -887,7 +908,8 @@ class TestSharedNetworks(cloudstackTestCase):
                     self.services["network"]["endip"])))
         if netaddr.IPAddress(unicode(vms[0].nic[0].ipaddress)) not in ip_range:
             self.fail(
-                "Virtual machine ip should be from the ip range assigned to network created.")
+                "Virtual machine ip should be from the ip range assigned to\
+                network created.")
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_createSharedNetwork_accountSpecific(self):
@@ -909,16 +931,24 @@ class TestSharedNetworks(cloudstackTestCase):
         #    - name = mysharednetwork, displaytext = mysharednetwork
         #    - vlan = 123 (say)
         #    - networkofferingid = <mysharedoffering>
-        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200, netmask=255.255.255.0
+        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200
+        #    - netmask=255.255.255.0
         #    - scope = account, account = user-SOPJD, domain = ROOT
-        #  6. deployVirtualMachine in this account and in admin account & within networkid = <mysharednetwork>
+        #  6. deployVirtualMachine in this account and in admin account
+        #     & within networkid = <mysharednetwork>
         #  7. delete the admin account and the user account
         # Validations,
-        #  1. listAccounts name=admin-XABU1 and user-SOPJD, state=enabled returns your account
-        #  2. listPhysicalNetworks should return at least one active physical network
-        #  3. listNetworkOfferings - name=mysharedoffering , should list offering in disabled state
-        #  4. listNetworkOfferings - name=mysharedoffering, should list enabled offering
-        #  5. listNetworks - name = mysharednetwork should list the successfully created network, verify the guestIp ranges and CIDR are as given in the createNetwork call
+        #  1. listAccounts name=admin-XABU1 and user-SOPJD, state=enabled
+        #     returns your account
+        #  2. listPhysicalNetworks should return at least one active
+        #     physical network
+        #  3. listNetworkOfferings - name=mysharedoffering , should list
+        #     offering in disabled state
+        #  4. listNetworkOfferings - name=mysharedoffering, should list
+        #     enabled offering
+        #  5. listNetworks - name = mysharednetwork should list the
+        #     successfully created network, verify the guestIp ranges and CIDR
+        #     are as given in the createNetwork call
         #  6. VM deployed in admin account should FAIL to deploy
         #     VM should be deployed in user account only
         #    verify VM's IP is within shared network range
@@ -1096,7 +1126,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+                    set to False.")
 
         self.debug("Network created: %s" % self.network.id)
 
@@ -1110,11 +1141,13 @@ class TestSharedNetworks(cloudstackTestCase):
                 serviceofferingid=self.service_offering.id
             )
             self.fail(
-                "Virtual Machine got created in admin account with network created but the network used is of scope account and for user account.")
+                "Virtual Machine got created in admin account with network\
+                 created but the network used is of scope account and for\
+                 user account.")
         except Exception as e:
             self.debug(
-                "Virtual Machine creation failed as network used have scoped only for user account. Exception: %s" %
-                e)
+                "Virtual Machine creation failed as network used have scoped\
+                only for user account. Exception: %s" % e)
 
         self.user_account_virtual_machine = VirtualMachine.create(
             self.api_client,
@@ -1147,7 +1180,8 @@ class TestSharedNetworks(cloudstackTestCase):
                     self.services["network"]["endip"])))
         if netaddr.IPAddress(unicode(vms[0].nic[0].ipaddress)) not in ip_range:
             self.fail(
-                "Virtual machine ip should be from the ip range assigned to network created.")
+                "Virtual machine ip should be from the ip range assigned\
+                 to network created.")
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_createSharedNetwork_domainSpecific(self):
@@ -1171,16 +1205,24 @@ class TestSharedNetworks(cloudstackTestCase):
         #    - name = mysharednetwork, displaytext = mysharednetwork
         #    - vlan = 123 (say)
         #    - networkofferingid = <mysharedoffering>
-        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200, netmask=255.255.255.0
+        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200
+        #    - netmask=255.255.255.0
         #    - scope = domain, domain = DOM
-        #  6. deployVirtualMachine in this admin, domainadmin and user account & within networkid = <mysharednetwork>
+        #  6. deployVirtualMachine in this admin, domainadmin and user account
+        #     & within networkid = <mysharednetwork>
         #  7. delete all the accounts
         # Validations,
-        #  1. listAccounts state=enabled returns your accounts, listDomains - DOM should be created
-        #  2. listPhysicalNetworks should return at least one active physical network
-        #  3. listNetworkOfferings - name=mysharedoffering , should list offering in disabled state
-        #  4. listNetworkOfferings - name=mysharedoffering, should list enabled offering
-        #  5. listNetworks - name = mysharednetwork should list the successfully created network, verify the guestIp ranges and CIDR are as given in the createNetwork call
+        #  1. listAccounts state=enabled returns your accounts,
+        #     listDomains - DOM should be created
+        #  2. listPhysicalNetworks should return at least one
+        #     active physical network
+        #  3. listNetworkOfferings - name=mysharedoffering , should list
+        #     offering in disabled state
+        #  4. listNetworkOfferings - name=mysharedoffering, should list
+        #     enabled offering
+        #  5. listNetworks - name = mysharednetwork should list the
+        #     successfully created network, verify the guestIp ranges and
+        #     CIDR are as given in the createNetwork call
         #  6. VM should NOT be deployed in admin account
         #     VM should be deployed in user account and domain admin account
         #     verify VM's IP are within shared network range
@@ -1424,7 +1466,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+                    set to False.")
 
         self.debug("Shared Network created: %s" % self.network.id)
 
@@ -1438,11 +1481,13 @@ class TestSharedNetworks(cloudstackTestCase):
                 serviceofferingid=self.service_offering.id
             )
             self.fail(
-                "Virtual Machine got created in admin account with network specified but the network used is of scope domain and admin account is not part of this domain.")
+                "Virtual Machine got created in admin account with network\
+                 specified but the network used is of scope domain and admin\
+                 account is not part of this domain.")
         except Exception as e:
             self.debug(
-                "Virtual Machine creation failed as network used have scoped only for DOM domain. Exception: %s" %
-                e)
+                "Virtual Machine creation failed as network used have scoped\
+                only for DOM domain. Exception: %s" % e)
 
         self.domain_user_account_virtual_machine = VirtualMachine.create(
             self.api_client,
@@ -1476,7 +1521,8 @@ class TestSharedNetworks(cloudstackTestCase):
                     self.services["network"]["endip"])))
         if netaddr.IPAddress(unicode(vms[0].nic[0].ipaddress)) not in ip_range:
             self.fail(
-                "Virtual machine ip should be from the ip range assigned to network created.")
+                "Virtual machine ip should be from the ip range\
+                        assigned to network created.")
 
         self.domain_admin_account_virtual_machine = VirtualMachine.create(
             self.api_client,
@@ -1510,7 +1556,8 @@ class TestSharedNetworks(cloudstackTestCase):
                     self.services["network"]["endip"])))
         if netaddr.IPAddress(unicode(vms[0].nic[0].ipaddress)) not in ip_range:
             self.fail(
-                "Virtual machine ip should be from the ip range assigned to network created.")
+                "Virtual machine ip should be from the ip range assigne\
+                 to network created.")
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_createSharedNetwork_projectSpecific(self):
@@ -1533,16 +1580,24 @@ class TestSharedNetworks(cloudstackTestCase):
         #    - name = mysharednetwork, displaytext = mysharednetwork
         #    - vlan = 123 (say)
         #    - networkofferingid = <mysharedoffering>
-        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200, netmask=255.255.255.0
+        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200
+        #    - netmask=255.255.255.0
         #    - scope = project, project =  proj-SLDJK
-        #  6. deployVirtualMachine in admin, project and user account & within networkid = <mysharednetwork>
+        #  6. deployVirtualMachine in admin, project and user account & within
+        #     networkid = <mysharednetwork>
         #  7. delete all the accounts
         # Validations,
-        #  1. listAccounts state=enabled returns your accounts, listDomains - DOM should be created
-        #  2. listPhysicalNetworks should return at least one active physical network
-        #  3. listNetworkOfferings - name=mysharedoffering , should list offering in disabled state
-        #  4. listNetworkOfferings - name=mysharedoffering, should list enabled offering
-        #  5. listNetworks - name = mysharednetwork should list the successfully created network, verify the guestIp ranges and CIDR are as given in the createNetwork call
+        #  1. listAccounts state=enabled returns your accounts, listDomains
+        #     - DOM should be created
+        #  2. listPhysicalNetworks should return at least one active physical
+        #     network
+        #  3. listNetworkOfferings - name=mysharedoffering , should list
+        #     offering in disabled state
+        #  4. listNetworkOfferings - name=mysharedoffering, should list
+        #     enabled offering
+        #  5. listNetworks - name = mysharednetwork should list the
+        #     successfully created network, verify the guestIp ranges
+        #     and CIDR are as given in the createNetwork call
         #  6. VM should NOT be deployed in admin account and user account
         #     VM should be deployed in project account only
         #     verify VM's IP are within shared network range
@@ -1748,17 +1803,19 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+             set to False")
 
         self.debug("Shared Network created: %s" % self.network.id)
 
         with self.assertRaises(Exception):
-            self.project2_admin_account_virtual_machine = VirtualMachine.create(
-                self.api_client,
-                self.services["virtual_machine"],
-                networkids=self.network.id,
-                projectid=self.project2.id,
-                serviceofferingid=self.service_offering.id)
+            self.project2_admin_account_virtual_machine =\
+                VirtualMachine.create(
+                    self.api_client,
+                    self.services["virtual_machine"],
+                    networkids=self.network.id,
+                    projectid=self.project2.id,
+                    serviceofferingid=self.service_offering.id)
         self.debug("Deploying a vm to project other than the one in which \
                    network is created raised an Exception as expected")
         self.project1_admin_account_virtual_machine = VirtualMachine.create(
@@ -1791,10 +1848,12 @@ class TestSharedNetworks(cloudstackTestCase):
                     self.services["network"]["endip"])))
         if netaddr.IPAddress(unicode(vms[0].nic[0].ipaddress)) not in ip_range:
             self.fail(
-                "Virtual machine ip should be from the ip range assigned to network created.")
+                "Virtual machine ip should be from the ip range assigned\
+                 to network created.")
 
     @unittest.skip(
-        "skipped - This is a redundant case and also this is causing issue for rest fo the cases ")
+        "skipped - This is a redundant case and also this\
+                is causing issue for rest fo the cases ")
     @attr(tags=["advanced", "advancedns", "NA"])
     def test_createSharedNetwork_usedVlan(self):
         """ Test Shared Network with used vlan 01 """
@@ -1809,15 +1868,20 @@ class TestSharedNetworks(cloudstackTestCase):
         #    - name = mysharednetwork, displaytext = mysharednetwork
         #    - vlan = any vlan between 10-90
         #    - networkofferingid = <mysharedoffering>
-        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200, netmask=255.255.255.0
+        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200
+        #    - netmask=255.255.255.0
         #    - scope = all
         #  6. delete admin account
         # Validations,
         #  1. listAccounts state=enabled returns your account
-        #  2. listNetworkOfferings - name=mysharedoffering , should list offering in disabled state
-        #  3. listNetworkOfferings - name=mysharedoffering, should list enabled offering
-        #  4. listPhysicalNetworks should return at least one active physical network
-        # 5. network creation should FAIL since VLAN is used for guest networks
+        #  2. listNetworkOfferings - name=mysharedoffering , should list
+        #     offering in disabled state
+        #  3. listNetworkOfferings - name=mysharedoffering, should list
+        #     enabled offering
+        #  4. listPhysicalNetworks should return at least one active
+        #     physical network
+        #  5. network creation should FAIL since VLAN is used for
+        #     guest networks
 
         # Create admin account
         self.admin_account = Account.create(
@@ -1943,8 +2007,8 @@ class TestSharedNetworks(cloudstackTestCase):
                 shared_vlan)
         except Exception as e:
             self.debug(
-                "Network creation failed because the valn id being used by another network. Exception: %s" %
-                e)
+                "Network creation failed because the valn id being used by\
+                 another network. Exception: %s" % e)
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_createSharedNetwork_usedVlan2(self):
@@ -1960,18 +2024,23 @@ class TestSharedNetworks(cloudstackTestCase):
         #    - name = mysharednetwork, displaytext = mysharednetwork
         #    - vlan = any vlan beyond 10-90 (123 for eg)
         #    - networkofferingid = <mysharedoffering>
-        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200, netmask=255.255.255.0
+        #    - gw = 172.16.15.1, startip = 172.16.15.2 , endip = 172.16.15.200
+        #    - netmask=255.255.255.0
         #    - scope = all
-        #  6. createNetwork again with same VLAN  but different IP ranges and gw
+        #  6. createNetwork again with same VLAN  but different IP ranges and
+        #     gateway
         #  7. delete admin account
         # Validations,
         #  1. listAccounts state=enabled returns your account
-        #  2. listNetworkOfferings - name=mysharedoffering , should list offering in disabled state
-        #  3. listNetworkOfferings - name=mysharedoffering, should list enabled offering
-        #  4. listPhysicalNetworks should return at least one active physical network
+        #  2. listNetworkOfferings - name=mysharedoffering , should list
+        #     offering in disabled state
+        #  3. listNetworkOfferings - name=mysharedoffering, should list
+        #     enabled offering
+        #  4. listPhysicalNetworks should return at least one active
+        #     physical network
         #  5. network creation shoud PASS
-        # 6. network creation should FAIL since VLAN is already used by
-        # previously created network
+        #  6. network creation should FAIL since VLAN is already used by
+        #     previously created network
 
         # Create admin account
         self.admin_account = Account.create(
@@ -2112,7 +2181,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+             set to False.")
 
         self.debug("Network created: %s" % self.network.id)
 
@@ -2134,8 +2204,8 @@ class TestSharedNetworks(cloudstackTestCase):
                 "Network got created with used vlan id, which is invalid")
         except Exception as e:
             self.debug(
-                "Network creation failed because the valn id being used by another network. Exception: %s" %
-                e)
+                "Network creation failed because the valn id being used by\
+                 another network. Exception: %s" % e)
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_deployVM_multipleSharedNetwork(self):
@@ -2144,7 +2214,8 @@ class TestSharedNetworks(cloudstackTestCase):
         # Steps,
         #  0. create a user account
         #  1. Create two shared Networks (scope=ALL, different IP ranges)
-        #  2. deployVirtualMachine in both the above networkids within the user account
+        #  2. deployVirtualMachine in both the above networkids within the
+        #     user account
         #  3. delete the user account
         # Validations,
         #  1. shared networks should be created successfully
@@ -2290,7 +2361,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+             set to False.")
 
         self.debug("Shared Network created: %s" % self.network.id)
 
@@ -2331,7 +2403,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+             set to False.")
 
         self.debug("Network created: %s" % self.network1.id)
 
@@ -2364,7 +2437,8 @@ class TestSharedNetworks(cloudstackTestCase):
             self.network_admin_account_virtual_machine.id)
 
         self.assertTrue(
-            self.network_admin_account_virtual_machine.nic[0].ipaddress is not None,
+            self.network_admin_account_virtual_machine.nic[0].ipaddress
+            is not None,
             "ip should be assigned to running virtual machine")
 
         self.network1_admin_account_virtual_machine = VirtualMachine.create(
@@ -2395,7 +2469,8 @@ class TestSharedNetworks(cloudstackTestCase):
             self.network1_admin_account_virtual_machine.id)
 
         self.assertTrue(
-            self.network1_admin_account_virtual_machine.nic[0].ipaddress is not None,
+            self.network1_admin_account_virtual_machine.nic[0].ipaddress
+            is not None,
             "ip should be assigned to running virtual machine")
 
     @attr(tags=["advanced", "advancedns"], required_hardware="true")
@@ -2406,15 +2481,18 @@ class TestSharedNetworks(cloudstackTestCase):
         #  0. create a user account
         #  1. Create one shared Network (scope=ALL, different IP ranges)
         #  2. Create one Isolated Network
-        #  3. deployVirtualMachine in both the above networkids within the user account
-        #  4. apply FW rule and enable PF for port 22 for guest VM on isolated network
+        #  3. deployVirtualMachine in both the above networkids within
+        #     the user account
+        #  4. apply FW rule and enable PF for port 22 for guest VM on
+        #     isolated network
         #  5. delete the user account
         # Validations,
         #  1. shared network should be created successfully
         #  2. isolated network should be created successfully
         #  3.
         #    a. VM should deploy successfully
-        #    b. VM should be deployed in both networks and have IP in both the networks
+        #    b. VM should be deployed in both networks and have IP in both
+        #       the networks
         # 4. FW and PF should apply successfully, ssh into the VM should work
         # over isolated network
 
@@ -2548,7 +2626,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_network_offerings_response[0].state,
             "Enabled",
-            "The isolated network offering state should get updated to Enabled.")
+            "The isolated network offering state should get\
+             updated to Enabled.")
 
         self.debug(
             "Isolated Network Offering created: %s" %
@@ -2594,7 +2673,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+                    set to False.")
 
         self.debug("Shared Network created: %s" % self.shared_network.id)
 
@@ -2655,7 +2735,8 @@ class TestSharedNetworks(cloudstackTestCase):
             self.shared_network_admin_account_virtual_machine.id)
 
         self.assertTrue(
-            self.shared_network_admin_account_virtual_machine.nic[0].ipaddress is not None,
+            self.shared_network_admin_account_virtual_machine.nic[0].ipaddress
+            is not None,
             "ip should be assigned to running virtual machine")
 
         self.isolated_network_admin_account_virtual_machine = \
@@ -2688,7 +2769,8 @@ class TestSharedNetworks(cloudstackTestCase):
             self.isolated_network_admin_account_virtual_machine.id)
 
         self.assertTrue(
-            self.isolated_network_admin_account_virtual_machine.nic[0].ipaddress is not None,
+            self.isolated_network_admin_account_virtual_machine.nic[0].ipaddress
+            is not None,
             "ip should be assigned to running virtual machine")
 
         self.debug(
@@ -2756,16 +2838,19 @@ class TestSharedNetworks(cloudstackTestCase):
         except Exception as e:
             self.fail(
                 "SSH Access failed for %s: %s" %
-                (self.isolated_network_admin_account_virtual_machine.ipaddress, e))
+                (self.isolated_network_admin_account_virtual_machine.ipaddress,
+                    e))
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_networkWithsubdomainaccessTrue(self):
         """ Test Shared Network with subdomainaccess=True """
 
         # Steps,
-        #  1. create Network using shared network offering for scope=Account and subdomainaccess=true.
+        #  1. create Network using shared network offering for scope=Account
+        #     and subdomainaccess=true.
         # Validations,
-        #  (Expected) API should fail saying that subdomainaccess cannot be given when scope is Account
+        #  (Expected) API should fail saying that subdomainaccess cannot be
+        #   given when scope is Account
 
         # Create admin account
         self.admin_account = Account.create(
@@ -2891,16 +2976,19 @@ class TestSharedNetworks(cloudstackTestCase):
             self.fail("Network creation should fail.")
         except:
             self.debug(
-                "Network creation failed because subdomainaccess parameter was passed when scope was account.")
+                "Network creation failed because subdomainaccess parameter was\
+                 passed when scope was account.")
 
     @attr(tags=["advanced", "advancedns"], required_hardware="false")
     def test_networkWithsubdomainaccessFalse(self):
         """ Test shared Network with subdomainaccess=False """
 
         # Steps,
-        #  1. create Network using shared network offering for scope=Account and subdomainaccess=false
-        # Validations,
-        #  (Expected) API should fail saying that subdomainaccess cannot be given when scope is Account
+        #  1. create Network using shared network offering for scope=Account
+        #     and subdomainaccess=false
+        #  Validations,
+        #  (Expected) API should fail saying that subdomainaccess cannot be
+        #  given when scope is Account
 
         # Create admin account
         self.admin_account = Account.create(
@@ -3026,7 +3114,8 @@ class TestSharedNetworks(cloudstackTestCase):
             self.fail("Network creation should fail.")
         except:
             self.debug(
-                "Network creation failed because subdomainaccess parameter was passed when scope was account.")
+                "Network creation failed because subdomainaccess parameter\
+                        was passed when scope was account.")
 
     @attr(tags=["advanced"], required_hardware="false")
     def test_escalation_ES1621(self):
@@ -3039,12 +3128,17 @@ class TestSharedNetworks(cloudstackTestCase):
         Step3: Update the network offering to Enabled state
         Step4: list network offering
         Step5: Create network with above offering
-        Step6: List netwokrs and verify the network created in step5 in the response
-        Step7: Create another network with offering,vlan and ip range same as in step6
+        Step6: List netwokrs and verify the network created in
+               step5 in the response
+        Step7: Create another network with offering,vlan and ip range
+               same as in step6
         Step8: Verify that network creationin Step7 should fail
-        Step9: Repeat step6 with diff vlan but same ip range and network offering
-        Step10: List netwokrs and verify the network created in step9 in the response
-        Step11: Dislable network offering for the cleanup to delete at the end of the test
+        Step9: Repeat step6 with diff vlan but same ip range and network
+               offering
+        Step10: List netwokrs and verify the network created in step9
+                in the response
+        Step11: Dislable network offering for the cleanup to delete at
+                the end of the test
         """
         # Creating Admin account
         self.admin_account = Account.create(
@@ -3120,7 +3214,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEquals(
             PASS,
             status[0],
-            "listNetworkOfferings returned invalid object in response after enabling it."
+            "listNetworkOfferings returned invalid object in\
+                    response after enabling it."
         )
         self.assertEqual(
             list_network_offerings_response[0].state,
@@ -3153,7 +3248,8 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False.")
+            "The network is created with ip range but the flag is\
+                    set to False.")
         self.debug(
             "Shared Network created for scope domain: %s" %
             self.network.id)
@@ -3167,7 +3263,8 @@ class TestSharedNetworks(cloudstackTestCase):
             )
             self.cleanup_networks.append(self.network1)
             self.fail(
-                "CS is allowing to create shared network with ip range and vlan same as used by another shared network")
+                "CS is allowing to create shared network with ip range and\
+                        vlan same as used by another shared network")
         except Exception as e:
             self.debug("Network Creation Exception Raised: %s" % e)
         # Create another shared network with overlapped ip range but different
@@ -3192,13 +3289,14 @@ class TestSharedNetworks(cloudstackTestCase):
         self.assertEquals(
             PASS,
             status[0],
-            "listNetworks returned invalid object in response after creating with overlapped ip range in diff vlan."
+            "listNetworks returned invalid object in response after\
+                    creating with overlapped ip range in diff vlan."
         )
         self.assertEqual(
             list_networks_response[0].specifyipranges,
             True,
-            "The network is created with ip range but the flag is set to False after creating with overlapped ip range in diff vlan."
-        )
+            "The network is created with ip range but the flag is set to\
+                False after creating with overlapped ip range in diff vlan")
         self.debug(
             "Shared Network created for scope domain: %s" %
             self.network2.id)
@@ -3210,4 +3308,114 @@ class TestSharedNetworks(cloudstackTestCase):
             state="disabled"
         )
         self.cleanup_networks.append(self.shared_network_offering)
+        return
+
+    @data(True, False)
+    @attr(tags=["advanced", "advancedns", "dvs"], required_hardware="false")
+    def test_restart_network(self, cleanup):
+        """ Test restart shared Network
+
+        # Steps
+        # 1. Create a shared network in an account
+        # 2. Deploy a VM in the network
+        # 3. Restart the network with cleanup true and false
+        # 4. List the router for the network and verify that publicip of
+             the router remain the same
+        """
+
+        # Create admin account
+        account = Account.create(
+            self.api_client,
+            self.services["account"],
+            domainid=self.domain.id
+        )
+        self.cleanup_accounts.append(account)
+
+        physical_network, shared_vlan = get_free_vlan(
+            self.api_client, self.zone.id)
+        if shared_vlan is None:
+            self.fail("Failed to get free vlan id for shared network")
+
+        self.debug("Physical network found: %s" % physical_network.id)
+
+        self.services["network_offering"]["specifyVlan"] = "True"
+        self.services["network_offering"]["specifyIpRanges"] = "True"
+
+        # Create Network Offering
+        shared_network_offering = NetworkOffering.create(
+            self.api_client,
+            self.services["network_offering"],
+            conservemode=False
+        )
+
+        # Update network offering state from disabled to enabled.
+        NetworkOffering.update(
+            shared_network_offering,
+            self.api_client,
+            id=shared_network_offering.id,
+            state="enabled"
+        )
+        #self._cleanup.append(shared_network_offering)
+
+        # create network using the shared network offering created
+        self.services["network"]["acltype"] = "Domain"
+        self.services["network"][
+            "networkofferingid"] = shared_network_offering.id
+        self.services["network"]["physicalnetworkid"] = physical_network.id
+        self.services["network"]["vlan"] = shared_vlan
+
+        shared_network = Network.create(
+            self.api_client,
+            self.services["network"],
+            networkofferingid=shared_network_offering.id,
+            zoneid=self.zone.id,
+        )
+
+        self.cleanup_networks.append(shared_network)
+
+        self.debug(
+            "Shared Network created for scope domain: %s" %
+            shared_network.id)
+
+        VirtualMachine.create(
+            self.api_client,
+            self.services["virtual_machine"],
+            networkids=shared_network.id,
+            serviceofferingid=self.service_offering.id
+        )
+
+        list_router_response = Router.list(
+            self.api_client,
+            networkid=shared_network.id,
+            listall=True
+        )
+        self.assertEqual(
+            validateList(list_router_response)[0],
+            PASS,
+            "Router list validation failed"
+        )
+        router = list_router_response[0]
+        # Store old values before restart
+        old_publicip = router.publicip
+
+        shared_network.restart(self.api_client, cleanup=cleanup)
+
+        # Get router details after restart
+        list_router_response = Router.list(
+            self.api_client,
+            networkid=shared_network.id,
+            listall=True
+        )
+        self.assertEqual(
+            validateList(list_router_response)[0],
+            PASS,
+            "Router list validation failed"
+        )
+        router = list_router_response[0]
+
+        self.assertEqual(
+            router.publicip,
+            old_publicip,
+            "Public IP of the router should remain same after network restart"
+        )
         return

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -57,10 +57,6 @@ from marvin.cloudstackAPI import (listConfigurations,
                                   listNetworkOfferings,
                                   listResourceLimits,
                                   listVPCOfferings)
-
-
-
-
 from marvin.sshClient import SshClient
 from marvin.codes import (PASS, FAILED, ISOLATED_NETWORK, VPC_NETWORK,
                           BASIC_ZONE, FAIL, NAT_RULE, STATIC_NAT_RULE,
@@ -83,7 +79,8 @@ from marvin.lib.base import (PhysicalNetwork,
                              Network,
                              Host,
                              Resources,
-                             Configurations)
+                             Configurations,
+                             Router)
 import random
 
 
@@ -1395,3 +1392,28 @@ def isNetworkDeleted(apiclient, networkid, timeout=600):
         time.sleep(60)
     #end while
     return networkDeleted
+
+def verifyRouterState(apiclient, routerid, state, listall=True):
+    """List router and check if the router state matches the given state"""
+    retriesCount = 10
+    isRouterInDesiredState = False
+    exceptionOccured = False
+    exceptionMessage = ""
+    try:
+        while retriesCount >= 0:
+            routers = Router.list(apiclient, id=routerid, listall=listall)
+            assert validateList(
+                routers)[0] == PASS, "Routers list validation failed"
+            if str(routers[0].state).lower() == state:
+                isRouterInDesiredState = True
+                break
+            retriesCount -= 1
+            time.sleep(60)
+        if not isRouterInDesiredState:
+            exceptionMessage = "Router state should be %s, it is %s" %\
+                                (state, routers[0].state)
+    except Exception as e:
+        exceptionOccured = True
+        exceptionMessage = e
+        return [exceptionOccured, isRouterInDesiredState, exceptionMessage]
+    return [exceptionOccured, isRouterInDesiredState, exceptionMessage]


### PR DESCRIPTION
Adding following basic test cases for shared networks.
1. Restart Network
2. Restart Router
3. Stop and Start Router
4. Acquire Public IP in network and disassociate

Added a function in common file to verify the router state.

The verification steps are written in detail in the test cases.

Also made following changes in existing code.
1. Fixed the pep8 issues already present in the file.
2. Remove hard coded Services dictionary
3. Improved existing code

Logs:
Test Shared Network ALL ... === TestName: test_createSharedNetwork_All | Status : SUCCESS ===
ok
Test Shared Network with scope account ... === TestName: test_createSharedNetwork_accountSpecific | Status : SUCCESS ===
ok
Test Shared Network with scope domain ... === TestName: test_createSharedNetwork_domainSpecific | Status : SUCCESS ===
ok
Test Shared Network with scope project ... === TestName: test_createSharedNetwork_projectSpecific | Status : SUCCESS ===
ok
Test Shared Network with used vlan 01 ... SKIP: skipped - This is a redundant case and also this                is causing
issue for rest fo the cases
Test Shared Network with used vlan 02 ... === TestName: test_createSharedNetwork_usedVlan2 | Status : SUCCESS ===
ok
Test Vm deployment with multiple shared networks ... === TestName: test_deployVM_multipleSharedNetwork | Status : SUCCESS
===
ok
ES1621:Allow creating shared networks with overlapping ... === TestName: test_escalation_ES1621 | Status :
SUCCESS ===
ok
Test shared Network with subdomainaccess=False ... === TestName: test_networkWithsubdomainaccessFalse | Status : SUCCESS ===
ok
Test Shared Network with subdomainaccess=True ... === TestName: test_networkWithsubdomainaccessTrue | Status : SUCCESS ===
ok
Test reboot router ... === TestName: test_reboot_router | Status : SUCCESS ===
ok
Test restart shared Network ... === TestName: test_restart_network_1_True | Status : SUCCESS ===
ok
Test restart shared Network ... === TestName: test_restart_network_2_False | Status : SUCCESS ===
ok
Test shared network Offering 01 ... === TestName: test_sharedNetworkOffering_01 | Status : SUCCESS ===
ok
Test Shared Network Offering 02 ... === TestName: test_sharedNetworkOffering_02 | Status : SUCCESS ===
ok
Test Shared Network Offering 03 ... === TestName: test_sharedNetworkOffering_03 | Status : SUCCESS ===
ok
Test stop and start router ... === TestName: test_stop_start_router | Status : SUCCESS ===
ok
Test VM deployment in shared and isolated networks ... === TestName: test_deployVM_isolatedAndShared | Status : SUCCESS ===
ok
Test acquire IP in shared network ... === TestName: test_acquire_ip | Status : SUCCESS ===
ok