### PR TITLE
kvm: for disabling pxe, don't pass any file argument

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -967,7 +967,7 @@ public class LibvirtVMDef {
                 netBuilder.append("<script path='" + _scriptPath + "'/>\n");
             }
             if (_pxeDisable) {
-                netBuilder.append("<rom bar='off' file='dummy'/>");
+                netBuilder.append("<rom bar='off' file=''/>");
             }
             if (_virtualPortType != null) {
                 netBuilder.append("<virtualport type='" + _virtualPortType + "'>\n");


### PR DESCRIPTION
Passing the file argument to the xml break for EL 7.1, the fix removes
the argument as just passing rombar='off' is enough to disable pxe booting
for libvirt 0.9.10+

http://askubuntu.com/questions/190929/how-do-i-disable-unwanted-ipxe-boot-attempt-in-libvirt-qemu-kvm