### PR TITLE
CLOUDSTACK-7888: unable to create remote vpn because of special character in password

### DIFF
--- a/systemvm/patches/debian/vpn/opt/cloud/bin/vpn_l2tp.sh
+++ b/systemvm/patches/debian/vpn/opt/cloud/bin/vpn_l2tp.sh
@@ -170,11 +170,11 @@ add_l2tp_ipsec_user() {
    local u=$1
    local passwd=$2
 
-   uptodate=$(grep "^$u \* $passwd \*$" /etc/ppp/chap-secrets)
+   uptodate=$(grep "^$u \* \"$passwd\" \*$" /etc/ppp/chap-secrets)
    if [ "$uptodate" == "" ]
    then
        remove_l2tp_ipsec_user $u
-       echo "$u * $passwd *" >> /etc/ppp/chap-secrets
+       echo "$u * \"$passwd\" *" >> /etc/ppp/chap-secrets
    fi
 }
 


### PR DESCRIPTION
Always enter chap-secrets as a quoted field. In the event of special characters it creates and deletes the entry properly, in the event there are not special characters there is no change behavior.