### PR TITLE
CLOUDSTACK-8380: Adding script to testSetupSuccess.py to check VCenter port groups are created for storage, management and public traffic as soon as zone is deployed

### DIFF
--- a/setup/dev/advanced.cfg
+++ b/setup/dev/advanced.cfg
@@ -55,6 +55,12 @@
                     ]
                 }
             ],
+            "vmwaredc": {
+                "username": "",
+                "vcenter": "",
+                "password": "",
+                "name": ""
+            },
             "ipranges": [
                 {
                     "startip": "192.168.2.2",


### PR DESCRIPTION
This test will be run on vmware zone once the zone is up, if the zone uses vmware DVS.
Data Center Details must filled up in config dict.

Tested on Vmware and KVM. On KVM it skips.

VMware:
Test correct VCenter ports are created for all traffic types ... === TestName: test_VCenterPorts | Status : SUCCESS ===
ok
system VMs need to be ready and Running for each zone in cloudstack ... SKIP: skip
built-in templates CentOS to be ready ... SKIP: skip

----------------------------------------------------------------------
Ran 3 tests in 25.920s

OK (SKIP=2)



on KVM:
Test correct VCenter ports are created for all traffic types ... SKIP: This test is intended only for vmware
system VMs need to be ready and Running for each zone in cloudstack ... SKIP: skip
built-in templates CentOS to be ready ... SKIP: skip

----------------------------------------------------------------------
Ran 3 tests in 0.021s

OK (SKIP=3)



Other Changes:
1. Increases retry count while checking system VM state
2. Fixed import* issues


Travis might fail in case the pull request at https://github.com/apache/cloudstack/pull/155 is not closed.
Please merge above mentioned pull request first and then try to merge this one.