### PR TITLE
Automation for issue, Private template not visible in project for user

### DIFF
--- a/test/integration/component/test_project_template.py
+++ b/test/integration/component/test_project_template.py
@@ -56,6 +56,12 @@ class TestProjectPrivateTemplate(cloudstackTestCase):
         cls.debug(cls.account.id)
         #Fetch an api client with the user account created
 
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cleanup_resources(cls.apiclient, cls.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
 
     def test_project_private_template(self):
         self.api_client = self.testClient.getUserApiClient(UserName=self.account.name, DomainName=self.account.domain)
@@ -109,16 +115,14 @@ class TestProjectPrivateTemplate(cloudstackTestCase):
         self.volume = list_volumes[0]
 
         #Create template from Virtual machine and Volume ID
-        self.services["projtemplate"]={}
-        self.services["projtemplate"]["name"] = "Project_Private_template"
-        self.services["projtemplate"]["ispublic"] = False
-        self.services["projtemplate"]["displaytext"] = "This template should be visible only in project scope"
-        self.services["projtemplate"]["ostype"] = self.services["ostype"]
-        self.services["projtemplate"]["templatefilter"] = self.services["templatefilter"]
+        self.services["project"]["ispublic"] = False
+        self.services["project"]["displaytext"] = "This template should be visible only in project scope"
+        self.services["project"]["ostype"] = self.services["ostype"]
+        self.services["project"]["templatefilter"] = self.services["templatefilter"]
 
         project_template = Template.create(
                                 self.api_client,
-                                self.services["projtemplate"],
+                                self.services["project"],
                                 self.volume.id,
                                 projectid=self.project.id
                                 )
@@ -128,7 +132,7 @@ class TestProjectPrivateTemplate(cloudstackTestCase):
 
         list_template_response = Template.list(
                                     self.api_client,
-                                    templatefilter=self.services["projtemplate"]["templatefilter"],
+                                    templatefilter=self.services["project"]["templatefilter"],
                                     projectid=self.project.id
                                     )
 
@@ -144,19 +148,8 @@ class TestProjectPrivateTemplate(cloudstackTestCase):
                             "There is one private template for this account in this project"
                         )
 
-        self.assertNotEqual(
-                            len(list_template_response),
-                            0,
-                            "There is not associated Private template for this account in this project"
-                        )
 
 
 
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cleanup_resources(cls.apiclient, cls.cleanup)
-        except Exception as e:
-            raise Exception("Warning: Exception during cleanup : %s" % e)
+    
 

--- a/test/integration/component/test_project_template.py
+++ b/test/integration/component/test_project_template.py
@@ -1,0 +1,162 @@
+from marvin.codes import FAILED, PASS
+from marvin.cloudstackTestCase import cloudstackTestCase
+from marvin.lib.base import Account, VirtualMachine, ServiceOffering,Project,Network,NetworkOffering,Domain,Volume,Template
+from marvin.lib.common import get_zone, get_domain, get_template
+from marvin.lib.utils import cleanup_resources
+from nose.plugins.attrib import attr
+
+
+
+class TestProjectPrivateTemplate(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        testClient = super(TestDeployVM, cls).getClsTestClient()
+        cls.apiclient = testClient.getApiClient()
+        cls.services = testClient.getParsedTestDataConfig()
+        cls.cleanup = []
+
+        # Get Zone, Domain and templates
+        cls.domain = get_domain(cls.apiclient)
+        cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+
+        template = get_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        if template == FAILED:
+            assert False, "get_template() failed to return template with description %s" % cls.services["ostype"]
+
+        # Set Zones and disk offerings
+        cls.services["small"]["zoneid"] = cls.zone.id
+        cls.services["small"]["template"] = template.id
+
+        cls.services["medium"]["zoneid"] = cls.zone.id
+        cls.services["medium"]["template"] = template.id
+        cls.services["iso1"]["zoneid"] = cls.zone.id
+
+        cls.service_offering = ServiceOffering.create(
+            cls.apiclient,
+            cls.services["service_offerings"]["tiny"]
+        )
+
+        cls.new_domain = Domain.create(
+                                   cls.apiclient,
+                                   cls.services["domain"],
+                                   )
+        cls.account = Account.create(
+                            cls.apiclient,
+                            cls.services["account"],
+                            admin=True,
+                            domainid=cls.new_domain.id
+                            )
+
+        cls.debug(cls.account.id)
+        #Fetch an api client with the user account created
+
+
+    def test_project_private_template(self):
+        self.api_client = self.testClient.getUserApiClient(UserName=self.account.name, DomainName=self.account.domain)
+
+        #Create a new project using the account created
+        self.project = Project.create(self.api_client,self.services["project"],account=self.account.name,domainid=self.new_domain.id)
+        self.debug("The project has been created")
+
+        self.network_offering = NetworkOffering.create(
+            self.apiclient,
+            self.services["network_offering"],
+        )
+        # Enable Network offering
+        self.network_offering.update(self.apiclient, state='Enabled')
+
+        self.services["network"]["networkoffering"] = self.network_offering.id
+
+
+
+        #cls.api_client = testClient.getUserApiClient(UserName=cls.account.name, DomainName=cls.account.domain)
+
+        self.project_network = Network.create(
+            self.api_client,
+            self.services["network"],
+            networkofferingid=self.network_offering.id,
+            zoneid=self.zone.id,
+            projectid=self.project.id
+        )
+
+
+        self.virtual_machine = VirtualMachine.create(
+            self.api_client,
+            self.services["small"],
+            serviceofferingid=self.service_offering.id,
+            projectid=self.project.id,
+            networkids=self.project_network.id,
+            zoneid=self.zone.id
+        )
+
+        #Stop virtual machine
+        self.virtual_machine.stop(self.api_client)
+
+        list_volumes = Volume.list(
+                                   self.api_client,
+                                   projectid=self.project.id,
+                                   virtualmachineid=self.virtual_machine.id,
+                                   type='ROOT',
+                                   listall=True
+                                   )
+
+        self.volume = list_volumes[0]
+
+        #Create template from Virtual machine and Volume ID
+        self.services["projtemplate"]={}
+        self.services["projtemplate"]["name"] = "Project_Private_template"
+        self.services["projtemplate"]["ispublic"] = False
+        self.services["projtemplate"]["displaytext"] = "This template should be visible only in project scope"
+        self.services["projtemplate"]["ostype"] = self.services["ostype"]
+        self.services["projtemplate"]["templatefilter"] = self.services["templatefilter"]
+
+        project_template = Template.create(
+                                self.api_client,
+                                self.services["projtemplate"],
+                                self.volume.id,
+                                projectid=self.project.id
+                                )
+        self.debug("Created template with ID: %s" % project_template.id)
+
+        #api_client = cls.testClient.getUserApiClient(UserName=cls.account.name, DomainName=cls.account.domain)
+
+        list_template_response = Template.list(
+                                    self.api_client,
+                                    templatefilter=self.services["projtemplate"]["templatefilter"],
+                                    projectid=self.project.id
+                                    )
+
+        self.cleanup.append(self.project)
+        self.cleanup.append(self.account)
+        self.cleanup.append(self.service_offering)
+        self.cleanup.append(self.network_offering)
+        self.cleanup.append(self.new_domain)
+
+        self.assertEqual(
+                           len(list_template_response),
+                            1,
+                            "There is one private template for this account in this project"
+                        )
+
+        self.assertNotEqual(
+                            len(list_template_response),
+                            0,
+                            "There is not associated Private template for this account in this project"
+                        )
+
+
+
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cleanup_resources(cls.apiclient, cls.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+

--- a/test/integration/component/test_user_taglisting.py
+++ b/test/integration/component/test_user_taglisting.py
@@ -33,7 +33,7 @@ class TestDeployVMWithTags(cloudstackTestCase):
                             domainid=cls.domain.id
                             )
 
-
+        cls.cleanup.append(cls.account)
         template = get_template(
             cls.apiclient,
             cls.zone.id,
@@ -54,11 +54,12 @@ class TestDeployVMWithTags(cloudstackTestCase):
             cls.apiclient,
             cls.services["service_offerings"]["tiny"]
         )
-
+        cls.cleanup.append(cls.service_offering)
         cls.network_offering = NetworkOffering.create(
             cls.apiclient,
             cls.services["network_offering"],
         )
+        cls.cleanup.append(cls.network_offering)
         # Enable Network offering
         cls.network_offering.update(cls.apiclient, state='Enabled')
 
@@ -72,7 +73,14 @@ class TestDeployVMWithTags(cloudstackTestCase):
             domainid=cls.domain.id,
             zoneid=cls.zone.id
         )
+        cls.cleanup.append(cls.network)
 
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cleanup_resources(cls.apiclient, cls.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
 
     def test_deploy_vm_with_tags(self):
         """Test Deploy Virtual Machine

--- a/test/integration/component/test_user_taglisting.py
+++ b/test/integration/component/test_user_taglisting.py
@@ -1,0 +1,129 @@
+from marvin.cloudstackTestCase import cloudstackTestCase
+from marvin.lib.base import (Account,
+                             ServiceOffering,
+                             VirtualMachine,
+                             NetworkOffering,
+                             Network,
+                             Tag
+                            )
+from marvin.lib.common import (get_domain,
+                                get_zone,
+                                get_template)
+from marvin.cloudstackAPI import *
+from nose.plugins.attrib import attr
+from marvin.codes import FAILED, PASS
+
+class TestDeployVMWithTags(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.apiclient = cls.testClient.getApiClient()
+        cls.dbclient = cls.testClient.getDbConnection()
+        cls.cleanup = []
+        cls.services = cls.testClient.getParsedTestDataConfig()
+
+        cls.domain = get_domain(cls.apiclient)
+        cls.zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+
+        cls.account = Account.create(
+                            cls.apiclient,
+                            cls.services["account"],
+                            admin=True,
+                            domainid=cls.domain.id
+                            )
+
+
+        template = get_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        if template == FAILED:
+            assert False, "get_template() failed to return template with description %s" % cls.services["ostype"]
+
+        # Set Zones and disk offerings
+        cls.services["small"]["zoneid"] = cls.zone.id
+        cls.services["small"]["template"] = template.id
+
+        cls.services["medium"]["zoneid"] = cls.zone.id
+        cls.services["medium"]["template"] = template.id
+        cls.services["iso1"]["zoneid"] = cls.zone.id
+
+        cls.service_offering = ServiceOffering.create(
+            cls.apiclient,
+            cls.services["service_offerings"]["tiny"]
+        )
+
+        cls.network_offering = NetworkOffering.create(
+            cls.apiclient,
+            cls.services["network_offering"],
+        )
+        # Enable Network offering
+        cls.network_offering.update(cls.apiclient, state='Enabled')
+
+        cls.services["network"]["networkoffering"] = cls.network_offering.id
+        cls.api_client = cls.testClient.getUserApiClient(UserName=cls.account.name, DomainName=cls.account.domain)
+        cls.network = Network.create(
+            cls.api_client,
+            cls.services["network"],
+            networkofferingid=cls.network_offering.id,
+            accountid=cls.account.name,
+            domainid=cls.domain.id,
+            zoneid=cls.zone.id
+        )
+
+
+    def test_deploy_vm_with_tags(self):
+        """Test Deploy Virtual Machine
+        """
+        # Validate the following:
+        # 1. User tags are created for VM
+        # 2. listing the tags for the VM will list the tag only once and doesn't list the same tag multiple times
+        self.virtual_machine = VirtualMachine.create(
+            self.api_client,
+            self.services["small"],
+            serviceofferingid=self.service_offering.id,
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            networkids=self.network.id,
+            zoneid=self.zone.id
+        )
+
+        tag1 = Tag.create(
+            self.apiclient,
+            resourceIds=self.virtual_machine.id,
+            resourceType='userVM',
+            tags={'vmtag': 'autotag'}
+        )
+        tag2 = Tag.create(
+            self.apiclient,
+            resourceIds=self.virtual_machine.id,
+            resourceType='userVM',
+            tags={'vmtag1': 'autotag'}
+        )
+
+        tags = Tag.list(
+            self.apiclient,
+            listall=True,
+            resourceType='userVM',
+            key='vmtag',
+            value='autotag'
+        )
+
+        self.assertEqual(
+                           len(tags),
+                            1,
+                            "There is just one tag listed with list tags"
+                        )
+
+        self.assertGreater(
+                            len(tags),
+                            1,
+                            "The user tag is listed multiple times"
+                        )
+
+
+
+
+


### PR DESCRIPTION
STEPS TO REPRODUCE:
Create an account and a user.
Create a project for that user.
Change view from default view.
Select project view, and go into volumes view
Create a template from a Volume and wait until the process is complete
List the templates and the template cannot be found in the project
Navigate back to the "Default view" The template can be found in the templates screen in this view

The above mentioned issue has been automated using this script.