### PR TITLE
Fixing the communication with VM via Public IP

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -129,10 +129,11 @@ class CsInterface:
         if self.config.is_vpc():
             return self.get_attr("gateway")
         else:
-            if self.config.cmdline().is_redundant():
-                return self.config.cmdline().get_guest_gw()
-            else:
-                return self.get_ip()
+            return self.config.cmdline().get_guest_gw()
+#             if self.config.cmdline().is_redundant():
+#                 return self.config.cmdline().get_guest_gw()
+#             else:
+#                 return self.get_ip()
 
     def ip_in_subnet(self, ip):
         ipo = IPAddress(ip)

--- a/systemvm/patches/debian/config/opt/cloud/templates/keepalived.conf.templ
+++ b/systemvm/patches/debian/config/opt/cloud/templates/keepalived.conf.templ
@@ -19,12 +19,6 @@ global_defs {
    router_id [ROUTER_ID]
 }
 
-!vrrp_script check_bumpup {
-    !script "[RROUTER_BIN_PATH]/check_bumpup.sh"
-    !interval 5
-    !weight [DELTA]
-!}
-
 vrrp_script heartbeat {
     script "[RROUTER_BIN_PATH]/heartbeat.sh"
     interval 10
@@ -48,7 +42,6 @@ vrrp_instance inside_network {
     }
 
     track_script {
-        !check_bumpup
         heartbeat
     }
 


### PR DESCRIPTION
   - Pub IP port forwarding and static NAT fixed for single VPCs
   - Pub IP port forwarding fixed for redundant VPCs

[wip] fix static NAT for redundant VPCs

XenServer 6.2 host running under our VMWare zone
Management Server running on my MacBook
MySQL running on my MacBook

Manual tests executed agains single/redundant VPC

1. Create Single VPC
2. Add ACL - port 22
3. Add 2 tiers
4. Add 1 VM to each tier
5. SSH into the VMs
6. Acquire a new pub IP
7. Add PF to the new pub IP associated with tier #1
8. SSH into the VM through the pub IP
9. Acquire a new pub IP
10. Create a static NAT connection associated with tier #2
11. SSH into the VM using the new pub IP

1. Create Redundant VPC
2. Add ACL - port 22
3. Add 2 tiers
4. Add 2 VMs to each tier
5. SSH into the VMs
6. Acquire a new pub IP
7. Add PF to the new pub IP associated with tier #1
8. SSH into the VM through the pub IP
9. Acquire a new pub IP
10. Create a static NAT connection associated with tier #2
11. SSH into the VM using the new pub IP