### PR TITLE
CLOUDSTACK-8468: Correct test case in test_bugs.py

### DIFF
--- a/test/integration/component/maint/test_bugs.py
+++ b/test/integration/component/maint/test_bugs.py
@@ -532,6 +532,12 @@ class Test42xBugsMgmtSvr(cloudstackTestCase):
 
          """
 
+        if not is_config_suitable(apiclient=self.apiClient,
+                                  name='apply.allocation.algorithm.to.pods',
+                                  value='true'):
+            self.skipTest('apply.allocation.algorithm.to.pods '
+                          'should be true. skipping')
+
         # register windows 2012 VM template as windows 8 template
         self.hypervisor = self.testClient.getHypervisorInfo()
         if self.hypervisor.lower() in ['lxc']:


### PR DESCRIPTION
test_es_47_list_os_types_win_2012 should be run only when the global setting "apply.allocation.algorithm.to.pods" is set to True.