### PR TITLE
CLOUDSTACK-8304: Modify tags accordingly for tests which can't be run on simulator

### DIFF
--- a/test/integration/smoke/test_iso.py
+++ b/test/integration/smoke/test_iso.py
@@ -85,7 +85,7 @@ class TestCreateIso(cloudstackTestCase):
             "eip",
             "sg",
             "advancedns"],
-        required_hardware="false")
+        required_hardware="true")
     def test_01_create_iso(self):
         """Test create public & private ISO
         """
@@ -258,7 +258,7 @@ class TestISO(cloudstackTestCase):
             "sg",
             "advancedns",
             "smoke"],
-        required_hardware="false")
+        required_hardware="true")
     def test_02_edit_iso(self):
         """Test Edit ISO
         """
@@ -325,7 +325,7 @@ class TestISO(cloudstackTestCase):
             "eip",
             "sg",
             "advancedns"],
-        required_hardware="false")
+        required_hardware="true")
     def test_03_delete_iso(self):
         """Test delete ISO
         """


### PR DESCRIPTION
The test cases try to download ISO, should not be run on simulator.
required_hardware tag value is easy identification of whether a test should be run on simulator or not (whether it requires hardware or not).