### PR TITLE
CLOUDSTACK-8335: removed ceph repository 

### DIFF
--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -18,15 +18,6 @@
     <version>4.5.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
-  <repositories>
-    <repository>
-      <id>ceph-com</id>
-      <url>http://eu.ceph.com/maven</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
   <dependencies>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
Backport to 4.5

Signed-off-by: Laszlo Hornyak <laszlo.hornyak@gmail.com>
Signed-off-by: Rajani Karuturi <rajanikaruturi@gmail.com>