### PR TITLE
Bump priority stragety is no longer used for redundant virtual routers

### DIFF
--- a/core/src/com/cloud/agent/api/CheckRouterAnswer.java
+++ b/core/src/com/cloud/agent/api/CheckRouterAnswer.java
@@ -22,63 +22,49 @@ package com.cloud.agent.api;
 import com.cloud.network.router.VirtualRouter.RedundantState;
 
 public class CheckRouterAnswer extends Answer {
+
     public static final String ROUTER_NAME = "router.name";
     public static final String ROUTER_IP = "router.ip";
     RedundantState state;
-    boolean isBumped;
 
     protected CheckRouterAnswer() {
     }
 
-    public CheckRouterAnswer(CheckRouterCommand cmd, String details, boolean parse) {
+    public CheckRouterAnswer(final CheckRouterCommand cmd, final String details, final boolean parse) {
         super(cmd, true, details);
         if (parse) {
             if (!parseDetails(details)) {
-                this.result = false;
+                result = false;
             }
         }
     }
 
-    public CheckRouterAnswer(CheckRouterCommand cmd, String details) {
+    public CheckRouterAnswer(final CheckRouterCommand cmd, final String details) {
         super(cmd, false, details);
     }
 
-    protected boolean parseDetails(String details) {
-        String[] lines = details.split("&");
-        if (lines.length != 2) {
+    protected boolean parseDetails(final String details) {
+        if (details == null || "".equals(details.trim())) {
+            state = RedundantState.UNKNOWN;
             return false;
         }
-        if (lines[0].startsWith("Status: MASTER")) {
+        if (details.startsWith("Status: MASTER")) {
             state = RedundantState.MASTER;
-        } else if (lines[0].startsWith("Status: BACKUP")) {
+        } else if (details.startsWith("Status: BACKUP")) {
             state = RedundantState.BACKUP;
-        } else if (lines[0].startsWith("Status: FAULT")) {
+        } else if (details.startsWith("Status: FAULT")) {
             state = RedundantState.FAULT;
         } else {
             state = RedundantState.UNKNOWN;
         }
-        if (lines[1].startsWith("Bumped: YES")) {
-            isBumped = true;
-        } else {
-            isBumped = false;
-        }
         return true;
     }
 
-    public void setState(RedundantState state) {
+    public void setState(final RedundantState state) {
         this.state = state;
     }
 
     public RedundantState getState() {
         return state;
     }
-
-    public boolean isBumped() {
-        return isBumped;
-    }
-
-    public void setIsBumped(boolean isBumped) {
-        this.isBumped = isBumped;
-    }
-
 }

--- a/core/src/com/cloud/agent/api/SetupGuestNetworkCommand.java
+++ b/core/src/com/cloud/agent/api/SetupGuestNetworkCommand.java
@@ -28,7 +28,6 @@ public class SetupGuestNetworkCommand extends NetworkElementCommand {
     String defaultDns1 = null;
     String defaultDns2 = null;
     boolean isRedundant = false;
-    Integer priority;
     boolean add = true;
     NicTO nic;
 
@@ -60,14 +59,13 @@ public class SetupGuestNetworkCommand extends NetworkElementCommand {
     protected SetupGuestNetworkCommand() {
     }
 
-    public SetupGuestNetworkCommand(String dhcpRange, String networkDomain, boolean isRedundant, Integer priority, String defaultDns1, String defaultDns2, boolean add,
-            NicTO nic) {
+    public SetupGuestNetworkCommand(final String dhcpRange, final String networkDomain, final boolean isRedundant, final String defaultDns1, final String defaultDns2, final boolean add,
+            final NicTO nic) {
         this.dhcpRange = dhcpRange;
         this.networkDomain = networkDomain;
         this.defaultDns1 = defaultDns1;
         this.defaultDns2 = defaultDns2;
         this.isRedundant = isRedundant;
-        this.priority = priority;
         this.add = add;
         this.nic = nic;
     }

--- a/core/test/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResourceTest.java
+++ b/core/test/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResourceTest.java
@@ -101,26 +101,26 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     String ROUTERNAME = "r-4-VM";
 
     @Override
-    public ExecutionResult executeInVR(String routerIp, String script, String args) {
+    public ExecutionResult executeInVR(final String routerIp, final String script, final String args) {
         return executeInVR(routerIp, script, args, 60);
     }
 
     @Override
-    public ExecutionResult executeInVR(String routerIp, String script, String args, int timeout) {
+    public ExecutionResult executeInVR(final String routerIp, final String script, final String args, final int timeout) {
         assertEquals(routerIp, ROUTERIP);
         verifyCommand(_currentCmd, script, args);
         return new ExecutionResult(true, null);
     }
 
     @Override
-    public ExecutionResult createFileInVR(String routerIp, String path, String filename, String content) {
+    public ExecutionResult createFileInVR(final String routerIp, final String path, final String filename, final String content) {
         assertEquals(routerIp, ROUTERIP);
         verifyFile(_currentCmd, path, filename, content);
         return new ExecutionResult(true, null);
     }
 
     @Override
-    public ExecutionResult prepareCommand(NetworkElementCommand cmd) {
+    public ExecutionResult prepareCommand(final NetworkElementCommand cmd) {
         cmd.setRouterAccessIp(ROUTERIP);
         _currentCmd = cmd;
         if (cmd instanceof IpAssocVpcCommand) {
@@ -138,7 +138,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     }
 
     @Override
-    public ExecutionResult cleanupCommand(NetworkElementCommand cmd) {
+    public ExecutionResult cleanupCommand(final NetworkElementCommand cmd) {
         return new ExecutionResult(true, null);
     }
 
@@ -147,12 +147,12 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         _resource = new VirtualRoutingResource(this);
         try {
             _resource.configure("VRResource", new HashMap<String, Object>());
-        } catch (ConfigurationException e) {
+        } catch (final ConfigurationException e) {
             e.printStackTrace();
         }
     }
 
-    private void verifyFile(NetworkElementCommand cmd, String path, String filename, String content) {
+    private void verifyFile(final NetworkElementCommand cmd, final String path, final String filename, final String content) {
         if (cmd instanceof AggregationControlCommand) {
             verifyFile((AggregationControlCommand)cmd, path, filename, content);
         } else if (cmd instanceof LoadBalancerConfigCommand) {
@@ -160,7 +160,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         }
     }
 
-    protected void verifyCommand(NetworkElementCommand cmd, String script, String args) {
+    protected void verifyCommand(final NetworkElementCommand cmd, final String script, final String args) {
         if (cmd instanceof SetPortForwardingRulesVpcCommand) {
             verifyArgs((SetPortForwardingRulesVpcCommand) cmd, script, args);
         } else if (cmd instanceof SetPortForwardingRulesCommand) {
@@ -210,54 +210,54 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         }
     }
 
-    private void verifyArgs(VpnUsersCfgCommand cmd, String script, String args) {
+    private void verifyArgs(final VpnUsersCfgCommand cmd, final String script, final String args) {
         //To change body of created methods use File | Settings | File Templates.
     }
 
-    private void verifyArgs(SetStaticRouteCommand cmd, String script, String args) {
+    private void verifyArgs(final SetStaticRouteCommand cmd, final String script, final String args) {
         //To change body of created methods use File | Settings | File Templates.
     }
 
-    private void verifyArgs(SetStaticNatRulesCommand cmd, String script, String args) {
+    private void verifyArgs(final SetStaticNatRulesCommand cmd, final String script, final String args) {
         //To change body of created methods use File | Settings | File Templates.
     }
 
     @Test
     public void testBumpUpCommand() {
-        BumpUpPriorityCommand cmd = new BumpUpPriorityCommand();
-        Answer answer = _resource.executeRequest(cmd);
+        final BumpUpPriorityCommand cmd = new BumpUpPriorityCommand();
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer.getResult());
     }
 
-    private void verifyArgs(BumpUpPriorityCommand cmd, String script, String args) {
+    private void verifyArgs(final BumpUpPriorityCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.RVR_BUMPUP_PRI);
         assertEquals(args, null);
     }
 
     @Test
     public void testSetPortForwardingRulesVpcCommand() {
-        SetPortForwardingRulesVpcCommand cmd = generateSetPortForwardingRulesVpcCommand();
+        final SetPortForwardingRulesVpcCommand cmd = generateSetPortForwardingRulesVpcCommand();
 
         // Reset rule check count
         _count = 0;
 
-        Answer answer = _resource.executeRequest(cmd);
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer instanceof GroupAnswer);
         assertEquals(((GroupAnswer) answer).getResults().length, 2);
         assertTrue(answer.getResult());
     }
 
     protected SetPortForwardingRulesVpcCommand generateSetPortForwardingRulesVpcCommand() {
-        List<PortForwardingRuleTO> pfRules = new ArrayList<>();
+        final List<PortForwardingRuleTO> pfRules = new ArrayList<>();
         pfRules.add(new PortForwardingRuleTO(1, "64.1.1.10", 22, 80, "10.10.1.10", 22, 80, "TCP", false, false));
         pfRules.add(new PortForwardingRuleTO(2, "64.1.1.11", 8080, 8080, "10.10.1.11", 8080, 8080, "UDP", true, false));
-        SetPortForwardingRulesVpcCommand cmd = new SetPortForwardingRulesVpcCommand(pfRules);
+        final SetPortForwardingRulesVpcCommand cmd = new SetPortForwardingRulesVpcCommand(pfRules);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         assertEquals(cmd.getAnswersCount(), 2);
         return cmd;
     }
 
-    private void verifyArgs(SetPortForwardingRulesVpcCommand cmd, String script, String args) {
+    private void verifyArgs(final SetPortForwardingRulesVpcCommand cmd, final String script, final String args) {
         assertTrue(script.equals(VRScripts.VPC_PORTFORWARDING));
         _count ++;
         switch (_count) {
@@ -274,27 +274,27 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     @Test
     public void testSetPortForwardingRulesCommand() {
-        SetPortForwardingRulesCommand cmd = generateSetPortForwardingRulesCommand();
+        final SetPortForwardingRulesCommand cmd = generateSetPortForwardingRulesCommand();
         // Reset rule check count
         _count = 0;
 
-        Answer answer = _resource.executeRequest(cmd);
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer instanceof GroupAnswer);
         assertEquals(((GroupAnswer) answer).getResults().length, 2);
         assertTrue(answer.getResult());
     }
 
     protected SetPortForwardingRulesCommand generateSetPortForwardingRulesCommand() {
-        List<PortForwardingRuleTO> pfRules = new ArrayList<>();
+        final List<PortForwardingRuleTO> pfRules = new ArrayList<>();
         pfRules.add(new PortForwardingRuleTO(1, "64.1.1.10", 22, 80, "10.10.1.10", 22, 80, "TCP", false, false));
         pfRules.add(new PortForwardingRuleTO(2, "64.1.1.11", 8080, 8080, "10.10.1.11", 8080, 8080, "UDP", true, false));
-        SetPortForwardingRulesCommand cmd = new SetPortForwardingRulesCommand(pfRules);
+        final SetPortForwardingRulesCommand cmd = new SetPortForwardingRulesCommand(pfRules);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         assertEquals(cmd.getAnswersCount(), 2);
         return cmd;
     }
 
-    private void verifyArgs(SetPortForwardingRulesCommand cmd, String script, String args) {
+    private void verifyArgs(final SetPortForwardingRulesCommand cmd, final String script, final String args) {
         assertTrue(script.equals(VRScripts.FIREWALL_NAT));
         _count ++;
         switch (_count) {
@@ -311,31 +311,31 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     @Test
     public void testIpAssocCommand() {
-        IpAssocCommand cmd = generateIpAssocCommand();
+        final IpAssocCommand cmd = generateIpAssocCommand();
         _count = 0;
 
-        Answer answer = _resource.executeRequest(cmd);
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer instanceof GroupAnswer);
         assertEquals(2, ((GroupAnswer)answer).getResults().length);
         assertTrue(answer.getResult());
 
     }
 
-    private ExecutionResult prepareNetworkElementCommand(IpAssocCommand cmd) {
-        IpAddressTO[] ips = cmd.getIpAddresses();
-        for (IpAddressTO ip : ips) {
+    private ExecutionResult prepareNetworkElementCommand(final IpAssocCommand cmd) {
+        final IpAddressTO[] ips = cmd.getIpAddresses();
+        for (final IpAddressTO ip : ips) {
             ip.setNicDevId(2);
         }
         return new ExecutionResult(true, null);
     }
 
     protected IpAssocCommand generateIpAssocCommand() {
-        List<IpAddressTO> ips = new ArrayList<>();
+        final List<IpAddressTO> ips = new ArrayList<>();
         ips.add(new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
         ips.add(new IpAddressTO(2, "64.1.1.11", false, false, false, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
         ips.add(new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", 1000, false));
-        IpAddressTO[] ipArray = ips.toArray(new IpAddressTO[ips.size()]);
-        IpAssocCommand cmd = new IpAssocCommand(ipArray);
+        final IpAddressTO[] ipArray = ips.toArray(new IpAddressTO[ips.size()]);
+        final IpAssocCommand cmd = new IpAssocCommand(ipArray);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         assertEquals(cmd.getAnswersCount(), 3);
 
@@ -344,38 +344,38 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     @Test
     public void testIpAssocVpcCommand() {
-        IpAssocVpcCommand cmd = generateIpAssocVpcCommand();
+        final IpAssocVpcCommand cmd = generateIpAssocVpcCommand();
         _count = 0;
 
-        Answer answer = _resource.executeRequest(cmd);
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer instanceof GroupAnswer);
         assertEquals(2, ((GroupAnswer)answer).getResults().length);
         assertTrue(answer.getResult());
 
     }
 
-    private ExecutionResult prepareNetworkElementCommand(IpAssocVpcCommand cmd) {
-        IpAddressTO[] ips = cmd.getIpAddresses();
-        for (IpAddressTO ip : ips) {
+    private ExecutionResult prepareNetworkElementCommand(final IpAssocVpcCommand cmd) {
+        final IpAddressTO[] ips = cmd.getIpAddresses();
+        for (final IpAddressTO ip : ips) {
             ip.setNicDevId(2);
         }
         return new ExecutionResult(true, null);
     }
 
     protected IpAssocVpcCommand generateIpAssocVpcCommand() {
-        List<IpAddressTO> ips = new ArrayList<IpAddressTO>();
+        final List<IpAddressTO> ips = new ArrayList<IpAddressTO>();
         ips.add(new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
         ips.add(new IpAddressTO(2, "64.1.1.11", false, false, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false));
         ips.add(new IpAddressTO(3, "65.1.1.11", true, false, false, "vlan://65", "65.1.1.1", "255.255.255.0", "11:23:45:67:89:AB", 1000, false));
-        IpAddressTO[] ipArray = ips.toArray(new IpAddressTO[ips.size()]);
-        IpAssocVpcCommand cmd = new IpAssocVpcCommand(ipArray);
+        final IpAddressTO[] ipArray = ips.toArray(new IpAddressTO[ips.size()]);
+        final IpAssocVpcCommand cmd = new IpAssocVpcCommand(ipArray);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         assertEquals(6, cmd.getAnswersCount()); // AnswersCount is clearly wrong as it doesn't know enough to tell
 
         return cmd;
     }
 
-    private void verifyArgs(IpAssocCommand cmd, String script, String args) {
+    private void verifyArgs(final IpAssocCommand cmd, final String script, final String args) {
         if (cmd instanceof IpAssocVpcCommand) {
             _count ++;
             switch (_count) {
@@ -423,32 +423,32 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     @Test
     public void testSourceNatCommand() {
-        SetSourceNatCommand cmd = generateSetSourceNatCommand();
-        Answer answer = _resource.executeRequest(cmd);
+        final SetSourceNatCommand cmd = generateSetSourceNatCommand();
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer.getResult());
     }
 
-    private ExecutionResult prepareNetworkElementCommand(SetSourceNatCommand cmd) {
-        IpAddressTO ip = cmd.getIpAddress();
+    private ExecutionResult prepareNetworkElementCommand(final SetSourceNatCommand cmd) {
+        final IpAddressTO ip = cmd.getIpAddress();
         ip.setNicDevId(1);
         return new ExecutionResult(true, null);
     }
 
     protected SetSourceNatCommand generateSetSourceNatCommand() {
-        IpAddressTO ip = new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false);
-        SetSourceNatCommand cmd = new SetSourceNatCommand(ip, true);
+        final IpAddressTO ip = new IpAddressTO(1, "64.1.1.10", true, true, true, "vlan://64", "64.1.1.1", "255.255.255.0", "01:23:45:67:89:AB", 1000, false);
+        final SetSourceNatCommand cmd = new SetSourceNatCommand(ip, true);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;
     }
 
-    private void verifyArgs(SetSourceNatCommand cmd, String script, String args) {
+    private void verifyArgs(final SetSourceNatCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.VPC_SOURCE_NAT);
         assertEquals(args, "-A -l 64.1.1.10 -c eth1");
     }
 
     @Test
     public void testNetworkACLCommand() {
-        SetNetworkACLCommand cmd = generateSetNetworkACLCommand();
+        final SetNetworkACLCommand cmd = generateSetNetworkACLCommand();
         _count = 0;
 
         Answer answer = _resource.executeRequest(cmd);
@@ -460,24 +460,24 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     }
 
     protected SetNetworkACLCommand generateSetNetworkACLCommand() {
-        List<NetworkACLTO> acls = new ArrayList<>();
-        List<String> cidrs = new ArrayList<>();
+        final List<NetworkACLTO> acls = new ArrayList<>();
+        final List<String> cidrs = new ArrayList<>();
         cidrs.add("192.168.0.1/24");
         cidrs.add("192.168.0.2/24");
         acls.add(new NetworkACLTO(1, "64", "TCP", 20, 80, false, false, cidrs, 0, 0, TrafficType.Ingress, true, 1));
         acls.add(new NetworkACLTO(2, "64", "ICMP", 0, 0, false, false, cidrs, -1, -1, TrafficType.Ingress, false, 2));
         acls.add(new NetworkACLTO(3, "65", "ALL", 0, 0, false, false, cidrs, -1, -1, TrafficType.Egress, true, 3));
-        NicTO nic = new NicTO();
+        final NicTO nic = new NicTO();
         nic.setMac("01:23:45:67:89:AB");
         nic.setIp("192.168.1.1");
         nic.setNetmask("255.255.255.0");
-        SetNetworkACLCommand cmd = new SetNetworkACLCommand(acls, nic);
+        final SetNetworkACLCommand cmd = new SetNetworkACLCommand(acls, nic);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
 
         return cmd;
     }
 
-    private void verifyArgs(SetNetworkACLCommand cmd, String script, String args) {
+    private void verifyArgs(final SetNetworkACLCommand cmd, final String script, final String args) {
         _count ++;
         switch (_count) {
         case 1:
@@ -496,32 +496,32 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         }
     }
 
-    private ExecutionResult prepareNetworkElementCommand(SetNetworkACLCommand cmd) {
-        NicTO nic = cmd.getNic();
+    private ExecutionResult prepareNetworkElementCommand(final SetNetworkACLCommand cmd) {
+        final NicTO nic = cmd.getNic();
         nic.setDeviceId(3);
         return new ExecutionResult(true, null);
     }
 
     @Test
     public void testSetupGuestNetworkCommand() {
-        SetupGuestNetworkCommand cmd = generateSetupGuestNetworkCommand();
-        Answer answer = _resource.executeRequest(cmd);
+        final SetupGuestNetworkCommand cmd = generateSetupGuestNetworkCommand();
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer.getResult());
     }
 
-    private ExecutionResult prepareNetworkElementCommand(SetupGuestNetworkCommand cmd) {
-        NicTO nic = cmd.getNic();
+    private ExecutionResult prepareNetworkElementCommand(final SetupGuestNetworkCommand cmd) {
+        final NicTO nic = cmd.getNic();
         nic.setDeviceId(4);
         return new ExecutionResult(true, null);
     }
 
     protected SetupGuestNetworkCommand generateSetupGuestNetworkCommand() {
-        NicTO nic = new NicTO();
+        final NicTO nic = new NicTO();
         nic.setMac("01:23:45:67:89:AB");
         nic.setIp("10.1.1.1");
         nic.setNetmask("255.255.255.0");
 
-        SetupGuestNetworkCommand cmd = new SetupGuestNetworkCommand("10.1.1.10-10.1.1.20", "cloud.test", false, 0, "8.8.8.8", "8.8.4.4", true, nic);
+        final SetupGuestNetworkCommand cmd = new SetupGuestNetworkCommand("10.1.1.10-10.1.1.20", "cloud.test", false, "8.8.8.8", "8.8.4.4", true, nic);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_GUEST_IP, "10.1.1.2");
         cmd.setAccessDetail(NetworkElementCommand.GUEST_NETWORK_GATEWAY, "10.1.1.1");
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
@@ -529,7 +529,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         return cmd;
     }
 
-    private void verifyArgs(SetupGuestNetworkCommand cmd, String script, String args) {
+    private void verifyArgs(final SetupGuestNetworkCommand cmd, final String script, final String args) {
         // TODO Check the contents of the json file
         //assertEquals(script, VRScripts.VPC_GUEST_NETWORK);
         //assertEquals(args, " -C -M 01:23:45:67:89:AB -d eth4 -i 10.1.1.2 -g 10.1.1.1 -m 24 -n 10.1.1.0 -s 8.8.8.8,8.8.4.4 -e cloud.test");
@@ -537,23 +537,23 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     @Test
     public void testSetMonitorServiceCommand() {
-        SetMonitorServiceCommand cmd = generateSetMonitorServiceCommand();
-        Answer answer = _resource.executeRequest(cmd);
+        final SetMonitorServiceCommand cmd = generateSetMonitorServiceCommand();
+        final Answer answer = _resource.executeRequest(cmd);
         assertTrue(answer.getResult());
     }
 
     protected SetMonitorServiceCommand generateSetMonitorServiceCommand() {
-        List<MonitorServiceTO> services = new ArrayList<>();
+        final List<MonitorServiceTO> services = new ArrayList<>();
         services.add(new MonitorServiceTO("service", "process", "name", "path", "file", true));
         services.add(new MonitorServiceTO("service_2", "process_2", "name_2", "path_2", "file_2", false));
 
-        SetMonitorServiceCommand cmd = new SetMonitorServiceCommand(services);
+        final SetMonitorServiceCommand cmd = new SetMonitorServiceCommand(services);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
 
         return cmd;
     }
 
-    private void verifyArgs(SetMonitorServiceCommand cmd, String script, String args) {
+    private void verifyArgs(final SetMonitorServiceCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.MONITOR_SERVICE);
         assertEquals(args, " -c [service]:processname=process:servicename=name:pidfile=file:,[service_2]:processname=process_2:servicename=name_2:pidfile=file_2:,");
     }
@@ -578,7 +578,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         assertTrue(answer.getResult());
     }
 
-    private void verifyArgs(Site2SiteVpnCfgCommand cmd, String script, String args) {
+    private void verifyArgs(final Site2SiteVpnCfgCommand cmd, final String script, final String args) {
         _count ++;
 
         assertEquals(script, VRScripts.S2SVPN_IPSEC);
@@ -612,27 +612,27 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     }
 
     protected RemoteAccessVpnCfgCommand generateRemoteAccessVpnCfgCommand1() {
-        RemoteAccessVpnCfgCommand cmd = new RemoteAccessVpnCfgCommand(true, "124.10.10.10", "10.10.1.1", "10.10.1.10-10.10.1.20", "sharedkey", false);
+        final RemoteAccessVpnCfgCommand cmd = new RemoteAccessVpnCfgCommand(true, "124.10.10.10", "10.10.1.1", "10.10.1.10-10.10.1.20", "sharedkey", false);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         cmd.setLocalCidr("10.1.1.1/24");
         return cmd;
     }
 
     protected RemoteAccessVpnCfgCommand generateRemoteAccessVpnCfgCommand2() {
-        RemoteAccessVpnCfgCommand cmd = new RemoteAccessVpnCfgCommand(false, "124.10.10.10", "10.10.1.1", "10.10.1.10-10.10.1.20", "sharedkey", false);
+        final RemoteAccessVpnCfgCommand cmd = new RemoteAccessVpnCfgCommand(false, "124.10.10.10", "10.10.1.1", "10.10.1.10-10.10.1.20", "sharedkey", false);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         cmd.setLocalCidr("10.1.1.1/24");
         return cmd;
     }
 
     protected RemoteAccessVpnCfgCommand generateRemoteAccessVpnCfgCommand3() {
-        RemoteAccessVpnCfgCommand cmd = new RemoteAccessVpnCfgCommand(true, "124.10.10.10", "10.10.1.1", "10.10.1.10-10.10.1.20", "sharedkey", true);
+        final RemoteAccessVpnCfgCommand cmd = new RemoteAccessVpnCfgCommand(true, "124.10.10.10", "10.10.1.1", "10.10.1.10-10.10.1.20", "sharedkey", true);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         cmd.setLocalCidr("10.1.1.1/24");
         return cmd;
     }
 
-    private void verifyArgs(RemoteAccessVpnCfgCommand cmd, String script, String args) {
+    private void verifyArgs(final RemoteAccessVpnCfgCommand cmd, final String script, final String args) {
         _count ++;
 
         assertEquals(script, VRScripts.VPN_L2TP);
@@ -656,27 +656,27 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     public void testFirewallRulesCommand() {
         _count = 0;
 
-        Answer answer = _resource.executeRequest(generateSetFirewallRulesCommand());
+        final Answer answer = _resource.executeRequest(generateSetFirewallRulesCommand());
         assertTrue(answer.getResult());
 
         //TODO Didn't test egress rule because not able to generate FirewallRuleVO object
     }
 
     protected SetFirewallRulesCommand generateSetFirewallRulesCommand() {
-        List<FirewallRuleTO> rules = new ArrayList<>();
-        List<String> sourceCidrs = new ArrayList<>();
+        final List<FirewallRuleTO> rules = new ArrayList<>();
+        final List<String> sourceCidrs = new ArrayList<>();
         sourceCidrs.add("10.10.1.1/24");
         sourceCidrs.add("10.10.1.2/24");
         rules.add(new FirewallRuleTO(1, "64.10.10.10", "TCP", 22, 80, false, false, Purpose.Firewall, sourceCidrs, 0, 0));
         rules.add(new FirewallRuleTO(2, "64.10.10.10", "ICMP", 0, 0, false, false, Purpose.Firewall, sourceCidrs, -1, -1));
         rules.add(new FirewallRuleTO(3, "64.10.10.10", "ICMP", 0, 0, true, true, Purpose.Firewall, sourceCidrs, -1, -1));
-        SetFirewallRulesCommand cmd = new SetFirewallRulesCommand(rules);
+        final SetFirewallRulesCommand cmd = new SetFirewallRulesCommand(rules);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
 
         return cmd;
     }
 
-    private void verifyArgs(SetFirewallRulesCommand cmd, String script, String args) {
+    private void verifyArgs(final SetFirewallRulesCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.FIREWALL_INGRESS);
 
         //Since the arguments are generated with a Set
@@ -689,12 +689,12 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     @Test
     public void testVmDataCommand() {
-        Answer answer = _resource.executeRequest(generateVmDataCommand());
+        final Answer answer = _resource.executeRequest(generateVmDataCommand());
         assertTrue(answer.getResult());
     }
 
     protected VmDataCommand generateVmDataCommand() {
-        VmDataCommand cmd = new VmDataCommand("10.1.10.4", "i-4-VM", true);
+        final VmDataCommand cmd = new VmDataCommand("10.1.10.4", "i-4-VM", true);
         // if you add new metadata files, also edit systemvm/patches/debian/config/var/www/html/latest/.htaccess
         cmd.addVmData("userdata", "user-data", "user-data");
         cmd.addVmData("metadata", "service-offering", "serviceOffering");
@@ -713,24 +713,24 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         return cmd;
     }
 
-    private void verifyArgs(VmDataCommand cmd, String script, String args) {
+    private void verifyArgs(final VmDataCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.UPDATE_CONFIG);
         assertEquals(args, VRScripts.VM_METADATA_CONFIG);
     }
 
     @Test
     public void testSavePasswordCommand() {
-        Answer answer = _resource.executeRequest(generateSavePasswordCommand());
+        final Answer answer = _resource.executeRequest(generateSavePasswordCommand());
         assertTrue(answer.getResult());
     }
 
     protected SavePasswordCommand generateSavePasswordCommand() {
-        SavePasswordCommand cmd = new SavePasswordCommand("123pass", "10.1.10.4", "i-4-VM", true);
+        final SavePasswordCommand cmd = new SavePasswordCommand("123pass", "10.1.10.4", "i-4-VM", true);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;
     }
 
-    private void verifyArgs(SavePasswordCommand cmd, String script, String args) {
+    private void verifyArgs(final SavePasswordCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.PASSWORD);
         assertEquals(args, "-v 10.1.10.4 -p 123pass");
     }
@@ -750,26 +750,26 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     }
 
     protected DhcpEntryCommand generateDhcpEntryCommand1() {
-        DhcpEntryCommand cmd = new DhcpEntryCommand("12:34:56:78:90:AB", "10.1.10.2", "vm1", null, true);
+        final DhcpEntryCommand cmd = new DhcpEntryCommand("12:34:56:78:90:AB", "10.1.10.2", "vm1", null, true);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;
     }
 
     protected DhcpEntryCommand generateDhcpEntryCommand2() {
-        DhcpEntryCommand cmd = new DhcpEntryCommand("12:34:56:78:90:AB", null, "vm1", "2001:db8:0:0:0:ff00:42:8329", true);
+        final DhcpEntryCommand cmd = new DhcpEntryCommand("12:34:56:78:90:AB", null, "vm1", "2001:db8:0:0:0:ff00:42:8329", true);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         cmd.setDuid(NetUtils.getDuidLL(cmd.getVmMac()));
         return cmd;
     }
 
     protected DhcpEntryCommand generateDhcpEntryCommand3() {
-        DhcpEntryCommand cmd = new DhcpEntryCommand("12:34:56:78:90:AB", "10.1.10.2", "vm1", "2001:db8:0:0:0:ff00:42:8329", true);
+        final DhcpEntryCommand cmd = new DhcpEntryCommand("12:34:56:78:90:AB", "10.1.10.2", "vm1", "2001:db8:0:0:0:ff00:42:8329", true);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         cmd.setDuid(NetUtils.getDuidLL(cmd.getVmMac()));
         return cmd;
     }
 
-    private void verifyArgs(DhcpEntryCommand cmd, String script, String args) {
+    private void verifyArgs(final DhcpEntryCommand cmd, final String script, final String args) {
         _count ++;
         assertEquals(script, VRScripts.DHCP);
         switch (_count) {
@@ -789,63 +789,63 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
 
     @Test
     public void testCreateIpAliasCommand() {
-        Answer answer = _resource.executeRequest(generateCreateIpAliasCommand());
+        final Answer answer = _resource.executeRequest(generateCreateIpAliasCommand());
         assertTrue(answer.getResult());
     }
 
     protected CreateIpAliasCommand generateCreateIpAliasCommand() {
-        List<IpAliasTO> aliases = new ArrayList<>();
+        final List<IpAliasTO> aliases = new ArrayList<>();
         aliases.add(new IpAliasTO("169.254.3.10", "255.255.255.0", "1"));
         aliases.add(new IpAliasTO("169.254.3.11", "255.255.255.0", "2"));
         aliases.add(new IpAliasTO("169.254.3.12", "255.255.255.0", "3"));
-        CreateIpAliasCommand cmd = new CreateIpAliasCommand("169.254.3.10", aliases);
+        final CreateIpAliasCommand cmd = new CreateIpAliasCommand("169.254.3.10", aliases);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
 
         return cmd;
     }
 
-    private void verifyArgs(CreateIpAliasCommand cmd, String script, String args) {
+    private void verifyArgs(final CreateIpAliasCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.IPALIAS_CREATE);
         assertEquals(args, "1:169.254.3.10:255.255.255.0-2:169.254.3.11:255.255.255.0-3:169.254.3.12:255.255.255.0-");
     }
 
     @Test
     public void testDeleteIpAliasCommand() {
-        Answer answer = _resource.executeRequest(generateDeleteIpAliasCommand());
+        final Answer answer = _resource.executeRequest(generateDeleteIpAliasCommand());
         assertTrue(answer.getResult());
     }
 
     protected DeleteIpAliasCommand generateDeleteIpAliasCommand() {
-        List<IpAliasTO> aliases = new ArrayList<>();
+        final List<IpAliasTO> aliases = new ArrayList<>();
         aliases.add(new IpAliasTO("169.254.3.10", "255.255.255.0", "1"));
         aliases.add(new IpAliasTO("169.254.3.11", "255.255.255.0", "2"));
         aliases.add(new IpAliasTO("169.254.3.12", "255.255.255.0", "3"));
-        DeleteIpAliasCommand cmd = new DeleteIpAliasCommand("169.254.10.1", aliases, aliases);
+        final DeleteIpAliasCommand cmd = new DeleteIpAliasCommand("169.254.10.1", aliases, aliases);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;
     }
 
-    private void verifyArgs(DeleteIpAliasCommand cmd, String script, String args) {
+    private void verifyArgs(final DeleteIpAliasCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.IPALIAS_DELETE);
         assertEquals(args, "1:169.254.3.10:255.255.255.0-2:169.254.3.11:255.255.255.0-3:169.254.3.12:255.255.255.0-- 1:169.254.3.10:255.255.255.0-2:169.254.3.11:255.255.255.0-3:169.254.3.12:255.255.255.0-");
     }
 
     @Test
     public void testDnsMasqConfigCommand() {
-        Answer answer = _resource.executeRequest(generateDnsMasqConfigCommand());
+        final Answer answer = _resource.executeRequest(generateDnsMasqConfigCommand());
         assertTrue(answer.getResult());
     }
 
     protected DnsMasqConfigCommand generateDnsMasqConfigCommand() {
-        List<DhcpTO> dhcps = new ArrayList<>();
+        final List<DhcpTO> dhcps = new ArrayList<>();
         dhcps.add(new DhcpTO("10.1.20.2", "10.1.20.1", "255.255.255.0", "10.1.20.5"));
         dhcps.add(new DhcpTO("10.1.21.2", "10.1.21.1", "255.255.255.0", "10.1.21.5"));
-        DnsMasqConfigCommand cmd = new DnsMasqConfigCommand(dhcps);
+        final DnsMasqConfigCommand cmd = new DnsMasqConfigCommand(dhcps);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;
     }
 
-    private void verifyArgs(DnsMasqConfigCommand cmd, String script, String args) {
+    private void verifyArgs(final DnsMasqConfigCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.DNSMASQ_CONFIG);
         assertEquals(args, "10.1.20.2:10.1.20.1:255.255.255.0:10.1.20.5-10.1.21.2:10.1.21.1:255.255.255.0:10.1.21.5-");
     }
@@ -863,37 +863,37 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     }
 
     protected LoadBalancerConfigCommand generateLoadBalancerConfigCommand1() {
-        List<LoadBalancerTO> lbs = new ArrayList<>();
-        List<LbDestination> dests = new ArrayList<>();
+        final List<LoadBalancerTO> lbs = new ArrayList<>();
+        final List<LbDestination> dests = new ArrayList<>();
         dests.add(new LbDestination(80, 8080, "10.1.10.2", false));
         dests.add(new LbDestination(80, 8080, "10.1.10.2", true));
         lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests));
-        LoadBalancerTO[] arrayLbs = new LoadBalancerTO[lbs.size()];
+        final LoadBalancerTO[] arrayLbs = new LoadBalancerTO[lbs.size()];
         lbs.toArray(arrayLbs);
-        NicTO nic = new NicTO();
-        LoadBalancerConfigCommand cmd = new LoadBalancerConfigCommand(arrayLbs, "64.10.2.10", "10.1.10.2", "192.168.1.2", nic, null, "1000", false);
+        final NicTO nic = new NicTO();
+        final LoadBalancerConfigCommand cmd = new LoadBalancerConfigCommand(arrayLbs, "64.10.2.10", "10.1.10.2", "192.168.1.2", nic, null, "1000", false);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, "10.1.10.2");
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;
     }
 
     protected LoadBalancerConfigCommand generateLoadBalancerConfigCommand2() {
-        List<LoadBalancerTO> lbs = new ArrayList<>();
-        List<LbDestination> dests = new ArrayList<>();
+        final List<LoadBalancerTO> lbs = new ArrayList<>();
+        final List<LbDestination> dests = new ArrayList<>();
         dests.add(new LbDestination(80, 8080, "10.1.10.2", false));
         dests.add(new LbDestination(80, 8080, "10.1.10.2", true));
         lbs.add(new LoadBalancerTO(UUID.randomUUID().toString(), "64.10.1.10", 80, "tcp", "algo", false, false, false, dests));
-        LoadBalancerTO[] arrayLbs = new LoadBalancerTO[lbs.size()];
+        final LoadBalancerTO[] arrayLbs = new LoadBalancerTO[lbs.size()];
         lbs.toArray(arrayLbs);
-        NicTO nic = new NicTO();
+        final NicTO nic = new NicTO();
         nic.setIp("10.1.10.2");
-        LoadBalancerConfigCommand cmd = new LoadBalancerConfigCommand(arrayLbs, "64.10.2.10", "10.1.10.2", "192.168.1.2", nic, Long.valueOf(1), "1000", false);
+        final LoadBalancerConfigCommand cmd = new LoadBalancerConfigCommand(arrayLbs, "64.10.2.10", "10.1.10.2", "192.168.1.2", nic, Long.valueOf(1), "1000", false);
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_IP, "10.1.10.2");
         cmd.setAccessDetail(NetworkElementCommand.ROUTER_NAME, ROUTERNAME);
         return cmd;
     }
 
-    protected void verifyFile(LoadBalancerConfigCommand cmd, String path, String filename, String content) {
+    protected void verifyFile(final LoadBalancerConfigCommand cmd, final String path, final String filename, final String content) {
         _count ++;
         switch (_count) {
         case 1:
@@ -944,7 +944,7 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         }
     }
 
-    private void verifyArgs(LoadBalancerConfigCommand cmd, String script, String args) {
+    private void verifyArgs(final LoadBalancerConfigCommand cmd, final String script, final String args) {
         _count ++;
         switch (_count) {
         case 2:
@@ -963,8 +963,8 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
     @Test
     @Ignore("Ignore this test while we are experimenting with the commands.")
     public void testAggregationCommands() {
-        List<NetworkElementCommand> cmds = new LinkedList<>();
-        AggregationControlCommand startCmd = new AggregationControlCommand(Action.Start, ROUTERNAME, ROUTERIP, ROUTERGUESTIP);
+        final List<NetworkElementCommand> cmds = new LinkedList<>();
+        final AggregationControlCommand startCmd = new AggregationControlCommand(Action.Start, ROUTERNAME, ROUTERIP, ROUTERGUESTIP);
         cmds.add(startCmd);
         cmds.add(generateIpAssocCommand());
         cmds.add(generateIpAssocVpcCommand());
@@ -995,41 +995,41 @@ public class VirtualRoutingResourceTest implements VirtualRouterDeployer {
         cmds.add(generateSavePasswordCommand());
         cmds.add(generateVmDataCommand());
 
-        AggregationControlCommand finishCmd = new AggregationControlCommand(Action.Finish, ROUTERNAME, ROUTERIP, ROUTERGUESTIP);
+        final AggregationControlCommand finishCmd = new AggregationControlCommand(Action.Finish, ROUTERNAME, ROUTERIP, ROUTERGUESTIP);
         cmds.add(finishCmd);
 
-        for (NetworkElementCommand cmd : cmds) {
-            Answer answer = _resource.executeRequest(cmd);
+        for (final NetworkElementCommand cmd : cmds) {
+            final Answer answer = _resource.executeRequest(cmd);
             assertTrue(answer.getResult());
         }
     }
 
-    private void verifyArgs(AggregationControlCommand cmd, String script, String args) {
+    private void verifyArgs(final AggregationControlCommand cmd, final String script, final String args) {
         assertEquals(script, VRScripts.VR_CFG);
         assertTrue(args.startsWith("-c /var/cache/cloud/VR-"));
         assertTrue(args.endsWith(".cfg"));
     }
 
-    protected void verifyFile(AggregationControlCommand cmd, String path, String filename, String content) {
+    protected void verifyFile(final AggregationControlCommand cmd, final String path, final String filename, final String content) {
         assertEquals(path, "/var/cache/cloud/");
         assertTrue(filename.startsWith("VR-"));
         assertTrue(filename.endsWith(".cfg"));
-        Collection<String> filteredScripts = Collections2.transform(Collections2.filter (
+        final Collection<String> filteredScripts = Collections2.transform(Collections2.filter (
                 Arrays.asList(content.split("</?script>")), new Predicate<String>() {
 
                     @Override
-                    public boolean apply(String str) {
+                    public boolean apply(final String str) {
                         return str.trim().startsWith("/opt/cloud");
                     }
                 }), new Function<String, String>() {
 
-                    @Override
-                    public String apply(String str) {
-                        return str.trim();
-                    }
-                });
-        String[] scripts = filteredScripts.toArray(new String[filteredScripts
-                .size()]);
+            @Override
+            public String apply(final String str) {
+                return str.trim();
+            }
+        });
+        final String[] scripts = filteredScripts.toArray(new String[filteredScripts
+                                                                    .size()]);
 
         assertEquals(
                 "/opt/cloud/bin/ipassoc.sh -A -s -f -l 64.1.1.10/24 -c eth2 -g 64.1.1.1",

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade451to460.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade451to460.java
@@ -33,7 +33,7 @@ public class Upgrade451to460 implements DbUpgrade {
 
     @Override
     public String[] getUpgradableVersionRange() {
-        return new String[] {"4.5.1", "4.6.0"};
+        return new String[] { "4.5.1", "4.6.0" };
     }
 
     @Override
@@ -53,7 +53,7 @@ public class Upgrade451to460 implements DbUpgrade {
             throw new CloudRuntimeException("Unable to find db/schema-451to460.sql");
         }
 
-        return new File[] {new File(script)};
+        return new File[] { new File(script) };
     }
 
     @Override
@@ -62,12 +62,13 @@ public class Upgrade451to460 implements DbUpgrade {
     }
 
     public void updateVMInstanceUserId(final Connection conn) {
-        // For schemas before this, copy first user from an account_id which deployed already running VMs
+        // For schemas before this, copy first user from an account_id which
+        // deployed already running VMs
         s_logger.debug("Updating vm_instance column user_id using first user in vm_instance's account_id");
         final String vmInstanceSql = "SELECT id, account_id FROM `cloud`.`vm_instance`";
         final String userSql = "SELECT id FROM `cloud`.`user` where account_id=?";
         final String userIdUpdateSql = "update `cloud`.`vm_instance` set user_id=? where id=?";
-        try(PreparedStatement selectStatement = conn.prepareStatement(vmInstanceSql)) {
+        try (PreparedStatement selectStatement = conn.prepareStatement(vmInstanceSql)) {
             final ResultSet results = selectStatement.executeQuery();
             while (results.next()) {
                 final long vmId = results.getLong(1);
@@ -95,34 +96,40 @@ public class Upgrade451to460 implements DbUpgrade {
         }
         s_logger.debug("Done updating user Ids for previously deployed VMs");
         addRedundancyForNwAndVpc(conn);
+        removeBumPriorityColumn(conn);
     }
 
     private void addRedundancyForNwAndVpc(final Connection conn) {
         ResultSet rs = null;
-        try (PreparedStatement addRedundantColToVpcOfferingPstmt = conn.prepareStatement(
-                "ALTER TABLE `cloud`.`vpc_offerings` ADD COLUMN `redundant_router_service` tinyint(1) DEFAULT 0");
-                PreparedStatement addRedundantColToVpcPstmt = conn.prepareStatement(
-                        "ALTER TABLE `cloud`.`vpc` ADD COLUMN `redundant` tinyint(1) DEFAULT 0");
-                PreparedStatement addRedundantColToNwPstmt = conn.prepareStatement(
-                        "ALTER TABLE `cloud`.`networks` ADD COLUMN `redundant` tinyint(1) DEFAULT 0");
+        try (PreparedStatement addRedundantColToVpcOfferingPstmt = conn
+                .prepareStatement("ALTER TABLE `cloud`.`vpc_offerings` ADD COLUMN `redundant_router_service` tinyint(1) DEFAULT 0");
+                PreparedStatement addRedundantColToVpcPstmt = conn.prepareStatement("ALTER TABLE `cloud`.`vpc` ADD COLUMN `redundant` tinyint(1) DEFAULT 0");
+                PreparedStatement addRedundantColToNwPstmt = conn.prepareStatement("ALTER TABLE `cloud`.`networks` ADD COLUMN `redundant` tinyint(1) DEFAULT 0");
 
-                // The redundancy of the networks must be based on the redundancy of their network offerings
-                PreparedStatement redundancyPerNwPstmt = conn.prepareStatement(
-                        "select distinct nw.network_offering_id from networks nw join network_offerings off " +
-                        "on nw.network_offering_id = off.id where off.redundant_router_service = 1");
-                PreparedStatement updateNwRedundancyPstmt = conn.prepareStatement(
-                        "update networks set redundant = 1 where network_offering_id = ?");
-                ) {
+                // The redundancy of the networks must be based on the
+                // redundancy of their network offerings
+                PreparedStatement redundancyPerNwPstmt = conn.prepareStatement("select distinct nw.network_offering_id from networks nw join network_offerings off "
+                        + "on nw.network_offering_id = off.id where off.redundant_router_service = 1");
+                PreparedStatement updateNwRedundancyPstmt = conn.prepareStatement("update networks set redundant = 1 where network_offering_id = ?");) {
             addRedundantColToVpcPstmt.executeUpdate();
             addRedundantColToVpcOfferingPstmt.executeUpdate();
             addRedundantColToNwPstmt.executeUpdate();
 
             rs = redundancyPerNwPstmt.executeQuery();
-            while(rs.next()){
+            while (rs.next()) {
                 final long nwOfferingId = rs.getLong("nw.network_offering_id");
                 updateNwRedundancyPstmt.setLong(1, nwOfferingId);
                 updateNwRedundancyPstmt.executeUpdate();
             }
+        } catch (final SQLException e) {
+            e.printStackTrace();
+            throw new CloudRuntimeException("Adding redundancy to vpc, networks and vpc_offerings failed", e);
+        }
+    }
+
+    private void removeBumPriorityColumn(final Connection conn) {
+        try (PreparedStatement removeBumPriorityColumnPstmt = conn.prepareStatement("ALTER TABLE `cloud`.`domain_router` DROP COLUMN `is_priority_bumpup`");) {
+            removeBumPriorityColumnPstmt.executeUpdate();
         } catch (final SQLException e) {
             e.printStackTrace();
             throw new CloudRuntimeException("Adding redundancy to vpc, networks and vpc_offerings failed", e);
@@ -136,7 +143,7 @@ public class Upgrade451to460 implements DbUpgrade {
             throw new CloudRuntimeException("Unable to find db/schema-451to460-cleanup.sql");
         }
 
-        return new File[] {new File(script)};
+        return new File[] { new File(script) };
     }
 
 }

--- a/engine/schema/src/com/cloud/vm/DomainRouterVO.java
+++ b/engine/schema/src/com/cloud/vm/DomainRouterVO.java
@@ -49,12 +49,6 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
     @Column(name = "is_redundant_router")
     boolean isRedundantRouter;
 
-    @Column(name = "priority")
-    int priority;
-
-    @Column(name = "is_priority_bumpup")
-    boolean isPriorityBumpUp;
-
     @Column(name = "redundant_state")
     @Enumerated(EnumType.STRING)
     private RedundantState redundantState;
@@ -75,28 +69,24 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
     @Column(name = "vpc_id")
     private Long vpcId;
 
-    public DomainRouterVO(long id, long serviceOfferingId, long elementId, String name, long templateId, HypervisorType hypervisorType, long guestOSId, long domainId,
-                          long accountId, long userId, boolean isRedundantRouter, int priority, boolean isPriorityBumpUp, RedundantState redundantState, boolean haEnabled, boolean stopPending,
-                          Long vpcId) {
+    public DomainRouterVO(final long id, final long serviceOfferingId, final long elementId, final String name, final long templateId, final HypervisorType hypervisorType, final long guestOSId, final long domainId,
+            final long accountId, final long userId, final boolean isRedundantRouter, final RedundantState redundantState, final boolean haEnabled, final boolean stopPending,
+            final Long vpcId) {
         super(id, serviceOfferingId, name, name, Type.DomainRouter, templateId, hypervisorType, guestOSId, domainId, accountId, userId, haEnabled);
         this.elementId = elementId;
         this.isRedundantRouter = isRedundantRouter;
-        this.priority = priority;
         this.redundantState = redundantState;
-        this.isPriorityBumpUp = isPriorityBumpUp;
         this.stopPending = stopPending;
         this.vpcId = vpcId;
     }
 
-    public DomainRouterVO(long id, long serviceOfferingId, long elementId, String name, long templateId, HypervisorType hypervisorType, long guestOSId, long domainId,
-                          long accountId, long userId, boolean isRedundantRouter, int priority, boolean isPriorityBumpUp, RedundantState redundantState, boolean haEnabled, boolean stopPending,
-                          Type vmType, Long vpcId) {
+    public DomainRouterVO(final long id, final long serviceOfferingId, final long elementId, final String name, final long templateId, final HypervisorType hypervisorType, final long guestOSId, final long domainId,
+            final long accountId, final long userId, final boolean isRedundantRouter, final RedundantState redundantState, final boolean haEnabled, final boolean stopPending,
+            final Type vmType, final Long vpcId) {
         super(id, serviceOfferingId, name, name, vmType, templateId, hypervisorType, guestOSId, domainId, accountId, userId, haEnabled);
         this.elementId = elementId;
         this.isRedundantRouter = isRedundantRouter;
-        this.priority = priority;
         this.redundantState = redundantState;
-        this.isPriorityBumpUp = isPriorityBumpUp;
         this.stopPending = stopPending;
         this.vpcId = vpcId;
     }
@@ -105,15 +95,15 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
         return elementId;
     }
 
-    public void setPublicIpAddress(String publicIpAddress) {
+    public void setPublicIpAddress(final String publicIpAddress) {
         this.publicIpAddress = publicIpAddress;
     }
 
-    public void setPublicMacAddress(String publicMacAddress) {
+    public void setPublicMacAddress(final String publicMacAddress) {
         this.publicMacAddress = publicMacAddress;
     }
 
-    public void setPublicNetmask(String publicNetmask) {
+    public void setPublicNetmask(final String publicNetmask) {
         this.publicNetmask = publicNetmask;
     }
 
@@ -144,16 +134,16 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
         return role;
     }
 
-    public void setRole(Role role) {
+    public void setRole(final Role role) {
         this.role = role;
     }
 
     @Override
     public boolean getIsRedundantRouter() {
-        return this.isRedundantRouter;
+        return isRedundantRouter;
     }
 
-    public void setIsRedundantRouter(boolean isRedundantRouter) {
+    public void setIsRedundantRouter(final boolean isRedundantRouter) {
         this.isRedundantRouter = isRedundantRouter;
     }
 
@@ -162,55 +152,39 @@ public class DomainRouterVO extends VMInstanceVO implements VirtualRouter {
         return serviceOfferingId;
     }
 
-    public int getPriority() {
-        return this.priority;
-    }
-
-    public void setPriority(int priority) {
-        this.priority = priority;
-    }
-
     @Override
     public RedundantState getRedundantState() {
-        return this.redundantState;
+        return redundantState;
     }
 
-    public void setRedundantState(RedundantState redundantState) {
+    public void setRedundantState(final RedundantState redundantState) {
         this.redundantState = redundantState;
-    }
-
-    public boolean getIsPriorityBumpUp() {
-        return this.isPriorityBumpUp;
-    }
-
-    public void setIsPriorityBumpUp(boolean isPriorityBumpUp) {
-        this.isPriorityBumpUp = isPriorityBumpUp;
     }
 
     @Override
     public boolean isStopPending() {
-        return this.stopPending;
+        return stopPending;
     }
 
     @Override
-    public void setStopPending(boolean stopPending) {
+    public void setStopPending(final boolean stopPending) {
         this.stopPending = stopPending;
     }
 
     @Override
     public String getTemplateVersion() {
-        return this.templateVersion;
+        return templateVersion;
     }
 
-    public void setTemplateVersion(String templateVersion) {
+    public void setTemplateVersion(final String templateVersion) {
         this.templateVersion = templateVersion;
     }
 
     public String getScriptsVersion() {
-        return this.scriptsVersion;
+        return scriptsVersion;
     }
 
-    public void setScriptsVersion(String scriptsVersion) {
+    public void setScriptsVersion(final String scriptsVersion) {
         this.scriptsVersion = scriptsVersion;
     }
 

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManager.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManager.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.cloud.agent.api.Answer;
-import com.cloud.agent.api.BumpUpPriorityCommand;
 import com.cloud.agent.api.CheckRouterAnswer;
 import com.cloud.agent.api.CheckRouterCommand;
 import com.cloud.agent.api.CheckVirtualMachineCommand;
@@ -97,8 +96,6 @@ public interface MockVmManager extends Manager {
     GetDomRVersionAnswer getDomRVersion(GetDomRVersionCmd cmd);
 
     CheckRouterAnswer checkRouter(CheckRouterCommand cmd);
-
-    Answer bumpPriority(BumpUpPriorityCommand cmd);
 
     Answer CleanupNetworkRules(CleanupNetworkRulesCmd cmd, SimulatorInfo info);
 

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/SimulatorManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/SimulatorManagerImpl.java
@@ -27,20 +27,17 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import com.cloud.agent.api.routing.SetMonitorServiceCommand;
-
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
 import org.apache.cloudstack.storage.command.DeleteCommand;
 import org.apache.cloudstack.storage.command.DownloadCommand;
 import org.apache.cloudstack.storage.command.DownloadProgressCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.AttachIsoCommand;
 import com.cloud.agent.api.AttachVolumeCommand;
 import com.cloud.agent.api.BackupSnapshotCommand;
-import com.cloud.agent.api.BumpUpPriorityCommand;
 import com.cloud.agent.api.CheckHealthCommand;
 import com.cloud.agent.api.CheckNetworkCommand;
 import com.cloud.agent.api.CheckRouterCommand;
@@ -75,6 +72,7 @@ import com.cloud.agent.api.PvlanSetupCommand;
 import com.cloud.agent.api.RebootCommand;
 import com.cloud.agent.api.RevertToVMSnapshotCommand;
 import com.cloud.agent.api.ScaleVmCommand;
+import com.cloud.agent.api.SecStorageFirewallCfgCommand;
 import com.cloud.agent.api.SecStorageSetupCommand;
 import com.cloud.agent.api.SecStorageVMSetupCommand;
 import com.cloud.agent.api.SecurityGroupRulesCmd;
@@ -95,6 +93,7 @@ import com.cloud.agent.api.routing.LoadBalancerConfigCommand;
 import com.cloud.agent.api.routing.RemoteAccessVpnCfgCommand;
 import com.cloud.agent.api.routing.SavePasswordCommand;
 import com.cloud.agent.api.routing.SetFirewallRulesCommand;
+import com.cloud.agent.api.routing.SetMonitorServiceCommand;
 import com.cloud.agent.api.routing.SetNetworkACLCommand;
 import com.cloud.agent.api.routing.SetPortForwardingRulesCommand;
 import com.cloud.agent.api.routing.SetPortForwardingRulesVpcCommand;
@@ -113,7 +112,6 @@ import com.cloud.agent.api.storage.PrimaryStorageDownloadCommand;
 import com.cloud.api.commands.CleanupSimulatorMockCmd;
 import com.cloud.api.commands.ConfigureSimulatorCmd;
 import com.cloud.api.commands.QuerySimulatorMockCmd;
-import com.cloud.agent.api.SecStorageFirewallCfgCommand;
 import com.cloud.resource.SimulatorStorageProcessor;
 import com.cloud.serializer.GsonHelper;
 import com.cloud.simulator.MockConfigurationVO;
@@ -153,9 +151,9 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
     protected StorageSubsystemCommandHandler storageHandler;
 
     @Override
-    public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
-        SimulatorStorageProcessor processor = new SimulatorStorageProcessor(this);
-        this.storageHandler = new StorageSubsystemCommandHandlerBase(processor);
+    public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
+        final SimulatorStorageProcessor processor = new SimulatorStorageProcessor(this);
+        storageHandler = new StorageSubsystemCommandHandlerBase(processor);
         return true;
     }
 
@@ -191,7 +189,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
 
     @Override
     public List<Class<?>> getCommands() {
-        List<Class<?>> cmdList = new ArrayList<Class<?>>();
+        final List<Class<?>> cmdList = new ArrayList<Class<?>>();
         cmdList.add(ConfigureSimulatorCmd.class);
         cmdList.add(QuerySimulatorMockCmd.class);
         cmdList.add(CleanupSimulatorMockCmd.class);
@@ -200,48 +198,48 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
 
     @DB
     @Override
-    public Answer simulate(Command cmd, String hostGuid) {
+    public Answer simulate(final Command cmd, final String hostGuid) {
         Answer answer = null;
         Exception exception = null;
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.SIMULATOR_DB);
         try {
-            MockHost host = _mockHost.findByGuid(hostGuid);
+            final MockHost host = _mockHost.findByGuid(hostGuid);
             String cmdName = cmd.toString();
-            int index = cmdName.lastIndexOf(".");
+            final int index = cmdName.lastIndexOf(".");
             if (index != -1) {
                 cmdName = cmdName.substring(index + 1);
             }
 
-            SimulatorInfo info = new SimulatorInfo();
+            final SimulatorInfo info = new SimulatorInfo();
             info.setHostUuid(hostGuid);
 
-            MockConfigurationVO config = _mockConfigDao.findByNameBottomUP(host.getDataCenterId(), host.getPodId(), host.getClusterId(), host.getId(), cmdName);
+            final MockConfigurationVO config = _mockConfigDao.findByNameBottomUP(host.getDataCenterId(), host.getPodId(), host.getClusterId(), host.getId(), cmdName);
             if (config != null && (config.getCount() == null || config.getCount().intValue() > 0)) {
-                Map<String, String> configParameters = config.getParameters();
-                for (Map.Entry<String, String> entry : configParameters.entrySet()) {
+                final Map<String, String> configParameters = config.getParameters();
+                for (final Map.Entry<String, String> entry : configParameters.entrySet()) {
                     if (entry.getKey().equalsIgnoreCase("enabled")) {
                         info.setEnabled(Boolean.parseBoolean(entry.getValue()));
                     } else if (entry.getKey().equalsIgnoreCase("timeout")) {
                         try {
                             info.setTimeout(Integer.valueOf(entry.getValue()));
-                        } catch (NumberFormatException e) {
+                        } catch (final NumberFormatException e) {
                             s_logger.debug("invalid timeout parameter: " + e.toString());
                         }
                     }
 
                     if (entry.getKey().equalsIgnoreCase("wait")) {
                         try {
-                            int wait = Integer.valueOf(entry.getValue());
+                            final int wait = Integer.valueOf(entry.getValue());
                             Thread.sleep(wait);
-                        } catch (NumberFormatException e) {
+                        } catch (final NumberFormatException e) {
                             s_logger.debug("invalid wait parameter: " + e.toString());
-                        } catch (InterruptedException e) {
+                        } catch (final InterruptedException e) {
                             s_logger.debug("thread is interrupted: " + e.toString());
                         }
                     }
 
                     if (entry.getKey().equalsIgnoreCase("result")) {
-                        String value = entry.getValue();
+                        final String value = entry.getValue();
                         if (value.equalsIgnoreCase("fail")) {
                             answer = new Answer(cmd, false, "Simulated failure");
                         } else if (value.equalsIgnoreCase("fault")) {
@@ -255,20 +253,20 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                 }
 
                 if (answer == null) {
-                    String message = config.getJsonResponse();
+                    final String message = config.getJsonResponse();
                     if (message != null) {
                         // json response looks like {"<Type>":....}
-                        String objectType = message.split(":")[0].substring(2).replace("\"", "");
-                        String objectData = message.substring(message.indexOf(':') + 1, message.length() - 1);
+                        final String objectType = message.split(":")[0].substring(2).replace("\"", "");
+                        final String objectData = message.substring(message.indexOf(':') + 1, message.length() - 1);
                         if (objectType != null) {
                             Class<?> clz = null;
                             try {
                                 clz = Class.forName(objectType);
-                            } catch (ClassNotFoundException e) {
+                            } catch (final ClassNotFoundException e) {
                             }
                             if (clz != null) {
-                                StringReader reader = new StringReader(objectData);
-                                JsonReader jsonReader = new JsonReader(reader);
+                                final StringReader reader = new StringReader(objectData);
+                                final JsonReader jsonReader = new JsonReader(reader);
                                 jsonReader.setLenient(true);
                                 answer = (Answer)s_gson.fromJson(jsonReader, clz);
                             }
@@ -378,8 +376,6 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                     answer = _mockVmMgr.getVmStats((GetVmStatsCommand)cmd);
                 } else if (cmd instanceof CheckRouterCommand) {
                     answer = _mockVmMgr.checkRouter((CheckRouterCommand)cmd);
-                } else if (cmd instanceof BumpUpPriorityCommand) {
-                    answer = _mockVmMgr.bumpPriority((BumpUpPriorityCommand)cmd);
                 } else if (cmd instanceof GetDomRVersionCmd) {
                     answer = _mockVmMgr.getDomRVersion((GetDomRVersionCmd)cmd);
                 } else if (cmd instanceof CopyVolumeCommand) {
@@ -419,7 +415,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                 } else if (cmd instanceof PvlanSetupCommand) {
                     answer = _mockNetworkMgr.setupPVLAN((PvlanSetupCommand)cmd);
                 } else if (cmd instanceof StorageSubSystemCommand) {
-                    answer = this.storageHandler.handleStorageCommands((StorageSubSystemCommand)cmd);
+                    answer = storageHandler.handleStorageCommands((StorageSubSystemCommand)cmd);
                 } else if (cmd instanceof FenceCommand) {
                     answer = _mockVmMgr.fence((FenceCommand)cmd);
                 } else if (cmd instanceof GetRouterAlertsCommand || cmd instanceof VpnUsersCfgCommand || cmd instanceof RemoteAccessVpnCfgCommand || cmd instanceof SetMonitorServiceCommand || cmd instanceof AggregationControlCommand ||
@@ -431,7 +427,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                 }
             }
 
-            if (config != null && (config.getCount() != null && config.getCount().intValue() > 0)) {
+            if (config != null && config.getCount() != null && config.getCount().intValue() > 0) {
                 if (answer != null) {
                     config.setCount(config.getCount().intValue() - 1);
                     _mockConfigDao.update(config.getId(), config);
@@ -439,7 +435,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
             }
 
             return answer;
-        } catch (Exception e) {
+        } catch (final Exception e) {
             s_logger.error("Failed execute cmd: ", e);
             txn.rollback();
             return new Answer(cmd, false, e.toString());
@@ -451,29 +447,29 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
     }
 
     @Override
-    public StoragePoolInfo getLocalStorage(String hostGuid) {
+    public StoragePoolInfo getLocalStorage(final String hostGuid) {
         return _mockStorageMgr.getLocalStorage(hostGuid);
     }
 
     @Override
-    public Map<String, PowerState> getVmStates(String hostGuid) {
+    public Map<String, PowerState> getVmStates(final String hostGuid) {
         return _mockVmMgr.getVmStates(hostGuid);
     }
 
     @Override
-    public Map<String, MockVMVO> getVms(String hostGuid) {
+    public Map<String, MockVMVO> getVms(final String hostGuid) {
         return _mockVmMgr.getVms(hostGuid);
     }
 
     @Override
-    public HashMap<String, Pair<Long, Long>> syncNetworkGroups(String hostGuid) {
-        SimulatorInfo info = new SimulatorInfo();
+    public HashMap<String, Pair<Long, Long>> syncNetworkGroups(final String hostGuid) {
+        final SimulatorInfo info = new SimulatorInfo();
         info.setHostUuid(hostGuid);
         return _mockVmMgr.syncNetworkGroups(info);
     }
 
     @Override
-    public Long configureSimulator(Long zoneId, Long podId, Long clusterId, Long hostId, String command, String values, Integer count, String jsonResponse) {
+    public Long configureSimulator(final Long zoneId, final Long podId, final Long clusterId, final Long hostId, final String command, final String values, final Integer count, final String jsonResponse) {
         Long id = null;
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.SIMULATOR_DB);
         try {
@@ -499,7 +495,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                 txn.commit();
             }
             id = config.getId();
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             txn.rollback();
             throw new CloudRuntimeException("Unable to configure simulator mock because of " + ex.getMessage(), ex);
         } finally {
@@ -511,12 +507,12 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
     }
 
     @Override
-    public MockConfigurationVO querySimulatorMock(Long id) {
+    public MockConfigurationVO querySimulatorMock(final Long id) {
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.SIMULATOR_DB);
         try {
             txn.start();
             return _mockConfigDao.findById(id);
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             txn.rollback();
             throw new CloudRuntimeException("Unable to query simulator mock because of " + ex.getMessage(), ex);
         } finally {
@@ -527,19 +523,19 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
     }
 
     @Override
-    public boolean clearSimulatorMock(Long id) {
+    public boolean clearSimulatorMock(final Long id) {
         boolean status = false;
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.SIMULATOR_DB);
         try {
             txn.start();
-            MockConfigurationVO config = _mockConfigDao.findById(id);
+            final MockConfigurationVO config = _mockConfigDao.findById(id);
             if (config != null) {
                 config.setRemoved(new Date());
                 _mockConfigDao.update(config.getId(), config);
                 status = true;
                 txn.commit();
             }
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             txn.rollback();
             throw new CloudRuntimeException("Unable to cleanup simulator mock because of " + ex.getMessage(), ex);
         } finally {

--- a/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMManagerTest.java
+++ b/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMManagerTest.java
@@ -24,9 +24,10 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import com.cloud.storage.Storage;
 import junit.framework.TestCase;
 
+import org.apache.cloudstack.lb.ApplicationLoadBalancerRuleVO;
+import org.apache.cloudstack.network.lb.InternalLoadBalancerVMManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,9 +35,6 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import org.apache.cloudstack.lb.ApplicationLoadBalancerRuleVO;
-import org.apache.cloudstack.network.lb.InternalLoadBalancerVMManager;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -60,6 +58,7 @@ import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
+import com.cloud.storage.Storage;
 import com.cloud.user.AccountManager;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.component.ComponentContext;
@@ -126,16 +125,16 @@ public class InternalLBVMManagerTest extends TestCase {
         ComponentContext.initComponentsLifeCycle();
 
         vm =
-            new DomainRouterVO(1L, off.getId(), 1, "alena", 1, HypervisorType.XenServer, 1, 1, 1, 1, false, 0, false, null, false, false,
-                VirtualMachine.Type.InternalLoadBalancerVm, null);
+                new DomainRouterVO(1L, off.getId(), 1, "alena", 1, HypervisorType.XenServer, 1, 1, 1, 1, false, null, false, false,
+                        VirtualMachine.Type.InternalLoadBalancerVm, null);
         vm.setRole(Role.INTERNAL_LB_VM);
         vm = setId(vm, 1);
         vm.setPrivateIpAddress("10.2.2.2");
-        NicVO nic = new NicVO("somereserver", 1L, 1L, VirtualMachine.Type.InternalLoadBalancerVm);
+        final NicVO nic = new NicVO("somereserver", 1L, 1L, VirtualMachine.Type.InternalLoadBalancerVm);
         nic.setIp4Address(requestedIp);
 
-        List<DomainRouterVO> emptyList = new ArrayList<DomainRouterVO>();
-        List<DomainRouterVO> nonEmptyList = new ArrayList<DomainRouterVO>();
+        final List<DomainRouterVO> emptyList = new ArrayList<DomainRouterVO>();
+        final List<DomainRouterVO> nonEmptyList = new ArrayList<DomainRouterVO>();
         nonEmptyList.add(vm);
 
         Mockito.when(_domainRouterDao.listByNetworkAndRole(invalidNtwkId, Role.INTERNAL_LB_VM)).thenReturn(emptyList);
@@ -144,16 +143,16 @@ public class InternalLBVMManagerTest extends TestCase {
         Mockito.when(_nicDao.findByNtwkIdAndInstanceId(validNtwkId, 1)).thenReturn(nic);
         Mockito.when(_nicDao.findByNtwkIdAndInstanceId(invalidNtwkId, 1)).thenReturn(nic);
 
-        Answer answer = new Answer(null, true, null);
-        Answer[] answers = new Answer[1];
+        final Answer answer = new Answer(null, true, null);
+        final Answer[] answers = new Answer[1];
         answers[0] = answer;
 
         try {
             Mockito.when(_agentMgr.send(Matchers.anyLong(), Matchers.any(Commands.class))).thenReturn(answers);
-        } catch (AgentUnavailableException e) {
+        } catch (final AgentUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (OperationTimedoutException e) {
+        } catch (final OperationTimedoutException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
@@ -163,9 +162,9 @@ public class InternalLBVMManagerTest extends TestCase {
 
         Mockito.when(_itMgr.toNicTO(Matchers.any(NicProfile.class), Matchers.any(HypervisorType.class))).thenReturn(null);
         Mockito.when(_domainRouterDao.findById(Matchers.anyLong())).thenReturn(vm);
-        DataCenterVO dc = new DataCenterVO(1L, null, null, null, null, null, null, null, null, null, NetworkType.Advanced, null, null);
+        final DataCenterVO dc = new DataCenterVO(1L, null, null, null, null, null, null, null, null, null, NetworkType.Advanced, null, null);
         Mockito.when(_dcDao.findById(Matchers.anyLong())).thenReturn(dc);
-        NetworkOfferingVO networkOfferingVO = new NetworkOfferingVO();
+        final NetworkOfferingVO networkOfferingVO = new NetworkOfferingVO();
         networkOfferingVO.setConcurrentConnections(500);
         Mockito.when(_offeringDao.findById(Matchers.anyLong())).thenReturn(networkOfferingVO);
 
@@ -178,7 +177,7 @@ public class InternalLBVMManagerTest extends TestCase {
         ntwk = new NetworkVO();
         try {
             ntwk.setBroadcastUri(new URI("somevlan"));
-        } catch (URISyntaxException e) {
+        } catch (final URISyntaxException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
@@ -190,13 +189,13 @@ public class InternalLBVMManagerTest extends TestCase {
 
     @Test
     public void findInternalLbVmsForInvalidNetwork() {
-        List<? extends VirtualRouter> vms = _lbVmMgr.findInternalLbVms(invalidNtwkId, new Ip(requestedIp));
+        final List<? extends VirtualRouter> vms = _lbVmMgr.findInternalLbVms(invalidNtwkId, new Ip(requestedIp));
         assertTrue("Non empty vm list was returned for invalid network id", vms.isEmpty());
     }
 
     @Test
     public void findInternalLbVmsForValidNetwork() {
-        List<? extends VirtualRouter> vms = _lbVmMgr.findInternalLbVms(validNtwkId, new Ip(requestedIp));
+        final List<? extends VirtualRouter> vms = _lbVmMgr.findInternalLbVms(validNtwkId, new Ip(requestedIp));
         assertTrue("Empty vm list was returned for valid network id", !vms.isEmpty());
     }
 
@@ -204,10 +203,10 @@ public class InternalLBVMManagerTest extends TestCase {
     @Test
     public void applyEmptyRulesSet() {
         boolean result = false;
-        List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
+        final List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
         try {
             result = _lbVmMgr.applyLoadBalancingRules(new NetworkVO(), new ArrayList<LoadBalancingRule>(), vms);
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
 
         } finally {
             assertTrue("Got failure when tried to apply empty list of rules", result);
@@ -217,14 +216,14 @@ public class InternalLBVMManagerTest extends TestCase {
     @Test(expected = CloudRuntimeException.class)
     public void applyWithEmptyVmsSet() {
         boolean result = false;
-        List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
-        List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
-        LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
+        final List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
+        final List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
+        final LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
 
         rules.add(rule);
         try {
             result = _lbVmMgr.applyLoadBalancingRules(new NetworkVO(), rules, vms);
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
         } finally {
             assertFalse("Got success when tried to apply with the empty internal lb vm list", result);
         }
@@ -233,12 +232,12 @@ public class InternalLBVMManagerTest extends TestCase {
     @Test(expected = ResourceUnavailableException.class)
     public void applyToVmInStartingState() throws ResourceUnavailableException {
         boolean result = false;
-        List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
+        final List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
         vm.setState(State.Starting);
         vms.add(vm);
 
-        List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
-        LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
+        final List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
+        final LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
 
         rules.add(rule);
         try {
@@ -251,12 +250,12 @@ public class InternalLBVMManagerTest extends TestCase {
     @Test
     public void applyToVmInStoppedState() throws ResourceUnavailableException {
         boolean result = false;
-        List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
+        final List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
         vm.setState(State.Stopped);
         vms.add(vm);
 
-        List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
-        LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
+        final List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
+        final LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
 
         rules.add(rule);
         try {
@@ -269,12 +268,12 @@ public class InternalLBVMManagerTest extends TestCase {
     @Test
     public void applyToVmInStoppingState() throws ResourceUnavailableException {
         boolean result = false;
-        List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
+        final List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
         vm.setState(State.Stopping);
         vms.add(vm);
 
-        List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
-        LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
+        final List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
+        final LoadBalancingRule rule = new LoadBalancingRule(null, null, null, null, null, null, null);
 
         rules.add(rule);
         try {
@@ -287,15 +286,15 @@ public class InternalLBVMManagerTest extends TestCase {
     @Test
     public void applyToVmInRunningState() throws ResourceUnavailableException {
         boolean result = false;
-        List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
+        final List<DomainRouterVO> vms = new ArrayList<DomainRouterVO>();
         vm.setState(State.Running);
         vms.add(vm);
 
-        List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
-        ApplicationLoadBalancerRuleVO lb = new ApplicationLoadBalancerRuleVO(null, null, 22, 22, "roundrobin", 1L, 1L, 1L, new Ip(requestedIp), 1L, Scheme.Internal);
+        final List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
+        final ApplicationLoadBalancerRuleVO lb = new ApplicationLoadBalancerRuleVO(null, null, 22, 22, "roundrobin", 1L, 1L, 1L, new Ip(requestedIp), 1L, Scheme.Internal);
         lb.setState(FirewallRule.State.Add);
 
-        LoadBalancingRule rule = new LoadBalancingRule(lb, null, null, null, new Ip(requestedIp));
+        final LoadBalancingRule rule = new LoadBalancingRule(lb, null, null, null, new Ip(requestedIp));
 
         rules.add(rule);
 
@@ -331,48 +330,48 @@ public class InternalLBVMManagerTest extends TestCase {
         }
     }
 
-    private static ServiceOfferingVO setId(ServiceOfferingVO vo, long id) {
-        ServiceOfferingVO voToReturn = vo;
-        Class<?> c = voToReturn.getClass();
+    private static ServiceOfferingVO setId(final ServiceOfferingVO vo, final long id) {
+        final ServiceOfferingVO voToReturn = vo;
+        final Class<?> c = voToReturn.getClass();
         try {
-            Field f = c.getSuperclass().getDeclaredField("id");
+            final Field f = c.getSuperclass().getDeclaredField("id");
             f.setAccessible(true);
             f.setLong(voToReturn, id);
-        } catch (NoSuchFieldException ex) {
+        } catch (final NoSuchFieldException ex) {
             return null;
-        } catch (IllegalAccessException ex) {
+        } catch (final IllegalAccessException ex) {
             return null;
         }
 
         return voToReturn;
     }
 
-    private static NetworkVO setId(NetworkVO vo, long id) {
-        NetworkVO voToReturn = vo;
-        Class<?> c = voToReturn.getClass();
+    private static NetworkVO setId(final NetworkVO vo, final long id) {
+        final NetworkVO voToReturn = vo;
+        final Class<?> c = voToReturn.getClass();
         try {
-            Field f = c.getDeclaredField("id");
+            final Field f = c.getDeclaredField("id");
             f.setAccessible(true);
             f.setLong(voToReturn, id);
-        } catch (NoSuchFieldException ex) {
+        } catch (final NoSuchFieldException ex) {
             return null;
-        } catch (IllegalAccessException ex) {
+        } catch (final IllegalAccessException ex) {
             return null;
         }
 
         return voToReturn;
     }
 
-    private static DomainRouterVO setId(DomainRouterVO vo, long id) {
-        DomainRouterVO voToReturn = vo;
-        Class<?> c = voToReturn.getClass();
+    private static DomainRouterVO setId(final DomainRouterVO vo, final long id) {
+        final DomainRouterVO voToReturn = vo;
+        final Class<?> c = voToReturn.getClass();
         try {
-            Field f = c.getSuperclass().getDeclaredField("id");
+            final Field f = c.getSuperclass().getDeclaredField("id");
             f.setAccessible(true);
             f.setLong(voToReturn, id);
-        } catch (NoSuchFieldException ex) {
+        } catch (final NoSuchFieldException ex) {
             return null;
-        } catch (IllegalAccessException ex) {
+        } catch (final IllegalAccessException ex) {
             return null;
         }
 

--- a/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMServiceTest.java
+++ b/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMServiceTest.java
@@ -20,9 +20,10 @@ import java.lang.reflect.Field;
 
 import javax.inject.Inject;
 
-import com.cloud.storage.Storage;
 import junit.framework.TestCase;
 
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.network.lb.InternalLoadBalancerVMService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,9 +32,6 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.network.lb.InternalLoadBalancerVMService;
 
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientCapacityException;
@@ -45,6 +43,7 @@ import com.cloud.network.router.VirtualRouter;
 import com.cloud.network.router.VirtualRouter.Role;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
+import com.cloud.storage.Storage;
 import com.cloud.user.AccountManager;
 import com.cloud.user.AccountVO;
 import com.cloud.user.UserVO;
@@ -100,13 +99,13 @@ public class InternalLBVMServiceTest extends TestCase {
         Mockito.when(_accountDao.findByIdIncludingRemoved(Matchers.anyLong())).thenReturn(new AccountVO(2));
         CallContext.register(_accountMgr.getSystemUser(), _accountMgr.getSystemAccount());
 
-        DomainRouterVO validVm =
-            new DomainRouterVO(validVmId, off.getId(), 1, "alena", 1, HypervisorType.XenServer, 1, 1, 1, 1, false, 0, false, null, false, false,
-                VirtualMachine.Type.InternalLoadBalancerVm, null);
+        final DomainRouterVO validVm =
+                new DomainRouterVO(validVmId, off.getId(), 1, "alena", 1, HypervisorType.XenServer, 1, 1, 1, 1, false, null, false, false,
+                        VirtualMachine.Type.InternalLoadBalancerVm, null);
         validVm.setRole(Role.INTERNAL_LB_VM);
-        DomainRouterVO nonInternalLbVm =
-            new DomainRouterVO(validVmId, off.getId(), 1, "alena", 1, HypervisorType.XenServer, 1, 1, 1, 1, false, 0, false, null, false, false,
-                VirtualMachine.Type.DomainRouter, null);
+        final DomainRouterVO nonInternalLbVm =
+                new DomainRouterVO(validVmId, off.getId(), 1, "alena", 1, HypervisorType.XenServer, 1, 1, 1, 1, false, null, false, false,
+                        VirtualMachine.Type.DomainRouter, null);
         nonInternalLbVm.setRole(Role.VIRTUAL_ROUTER);
 
         Mockito.when(_domainRouterDao.findById(validVmId)).thenReturn(validVm);
@@ -124,19 +123,19 @@ public class InternalLBVMServiceTest extends TestCase {
 
     @Test(expected = InvalidParameterValueException.class)
     public void startNonExistingVm() {
-        String expectedExcText = null;
+        final String expectedExcText = null;
         try {
             _lbVmSvc.startInternalLbVm(nonExistingVmId, _accountMgr.getAccount(1L), 1L);
-        } catch (StorageUnavailableException e) {
+        } catch (final StorageUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (InsufficientCapacityException e) {
+        } catch (final InsufficientCapacityException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ConcurrentOperationException e) {
+        } catch (final ConcurrentOperationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
@@ -144,19 +143,19 @@ public class InternalLBVMServiceTest extends TestCase {
 
     @Test(expected = InvalidParameterValueException.class)
     public void startNonInternalLbVmVm() {
-        String expectedExcText = null;
+        final String expectedExcText = null;
         try {
             _lbVmSvc.startInternalLbVm(nonInternalLbVmId, _accountMgr.getAccount(1L), 1L);
-        } catch (StorageUnavailableException e) {
+        } catch (final StorageUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (InsufficientCapacityException e) {
+        } catch (final InsufficientCapacityException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ConcurrentOperationException e) {
+        } catch (final ConcurrentOperationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
@@ -167,16 +166,16 @@ public class InternalLBVMServiceTest extends TestCase {
         VirtualRouter vr = null;
         try {
             vr = _lbVmSvc.startInternalLbVm(validVmId, _accountMgr.getAccount(1L), 1L);
-        } catch (StorageUnavailableException e) {
+        } catch (final StorageUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (InsufficientCapacityException e) {
+        } catch (final InsufficientCapacityException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ConcurrentOperationException e) {
+        } catch (final ConcurrentOperationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         } finally {
@@ -187,16 +186,16 @@ public class InternalLBVMServiceTest extends TestCase {
     //TEST FOR STOP COMMAND
     @Test(expected = InvalidParameterValueException.class)
     public void stopNonExistingVm() {
-        String expectedExcText = null;
+        final String expectedExcText = null;
         try {
             _lbVmSvc.stopInternalLbVm(nonExistingVmId, false, _accountMgr.getAccount(1L), 1L);
-        } catch (StorageUnavailableException e) {
+        } catch (final StorageUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ConcurrentOperationException e) {
+        } catch (final ConcurrentOperationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
@@ -204,16 +203,16 @@ public class InternalLBVMServiceTest extends TestCase {
 
     @Test(expected = InvalidParameterValueException.class)
     public void stopNonInternalLbVmVm() {
-        String expectedExcText = null;
+        final String expectedExcText = null;
         try {
             _lbVmSvc.stopInternalLbVm(nonInternalLbVmId, false, _accountMgr.getAccount(1L), 1L);
-        } catch (StorageUnavailableException e) {
+        } catch (final StorageUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ConcurrentOperationException e) {
+        } catch (final ConcurrentOperationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
@@ -224,13 +223,13 @@ public class InternalLBVMServiceTest extends TestCase {
         VirtualRouter vr = null;
         try {
             vr = _lbVmSvc.stopInternalLbVm(validVmId, false, _accountMgr.getAccount(1L), 1L);
-        } catch (StorageUnavailableException e) {
+        } catch (final StorageUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ConcurrentOperationException e) {
+        } catch (final ConcurrentOperationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         } finally {
@@ -238,16 +237,16 @@ public class InternalLBVMServiceTest extends TestCase {
         }
     }
 
-    private static ServiceOfferingVO setId(ServiceOfferingVO vo, long id) {
-        ServiceOfferingVO voToReturn = vo;
-        Class<?> c = voToReturn.getClass();
+    private static ServiceOfferingVO setId(final ServiceOfferingVO vo, final long id) {
+        final ServiceOfferingVO voToReturn = vo;
+        final Class<?> c = voToReturn.getClass();
         try {
-            Field f = c.getSuperclass().getDeclaredField("id");
+            final Field f = c.getSuperclass().getDeclaredField("id");
             f.setAccessible(true);
             f.setLong(voToReturn, id);
-        } catch (NoSuchFieldException ex) {
+        } catch (final NoSuchFieldException ex) {
             return null;
-        } catch (IllegalAccessException ex) {
+        } catch (final IllegalAccessException ex) {
             return null;
         }
 

--- a/server/src/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/com/cloud/network/router/CommandSetupHelper.java
@@ -930,9 +930,8 @@ public class CommandSetupHelper {
         final String dhcpRange = getGuestDhcpRange(guestNic, network, _entityMgr.findById(DataCenter.class, network.getDataCenterId()));
 
         final NicProfile nicProfile = _networkModel.getNicProfile(router, nic.getNetworkId(), null);
-        final int priority = _networkHelper.getRealPriority(router);
 
-        final SetupGuestNetworkCommand setupCmd = new SetupGuestNetworkCommand(dhcpRange, networkDomain, router.getIsRedundantRouter(), priority, defaultDns1, defaultDns2, add, _itMgr.toNicTO(nicProfile,
+        final SetupGuestNetworkCommand setupCmd = new SetupGuestNetworkCommand(dhcpRange, networkDomain, router.getIsRedundantRouter(), defaultDns1, defaultDns2, add, _itMgr.toNicTO(nicProfile,
                 router.getHypervisorType()));
 
         final String brd = NetUtils.long2Ip(NetUtils.ip2Long(guestNic.getIp4Address()) | ~NetUtils.ip2Long(guestNic.getNetmask()));

--- a/server/src/com/cloud/network/router/NetworkHelper.java
+++ b/server/src/com/cloud/network/router/NetworkHelper.java
@@ -50,8 +50,6 @@ public interface NetworkHelper {
             List<? extends VirtualRouter> disconnectedRouters, String reason)
                     throws ResourceUnavailableException;
 
-    public abstract int getRealPriority(DomainRouterVO router);
-
     public abstract NicTO getNicTO(VirtualRouter router, Long networkId,
             String broadcastUri);
 

--- a/server/src/org/cloud/network/router/deployment/RouterDeploymentDefinition.java
+++ b/server/src/org/cloud/network/router/deployment/RouterDeploymentDefinition.java
@@ -338,7 +338,6 @@ public class RouterDeploymentDefinition {
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException {
         //Check current redundant routers, if possible(all routers are stopped), reset the priority
         planDeploymentRouters();
-        setupPriorityOfRedundantRouter();
 
         if (getNumberOfRoutersToDeploy() > 0 && prepareDeployment()) {
             findVirtualProvider();
@@ -441,20 +440,5 @@ public class RouterDeploymentDefinition {
         }
 
         return needReset;
-    }
-
-    /**
-     * Only for redundant deployment and if any routers needed reset, we shall
-     * reset all routers priorities
-     */
-    protected void setupPriorityOfRedundantRouter() {
-        if (isRedundant() && routersNeedReset()) {
-            for (final DomainRouterVO router : routers) {
-                // getUpdatedPriority() would update the value later
-                router.setPriority(0);
-                router.setIsPriorityBumpUp(false);
-                routerDao.update(router.getId(), router);
-            }
-        }
     }
 }

--- a/server/test/com/cloud/network/element/VirtualRouterElementTest.java
+++ b/server/test/com/cloud/network/element/VirtualRouterElementTest.java
@@ -201,7 +201,7 @@ public class VirtualRouterElementTest {
         mockDAOs(testNetwork, testOffering);
         mockMgrs();
 
-        boolean done = virtualRouterElement.implement(testNetwork, testOffering, testDestination, testContext);
+        final boolean done = virtualRouterElement.implement(testNetwork, testOffering, testDestination, testContext);
         assertTrue("no cigar for network daddy",done);
     }
 
@@ -209,7 +209,7 @@ public class VirtualRouterElementTest {
     @Ignore("Ignore it until it's fixed in order not to brake the build")
     public void testPrepare() {
         virtualRouterElement._routerMgr = _routerMgr;
-        virtualRouterElement.routerDeploymentDefinitionBuilder = this.routerDeploymentDefinitionBuilder;
+        virtualRouterElement.routerDeploymentDefinitionBuilder = routerDeploymentDefinitionBuilder;
         mockDAOs(testNetwork,testOffering);
         mockMgrs();
 
@@ -230,7 +230,7 @@ public class VirtualRouterElementTest {
      * @throws ConcurrentOperationException
      */
     private void mockMgrs() throws ConcurrentOperationException {
-        Service service = Service.Connectivity;
+        final Service service = Service.Connectivity;
         testNetwork.setState(Network.State.Implementing);
         testNetwork.setTrafficType(TrafficType.Guest);
         when(_networkMdl.isProviderEnabledInPhysicalNetwork(0L, "VirtualRouter")).thenReturn(true);
@@ -238,13 +238,13 @@ public class VirtualRouterElementTest {
         when(_networkMdl.isProviderForNetwork(Network.Provider.VirtualRouter, 0L)).thenReturn(true);
         when(testVMProfile.getType()).thenReturn(VirtualMachine.Type.User);
         when(testVMProfile.getHypervisorType()).thenReturn(HypervisorType.XenServer);
-        List<NetworkVO> networks = new ArrayList<NetworkVO>(1);
+        final List<NetworkVO> networks = new ArrayList<NetworkVO>(1);
         networks.add(testNetwork);
-        List<NetworkOfferingVO> offerings = new ArrayList<NetworkOfferingVO>(1);
+        final List<NetworkOfferingVO> offerings = new ArrayList<NetworkOfferingVO>(1);
         offerings.add(testOffering);
         doReturn(offerings).when(_networkModel).getSystemAccountNetworkOfferings(NetworkOffering.SystemControlNetwork);
         doReturn(networks).when(_networkMgr).setupNetwork(any(Account.class), any(NetworkOffering.class), any(DeploymentPlan.class), any(String.class), any(String.class), anyBoolean());
-     // being anti-social and testing my own case first
+        // being anti-social and testing my own case first
         doReturn(HypervisorType.XenServer).when(_resourceMgr).getDefaultHypervisor(anyLong());
         doReturn(new AccountVO()).when(_accountMgr).getAccount(testNetwork.getAccountId());
     }
@@ -252,7 +252,7 @@ public class VirtualRouterElementTest {
     /**
      * @param network
      */
-    private void mockDAOs(NetworkVO network, NetworkOfferingVO offering) {
+    private void mockDAOs(final NetworkVO network, final NetworkOfferingVO offering) {
         when(_networkDao.acquireInLockTable(network.getId(), NetworkOrchestrationService.NetworkLockTimeout.value())).thenReturn(network);
         when(_networksDao.acquireInLockTable(network.getId(), NetworkOrchestrationService.NetworkLockTimeout.value())).thenReturn(network);
         when(_physicalProviderDao.findByServiceProvider(0L, "VirtualRouter")).thenReturn(new PhysicalNetworkServiceProviderVO());
@@ -260,7 +260,7 @@ public class VirtualRouterElementTest {
         when(_networkOfferingDao.findById(0L)).thenReturn(offering);
         // watchit: (in this test) there can be only one
         when(_routerDao.getNextInSequence(Long.class, "id")).thenReturn(0L);
-        ServiceOfferingVO svcoff = new ServiceOfferingVO("name",
+        final ServiceOfferingVO svcoff = new ServiceOfferingVO("name",
                 /* cpu */ 1,
                 /* ramsize */ 1024*1024,
                 /* (clock?)speed */ 1024*1024*1024,
@@ -276,7 +276,7 @@ public class VirtualRouterElementTest {
                 VirtualMachine.Type.DomainRouter,
                 /* defaultUse */ false);
         when(_serviceOfferingDao.findById(0L)).thenReturn(svcoff);
-        DomainRouterVO router = new DomainRouterVO(/* id */ 1L,
+        final DomainRouterVO router = new DomainRouterVO(/* id */ 1L,
                 /* serviceOfferingId */ 1L,
                 /* elementId */ 0L,
                 "name",
@@ -287,8 +287,6 @@ public class VirtualRouterElementTest {
                 /* accountId */ 1L,
                 /* userId */ 1L,
                 /* isRedundantRouter */ false,
-                /* priority */ 0,
-                /* isPriorityBumpUp */ false,
                 RedundantState.UNKNOWN,
                 /* haEnabled */ false,
                 /* stopPending */ false,

--- a/server/test/org/cloud/network/router/deployment/RouterDeploymentDefinitionTest.java
+++ b/server/test/org/cloud/network/router/deployment/RouterDeploymentDefinitionTest.java
@@ -22,10 +22,7 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -526,117 +523,6 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
         fail();
     }
 
-    /**
-     * If any router is NOT redundant, then it shouldn't update routers
-     */
-    @Test
-    public void testSetupPriorityOfRedundantRouterWithNonRedundantRouters() {
-        // Prepare
-        deployment.routers = new ArrayList<>();
-        final DomainRouterVO routerVO1 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO1);
-        when(routerVO1.getIsRedundantRouter()).thenReturn(true);
-        when(routerVO1.getState()).thenReturn(VirtualMachine.State.Stopped);
-        final DomainRouterVO routerVO2 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO2);
-        when(routerVO2.getIsRedundantRouter()).thenReturn(false);
-        when(routerVO2.getState()).thenReturn(VirtualMachine.State.Stopped);
-        // If this deployment is not redundant nothing will be executed
-        when(mockNw.isRedundant()).thenReturn(true);
-
-        // Execute
-        deployment.setupPriorityOfRedundantRouter();
-
-        // Assert
-        verify(routerVO1, times(0)).setPriority(anyInt());
-        verify(routerVO1, times(0)).setIsPriorityBumpUp(anyBoolean());
-        verify(mockRouterDao, times(0)).update(anyLong(), (DomainRouterVO) anyObject());
-    }
-
-    /**
-     * If any router is NOT Stopped, then it shouldn't update routers
-     */
-    @Test
-    public void testSetupPriorityOfRedundantRouterWithRunningRouters() {
-        // Prepare
-        deployment.routers = new ArrayList<>();
-        final DomainRouterVO routerVO1 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO1);
-        when(routerVO1.getIsRedundantRouter()).thenReturn(true);
-        when(routerVO1.getState()).thenReturn(VirtualMachine.State.Stopped);
-        final DomainRouterVO routerVO2 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO2);
-        when(routerVO2.getIsRedundantRouter()).thenReturn(true);
-        when(routerVO2.getState()).thenReturn(VirtualMachine.State.Running);
-        // If this deployment is not redundant nothing will be executed
-        when(mockNw.isRedundant()).thenReturn(true);
-
-        // Execute
-        deployment.setupPriorityOfRedundantRouter();
-
-        // Assert
-        verify(routerVO1, times(0)).setPriority(anyInt());
-        verify(routerVO1, times(0)).setIsPriorityBumpUp(anyBoolean());
-        verify(mockRouterDao, times(0)).update(anyLong(), (DomainRouterVO) anyObject());
-    }
-
-    /**
-     * Given all routers are redundant and Stopped, then it should update ALL routers
-     */
-    @Test
-    public void testSetupPriorityOfRedundantRouter() {
-        // Prepare
-        deployment.routers = new ArrayList<>();
-        final DomainRouterVO routerVO1 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO1);
-        when(routerVO1.getId()).thenReturn(ROUTER1_ID);
-        when(routerVO1.getIsRedundantRouter()).thenReturn(true);
-        when(routerVO1.getState()).thenReturn(VirtualMachine.State.Stopped);
-        final DomainRouterVO routerVO2 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO2);
-        when(routerVO2.getId()).thenReturn(ROUTER2_ID);
-        when(routerVO2.getIsRedundantRouter()).thenReturn(true);
-        when(routerVO2.getState()).thenReturn(VirtualMachine.State.Stopped);
-        // If this deployment is not redundant nothing will be executed
-        when(mockNw.isRedundant()).thenReturn(true);
-
-        // Execute
-        deployment.setupPriorityOfRedundantRouter();
-
-        // Assert
-        verify(routerVO1, times(1)).setPriority(0);
-        verify(routerVO1, times(1)).setIsPriorityBumpUp(false);
-        verify(mockRouterDao, times(1)).update(ROUTER1_ID, routerVO1);
-        verify(routerVO2, times(1)).setPriority(0);
-        verify(routerVO2, times(1)).setIsPriorityBumpUp(false);
-        verify(mockRouterDao, times(1)).update(ROUTER2_ID, routerVO2);
-    }
-
-    /**
-     * If this is not a redundant deployment, then we shouldn't reset priorities
-     */
-    @Test
-    public void testSetupPriorityOfRedundantRouterWithNonRedundantDeployment() {
-        // Prepare
-        deployment.routers = new ArrayList<>();
-        final DomainRouterVO routerVO1 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO1);
-        when(routerVO1.getIsRedundantRouter()).thenReturn(true);
-        when(routerVO1.getState()).thenReturn(VirtualMachine.State.Stopped);
-        final DomainRouterVO routerVO2 = mock(DomainRouterVO.class);
-        deployment.routers.add(routerVO2);
-        when(routerVO2.getIsRedundantRouter()).thenReturn(true);
-        when(routerVO2.getState()).thenReturn(VirtualMachine.State.Stopped);
-
-        // Execute
-        deployment.setupPriorityOfRedundantRouter();
-
-        // Assert
-        verify(routerVO1, times(0)).setPriority(anyInt());
-        verify(routerVO1, times(0)).setIsPriorityBumpUp(anyBoolean());
-        verify(mockRouterDao, times(0)).update(anyLong(), (DomainRouterVO) anyObject());
-    }
-
     @Test
     public void testGetNumberOfRoutersToDeploy() {
         // Prepare
@@ -886,7 +772,6 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException {
         // Prepare
         final RouterDeploymentDefinition deploymentUT = spy(deployment);
-        doNothing().when(deploymentUT).setupPriorityOfRedundantRouter();
         doReturn(noOfRoutersToDeploy).when(deploymentUT).getNumberOfRoutersToDeploy();
         doReturn(passPreparation).when(deploymentUT).prepareDeployment();
         doNothing().when(deploymentUT).findVirtualProvider();
@@ -898,7 +783,6 @@ public class RouterDeploymentDefinitionTest extends RouterDeploymentDefinitionTe
         deploymentUT.executeDeployment();
 
         // Assert
-        verify(deploymentUT, times(1)).setupPriorityOfRedundantRouter();
         verify(deploymentUT, times(1)).getNumberOfRoutersToDeploy();
         int proceedToDeployment = 0;
         if (noOfRoutersToDeploy > 0) {

--- a/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
@@ -21,4 +21,4 @@ if [ "$?" -ne "0" ]
 then
 	   STATUS=MASTER
 fi
-echo "Status: ${STATUS}&Bumped: NO"
+echo "Status: ${STATUS}"

--- a/systemvm/patches/debian/config/opt/cloud/templates/checkrouter.sh.templ
+++ b/systemvm/patches/debian/config/opt/cloud/templates/checkrouter.sh.templ
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,45 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-source /root/func.sh
-
-nolock=0
-if [ $# -eq 1 ]
+STATUS=$(cat /etc/cloudstack/cmdline.json | grep redundant_state | awk '{print $2;}' | sed -e 's/[,\"]//g')
+if [ "$?" -ne "0" ]
 then
-    if [ $1 == "--no-lock" ]
-    then
-        nolock=1
-    fi
+	   STATUS=MASTER
 fi
-
-if [ $nolock -eq 0 ]
-then
-    lock="biglock"
-    locked=$(getLockFile $lock)
-    if [ "$locked" != "1" ]
-    then
-        exit 1
-    fi
-fi
-
-bumped="Bumped: NO"
-if [ -e /tmp/rrouter_bumped ]
-then
-    bumped="Bumped: YES"
-fi
-
-state="Status: BACKUP"
-isMaster=`grep -Po '(?<="redundant_master": ")[^"]*' /etc/cloudstack/cmdline.json`
-if [ $? -eq 0 ]
-then
-    if [ "$isMaster" = true ] ; then
-        state="Status: MASTER"
-    fi
-    echo "$state&$bumped"
-fi
-
-if [ $nolock -eq 0 ]
-then
-    unlock_exit $? $lock $locked
-fi
+echo "Status: ${STATUS}"


### PR DESCRIPTION
   - With the changes added by the rVPC work, the bump priority became deprecated.
     This commit includes a refactor to get it removed from the following resources:
     * Java classes
     * domain_router table - removing the is_priority_bumpup column
     * Fixing unit tests

All changes were tested with:

XenServer 6.2 running under our VMWare zone
CloudStack Management Server running on MacBook Pro
MySql running on MackBook Pro
Storage Type: Local

Test Create Account and user for that account ... === TestName: test_01_create_account | Status : SUCCESS ===
ok
Test Sub domain allowed to launch VM  when a Domain level zone is created ... === TestName: test_01_add_vm_to_subdomain | Status : SUCCESS ===
ok
Test delete domain without force option ... === TestName: test_DeleteDomain | Status : SUCCESS ===
ok
Test delete domain with force option ... === TestName: test_forceDeleteDomain | Status : SUCCESS ===
ok
Test update admin details ... === TestName: test_updateAdminDetails | Status : SUCCESS ===
ok
Test update domain admin details ... === TestName: test_updateDomainAdminDetails | Status : SUCCESS ===
ok
Test user update API ... === TestName: test_updateUserDetails | Status : SUCCESS ===
ok
Test login API with domain ... === TestName: test_LoginApiDomain | Status : SUCCESS ===
ok
Test if Login API does not return UUID's ... === TestName: test_LoginApiUuidResponse | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 9 tests in 1165.016s

OK
/tmp//MarvinLogs/test_accounts_7Q4OAG/results.txt (END)




Test router internal advanced zone ... SKIP: Marvin configuration has no host credentials to check router services
Test restart network ... === TestName: test_03_restart_network_cleanup | Status : SUCCESS ===
ok
Test router basic setup ... === TestName: test_05_router_basic | Status : SUCCESS ===
ok
Test router advanced setup ... === TestName: test_06_router_advanced | Status : SUCCESS ===
ok
Test stop router ... === TestName: test_07_stop_router | Status : SUCCESS ===
ok
Test start router ... === TestName: test_08_start_router | Status : SUCCESS ===
ok
Test reboot router ... === TestName: test_09_reboot_router | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 7 tests in 438.824s

OK (SKIP=1)
/tmp//MarvinLogs/test_routers_IYY39F/results.txt (END)




Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... SKIP: At least two hosts should be present in the zone for migration
Test destroy(expunge) Virtual Machine ... === TestName: test_09_expunge_vm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 10 tests in 896.406s

OK (SKIP=1)
/tmp//MarvinLogs/test_vm_life_cycle_YMQT53/results.txt (END)




Test migrate of router after addition of one guest network ... SKIP: No host available for migration. Test requires atleast 2 hosts
Test to change service offering of router after addition of one guest network ... === TestName: test_07_chg_srv_off_router_after_addition_of_one_guest_network | Status : SUCCESS ===
ok
Test destroy of router after addition of one guest network ... === TestName: test_08_destroy_router_after_addition_of_one_guest_network | Status : SUCCESS ===
ok
Test to stop and start router after creation of VPC ... === TestName: test_01_stop_start_router_after_creating_vpc | Status : SUCCESS ===
ok
Test to reboot the router after creating a VPC ... === TestName: test_02_reboot_router_after_creating_vpc | Status : SUCCESS ===
ok
Test migration of router to another host after creating VPC ... SKIP: No host available for migration. Test requires atleast 2 hosts
Tests to change service offering of the Router after ... === TestName: test_04_change_service_offerring_vpc | Status : SUCCESS ===
ok
Test to destroy the router after creating a VPC ... === TestName: test_05_destroy_router_after_creating_vpc | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 8 tests in 658.661s

OK (SKIP=2)
/tmp//MarvinLogs/test_redundant_vpc_B8W8PF/results.txt (END)




Test to create service offering ... === TestName: test_01_create_service_offering | Status : SUCCESS ===
ok
Test to update existing service offering ... === TestName: test_02_edit_service_offering | Status : SUCCESS ===
ok
Test to delete service offering ... === TestName: test_03_delete_service_offering | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 3 tests in 257.889s

OK
/tmp//MarvinLogs/test_service_offerings_XQKSQK/results.txt (END)




Test start/stop of router after addition of one guest network ... === TestName: test_01_start_stop_router_after_addition_of_one_guest_network | Status : SUCCESS ===
ok
Test reboot of router after addition of one guest network ... === TestName: test_02_reboot_router_after_addition_of_one_guest_network | Status : SUCCESS ===
ok
Test to change service offering of router after addition of one guest network ... === TestName: test_04_chg_srv_off_router_after_addition_of_one_guest_network | Status : SUCCESS ===
ok
Test destroy of router after addition of one guest network ... === TestName: test_05_destroy_router_after_addition_of_one_guest_network | Status : SUCCESS ===
ok
Test to stop and start router after creation of VPC ... === TestName: test_01_stop_start_router_after_creating_vpc | Status : SUCCESS ===
ok
Test to reboot the router after creating a VPC ... === TestName: test_02_reboot_router_after_creating_vpc | Status : SUCCESS ===
ok
Tests to change service offering of the Router after ... === TestName: test_04_change_service_offerring_vpc | Status : SUCCESS ===
ok
Test to destroy the router after creating a VPC ... === TestName: test_05_destroy_router_after_creating_vpc | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 8 tests in 843.583s

OK
/tmp//MarvinLogs/test_vpc_routers_U0K0B9/results.txt (END)



Test create VPC offering ... === TestName: test_01_create_vpc_offering | Status : SUCCESS ===
ok
Test VPC offering without load balancing service ... === TestName: test_03_vpc_off_without_lb | Status : SUCCESS ===
ok
Test VPC offering without static NAT service ... === TestName: test_04_vpc_off_without_static_nat | Status : SUCCESS ===
ok
Test VPC offering without port forwarding service ... === TestName: test_05_vpc_off_without_pf | Status : SUCCESS ===
ok
Test VPC offering with invalid services ... === TestName: test_06_vpc_off_invalid_services | Status : SUCCESS ===
ok
Test update VPC offering ... === TestName: test_07_update_vpc_off | Status : SUCCESS ===
ok
Test list VPC offering ... === TestName: test_08_list_vpc_off | Status : SUCCESS ===
ok
test_09_create_redundant_vpc_offering (integration.acs.tests.test_vpc_offerings.TestVPCOffering) ... === TestName: test_09_create_redundant_vpc_offering | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 8 tests in 676.956s

OK
/tmp//MarvinLogs/test_vpc_offerings_0M441V/results.txt (END)



test_privategw_acl (integration.acs.tests.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_privategw_acl | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 100.801s

OK
/tmp//MarvinLogs/test_privategw_acl_3R9O5I/results.txt (END)



Test VPN in VPC ... === TestName: test_vpc_remote_access_vpn | Status : SUCCESS ===
ok
Test VPN in VPC ... === TestName: test_vpc_site2site_vpn | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 2 tests in 395.555s

OK
/tmp//MarvinLogs/test_vpc_vpn_P94PXY/results.txt (END)



Test reset virtual machine on reboot ... === TestName: test_01_reset_vm_on_reboot | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 227.783s

OK
/tmp//MarvinLogs/test_reset_vm_on_reboot_YUAXBK/results.txt (END)