### PR TITLE
CLOUDSTACK-8335: removed libvirt.org repository

### DIFF
--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -20,13 +20,6 @@
   </parent>
   <repositories>
     <repository>
-      <id>libvirt-org</id>
-      <url>http://libvirt.org/maven2</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <id>ceph-com</id>
       <url>http://eu.ceph.com/maven</url>
       <snapshots>


### PR DESCRIPTION
The only artifact resolved from libvirt.org was org.libvirt:libvirt:0.5.1
this artifact is now available from maven's default central repository

Signed-off-by: Laszlo Hornyak <laszlo.hornyak@gmail.com>