### PR TITLE
CLOUDSTACK-8413: Fixed resource tags on disk are lost when migrate to another storage

### DIFF
--- a/api/src/com/cloud/server/ResourceTag.java
+++ b/api/src/com/cloud/server/ResourceTag.java
@@ -92,6 +92,8 @@ public interface ResourceTag extends ControlledEntity, Identity, InternalIdentit
      */
     long getResourceId();
 
+    void setResourceId(long resourceId);
+
     /**
      * @return
      */

--- a/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -626,6 +626,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
             destVol.setInstanceId(instanceId);
             update(srcVolId, srcVol);
             update(destVolId, destVol);
+            _tagsDao.updateResourceId(srcVolId, destVolId, ResourceObjectType.Volume);
         } catch (Exception e) {
             throw new CloudRuntimeException("Unable to persist the sequence number for this host");
         }

--- a/engine/schema/src/com/cloud/tags/ResourceTagVO.java
+++ b/engine/schema/src/com/cloud/tags/ResourceTagVO.java
@@ -143,6 +143,10 @@ public class ResourceTagVO implements ResourceTag {
         return resourceId;
     }
 
+    @Override public void setResourceId(long resourceId) {
+        this.resourceId = resourceId;
+    }
+
     @Override
     public ResourceObjectType getResourceType() {
         return resourceType;

--- a/engine/schema/src/com/cloud/tags/dao/ResourceTagDao.java
+++ b/engine/schema/src/com/cloud/tags/dao/ResourceTagDao.java
@@ -34,4 +34,5 @@ public interface ResourceTagDao extends GenericDao<ResourceTagVO, Long> {
 
     List<? extends ResourceTag> listBy(long resourceId, ResourceObjectType resourceType);
 
+    void updateResourceId(long srcId, long destId, ResourceObjectType resourceType);
 }

--- a/engine/schema/src/com/cloud/tags/dao/ResourceTagsDaoImpl.java
+++ b/engine/schema/src/com/cloud/tags/dao/ResourceTagsDaoImpl.java
@@ -59,4 +59,14 @@ public class ResourceTagsDaoImpl extends GenericDaoBase<ResourceTagVO, Long> imp
         sc.setParameters("resourceType", resourceType);
         return listBy(sc);
     }
+
+    @Override public void updateResourceId(long srcId, long destId, ResourceObjectType resourceType) {
+        SearchCriteria<ResourceTagVO> sc = AllFieldsSearch.create();
+        sc.setParameters("resourceId", srcId);
+        sc.setParameters("resourceType", resourceType);
+        for( ResourceTagVO tag : listBy(sc)) {
+            tag.setResourceId(destId);
+            update(tag.getId(), tag);
+        }
+    }
 }


### PR DESCRIPTION
During cold volume migration we are duplicating volume entry in volumes table.
When migration is complete, we update the uuid of new entry and expunge the older entry.
This results in removal of resource tags on volume as its resource id still pointing to older volume.
As part of fix while updating uuid for volume, we are updating resource_id for tags also.