### PR TITLE
CLOUDSTACK-8366 Add more Test cases for vMotion support on VMFS as primary storage

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -1003,6 +1003,13 @@ class Snapshot:
             cmd.projectid = projectid
         return Snapshot(apiclient.createSnapshot(cmd).__dict__)
 
+    @classmethod
+    def deletesnap(cls, apiclient, snapid):
+        """Delete Snapshot"""
+        cmd = deleteSnapshot.deleteSnapshotCmd()
+        cmd.id = snapid
+        return apiclient.deleteSnapshot(cmd)
+
     def delete(self, apiclient):
         """Delete Snapshot"""
         cmd = deleteSnapshot.deleteSnapshotCmd()
@@ -4794,33 +4801,5 @@ class Usage:
         cmd = generateUsageRecords.generateUsageRecordsCmd()
         [setattr(cmd, k, v) for k, v in kwargs.items()]
         return(apiclient.generateUsageRecords(cmd))
-
-class TrafficType:
-    """Manage different traffic types in the setup"""
-
-    def __init__(self, items):
-        self.__dict__.update(items)
-
-    @classmethod
-    def list(cls, apiclient, **kwargs):
-        """Lists traffic types"""
-
-        cmd = listTrafficTypes.listTrafficTypesCmd()
-        [setattr(cmd, k, v) for k, v in kwargs.items()]
-        return(apiclient.listTrafficTypes(cmd))
-
-class StorageNetworkIpRange:
-    """Manage Storage Network Ip Range"""
-
-    def __init__(self, items):
-        self.__dict__.update(items)
-
-    @classmethod
-    def list(cls, apiclient, **kwargs):
-        """Lists Storage Network IP Ranges"""
-
-        cmd = listStorageNetworkIpRange.listStorageNetworkIpRangeCmd()
-        [setattr(cmd, k, v) for k, v in kwargs.items()]
-        return(apiclient.listStorageNetworkIpRange(cmd))
 
 

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -1003,13 +1003,6 @@ class Snapshot:
             cmd.projectid = projectid
         return Snapshot(apiclient.createSnapshot(cmd).__dict__)
 
-    @classmethod
-    def deletesnap(cls, apiclient, snapid):
-        """Delete Snapshot"""
-        cmd = deleteSnapshot.deleteSnapshotCmd()
-        cmd.id = snapid
-        return apiclient.deleteSnapshot(cmd)
-
     def delete(self, apiclient):
         """Delete Snapshot"""
         cmd = deleteSnapshot.deleteSnapshotCmd()
@@ -2512,6 +2505,35 @@ class Host:
         return(apiclient.updateHost(cmd))
 
     @classmethod
+    def getState(cls, apiclient, hostid, state, resourcestate, timeout=600):
+        """List Host and check if its resource state is as expected
+        @returnValue - List[Result, Reason]
+                       1) Result - FAIL if there is any exception
+                       in the operation or Host state does not change
+                       to expected state in given time else PASS
+                       2) Reason - Reason for failure"""
+
+        returnValue = [FAIL, "VM state not trasited to %s,\
+                        operation timed out" % state]
+
+        while timeout > 0:
+            try:
+                hosts = Host.list(apiclient, 
+                          id=hostid, listall=True)
+                validationresult = validateList(hosts)
+                if validationresult[0] == FAIL:
+                    raise Exception("Host list validation failed: %s" % validationresult[2])
+                elif str(hosts[0].state).lower().decode("string_escape") == str(state).lower() and str(hosts[0].resourcestate).lower().decode("string_escape") == str(resourcestate).lower():
+                    returnValue = [PASS, None]
+                    break
+            except Exception as e:
+                returnValue = [FAIL, e]
+                break
+            time.sleep(60)
+            timeout -= 60
+        return returnValue
+
+    @classmethod
     def reconnect(cls, apiclient, **kwargs):
         """Reconnect the Host"""
         
@@ -2628,6 +2650,35 @@ class StoragePool:
         cmd=updateStoragePool.updateStoragePoolCmd()
         [setattr(cmd, k, v) for k, v in kwargs.items()]
         return apiclient.updateStoragePool(cmd)
+
+    @classmethod
+    def getState(cls, apiclient, poolid, state, timeout=600):
+        """List StoragePools and check if its  state is as expected
+        @returnValue - List[Result, Reason]
+                       1) Result - FAIL if there is any exception
+                       in the operation or pool state does not change
+                       to expected state in given time else PASS
+                       2) Reason - Reason for failure"""
+
+        returnValue = [FAIL, "VM state not trasited to %s,\
+                        operation timed out" % state]
+
+        while timeout > 0:
+            try:
+                pools = StoragePool.list(apiclient, 
+                          id=poolid, listAll=True)
+                validationresult = validateList(pools)
+                if validationresult[0] == FAIL:
+                    raise Exception("Host list validation failed: %s" % validationresult[2])
+                elif str(pools[0].state).lower().decode("string_escape") == str(state).lower():
+                    returnValue = [PASS, None]
+                    break
+            except Exception as e:
+                returnValue = [FAIL, e]
+                break
+            time.sleep(60)
+            timeout -= 60
+        return returnValue
 
 class Network:
     """Manage Network pools"""

--- a/tools/marvin/marvin/lib/utils.py
+++ b/tools/marvin/marvin/lib/utils.py
@@ -41,18 +41,18 @@ from marvin.codes import (
                           EMPTY_LIST,
                           FAILED)
 
-def restart_mgmt_server(server):
+def restart_mgmt_server(hostip, port, username, password):
     """Restarts the management server"""
 
     try:
         # Get the SSH client
         ssh = is_server_ssh_ready(
-            server["ipaddress"],
-            server["port"],
-            server["username"],
-            server["password"],
+            hostip,
+            port,
+            username,
+            password,
         )
-        result = ssh.execute("/etc/init.d/cloud-management restart")
+        result = ssh.execute("/etc/init.d/cloudstack-management restart")
         res = str(result)
         # Server Stop - OK
         # Server Start - OK
@@ -60,7 +60,7 @@ def restart_mgmt_server(server):
             raise ("ErrorInReboot!")
     except Exception as e:
         raise e
-    return
+    return 
 
 
 def fetch_latest_mail(services, from_mail):

--- a/tools/marvin/marvin/lib/utils.py
+++ b/tools/marvin/marvin/lib/utils.py
@@ -41,18 +41,18 @@ from marvin.codes import (
                           EMPTY_LIST,
                           FAILED)
 
-def restart_mgmt_server(hostip, port, username, password):
+def restart_mgmt_server(server):
     """Restarts the management server"""
 
     try:
         # Get the SSH client
         ssh = is_server_ssh_ready(
-            hostip,
-            port,
-            username,
-            password,
+            server["ipaddress"],
+            server["port"],
+            server["username"],
+            server["password"],
         )
-        result = ssh.execute("/etc/init.d/cloudstack-management restart")
+        result = ssh.execute("/etc/init.d/cloud-management restart")
         res = str(result)
         # Server Stop - OK
         # Server Start - OK
@@ -60,8 +60,7 @@ def restart_mgmt_server(hostip, port, username, password):
             raise ("ErrorInReboot!")
     except Exception as e:
         raise e
-    return 
-
+    return
 
 def fetch_latest_mail(services, from_mail):
     """Fetch mail"""


### PR DESCRIPTION
This commits adds few more tests for storage live migration.
It has used data driven testing to add  tests for migration within same cluster and across clusters.

The code has been tested on a vmware environment having multiple clusters and VMFS type primary storages.

Migrate VMs/Volumes on VMware with VMFS storage ... === TestName: test_01_vm_and_volumes_live_for_vmware_vmfs_in_same_cluster_1_different_cluster | Status : SUCCESS ===
ok
Migrate VMs/Volumes on VMware with VMFS storage ... === TestName: test_01_vm_and_volumes_live_for_vmware_vmfs_in_same_cluster_2_same_cluster | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 2 tests in 2120.147s

OK