### PR TITLE
Fix agent/management conflict

### DIFF
--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -593,7 +593,6 @@ fi
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/work
 %dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/management/temp
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/management
-%dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/agent
 %dir %attr(0770,root,cloud) %{_localstatedir}/log/%{name}/awsapi
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}-management
 %config(noreplace) %attr(0640,root,cloud) %{_sysconfdir}/%{name}/management/db.properties


### PR DESCRIPTION
There is an entry for the agent log directory in the management packaging, creating a conflict between the two RPMs.
This issue occurs in both 4.4.x and 4.5.x
This fixes not being able to install cloudstack-agent and cloudstack-management in the same machine in CentOS.