### PR TITLE
CLOUDSTACK-8445: Keep only dvs tag for test case which tests the VCenter port groups

### DIFF
--- a/test/integration/component/test_shared_networks.py
+++ b/test/integration/component/test_shared_networks.py
@@ -3675,7 +3675,7 @@ class TestSharedNetworks(cloudstackTestCase):
         )
         return
 
-    @attr(tags=["advanced", "dvs"], required_hardware="true")
+    @attr(tags=["dvs"], required_hardware="true")
     def test_guest_traffic_port_groups_shared_network(self):
         """ Verify vcenter port groups are created for shared network
 

--- a/test/integration/component/test_vpc_vm_life_cycle.py
+++ b/test/integration/component/test_vpc_vm_life_cycle.py
@@ -2064,7 +2064,7 @@ class TestVMLifeCycleBothIsolated(cloudstackTestCase):
                          )
         return
 
-    @attr(tags=["advanced", "dvs"], required_hardware="true")
+    @attr(tags=["dvs"], required_hardware="true")
     def test_guest_traffic_port_groups_vpc_network(self):
         """ Verify port groups are created for guest traffic
         used by vpc network """


### PR DESCRIPTION
The test cases need to be run only on dvs configuration and not on all advanced configurations. Hence keeping only "dvs" tag.