### PR TITLE
CLOUDSTACK-8344: Fixed SSH failures in test_haproxy.py test suite

### DIFF
--- a/test/integration/component/test_haproxy.py
+++ b/test/integration/component/test_haproxy.py
@@ -325,8 +325,8 @@ class TestHAProxyStickyness(cloudstackTestCase):
             ssh_1 = SshClient(
                 ip_addr,
                 22,
-                self.services["configurableData"]["host"]["username"],
-                self.services["configurableData"]["host"]["password"]
+                self.virtual_machine.username,
+                self.virtual_machine.password
             )
             hostnames.append(ssh_1.execute("hostname")[0])
             self.debug(hostnames)


### PR DESCRIPTION
The test case in test suite test_haproxy.py are failing while attempting SSH due to Authentication error.
The test cases are using host credentials while trying to connect to user VM. Instead they should use VM username and password.

Tested on KVM setup.

Logs:
Test Configure stickiness policies with default values ... === TestName: test_01_create_sticky_policy_default_values |
Status : SUCCESS ===
ok
Test Configure stickiness policies with custom values ... === TestName: test_02_create_sticky_policy_custom_values |
Status : SUCCESS ===
ok
Test listnetworks response to check supported stickiness policies ... === TestName: test_03_supported_policies_by_network
| Status : SUCCESS ===
ok
Test LB rule before/after stickiness policy creation ... === TestName: test_04_delete_lb_rule | Status : SUCCESS ===
ok
Test error/alerts after creating stickiness policy ... === TestName: test_05_error_alerts_after_create | Status : SUCCESS
===
ok
Test release public IP with stickiness policy ... === TestName: test_06_release_ip | Status : SUCCESS ===
ok
Test Delete account  and check the router and its rules ... === TestName: test_07_delete_account | Status : SUCCESS ===
ok
Test verify create stickiness policy when router is stopped state ... === TestName: test_08_create_policy_router_stopped |
Status : SUCCESS ===
ok
Test check the stickiness policy rules after destroying router ... === TestName: test_09_create_policy_router_destroy |
Status : SUCCESS ===
ok
Test enable/disable the VPN after applying sticky policy rules ... === TestName: test_10_create_policy_enable_disable_vpn
| Status : SUCCESS ===
ok
Test verfify functionality syncronous and asyncronous validations ... === TestName: test_11_invalid_params | Status :
SUCCESS ===
ok

----------------------------------------------------------------------
Ran 11 tests in 3936.193s

OK