### PR TITLE
CLOUDSTACK-8394: Use custom decorator to skip test case

### DIFF
--- a/tools/marvin/marvin/lib/decoratorGenerators.py
+++ b/tools/marvin/marvin/lib/decoratorGenerators.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Custom decorator generators used across test cases
+"""
+
+from functools import wraps
+
+def skipTestIf(attribute):
+    def decorator(test):
+        @wraps(test)
+        def test_wrapper(self, *args, **kwargs):
+            if hasattr(self, attribute):
+                if getattr(self, attribute):
+                    self.skipTest("Skipping test: Reason -  %s" % attribute)
+                else:
+                    return test(self, *args, **kwargs)
+            else:
+                return test(self, *args, **kwargs)
+        return test_wrapper
+    return decorator


### PR DESCRIPTION
When the tests are skipped through setUpClass, the statement "raise unittest.SkipTest()" is used. This is seen as exception in the logs. To avoid this, alternatively we can set class level variable in setUpClass and read this variable value in a custom decorator. Decorator will skip or run test cases accordingly.

This patch demonstrates that, when test is run on a hypervisor on which the feature is not supported, we set "hypervisorNotSupported" variable to True and pass this variable as argument to the decorator.
Decorator gets the value of this attribute, examines it, if it's true, skips the test case, or else runs the test case as it is.

Also the expensive steps in setUpClass are run only if hypervisor is supported.

Miscellaneous changes:
1. Fix import *
2. Remove unused variables


Tested with hypervisor value as "hyperv" and it skipped it successfully without raising any exception.
Test Snapshot Root Disk ... SKIP: Skipping test: Reason -  hypervisorNotSupported

----------------------------------------------------------------------
Ran 1 test in 0.051s

OK (SKIP=1)