### PR TITLE
CLOUDSTACK-8445: Keep only dvs tag for test case which tests the VCenter port groups

### DIFF
--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -554,7 +554,7 @@ class TestPortForwarding(cloudstackTestCase):
             )
         return
 
-    @attr(tags=["advanced", "dvs"], required_hardware="true")
+    @attr(tags=["dvs"], required_hardware="true")
     def test_guest_traffic_port_groups_isolated_network(self):
         """ Verify port groups are created for guest traffic
         used by isolated network """


### PR DESCRIPTION
The test cases is tested only for DVS. This will prevent it to run on normal configuration.