### PR TITLE
Fixed yum and apt repo locations used by chef in devcloud4

### DIFF
--- a/tools/devcloud4/binary-installation-basic/chef_configuration.json
+++ b/tools/devcloud4/binary-installation-basic/chef_configuration.json
@@ -27,8 +27,8 @@
         "xenserver": "http://packages.shapeblue.com/systemvmtemplate/4.5/systemvm64template-4.5-xen.vhd.bz2"
       },
       "configuration": "/vagrant/marvin.cfg.erb",
-      "yum_repo": "http://packages.shapeblue.com/cloudstack/testing/centos/4.5/",
-      "apt_repo": "http://packages.shapeblue.com/cloudstack/testing/debian/4.5/",
+      "yum_repo": "http://packages.shapeblue.com/cloudstack/upstream/centos/4.5/",
+      "apt_repo": "http://packages.shapeblue.com/cloudstack/upstream/debian/4.5/",
       "version": "4.5.0"
   }
 }


### PR DESCRIPTION
The testing repos seem to be gone - currently returning HTTP 404. I'm modified the urls to point at the upstream apache versions 