### PR TITLE
CLOUDSTACK-8361: Adding functionality in marvin to check the port groups in VCenter corresponding to configuration of traffics in physical networks

### DIFF
--- a/tools/marvin/marvin/codes.py
+++ b/tools/marvin/marvin/codes.py
@@ -111,6 +111,7 @@ CHILD_DOMAIN_ADMIN="child domain admin"
 Network states
 '''
 ALLOCATED = "Allocated"
+
 '''
 Storage Tags
 '''
@@ -118,3 +119,11 @@ ZONETAG1 = "zwps1"
 ZONETAG2 = "zwps2"
 CLUSTERTAG1 = "cwps1"
 CLUSTERTAG2 = "cwps2"
+
+'''
+Traffic Types
+'''
+PUBLIC_TRAFFIC = "public"
+GUEST_TRAFFIC = "guest"
+MANAGEMENT_TRAFFIC = "management"
+STORAGE_TRAFFIC = "storage"

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -4795,4 +4795,32 @@ class Usage:
         [setattr(cmd, k, v) for k, v in kwargs.items()]
         return(apiclient.generateUsageRecords(cmd))
 
+class TrafficType:
+    """Manage different traffic types in the setup"""
+
+    def __init__(self, items):
+        self.__dict__.update(items)
+
+    @classmethod
+    def list(cls, apiclient, **kwargs):
+        """Lists traffic types"""
+
+        cmd = listTrafficTypes.listTrafficTypesCmd()
+        [setattr(cmd, k, v) for k, v in kwargs.items()]
+        return(apiclient.listTrafficTypes(cmd))
+
+class StorageNetworkIpRange:
+    """Manage Storage Network Ip Range"""
+
+    def __init__(self, items):
+        self.__dict__.update(items)
+
+    @classmethod
+    def list(cls, apiclient, **kwargs):
+        """Lists Storage Network IP Ranges"""
+
+        cmd = listStorageNetworkIpRange.listStorageNetworkIpRangeCmd()
+        [setattr(cmd, k, v) for k, v in kwargs.items()]
+        return(apiclient.listStorageNetworkIpRange(cmd))
+
 


### PR DESCRIPTION
Adding common function in marvin which can be called from any test case. The function verifies that Port groups are present in a VCenter corresponding the different traffics present in physical networks of zones.