### PR TITLE
CLOUDSTACK-8515: Skipping snapshot test cases for HyperV and LXC

### DIFF
--- a/test/integration/testpaths/testpath_volume_cuncurrent_snapshots.py
+++ b/test/integration/testpaths/testpath_volume_cuncurrent_snapshots.py
@@ -148,6 +148,12 @@ class TestConcurrentSnapshots(cloudstackTestCase):
             cls.testdata["ostype"])
 
         cls._cleanup = []
+        cls.vm_pool = []
+        cls.snapshotSupported = True
+
+        if cls.hypervisor.lower() in ["hyperv", "lxc"]:
+            cls.snapshotSupported = False
+            return
 
         # Set sleep time as per Snapshot Recurring Policy - HOURLY
         cls.sleep_time_for_hourly_policy = 60 * 60 * 1
@@ -177,7 +183,6 @@ class TestConcurrentSnapshots(cloudstackTestCase):
             )
             cls._cleanup.append(cls.service_offering)
 
-            cls.vm_pool = []
             for i in range(4):
                 cls.vm = VirtualMachine.create(
                     cls.apiclient,
@@ -235,6 +240,9 @@ class TestConcurrentSnapshots(cloudstackTestCase):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
+
+        if not self.snapshotSupported:
+            self.skipTest("Snapshot is not supported on %s" % self.hypervisor)
 
     def tearDown(self):
         try:


### PR DESCRIPTION
Skipping because snapshot not supported on HyperV and LXC.

Concurrent Snapshots ... SKIP: Snapshot is not supported on hyperv
Concurrent Snapshots ... SKIP: Snapshot is not supported on hyperv

----------------------------------------------------------------------
Ran 2 tests in 1.157s

OK (SKIP=2)