### PR TITLE
CLOUDSTACK-8420: [Hyper-V] Fixed number format exception when untagged vlan is used for Hyper-V setup

### DIFF
--- a/core/src/com/cloud/agent/api/GetVmConfigAnswer.java
+++ b/core/src/com/cloud/agent/api/GetVmConfigAnswer.java
@@ -44,13 +44,13 @@ public class GetVmConfigAnswer extends Answer {
 
     public class NicDetails {
         String macAddress;
-        int vlanid;
+        String vlanid;
         boolean state;
 
         public NicDetails() {
         }
 
-        public NicDetails(String macAddress, int vlanid, boolean state) {
+        public NicDetails(String macAddress, String vlanid, boolean state) {
             this.macAddress = macAddress;
             this.vlanid = vlanid;
             this.state = state;
@@ -60,7 +60,7 @@ public class GetVmConfigAnswer extends Answer {
             return macAddress;
         }
 
-        public int getVlanid() {
+        public String getVlanid() {
             return vlanid;
         }
 

--- a/core/src/com/cloud/agent/api/ModifyVmNicConfigCommand.java
+++ b/core/src/com/cloud/agent/api/ModifyVmNicConfigCommand.java
@@ -22,7 +22,7 @@ package com.cloud.agent.api;
 
 public class ModifyVmNicConfigCommand extends Command {
     String vmName;
-    int vlan;
+    String vlan;
     String macAddress;
     int index;
     boolean enable;
@@ -31,19 +31,19 @@ public class ModifyVmNicConfigCommand extends Command {
     protected ModifyVmNicConfigCommand() {
     }
 
-    public ModifyVmNicConfigCommand(String vmName, int vlan, String macAddress) {
+    public ModifyVmNicConfigCommand(String vmName, String vlan, String macAddress) {
         this.vmName = vmName;
         this.vlan = vlan;
         this.macAddress = macAddress;
     }
 
-    public ModifyVmNicConfigCommand(String vmName, int vlan, int position) {
+    public ModifyVmNicConfigCommand(String vmName, String vlan, int position) {
         this.vmName = vmName;
         this.vlan = vlan;
         this.index = position;
     }
 
-    public ModifyVmNicConfigCommand(String vmName, int vlan, int position, boolean enable) {
+    public ModifyVmNicConfigCommand(String vmName, String vlan, int position, boolean enable) {
         this.vmName = vmName;
         this.vlan = vlan;
         this.index = position;

--- a/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/WmiCallsV2.cs
+++ b/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/WmiCallsV2.cs
@@ -947,6 +947,12 @@ namespace HypervResource
 
             EthernetSwitchPortVlanSettingData vlanSettings = GetVlanSettings(ethernetConnections[index]);
 
+            if (vlanid.Equals("untagged", StringComparison.CurrentCultureIgnoreCase))
+            {
+                // recevied vlan is untagged, don't parse for the vlan in the isolation uri
+                vlanid = null;
+            }
+
             if (vlanSettings == null)
             {
                 // when modifying  nic to not connected dont create vlan
@@ -1104,6 +1110,12 @@ namespace HypervResource
             // check when nic is disabled, removing vlan is required or not.
             EthernetPortAllocationSettingData[] vmEthernetConnections = GetEthernetConnections(vm);
             EthernetSwitchPortVlanSettingData vlanSettings = GetVlanSettings(vmEthernetConnections[pos]);
+
+            if (vlanid.Equals("untagged", StringComparison.CurrentCultureIgnoreCase))
+            {
+                // recevied vlan is untagged, don't parse for the vlan in the isolation uri
+                vlanid = null;
+            }
 
             if (vlanSettings == null)
             {


### PR DESCRIPTION

Change the vlan data type to string from int and handled the untagged vlan cases