### PR TITLE
Mocking the Connect object used in the LibvirtMigrateCommandWrapper.

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -86,7 +86,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
              */
             xmlDesc = dm.getXMLDesc(0).replace(libvirtComputingResource.getPrivateIp(), command.getDestinationIp());
 
-            dconn = new Connect("qemu+tcp://" + command.getDestinationIp() + "/system");
+            dconn = libvirtUtilitiesHelper.retrieveQemuConnection("qemu+tcp://" + command.getDestinationIp() + "/system");
 
             //run migration in thread so we can monitor it
             s_logger.info("Live migration of instance " + vmName + " initiated");

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtUtilitiesHelper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtUtilitiesHelper.java
@@ -86,4 +86,8 @@ public class LibvirtUtilitiesHelper {
     public String retrieveBashScriptPath() {
         return LibvirtComputingResource.BASH_SCRIPT_PATH;
     }
+
+    public Connect retrieveQemuConnection(final String qemuURI) throws LibvirtException {
+        return new Connect(qemuURI);
+    }
 }

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -1205,13 +1205,10 @@ public class LibvirtComputingResourceTest {
         verify(vm, times(1)).getNics();
     }
 
-    @Test(expected = UnsatisfiedLinkError.class)
+    @Test
     public void testMigrateCommand() {
-        // The Connect constructor used inside the LibvirtMigrateCommandWrapper has a call to native methods, which
-        // makes difficult to test it now.
-        // Will keep it expecting the UnsatisfiedLinkError and fix later.
-
         final Connect conn = Mockito.mock(Connect.class);
+        final Connect dconn = Mockito.mock(Connect.class);
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
 
         final String vmName = "Test";
@@ -1225,6 +1222,8 @@ public class LibvirtComputingResourceTest {
         when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
         try {
             when(libvirtUtilitiesHelper.getConnectionByVmName(vmName)).thenReturn(conn);
+            when(libvirtUtilitiesHelper.retrieveQemuConnection("qemu+tcp://" + command.getDestinationIp() + "/system")).thenReturn(dconn);
+
         } catch (final LibvirtException e) {
             fail(e.getMessage());
         }
@@ -1259,11 +1258,12 @@ public class LibvirtComputingResourceTest {
         assertNotNull(wrapper);
 
         final Answer answer = wrapper.execute(command, libvirtComputingResource);
-        assertFalse(answer.getResult());
+        assertTrue(answer.getResult());
 
         verify(libvirtComputingResource, times(1)).getLibvirtUtilitiesHelper();
         try {
             verify(libvirtUtilitiesHelper, times(1)).getConnectionByVmName(vmName);
+            verify(libvirtUtilitiesHelper, times(1)).retrieveQemuConnection("qemu+tcp://" + command.getDestinationIp() + "/system");
         } catch (final LibvirtException e) {
             fail(e.getMessage());
         }


### PR DESCRIPTION
  - When executing the tests in an environment where Libvirt is also installed, it caused errors.

Hi @bhaisaab and @rsafonseca,

The Connect class is now being mocked, which means it will not load any native library.

Build environment:

[root@kvm3 cloudstack]# uname -a
Linux kvm3 3.10.0-229.1.2.el7.x86_64 #1 SMP Fri Mar 27 03:04:26 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

[root@kvm3 cloudstack]# cat /etc/centos-release
CentOS Linux release 7.1.1503 (Core)

[root@kvm3 cloudstack]# virsh --version=long 
Virsh command line tool of libvirt 1.2.8
See web site at http://libvirt.org/

Compiled with support for:
 Hypervisors: QEMU/KVM LXC ESX Test
 Networking: Remote Network Bridging Interface netcf Nwfilter VirtualPort
 Storage: Dir Disk Filesystem SCSI Multipath iSCSI LVM Gluster
 Miscellaneous: Daemon Nodedev SELinux Secrets Debug DTrace Readline Modular

Command executed: mvn -P developer,systemvm clean install

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 16:50.546s
[INFO] Finished at: Mon Jun 01 09:04:28 EDT 2015
[INFO] Final Memory: 103M/671M
[INFO] ------------------------------------------------------------------------
[root@kvm3 cloudstack]#

Cheers,
Wilder