### PR TITLE
ListFirewallEgressRulesCmd: extend from BaseListTaggedResourcesCmd an…

### DIFF
--- a/api/src/com/cloud/network/firewall/FirewallService.java
+++ b/api/src/com/cloud/network/firewall/FirewallService.java
@@ -18,7 +18,7 @@ package com.cloud.network.firewall;
 
 import java.util.List;
 
-import org.apache.cloudstack.api.command.user.firewall.ListFirewallRulesCmd;
+import org.apache.cloudstack.api.command.user.firewall.IListFirewallRulesCmd;
 
 import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.ResourceUnavailableException;
@@ -28,10 +28,9 @@ import com.cloud.utils.Pair;
 
 public interface FirewallService {
     FirewallRule createIngressFirewallRule(FirewallRule rule) throws NetworkRuleConflictException;
-
     FirewallRule createEgressFirewallRule(FirewallRule rule) throws NetworkRuleConflictException;
 
-    Pair<List<? extends FirewallRule>, Integer> listFirewallRules(ListFirewallRulesCmd cmd);
+    Pair<List<? extends FirewallRule>, Integer> listFirewallRules(IListFirewallRulesCmd cmd);
 
     /**
      * Revokes a firewall rule
@@ -44,7 +43,6 @@ public interface FirewallService {
     boolean revokeEgressFirewallRule(long ruleId, boolean apply);
 
     boolean applyEgressFirewallRules(FirewallRule rule, Account caller) throws ResourceUnavailableException;
-
     boolean applyIngressFirewallRules(long ipId, Account caller) throws ResourceUnavailableException;
 
     FirewallRule getFirewallRule(long ruleId);

--- a/api/src/org/apache/cloudstack/api/BaseListAccountResourcesCmd.java
+++ b/api/src/org/apache/cloudstack/api/BaseListAccountResourcesCmd.java
@@ -17,15 +17,17 @@
 package org.apache.cloudstack.api;
 
 
-public abstract class BaseListAccountResourcesCmd extends BaseListDomainResourcesCmd {
+public abstract class BaseListAccountResourcesCmd extends BaseListDomainResourcesCmd implements IBaseListAccountResourcesCmd {
 
     @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, description = "list resources by account. Must be used with the domainId parameter.")
     private String accountName;
 
+    @Override
     public String getAccountName() {
         return accountName;
     }
 
+    @Override
     public Boolean getDisplay() {
         return true;
     }

--- a/api/src/org/apache/cloudstack/api/BaseListCmd.java
+++ b/api/src/org/apache/cloudstack/api/BaseListCmd.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.utils.exception.CSExceptionErrorCode;
 
-public abstract class BaseListCmd extends BaseCmd {
+public abstract class BaseListCmd extends BaseCmd implements IBaseListCmd {
 
     private static Long s_maxPageSize = null;
     public static final Long s_pageSizeUnlimited = -1L;
@@ -47,14 +47,17 @@ public abstract class BaseListCmd extends BaseCmd {
     public BaseListCmd() {
     }
 
+    @Override
     public String getKeyword() {
         return keyword;
     }
 
+    @Override
     public Integer getPage() {
         return page;
     }
 
+    @Override
     public Integer getPageSize() {
         if (pageSize != null && s_maxPageSize.longValue() != s_pageSizeUnlimited && pageSize.longValue() > s_maxPageSize.longValue()) {
             throw new InvalidParameterValueException("Page size can't exceed max allowed page size value: " + s_maxPageSize.longValue());
@@ -84,6 +87,7 @@ public abstract class BaseListCmd extends BaseCmd {
         return 0;
     }
 
+    @Override
     public Long getPageSizeVal() {
         Long defaultPageSize = s_maxPageSize;
         final Integer pageSizeInt = getPageSize();
@@ -97,6 +101,7 @@ public abstract class BaseListCmd extends BaseCmd {
         return defaultPageSize;
     }
 
+    @Override
     public Long getStartIndex() {
         Long startIndex = Long.valueOf(0);
         final Long pageSizeVal = getPageSizeVal();
@@ -112,6 +117,7 @@ public abstract class BaseListCmd extends BaseCmd {
         return startIndex;
     }
 
+    @Override
     public ApiCommandJobType getInstanceType() {
         return ApiCommandJobType.None;
     }

--- a/api/src/org/apache/cloudstack/api/BaseListDomainResourcesCmd.java
+++ b/api/src/org/apache/cloudstack/api/BaseListDomainResourcesCmd.java
@@ -18,7 +18,7 @@ package org.apache.cloudstack.api;
 
 import org.apache.cloudstack.api.response.DomainResponse;
 
-public abstract class BaseListDomainResourcesCmd extends BaseListCmd {
+public abstract class BaseListDomainResourcesCmd extends BaseListCmd implements IBaseListDomainResourcesCmd {
 
     @Parameter(name = ApiConstants.LIST_ALL, type = CommandType.BOOLEAN, description = "If set to false, "
         + "list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false")
@@ -34,14 +34,17 @@ public abstract class BaseListDomainResourcesCmd extends BaseListCmd {
         + " but if true, lists all resources from the parent specified by the domainId till leaves.")
     private Boolean recursive;
 
+    @Override
     public boolean listAll() {
         return listAll == null ? false : listAll;
     }
 
+    @Override
     public boolean isRecursive() {
         return recursive == null ? false : recursive;
     }
 
+    @Override
     public Long getDomainId() {
         return domainId;
     }

--- a/api/src/org/apache/cloudstack/api/BaseListTaggedResourcesCmd.java
+++ b/api/src/org/apache/cloudstack/api/BaseListTaggedResourcesCmd.java
@@ -23,10 +23,11 @@ import java.util.Map;
 
 import com.cloud.exception.InvalidParameterValueException;
 
-public abstract class BaseListTaggedResourcesCmd extends BaseListProjectAndAccountResourcesCmd {
+public abstract class BaseListTaggedResourcesCmd extends BaseListProjectAndAccountResourcesCmd implements IBaseListTaggedResourcesCmd {
     @Parameter(name = ApiConstants.TAGS, type = CommandType.MAP, description = "List resources by tags (key/value pairs)")
     private Map tags;
 
+    @Override
     public Map<String, String> getTags() {
         Map<String, String> tagsMap = null;
         if (tags != null && !tags.isEmpty()) {

--- a/api/src/org/apache/cloudstack/api/IBaseListAccountResourcesCmd.java
+++ b/api/src/org/apache/cloudstack/api/IBaseListAccountResourcesCmd.java
@@ -14,17 +14,11 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.api;
 
-import org.apache.cloudstack.api.response.ProjectResponse;
+public interface IBaseListAccountResourcesCmd extends IBaseListDomainResourcesCmd {
+    String getAccountName();
 
-public abstract class BaseListProjectAndAccountResourcesCmd extends BaseListAccountResourcesCmd implements IBaseListProjectAndAccountResourcesCmd {
-
-    @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "list objects by project")
-    private Long projectId;
-
-    @Override
-    public Long getProjectId() {
-        return projectId;
-    }
+    Boolean getDisplay();
 }

--- a/api/src/org/apache/cloudstack/api/IBaseListCmd.java
+++ b/api/src/org/apache/cloudstack/api/IBaseListCmd.java
@@ -14,17 +14,19 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.api;
 
-import org.apache.cloudstack.api.response.ProjectResponse;
+public interface IBaseListCmd {
+    String getKeyword();
 
-public abstract class BaseListProjectAndAccountResourcesCmd extends BaseListAccountResourcesCmd implements IBaseListProjectAndAccountResourcesCmd {
+    Integer getPage();
 
-    @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "list objects by project")
-    private Long projectId;
+    Integer getPageSize();
 
-    @Override
-    public Long getProjectId() {
-        return projectId;
-    }
+    Long getPageSizeVal();
+
+    Long getStartIndex();
+
+    ApiCommandJobType getInstanceType();
 }

--- a/api/src/org/apache/cloudstack/api/IBaseListDomainResourcesCmd.java
+++ b/api/src/org/apache/cloudstack/api/IBaseListDomainResourcesCmd.java
@@ -14,17 +14,13 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.api;
 
-import org.apache.cloudstack.api.response.ProjectResponse;
+public interface IBaseListDomainResourcesCmd extends IBaseListCmd {
+    boolean listAll();
 
-public abstract class BaseListProjectAndAccountResourcesCmd extends BaseListAccountResourcesCmd implements IBaseListProjectAndAccountResourcesCmd {
+    boolean isRecursive();
 
-    @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "list objects by project")
-    private Long projectId;
-
-    @Override
-    public Long getProjectId() {
-        return projectId;
-    }
+    Long getDomainId();
 }

--- a/api/src/org/apache/cloudstack/api/IBaseListProjectAndAccountResourcesCmd.java
+++ b/api/src/org/apache/cloudstack/api/IBaseListProjectAndAccountResourcesCmd.java
@@ -14,17 +14,9 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.api;
 
-import org.apache.cloudstack.api.response.ProjectResponse;
-
-public abstract class BaseListProjectAndAccountResourcesCmd extends BaseListAccountResourcesCmd implements IBaseListProjectAndAccountResourcesCmd {
-
-    @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "list objects by project")
-    private Long projectId;
-
-    @Override
-    public Long getProjectId() {
-        return projectId;
-    }
+public interface IBaseListProjectAndAccountResourcesCmd extends IBaseListAccountResourcesCmd {
+    Long getProjectId();
 }

--- a/api/src/org/apache/cloudstack/api/IBaseListTaggedResourcesCmd.java
+++ b/api/src/org/apache/cloudstack/api/IBaseListTaggedResourcesCmd.java
@@ -14,17 +14,11 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package org.apache.cloudstack.api;
 
-import org.apache.cloudstack.api.response.ProjectResponse;
+import java.util.Map;
 
-public abstract class BaseListProjectAndAccountResourcesCmd extends BaseListAccountResourcesCmd implements IBaseListProjectAndAccountResourcesCmd {
-
-    @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "list objects by project")
-    private Long projectId;
-
-    @Override
-    public Long getProjectId() {
-        return projectId;
-    }
+public interface IBaseListTaggedResourcesCmd extends IBaseListProjectAndAccountResourcesCmd {
+    Map<String, String> getTags();
 }

--- a/api/src/org/apache/cloudstack/api/command/user/firewall/IListFirewallRulesCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/firewall/IListFirewallRulesCmd.java
@@ -14,17 +14,18 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-package org.apache.cloudstack.api;
 
-import org.apache.cloudstack.api.response.ProjectResponse;
+package org.apache.cloudstack.api.command.user.firewall;
 
-public abstract class BaseListProjectAndAccountResourcesCmd extends BaseListAccountResourcesCmd implements IBaseListProjectAndAccountResourcesCmd {
+import com.cloud.network.rules.FirewallRule;
+import org.apache.cloudstack.api.IBaseListTaggedResourcesCmd;
 
-    @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "list objects by project")
-    private Long projectId;
+public interface IListFirewallRulesCmd extends IBaseListTaggedResourcesCmd {
+    Long getIpAddressId();
 
-    @Override
-    public Long getProjectId() {
-        return projectId;
-    }
+    FirewallRule.TrafficType getTrafficType();
+
+    Long getId();
+
+    Long getNetworkId();
 }

--- a/api/src/org/apache/cloudstack/api/command/user/firewall/ListEgressFirewallRulesCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/firewall/ListEgressFirewallRulesCmd.java
@@ -22,11 +22,14 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseListTaggedResourcesCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.FirewallResponse;
 import org.apache.cloudstack.api.response.FirewallRuleResponse;
+import org.apache.cloudstack.api.response.IPAddressResponse;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.NetworkResponse;
 
@@ -35,7 +38,7 @@ import com.cloud.utils.Pair;
 
 @APICommand(name = "listEgressFirewallRules", description = "Lists all egress firewall rules for network id.", responseObject = FirewallResponse.class, entityType = {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class ListEgressFirewallRulesCmd extends ListFirewallRulesCmd {
+public class ListEgressFirewallRulesCmd extends BaseListTaggedResourcesCmd implements IListFirewallRulesCmd {
     public static final Logger s_logger = Logger.getLogger(ListEgressFirewallRulesCmd.class.getName());
     private static final String s_name = "listegressfirewallrulesresponse";
 
@@ -48,26 +51,44 @@ public class ListEgressFirewallRulesCmd extends ListFirewallRulesCmd {
     @Parameter(name = ApiConstants.NETWORK_ID,
                type = CommandType.UUID,
                entityType = NetworkResponse.class,
-               description = "the id network network for the egress firwall services")
+               description = "the network id for the egress firewall services")
     private Long networkId;
+
+    @Parameter(name = ApiConstants.IP_ADDRESS_ID,
+               type = CommandType.UUID,
+               entityType = IPAddressResponse.class,
+               description = "the id of IP address of the firewall services")
+    private Long ipAddressId;
+
+    @Parameter(name = ApiConstants.FOR_DISPLAY, type = CommandType.BOOLEAN, description = "list resources by display flag; only ROOT admin is eligible to pass this parameter", since = "4.4", authorized = {RoleType.Admin})
+    private Boolean display;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
-    @Override
+    public Long getIpAddressId() {
+        return ipAddressId;
+    }
+
     public Long getNetworkId() {
         return networkId;
     }
 
-    @Override
     public FirewallRule.TrafficType getTrafficType() {
         return FirewallRule.TrafficType.Egress;
     }
 
-    @Override
     public Long getId() {
         return id;
+    }
+
+    @Override
+    public Boolean getDisplay() {
+        if (display != null) {
+            return display;
+        }
+        return super.getDisplay();
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/org/apache/cloudstack/api/command/user/firewall/ListFirewallRulesCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/firewall/ListFirewallRulesCmd.java
@@ -37,7 +37,7 @@ import com.cloud.utils.Pair;
 
 @APICommand(name = "listFirewallRules", description = "Lists all firewall rules for an IP address.", responseObject = FirewallResponse.class, entityType = {FirewallRule.class},
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class ListFirewallRulesCmd extends BaseListTaggedResourcesCmd {
+public class ListFirewallRulesCmd extends BaseListTaggedResourcesCmd implements IListFirewallRulesCmd {
     public static final Logger s_logger = Logger.getLogger(ListFirewallRulesCmd.class.getName());
     private static final String s_name = "listfirewallrulesresponse";
 
@@ -50,13 +50,13 @@ public class ListFirewallRulesCmd extends BaseListTaggedResourcesCmd {
     @Parameter(name = ApiConstants.IP_ADDRESS_ID,
                type = CommandType.UUID,
                entityType = IPAddressResponse.class,
-               description = "the id of IP address of the firwall services")
+               description = "the id of IP address of the firewall services")
     private Long ipAddressId;
 
     @Parameter(name = ApiConstants.NETWORK_ID,
                type = CommandType.UUID,
                entityType = NetworkResponse.class,
-               description = "list firewall rules for ceratin network",
+               description = "list firewall rules for certain network",
                since = "4.3")
     private Long networkId;
 
@@ -67,18 +67,22 @@ public class ListFirewallRulesCmd extends BaseListTaggedResourcesCmd {
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
+    @Override
     public Long getIpAddressId() {
         return ipAddressId;
     }
 
+    @Override
     public FirewallRule.TrafficType getTrafficType() {
         return FirewallRule.TrafficType.Ingress;
     }
 
+    @Override
     public Long getId() {
         return id;
     }
 
+    @Override
     public Long getNetworkId() {
         return networkId;
     }

--- a/server/src/com/cloud/network/firewall/FirewallManagerImpl.java
+++ b/server/src/com/cloud/network/firewall/FirewallManagerImpl.java
@@ -30,7 +30,7 @@ import javax.naming.ConfigurationException;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
-import org.apache.cloudstack.api.command.user.firewall.ListFirewallRulesCmd;
+import org.apache.cloudstack.api.command.user.firewall.IListFirewallRulesCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -254,7 +254,7 @@ public class FirewallManagerImpl extends ManagerBase implements FirewallService,
     }
 
     @Override
-    public Pair<List<? extends FirewallRule>, Integer> listFirewallRules(ListFirewallRulesCmd cmd) {
+    public Pair<List<? extends FirewallRule>, Integer> listFirewallRules(IListFirewallRulesCmd cmd) {
         Long ipId = cmd.getIpAddressId();
         Long id = cmd.getId();
         Long networkId = cmd.getNetworkId();

--- a/server/test/com/cloud/network/MockFirewallManagerImpl.java
+++ b/server/test/com/cloud/network/MockFirewallManagerImpl.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.cloudstack.api.command.user.firewall.ListFirewallRulesCmd;
+import org.apache.cloudstack.api.command.user.firewall.IListFirewallRulesCmd;
 
 import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.ResourceUnavailableException;
@@ -64,7 +64,7 @@ public class MockFirewallManagerImpl extends ManagerBase implements FirewallMana
     }
 
     @Override
-    public Pair<List<? extends FirewallRule>, Integer> listFirewallRules(ListFirewallRulesCmd cmd) {
+    public Pair<List<? extends FirewallRule>, Integer> listFirewallRules(IListFirewallRulesCmd cmd) {
         // TODO Auto-generated method stub
         return null;
     }


### PR DESCRIPTION
…d cleanup

Fixes API duplicate parameter in docs and makes it more clear.
Fixes a bunch of typos.