### PR TITLE
KVM: make sure sync cannot block reboot

### DIFF
--- a/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
+++ b/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
@@ -156,7 +156,8 @@ then
 elif [ "$cflag" == "1" ]
 then
   /usr/bin/logger -t heartbeat "kvmheartbeat.sh rebooted system because it was unable to write the heartbeat to the storage."
-  sync
+  sync &
+  sleep 5
   echo b > /proc/sysrq-trigger
   exit $?
 else


### PR DESCRIPTION
The recent discussed improvement has the risk that if 'sync' hangs, the reboot may be delayed in the same way as the 'reboot' command would do. To work around, we're adding a 5 second timeout. If it cannot sync in 5 seconds, it will not succeed anyway and we should proceed the reset.

@snuf: As a future improvement: Could we use your OVM3 heartbeat script for other hypervisors as well? One way to do it seems like a nice idea :-)