### PR TITLE
CLOUDSTACK-8390: Skipping VPC tests on Hyperv

### DIFF
--- a/test/integration/component/test_multiple_ips_per_nic.py
+++ b/test/integration/component/test_multiple_ips_per_nic.py
@@ -192,6 +192,7 @@ class TestBasicOperations(cloudstackTestCase):
     def setUpClass(cls):
         cls.testClient = super(TestBasicOperations, cls).getClsTestClient()
         cls.api_client = cls.testClient.getApiClient()
+        cls.hypervisor = cls.testClient.getHypervisorInfo().lower()
 
         # Fill services from the external config file
         cls.services = cls.testClient.getParsedTestDataConfig()
@@ -376,6 +377,9 @@ class TestBasicOperations(cloudstackTestCase):
         # 1. Step 4 should succeed
         # 2. Step 5 should fail
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         self.account = Account.create(
             self.apiclient,
             self.services["account"],
@@ -455,6 +459,9 @@ class TestBasicOperations(cloudstackTestCase):
         # 4. Step 7 should fail
         # 5. Step 8 should fail
         # 6. Step 9 should fail
+
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
 
         self.account = Account.create(
             self.apiclient,
@@ -559,6 +566,9 @@ class TestBasicOperations(cloudstackTestCase):
         # Validations:
         # 1. All the operations should be successful
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         child_domain = Domain.create(
             self.apiclient,
             services=self.services["domain"],
@@ -625,6 +635,7 @@ class TestNetworkRules(cloudstackTestCase):
     def setUpClass(cls):
         cls.testClient = super(TestNetworkRules, cls).getClsTestClient()
         cls.api_client = cls.testClient.getApiClient()
+        cls.hypervisor = cls.testClient.getHypervisorInfo().lower()
 
         # Fill services from the external config file
         cls.services = cls.testClient.getParsedTestDataConfig()
@@ -738,6 +749,9 @@ class TestNetworkRules(cloudstackTestCase):
         # 3. Step 6 should succeed
         # 4. Step 7 should fail
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         self.account = Account.create(
             self.apiclient,
             self.services["account"],
@@ -822,6 +836,9 @@ class TestNetworkRules(cloudstackTestCase):
         # Validations:
         # 1. Step 5 should fail
         # 2. Step 6 should succeed
+
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
 
         self.account = Account.create(
             self.apiclient,
@@ -908,6 +925,9 @@ class TestNetworkRules(cloudstackTestCase):
         # Validations:
         # 1. Step 5 should succeed
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         self.account = Account.create(
             self.apiclient,
             self.services["account"],
@@ -981,6 +1001,9 @@ class TestNetworkRules(cloudstackTestCase):
         # 3. Step 6 should succeed
         # 4. Step 7 should fail
         # 5. Step 8 should succeed
+
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
 
         self.account = Account.create(
             self.apiclient,
@@ -1075,6 +1098,9 @@ class TestNetworkRules(cloudstackTestCase):
         # 1. Verify step 5 by listing seconday IP and checking the appropriate
         # flag
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         self.account = Account.create(
             self.apiclient,
             self.services["account"],
@@ -1151,6 +1177,7 @@ class TestVmNetworkOperations(cloudstackTestCase):
     def setUpClass(cls):
         cls.testClient = super(TestVmNetworkOperations, cls).getClsTestClient()
         cls.api_client = cls.testClient.getApiClient()
+        cls.hypervisor = cls.testClient.getHypervisorInfo().lower()
 
         # Fill services from the external config file
         cls.services = cls.testClient.getParsedTestDataConfig()
@@ -1257,6 +1284,9 @@ class TestVmNetworkOperations(cloudstackTestCase):
         # 7. Verify that nat rule does not exist and static nat is not enabled for
         #    secondary IP
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         self.account = Account.create(
             self.apiclient,
             self.services["account"],
@@ -1361,6 +1391,9 @@ class TestVmNetworkOperations(cloudstackTestCase):
         #    static nat rule to 2nd private IP
         # 6. Destroy the virtual machine and recover it
         # 7. Verify that nat and static nat rules exist
+
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
 
         self.account = Account.create(
             self.apiclient,
@@ -1469,6 +1502,9 @@ class TestVmNetworkOperations(cloudstackTestCase):
         # 6. Restart the network with cleanup option True
         # 7. Verify that nat and static nat rules exist after network restart
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         self.account = Account.create(
             self.apiclient,
             self.services["account"],
@@ -1560,6 +1596,9 @@ class TestVmNetworkOperations(cloudstackTestCase):
         # 6. Restart the network with cleanup option False
         # 7. Verify that nat and static nat rules exist after network restart
 
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
+
         self.account = Account.create(
             self.apiclient,
             self.services["account"],
@@ -1650,6 +1689,9 @@ class TestVmNetworkOperations(cloudstackTestCase):
         #    static nat rule to 2nd private IP
         # 6. Reboot router VM
         # 7. Verify that nat and static nat rules exist after router restart
+
+        if value == VPC_NETWORK and self.hypervisor == 'hyperv':
+            self.skipTest("VPC is not supported on Hyper-V")
 
         self.account = Account.create(
             self.apiclient,


### PR DESCRIPTION
VPC network is not supported on hyper-v hypervisor. Skip relevant test cases accordingly.