### PR TITLE
Make the routers iptables config persistent through reboot/crash

### DIFF
--- a/systemvm/patches/debian/config/etc/rc.local
+++ b/systemvm/patches/debian/config/etc/rc.local
@@ -46,3 +46,16 @@ python /opt/cloud/bin/baremetal-vr.py &
 
 date > /var/cache/cloud/boot_up_done
 logger -t cloud "Boot up process done"
+
+#Restore the persistent iptables nat, rules and filters for IPv4 and IPv6 if they exist
+ipv4="/etc/iptables/router_rules.v4"
+if [ -e $ipv4 ]
+then
+   iptables-restore < $ipv4
+fi
+
+ipv6="/etc/iptables/router_rules.v6"
+if [ -e $ipv6 ]
+then
+   iptables-restore < $ipv6
+fi

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -676,6 +676,10 @@ def main(argv):
 
     mon = CsMonitor("monitorservice", config)
     mon.process()
-
+    
+    #Save iptables configuration - will be loaded on reboot by the iptables-restore that is configured on /etc/rc.local
+    CsHelper.save_iptables("iptables-save", "/etc/iptables/router_rules.v4")
+    CsHelper.save_iptables("ip6tables-save", "/etc/iptables/router_rules.v6")
+    
 if __name__ == "__main__":
     main(sys.argv)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """ General helper functions
-for use in the configuation process
+for use in the configuration process
 
 """
 import subprocess
@@ -26,7 +26,6 @@ import re
 import shutil
 from netaddr import *
 from pprint import pprint
-
 
 def is_mounted(name):
     for i in execute("mount"):
@@ -161,6 +160,19 @@ def execute(command):
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     result = p.communicate()[0]
     return result.splitlines()
+
+
+def save_iptables(command, iptables_file):
+    """ Execute command """
+    logging.debug("Saving iptables for %s" % command)
+    
+    result = execute(command)
+    fIptables = open(iptables_file, "w+")
+    
+    for line in result:
+        fIptables.write(line)
+        fIptables.write("\n")
+    fIptables.close()
 
 
 def execute2(command):


### PR DESCRIPTION
  - After configuration save the ipdated in files
    * /etc/iptables/router_rules.v4 and /etc/iptables/router_rules.v6
    * Reload the configuration on reboot via the /etc/rc.local using iptables-restore

- All the information about the router VMs is now persisted due to the work on the rVPC/Persistent SystemVM done in the few months ago. The missing bit was the iptables configuration, which was not surviving a crash or reboot not done via the management server. 

- Manual tests
  * Create single VPC, 3 Tiers, 3 VMs, 3 pub IPs
  * Connect to router and reboot it
  * Wait for the router to come back and check IPtables/connect to VMs
  * Create redundant VPC, 3 Tiers, 3 VMs, 3 pub IPs
  * Connect to router and reboot it
  * Wait for the router to come back and check IPtables/connect to VMs
  * Create isolated network, 1 VM, 1 pub IP
  * Connect to router and reboot it
  * Wait for the router to come back and check IPtables/connect to VM

Tests executed against XenServer 6.2 compliant host

This fix CLOUDSTACK-4605