### PR TITLE
Change tests random number generator to /dev/urandom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -963,6 +963,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.18.1</version>
+          <configuration>
+              <argLine>-Djava.security.egd=file:/dev/./urandom</argLine>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -958,14 +958,14 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.18.1</version>
+          <configuration>
+              <argLine>-Djava.security.egd=file:/dev/./urandom</argLine>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.18.1</version>
-          <configuration>
-              <argLine>-Djava.security.egd=file:/dev/./urandom</argLine>
-          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -174,7 +174,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-Xmx1024m</argLine>
+          <argLine>-Xmx1024m -Djava.security.egd=file:/dev/./urandom</argLine>
           <excludes>
             <exclude>%regex[.*[0-9]*To[0-9]*.*Test.*]</exclude>
             <exclude>com/cloud/upgrade/AdvanceZone223To224UpgradeTest</exclude>


### PR DESCRIPTION
This fixes a big performance issue with random number generation with more recent kernels and java versions in linux, the impact is specially higher on VMs
Some tests (that use random number generation) in some environments take randomly 1 - 20 mins to perform tests that should take only seconds to run.
This PR is just intended for fixing it on the tests.