### PR TITLE
CLOUDSTACK-8498: Including schedule as default key in recurring_snapshot dict used to create recurring snapshot policy

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -959,6 +959,7 @@ test_data = {
     "recurring_snapshot": {
         "maxsnaps": 2,
         "timezone": "US/Arizona",
+        "schedule": 1
     },
     "volume_offerings": {
         0: {"diskname": "TestDiskServ"},


### PR DESCRIPTION
Some test cases are failing because schedule key is absent in recurring_snapshot dict.