### PR TITLE
CLOUDSTACK-8394: Skip test cases through setUp() instead of setUpClass()

### DIFF
--- a/test/integration/smoke/test_nic.py
+++ b/test/integration/smoke/test_nic.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """ NIC tests for VM """
-from marvin.cloudstackTestCase import cloudstackTestCase, unittest
+from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.lib.base import (Account,
                              ServiceOffering,
                              Network,
@@ -47,7 +47,7 @@ class TestNic(cloudstackTestCase):
 
         self.hypervisor = self.testClient.getHypervisorInfo()
         if self.hypervisor.lower() == "hyperv":
-            raise unittest.SkipTest("Not supported on Hyper-V")
+            self.skipTest("Not supported on Hyper-V")
 
         try:
             self.apiclient = self.testClient.getApiClient()

--- a/test/integration/smoke/test_nic_adapter_type.py
+++ b/test/integration/smoke/test_nic_adapter_type.py
@@ -125,7 +125,7 @@ class TestAdapterTypeForNic(cloudstackTestCase):
         """
 
         if self.hypervisor.lower() not in ["vmware"]:
-            raise unittest.SkipTest("This test case is written specifically\
+            self.skipTest("This test case is written specifically\
                     for Vmware hypervisor")
 
         # Register a private template in the account with nic adapter vmxnet3

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -18,7 +18,7 @@
 """
 # Import Local Modules
 from marvin.codes import FAILED
-from marvin.cloudstackTestCase import cloudstackTestCase, unittest
+from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.cloudstackAPI import scaleVirtualMachine
 from marvin.lib.utils import cleanup_resources
 from marvin.lib.base import (Account,
@@ -39,11 +39,12 @@ class TestScaleVm(cloudstackTestCase):
         testClient = super(TestScaleVm, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
         cls.services = testClient.getParsedTestDataConfig()
+        cls._cleanup = []
+        cls.unsupportedHypervisor = False
         cls.hypervisor = cls.testClient.getHypervisorInfo()
         if cls.hypervisor.lower() in ('kvm', 'hyperv', 'lxc'):
-            raise unittest.SkipTest(
-                "ScaleVM is not supported on KVM, Hyper-V or LXC.\
-                        Hence, skipping the test")
+            cls.unsupportedHypervisor = True
+            return
 
         # Get Zone, Domain and templates
         domain = get_domain(cls.apiclient)
@@ -106,6 +107,10 @@ class TestScaleVm(cloudstackTestCase):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
+
+        if self.unsupportedHypervisor:
+            self.skipTest("Skipping test because unsupported hypervisor\
+                    %s" % self.hypervisor)
 
     def tearDown(self):
         # Clean up, terminate the created ISOs

--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -44,6 +44,10 @@ class TestCreateTemplate(cloudstackTestCase):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
+
+        if self.unsupportedHypervisor:
+            self.skipTest("Skipping test because unsupported hypervisor\
+                    %s" % self.hypervisor)
         return
 
     def tearDown(self):
@@ -59,17 +63,19 @@ class TestCreateTemplate(cloudstackTestCase):
     def setUpClass(cls):
         testClient = super(TestCreateTemplate, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
+        cls._cleanup = []
         cls.services = testClient.getParsedTestDataConfig()
+        cls.unsupportedHypervisor = False
         cls.hypervisor = testClient.getHypervisorInfo()
         if cls.hypervisor.lower() in ['lxc']:
-            raise unittest.SkipTest("Template creation from root volume is not supported in LXC")
+            # Template creation from root volume is not supported in LXC
+            cls.unsupportedHypervisor = True
+            return
 
         # Get Zone, Domain and templates
         cls.domain = get_domain(cls.apiclient)
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.services['mode'] = cls.zone.networktype
-
-        cls._cleanup = []
         try:
             cls.disk_offering = DiskOffering.create(
                                     cls.apiclient,
@@ -210,10 +216,14 @@ class TestTemplates(cloudstackTestCase):
 
         testClient = super(TestTemplates, cls).getClsTestClient()
         cls.apiclient = testClient.getApiClient()
+        cls._cleanup = []
         cls.services = testClient.getParsedTestDataConfig()
+        cls.unsupportedHypervisor = False
         cls.hypervisor = testClient.getHypervisorInfo()
         if cls.hypervisor.lower() in ['lxc']:
-            raise unittest.SkipTest("Template creation from root volume is not supported in LXC")
+            # Template creation from root volume is not supported in LXC
+            cls.unsupportedHypervisor = True
+            return
 
         # Get Zone, Domain and templates
         cls.domain = get_domain(cls.apiclient)
@@ -325,6 +335,10 @@ class TestTemplates(cloudstackTestCase):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
+
+        if self.unsupportedHypervisor:
+            self.skipTest("Skipping test because unsupported hypervisor\
+                    %s" % self.hypervisor)
         return
 
     def tearDown(self):


### PR DESCRIPTION
When the tests are skipped through setUpClass, the statement "raise unittest.SkipTest()" is used. This is seen as exception in the logs. To avoid this, alternatively we can set class level variable in setUpClass and read this variable value in setUp() and skip the test case.

All test cases are run and tested.