### PR TITLE
use eu.ceph.com as ceph.com is down

### DIFF
--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -25,7 +25,7 @@
     </repository>
     <repository>
       <id>ceph-com</id>
-      <url>http://ceph.com/maven</url>
+      <url>http://eu.ceph.com/maven</url>
     </repository>
   </repositories>
   <dependencies>


### PR DESCRIPTION
Same change as in https://github.com/apache/cloudstack/commit/05e4ba7350e7da36e3b9511d5e987c84b0be7ab5