### PR TITLE
CLOUDSTACK-8482: Enhacing recurring snapshots test cases

### DIFF
--- a/test/integration/component/test_recurring_snapshots.py
+++ b/test/integration/component/test_recurring_snapshots.py
@@ -104,7 +104,7 @@ class Services:
             "recurring_snapshot": {
                 "intervaltype": 'HOURLY',
                 # Frequency of snapshots
-                "maxsnaps": 1,  # Should be min 2
+                "maxsnaps": 2,  # Should be min 2
                 "schedule": 1,
                 "timezone": 'US/Arizona',
                 # Timezone Formats -
@@ -182,15 +182,14 @@ class TestRecurringSnapshots(cloudstackTestCase):
             cls.api_client,
             cls.services["service_offering"]
         )
-        cls.virtual_machine = cls.virtual_machine_with_disk = \
+        cls.virtual_machine_with_disk = \
             VirtualMachine.create(
                 cls.api_client,
                 cls.services["server_with_disk"],
                 templateid=template.id,
                 accountid=cls.account.name,
                 domainid=cls.account.domainid,
-                serviceofferingid=cls.service_offering.id,
-                mode=cls.services["mode"]
+                serviceofferingid=cls.service_offering.id
             )
         cls.virtual_machine_without_disk = \
             VirtualMachine.create(
@@ -199,8 +198,7 @@ class TestRecurringSnapshots(cloudstackTestCase):
                 templateid=template.id,
                 accountid=cls.account.name,
                 domainid=cls.account.domainid,
-                serviceofferingid=cls.service_offering.id,
-                mode=cls.services["mode"]
+                serviceofferingid=cls.service_offering.id
             )
         cls._cleanup = [
             cls.service_offering,
@@ -233,7 +231,7 @@ class TestRecurringSnapshots(cloudstackTestCase):
         return
 
     @attr(speed="slow")
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "basic"], required_hardware="true")
     def test_recurring_snapshot_root_disk(self):
         """Test Recurring Snapshot Root Disk
         """
@@ -243,7 +241,7 @@ class TestRecurringSnapshots(cloudstackTestCase):
 
         volume = list_volumes(
             self.apiclient,
-            virtualmachineid=self.virtual_machine_with_disk.id,
+            virtualmachineid=self.virtual_machine_without_disk.id,
             type='ROOT',
             listall=True
         )
@@ -286,10 +284,12 @@ class TestRecurringSnapshots(cloudstackTestCase):
             self.services["recurring_snapshot"]["maxsnaps"],
             "Check interval type in list resources call"
         )
-        # Sleep for (maxsnaps+1) hours to verify
+
+        max_snapshots = self.services["recurring_snapshot"]["maxsnaps"]
+        # Sleep for (max_snapshots*2) hours to verify
         # only maxsnaps snapshots are retained
         time.sleep(
-            (self.services["recurring_snapshot"]["maxsnaps"]) * 3600
+            (max_snapshots * 2) * 3600
         )
 
         timeout = self.services["timeout"]
@@ -319,13 +319,13 @@ class TestRecurringSnapshots(cloudstackTestCase):
 
         self.assertEqual(
             len(snapshots),
-            self.services["recurring_snapshot"]["maxsnaps"],
+            max_snapshots,
             "Check maximum number of recurring snapshots retained"
         )
         return
 
     @attr(speed="slow")
-    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns", "basic"], required_hardware="true")
     def test_recurring_snapshot_data_disk(self):
         """Test Recurring Snapshot data Disk
         """
@@ -382,10 +382,11 @@ class TestRecurringSnapshots(cloudstackTestCase):
             "Check interval type in list resources call"
         )
 
+        max_snapshots = self.services["recurring_snapshot"]["maxsnaps"]
         # Sleep for (maxsnaps) hours to verify only maxsnaps snapshots are
         # retained
         time.sleep(
-            (self.services["recurring_snapshot"]["maxsnaps"]) * 3600
+            (max_snapshots * 2) * 3600
         )
 
         timeout = self.services["timeout"]
@@ -414,7 +415,7 @@ class TestRecurringSnapshots(cloudstackTestCase):
         )
         self.assertEqual(
             len(snapshots),
-            self.services["recurring_snapshot"]["maxsnaps"],
+            max_snapshots,
             "Check maximum number of recurring snapshots retained"
         )
         return


### PR DESCRIPTION
Current test cases do not verify that only maximum snapshots mentioned in the snapshot policy are retained after minimum hours required to create the snapshots are passed.
Enhancing the current test cases to take care of this.