### PR TITLE
CLOUDSTACK-8517 Fix the NPE that was being caught by the executeRequest() method.

### DIFF
--- a/plugins/hypervisors/kvm/resources/META-INF/cloudstack/kvm-compute/spring-kvm-compute-context.xml
+++ b/plugins/hypervisors/kvm/resources/META-INF/cloudstack/kvm-compute/spring-kvm-compute-context.xml
@@ -31,7 +31,4 @@
         <property name="name" value="KVMInvestigator" />
     </bean>
     
-    <bean id="libvirtUtilitiesHelper"
-        class="com.cloud.hypervisor.kvm.resource.wrapper.LibvirtUtilitiesHelper" />
-    
 </beans>


### PR DESCRIPTION
   - The LibvirtUtilitiesHelper should have been injected, but it did not work on the Agent side.
     Due to that, when sending a StartCommand we were experiencing NPE, which made impossible to get SSVM/CPVM started.
   - The LibvirtUtilitiesHelper class is now being instantiated withing the LibvirtComputingResource

Hi @DaanHoogland and @bhaisaab 

This one is quite urgent given the problem with starting SSVM/CPVM with master.

Environment / tests:

Centos7 + KVM + Qemu
MySQL/MariaDB 5.5.41
Management Server running CentOS 7
Component/Smoke tests: https://github.com/apache/cloudstack (test/integration/component and smoke)
Storage type: NFS shared
Isolation method: VLAN
Agent: 4.6.0-SNAPSHOT - built locally
  - git clean -fdx
  - ./package.sh -d centos7



Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... SKIP: At least two hosts should be present in the zone for migration
Test destroy(expunge) Virtual Machine ... === TestName: test_09_expunge_vm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 10 tests in 2807.953s

OK (SKIP=1)
/tmp//MarvinLogs/test_vm_life_cycle_121Y28/results.txt (END)




====Trying SSH Connection: Host:192.168.22.21 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 192.168.22.21 port : 22 SUCCESSFUL===
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.3.20 service dnsmasq status via Host: 192.168.22.21} {returns: [u'Checking DNS forwarder and DHCP server: dnsmasq(running).']}
====Trying SSH Connection: Host:192.168.22.21 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.22.21 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 192.168.22.21 port : 22 SUCCESSFUL===
===SSH to Host 192.168.22.21 port : 22 SUCCESSFUL===
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.3.20 service haproxy status via Host: 192.168.22.21} {returns: [u'haproxy is running.']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.3.20 service haproxy status via Host: 192.168.22.21} {returns: [u'haproxy is running.']}
Test router internal advanced zone ... === TestName: test_02_router_internal_adv | Status : SUCCESS ===
ok
Test restart network ... === TestName: test_03_restart_network_cleanup | Status : SUCCESS ===
ok
Test router basic setup ... === TestName: test_05_router_basic | Status : SUCCESS ===
ok
Test router advanced setup ... === TestName: test_06_router_advanced | Status : SUCCESS ===
ok
Test stop router ... === TestName: test_07_stop_router | Status : SUCCESS ===
ok
Test start router ... === TestName: test_08_start_router | Status : SUCCESS ===
ok
Test reboot router ... === TestName: test_09_reboot_router | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 7 tests in 1884.899s

OK
/tmp//MarvinLogs/test_routers_R18J6Q/results.txt (END)



Test to create service offering ... === TestName: test_01_create_service_offering | Status : SUCCESS ===
ok
Test to update existing service offering ... === TestName: test_02_edit_service_offering | Status : SUCCESS ===
ok
Test to delete service offering ... === TestName: test_03_delete_service_offering | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 3 tests in 716.320s

OK
/tmp//MarvinLogs/test_service_offerings_IXHWCH/results.txt (END)