### PR TITLE
CLOUDSTACK-8506

### DIFF
--- a/utils/test/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/test/com/cloud/utils/net/NetUtilsTest.java
@@ -378,13 +378,7 @@ public class NetUtilsTest {
         String ip1;
         String ip2;
 
-        // 192.168.0.0 - 192.168.0.0 - 192.168.0.1
-        // GW and IP1 overlaps, but in that case it's a 31bit IP.
-        // 192.168.0.0 - 192.168.0.1 - 192.168.0.2
-        // GW and IP1 overlaps, but in that case it's a 31bit IP.
-        // and so on.
-
-        for (int i = 0, j = 1; i <= 254; i++, j++) {
+        for (int i = 1, j = 2; i <= 254; i++, j++) {
             ip1 = "192.168.0." + i;
             ip2 = "192.168.0." + j;
 
@@ -399,9 +393,6 @@ public class NetUtilsTest {
         String ip1;
         String ip2;
 
-        // 192.168.0.10 - 192.168.0.10 - 192.168.0.12
-        // GW and IP1 overlaps and in that case it's not a 31bit IP.
-
         for (int i = 10, j = 12; i <= 254; i++, j++) {
             gw = "192.168.0." + i;
             ip1 = "192.168.0." + i;
@@ -410,5 +401,21 @@ public class NetUtilsTest {
             final boolean doesOverlap = NetUtils.ipRangesOverlap(ip1, ip2, gw, gw);
             assertTrue("It overlaps!", doesOverlap);
         }
+    }
+
+    @Test
+    public void testIs31PrefixCidrFail() {
+        final String cidr = "10.10.0.0/32";
+        final boolean is31PrefixCidr = NetUtils.is31PrefixCidr(cidr);
+
+        assertFalse("It should fail! 32 bit prefix.", is31PrefixCidr);
+    }
+
+    @Test
+    public void testIs31PrefixCidr() {
+        final String cidr = "10.10.0.0/31";
+        final boolean is31PrefixCidr = NetUtils.is31PrefixCidr(cidr);
+
+        assertTrue("It should pass! 31 bit prefix.", is31PrefixCidr);
     }
 }


### PR DESCRIPTION
Removing the previous logic and adding a method to check if the CIDR is 31 bit prefixed
Adding tests for the new method

@DaanHoogland, could you have a look?

Tests:

Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... SKIP: At least two hosts should be present in the zone for migration
Test destroy(expunge) Virtual Machine ... === TestName: test_09_expunge_vm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 10 tests in 2662.908s

OK (SKIP=1)
/tmp//MarvinLogs/test_vm_life_cycle_R8HIX4/results.txt (END

Manual tests:

Added 2 pub networks on my KVM based  DC

![image](https://cloud.githubusercontent.com/assets/5129209/7809140/791823c8-0398-11e5-863d-279477cadd18.png)

Smae was done for  XenServer 6.32

Cheers,
Wilder