### PR TITLE
CLOUDSTACK-8526: Use more memory for VM deployment on HyperV when SSH is tried to VM

### DIFF
--- a/test/integration/testpaths/testpath_stopped_vm.py
+++ b/test/integration/testpaths/testpath_stopped_vm.py
@@ -148,9 +148,13 @@ class TestAdvancedZoneStoppedVM(cloudstackTestCase):
             # Create 2 service offerings with different values for
             # for cpunumber, cpuspeed, and memory
 
-            cls.testdata["service_offering"]["cpunumber"] = "1"
-            cls.testdata["service_offering"]["cpuspeed"] = "128"
-            cls.testdata["service_offering"]["memory"] = "256"
+            cls.testdata["service_offering"]["cpunumber"] = 1
+            cls.testdata["service_offering"]["cpuspeed"] = 128
+            cls.testdata["service_offering"]["memory"] = 256
+
+            if cls.hypervisor.lower() == "hyperv":
+                cls.testdata["service_offering"]["cpuspeed"] = 1024
+                cls.testdata["service_offering"]["memory"] = 1024
 
             cls.service_offering = ServiceOffering.create(
                 cls.apiclient,
@@ -158,9 +162,7 @@ class TestAdvancedZoneStoppedVM(cloudstackTestCase):
             )
             cls._cleanup.append(cls.service_offering)
 
-            cls.testdata["service_offering"]["cpunumber"] = "2"
-            cls.testdata["service_offering"]["cpuspeed"] = "256"
-            cls.testdata["service_offering"]["memory"] = "512"
+            cls.testdata["service_offering"]["cpunumber"] = 2
 
             cls.service_offering_2 = ServiceOffering.create(
                 cls.apiclient,


### PR DESCRIPTION
HyperV VMs are GUI based. So if SSH to VM is to be successful, they need at least 1 GB memory.

Log:
Positive test for stopped VM test path - T1 ... === TestName: test_01_pt_deploy_vm_without_startvm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 2644.895s

OK