### PR TITLE
Systemvm: Disable services that slow down boot

### DIFF
--- a/tools/appliance/definitions/systemvmtemplate/configure_systemvm_services.sh
+++ b/tools/appliance/definitions/systemvmtemplate/configure_systemvm_services.sh
@@ -70,6 +70,10 @@ function configure_services() {
 
   chkconfig xl2tpd off
 
+  # Disable services that slow down boot and are not used anyway
+  chkconfig x11-common off
+  chkconfig console-setup off
+
   # Hyperv kvp daemon - 64bit only
   local arch=`dpkg --print-architecture`
   if [ "${arch}" == "amd64" ]; then


### PR DESCRIPTION
The console-setup service brings a nice font to the console, but why would we want to use it. In most cases it takes a <10 seconds to set it up. When using nested hypervising, I found this takes much longer time that causes tests to time-out. I'd suggest turning off these unused services. They are not required for the services the systemvm provides.
