### PR TITLE
fix typo in rsyslog logrotate script on VR

### DIFF
--- a/systemvm/patches/debian/config/etc/logrotate.d/rsyslog
+++ b/systemvm/patches/debian/config/etc/logrotate.d/rsyslog
@@ -32,6 +32,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		/usr/sbin/nvoke-rc.d rsyslog reload > /dev/null
+		/usr/sbin/invoke-rc.d rsyslog reload > /dev/null
 	endscript
 }


### PR DESCRIPTION
This is fixed already in master and 4.5 and did not occur in 4.3 and before. This is a PR against 4.4 to fix it in 4.4 as well.