### PR TITLE
return a state instead of null in AbstractInvestigatorImpl

### DIFF
--- a/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
+++ b/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
@@ -92,7 +92,7 @@ public abstract class AbstractInvestigatorImpl extends AdapterBase implements In
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("host (" + testHostIp + ") returns null answer");
                 }
-                return null;
+                return Status.Alert;
             }
 
             if (pingTestAnswer.getResult()) {
@@ -103,14 +103,20 @@ public abstract class AbstractInvestigatorImpl extends AdapterBase implements In
                 return Status.Up;
             } else {
                 if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("host (" + testHostIp + ") cannot be pinged, returning null ('I don't know')");
+                    s_logger.debug("host (" + testHostIp + ") cannot be pinged, returning Alert state");
                 }
-                return null;
+                return Status.Alert;
             }
         } catch (AgentUnavailableException e) {
-            return null;
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", returning Disconnected state");
+            }
+            return Status.Disconnected;
         } catch (OperationTimedoutException e) {
-            return null;
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", returning Alert state");
+            }
+            return Status.Alert;
         }
     }
 }


### PR DESCRIPTION
When a full cluster is down or unreachable,
CloudStack currently reports everything the
same as the last known state, which is usually
Up. When it cannot reach a host and cannot
reach another host in the same cluster either,
it returns null and says "I don't know". This
prevents it from reporting the problem. Now,
we return an Alert or Disconnected state so
proper action can be taken.

Also logging was added, so we know what part
of the code put it to Alert or Disconnected.

When the host is available again, it goes
from Alert state back to Up and CloudStack
starts HA work to recover the VMs. I tested
it on 4.6/master and it works fine now.

As this is a nasty bug, we might want to fix
this also in 4.5 and 4.4.

Thanks to @dahn and @snuf for their
help solving this issue.