### PR TITLE
Allow custom command role ACL files on classpath in Static Role API Checker

### DIFF
--- a/plugins/acl/static-role-based/resources/META-INF/cloudstack/acl-static-role-based/spring-acl-static-role-based-context.xml
+++ b/plugins/acl/static-role-based/resources/META-INF/cloudstack/acl-static-role-based/spring-acl-static-role-based-context.xml
@@ -29,6 +29,11 @@
 
     <bean id="StaticRoleBasedAPIAccessChecker" class="org.apache.cloudstack.acl.StaticRoleBasedAPIAccessChecker" >
         <property name="services" value="#{apiCommandsRegistry.registered}" />
+        <property name="commandPropertyFiles">
+            <set>
+                <value>commands.properties</value>
+            </set>
+        </property>
     </bean>
 
 </beans>

--- a/plugins/acl/static-role-based/src/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/static-role-based/src/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
@@ -45,6 +45,7 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIC
 
     protected static final Logger s_logger = Logger.getLogger(StaticRoleBasedAPIAccessChecker.class);
 
+    Set<String> commandPropertyFiles = new HashSet<String>();
     Set<String> commandsPropertiesOverrides = new HashSet<String>();
     Map<RoleType, Set<String>> commandsPropertiesRoleBasedApisMap = new HashMap<RoleType, Set<String>>();
     Map<RoleType, Set<String>> annotationRoleBasedApisMap = new HashMap<RoleType, Set<String>>();
@@ -84,7 +85,9 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIC
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
         super.configure(name, params);
 
-        processMapping(PropertiesUtil.processConfigFile(new String[] {"commands.properties"}));
+        for (String commandPropertyFile : commandPropertyFiles) {
+            processMapping(PropertiesUtil.processConfigFile(new String[] { commandPropertyFile }));
+        }
         return true;
     }
 
@@ -127,6 +130,14 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIC
     @Inject
     public void setServices(List<PluggableService> services) {
         this._services = services;
+    }
+
+    public Set<String> getCommandPropertyFiles() {
+        return commandPropertyFiles;
+    }
+
+    public void setCommandPropertyFiles(Set<String> commandPropertyFiles) {
+        this.commandPropertyFiles = commandPropertyFiles;
     }
 
 }


### PR DESCRIPTION
## Commit Message
This commit has a small refactoring of cloud-plugin-acl-static-role-based
to allow it to read files on the classpath that might have a different name
than "commands.properties". It also allows more than one file to be read from.

Rationale: Third-party plugins may want to keep their API command access level
configuration separate from the main file so as to reduce configuration
maintenance work during packaging and deployments.

## Testing Performed
Ran the simulator locally and connected to it with Cloudmonkey. Ran sync and then executed some API commands to verify that they are not blacklisted (i.e. not found because CS could not read the file on the classpath).