### PR TITLE
maven plugin cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,11 +521,6 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.3</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${cs.checkstyle.version}</version>
           <dependencies>
@@ -1007,6 +1002,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.4</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.7</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
1. removed redundant maven-site-plugin
2. added maven-resources-plugin version 2.7 which has the fix for
   http://jira.codehaus.org/browse/MRESOURCES-140