### PR TITLE
CLOUDSTACK-8453: Fix DB result check in test_VirtualRouter_alerts.py

### DIFF
--- a/test/integration/component/test_VirtualRouter_alerts.py
+++ b/test/integration/component/test_VirtualRouter_alerts.py
@@ -203,9 +203,9 @@ class TestVRServiceFailureAlerting(cloudstackTestCase):
         # 30minutes)
 
         qresultset = self.dbclient.execute(
-            "select id from alert where subject \
-                    = '%s' ORDER BY id DESC LIMIT 1;" %
-            str(alertSubject))
+            "select id from alert where subject like\
+                    '%{0}%' ORDER BY id DESC LIMIT 1;".format(
+            str(alertSubject)))
         self.assertNotEqual(
             len(qresultset),
             0,


### PR DESCRIPTION
After stopping the apache service, the alerts in database is matched currently with the string "Monitoring Service on VR RouterName".
The database contains the subject as "Monitoring Service on VR RouterName. 2015-05-07 10:36:07,207 [INFO] [The process apache2 is not running trying recover ] apache2"
The string matching should be made less strict and should be made to use like % operator.


Tested on Xenserver:
test_01_VRServiceFailureAlerting (test_VirtualRouter_alerts.TestVRServiceFailureAlerting) ... === TestName: test_01_VRServiceFailureAlerting | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 1920.846s

OK
