### PR TITLE
CLOUDSTACK-8247: Pull average Cpu util report between polling

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -16,50 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.kvm.resource;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.ejb.Local;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-
-import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-import org.apache.cloudstack.storage.to.VolumeObjectTO;
-import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
-import org.libvirt.Connect;
-import org.libvirt.Domain;
-import org.libvirt.DomainBlockStats;
-import org.libvirt.DomainInfo;
-import org.libvirt.DomainInfo.DomainState;
-import org.libvirt.DomainInterfaceStats;
-import org.libvirt.LibvirtException;
-import org.libvirt.NodeInfo;
-
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.HostVmStateReportEntry;
@@ -139,6 +95,50 @@ import com.cloud.utils.script.Script;
 import com.cloud.utils.ssh.SshHelper;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.PowerState;
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
+import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.apache.cloudstack.utils.linux.CPUStat;
+import org.apache.cloudstack.utils.linux.MemStat;
+import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.libvirt.Connect;
+import org.libvirt.Domain;
+import org.libvirt.DomainBlockStats;
+import org.libvirt.DomainInfo;
+import org.libvirt.DomainInfo.DomainState;
+import org.libvirt.DomainInterfaceStats;
+import org.libvirt.LibvirtException;
+import org.libvirt.NodeInfo;
+
+import javax.ejb.Local;
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * LibvirtComputingResource execute requests on the computing/routing host using
@@ -261,6 +261,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     protected boolean _disconnected = true;
     protected int _cmdsTimeout;
     protected int _stopTimeout;
+    protected CPUStat _cpuStat = new CPUStat();
+    protected MemStat _memStat = new MemStat();
 
     @Inject
     private LibvirtUtilitiesHelper libvirtUtilitiesHelper;
@@ -328,6 +330,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     public LibvirtUtilitiesHelper getLibvirtUtilitiesHelper() {
         return libvirtUtilitiesHelper;
+    }
+
+    public CPUStat getCPUStat() {
+        return _cpuStat;
+    }
+
+    public MemStat getMemStat() {
+        return _memStat;
     }
 
     public VirtualRoutingResource getVirtRouterResource() {

--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/linux/CPUStat.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/linux/CPUStat.java
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.utils.linux;
+
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Scanner;
+
+public class CPUStat {
+    private static final Logger s_logger = Logger.getLogger(CPUStat.class);
+
+    private Integer _cores;
+    private UptimeStats _lastStats;
+    private final String _sysfsCpuDir = "/sys/devices/system/cpu";
+    private final String _uptimeFile = "/proc/uptime";
+
+    class UptimeStats {
+        public Double upTime = 0d;
+        public Double cpuIdleTime = 0d;
+
+        public UptimeStats(Double upTime, Double cpuIdleTime) {
+            this.upTime = upTime;
+            this.cpuIdleTime = cpuIdleTime;
+        }
+    }
+
+    public CPUStat () {
+        init();
+    }
+
+    private void init() {
+        _cores = getCoresFromLinux();
+        _lastStats = getUptimeAndCpuIdleTime();
+    }
+
+    private UptimeStats getUptimeAndCpuIdleTime() {
+        UptimeStats uptime = new UptimeStats(0d, 0d);
+        try {
+            String[] stats =  new Scanner(new File(_uptimeFile)).useDelimiter("\\Z").next().split("\\s+");
+            uptime = new UptimeStats(Double.parseDouble(stats[0]), Double.parseDouble(stats[1]));
+        } catch (FileNotFoundException ex) {
+            s_logger.warn("File " + _uptimeFile + " not found:" + ex.toString());
+        }
+        return uptime;
+    }
+
+    private Integer getCoresFromLinux() {
+        Integer cpus = 0;
+        File cpuDir = new File(_sysfsCpuDir);
+        File[] files = cpuDir.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.getName().matches("cpu\\d+")) {
+                    cpus++;
+                }
+            }
+        }
+        return cpus;
+    }
+
+    public Integer getCores() {
+        return _cores;
+    }
+
+    public Double getCpuUsedPercent() {
+        Double cpuUsed = 0d;
+        if (_cores == null || _cores == 0) {
+            _cores = getCoresFromLinux();
+        }
+
+        UptimeStats currentStats = getUptimeAndCpuIdleTime();
+        if (currentStats == null) {
+            return cpuUsed;
+        }
+
+        Double timeElapsed = currentStats.upTime - _lastStats.upTime;
+        Double cpuElapsed = (currentStats.cpuIdleTime - _lastStats.cpuIdleTime) / _cores;
+        if (timeElapsed > 0) {
+            cpuUsed = (1 - (cpuElapsed / timeElapsed)) * 100;
+        }
+        if (cpuUsed < 0) {
+            cpuUsed = 0d;
+        }
+        _lastStats = currentStats;
+        return cpuUsed;
+    }
+}


### PR DESCRIPTION
Pull average Cpu util report between polling intervals instead of since boot
instead of using values since uptime

While cherry picked from commit 04176eaf171b46638be99b2f675aa2f09e99e1b8, since codebases are different wrt kvm. It's slightly different than the original commit.