### PR TITLE
CLOUDSTACK-8414: [Hyper-V] Fixed template_spool_ref table is not getting updated with correct template size and local path

### DIFF
--- a/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/HypervResourceController.cs
+++ b/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/HypervResourceController.cs
@@ -1647,7 +1647,10 @@ namespace HypervResource
                                     throw new IOException(errMsg);
                                 }
 
-                                newData = cmd.destTO;
+                                FileInfo destFileInfo = new FileInfo(destFile);
+                                destTemplateObjectTO.size = destFileInfo.Length.ToString();
+                                JObject ansObj = Utils.CreateCloudStackObject(CloudStackTypes.TemplateObjectTO, destTemplateObjectTO);
+                                newData = ansObj;
                                 result = true;
                             }
                             else
@@ -1786,7 +1789,6 @@ namespace HypervResource
                                 }
                                 destTemplateObject.nfsDataStoreTO = destTemplateObjectTO.nfsDataStoreTO;
                                 destTemplateObject.checksum = destTemplateObjectTO.checksum;
-                                newData = destTemplateObject;
                                 JObject ansObj = Utils.CreateCloudStackObject(CloudStackTypes.TemplateObjectTO, destTemplateObject);
                                 newData = ansObj;
                                 result = true;

--- a/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/HypervResourceController.cs
+++ b/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/HypervResourceController.cs
@@ -1649,6 +1649,7 @@ namespace HypervResource
 
                                 FileInfo destFileInfo = new FileInfo(destFile);
                                 destTemplateObjectTO.size = destFileInfo.Length.ToString();
+                                destTemplateObjectTO.path = destTemplateObjectTO.uuid;
                                 JObject ansObj = Utils.CreateCloudStackObject(CloudStackTypes.TemplateObjectTO, destTemplateObjectTO);
                                 newData = ansObj;
                                 result = true;


### PR DESCRIPTION
Fixed template_spool_ref table is not getting updated with correct template size and local path

Now returning file size and local path instead of null.