### PR TITLE
Reflections upgrade to 0.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <cs.lang.version>2.6</cs.lang.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>
     <cs.commons-validator.version>1.4.0</cs.commons-validator.version>
-    <cs.reflections.version>0.9.8</cs.reflections.version>
+    <cs.reflections.version>0.9.9</cs.reflections.version>
     <cs.java-ipv6.version>0.15</cs.java-ipv6.version>
     <cs.replace.properties>build/replace.properties</cs.replace.properties>
     <cs.libvirt-java.version>0.5.1</cs.libvirt-java.version>

--- a/server/src/com/cloud/api/doc/ApiXmlDocWriter.java
+++ b/server/src/com/cloud/api/doc/ApiXmlDocWriter.java
@@ -96,12 +96,15 @@ public class ApiXmlDocWriter {
     }
 
     public static void main(String[] args) {
-
         Set<Class<?>> cmdClasses = ReflectUtil.getClassesWithAnnotation(APICommand.class, new String[] {"org.apache.cloudstack.api", "com.cloud.api",
                 "com.cloud.api.commands", "com.globo.globodns.cloudstack.api", "org.apache.cloudstack.network.opendaylight.api",
                 "com.cloud.api.commands.netapp", "org.apache.cloudstack.api.command.admin.zone", "org.apache.cloudstack.network.contrail.api.command"});
 
         for (Class<?> cmdClass : cmdClasses) {
+            if(cmdClass.getAnnotation(APICommand.class)==null){
+               System.out.println("Warning, API Cmd class " + cmdClass.getName() + " has no APICommand annotation ");
+               continue;
+            }
             String apiName = cmdClass.getAnnotation(APICommand.class).name();
             if (s_apiNameCmdClassMap.containsKey(apiName)) {
                 // handle API cmd separation into admin cmd and user cmd with the common api name

--- a/utils/src/com/cloud/utils/ReflectUtil.java
+++ b/utils/src/com/cloud/utils/ReflectUtil.java
@@ -37,6 +37,10 @@ import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -45,6 +49,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 public class ReflectUtil {
 
     private static final Logger s_logger = Logger.getLogger(ReflectUtil.class);
+    private static final Logger logger = Logger.getLogger(Reflections.class);
 
     public static Pair<Class<?>, Field> getAnyField(Class<?> clazz, String fieldName) {
         try {
@@ -65,10 +70,13 @@ public class ReflectUtil {
     public static Set<Class<?>> getClassesWithAnnotation(Class<? extends Annotation> annotation, String[] packageNames) {
         Reflections reflections;
         Set<Class<?>> classes = new HashSet<Class<?>>();
+        ConfigurationBuilder builder=new ConfigurationBuilder();
         for (String packageName : packageNames) {
-            reflections = new Reflections(packageName);
-            classes.addAll(reflections.getTypesAnnotatedWith(annotation));
+             builder.addUrls(ClasspathHelper.forPackage(packageName));
         }
+        builder.setScanners(new SubTypesScanner(),new TypeAnnotationsScanner());
+        reflections = new Reflections(builder);
+        classes.addAll(reflections.getTypesAnnotatedWith(annotation));
         return classes;
     }
 


### PR DESCRIPTION
Reflection's 0.9.8 dependency javassist doen't properly support java8 and was throwing:

 Error: java.io.IOException: invalid constant type: 18

Running some unit tests with PowerMockRunner caused this issue, so this fixes it for future tests that use it.