### PR TITLE
CLOUDSTACK-1667: Make a better description of the extractable flag

### DIFF
--- a/ui/scripts/docs.js
+++ b/ui/scripts/docs.js
@@ -1168,7 +1168,7 @@ cloudStack.docs = {
         externalLink: ''
     },
     helpRegisterISOExtractable: {
-        desc: 'Whether the ISO is extractable or not',
+        desc: 'Whether the ISO is downloadable by users or not',
         externalLink: ''
     },
     helpRegisterISOPublic: {
@@ -1209,7 +1209,7 @@ cloudStack.docs = {
         externalLink: ''
     },
     helpRegisterTemplateExtractable: {
-        desc: 'Whether the template is extractable or not',
+        desc: 'Whether the template is downloadable by users or not',
         externalLink: ''
     },
     helpRegisterTemplateDynamicallyScalable: {


### PR DESCRIPTION
The extractable flag is a bit confusing, as it is easy to imply some sort of extraction (zip, bzip2, gzip etc.) support, while it actually refers to permission to extract (or download) the ISO/template from the system.

This is a simple fix to give it a bit more meaning, until someone can come up with a better explanation of the feature.

Documentation of the feature: 
http://markmail.org/search/?q=list%3Aorg.apache.incubator.cloudstack-users+extractable#query:list%3Aorg.apache.incubator.cloudstack-users%20extractable+page:1+mid:24qagnqoed6lxhcx+state:results
