### PR TITLE
Set the url accordingly when installing a system vm template

### DIFF
--- a/scripts/storage/secondary/cloud-install-sys-tmplt
+++ b/scripts/storage/secondary/cloud-install-sys-tmplt
@@ -184,7 +184,7 @@ fi
 _uuid=$(uuidgen)
 localfile=$_uuid.$ext
 
-_res=(`mysql -h $dbHost --user=$dbUser --password=$dbPassword --skip-column-names -U cloud -e "update cloud.vm_template set uuid=\"$_uuid\" where id=\"$templateId\""`)
+_res=(`mysql -h $dbHost --user=$dbUser --password=$dbPassword --skip-column-names -U cloud -e "update cloud.vm_template set uuid=\"$_uuid\", url=\"$url\" where id=\"$templateId\""`)
 
 mntpoint=`echo "$mntpoint" | sed 's|/*$||'`
 


### PR DESCRIPTION
The script that installs the system vm templates sets the uuid column in table vm_template, however it does not set the respective url column. This PR addresses that.

Before the change, I would install the system vm template for master, using this url: http://jenkins.buildacloud.org/job/build-systemvm64-master/lastSuccessfulBuild/artifact/tools/appliance/dist/systemvm64template-master-4.6.0-xen.vhd.bz2

But a select on the vm_template table would show a different url:
```sql
use cloud
select * from vm_template;

+----+--------------------+---------------------------------------+--------------------------------------+--------+----------+---------+-----+------+------------------------------------------------------------------------------------------------------------+--------+---------------------+---------------------+------------+----------------------------------+---------------------------------------+-----------------+---------------+-------------+----------+-------------+-------------+-------------+-----------------+--------------------+--------------+----------+------+----------+--------------+---------+----------------------+
| id | unique_name        | name                                  | uuid                                 | public | featured | type    | hvm | bits | url                                                                                                        | format | created             | removed             | account_id | checksum                         | display_text                          | enable_password | enable_sshkey | guest_os_id | bootable | prepopulate | cross_zones | extractable | hypervisor_type | source_template_id | template_tag | sort_key | size | state    | update_count | updated | dynamically_scalable |
+----+--------------------+---------------------------------------+--------------------------------------+--------+----------+---------+-----+------+------------------------------------------------------------------------------------------------------------+--------+---------------------+---------------------+------------+----------------------------------+---------------------------------------+-----------------+---------------+-------------+----------+-------------+-------------+-------------+-----------------+--------------------+--------------+----------+------+----------+--------------+---------+----------------------+
|  1 | routing-1          | SystemVM Template (XenServer)         | 1a6bf182-091c-11e5-b368-5254001daa61 |      0 |        0 | SYSTEM  |   0 |   64 | http://download.cloud.com/templates/4.5/systemvm64template-4.5-xen.vhd.bz2                                 | VHD    | 2015-06-02 07:40:01 | NULL                |          1 | 2b15ab4401c2d655264732d3fc600241 | SystemVM Template (XenServer)         |               0 |             0 |         184 |        1 |           0 |           1 |           0 | XenServer       |               NULL | NULL         |        0 | NULL | Active   |            0 | NULL    |                    0 |
```

After the change, I re-installed the template using the same url, and it got propagated to the table:
```sql
use cloud
select * from vm_template;

+----+--------------------+---------------------------------------+--------------------------------------+--------+----------+---------+-----+------+----------------------------------------------------------------------------------------------------------------------------------------------------------+--------+---------------------+---------------------+------------+----------------------------------+---------------------------------------+-----------------+---------------+-------------+----------+-------------+-------------+-------------+-----------------+--------------------+--------------+----------+------+----------+--------------+---------+----------------------+
| id | unique_name        | name                                  | uuid                                 | public | featured | type    | hvm | bits | url                                                                                                                                                      | format | created             | removed             | account_id | checksum                         | display_text                          | enable_password | enable_sshkey | guest_os_id | bootable | prepopulate | cross_zones | extractable | hypervisor_type | source_template_id | template_tag | sort_key | size | state    | update_count | updated | dynamically_scalable |
+----+--------------------+---------------------------------------+--------------------------------------+--------+----------+---------+-----+------+----------------------------------------------------------------------------------------------------------------------------------------------------------+--------+---------------------+---------------------+------------+----------------------------------+---------------------------------------+-----------------+---------------+-------------+----------+-------------+-------------+-------------+-----------------+--------------------+--------------+----------+------+----------+--------------+---------+----------------------+
|  1 | routing-1          | SystemVM Template (XenServer)         | b41f2028-a53c-4528-84ca-e0eddec14280 |      0 |        0 | SYSTEM  |   0 |   64 | http://jenkins.buildacloud.org/job/build-systemvm64-master/lastSuccessfulBuild/artifact/tools/appliance/dist/systemvm64template-master-4.6.0-xen.vhd.bz2 | VHD    | 2015-06-02 07:40:01 | NULL                |          1 | 2b15ab4401c2d655264732d3fc600241 | SystemVM Template (XenServer)         |               0 |             0 |         184 |        1 |           0 |           1 |           0 | XenServer       |               NULL | NULL         |        0 | NULL | Active   |            0 | NULL    |                    0 |
```

Note that I do not check if the `-u` option was specified as is mandatory for the execution of the script, and the script will abort if it is not present:
```bash
...

while getopts 'm:h:f:u:Ft:e:s:o:r:d:' OPTION
do
  case $OPTION in
...
  u)    uflag=1
                url="$OPTARG"
                ;;
...
  esac
done

if [[ "$mflag$fflag" != "11"  && "$mflag$uflag" != "11" ]]
then
  usage
  failed 2
fi
...
```