### PR TITLE
CLOUDSTACK-8449: Include zoneid parameter in base library for updateConfiuration method

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -3659,12 +3659,15 @@ class Configurations:
     """Manage Configuration"""
 
     @classmethod
-    def update(cls, apiclient, name, value=None):
+    def update(cls, apiclient, name, value=None, zoneid=None):
         """Updates the specified configuration"""
 
         cmd = updateConfiguration.updateConfigurationCmd()
         cmd.name = name
         cmd.value = value
+
+        if zoneid:
+            cmd.zoneid = zoneid
         apiclient.updateConfiguration(cmd)
 
     @classmethod


### PR DESCRIPTION
Some test cases pass zoneid for Configurations.update method but it is absent in base library.