### PR TITLE
Skip snapshot tests since it is not supported on LXC

### DIFF
--- a/test/integration/component/test_escalations_snapshots.py
+++ b/test/integration/component/test_escalations_snapshots.py
@@ -40,9 +40,11 @@ class TestSnapshots(cloudstackTestCase):
             cls.testClient = super(TestSnapshots, cls).getClsTestClient()
             cls.api_client = cls.testClient.getApiClient()
             cls.services = cls.testClient.getParsedTestDataConfig()
+            cls.unsupportedHypervisor = False
             cls.hypervisor = cls.testClient.getHypervisorInfo()
-            if cls.hypervisor.lower() == 'lxc':
-                raise unittest.SkipTest("snapshots are not supported on %s" % cls.hypervisor.lower())
+            if cls.hypervisor.lower() in ("lxc"):
+                cls.unsupportedHypervisor = True
+                return
             # Get Domain, Zone, Template
             cls.domain = get_domain(cls.api_client)
             cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
@@ -102,6 +104,8 @@ class TestSnapshots(cloudstackTestCase):
 
         self.apiClient = self.testClient.getApiClient()
         self.cleanup = []
+        if self.unsupportedHypervisor:
+            self.skipTest("Snapshots are not supported on %s" %self.hypervisor)
 
     def tearDown(self):
         # Clean up, terminate the created resources


### PR DESCRIPTION
@Desc: Test to List Volume Snapshots pagination ... SKIP: Snapshots are not supported on LXC
@Desc: Test to List Volume Snapshots by Id ... SKIP: Snapshots are not supported on LXC
@Desc: Test to List VM Snapshots pagination ... SKIP: Snapshots are not supported on LXC
@summary: Test to List VM Snapshots by Id ... SKIP: Snapshots are not supported on LXC

----------------------------------------------------------------------
Ran 4 tests in 0.009s

OK (SKIP=4)