### PR TITLE
Upgrades from 4.4: disable foreign key checks when altering them

### DIFF
--- a/setup/db/db/schema-442to450.sql
+++ b/setup/db/db/schema-442to450.sql
@@ -37,6 +37,7 @@ ALTER TABLE `cloud`.`volumes` ADD COLUMN `provisioning_type` VARCHAR(32) NOT NUL
 ALTER TABLE `cloud`.`disk_offering` ADD COLUMN `provisioning_type` VARCHAR(32) NOT NULL DEFAULT 'thin' COMMENT 'pre allocation setting of the volume';
 
 -- Have primary keys of following table AUTO_INCREMENT
+SET foreign_key_checks = 0;
 ALTER TABLE `cloud`.`region` MODIFY `id` int unsigned AUTO_INCREMENT UNIQUE NOT NULL;
 ALTER TABLE `cloud`.`vm_instance` MODIFY `id` bigint unsigned AUTO_INCREMENT UNIQUE NOT NULL;
 ALTER TABLE `cloud`.`user_vm` MODIFY `id` bigint unsigned AUTO_INCREMENT UNIQUE NOT NULL;
@@ -44,6 +45,7 @@ ALTER TABLE `cloud`.`domain_router` MODIFY `id` bigint unsigned AUTO_INCREMENT U
 ALTER TABLE `cloud`.`service_offering` MODIFY `id` bigint unsigned AUTO_INCREMENT NOT NULL;
 ALTER TABLE `cloud`.`load_balancing_rules` MODIFY `id` bigint unsigned AUTO_INCREMENT NOT NULL;
 ALTER TABLE `cloud`.`port_forwarding_rules` MODIFY `id` bigint unsigned AUTO_INCREMENT NOT NULL;
+SET foreign_key_checks = 1;
 
 DROP VIEW IF EXISTS `cloud`.`disk_offering_view`;
 CREATE VIEW `cloud`.`disk_offering_view` AS


### PR DESCRIPTION
Upgrades from 4.4 where not working properly due to errors like this:

ERROR 1833 (HY000): Cannot change column 'id': used in a foreign key constraint 'fk_global_load_balancing_rules_region_id' of table 'cloud.global_load_balancing_rules'

The disabling of the checks is for the current session only, so it's safe.

@bhaisaab: Could you have a look since I changed your code? Thanks!

Note: In the 4.4 branch, this file used to be at:
client/target/utilities/scripts/db/db/schema-442to450.sql
It's now moved. We need to edit it in 4.4 and 4.5 to have it effective for all upgrade paths.
