### PR TITLE
CLOUDSTACK-8374: Adding tests for guest traffic port group verification -  Shared and Isolated networks

### DIFF
--- a/test/integration/component/test_vpc_vm_life_cycle.py
+++ b/test/integration/component/test_vpc_vm_life_cycle.py
@@ -43,7 +43,8 @@ from marvin.lib.common import (get_domain,
                                            wait_for_cleanup,
                                            list_virtual_machines,
                                            list_hosts,
-                                           findSuitableHostForMigration)
+                                           findSuitableHostForMigration,
+                                           verifyGuestTrafficPortGroups)
 
 from marvin.codes import PASS, ERROR_NO_HOST_FOR_MIGRATION
 
@@ -1734,6 +1735,7 @@ class TestVMLifeCycleBothIsolated(cloudstackTestCase):
         cls.api_client = cls.testClient.getApiClient()
 
         cls.services = Services().services
+        cls.hypervisor = cls.testClient.getHypervisorInfo()
         # Get Zone, Domain and templates
         cls.domain = get_domain(cls.api_client)
         cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
@@ -2059,6 +2061,17 @@ class TestVMLifeCycleBothIsolated(cloudstackTestCase):
                          "VM state should be running after deployment"
                          )
         return
+
+    @attr(tags=["advanced", "dvs"], required_hardware="true")
+    def test_guest_traffic_port_groups_vpc_network(self):
+        """ Verify port groups are created for guest traffic
+        used by vpc network """
+
+        if self.hypervisor.lower() == "vmware":
+            response = verifyGuestTrafficPortGroups(self.apiclient,
+                                                    self.config,
+                                                    self.zone)
+            assert response[0] == PASS, response[1]
 
 class TestVMLifeCycleStoppedVPCVR(cloudstackTestCase):
 

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -17,7 +17,8 @@
 """ BVT tests for Network Life Cycle
 """
 # Import Local Modules
-from marvin.codes import FAILED, STATIC_NAT_RULE, LB_RULE, NAT_RULE
+from marvin.codes import (FAILED, STATIC_NAT_RULE, LB_RULE,
+                          NAT_RULE, PASS)
 from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.cloudstackException import CloudstackAPIException
 from marvin.cloudstackAPI import rebootRouter
@@ -43,7 +44,8 @@ from marvin.lib.common import (get_domain,
                                list_routers,
                                list_virtual_machines,
                                list_lb_rules,
-                               list_configurations)
+                               list_configurations,
+                               verifyGuestTrafficPortGroups)
 from nose.plugins.attrib import attr
 from ddt import ddt, data
 # Import System modules
@@ -247,6 +249,7 @@ class TestPortForwarding(cloudstackTestCase):
         testClient = super(TestPortForwarding, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
         cls.services = testClient.getParsedTestDataConfig()
+        cls.hypervisor = testClient.getHypervisorInfo()
         # Get Zone, Domain and templates
         cls.domain = get_domain(cls.apiclient)
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
@@ -550,6 +553,17 @@ class TestPortForwarding(cloudstackTestCase):
                 delay=0
             )
         return
+
+    @attr(tags=["advanced", "dvs"], required_hardware="true")
+    def test_guest_traffic_port_groups_isolated_network(self):
+        """ Verify port groups are created for guest traffic
+        used by isolated network """
+
+        if self.hypervisor.lower() == "vmware":
+            response = verifyGuestTrafficPortGroups(self.apiclient,
+                                                    self.config,
+                                                    self.zone)
+            assert response[0] == PASS, response[1]
 
 
 class TestRebootRouter(cloudstackTestCase):


### PR DESCRIPTION
For Isolated network, network and VM is already created in setUpClass, so only adding verification steps as separate test case.
Adding new test case for shared network.

Could not run this on DVS setup. Port group verification code has been already tested on DVS setup. Tested remaining steps on advanced KVM setup to ensure there are no other issues.

Log:
Verify vcenter port groups are created for shared network ... === TestName: test_guest_traffic_port_groups_shared_network | Status : SUCCESS   ===
ok