### PR TITLE
Replacing real IPs by 127.0.0.1.

### DIFF
--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -19,6 +19,61 @@
 
 package com.cloud.hypervisor.kvm.resource;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import javax.naming.ConfigurationException;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.cloudstack.storage.command.AttachAnswer;
+import org.apache.cloudstack.storage.command.AttachCommand;
+import org.apache.cloudstack.utils.linux.CPUStat;
+import org.apache.cloudstack.utils.linux.MemStat;
+import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
+import org.apache.commons.lang.SystemUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.libvirt.Connect;
+import org.libvirt.Domain;
+import org.libvirt.DomainBlockStats;
+import org.libvirt.DomainInfo;
+import org.libvirt.DomainInfo.DomainState;
+import org.libvirt.DomainInterfaceStats;
+import org.libvirt.LibvirtException;
+import org.libvirt.NodeInfo;
+import org.libvirt.StorageVol;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.AttachIsoCommand;
 import com.cloud.agent.api.AttachVolumeCommand;
@@ -116,59 +171,6 @@ import com.cloud.vm.DiskProfile;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.PowerState;
 import com.cloud.vm.VirtualMachine.Type;
-import org.apache.cloudstack.storage.command.AttachAnswer;
-import org.apache.cloudstack.storage.command.AttachCommand;
-import org.apache.cloudstack.utils.linux.CPUStat;
-import org.apache.cloudstack.utils.linux.MemStat;
-import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
-import org.apache.commons.lang.SystemUtils;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.libvirt.Connect;
-import org.libvirt.Domain;
-import org.libvirt.DomainBlockStats;
-import org.libvirt.DomainInfo;
-import org.libvirt.DomainInfo.DomainState;
-import org.libvirt.DomainInterfaceStats;
-import org.libvirt.LibvirtException;
-import org.libvirt.NodeInfo;
-import org.libvirt.StorageVol;
-import org.mockito.Matchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import javax.naming.ConfigurationException;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LibvirtComputingResourceTest {
@@ -1213,7 +1215,7 @@ public class LibvirtComputingResourceTest {
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
 
         final String vmName = "Test";
-        final String destIp = "10.1.1.100";
+        final String destIp = "127.0.0.100";
         final boolean isWindows = false;
         final VirtualMachineTO vmTO = Mockito.mock(VirtualMachineTO.class);
         final boolean executeInSequence = false;
@@ -3494,10 +3496,10 @@ public class LibvirtComputingResourceTest {
 
     @Test
     public void testNetworkUsageCommandNonVpc() {
-        final String privateIP = "169.16.16.16";
+        final String privateIP = "127.0.0.1";
         final String domRName = "domR";
         final boolean forVpc = false;
-        final String gatewayIP = "10.1.1.1";
+        final String gatewayIP = "127.0.0.1";
 
         final NetworkUsageCommand command = new NetworkUsageCommand(privateIP, domRName, forVpc, gatewayIP);
 
@@ -3517,7 +3519,7 @@ public class LibvirtComputingResourceTest {
 
     @Test
     public void testNetworkUsageCommandNonVpcCreate() {
-        final String privateIP = "169.16.16.16";
+        final String privateIP = "127.0.0.1";
         final String domRName = "domR";
         final boolean forVpc = false;
 
@@ -3538,10 +3540,10 @@ public class LibvirtComputingResourceTest {
 
     @Test
     public void testNetworkUsageCommandVpcCreate() {
-        final String privateIP = "169.16.16.16";
+        final String privateIP = "127.0.0.1";
         final String domRName = "domR";
         final boolean forVpc = true;
-        final String gatewayIP = "10.1.1.1";
+        final String gatewayIP = "127.0.0.1";
         final String vpcCidr = "10.1.1.0/24";
 
         final NetworkUsageCommand command = new NetworkUsageCommand(privateIP, domRName, forVpc, gatewayIP, vpcCidr);
@@ -3561,10 +3563,10 @@ public class LibvirtComputingResourceTest {
 
     @Test
     public void testNetworkUsageCommandVpcGet() {
-        final String privateIP = "169.16.16.16";
+        final String privateIP = "127.0.0.1";
         final String domRName = "domR";
         final boolean forVpc = true;
-        final String gatewayIP = "10.1.1.1";
+        final String gatewayIP = "127.0.0.1";
 
         final NetworkUsageCommand command = new NetworkUsageCommand(privateIP, domRName, forVpc, gatewayIP);
 
@@ -3583,10 +3585,10 @@ public class LibvirtComputingResourceTest {
 
     @Test
     public void testNetworkUsageCommandVpcVpn() {
-        final String privateIP = "169.16.16.16";
+        final String privateIP = "127.0.0.1";
         final String domRName = "domR";
         final boolean forVpc = true;
-        final String gatewayIP = "10.1.1.1";
+        final String gatewayIP = "127.0.0.1";
 
         final NetworkUsageCommand command = new NetworkUsageCommand(privateIP, domRName, "vpn", forVpc, gatewayIP);
 
@@ -3605,10 +3607,10 @@ public class LibvirtComputingResourceTest {
 
     @Test
     public void testNetworkUsageCommandVpcNoOption() {
-        final String privateIP = "169.16.16.16";
+        final String privateIP = "127.0.0.1";
         final String domRName = "domR";
         final boolean forVpc = true;
-        final String gatewayIP = "10.1.1.1";
+        final String gatewayIP = "127.0.0.1";
 
         final NetworkUsageCommand command = new NetworkUsageCommand(privateIP, domRName, null, forVpc, gatewayIP);
 
@@ -4939,7 +4941,7 @@ public class LibvirtComputingResourceTest {
         final NicTO[] nics = new NicTO[]{nic};
 
         final String vmName = "Test";
-        final String controlIp = "169.122.10.10";
+        final String controlIp = "127.0.0.1";
 
         when(libvirtComputingResource.getStoragePoolMgr()).thenReturn(storagePoolMgr);
         when(vmSpec.getNics()).thenReturn(nics);
@@ -5011,7 +5013,7 @@ public class LibvirtComputingResourceTest {
         final NicTO[] nics = new NicTO[]{nic};
 
         final String vmName = "Test";
-        final String controlIp = "169.122.10.10";
+        final String controlIp = "127.0.0.1";
 
         when(libvirtComputingResource.getStoragePoolMgr()).thenReturn(storagePoolMgr);
         when(vmSpec.getNics()).thenReturn(nics);

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
@@ -34,9 +34,6 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
-import com.cloud.agent.api.GetVmIpAddressCommand;
-import com.xensource.xenapi.VM;
-import com.xensource.xenapi.VMGuestMetrics;
 import org.apache.cloudstack.storage.command.AttachAnswer;
 import org.apache.cloudstack.storage.command.AttachCommand;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
@@ -67,6 +64,7 @@ import com.cloud.agent.api.DeleteVMSnapshotCommand;
 import com.cloud.agent.api.GetHostStatsCommand;
 import com.cloud.agent.api.GetStorageStatsCommand;
 import com.cloud.agent.api.GetVmDiskStatsCommand;
+import com.cloud.agent.api.GetVmIpAddressCommand;
 import com.cloud.agent.api.GetVmStatsCommand;
 import com.cloud.agent.api.GetVncPortCommand;
 import com.cloud.agent.api.MaintainCommand;
@@ -141,6 +139,8 @@ import com.xensource.xenapi.PIF;
 import com.xensource.xenapi.Pool;
 import com.xensource.xenapi.Types.BadServerResponse;
 import com.xensource.xenapi.Types.XenAPIException;
+import com.xensource.xenapi.VM;
+import com.xensource.xenapi.VMGuestMetrics;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -650,7 +650,7 @@ public class CitrixRequestWrapperTest {
 
     @Test
     public void testPingTestCommandRouterPvtIps() {
-        final PingTestCommand pingTestCommand = new PingTestCommand("127.0.0.1", "192.168.0.1");
+        final PingTestCommand pingTestCommand = new PingTestCommand("127.0.0.1", "127.0.0.1");
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -819,7 +819,7 @@ public class CitrixRequestWrapperTest {
         final Network network = Mockito.mock(Network.class);
         final XsHost xsHost = Mockito.mock(XsHost.class);
 
-        final OvsCreateGreTunnelCommand createGreCommand = new OvsCreateGreTunnelCommand("172.0.0.1", "KEY", 1l, 2l);
+        final OvsCreateGreTunnelCommand createGreCommand = new OvsCreateGreTunnelCommand("127.0.0.1", "KEY", 1l, 2l);
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -1841,13 +1841,13 @@ public class CitrixRequestWrapperTest {
         final Connection conn = Mockito.mock(Connection.class);
         final VM vm = Mockito.mock(VM.class);
         final VMGuestMetrics mtr = Mockito.mock(VMGuestMetrics.class);
-        VMGuestMetrics.Record rec = Mockito.mock(VMGuestMetrics.Record.class);
+        final VMGuestMetrics.Record rec = Mockito.mock(VMGuestMetrics.Record.class);
 
-        Map<String, String> vmIpsMap = new HashMap<>();
-        vmIpsMap.put("Test", "10.1.1.121");
+        final Map<String, String> vmIpsMap = new HashMap<>();
+        vmIpsMap.put("Test", "127.0.0.1");
         rec.networks = vmIpsMap;
 
-        final GetVmIpAddressCommand getVmIpAddrCmd = new GetVmIpAddressCommand("Test", "10.1.1.0/24", false);
+        final GetVmIpAddressCommand getVmIpAddrCmd = new GetVmIpAddressCommand("Test", "127.0.0.1/24", false);
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);


### PR DESCRIPTION
  - It was causing problems in some environments
  - The Ips should have been removed in a previous commit, but some of them were missed

@bhaisaab @rsafonseca 

There goes the PR with the IP changes you mentioned on the 25th May.

ACS builds successfully with Java 7 and 8 on MacOS and CentOS 7 machines.
Only unit tests were changed.

Cheers,
Wilder