### PR TITLE
CLOUDSTACK-6885: fix logrotate on VR to depend on size

### DIFF
--- a/systemvm/patches/debian/config/etc/logrotate.d/apache2
+++ b/systemvm/patches/debian/config/etc/logrotate.d/apache2
@@ -4,6 +4,6 @@
        rotate 3
        compress
        dateext
-       size=+10M
+       size 10M
        notifempty
 }

--- a/systemvm/patches/debian/config/etc/logrotate.d/cloud
+++ b/systemvm/patches/debian/config/etc/logrotate.d/cloud
@@ -17,6 +17,7 @@
 /var/log/cloud.log {
         rotate 4
         daily
+        size 10M
         missingok
         notifempty
         compress

--- a/systemvm/patches/debian/config/etc/logrotate.d/conntrackd
+++ b/systemvm/patches/debian/config/etc/logrotate.d/conntrackd
@@ -1,5 +1,6 @@
 /var/log/conntrackd-stats.log {
     daily
+    size 10M
     rotate 2
     missingok
     compress

--- a/systemvm/patches/debian/config/etc/logrotate.d/dnsmasq
+++ b/systemvm/patches/debian/config/etc/logrotate.d/dnsmasq
@@ -1,5 +1,6 @@
 /var/log/dnsmasq.log {
     daily
+    size 10M
     missingok
     rotate 5
     notifempty

--- a/systemvm/patches/debian/config/etc/logrotate.d/ppp
+++ b/systemvm/patches/debian/config/etc/logrotate.d/ppp
@@ -1,5 +1,6 @@
 /var/log/ppp-connect-errors {
 	daily
+	size 10M
 	rotate 5
 	missingok
 	notifempty


### PR DESCRIPTION
In 6ac06e5e5e3ceed4a3e3a86ea5f82ffb59c266f2 logrotate was changed to run hourly. Some logrotate configs still have set `daily` only which results in logs not rotated hourly. The only way to ensure the log is rotated is to use size.