### PR TITLE
server: Introduce Unknown Status to be used in AbstractInvestigatorImpl

### DIFF
--- a/api/src/com/cloud/host/Status.java
+++ b/api/src/com/cloud/host/Status.java
@@ -31,7 +31,8 @@ public enum Status {
     Alert(true, true, true),
     Removed(true, false, true),
     Error(true, false, true),
-    Rebalancing(true, false, true);
+    Rebalancing(true, false, true),
+    Unknown(false, false, false); // null
 
     private final boolean updateManagementServer;
     private final boolean checkManagementServer;

--- a/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
+++ b/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
@@ -85,6 +85,7 @@ public abstract class AbstractInvestigatorImpl extends AdapterBase implements In
         return hostIds;
     }
 
+    // Method only returns Status.Up, Status.Down and Status.Unknown
     protected Status testIpAddress(Long hostId, String testHostIp) {
         try {
             Answer pingTestAnswer = _agentMgr.send(hostId, new PingTestCommand(testHostIp));

--- a/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
+++ b/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
@@ -90,9 +90,9 @@ public abstract class AbstractInvestigatorImpl extends AdapterBase implements In
             Answer pingTestAnswer = _agentMgr.send(hostId, new PingTestCommand(testHostIp));
             if (pingTestAnswer == null) {
                 if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("host (" + testHostIp + ") returns null answer");
+                    s_logger.debug("host (" + testHostIp + ") returns Unknown (null) answer");
                 }
-                return Status.Alert;
+                return Status.Unknown;
             }
 
             if (pingTestAnswer.getResult()) {
@@ -103,20 +103,20 @@ public abstract class AbstractInvestigatorImpl extends AdapterBase implements In
                 return Status.Up;
             } else {
                 if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("host (" + testHostIp + ") cannot be pinged, returning Alert state");
+                    s_logger.debug("host (" + testHostIp + ") cannot be pinged, returning Unknown (I don't know) state");
                 }
-                return Status.Alert;
+                return Status.Unknown;
             }
         } catch (AgentUnavailableException e) {
             if (s_logger.isDebugEnabled()) {
-                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", returning Disconnected state");
+                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", trapped AgentUnavailableException returning Unknown state");
             }
-            return Status.Disconnected;
+            return Status.Unknown;
         } catch (OperationTimedoutException e) {
             if (s_logger.isDebugEnabled()) {
-                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", returning Alert state");
+                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", trapped OperationTimedoutException returning Unknown state");
             }
-            return Status.Alert;
+            return Status.Unknown;
         }
     }
 }

--- a/server/src/com/cloud/ha/ManagementIPSystemVMInvestigator.java
+++ b/server/src/com/cloud/ha/ManagementIPSystemVMInvestigator.java
@@ -78,7 +78,7 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
             List<Long> otherHosts = findHostByPod(vmHost.getPodId(), vm.getHostId());
             for (Long otherHost : otherHosts) {
                 Status vmState = testIpAddress(otherHost, nic.getIp4Address());
-                if (vmState == null) {
+                if (vmState == null || vmState == Status.Unknown) {
                     // can't get information from that host, try the next one
                     continue;
                 }
@@ -91,7 +91,7 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
                     // We can't ping the VM directly...if we can ping the host, then report the VM down.
                     // If we can't ping the host, then we don't have enough information.
                     Status vmHostState = testIpAddress(otherHost, vmHost.getPrivateIpAddress());
-                    if ((vmHostState != null) && (vmHostState == Status.Up)) {
+                    if ((vmHostState != null) && (vmHostState != Status.Unknown) && (vmHostState == Status.Up)) {
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("successfully pinged vm's host IP (" + vmHost.getPrivateIpAddress() +
                                 "), but could not ping VM, returning that the VM is down");

--- a/server/src/com/cloud/ha/ManagementIPSystemVMInvestigator.java
+++ b/server/src/com/cloud/ha/ManagementIPSystemVMInvestigator.java
@@ -78,10 +78,8 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
             List<Long> otherHosts = findHostByPod(vmHost.getPodId(), vm.getHostId());
             for (Long otherHost : otherHosts) {
                 Status vmState = testIpAddress(otherHost, nic.getIp4Address());
-                if (vmState == null || vmState == Status.Unknown) {
-                    // can't get information from that host, try the next one
-                    continue;
-                }
+                assert vmState != null;
+                // In case of Status.Unknown, next host will be tried
                 if (vmState == Status.Up) {
                     if (s_logger.isDebugEnabled()) {
                         s_logger.debug("successfully pinged vm's private IP (" + vm.getPrivateIpAddress() + "), returning that the VM is up");
@@ -91,7 +89,8 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
                     // We can't ping the VM directly...if we can ping the host, then report the VM down.
                     // If we can't ping the host, then we don't have enough information.
                     Status vmHostState = testIpAddress(otherHost, vmHost.getPrivateIpAddress());
-                    if ((vmHostState != null) && (vmHostState != Status.Unknown) && (vmHostState == Status.Up)) {
+                    assert vmHostState != null;
+                    if (vmHostState == Status.Up) {
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("successfully pinged vm's host IP (" + vmHost.getPrivateIpAddress() +
                                 "), but could not ping VM, returning that the VM is down");

--- a/server/src/com/cloud/ha/UserVmDomRInvestigator.java
+++ b/server/src/com/cloud/ha/UserVmDomRInvestigator.java
@@ -116,14 +116,12 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
         List<Long> otherHosts = findHostByPod(agent.getPodId(), agent.getId());
 
         for (Long hostId : otherHosts) {
-
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("sending ping from (" + hostId + ") to agent's host ip address (" + agent.getPrivateIpAddress() + ")");
             }
             Status hostState = testIpAddress(hostId, agent.getPrivateIpAddress());
-            if (hostState == null || hostState == Status.Unknown) {
-                continue;
-            }
+            assert hostState != null;
+            // In case of Status.Unknown, next host will be tried
             if (hostState == Status.Up) {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("ping from (" + hostId + ") to agent's host ip address (" + agent.getPrivateIpAddress() +
@@ -134,7 +132,7 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("returning host state: " + hostState);
                 }
-                return hostState;
+                return Status.Down;
             }
         }
 

--- a/server/src/com/cloud/ha/UserVmDomRInvestigator.java
+++ b/server/src/com/cloud/ha/UserVmDomRInvestigator.java
@@ -121,7 +121,7 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
                 s_logger.debug("sending ping from (" + hostId + ") to agent's host ip address (" + agent.getPrivateIpAddress() + ")");
             }
             Status hostState = testIpAddress(hostId, agent.getPrivateIpAddress());
-            if (hostState == null) {
+            if (hostState == null || hostState == Status.Unknown) {
                 continue;
             }
             if (hostState == Status.Up) {


### PR DESCRIPTION
The PR #211 introduced changes where the abstract investigator testIpAddress()
would return other Status, which previously only returned null, Up or Down. In
this patch we introduce a new Status "Unknown" that replaces null's semantics.

The important changes #211 introduced was the debugging statements as semantically
the changes would work same as the consumers of testIpAddress() method only used
if returned values were Up or Down and in other cases (null, Alert etc) it would
simply continue to loop through the resources being investigated.

Keeping the debug logs, this commit only replaces the previously returned null
values with Status.Unknown and fixed the debug statements to reflect the same.
In case of trapped exceptions too, we return Unknown status but log the exception
we trapped.

Signed-off-by: Rohit Yadav <rohit.yadav@shapeblue.com>