### PR TITLE
CLOUDSTACK-8492: Fix dictionary access issue in createChecksum method common.py

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -936,7 +936,7 @@ test_data = {
                      "datadiskdevice_1": '/dev/xvdb',
                     "datadiskdevice_2": '/dev/xvdc',   # Data Disk
                     },
-        "KVM":       {"rootdiskdevice": "/dev/vda",
+        "kvm":       {"rootdiskdevice": "/dev/vda",
                     "datadiskdevice_1": "/dev/vdb",
                     "datadiskdevice_2": "/dev/vdc"
                     },

--- a/tools/marvin/marvin/lib/common.py
+++ b/tools/marvin/marvin/lib/common.py
@@ -1438,13 +1438,13 @@ def createChecksum(service=None,
     format_volume_to_ext3(
         ssh_client,
         service["volume_write_path"][
-            virtual_machine.hypervisor][disk_type]
+            virtual_machine.hypervisor.lower()][disk_type]
     )
     cmds = ["fdisk -l",
             "mkdir -p %s" % service["data_write_paths"]["mount_dir"],
             "mount -t ext3 %s1 %s" % (
                 service["volume_write_path"][
-                    virtual_machine.hypervisor][disk_type],
+                    virtual_machine.hypervisor.lower()][disk_type],
                 service["data_write_paths"]["mount_dir"]
             ),
             "mkdir -p %s/%s/%s " % (
@@ -1514,7 +1514,7 @@ def compareChecksum(
             "mkdir -p %s" % service["data_write_paths"]["mount_dir"],
             "mount -t ext3 %s1 %s" % (
                 service["volume_write_path"][
-                    virt_machine.hypervisor][disk_type],
+                    virt_machine.hypervisor.lower()][disk_type],
                 service["data_write_paths"]["mount_dir"]
             ),
             ]


### PR DESCRIPTION
The hypervisor string is not converted to lowercase, hence it's failing for some hypervisors while trying to access element in dictionary "volume_write_path". Added lower() conversion.