### PR TITLE
CLOUDSTACK-8231: Fixed UI empty drop-down list for LB rules

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1703,7 +1703,7 @@
                                                             name: 'source',
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
-                                                    if (typeof args.context != 'undefined') {
+                                                    if (typeof args.context == 'undefined') {
                                                         data = getLBAlgorithms(args.context.networks[0]);
                                                     }
                                                     args.response.success({
@@ -3551,7 +3551,7 @@
                                                             name: 'source',
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
-                                                    if (typeof args.context != 'undefined') {
+                                                    if (typeof args.context == 'undefined') {
                                                         data = getLBAlgorithms(args.context.networks[0]);
                                                     }
                                                     args.response.success({


### PR DESCRIPTION
It seems that getLbAlgorithms() function must be called if context is "undefined".  If context is defined then function returns empty list. That is why drop-down menu is also empty when I add new LB rule.