### PR TITLE
CLOUDSTACK-8486: Refactoring LibVirt (KVM) Hypervisor Plugin

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -195,6 +195,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     public static final String SSHPUBKEYPATH = SSHKEYSPATH + File.separator + "id_rsa.pub.cloud";
 
     public static final String BASH_SCRIPT_PATH = "/bin/bash";
+    public static final int DEFAULT_PING_TIMEOUT = 10000;
 
     private String _mountPoint = "/mnt";
     private StorageLayer _storage;

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPingTestCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPingTestCommandWrapper.java
@@ -33,13 +33,16 @@ public final class LibvirtPingTestCommandWrapper extends CommandWrapper<PingTest
 
     @Override
     public Answer execute(final PingTestCommand command, final LibvirtComputingResource libvirtComputingResource) {
+        final LibvirtUtilitiesHelper libvirtUtilitiesHelper = libvirtComputingResource.getLibvirtUtilitiesHelper();
+        final int defaultPingTimeout = libvirtUtilitiesHelper.retrieveDefaultPingTieout();
+
         String result = null;
         final String computingHostIp = command.getComputingHostIp(); // TODO, split the command into 2 types
 
         if (computingHostIp != null) {
-            result = doPingTest(libvirtComputingResource, computingHostIp);
+            result = doPingTest(libvirtComputingResource, computingHostIp, defaultPingTimeout);
         } else if (command.getRouterIp() != null && command.getPrivateIp() != null) {
-            result = doPingTest(libvirtComputingResource, command.getRouterIp(), command.getPrivateIp());
+            result = doPingTest(libvirtComputingResource, command.getRouterIp(), command.getPrivateIp(), defaultPingTimeout);
         } else {
             return new Answer(command, false, "routerip and private ip is null");
         }
@@ -50,14 +53,14 @@ public final class LibvirtPingTestCommandWrapper extends CommandWrapper<PingTest
         return new Answer(command);
     }
 
-    protected String doPingTest(final LibvirtComputingResource libvirtComputingResource, final String computingHostIp) {
-        final Script command = new Script(libvirtComputingResource.getPingTestPath(), 10000, s_logger);
+    protected String doPingTest(final LibvirtComputingResource libvirtComputingResource, final String computingHostIp, final int defaultPingTimeout) {
+        final Script command = new Script(libvirtComputingResource.getPingTestPath(), defaultPingTimeout, s_logger);
         command.add("-h", computingHostIp);
         return command.execute();
     }
 
-    protected String doPingTest(final LibvirtComputingResource libvirtComputingResource, final String domRIp, final String vmIp) {
-        final Script command = new Script(libvirtComputingResource.getPingTestPath(), 10000, s_logger);
+    protected String doPingTest(final LibvirtComputingResource libvirtComputingResource, final String domRIp, final String vmIp, final int defaultPingTimeout) {
+        final Script command = new Script(libvirtComputingResource.getPingTestPath(), defaultPingTimeout, s_logger);
         command.add("-i", domRIp);
         command.add("-p", vmIp);
         return command.execute();

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtUtilitiesHelper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtUtilitiesHelper.java
@@ -86,4 +86,8 @@ public class LibvirtUtilitiesHelper {
     public String retrieveBashScriptPath() {
         return LibvirtComputingResource.BASH_SCRIPT_PATH;
     }
+
+    public int retrieveDefaultPingTieout() {
+        return LibvirtComputingResource.DEFAULT_PING_TIMEOUT;
+    }
 }

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -68,7 +68,7 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -170,7 +170,7 @@ import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.PowerState;
 import com.cloud.vm.VirtualMachine.Type;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class LibvirtComputingResourceTest {
 
     @Mock

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -1273,33 +1273,57 @@ public class LibvirtComputingResourceTest {
     public void testPingTestHostIpCommand() {
         final PingTestCommand command = new PingTestCommand("172.1.10.10");
 
+        final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
+
+        when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
+        when(libvirtUtilitiesHelper.retrieveDefaultPingTieout()).thenReturn(1);
+
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
         assertNotNull(wrapper);
 
         final Answer answer = wrapper.execute(command, libvirtComputingResource);
         assertFalse(answer.getResult());
+
+        verify(libvirtComputingResource, times(1)).getLibvirtUtilitiesHelper();
+        verify(libvirtUtilitiesHelper, times(1)).retrieveDefaultPingTieout();
     }
 
     @Test
     public void testPingTestPvtIpCommand() {
         final PingTestCommand command = new PingTestCommand("169.17.1.10", "192.168.10.10");
 
+        final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
+
+        when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
+        when(libvirtUtilitiesHelper.retrieveDefaultPingTieout()).thenReturn(1);
+
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
         assertNotNull(wrapper);
 
         final Answer answer = wrapper.execute(command, libvirtComputingResource);
         assertFalse(answer.getResult());
+
+        verify(libvirtComputingResource, times(1)).getLibvirtUtilitiesHelper();
+        verify(libvirtUtilitiesHelper, times(1)).retrieveDefaultPingTieout();
     }
 
     @Test
     public void testPingOnlyOneIpCommand() {
         final PingTestCommand command = new PingTestCommand("169.17.1.10", null);
 
+        final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
+
+        when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
+        when(libvirtUtilitiesHelper.retrieveDefaultPingTieout()).thenReturn(1);
+
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
         assertNotNull(wrapper);
 
         final Answer answer = wrapper.execute(command, libvirtComputingResource);
         assertFalse(answer.getResult());
+
+        verify(libvirtComputingResource, times(1)).getLibvirtUtilitiesHelper();
+        verify(libvirtUtilitiesHelper, times(1)).retrieveDefaultPingTieout();
     }
 
     @Test

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/CitrixRequestWrapperTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/CitrixRequestWrapperTest.java
@@ -41,8 +41,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.AttachIsoCommand;
@@ -134,7 +134,7 @@ import com.xensource.xenapi.Pool;
 import com.xensource.xenapi.Types.BadServerResponse;
 import com.xensource.xenapi.Types.XenAPIException;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class CitrixRequestWrapperTest {
 
     @Mock


### PR DESCRIPTION
Hi @bhaisaab and @DaanHoogland

There goes a PR to fix JDK 1.8 build (whenever use start using them)

    Changing the JUnit runner in order to avoid problems with Java 8
      - All tests passed using different approaches
        - Maven with parameters: -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8
        - Maven without parameters
    
    All builds were executed using javac 1.8.0_31

    Parameterising a hardcoded timeout of 10000 milli seconds.
      - This timeout was hanging when running the unit tests (3, in total)
      - The value is now mocked and 1 is returned instead of 10000

Environment:

Centos7 + KVM + Qemu
MySQL/MariaDB 5.5.41
Management Server running CentOS 7
Component/Smoke tests: https://github.com/apache/cloudstack (test/integration/component and smoke)
Storage type: NFS shared
Isolation method: VLAN

Test Create Account and user for that account ... === TestName: test_01_create_account | Status : SUCCESS ===
ok
Test Sub domain allowed to launch VM  when a Domain ... === TestName: test_01_add_vm_to_subdomain | Status : SUCCESS ===
ok
Test delete domain without force option ... === TestName: test_DeleteDomain | Status : SUCCESS ===
ok
Test delete domain with force option ... === TestName: test_forceDeleteDomain | Status : SUCCESS ===
ok
Test to verify Non Root admin previleges ... === TestName: test_01_non_root_admin_Privileges | Status : SUCCESS ===
ok
Test Remove one user from the account ... === TestName: test_01_user_remove_VM_running | Status : SUCCESS ===
ok
Test to verify service offerings at same level in hierarchy ... === TestName: test_01_service_offering_hierarchy | Status : SUCCESS ===
ok
Test to verify service offerings at same level in hierarchy ... === TestName: test_01_service_offering_siblings | Status : SUCCESS ===
ok
Test to verify template at same level in hierarchy ... === TestName: test_01_template_hierarchy | Status : SUCCESS ===
ok
Test update admin details ... === TestName: test_updateAdminDetails | Status : SUCCESS ===
ok
Test update domain admin details ... === TestName: test_updateDomainAdminDetails | Status : SUCCESS ===
ok
Test user update API ... === TestName: test_updateUserDetails | Status : SUCCESS ===
ok
Test login API with domain ... === TestName: test_LoginApiDomain | Status : SUCCESS ===
ok
Test if Login API does not return UUID's ... === TestName: test_LoginApiUuidResponse | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 14 tests in 7907.566s

OK
/tmp//MarvinLogs/test_accounts_D6DDT5/results.txt


Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... SKIP: At least two hosts should be present in the zone for migration
Test destroy(expunge) Virtual Machine ... === TestName: test_09_expunge_vm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 10 tests in 2997.472s

OK (SKIP=1)
/tmp//MarvinLogs/test_vm_life_cycle_KWTICX/results.txt