### PR TITLE
CLOUDSTACK-8357 Add Test cases for vMotion support on VMFS as primary st...

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -651,6 +651,21 @@ class VirtualMachine:
             cmd.hostid = hostid
         apiclient.migrateVirtualMachine(cmd)
 
+    def migrate_vm_with_volume(self, apiclient, hostid=None, migrateto=None):
+        """migrate an Instance and its volumes"""
+        cmd = migrateVirtualMachineWithVolume.migrateVirtualMachineWithVolumeCmd()
+        cmd.virtualmachineid = self.id
+        if hostid:
+            cmd.hostid = hostid
+        if migrateto:
+            migrateto = []
+            for volume, pool in migrateto.items():
+                cmd.migrateto.append({
+                    'volume': volume,
+                    'pool': pool
+            })
+        apiclient.migrateVirtualMachineWithVolume(cmd)
+
     def attach_volume(self, apiclient, volume):
         """Attach volume to instance"""
         cmd = attachVolume.attachVolumeCmd()
@@ -3636,11 +3651,12 @@ class Configurations:
     """Manage Configuration"""
 
     @classmethod
-    def update(cls, apiclient, **kwargs):
+    def update(cls, apiclient, name, value=None):
         """Updates the specified configuration"""
 
         cmd = updateConfiguration.updateConfigurationCmd()
-        [setattr(cmd, k, v) for k, v in kwargs.items()]
+        cmd.name = name
+        cmd.value = value
         apiclient.updateConfiguration(cmd)
 
     @classmethod


### PR DESCRIPTION
This commit has the vMotion related test cases. Following are the tests  

1. Create a VM and migrate it.
2. Migrate only ROOT volume of VM and check for vmx and vmdk files in storage.
3. Migrate VM and its ROOT volume and check for vmx and vmdk files in storage.
4. Attach Data disk to VM and then migrate VM and all its volumes followed by the check for files.
5. Upload a volume, attach it to VM and then migrate VM and all its volumes followed by the check for files.
6. Take Volume snapshots of all the volumes then migrate VM and all its volumes followed by the check for files.
7. Resize the Data disk then migrate VM and all its volumes followed by the check for files.
8. Restore the VM then migrate VM and all its volumes followed by the check for files.

All these are part of a test path so there is a single test written which has all the cases.

Here is the output after executing them locally:
Migrate VMs/Volumes on VMware with VMFS storage ... === TestName: 
test_01_migrate_root_and_data_disk_live | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 855.918s

OK
