### PR TITLE
CLOUDSTACK-8377: Marvin - base library - Fix list method for PhysicalNetwork class

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -3327,8 +3327,7 @@ class PhysicalNetwork:
         [setattr(cmd, k, v) for k, v in kwargs.items()]
         if 'account' in kwargs.keys() and 'domainid' in kwargs.keys():
             cmd.listall = True
-        return map(lambda pn: PhysicalNetwork(
-            pn.__dict__), apiclient.listPhysicalNetworks(cmd))
+        return(apiclient.listPhysicalNetworks(cmd))
 
 
 class SecurityGroup:


### PR DESCRIPTION
Removed map() from list method for PhysicalNetwork class.
map() function works only when the second argument is a list. However, when there are no physical networks in the zone, the API will return None and it will be passed as second argument to map. It will fail in this case.

Instead return the API response as it is. No need to use map().

Tested.