### PR TITLE
Version evaluated with native tools instead of maven

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-VERSION := $(shell mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v "\[")
+VERSION := $(shell awk 'f{print;f=0} /<artifactId>cloudstack/{f=1}' pom.xml| sed -e 's/<[^>]*>//g'  -e 's/^[ \t]*//')
 PACKAGE = $(shell dh_listpackages|head -n 1|cut -d '-' -f 1)
 SYSCONFDIR = "/etc"
 DESTDIR = "debian/tmp"


### PR DESCRIPTION
I think i saw a build failure yesterday on buildacloud.com due to missing plexus libs invoking the mvn command.
Can't seem to pinpoint it now, but this fixes it if it reoccurs, and also makes this specific task much faster.