### PR TITLE
CLOUDSTACK-8278: Usage test path - Correct code flow in case the usage job configuration is not to be set through test case

### DIFF
--- a/test/integration/testpaths/testpath_usage.py
+++ b/test/integration/testpaths/testpath_usage.py
@@ -91,6 +91,10 @@ class TestUsage(cloudstackTestCase):
                 "setUsageConfigurationThroughTestCase"]:
             cls.setUsageConfiguration()
             cls.RestartServers()
+        else:
+            currentMgtSvrTime = cls.getCurrentMgtSvrTime()
+            dateTimeSplit = currentMgtSvrTime.split("/")
+            cls.curDate = dateTimeSplit[0]
 
         cls.hypervisor = testClient.getHypervisorInfo()
 
@@ -2966,6 +2970,10 @@ class TestUsageDirectMeteringBasicZone(cloudstackTestCase):
                 "setUsageConfigurationThroughTestCase"]:
             cls.setUsageConfiguration()
             cls.RestartServers()
+        else:
+            currentMgtSvrTime = cls.getCurrentMgtSvrTime()
+            dateTimeSplit = currentMgtSvrTime.split("/")
+            cls.curDate = dateTimeSplit[0]
 
         cls.template = get_template(
             cls.apiclient,

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -1484,7 +1484,7 @@ test_data = {
             "ldapPassword": ""
         },
         "systemVmDelay": 120,
-	"setUsageConfigurationThroughTestCase": True,
+	"setUsageConfigurationThroughTestCase": False,
 	"vmware_cluster" : {
             "hypervisor": 'VMware',
             "clustertype": 'ExternalManaged',


### PR DESCRIPTION
The flag "setUsageConfigurationThroughTestCase" dictates whether we should set the usage related config from test case itself (And restart the management server and usage server in the process) or not.

When the flag is False (When we don't want to disrupt other test cases and/or usage server/job is already configured), then it should be ensured that the code is not broken anywhere.

Currently the value of the flag is True, hence by default test case sets the usage global setting values and restarts the management and usage server in the process. This can disrupt other test case execution going on in parallel. So making the default value of the flag to False and also making changes in the test case to ensure test case works correctly in this case.

If we are running the test suite on a separate setup and want to set global settings related to usage through test case itself, then we can turn the flag to True whenever required before the run.