### PR TITLE
CLOUDSTACK-8512: Fixed test script issues in test_escalations_hosts.py

### DIFF
--- a/test/integration/component/maint/test_escalations_hosts.py
+++ b/test/integration/component/maint/test_escalations_hosts.py
@@ -77,13 +77,12 @@ def update_pod(apiclient, state, pod_id):
     return pod_status.allocationstate
 
 
-def update_zone(apiclient, state, zone_id):
+def update_zone(apiclient, state, zone):
     """
     Function to Enable/Disable zone
     """
-    zone_status = Zone.update(
+    zone_status = zone.update(
         apiclient,
-        id=zone_id,
         allocationstate=state
     )
     return zone_status.allocationstate
@@ -119,12 +118,12 @@ class TestHosts(cloudstackTestCase):
         cls._cleanup = []
 
         # get zone, domain etc
-        cls.zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
+        cls.zone = Zone(get_zone(cls.apiclient, cls.testClient.getZoneForTests()).__dict__)
         cls.domain = get_domain(cls.apiclient)
         cls.pod = get_pod(cls.apiclient, cls.zone.id)
 
         # list hosts
-        hosts = list_hosts(cls.apiclient)
+        hosts = list_hosts(cls.apiclient, type="Routing")
         if len(hosts) > 0:
             cls.my_host_id = hosts[0].id
             cls.host_db_id = cls.dbclient.execute(
@@ -299,7 +298,7 @@ class TestHosts(cloudstackTestCase):
         zone_allocationstate = update_zone(
             self.apiclient,
             zone_state,
-            self.zone.id)
+            self.zone)
         self.assertEqual(
             zone_allocationstate,
             zone_state,
@@ -311,7 +310,7 @@ class TestHosts(cloudstackTestCase):
         zone_allocationstate = update_zone(
             self.apiclient,
             zone_state,
-            self.zone.id)
+            self.zone)
         self.assertEqual(
             zone_allocationstate,
             zone_state,


### PR DESCRIPTION
The test script has several issues related to calling base class methods and retrieving data from database.
Fixed them.

Logs:
Disable the host and it's cluster, ... === TestName: test_01_op_host_capacity_disable_cluster | Status : SUCCESS ===
ok
Disable the host and it's pod, ... === TestName: test_02_op_host_capacity_disable_pod | Status : SUCCESS ===
ok
Disable the host and it's zone, ... === TestName: test_03_op_host_capacity_disable_zone | Status : SUCCESS ===
ok
Disable the host then unmanage the cluster, ... === TestName: test_04_disable_host_unmanage_cluster_check_hosts_status | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 4 tests in 126.470s

OK
