### PR TITLE
CLOUDSTACK-8356: Mentioning netaddr module in setup.py in marvin as it is used across test cases

### DIFF
--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -51,7 +51,8 @@ setup(name="Marvin",
           "paramiko >= 1.13.0",
           "nose >= 1.3.3",
           "ddt >= 0.4.0",
-          "pyvmomi >= 5.5.0"
+          "pyvmomi >= 5.5.0",
+          "netaddr >= 0.7.14"
       ],
       py_modules=['marvin.marvinPlugin'],
       zip_safe=False,


### PR DESCRIPTION
The netaddr module is used in various test cases but it is not mentioned in setup.py file. Test cases will fail with import error if the module is absent on user machine even when marvin is installed.

Mentioning the netaddr module in setup.py file so it is installed with marvin.

Tested the change with packaging new marvin tar with the change and installing marvin with pip on a machine which did not have netaddr module. It downloaded and installed it automatically.

pip install Marvin-4.5.1.0.tar.gz
Unpacking ./Marvin-4.5.1.0.tar.gz
Running setup.py (path:/tmp/pip-D49qWR-build/setup.py) egg_info for package from file:///root/Marvin-4.5.1.0/dist/Marvin-4.5.1.0.tar.gz
    warning: no files found matching '*.txt' under directory 'docs'
Requirement already satisfied (use --upgrade to upgrade): mysql-connector-python>=1.1.6 in /usr/lib/python2.6/site-packages (from Marvin==4.5.1.0)
Requirement already satisfied (use --upgrade to upgrade): requests>=2.2.1 in /usr/lib/python2.6/site-packages (from Marvin==4.5.1.0)
Requirement already satisfied (use --upgrade to upgrade): paramiko>=1.13.0 in /usr/lib/python2.6/site-packages (from Marvin==4.5.1.0)
Requirement already satisfied (use --upgrade to upgrade): nose>=1.3.3 in /usr/lib/python2.6/site-packages (from Marvin==4.5.1.0)
Requirement already satisfied (use --upgrade to upgrade): ddt>=0.4.0 in /usr/lib/python2.6/site-packages (from Marvin==4.5.1.0)
Downloading/unpacking netaddr>=0.7.11 (from Marvin==4.5.1.0)
  Downloading netaddr-0.7.14-py2.py3-none-any.whl (1.5MB): 1.5MB downloaded
Installing collected packages: netaddr, Marvin
  Found existing installation: Marvin 0.1.0
    Uninstalling Marvin:
      Successfully uninstalled Marvin
  Running setup.py install for Marvin
    warning: no files found matching '*.txt' under directory 'docs'
    Installing marvincli script to /usr/bin
Successfully installed netaddr Marvin
Cleaning up...
