### PR TITLE
listFirewallRules: cleanup and fix duplicate params in API

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/firewall/ListEgressFirewallRulesCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/firewall/ListEgressFirewallRulesCmd.java
@@ -23,12 +23,8 @@ import java.util.List;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.FirewallResponse;
-import org.apache.cloudstack.api.response.FirewallRuleResponse;
 import org.apache.cloudstack.api.response.ListResponse;
-import org.apache.cloudstack.api.response.NetworkResponse;
 
 import com.cloud.network.rules.FirewallRule;
 import com.cloud.utils.Pair;
@@ -39,45 +35,19 @@ public class ListEgressFirewallRulesCmd extends ListFirewallRulesCmd {
     public static final Logger s_logger = Logger.getLogger(ListEgressFirewallRulesCmd.class.getName());
     private static final String s_name = "listegressfirewallrulesresponse";
 
-    /////////////////////////////////////////////////////
-    //////////////// API parameters /////////////////////
-    /////////////////////////////////////////////////////
-    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = FirewallRuleResponse.class, description = "Lists rule with the specified ID.")
-    private Long id;
-
-    @Parameter(name = ApiConstants.NETWORK_ID,
-               type = CommandType.UUID,
-               entityType = NetworkResponse.class,
-               description = "the id network network for the egress firwall services")
-    private Long networkId;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
     @Override
-    public Long getNetworkId() {
-        return networkId;
-    }
-
-    @Override
     public FirewallRule.TrafficType getTrafficType() {
         return FirewallRule.TrafficType.Egress;
-    }
-
-    @Override
-    public Long getId() {
-        return id;
     }
 
     /////////////////////////////////////////////////////
     /////////////// API Implementation///////////////////
     /////////////////////////////////////////////////////
-
-    @Override
-    public String getCommandName() {
-        return s_name;
-    }
 
     @Override
     public void execute() {

--- a/api/src/org/apache/cloudstack/api/command/user/firewall/ListFirewallRulesCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/firewall/ListFirewallRulesCmd.java
@@ -45,23 +45,23 @@ public class ListFirewallRulesCmd extends BaseListTaggedResourcesCmd {
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
     @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = FirewallRuleResponse.class, description = "Lists rule with the specified ID.")
-    private Long id;
+    protected Long id;
 
     @Parameter(name = ApiConstants.IP_ADDRESS_ID,
                type = CommandType.UUID,
                entityType = IPAddressResponse.class,
-               description = "the id of IP address of the firwall services")
-    private Long ipAddressId;
+               description = "the id of IP address of the firewall services")
+    protected Long ipAddressId;
 
     @Parameter(name = ApiConstants.NETWORK_ID,
                type = CommandType.UUID,
                entityType = NetworkResponse.class,
-               description = "list firewall rules for ceratin network",
+               description = "list firewall rules for certain network",
                since = "4.3")
-    private Long networkId;
+    protected Long networkId;
 
     @Parameter(name = ApiConstants.FOR_DISPLAY, type = CommandType.BOOLEAN, description = "list resources by display flag; only ROOT admin is eligible to pass this parameter", since = "4.4", authorized = {RoleType.Admin})
-    private Boolean display;
+    protected Boolean display;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////


### PR DESCRIPTION
The parts deleted are already defined in the extended class.