### PR TITLE
Add more verifications to make sure that removeIpFromNic works fine in case of shared network

### DIFF
--- a/test/integration/component/test_multiple_ips_per_nic.py
+++ b/test/integration/component/test_multiple_ips_per_nic.py
@@ -361,9 +361,8 @@ class TestBasicOperations(cloudstackTestCase):
                 (virtual_machine.id, e))
         return
 
-    #@data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
-    @data(SHARED_NETWORK)
-    @attr(tags=["advanced", "sanj"])
+    @data(ISOLATED_NETWORK, SHARED_NETWORK, VPC_NETWORK)
+    @attr(tags=["advanced"])
     def test_remove_ip_from_nic(self, value):
         """ Remove secondary IP from NIC of a VM"""
 


### PR DESCRIPTION
Added following steps to existing test in case of shared network:
1.After removing secondary ip from nic verify that the allocated state is marked as NULL in user_ip_address table for the ip which was released
2.Add the same ip address again to the same nic to make sure that previous ip removal was successful
3.Then remove it