### PR TITLE
CLOUDSTACK-8514: test_haproxy.py - Verifying router state before validating network rules

### DIFF
--- a/test/integration/component/test_haproxy.py
+++ b/test/integration/component/test_haproxy.py
@@ -36,8 +36,10 @@ from marvin.lib.common import (get_domain,
                                get_template
                                )
 from marvin.lib.utils import (cleanup_resources,
-                              random_gen)
+                              random_gen,
+                              verifyRouterState)
 from marvin.cloudstackAPI import createLBStickinessPolicy
+from marvin.codes import PASS
 from marvin.sshClient import SshClient
 
 
@@ -753,6 +755,11 @@ class TestHAProxyStickyness(cloudstackTestCase):
 
         self.debug("Starting the router: %s" % router.name)
         Router.start(self.apiclient, id=router.id)
+
+        response = verifyRouterState(self.apiclient,
+                                     router.id,
+                                     "running")
+        self.assertEqual(response[0], PASS, response[1])
 
         self.debug("Policy: %s" % str(policy))
         self.debug("Validating the stickiness policy")


### PR DESCRIPTION
The test case test_08_create_policy_router_stopped fails in automation runs because the router state is not verified if running, when the routers is stopped and started again.
In this case SSH fails if the router is still in starting state.
Hence, before doing SSH, check if the router it is in running state, then only proceed.