### PR TITLE
CLOUDSTACK-8231: fixed call to getLbAlgorithms() function

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1703,7 +1703,7 @@
                                                             name: 'source',
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
-                                                    if (typeof args.context != 'undefined') {
+                                                    if (typeof args.context == 'undefined') {
                                                         data = getLBAlgorithms(args.context.networks[0]);
                                                     }
                                                     args.response.success({
@@ -3551,7 +3551,7 @@
                                                             name: 'source',
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
-                                                    if (typeof args.context != 'undefined') {
+                                                    if (typeof args.context == 'undefined') {
                                                         data = getLBAlgorithms(args.context.networks[0]);
                                                     }
                                                     args.response.success({

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1703,7 +1703,7 @@
                                                             name: 'source',
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
-                                                    if (typeof args.context == 'undefined') {
+                                                    if (typeof args.context != 'undefined') {
                                                         var lbAlgs = getLBAlgorithms(args.context.networks[0]);
                                                         data = (lbAlgs.length == 0) ? data : lbAlgs ;
                                                     }
@@ -3552,7 +3552,7 @@
                                                             name: 'source',
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
-                                                    if (typeof args.context == 'undefined') {
+                                                    if (typeof args.context != 'undefined') {
                                                         var lbAlgs = getLBAlgorithms(args.context.networks[0]);
                                                         data = (lbAlgs.length == 0) ? data : lbAlgs ;
                                                     }

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1704,7 +1704,8 @@
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
                                                     if (typeof args.context == 'undefined') {
-                                                        data = getLBAlgorithms(args.context.networks[0]);
+                                                        var lbAlgs = getLBAlgorithms(args.context.networks[0]);
+                                                        data = (lbAlgs.length == 0) ? data : lbAlgs ;
                                                     }
                                                     args.response.success({
                                                         data: data
@@ -3552,7 +3553,8 @@
                                                             description: _l('label.lb.algorithm.source')
                                                         }];
                                                     if (typeof args.context == 'undefined') {
-                                                        data = getLBAlgorithms(args.context.networks[0]);
+                                                        var lbAlgs = getLBAlgorithms(args.context.networks[0]);
+                                                        data = (lbAlgs.length == 0) ? data : lbAlgs ;
                                                     }
                                                     args.response.success({
                                                         data: data


### PR DESCRIPTION
Context must be not empty before calling getLbAlgorithms() function, so previous commit may cause side-effects while trying to get LB algorithms with empty context. 
The list in drop-down menu is either static list of LB rules or result of getLbAlgorithms() function if it is not empty