### PR TITLE
verifying template creation permission based on global parameter

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -791,6 +791,8 @@ test_data = {
         "displaytext": "xs",
         "name": "xs",
         "passwordenabled": False,
+        "ostype": "CentOS 5.6 (64-bit)"
+
     },
     "template_2": {
         "displaytext": "Public Template",

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -872,6 +872,10 @@ class Volume:
         cmd.snapshotid = snapshot_id
         cmd.zoneid = services["zoneid"]
         cmd.size = services["size"]
+        if services["ispublic"]:
+            cmd.ispublic = services["ispublic"]
+        else:
+            cmd.ispublic = False
         if account:
             cmd.account = account
         else:


### PR DESCRIPTION
Test to create Public Template by registering or by snapshot and volume when
        Global parameter 'allow.public.user.template' is set to  False
        @steps:
        1.Set Global parameter 'allow.public.user.template' as False. Restart Management server
        2. Create a domain
        3. Create a domain admin and a domain user
        4. Create a vm as domain user
        5. take snapshot of root disk as user vm
        6. try to create public template from snapshot . It should fail
        7. stop the VM
        8. take the public template from volume. it should fail
        9. register a public template as a domain user . it should fail
        10. create a VM  as domain admin
        11. create a snapshot of root disk as domain admin
        12 create a public template of the snapshot .it should fail
        13. Register a public template as domain admin. it should fail
        14 Stop the vm as domain admin
        15. Create a template from volume as domain admin . it should fail