### PR TITLE
CLOUDSTACK-8500: Adding missing key in test_data.py

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -1709,6 +1709,7 @@ test_data = {
                     "mode": 'HTTP_DOWNLOAD'
         },
      "setHostConfigurationForIngressRule": False,
+     "restartManagementServerThroughTestCase": False,
      "vmxnet3template": {
             "displaytext": "VMXNET3 Template",
             "name": "VMXNET3 template",


### PR DESCRIPTION
The key "restartManagementServerThroughTestCase" is absent in test_data.py while it is being used in the test cases.