### PR TITLE
RFC: improve iptables persistent on VR

### DIFF
--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -984,9 +984,9 @@ setup_router() {
   enable_fwding 1
   enable_rpsrfs 1
   chkconfig nfs-common off
-  cp /etc/iptables/iptables-router /etc/iptables/rules.v4
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-router /etc/iptables/rules.v4
 #for old templates
-  cp /etc/iptables/iptables-router /etc/iptables/rules
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-router /etc/iptables/rules
   setup_sshd $ETH1_IP "eth1"
   load_modules
 
@@ -1075,8 +1075,8 @@ EOF
   enable_svc cloud 0
   disable_rpfilter
   enable_fwding 1
-  cp /etc/iptables/iptables-vpcrouter /etc/iptables/rules.v4
-  cp /etc/iptables/iptables-vpcrouter /etc/iptables/rules
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-vpcrouter /etc/iptables/rules.v4
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-vpcrouter /etc/iptables/rules
   setup_sshd $ETH0_IP "eth0"
   cp /etc/vpcdnsmasq.conf /etc/dnsmasq.conf
   cp /etc/cloud-nic.rules /etc/udev/rules.d/cloud-nic.rules
@@ -1121,8 +1121,8 @@ setup_dhcpsrvr() {
   enable_fwding 0
   chkconfig nfs-common off
 
-  cp /etc/iptables/iptables-router /etc/iptables/rules.v4
-  cp /etc/iptables/iptables-router /etc/iptables/rules
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-router /etc/iptables/rules.v4
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-router /etc/iptables/rules
 
   #Only allow DNS service for current network
   sed -i "s/-A INPUT -i eth0 -p udp -m udp --dport 53 -j ACCEPT/-A INPUT -i eth0 -p udp -m udp --dport 53 -s $DHCP_RANGE\/$CIDR_SIZE -j ACCEPT/g" /etc/iptables/rules.v4
@@ -1165,8 +1165,8 @@ setup_secstorage() {
   [ "$ETH2_IP" == "0.0.0.0" ] && public_ip=$ETH1_IP
   echo "$public_ip $NAME" >> /etc/hosts
 
-  cp /etc/iptables/iptables-secstorage /etc/iptables/rules.v4
-  cp /etc/iptables/iptables-secstorage /etc/iptables/rules
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-secstorage /etc/iptables/rules.v4
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-secstorage /etc/iptables/rules
   if [ "$hyp" == "vmware" ] || [ "$hyp" == "hyperv" ]; then
     setup_sshd $ETH1_IP "eth1"
   else
@@ -1192,8 +1192,8 @@ setup_console_proxy() {
   [ "$ETH2_IP" == "0.0.0.0" ] && public_ip=$ETH1_IP
   sed -i  /gateway/d /etc/hosts
   echo "$public_ip $NAME" >> /etc/hosts
-  cp /etc/iptables/iptables-consoleproxy /etc/iptables/rules.v4
-  cp /etc/iptables/iptables-consoleproxy /etc/iptables/rules
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-consoleproxy /etc/iptables/rules.v4
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-consoleproxy /etc/iptables/rules
   if [ "$hyp" == "vmware" ] || [ "$hyp" == "hyperv" ]; then
     setup_sshd $ETH1_IP "eth1"
   else
@@ -1220,8 +1220,8 @@ setup_elbvm() {
   [ "$ETH2_IP" == "0.0.0.0" ] || [ "$ETH2_IP" == "" ] && public_ip=$ETH0_IP
   echo "$public_ip $NAME" >> /etc/hosts
 
-  cp /etc/iptables/iptables-elbvm /etc/iptables/rules.v4
-  cp /etc/iptables/iptables-elbvm /etc/iptables/rules
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-elbvm /etc/iptables/rules.v4
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-elbvm /etc/iptables/rules
   if [ "$SSHONGUEST" == "true" ]
   then
     setup_sshd $ETH0_IP "eth0"
@@ -1248,8 +1248,8 @@ setup_ilbvm() {
   sed -i  /$NAME/d /etc/hosts
   echo "$ETH0_IP $NAME" >> /etc/hosts
 
-  cp /etc/iptables/iptables-ilbvm /etc/iptables/rules.v4
-  cp /etc/iptables/iptables-ilbvm /etc/iptables/rules
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-ilbvm /etc/iptables/rules.v4
+  [ -e /etc/iptables/cloud-early-config-iptables.lock ] || cp /etc/iptables/iptables-ilbvm /etc/iptables/rules
   setup_sshd $ETH1_IP "eth1"
   
   enable_fwding 0

--- a/systemvm/patches/debian/config/etc/rc.local
+++ b/systemvm/patches/debian/config/etc/rc.local
@@ -46,16 +46,3 @@ python /opt/cloud/bin/baremetal-vr.py &
 
 date > /var/cache/cloud/boot_up_done
 logger -t cloud "Boot up process done"
-
-#Restore the persistent iptables nat, rules and filters for IPv4 and IPv6 if they exist
-ipv4="/etc/iptables/router_rules.v4"
-if [ -e $ipv4 ]
-then
-   iptables-restore < $ipv4
-fi
-
-ipv6="/etc/iptables/router_rules.v6"
-if [ -e $ipv6 ]
-then
-   iptables-restore < $ipv6
-fi

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -676,10 +676,6 @@ def main(argv):
 
     mon = CsMonitor("monitorservice", config)
     mon.process()
-    
-    #Save iptables configuration - will be loaded on reboot by the iptables-restore that is configured on /etc/rc.local
-    CsHelper.save_iptables("iptables-save", "/etc/iptables/router_rules.v4")
-    CsHelper.save_iptables("ip6tables-save", "/etc/iptables/router_rules.v6")
-    
+
 if __name__ == "__main__":
     main(sys.argv)

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -630,6 +630,24 @@ class CsForwardingRules(CsDataBag):
                         "-A OUTPUT -d %s/32 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])
 
 
+class CsIptables():
+
+    def process(self):
+        self.save_iptables()
+        self.create_lock_file()
+
+    def save_iptables(self):
+        """ Save iptables """
+        logging.debug("Saving iptables")
+        result = CsHelper.execute("service iptables-persistent save")
+
+    def create_lock_file(self):
+        """ Create lockfile, so iptables won't be overwritten in cloud-early-config """
+        lockfile = "/etc/iptables/cloud-early-config-iptables.lock"
+        if CsHelper.addifmissing(lockfile, "if this file exists, iptables won't be overwritten on boot."):
+            logging.debug("Creating iptables lockfile %s" % lockfile)
+
+
 def main(argv):
     config = CsConfig()
     logging.basicConfig(filename=config.get_logger(),
@@ -676,6 +694,9 @@ def main(argv):
 
     mon = CsMonitor("monitorservice", config)
     mon.process()
+
+    iptables = CsIptables()
+    iptables.process()
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """ General helper functions
-for use in the configuration process
+for use in the configuation process
 
 """
 import subprocess
@@ -26,6 +26,7 @@ import re
 import shutil
 from netaddr import *
 from pprint import pprint
+
 
 def is_mounted(name):
     for i in execute("mount"):
@@ -160,19 +161,6 @@ def execute(command):
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     result = p.communicate()[0]
     return result.splitlines()
-
-
-def save_iptables(command, iptables_file):
-    """ Execute command """
-    logging.debug("Saving iptables for %s" % command)
-    
-    result = execute(command)
-    fIptables = open(iptables_file, "w+")
-    
-    for line in result:
-        fIptables.write(line)
-        fIptables.write("\n")
-    fIptables.close()
 
 
 def execute2(command):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """ General helper functions
-for use in the configuation process
+for use in the configuration process
 
 """
 import subprocess


### PR DESCRIPTION
Iptables rules were loaded in `iptables-persistent` service during boot.  So the first try was to save them where `iptables-persistent` reads them in /etc/iptables/rules.v4 / .v6.

The problem was, that the service `cloud-early-config` resets  /etc/iptables/rules.v4 / .v6 to the setup state. So even if you save iptables rules, they were overwritten during boot.

That is why a fix was made in 2fad87d to workaround the problem.

I reverted the workaround and made sure /etc/iptables/rules.v4 / .v6. won't get overwritten by  `cloud-early-config`

Signed-off-by: Rene Moser <resmo@apache.org>