### PR TITLE
Fix/coverity issues

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/VersionDaoImpl.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/VersionDaoImpl.java
@@ -108,7 +108,7 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                         rs.close();
                         pstmt.close();
                         pstmt = conn.prepareStatement("SELECT is_static_nat from firewall_rules");
-                        pstmt.executeQuery();
+                        rs = pstmt.executeQuery();
                         return "2.2.1";
                     } catch (final SQLException e) {
                         s_logger.debug("Assuming the exception means static_nat field doesn't exist in firewall_rules table, returning version 2.2.2");

--- a/engine/schema/src/com/cloud/upgrade/dao/VersionDaoImpl.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/VersionDaoImpl.java
@@ -64,8 +64,8 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
     }
 
     @Override
-    public VersionVO findByVersion(String version, Step step) {
-        SearchCriteria<VersionVO> sc = AllFieldsSearch.create();
+    public VersionVO findByVersion(final String version, final Step step) {
+        final SearchCriteria<VersionVO> sc = AllFieldsSearch.create();
         sc.setParameters("version", version);
         sc.setParameters("step", step);
 
@@ -96,7 +96,7 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                     try {
                         pstmt.executeQuery();
                         return "2.1.8";
-                    } catch (SQLException e) {
+                    } catch (final SQLException e) {
                         s_logger.debug("Assuming the exception means domain_id is not there.");
                         s_logger.debug("No version table and no nics table, returning 2.1.7");
                         return "2.1.7";
@@ -110,7 +110,7 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                         pstmt = conn.prepareStatement("SELECT is_static_nat from firewall_rules");
                         pstmt.executeQuery();
                         return "2.2.1";
-                    } catch (SQLException e) {
+                    } catch (final SQLException e) {
                         s_logger.debug("Assuming the exception means static_nat field doesn't exist in firewall_rules table, returning version 2.2.2");
                         return "2.2.2";
                     } finally {
@@ -124,14 +124,14 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
 
             sc.setParameters("step", Step.Complete);
             Filter filter = new Filter(VersionVO.class, "id", false, 0l, 1l);
-            List<String> upgradedVersions = customSearch(sc, filter);
+            final List<String> upgradedVersions = customSearch(sc, filter);
 
             if (upgradedVersions.isEmpty()) {
 
                 // Check if there are records in Version table
                 filter = new Filter(VersionVO.class, "id", false, 0l, 1l);
                 sc = CurrentVersionSearch.create();
-                List<String> vers = customSearch(sc, filter);
+                final List<String> vers = customSearch(sc, filter);
                 if (!vers.isEmpty()) {
                     throw new CloudRuntimeException("Version table contains records for which upgrade wasn't completed");
                 }
@@ -147,9 +147,9 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                         pstmt = conn.prepareStatement("SELECT is_static_nat from firewall_rules");
                         pstmt.executeQuery();
                         throw new CloudRuntimeException("Unable to determine the current version, version table exists and empty, " +
-                            "nics table doesn't exist, is_static_nat field exists in firewall_rules table");
+                                "nics table doesn't exist, is_static_nat field exists in firewall_rules table");
                     }
-                } catch (SQLException e) {
+                } catch (final SQLException e) {
                     s_logger.debug("Assuming the exception means static_nat field doesn't exist in firewall_rules table, returning version 2.2.2");
                     return "2.2.2";
                 } finally {
@@ -160,12 +160,12 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                 return upgradedVersions.get(0);
             }
 
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new CloudRuntimeException("Unable to get the current version", e);
         } finally {
             try {
                 conn.close();
-            } catch (SQLException e) {
+            } catch (final SQLException e) {
             }
         }
 

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -59,7 +59,6 @@ import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
 import org.apache.cloudstack.utils.qemu.QemuImgException;
 import org.apache.cloudstack.utils.qemu.QemuImgFile;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.libvirt.Connect;
 import org.libvirt.Domain;
@@ -543,14 +542,12 @@ public class KVMStorageProcessor implements StorageProcessor {
                 final Date date = new Date();
                 templateContent += "snapshot.name=" + dateFormat.format(date) + System.getProperty("line.separator");
 
-                final FileOutputStream templFo = new FileOutputStream(templateProp);
-                try {
+
+                try(FileOutputStream templFo = new FileOutputStream(templateProp);){
                     templFo.write(templateContent.getBytes());
                     templFo.flush();
                 } catch (final IOException e) {
                     throw e;
-                } finally {
-                    IOUtils.closeQuietly(templFo);
                 }
             }
 

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -37,20 +37,6 @@ import java.util.UUID;
 
 import javax.naming.ConfigurationException;
 
-import com.cloud.hypervisor.Hypervisor;
-import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
-import org.libvirt.Connect;
-import org.libvirt.Domain;
-import org.libvirt.DomainInfo;
-import org.libvirt.DomainSnapshot;
-import org.libvirt.LibvirtException;
-
-import com.ceph.rados.IoCTX;
-import com.ceph.rados.Rados;
-import com.ceph.rbd.Rbd;
-import com.ceph.rbd.RbdImage;
-
 import org.apache.cloudstack.storage.command.AttachAnswer;
 import org.apache.cloudstack.storage.command.AttachCommand;
 import org.apache.cloudstack.storage.command.CopyCmdAnswer;
@@ -72,7 +58,18 @@ import org.apache.cloudstack.utils.qemu.QemuImg;
 import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
 import org.apache.cloudstack.utils.qemu.QemuImgException;
 import org.apache.cloudstack.utils.qemu.QemuImgFile;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+import org.libvirt.Connect;
+import org.libvirt.Domain;
+import org.libvirt.DomainInfo;
+import org.libvirt.DomainSnapshot;
+import org.libvirt.LibvirtException;
 
+import com.ceph.rados.IoCTX;
+import com.ceph.rados.Rados;
+import com.ceph.rbd.Rbd;
+import com.ceph.rbd.RbdImage;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.storage.PrimaryStorageDownloadAnswer;
 import com.cloud.agent.api.to.DataObjectType;
@@ -82,6 +79,7 @@ import com.cloud.agent.api.to.DiskTO;
 import com.cloud.agent.api.to.NfsTO;
 import com.cloud.agent.api.to.S3TO;
 import com.cloud.exception.InternalErrorException;
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
 import com.cloud.hypervisor.kvm.resource.LibvirtConnection;
 import com.cloud.hypervisor.kvm.resource.LibvirtDomainXMLParser;
@@ -110,7 +108,7 @@ public class KVMStorageProcessor implements StorageProcessor {
     private String _manageSnapshotPath;
     private int _cmdsTimeout;
 
-    public KVMStorageProcessor(KVMStoragePoolManager storagePoolMgr, LibvirtComputingResource resource) {
+    public KVMStorageProcessor(final KVMStoragePoolManager storagePoolMgr, final LibvirtComputingResource resource) {
         this.storagePoolMgr = storagePoolMgr;
         this.resource = resource;
     }
@@ -119,7 +117,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         return "scripts/storage/qcow2";
     }
 
-    public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
+    public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
         storageLayer = new JavaStorageLayer();
         storageLayer.configure("StorageLayer", params);
 
@@ -138,34 +136,34 @@ public class KVMStorageProcessor implements StorageProcessor {
             throw new ConfigurationException("Unable to find the managesnapshot.sh");
         }
 
-        String value = (String)params.get("cmds.timeout");
+        final String value = (String)params.get("cmds.timeout");
         _cmdsTimeout = NumbersUtil.parseInt(value, 7200) * 1000;
         return true;
     }
 
     @Override
-    public SnapshotAndCopyAnswer snapshotAndCopy(SnapshotAndCopyCommand cmd) {
+    public SnapshotAndCopyAnswer snapshotAndCopy(final SnapshotAndCopyCommand cmd) {
         s_logger.info("'SnapshotAndCopyAnswer snapshotAndCopy(SnapshotAndCopyCommand)' not currently used for KVMStorageProcessor");
 
         return new SnapshotAndCopyAnswer();
     }
 
     @Override
-    public Answer copyTemplateToPrimaryStorage(CopyCommand cmd) {
-        DataTO srcData = cmd.getSrcTO();
-        DataTO destData = cmd.getDestTO();
-        TemplateObjectTO template = (TemplateObjectTO)srcData;
-        DataStoreTO imageStore = template.getDataStore();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)destData.getDataStore();
+    public Answer copyTemplateToPrimaryStorage(final CopyCommand cmd) {
+        final DataTO srcData = cmd.getSrcTO();
+        final DataTO destData = cmd.getDestTO();
+        final TemplateObjectTO template = (TemplateObjectTO)srcData;
+        final DataStoreTO imageStore = template.getDataStore();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)destData.getDataStore();
 
         if (!(imageStore instanceof NfsTO)) {
             return new CopyCmdAnswer("unsupported protocol");
         }
 
-        NfsTO nfsImageStore = (NfsTO)imageStore;
-        String tmplturl = nfsImageStore.getUrl() + File.separator + template.getPath();
-        int index = tmplturl.lastIndexOf("/");
-        String mountpoint = tmplturl.substring(0, index);
+        final NfsTO nfsImageStore = (NfsTO)imageStore;
+        final String tmplturl = nfsImageStore.getUrl() + File.separator + template.getPath();
+        final int index = tmplturl.lastIndexOf("/");
+        final String mountpoint = tmplturl.substring(0, index);
         String tmpltname = null;
         if (index < tmplturl.length() - 1) {
             tmpltname = tmplturl.substring(index + 1);
@@ -179,11 +177,11 @@ public class KVMStorageProcessor implements StorageProcessor {
             /* Get template vol */
             if (tmpltname == null) {
                 secondaryPool.refresh();
-                List<KVMPhysicalDisk> disks = secondaryPool.listPhysicalDisks();
+                final List<KVMPhysicalDisk> disks = secondaryPool.listPhysicalDisks();
                 if (disks == null || disks.isEmpty()) {
                     return new PrimaryStorageDownloadAnswer("Failed to get volumes from pool: " + secondaryPool.getUuid());
                 }
-                for (KVMPhysicalDisk disk : disks) {
+                for (final KVMPhysicalDisk disk : disks) {
                     if (disk.getName().endsWith("qcow2")) {
                         tmplVol = disk;
                         break;
@@ -199,11 +197,11 @@ public class KVMStorageProcessor implements StorageProcessor {
 
             /* Copy volume to primary storage */
             s_logger.debug("Copying template to primary storage, template format is " + tmplVol.getFormat() );
-            KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
+            final KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
 
             KVMPhysicalDisk primaryVol = null;
             if (destData instanceof VolumeObjectTO) {
-                VolumeObjectTO volume = (VolumeObjectTO)destData;
+                final VolumeObjectTO volume = (VolumeObjectTO)destData;
                 // pass along volume's target size if it's bigger than template's size, for storage types that copy template rather than cloning on deploy
                 if (volume.getSize() != null && volume.getSize() > tmplVol.getVirtualSize()) {
                     s_logger.debug("Using configured size of " + volume.getSize());
@@ -214,7 +212,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 }
                 primaryVol = storagePoolMgr.copyPhysicalDisk(tmplVol, volume.getUuid(), primaryPool, cmd.getWaitInMillSeconds());
             } else if (destData instanceof TemplateObjectTO) {
-                TemplateObjectTO destTempl = (TemplateObjectTO)destData;
+                final TemplateObjectTO destTempl = (TemplateObjectTO)destData;
                 primaryVol = storagePoolMgr.copyPhysicalDisk(tmplVol, destTempl.getUuid(), primaryPool, cmd.getWaitInMillSeconds());
             } else {
                 primaryVol = storagePoolMgr.copyPhysicalDisk(tmplVol, UUID.randomUUID().toString(), primaryPool, cmd.getWaitInMillSeconds());
@@ -226,7 +224,7 @@ public class KVMStorageProcessor implements StorageProcessor {
              *
              */
             if (destData.getObjectType() == DataObjectType.TEMPLATE) {
-                TemplateObjectTO newTemplate = new TemplateObjectTO();
+                final TemplateObjectTO newTemplate = new TemplateObjectTO();
                 newTemplate.setPath(primaryVol.getName());
                 newTemplate.setSize(primaryVol.getSize());
                 if (primaryPool.getType() == StoragePoolType.RBD) {
@@ -236,34 +234,34 @@ public class KVMStorageProcessor implements StorageProcessor {
                 }
                 data = newTemplate;
             } else if (destData.getObjectType() == DataObjectType.VOLUME) {
-                VolumeObjectTO volumeObjectTO = new VolumeObjectTO();
+                final VolumeObjectTO volumeObjectTO = new VolumeObjectTO();
                 volumeObjectTO.setPath(primaryVol.getName());
                 volumeObjectTO.setSize(primaryVol.getSize());
-                if (primaryVol.getFormat() == PhysicalDiskFormat.RAW)
+                if (primaryVol.getFormat() == PhysicalDiskFormat.RAW) {
                     volumeObjectTO.setFormat(ImageFormat.RAW);
-                else if (primaryVol.getFormat() == PhysicalDiskFormat.QCOW2) {
+                } else if (primaryVol.getFormat() == PhysicalDiskFormat.QCOW2) {
                     volumeObjectTO.setFormat(ImageFormat.QCOW2);
                 }
                 data = volumeObjectTO;
             }
             return new CopyCmdAnswer(data);
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             return new CopyCmdAnswer(e.toString());
         } finally {
             try {
                 if (secondaryPool != null) {
                     secondaryPool.delete();
                 }
-            } catch(Exception e) {
+            } catch(final Exception e) {
                 s_logger.debug("Failed to clean up secondary storage", e);
             }
         }
     }
 
     // this is much like PrimaryStorageDownloadCommand, but keeping it separate. copies template direct to root disk
-    private KVMPhysicalDisk templateToPrimaryDownload(String templateUrl, KVMStoragePool primaryPool, String volUuid, Long size, int timeout) {
-        int index = templateUrl.lastIndexOf("/");
-        String mountpoint = templateUrl.substring(0, index);
+    private KVMPhysicalDisk templateToPrimaryDownload(final String templateUrl, final KVMStoragePool primaryPool, final String volUuid, final Long size, final int timeout) {
+        final int index = templateUrl.lastIndexOf("/");
+        final String mountpoint = templateUrl.substring(0, index);
         String templateName = null;
         if (index < templateUrl.length() - 1) {
             templateName = templateUrl.substring(index + 1);
@@ -276,12 +274,12 @@ public class KVMStorageProcessor implements StorageProcessor {
             /* Get template vol */
             if (templateName == null) {
                 secondaryPool.refresh();
-                List<KVMPhysicalDisk> disks = secondaryPool.listPhysicalDisks();
+                final List<KVMPhysicalDisk> disks = secondaryPool.listPhysicalDisks();
                 if (disks == null || disks.isEmpty()) {
                     s_logger.error("Failed to get volumes from pool: " + secondaryPool.getUuid());
                     return null;
                 }
-                for (KVMPhysicalDisk disk : disks) {
+                for (final KVMPhysicalDisk disk : disks) {
                     if (disk.getName().endsWith("qcow2")) {
                         templateVol = disk;
                         break;
@@ -305,9 +303,9 @@ public class KVMStorageProcessor implements StorageProcessor {
                 s_logger.debug("Using templates disk size of " + templateVol.getVirtualSize() + "since size passed was " + size);
             }
 
-            KVMPhysicalDisk primaryVol = storagePoolMgr.copyPhysicalDisk(templateVol, volUuid, primaryPool, timeout);
+            final KVMPhysicalDisk primaryVol = storagePoolMgr.copyPhysicalDisk(templateVol, volUuid, primaryPool, timeout);
             return primaryVol;
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             s_logger.error("Failed to download template to primary storage", e);
             return null;
         } finally {
@@ -318,13 +316,13 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer cloneVolumeFromBaseTemplate(CopyCommand cmd) {
-        DataTO srcData = cmd.getSrcTO();
-        DataTO destData = cmd.getDestTO();
-        TemplateObjectTO template = (TemplateObjectTO)srcData;
-        DataStoreTO imageStore = template.getDataStore();
-        VolumeObjectTO volume = (VolumeObjectTO)destData;
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)volume.getDataStore();
+    public Answer cloneVolumeFromBaseTemplate(final CopyCommand cmd) {
+        final DataTO srcData = cmd.getSrcTO();
+        final DataTO destData = cmd.getDestTO();
+        final TemplateObjectTO template = (TemplateObjectTO)srcData;
+        final DataStoreTO imageStore = template.getDataStore();
+        final VolumeObjectTO volume = (VolumeObjectTO)destData;
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)volume.getDataStore();
         KVMPhysicalDisk BaseVol = null;
         KVMStoragePool primaryPool = null;
         KVMPhysicalDisk vol = null;
@@ -350,7 +348,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 return new CopyCmdAnswer(" Can't create storage volume on storage pool");
             }
 
-            VolumeObjectTO newVol = new VolumeObjectTO();
+            final VolumeObjectTO newVol = new VolumeObjectTO();
             newVol.setPath(vol.getName());
             newVol.setSize(volume.getSize());
 
@@ -363,59 +361,59 @@ public class KVMStorageProcessor implements StorageProcessor {
             }
 
             return new CopyCmdAnswer(newVol);
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             s_logger.debug("Failed to create volume: ", e);
             return new CopyCmdAnswer(e.toString());
         }
     }
 
     @Override
-    public Answer copyVolumeFromImageCacheToPrimary(CopyCommand cmd) {
-        DataTO srcData = cmd.getSrcTO();
-        DataTO destData = cmd.getDestTO();
-        DataStoreTO srcStore = srcData.getDataStore();
-        DataStoreTO destStore = destData.getDataStore();
-        VolumeObjectTO srcVol = (VolumeObjectTO)srcData;
-        ImageFormat srcFormat = srcVol.getFormat();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)destStore;
+    public Answer copyVolumeFromImageCacheToPrimary(final CopyCommand cmd) {
+        final DataTO srcData = cmd.getSrcTO();
+        final DataTO destData = cmd.getDestTO();
+        final DataStoreTO srcStore = srcData.getDataStore();
+        final DataStoreTO destStore = destData.getDataStore();
+        final VolumeObjectTO srcVol = (VolumeObjectTO)srcData;
+        final ImageFormat srcFormat = srcVol.getFormat();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)destStore;
         if (!(srcStore instanceof NfsTO)) {
             return new CopyCmdAnswer("can only handle nfs storage");
         }
-        NfsTO nfsStore = (NfsTO)srcStore;
-        String srcVolumePath = srcData.getPath();
-        String secondaryStorageUrl = nfsStore.getUrl();
+        final NfsTO nfsStore = (NfsTO)srcStore;
+        final String srcVolumePath = srcData.getPath();
+        final String secondaryStorageUrl = nfsStore.getUrl();
         KVMStoragePool secondaryStoragePool = null;
         KVMStoragePool primaryPool = null;
         try {
             try {
                 primaryPool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
-            } catch (CloudRuntimeException e) {
+            } catch (final CloudRuntimeException e) {
                 if (e.getMessage().contains("not found")) {
                     primaryPool =
-                        storagePoolMgr.createStoragePool(primaryStore.getUuid(), primaryStore.getHost(), primaryStore.getPort(), primaryStore.getPath(), null,
-                            primaryStore.getPoolType());
+                            storagePoolMgr.createStoragePool(primaryStore.getUuid(), primaryStore.getHost(), primaryStore.getPort(), primaryStore.getPath(), null,
+                                    primaryStore.getPoolType());
                 } else {
                     return new CopyCmdAnswer(e.getMessage());
                 }
             }
 
-            String volumeName = UUID.randomUUID().toString();
+            final String volumeName = UUID.randomUUID().toString();
 
-            int index = srcVolumePath.lastIndexOf(File.separator);
-            String volumeDir = srcVolumePath.substring(0, index);
+            final int index = srcVolumePath.lastIndexOf(File.separator);
+            final String volumeDir = srcVolumePath.substring(0, index);
             String srcVolumeName = srcVolumePath.substring(index + 1);
             secondaryStoragePool = storagePoolMgr.getStoragePoolByURI(secondaryStorageUrl + File.separator + volumeDir);
             if (!srcVolumeName.endsWith(".qcow2") && srcFormat == ImageFormat.QCOW2) {
                 srcVolumeName = srcVolumeName + ".qcow2";
             }
-            KVMPhysicalDisk volume = secondaryStoragePool.getPhysicalDisk(srcVolumeName);
+            final KVMPhysicalDisk volume = secondaryStoragePool.getPhysicalDisk(srcVolumeName);
             volume.setFormat(PhysicalDiskFormat.valueOf(srcFormat.toString()));
-            KVMPhysicalDisk newDisk = storagePoolMgr.copyPhysicalDisk(volume, volumeName, primaryPool, cmd.getWaitInMillSeconds());
-            VolumeObjectTO newVol = new VolumeObjectTO();
+            final KVMPhysicalDisk newDisk = storagePoolMgr.copyPhysicalDisk(volume, volumeName, primaryPool, cmd.getWaitInMillSeconds());
+            final VolumeObjectTO newVol = new VolumeObjectTO();
             newVol.setFormat(ImageFormat.valueOf(newDisk.getFormat().toString().toUpperCase()));
             newVol.setPath(volumeName);
             return new CopyCmdAnswer(newVol);
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             s_logger.debug("Failed to ccopyVolumeFromImageCacheToPrimary: ", e);
             return new CopyCmdAnswer(e.toString());
         } finally {
@@ -426,30 +424,30 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer copyVolumeFromPrimaryToSecondary(CopyCommand cmd) {
-        DataTO srcData = cmd.getSrcTO();
-        DataTO destData = cmd.getDestTO();
-        VolumeObjectTO srcVol = (VolumeObjectTO)srcData;
-        VolumeObjectTO destVol = (VolumeObjectTO)destData;
-        ImageFormat srcFormat = srcVol.getFormat();
-        ImageFormat destFormat = destVol.getFormat();
-        DataStoreTO srcStore = srcData.getDataStore();
-        DataStoreTO destStore = destData.getDataStore();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)srcStore;
+    public Answer copyVolumeFromPrimaryToSecondary(final CopyCommand cmd) {
+        final DataTO srcData = cmd.getSrcTO();
+        final DataTO destData = cmd.getDestTO();
+        final VolumeObjectTO srcVol = (VolumeObjectTO)srcData;
+        final VolumeObjectTO destVol = (VolumeObjectTO)destData;
+        final ImageFormat srcFormat = srcVol.getFormat();
+        final ImageFormat destFormat = destVol.getFormat();
+        final DataStoreTO srcStore = srcData.getDataStore();
+        final DataStoreTO destStore = destData.getDataStore();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)srcStore;
         if (!(destStore instanceof NfsTO)) {
             return new CopyCmdAnswer("can only handle nfs storage");
         }
-        NfsTO nfsStore = (NfsTO)destStore;
-        String srcVolumePath = srcData.getPath();
-        String destVolumePath = destData.getPath();
-        String secondaryStorageUrl = nfsStore.getUrl();
+        final NfsTO nfsStore = (NfsTO)destStore;
+        final String srcVolumePath = srcData.getPath();
+        final String destVolumePath = destData.getPath();
+        final String secondaryStorageUrl = nfsStore.getUrl();
         KVMStoragePool secondaryStoragePool = null;
 
         try {
-            String volumeName = UUID.randomUUID().toString();
+            final String volumeName = UUID.randomUUID().toString();
 
-            String destVolumeName = volumeName + "." + destFormat.getFileExtension();
-            KVMPhysicalDisk volume = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), srcVolumePath);
+            final String destVolumeName = volumeName + "." + destFormat.getFileExtension();
+            final KVMPhysicalDisk volume = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), srcVolumePath);
             volume.setFormat(PhysicalDiskFormat.valueOf(srcFormat.toString()));
 
             secondaryStoragePool = storagePoolMgr.getStoragePoolByURI(secondaryStorageUrl);
@@ -457,11 +455,11 @@ public class KVMStorageProcessor implements StorageProcessor {
             storagePoolMgr.deleteStoragePool(secondaryStoragePool.getType(), secondaryStoragePool.getUuid());
             secondaryStoragePool = storagePoolMgr.getStoragePoolByURI(secondaryStorageUrl + File.separator + destVolumePath);
             storagePoolMgr.copyPhysicalDisk(volume, destVolumeName, secondaryStoragePool, cmd.getWaitInMillSeconds());
-            VolumeObjectTO newVol = new VolumeObjectTO();
+            final VolumeObjectTO newVol = new VolumeObjectTO();
             newVol.setPath(destVolumePath + File.separator + destVolumeName);
             newVol.setFormat(destFormat);
             return new CopyCmdAnswer(newVol);
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             s_logger.debug("Failed to copyVolumeFromPrimaryToSecondary: ", e);
             return new CopyCmdAnswer(e.toString());
         } finally {
@@ -472,41 +470,41 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer createTemplateFromVolume(CopyCommand cmd) {
-        DataTO srcData = cmd.getSrcTO();
-        DataTO destData = cmd.getDestTO();
-        int wait = cmd.getWaitInMillSeconds();
-        TemplateObjectTO template = (TemplateObjectTO)destData;
-        DataStoreTO imageStore = template.getDataStore();
-        VolumeObjectTO volume = (VolumeObjectTO)srcData;
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)volume.getDataStore();
+    public Answer createTemplateFromVolume(final CopyCommand cmd) {
+        final DataTO srcData = cmd.getSrcTO();
+        final DataTO destData = cmd.getDestTO();
+        final int wait = cmd.getWaitInMillSeconds();
+        final TemplateObjectTO template = (TemplateObjectTO)destData;
+        final DataStoreTO imageStore = template.getDataStore();
+        final VolumeObjectTO volume = (VolumeObjectTO)srcData;
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)volume.getDataStore();
 
         if (!(imageStore instanceof NfsTO)) {
             return new CopyCmdAnswer("unsupported protocol");
         }
-        NfsTO nfsImageStore = (NfsTO)imageStore;
+        final NfsTO nfsImageStore = (NfsTO)imageStore;
 
         KVMStoragePool secondaryStorage = null;
         KVMStoragePool primary = null;
         try {
-            String templateFolder = template.getPath();
+            final String templateFolder = template.getPath();
 
             secondaryStorage = storagePoolMgr.getStoragePoolByURI(nfsImageStore.getUrl());
 
             primary = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
 
-            KVMPhysicalDisk disk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), volume.getPath());
-            String tmpltPath = secondaryStorage.getLocalPath() + File.separator + templateFolder;
+            final KVMPhysicalDisk disk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), volume.getPath());
+            final String tmpltPath = secondaryStorage.getLocalPath() + File.separator + templateFolder;
             storageLayer.mkdirs(tmpltPath);
-            String templateName = UUID.randomUUID().toString();
+            final String templateName = UUID.randomUUID().toString();
 
             if (primary.getType() != StoragePoolType.RBD) {
-                Script command = new Script(_createTmplPath, wait, s_logger);
+                final Script command = new Script(_createTmplPath, wait, s_logger);
                 command.add("-f", disk.getPath());
                 command.add("-t", tmpltPath);
                 command.add("-n", templateName + ".qcow2");
 
-                String result = command.execute();
+                final String result = command.execute();
 
                 if (result != null) {
                     s_logger.debug("failed to create template: " + result);
@@ -515,60 +513,60 @@ public class KVMStorageProcessor implements StorageProcessor {
             } else {
                 s_logger.debug("Converting RBD disk " + disk.getPath() + " into template " + templateName);
 
-                QemuImgFile srcFile =
-                    new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primary.getSourceHost(), primary.getSourcePort(), primary.getAuthUserName(),
-                        primary.getAuthSecret(), disk.getPath()));
+                final QemuImgFile srcFile =
+                        new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primary.getSourceHost(), primary.getSourcePort(), primary.getAuthUserName(),
+                                primary.getAuthSecret(), disk.getPath()));
                 srcFile.setFormat(PhysicalDiskFormat.RAW);
 
-                QemuImgFile destFile = new QemuImgFile(tmpltPath + "/" + templateName + ".qcow2");
+                final QemuImgFile destFile = new QemuImgFile(tmpltPath + "/" + templateName + ".qcow2");
                 destFile.setFormat(PhysicalDiskFormat.QCOW2);
 
-                QemuImg q = new QemuImg(cmd.getWaitInMillSeconds());
+                final QemuImg q = new QemuImg(cmd.getWaitInMillSeconds());
                 try {
                     q.convert(srcFile, destFile);
-                } catch (QemuImgException e) {
+                } catch (final QemuImgException e) {
                     s_logger.error("Failed to create new template while converting " + srcFile.getFileName() + " to " + destFile.getFileName() + " the error was: " +
-                        e.getMessage());
+                            e.getMessage());
                 }
 
-                File templateProp = new File(tmpltPath + "/template.properties");
+                final File templateProp = new File(tmpltPath + "/template.properties");
                 if (!templateProp.exists()) {
                     templateProp.createNewFile();
                 }
 
                 String templateContent = "filename=" + templateName + ".qcow2" + System.getProperty("line.separator");
 
-                DateFormat dateFormat = new SimpleDateFormat("MM_dd_yyyy");
-                Date date = new Date();
+                final DateFormat dateFormat = new SimpleDateFormat("MM_dd_yyyy");
+                final Date date = new Date();
                 templateContent += "snapshot.name=" + dateFormat.format(date) + System.getProperty("line.separator");
 
-                FileOutputStream templFo = new FileOutputStream(templateProp);
+                final FileOutputStream templFo = new FileOutputStream(templateProp);
                 templFo.write(templateContent.getBytes());
                 templFo.flush();
                 templFo.close();
             }
 
-            Map<String, Object> params = new HashMap<String, Object>();
+            final Map<String, Object> params = new HashMap<String, Object>();
             params.put(StorageLayer.InstanceConfigKey, storageLayer);
-            Processor qcow2Processor = new QCOW2Processor();
+            final Processor qcow2Processor = new QCOW2Processor();
 
             qcow2Processor.configure("QCOW2 Processor", params);
 
-            FormatInfo info = qcow2Processor.process(tmpltPath, null, templateName);
+            final FormatInfo info = qcow2Processor.process(tmpltPath, null, templateName);
 
-            TemplateLocation loc = new TemplateLocation(storageLayer, tmpltPath);
+            final TemplateLocation loc = new TemplateLocation(storageLayer, tmpltPath);
             loc.create(1, true, templateName);
             loc.addFormat(info);
             loc.save();
 
-            TemplateObjectTO newTemplate = new TemplateObjectTO();
+            final TemplateObjectTO newTemplate = new TemplateObjectTO();
             newTemplate.setPath(templateFolder + File.separator + templateName + ".qcow2");
             newTemplate.setSize(info.virtualSize);
             newTemplate.setPhysicalSize(info.size);
             newTemplate.setFormat(ImageFormat.QCOW2);
             newTemplate.setName(templateName);
             return new CopyCmdAnswer(newTemplate);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             s_logger.debug("Failed to createTemplateFromVolume: ", e);
             return new CopyCmdAnswer(e.toString());
         } finally {
@@ -579,15 +577,15 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer createTemplateFromSnapshot(CopyCommand cmd) {
+    public Answer createTemplateFromSnapshot(final CopyCommand cmd) {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 
-    protected String copyToS3(File srcFile, S3TO destStore, String destPath) throws InterruptedException {
+    protected String copyToS3(final File srcFile, final S3TO destStore, final String destPath) throws InterruptedException {
         final String bucket = destStore.getBucketName();
 
-        long srcSize = srcFile.length();
-        String key = destPath + S3Utils.SEPARATOR + srcFile.getName();
+        final long srcSize = srcFile.length();
+        final String key = destPath + S3Utils.SEPARATOR + srcFile.getName();
         if (!destStore.getSingleUpload(srcSize)) {
             mputFile(destStore, srcFile, bucket, key);
         } else {
@@ -596,15 +594,15 @@ public class KVMStorageProcessor implements StorageProcessor {
         return key;
     }
 
-    protected Answer copyToObjectStore(CopyCommand cmd) {
-        DataTO srcData = cmd.getSrcTO();
-        DataTO destData = cmd.getDestTO();
-        DataStoreTO imageStore = destData.getDataStore();
-        NfsTO srcStore = (NfsTO)srcData.getDataStore();
-        String srcPath = srcData.getPath();
-        int index = srcPath.lastIndexOf(File.separator);
-        String srcSnapshotDir = srcPath.substring(0, index);
-        String srcFileName = srcPath.substring(index + 1);
+    protected Answer copyToObjectStore(final CopyCommand cmd) {
+        final DataTO srcData = cmd.getSrcTO();
+        final DataTO destData = cmd.getDestTO();
+        final DataStoreTO imageStore = destData.getDataStore();
+        final NfsTO srcStore = (NfsTO)srcData.getDataStore();
+        final String srcPath = srcData.getPath();
+        final int index = srcPath.lastIndexOf(File.separator);
+        final String srcSnapshotDir = srcPath.substring(0, index);
+        final String srcFileName = srcPath.substring(index + 1);
         KVMStoragePool srcStorePool = null;
         File srcFile = null;
         try {
@@ -622,10 +620,10 @@ public class KVMStorageProcessor implements StorageProcessor {
             } else {
                 return new CopyCmdAnswer("Unsupported protocol");
             }
-            SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
+            final SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
             newSnapshot.setPath(destPath);
             return new CopyCmdAnswer(newSnapshot);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             s_logger.error("failed to upload" + srcPath, e);
             return new CopyCmdAnswer("failed to upload" + srcPath + e.toString());
         } finally {
@@ -636,55 +634,55 @@ public class KVMStorageProcessor implements StorageProcessor {
                 if (srcStorePool != null) {
                     srcStorePool.delete();
                 }
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 s_logger.debug("Failed to clean up:", e);
             }
         }
     }
 
-    protected Answer backupSnapshotForObjectStore(CopyCommand cmd) {
-        DataTO destData = cmd.getDestTO();
-        DataStoreTO imageStore = destData.getDataStore();
-        DataTO cacheData = cmd.getCacheTO();
+    protected Answer backupSnapshotForObjectStore(final CopyCommand cmd) {
+        final DataTO destData = cmd.getDestTO();
+        final DataStoreTO imageStore = destData.getDataStore();
+        final DataTO cacheData = cmd.getCacheTO();
         if (cacheData == null) {
             return new CopyCmdAnswer("Failed to copy to object store without cache store");
         }
-        DataStoreTO cacheStore = cacheData.getDataStore();
+        final DataStoreTO cacheStore = cacheData.getDataStore();
         ((SnapshotObjectTO)destData).setDataStore(cacheStore);
-        CopyCmdAnswer answer = (CopyCmdAnswer)backupSnapshot(cmd);
+        final CopyCmdAnswer answer = (CopyCmdAnswer)backupSnapshot(cmd);
         if (!answer.getResult()) {
             return answer;
         }
-        SnapshotObjectTO snapshotOnCacheStore = (SnapshotObjectTO)answer.getNewData();
+        final SnapshotObjectTO snapshotOnCacheStore = (SnapshotObjectTO)answer.getNewData();
         snapshotOnCacheStore.setDataStore(cacheStore);
         ((SnapshotObjectTO)destData).setDataStore(imageStore);
-        CopyCommand newCpyCmd = new CopyCommand(snapshotOnCacheStore, destData, cmd.getWaitInMillSeconds(), cmd.executeInSequence());
+        final CopyCommand newCpyCmd = new CopyCommand(snapshotOnCacheStore, destData, cmd.getWaitInMillSeconds(), cmd.executeInSequence());
         return copyToObjectStore(newCpyCmd);
     }
 
     @Override
-    public Answer backupSnapshot(CopyCommand cmd) {
-        DataTO srcData = cmd.getSrcTO();
-        DataTO destData = cmd.getDestTO();
-        SnapshotObjectTO snapshot = (SnapshotObjectTO)srcData;
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)snapshot.getDataStore();
-        SnapshotObjectTO destSnapshot = (SnapshotObjectTO)destData;
-        DataStoreTO imageStore = destData.getDataStore();
+    public Answer backupSnapshot(final CopyCommand cmd) {
+        final DataTO srcData = cmd.getSrcTO();
+        final DataTO destData = cmd.getDestTO();
+        final SnapshotObjectTO snapshot = (SnapshotObjectTO)srcData;
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)snapshot.getDataStore();
+        final SnapshotObjectTO destSnapshot = (SnapshotObjectTO)destData;
+        final DataStoreTO imageStore = destData.getDataStore();
 
         if (!(imageStore instanceof NfsTO)) {
             return backupSnapshotForObjectStore(cmd);
         }
-        NfsTO nfsImageStore = (NfsTO)imageStore;
+        final NfsTO nfsImageStore = (NfsTO)imageStore;
 
-        String secondaryStoragePoolUrl = nfsImageStore.getUrl();
+        final String secondaryStoragePoolUrl = nfsImageStore.getUrl();
         // NOTE: snapshot name is encoded in snapshot path
-        int index = snapshot.getPath().lastIndexOf("/");
+        final int index = snapshot.getPath().lastIndexOf("/");
 
-        String snapshotName = snapshot.getPath().substring(index + 1);
-        String volumePath = snapshot.getVolume().getPath();
+        final String snapshotName = snapshot.getPath().substring(index + 1);
+        final String volumePath = snapshot.getVolume().getPath();
         String snapshotDestPath = null;
         String snapshotRelPath = null;
-        String vmName = snapshot.getVmName();
+        final String vmName = snapshot.getVmName();
         KVMStoragePool secondaryStoragePool = null;
         Connect conn = null;
         KVMPhysicalDisk snapshotDisk = null;
@@ -694,7 +692,7 @@ public class KVMStorageProcessor implements StorageProcessor {
 
             secondaryStoragePool = storagePoolMgr.getStoragePoolByURI(secondaryStoragePoolUrl);
 
-            String ssPmountPath = secondaryStoragePool.getLocalPath();
+            final String ssPmountPath = secondaryStoragePool.getLocalPath();
             snapshotRelPath = destSnapshot.getPath();
 
             snapshotDestPath = ssPmountPath + File.separator + snapshotRelPath;
@@ -709,69 +707,69 @@ public class KVMStorageProcessor implements StorageProcessor {
              * This reduces the amount of time and storage it takes to back up a snapshot dramatically
              */
             if (primaryPool.getType() == StoragePoolType.RBD) {
-                String rbdSnapshot = snapshotDisk.getPath() +  "@" + snapshotName;
-                String snapshotFile = snapshotDestPath + "/" + snapshotName;
+                final String rbdSnapshot = snapshotDisk.getPath() +  "@" + snapshotName;
+                final String snapshotFile = snapshotDestPath + "/" + snapshotName;
                 try {
                     s_logger.debug("Attempting to backup RBD snapshot " + rbdSnapshot);
 
-                    File snapDir = new File(snapshotDestPath);
+                    final File snapDir = new File(snapshotDestPath);
                     s_logger.debug("Attempting to create " + snapDir.getAbsolutePath() + " recursively for snapshot storage");
                     FileUtils.forceMkdir(snapDir);
 
-                    QemuImgFile srcFile =
-                        new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primaryPool.getSourceHost(), primaryPool.getSourcePort(), primaryPool.getAuthUserName(),
-                                                                         primaryPool.getAuthSecret(), rbdSnapshot));
+                    final QemuImgFile srcFile =
+                            new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(primaryPool.getSourceHost(), primaryPool.getSourcePort(), primaryPool.getAuthUserName(),
+                                    primaryPool.getAuthSecret(), rbdSnapshot));
                     srcFile.setFormat(PhysicalDiskFormat.RAW);
 
-                    QemuImgFile destFile = new QemuImgFile(snapshotFile);
+                    final QemuImgFile destFile = new QemuImgFile(snapshotFile);
                     destFile.setFormat(snapshotDisk.getFormat());
 
                     s_logger.debug("Backing up RBD snapshot " + rbdSnapshot + " to " + snapshotFile);
-                    QemuImg q = new QemuImg(cmd.getWaitInMillSeconds());
+                    final QemuImg q = new QemuImg(cmd.getWaitInMillSeconds());
                     q.convert(srcFile, destFile);
 
-                    File snapFile = new File(snapshotFile);
+                    final File snapFile = new File(snapshotFile);
                     if(snapFile.exists()) {
                         size = snapFile.length();
                     }
 
                     s_logger.debug("Finished backing up RBD snapshot " + rbdSnapshot + " to " + snapshotFile + " Snapshot size: " + size);
-                } catch (FileNotFoundException e) {
+                } catch (final FileNotFoundException e) {
                     s_logger.error("Failed to open " + snapshotDestPath + ". The error was: " + e.getMessage());
                     return new CopyCmdAnswer(e.toString());
-                } catch (IOException e) {
+                } catch (final IOException e) {
                     s_logger.error("Failed to create " + snapshotDestPath + ". The error was: " + e.getMessage());
                     return new CopyCmdAnswer(e.toString());
-                }  catch (QemuImgException e) {
+                }  catch (final QemuImgException e) {
                     s_logger.error("Failed to backup the RBD snapshot from " + rbdSnapshot +
-                                   " to " + snapshotFile + " the error was: " + e.getMessage());
+                            " to " + snapshotFile + " the error was: " + e.getMessage());
                     return new CopyCmdAnswer(e.toString());
                 }
             } else {
-                Script command = new Script(_manageSnapshotPath, cmd.getWaitInMillSeconds(), s_logger);
+                final Script command = new Script(_manageSnapshotPath, cmd.getWaitInMillSeconds(), s_logger);
                 command.add("-b", snapshotDisk.getPath());
                 command.add("-n", snapshotName);
                 command.add("-p", snapshotDestPath);
                 command.add("-t", snapshotName);
-                String result = command.execute();
+                final String result = command.execute();
                 if (result != null) {
                     s_logger.debug("Failed to backup snaptshot: " + result);
                     return new CopyCmdAnswer(result);
                 }
-                File snapFile = new File(snapshotDestPath + "/" + snapshotName);
+                final File snapFile = new File(snapshotDestPath + "/" + snapshotName);
                 if(snapFile.exists()){
                     size = snapFile.length();
                 }
             }
 
-            SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
+            final SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
             newSnapshot.setPath(snapshotRelPath + File.separator + snapshotName);
             newSnapshot.setPhysicalSize(size);
             return new CopyCmdAnswer(newSnapshot);
-        } catch (LibvirtException e) {
+        } catch (final LibvirtException e) {
             s_logger.debug("Failed to backup snapshot: ", e);
             return new CopyCmdAnswer(e.toString());
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             s_logger.debug("Failed to backup snapshot: ", e);
             return new CopyCmdAnswer(e.toString());
         } finally {
@@ -783,15 +781,15 @@ public class KVMStorageProcessor implements StorageProcessor {
                     try {
                         vm = resource.getDomain(conn, vmName);
                         state = vm.getInfo().state;
-                    } catch (LibvirtException e) {
+                    } catch (final LibvirtException e) {
                         s_logger.trace("Ignoring libvirt error.", e);
                     }
                 }
 
-                KVMStoragePool primaryStorage = storagePoolMgr.getStoragePool(primaryStore.getPoolType(),
+                final KVMStoragePool primaryStorage = storagePoolMgr.getStoragePool(primaryStore.getPoolType(),
                         primaryStore.getUuid());
                 if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot()) {
-                    DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
+                    final DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
                     snap.delete(0);
 
                     /*
@@ -805,17 +803,17 @@ public class KVMStorageProcessor implements StorageProcessor {
                     }
                 } else {
                     if (primaryPool.getType() != StoragePoolType.RBD) {
-                        Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
+                        final Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
                         command.add("-d", snapshotDisk.getPath());
                         command.add("-n", snapshotName);
-                        String result = command.execute();
+                        final String result = command.execute();
                         if (result != null) {
                             s_logger.debug("Failed to delete snapshot on primary: " + result);
                             // return new CopyCmdAnswer("Failed to backup snapshot: " + result);
                         }
                     }
                 }
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 s_logger.debug("Failed to delete snapshots on primary", ex);
             }
 
@@ -823,36 +821,36 @@ public class KVMStorageProcessor implements StorageProcessor {
                 if (secondaryStoragePool != null) {
                     secondaryStoragePool.delete();
                 }
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 s_logger.debug("Failed to delete secondary storage", ex);
             }
         }
     }
 
-    protected synchronized String attachOrDetachISO(Connect conn, String vmName, String isoPath, boolean isAttach) throws LibvirtException, URISyntaxException,
-        InternalErrorException {
+    protected synchronized String attachOrDetachISO(final Connect conn, final String vmName, String isoPath, final boolean isAttach) throws LibvirtException, URISyntaxException,
+    InternalErrorException {
         String isoXml = null;
         if (isoPath != null && isAttach) {
-            int index = isoPath.lastIndexOf("/");
-            String path = isoPath.substring(0, index);
-            String name = isoPath.substring(index + 1);
-            KVMStoragePool secondaryPool = storagePoolMgr.getStoragePoolByURI(path);
-            KVMPhysicalDisk isoVol = secondaryPool.getPhysicalDisk(name);
+            final int index = isoPath.lastIndexOf("/");
+            final String path = isoPath.substring(0, index);
+            final String name = isoPath.substring(index + 1);
+            final KVMStoragePool secondaryPool = storagePoolMgr.getStoragePoolByURI(path);
+            final KVMPhysicalDisk isoVol = secondaryPool.getPhysicalDisk(name);
             isoPath = isoVol.getPath();
 
-            DiskDef iso = new DiskDef();
+            final DiskDef iso = new DiskDef();
             iso.defISODisk(isoPath);
             isoXml = iso.toString();
         } else {
-            DiskDef iso = new DiskDef();
+            final DiskDef iso = new DiskDef();
             iso.defISODisk(null);
             isoXml = iso.toString();
         }
 
-        List<DiskDef> disks = resource.getDisks(conn, vmName);
-        String result = attachOrDetachDevice(conn, true, vmName, isoXml);
+        final List<DiskDef> disks = resource.getDisks(conn, vmName);
+        final String result = attachOrDetachDevice(conn, true, vmName, isoXml);
         if (result == null && !isAttach) {
-            for (DiskDef disk : disks) {
+            for (final DiskDef disk : disks) {
                 if (disk.getDeviceType() == DiskDef.deviceType.CDROM) {
                     resource.cleanupDisk(disk);
                 }
@@ -863,22 +861,22 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer attachIso(AttachCommand cmd) {
-        DiskTO disk = cmd.getDisk();
-        TemplateObjectTO isoTO = (TemplateObjectTO)disk.getData();
-        DataStoreTO store = isoTO.getDataStore();
+    public Answer attachIso(final AttachCommand cmd) {
+        final DiskTO disk = cmd.getDisk();
+        final TemplateObjectTO isoTO = (TemplateObjectTO)disk.getData();
+        final DataStoreTO store = isoTO.getDataStore();
         if (!(store instanceof NfsTO)) {
             return new AttachAnswer("unsupported protocol");
         }
-        NfsTO nfsStore = (NfsTO)store;
+        final NfsTO nfsStore = (NfsTO)store;
         try {
-            Connect conn = LibvirtConnection.getConnectionByVmName(cmd.getVmName());
+            final Connect conn = LibvirtConnection.getConnectionByVmName(cmd.getVmName());
             attachOrDetachISO(conn, cmd.getVmName(), nfsStore.getUrl() + File.separator + isoTO.getPath(), true);
-        } catch (LibvirtException e) {
+        } catch (final LibvirtException e) {
             return new Answer(cmd, false, e.toString());
-        } catch (URISyntaxException e) {
+        } catch (final URISyntaxException e) {
             return new Answer(cmd, false, e.toString());
-        } catch (InternalErrorException e) {
+        } catch (final InternalErrorException e) {
             return new Answer(cmd, false, e.toString());
         }
 
@@ -886,29 +884,29 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer dettachIso(DettachCommand cmd) {
-        DiskTO disk = cmd.getDisk();
-        TemplateObjectTO isoTO = (TemplateObjectTO)disk.getData();
-        DataStoreTO store = isoTO.getDataStore();
+    public Answer dettachIso(final DettachCommand cmd) {
+        final DiskTO disk = cmd.getDisk();
+        final TemplateObjectTO isoTO = (TemplateObjectTO)disk.getData();
+        final DataStoreTO store = isoTO.getDataStore();
         if (!(store instanceof NfsTO)) {
             return new AttachAnswer("unsupported protocol");
         }
-        NfsTO nfsStore = (NfsTO)store;
+        final NfsTO nfsStore = (NfsTO)store;
         try {
-            Connect conn = LibvirtConnection.getConnectionByVmName(cmd.getVmName());
+            final Connect conn = LibvirtConnection.getConnectionByVmName(cmd.getVmName());
             attachOrDetachISO(conn, cmd.getVmName(), nfsStore.getUrl() + File.separator + isoTO.getPath(), false);
-        } catch (LibvirtException e) {
+        } catch (final LibvirtException e) {
             return new Answer(cmd, false, e.toString());
-        } catch (URISyntaxException e) {
+        } catch (final URISyntaxException e) {
             return new Answer(cmd, false, e.toString());
-        } catch (InternalErrorException e) {
+        } catch (final InternalErrorException e) {
             return new Answer(cmd, false, e.toString());
         }
 
         return new Answer(cmd);
     }
 
-    protected synchronized String attachOrDetachDevice(Connect conn, boolean attach, String vmName, String xml) throws LibvirtException, InternalErrorException {
+    protected synchronized String attachOrDetachDevice(final Connect conn, final boolean attach, final String vmName, final String xml) throws LibvirtException, InternalErrorException {
         Domain dm = null;
         try {
             dm = conn.domainLookupByName(vmName);
@@ -920,7 +918,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 s_logger.debug("Detaching device: " + xml);
                 dm.detachDevice(xml);
             }
-        } catch (LibvirtException e) {
+        } catch (final LibvirtException e) {
             if (attach) {
                 s_logger.warn("Failed to attach device to " + vmName + ": " + e.getMessage());
             } else {
@@ -931,7 +929,7 @@ public class KVMStorageProcessor implements StorageProcessor {
             if (dm != null) {
                 try {
                     dm.free();
-                } catch (LibvirtException l) {
+                } catch (final LibvirtException l) {
                     s_logger.trace("Ignoring libvirt error.", l);
                 }
             }
@@ -940,23 +938,23 @@ public class KVMStorageProcessor implements StorageProcessor {
         return null;
     }
 
-    protected synchronized String attachOrDetachDisk(Connect conn, boolean attach, String vmName, KVMPhysicalDisk attachingDisk, int devId) throws LibvirtException,
-        InternalErrorException {
+    protected synchronized String attachOrDetachDisk(final Connect conn, final boolean attach, final String vmName, final KVMPhysicalDisk attachingDisk, final int devId) throws LibvirtException,
+    InternalErrorException {
         List<DiskDef> disks = null;
         Domain dm = null;
         DiskDef diskdef = null;
-        KVMStoragePool attachingPool = attachingDisk.getPool();
+        final KVMStoragePool attachingPool = attachingDisk.getPool();
         try {
             if (!attach) {
                 dm = conn.domainLookupByName(vmName);
-                LibvirtDomainXMLParser parser = new LibvirtDomainXMLParser();
-                String xml = dm.getXMLDesc(0);
+                final LibvirtDomainXMLParser parser = new LibvirtDomainXMLParser();
+                final String xml = dm.getXMLDesc(0);
                 parser.parseDomainXML(xml);
                 disks = parser.getDisks();
 
                 if (attachingPool.getType() == StoragePoolType.RBD) {
                     if (resource.getHypervisorType() == Hypervisor.HypervisorType.LXC) {
-                        String device = resource.mapRbdDevice(attachingDisk);
+                        final String device = resource.mapRbdDevice(attachingDisk);
                         if (device != null) {
                             s_logger.debug("RBD device on host is: "+device);
                             attachingDisk.setPath(device);
@@ -964,8 +962,8 @@ public class KVMStorageProcessor implements StorageProcessor {
                     }
                 }
 
-                for (DiskDef disk : disks) {
-                    String file = disk.getDiskPath();
+                for (final DiskDef disk : disks) {
+                    final String file = disk.getDiskPath();
                     if (file != null && file.equalsIgnoreCase(attachingDisk.getPath())) {
                         diskdef = disk;
                         break;
@@ -979,7 +977,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 if (attachingPool.getType() == StoragePoolType.RBD) {
                     if(resource.getHypervisorType() == Hypervisor.HypervisorType.LXC){
                         // For LXC, map image to host and then attach to Vm
-                        String device = resource.mapRbdDevice(attachingDisk);
+                        final String device = resource.mapRbdDevice(attachingDisk);
                         if (device != null) {
                             s_logger.debug("RBD device on host is: "+device);
                             diskdef.defBlockBasedDisk(device, devId, DiskDef.diskBus.VIRTIO);
@@ -991,11 +989,11 @@ public class KVMStorageProcessor implements StorageProcessor {
                                 attachingPool.getUuid(), devId, DiskDef.diskBus.VIRTIO, diskProtocol.RBD, DiskDef.diskFmtType.RAW);
                     }
                 } else if (attachingPool.getType() == StoragePoolType.Gluster) {
-                    String mountpoint = attachingPool.getLocalPath();
-                    String path = attachingDisk.getPath();
-                    String glusterVolume = attachingPool.getSourceDir().replace("/", "");
+                    final String mountpoint = attachingPool.getLocalPath();
+                    final String path = attachingDisk.getPath();
+                    final String glusterVolume = attachingPool.getSourceDir().replace("/", "");
                     diskdef.defNetworkBasedDisk(glusterVolume + path.replace(mountpoint, ""), attachingPool.getSourceHost(), attachingPool.getSourcePort(), null,
-                        null, devId, DiskDef.diskBus.VIRTIO, diskProtocol.GLUSTER, DiskDef.diskFmtType.QCOW2);
+                            null, devId, DiskDef.diskBus.VIRTIO, diskProtocol.GLUSTER, DiskDef.diskFmtType.QCOW2);
                 } else if (attachingDisk.getFormat() == PhysicalDiskFormat.QCOW2) {
                     diskdef.defFileBasedDisk(attachingDisk.getPath(), devId, DiskDef.diskBus.VIRTIO, DiskDef.diskFmtType.QCOW2);
                 } else if (attachingDisk.getFormat() == PhysicalDiskFormat.RAW) {
@@ -1003,7 +1001,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 }
             }
 
-            String xml = diskdef.toString();
+            final String xml = diskdef.toString();
             return attachOrDetachDevice(conn, attach, vmName, xml);
         } finally {
             if (dm != null) {
@@ -1013,60 +1011,60 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer attachVolume(AttachCommand cmd) {
-        DiskTO disk = cmd.getDisk();
-        VolumeObjectTO vol = (VolumeObjectTO)disk.getData();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)vol.getDataStore();
-        String vmName = cmd.getVmName();
+    public Answer attachVolume(final AttachCommand cmd) {
+        final DiskTO disk = cmd.getDisk();
+        final VolumeObjectTO vol = (VolumeObjectTO)disk.getData();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)vol.getDataStore();
+        final String vmName = cmd.getVmName();
         try {
-            Connect conn = LibvirtConnection.getConnectionByVmName(vmName);
+            final Connect conn = LibvirtConnection.getConnectionByVmName(vmName);
 
             storagePoolMgr.connectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), vol.getPath(), disk.getDetails());
 
-            KVMPhysicalDisk phyDisk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), vol.getPath());
+            final KVMPhysicalDisk phyDisk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), vol.getPath());
 
             attachOrDetachDisk(conn, true, vmName, phyDisk, disk.getDiskSeq().intValue());
 
             return new AttachAnswer(disk);
-        } catch (LibvirtException e) {
+        } catch (final LibvirtException e) {
             s_logger.debug("Failed to attach volume: " + vol.getPath() + ", due to ", e);
             storagePoolMgr.disconnectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), vol.getPath());
             return new AttachAnswer(e.toString());
-        } catch (InternalErrorException e) {
+        } catch (final InternalErrorException e) {
             s_logger.debug("Failed to attach volume: " + vol.getPath() + ", due to ", e);
             return new AttachAnswer(e.toString());
         }
     }
 
     @Override
-    public Answer dettachVolume(DettachCommand cmd) {
-        DiskTO disk = cmd.getDisk();
-        VolumeObjectTO vol = (VolumeObjectTO)disk.getData();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)vol.getDataStore();
-        String vmName = cmd.getVmName();
+    public Answer dettachVolume(final DettachCommand cmd) {
+        final DiskTO disk = cmd.getDisk();
+        final VolumeObjectTO vol = (VolumeObjectTO)disk.getData();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)vol.getDataStore();
+        final String vmName = cmd.getVmName();
         try {
-            Connect conn = LibvirtConnection.getConnectionByVmName(vmName);
+            final Connect conn = LibvirtConnection.getConnectionByVmName(vmName);
 
-            KVMPhysicalDisk phyDisk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), vol.getPath());
+            final KVMPhysicalDisk phyDisk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), vol.getPath());
 
             attachOrDetachDisk(conn, false, vmName, phyDisk, disk.getDiskSeq().intValue());
 
             storagePoolMgr.disconnectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), vol.getPath());
 
             return new DettachAnswer(disk);
-        } catch (LibvirtException e) {
+        } catch (final LibvirtException e) {
             s_logger.debug("Failed to attach volume: " + vol.getPath() + ", due to ", e);
             return new DettachAnswer(e.toString());
-        } catch (InternalErrorException e) {
+        } catch (final InternalErrorException e) {
             s_logger.debug("Failed to attach volume: " + vol.getPath() + ", due to ", e);
             return new DettachAnswer(e.toString());
         }
     }
 
     @Override
-    public Answer createVolume(CreateObjectCommand cmd) {
-        VolumeObjectTO volume = (VolumeObjectTO)cmd.getData();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)volume.getDataStore();
+    public Answer createVolume(final CreateObjectCommand cmd) {
+        final VolumeObjectTO volume = (VolumeObjectTO)cmd.getData();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)volume.getDataStore();
 
         KVMStoragePool primaryPool = null;
         KVMPhysicalDisk vol = null;
@@ -1081,9 +1079,9 @@ public class KVMStorageProcessor implements StorageProcessor {
                 format = PhysicalDiskFormat.valueOf(volume.getFormat().toString().toUpperCase());
             }
             vol = primaryPool.createPhysicalDisk(volume.getUuid(), format,
-                                                 volume.getProvisioningType(), disksize);
+                    volume.getProvisioningType(), disksize);
 
-            VolumeObjectTO newVol = new VolumeObjectTO();
+            final VolumeObjectTO newVol = new VolumeObjectTO();
             if(vol != null) {
                 newVol.setPath(vol.getName());
             }
@@ -1091,46 +1089,46 @@ public class KVMStorageProcessor implements StorageProcessor {
             newVol.setFormat(ImageFormat.valueOf(format.toString().toUpperCase()));
 
             return new CreateObjectAnswer(newVol);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             s_logger.debug("Failed to create volume: ", e);
             return new CreateObjectAnswer(e.toString());
         }
     }
 
     protected static final MessageFormat SnapshotXML = new MessageFormat("   <domainsnapshot>" + "       <name>{0}</name>" + "          <domain>"
-        + "            <uuid>{1}</uuid>" + "        </domain>" + "    </domainsnapshot>");
+            + "            <uuid>{1}</uuid>" + "        </domain>" + "    </domainsnapshot>");
 
     @Override
-    public Answer createSnapshot(CreateObjectCommand cmd) {
-        SnapshotObjectTO snapshotTO = (SnapshotObjectTO)cmd.getData();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)snapshotTO.getDataStore();
-        VolumeObjectTO volume = snapshotTO.getVolume();
-        String snapshotName = UUID.randomUUID().toString();
-        String vmName = volume.getVmName();
+    public Answer createSnapshot(final CreateObjectCommand cmd) {
+        final SnapshotObjectTO snapshotTO = (SnapshotObjectTO)cmd.getData();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)snapshotTO.getDataStore();
+        final VolumeObjectTO volume = snapshotTO.getVolume();
+        final String snapshotName = UUID.randomUUID().toString();
+        final String vmName = volume.getVmName();
         try {
-            Connect conn = LibvirtConnection.getConnectionByVmName(vmName);
+            final Connect conn = LibvirtConnection.getConnectionByVmName(vmName);
             DomainInfo.DomainState state = null;
             Domain vm = null;
             if (vmName != null) {
                 try {
                     vm = resource.getDomain(conn, vmName);
                     state = vm.getInfo().state;
-                } catch (LibvirtException e) {
+                } catch (final LibvirtException e) {
                     s_logger.trace("Ignoring libvirt error.", e);
                 }
             }
 
-            KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
+            final KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
 
-            KVMPhysicalDisk disk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), volume.getPath());
+            final KVMPhysicalDisk disk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), volume.getPath());
             if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryPool.isExternalSnapshot()) {
-                String vmUuid = vm.getUUIDString();
-                Object[] args = new Object[] {snapshotName, vmUuid};
-                String snapshot = SnapshotXML.format(args);
+                final String vmUuid = vm.getUUIDString();
+                final Object[] args = new Object[] {snapshotName, vmUuid};
+                final String snapshot = SnapshotXML.format(args);
 
-                long start = System.currentTimeMillis();
+                final long start = System.currentTimeMillis();
                 vm.snapshotCreateXML(snapshot);
-                long total = (System.currentTimeMillis() - start)/1000;
+                final long total = (System.currentTimeMillis() - start)/1000;
                 s_logger.debug("snapshot takes " + total + " seconds to finish");
 
                 /*
@@ -1158,23 +1156,23 @@ public class KVMStorageProcessor implements StorageProcessor {
                  */
                 if (primaryPool.getType() == StoragePoolType.RBD) {
                     try {
-                        Rados r = new Rados(primaryPool.getAuthUserName());
+                        final Rados r = new Rados(primaryPool.getAuthUserName());
                         r.confSet("mon_host", primaryPool.getSourceHost() + ":" + primaryPool.getSourcePort());
                         r.confSet("key", primaryPool.getAuthSecret());
                         r.confSet("client_mount_timeout", "30");
                         r.connect();
                         s_logger.debug("Succesfully connected to Ceph cluster at " + r.confGet("mon_host"));
 
-                        IoCTX io = r.ioCtxCreate(primaryPool.getSourceDir());
-                        Rbd rbd = new Rbd(io);
-                        RbdImage image = rbd.open(disk.getName());
+                        final IoCTX io = r.ioCtxCreate(primaryPool.getSourceDir());
+                        final Rbd rbd = new Rbd(io);
+                        final RbdImage image = rbd.open(disk.getName());
 
                         s_logger.debug("Attempting to create RBD snapshot " + disk.getName() + "@" + snapshotName);
                         image.snapCreate(snapshotName);
 
                         rbd.close(image);
                         r.ioCtxDestroy(io);
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         s_logger.error("A RBD snapshot operation on " + disk.getName() + " failed. The error was: " + e.getMessage());
                     }
                 } else {
@@ -1182,7 +1180,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                     final Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
                     command.add("-c", disk.getPath());
                     command.add("-n", snapshotName);
-                    String result = command.execute();
+                    final String result = command.execute();
                     if (result != null) {
                         s_logger.debug("Failed to manage snapshot: " + result);
                         return new CreateObjectAnswer("Failed to manage snapshot: " + result);
@@ -1190,58 +1188,58 @@ public class KVMStorageProcessor implements StorageProcessor {
                 }
             }
 
-            SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
+            final SnapshotObjectTO newSnapshot = new SnapshotObjectTO();
             // NOTE: sort of hack, we'd better just put snapshtoName
             newSnapshot.setPath(disk.getPath() + File.separator + snapshotName);
             return new CreateObjectAnswer(newSnapshot);
-        } catch (LibvirtException e) {
+        } catch (final LibvirtException e) {
             s_logger.debug("Failed to manage snapshot: ", e);
             return new CreateObjectAnswer("Failed to manage snapshot: " + e.toString());
         }
     }
 
     @Override
-    public Answer deleteVolume(DeleteCommand cmd) {
-        VolumeObjectTO vol = (VolumeObjectTO)cmd.getData();
-        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)vol.getDataStore();
+    public Answer deleteVolume(final DeleteCommand cmd) {
+        final VolumeObjectTO vol = (VolumeObjectTO)cmd.getData();
+        final PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)vol.getDataStore();
         try {
-            KVMStoragePool pool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
+            final KVMStoragePool pool = storagePoolMgr.getStoragePool(primaryStore.getPoolType(), primaryStore.getUuid());
             try {
                 pool.getPhysicalDisk(vol.getPath());
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 s_logger.debug("can't find volume: " + vol.getPath() + ", return true");
                 return new Answer(null);
             }
             pool.deletePhysicalDisk(vol.getPath(), vol.getFormat());
             return new Answer(null);
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             s_logger.debug("Failed to delete volume: ", e);
             return new Answer(null, false, e.toString());
         }
     }
 
     @Override
-    public Answer createVolumeFromSnapshot(CopyCommand cmd) {
+    public Answer createVolumeFromSnapshot(final CopyCommand cmd) {
         try {
-            DataTO srcData = cmd.getSrcTO();
-            SnapshotObjectTO snapshot = (SnapshotObjectTO)srcData;
-            DataTO destData = cmd.getDestTO();
-            PrimaryDataStoreTO pool = (PrimaryDataStoreTO)destData.getDataStore();
-            DataStoreTO imageStore = srcData.getDataStore();
-            VolumeObjectTO volume = snapshot.getVolume();
+            final DataTO srcData = cmd.getSrcTO();
+            final SnapshotObjectTO snapshot = (SnapshotObjectTO)srcData;
+            final DataTO destData = cmd.getDestTO();
+            final PrimaryDataStoreTO pool = (PrimaryDataStoreTO)destData.getDataStore();
+            final DataStoreTO imageStore = srcData.getDataStore();
+            final VolumeObjectTO volume = snapshot.getVolume();
 
             if (!(imageStore instanceof NfsTO)) {
                 return new CopyCmdAnswer("unsupported protocol");
             }
 
-            NfsTO nfsImageStore = (NfsTO)imageStore;
+            final NfsTO nfsImageStore = (NfsTO)imageStore;
 
-            String snapshotFullPath = snapshot.getPath();
-            int index = snapshotFullPath.lastIndexOf("/");
-            String snapshotPath = snapshotFullPath.substring(0, index);
-            String snapshotName = snapshotFullPath.substring(index + 1);
-            KVMStoragePool secondaryPool = storagePoolMgr.getStoragePoolByURI(nfsImageStore.getUrl() + File.separator + snapshotPath);
-            KVMPhysicalDisk snapshotDisk = secondaryPool.getPhysicalDisk(snapshotName);
+            final String snapshotFullPath = snapshot.getPath();
+            final int index = snapshotFullPath.lastIndexOf("/");
+            final String snapshotPath = snapshotFullPath.substring(0, index);
+            final String snapshotName = snapshotFullPath.substring(index + 1);
+            final KVMStoragePool secondaryPool = storagePoolMgr.getStoragePoolByURI(nfsImageStore.getUrl() + File.separator + snapshotPath);
+            final KVMPhysicalDisk snapshotDisk = secondaryPool.getPhysicalDisk(snapshotName);
 
             if (volume.getFormat() == ImageFormat.RAW) {
                 snapshotDisk.setFormat(PhysicalDiskFormat.RAW);
@@ -1249,34 +1247,34 @@ public class KVMStorageProcessor implements StorageProcessor {
                 snapshotDisk.setFormat(PhysicalDiskFormat.QCOW2);
             }
 
-            String primaryUuid = pool.getUuid();
-            KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(pool.getPoolType(), primaryUuid);
-            String volUuid = UUID.randomUUID().toString();
-            KVMPhysicalDisk disk = storagePoolMgr.copyPhysicalDisk(snapshotDisk, volUuid, primaryPool, cmd.getWaitInMillSeconds());
-            VolumeObjectTO newVol = new VolumeObjectTO();
+            final String primaryUuid = pool.getUuid();
+            final KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(pool.getPoolType(), primaryUuid);
+            final String volUuid = UUID.randomUUID().toString();
+            final KVMPhysicalDisk disk = storagePoolMgr.copyPhysicalDisk(snapshotDisk, volUuid, primaryPool, cmd.getWaitInMillSeconds());
+            final VolumeObjectTO newVol = new VolumeObjectTO();
             newVol.setPath(disk.getName());
             newVol.setSize(disk.getVirtualSize());
             newVol.setFormat(ImageFormat.valueOf(disk.getFormat().toString().toUpperCase()));
 
             return new CopyCmdAnswer(newVol);
-        } catch (CloudRuntimeException e) {
+        } catch (final CloudRuntimeException e) {
             s_logger.debug("Failed to createVolumeFromSnapshot: ", e);
             return new CopyCmdAnswer(e.toString());
         }
     }
 
     @Override
-    public Answer deleteSnapshot(DeleteCommand cmd) {
+    public Answer deleteSnapshot(final DeleteCommand cmd) {
         return new Answer(cmd);
     }
 
     @Override
-    public Answer introduceObject(IntroduceObjectCmd cmd) {
+    public Answer introduceObject(final IntroduceObjectCmd cmd) {
         return new Answer(cmd, false, "not implememented yet");
     }
 
     @Override
-    public Answer forgetObject(ForgetObjectCmd cmd) {
+    public Answer forgetObject(final ForgetObjectCmd cmd) {
         return new Answer(cmd, false, "not implememented yet");
     }
 

--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -224,29 +224,29 @@ public class QemuImg {
      * @return void
      */
     public void convert(final QemuImgFile srcFile, final QemuImgFile destFile, final Map<String, String> options) throws QemuImgException {
-        final Script s = new Script(_qemuImgPath, timeout);
-        s.add("convert");
+        final Script script = new Script(_qemuImgPath, timeout);
+        script.add("convert");
         // autodetect source format. Sometime int he future we may teach KVMPhysicalDisk about more formats, then we can explicitly pass them if necessary
         //s.add("-f");
         //s.add(srcFile.getFormat().toString());
-        s.add("-O");
-        s.add(destFile.getFormat().toString());
+        script.add("-O");
+        script.add(destFile.getFormat().toString());
 
         if (options != null && !options.isEmpty()) {
-            s.add("-o");
+            script.add("-o");
             final StringBuffer optionsBuffer = new StringBuffer();
             for (final Map.Entry<String, String> option : options.entrySet()) {
                 optionsBuffer.append(option.getKey()).append('=').append(option.getValue()).append(',');
             }
             String optionsStr = optionsBuffer.toString();
             optionsStr = optionsStr.replaceAll(",$", "");
-            s.add(optionsStr);
+            script.add(optionsStr);
         }
 
-        s.add(srcFile.getFileName());
-        s.add(destFile.getFileName());
+        script.add(srcFile.getFileName());
+        script.add(destFile.getFileName());
 
-        final String result = s.execute();
+        final String result = script.execute();
         if (result != null) {
             throw new QemuImgException(result);
         }

--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/qemu/QemuImg.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/qemu/QemuImg.java
@@ -19,11 +19,12 @@ package org.apache.cloudstack.utils.qemu;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import com.cloud.storage.Storage;
 
-import com.cloud.utils.script.Script;
-import com.cloud.utils.script.OutputInterpreter;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import com.cloud.storage.Storage;
+import com.cloud.utils.script.OutputInterpreter;
+import com.cloud.utils.script.Script;
 
 public class QemuImg {
 
@@ -36,13 +37,13 @@ public class QemuImg {
         RAW("raw"), QCOW2("qcow2"), VMDK("vmdk"), FILE("file"), RBD("rbd"), SHEEPDOG("sheepdog"), HTTP("http"), HTTPS("https"), TAR("tar"), DIR("dir");
         String format;
 
-        private PhysicalDiskFormat(String format) {
+        private PhysicalDiskFormat(final String format) {
             this.format = format;
         }
 
         @Override
         public String toString() {
-            return this.format;
+            return format;
         }
     }
 
@@ -53,33 +54,34 @@ public class QemuImg {
 
         private final String preallocationType;
 
-        private PreallocationType(String preallocationType){
+        private PreallocationType(final String preallocationType){
             this.preallocationType = preallocationType;
         }
 
+        @Override
         public String toString(){
-            return this.preallocationType;
+            return preallocationType;
         }
 
-        public static PreallocationType getPreallocationType(Storage.ProvisioningType provisioningType){
+        public static PreallocationType getPreallocationType(final Storage.ProvisioningType provisioningType){
             switch (provisioningType){
-                case THIN:
-                    return PreallocationType.Off;
-                case SPARSE:
-                    return PreallocationType.Metadata;
-                case FAT:
-                    return PreallocationType.Full;
-                default:
-                    throw new NotImplementedException();
+            case THIN:
+                return PreallocationType.Off;
+            case SPARSE:
+                return PreallocationType.Metadata;
+            case FAT:
+                return PreallocationType.Full;
+            default:
+                throw new NotImplementedException();
             }
         }
     }
 
-    public QemuImg(int timeout) {
+    public QemuImg(final int timeout) {
         this.timeout = timeout;
     }
 
-    public void setTimeout(int timeout) {
+    public void setTimeout(final int timeout) {
         this.timeout = timeout;
     }
 
@@ -91,14 +93,14 @@ public class QemuImg {
      *            A alternative path to the qemu-img binary
      * @return void
      */
-    public QemuImg(String qemuImgPath) {
-        this._qemuImgPath = qemuImgPath;
+    public QemuImg(final String qemuImgPath) {
+        _qemuImgPath = qemuImgPath;
     }
 
     /* These are all methods supported by the qemu-img tool */
 
     /* Perform a consistency check on the disk image */
-    public void check(QemuImgFile file) {
+    public void check(final QemuImgFile file) {
 
     }
 
@@ -116,16 +118,16 @@ public class QemuImg {
      *            pairs which are passed on to qemu-img without validation.
      * @return void
      */
-    public void create(QemuImgFile file, QemuImgFile backingFile, Map<String, String> options) throws QemuImgException {
-        Script s = new Script(_qemuImgPath, timeout);
+    public void create(final QemuImgFile file, final QemuImgFile backingFile, final Map<String, String> options) throws QemuImgException {
+        final Script s = new Script(_qemuImgPath, timeout);
         s.add("create");
 
         if (options != null && !options.isEmpty()) {
             s.add("-o");
             final StringBuilder optionsStr = new StringBuilder();
-            Iterator<Map.Entry<String, String>> optionsIter = options.entrySet().iterator();
+            final Iterator<Map.Entry<String, String>> optionsIter = options.entrySet().iterator();
             while(optionsIter.hasNext()){
-                Map.Entry option = optionsIter.next();
+                final Map.Entry option = optionsIter.next();
                 optionsStr.append(option.getKey()).append('=').append(option.getValue());
                 if(optionsIter.hasNext()){
                     //Add "," only if there are more options
@@ -138,7 +140,7 @@ public class QemuImg {
         /*
             -b for a backing file does not show up in the docs, but it works.
             Shouldn't this be -o backing_file=filename instead?
-        */
+         */
         s.add("-f");
         if (backingFile != null) {
             s.add(backingFile.getFormat().toString());
@@ -155,7 +157,7 @@ public class QemuImg {
             throw new QemuImgException("No size was passed, and no backing file was passed");
         }
 
-        String result = s.execute();
+        final String result = s.execute();
         if (result != null) {
             throw new QemuImgException(result);
         }
@@ -170,7 +172,7 @@ public class QemuImg {
      *            The file to create
      * @return void
      */
-    public void create(QemuImgFile file) throws QemuImgException {
+    public void create(final QemuImgFile file) throws QemuImgException {
         this.create(file, null, null);
     }
 
@@ -185,7 +187,7 @@ public class QemuImg {
      *            A backing file if used (for example with qcow2)
      * @return void
      */
-    public void create(QemuImgFile file, QemuImgFile backingFile) throws QemuImgException {
+    public void create(final QemuImgFile file, final QemuImgFile backingFile) throws QemuImgException {
         this.create(file, backingFile, null);
     }
 
@@ -201,7 +203,7 @@ public class QemuImg {
      *            pairs which are passed on to qemu-img without validation.
      * @return void
      */
-    public void create(QemuImgFile file, Map<String, String> options) throws QemuImgException {
+    public void create(final QemuImgFile file, final Map<String, String> options) throws QemuImgException {
         this.create(file, null, options);
     }
 
@@ -221,8 +223,8 @@ public class QemuImg {
      *            pairs which are passed on to qemu-img without validation.
      * @return void
      */
-    public void convert(QemuImgFile srcFile, QemuImgFile destFile, Map<String, String> options) throws QemuImgException {
-        Script s = new Script(_qemuImgPath, timeout);
+    public void convert(final QemuImgFile srcFile, final QemuImgFile destFile, final Map<String, String> options) throws QemuImgException {
+        final Script s = new Script(_qemuImgPath, timeout);
         s.add("convert");
         // autodetect source format. Sometime int he future we may teach KVMPhysicalDisk about more formats, then we can explicitly pass them if necessary
         //s.add("-f");
@@ -232,10 +234,11 @@ public class QemuImg {
 
         if (options != null && !options.isEmpty()) {
             s.add("-o");
-            String optionsStr = "";
-            for (Map.Entry<String, String> option : options.entrySet()) {
-                optionsStr += option.getKey() + "=" + option.getValue() + ",";
+            final StringBuffer optionsBuffer = new StringBuffer();
+            for (final Map.Entry<String, String> option : options.entrySet()) {
+                optionsBuffer.append(option.getKey()).append('=').append(option.getValue()).append(',');
             }
+            String optionsStr = optionsBuffer.toString();
             optionsStr = optionsStr.replaceAll(",$", "");
             s.add(optionsStr);
         }
@@ -243,7 +246,7 @@ public class QemuImg {
         s.add(srcFile.getFileName());
         s.add(destFile.getFileName());
 
-        String result = s.execute();
+        final String result = s.execute();
         if (result != null) {
             throw new QemuImgException(result);
         }
@@ -266,7 +269,7 @@ public class QemuImg {
      *            The destination file
      * @return void
      */
-    public void convert(QemuImgFile srcFile, QemuImgFile destFile) throws QemuImgException {
+    public void convert(final QemuImgFile srcFile, final QemuImgFile destFile) throws QemuImgException {
         this.convert(srcFile, destFile, null);
     }
 
@@ -280,7 +283,7 @@ public class QemuImg {
      *            The file of which changes have to be committed
      * @return void
      */
-    public void commit(QemuImgFile file) throws QemuImgException {
+    public void commit(final QemuImgFile file) throws QemuImgException {
 
     }
 
@@ -298,22 +301,22 @@ public class QemuImg {
      *            A QemuImgFile object containing the file to get the information from
      * @return A HashMap with String key-value information as returned by 'qemu-img info'
      */
-    public Map<String, String> info(QemuImgFile file) throws QemuImgException {
-        Script s = new Script(_qemuImgPath);
+    public Map<String, String> info(final QemuImgFile file) throws QemuImgException {
+        final Script s = new Script(_qemuImgPath);
         s.add("info");
         s.add(file.getFileName());
-        OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
-        String result = s.execute(parser);
+        final OutputInterpreter.AllLinesParser parser = new OutputInterpreter.AllLinesParser();
+        final String result = s.execute(parser);
         if (result != null) {
             throw new QemuImgException(result);
         }
 
-        HashMap<String, String> info = new HashMap<String, String>();
-        String[] outputBuffer = parser.getLines().trim().split("\n");
+        final HashMap<String, String> info = new HashMap<String, String>();
+        final String[] outputBuffer = parser.getLines().trim().split("\n");
         for (int i = 0; i < outputBuffer.length; i++) {
-            String[] lineBuffer = outputBuffer[i].split(":", 2);
+            final String[] lineBuffer = outputBuffer[i].split(":", 2);
             if (lineBuffer.length == 2) {
-                String key = lineBuffer[0].trim().replace(" ", "_");
+                final String key = lineBuffer[0].trim().replace(" ", "_");
                 String value = null;
 
                 if (key.equals("virtual_size")) {
@@ -353,7 +356,7 @@ public class QemuImg {
      * @param delta
      *            Flag if the new size is a delta
      */
-    public void resize(QemuImgFile file, long size, boolean delta) throws QemuImgException {
+    public void resize(final QemuImgFile file, final long size, final boolean delta) throws QemuImgException {
         String newSize = null;
 
         if (size == 0) {
@@ -373,7 +376,7 @@ public class QemuImg {
             newSize = Long.toString(size);
         }
 
-        Script s = new Script(_qemuImgPath);
+        final Script s = new Script(_qemuImgPath);
         s.add("resize");
         s.add(file.getFileName());
         s.add(newSize);
@@ -393,7 +396,7 @@ public class QemuImg {
      * @param size
      *            The new size
      */
-    public void resize(QemuImgFile file, long size) throws QemuImgException {
+    public void resize(final QemuImgFile file, final long size) throws QemuImgException {
         this.resize(file, size, false);
     }
 }

--- a/plugins/hypervisors/ovm/src/com/cloud/ovm/object/Test.java
+++ b/plugins/hypervisors/ovm/src/com/cloud/ovm/object/Test.java
@@ -85,8 +85,12 @@ public class Test {
             //System.out.println(vm.toJson());
             final Connection c = new Connection("192.168.189.12", "oracle", "password");
             //System.out.println(Coder.toJson(OvmHost.getDetails(c)));
-            final String txt =
-                    "{\"MasterIp\": \"192.168.189.12\", \"dom0Memory\": 790626304, \"freeMemory\": 16378757120, \"totalMemory\": 17169383424, \"cpuNum\": 4, \"agentVersion\": \"2.3-38\", \"cpuSpeed\": 2261}";
+
+            /* This is not being used at the moment.
+             * Coverity issue: 1012179
+             */
+            //final String txt =
+            //        "{\"MasterIp\": \"192.168.189.12\", \"dom0Memory\": 790626304, \"freeMemory\": 16378757120, \"totalMemory\": 17169383424, \"cpuNum\": 4, \"agentVersion\": \"2.3-38\", \"cpuSpeed\": 2261}";
 
             //OvmHost.Details d = new GsonBuilder().create().fromJson(txt, OvmHost.Details.class);
             //OvmHost.Details d = Coder.fromJson(txt, OvmHost.Details.class);

--- a/plugins/hypervisors/ovm/src/com/cloud/ovm/object/Test.java
+++ b/plugins/hypervisors/ovm/src/com/cloud/ovm/object/Test.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Test {
-    public static void main(String[] args) {
+    public static void main(final String[] args) {
         try {
             /*Connection c = new Connection("192.168.105.155", "oracle", "password");
             Utils util = new UtilsImpl(c);
@@ -56,16 +56,16 @@ public class Test {
             Pair<Long, Long> spaceInfo = storage.getSrSpaceInfo("192.168.110.232:/export/frank/nfs");
             System.out.println("Total:" + spaceInfo.first());
             System.out.println("Free:" + spaceInfo.second());*/
-            OvmVm.Details vm = new OvmVm.Details();
+            final OvmVm.Details vm = new OvmVm.Details();
             vm.cpuNum = 1;
             vm.memory = 512;
             vm.name = "Test";
             vm.uuid = "This-is-a-test";
-            OvmDisk.Details rootDisk = new OvmDisk.Details();
+            final OvmDisk.Details rootDisk = new OvmDisk.Details();
             rootDisk.path = "/root/root.raw";
             rootDisk.type = OvmDisk.WRITE;
             vm.rootDisk = rootDisk;
-            OvmDisk.Details dataDisk = new OvmDisk.Details();
+            final OvmDisk.Details dataDisk = new OvmDisk.Details();
             dataDisk.path = "/tmp/data.raw";
             dataDisk.type = OvmDisk.SHAREDWRITE;
             vm.disks.add(dataDisk);
@@ -73,7 +73,7 @@ public class Test {
             vm.disks.add(dataDisk);
             vm.disks.add(dataDisk);
             vm.disks.add(dataDisk);
-            OvmVif.Details vif = new OvmVif.Details();
+            final OvmVif.Details vif = new OvmVif.Details();
             vif.mac = "00:ff:ff:ff:ff:ee";
             vif.bridge = "xenbr0";
             vif.type = OvmVif.NETFRONT;
@@ -83,34 +83,35 @@ public class Test {
             vm.vifs.add(vif);
             vm.vifs.add(vif);
             //System.out.println(vm.toJson());
-            Connection c = new Connection("192.168.189.12", "oracle", "password");
+            final Connection c = new Connection("192.168.189.12", "oracle", "password");
             //System.out.println(Coder.toJson(OvmHost.getDetails(c)));
-            String txt =
-                "{\"MasterIp\": \"192.168.189.12\", \"dom0Memory\": 790626304, \"freeMemory\": 16378757120, \"totalMemory\": 17169383424, \"cpuNum\": 4, \"agentVersion\": \"2.3-38\", \"cpuSpeed\": 2261}";
+            final String txt =
+                    "{\"MasterIp\": \"192.168.189.12\", \"dom0Memory\": 790626304, \"freeMemory\": 16378757120, \"totalMemory\": 17169383424, \"cpuNum\": 4, \"agentVersion\": \"2.3-38\", \"cpuSpeed\": 2261}";
+
             //OvmHost.Details d = new GsonBuilder().create().fromJson(txt, OvmHost.Details.class);
             //OvmHost.Details d = Coder.fromJson(txt, OvmHost.Details.class);
             //OvmHost.Details d = OvmHost.getDetails(c);
             //System.out.println(Coder.toJson(d));
-//            OvmStoragePool.Details pool = new OvmStoragePool.Details();
-//            pool.path = "192.168.110.232:/export/frank/ovs";
-//            pool.type = OvmStoragePool.NFS;
-//            pool.uuid = "123";
-//            System.out.println(pool.toJson());
+            //            OvmStoragePool.Details pool = new OvmStoragePool.Details();
+            //            pool.path = "192.168.110.232:/export/frank/ovs";
+            //            pool.type = OvmStoragePool.NFS;
+            //            pool.uuid = "123";
+            //            System.out.println(pool.toJson());
 
             String cmd = null;
             System.out.println(args.length);
             if (args.length >= 1) {
                 cmd = args[0];
-                OvmVm.Details d = new OvmVm.Details();
+                final OvmVm.Details d = new OvmVm.Details();
                 d.cpuNum = 1;
                 d.memory = 512 * 1024 * 1024;
                 d.name = "MyTest";
                 d.uuid = "1-2-3-4-5";
-                OvmDisk.Details r = new OvmDisk.Details();
+                final OvmDisk.Details r = new OvmDisk.Details();
                 r.path = "/var/ovs/mount/60D0985974CA425AAF5D01A1F161CC8B/running_pool/36_systemvm/System.img";
                 r.type = OvmDisk.WRITE;
                 d.rootDisk = r;
-                OvmVif.Details v = new OvmVif.Details();
+                final OvmVif.Details v = new OvmVif.Details();
                 v.mac = "00:16:3E:5C:B1:D1";
                 v.bridge = "xenbr0";
                 v.type = OvmVif.NETFRONT;
@@ -123,55 +124,55 @@ public class Test {
                     OvmVm.create(c, d);
                     // c.call("OvmVm.echo", new Object[]{s});
                 } else if (cmd.equalsIgnoreCase("reboot")) {
-                    Map<String, String> res = OvmVm.reboot(c, "MyTest");
+                    final Map<String, String> res = OvmVm.reboot(c, "MyTest");
                     System.out.println(res.get("vncPort"));
                     //OvmVm.stop(c, "MyTest");
                     //OvmVm.create(c, d);
                 } else if (cmd.equalsIgnoreCase("stop")) {
                     OvmVm.stop(c, "MyTest");
                 } else if (cmd.equalsIgnoreCase("details")) {
-                    OvmVm.Details ddd = OvmVm.getDetails(c, "MyTest");
+                    final OvmVm.Details ddd = OvmVm.getDetails(c, "MyTest");
                     System.out.println(ddd.vifs.size());
                     System.out.println(ddd.rootDisk.path);
                     System.out.println(ddd.powerState);
                 } else if (cmd.equalsIgnoreCase("all")) {
                     System.out.println(OvmHost.getAllVms(c));
                 } else if (cmd.equalsIgnoreCase("createBridge")) {
-                    OvmBridge.Details bd = new OvmBridge.Details();
+                    final OvmBridge.Details bd = new OvmBridge.Details();
                     bd.name = "xenbr10";
                     bd.attach = args[1];
                     OvmBridge.create(c, bd);
                 } else if (cmd.equalsIgnoreCase("createVlan")) {
-                    OvmVlan.Details vd = new OvmVlan.Details();
+                    final OvmVlan.Details vd = new OvmVlan.Details();
                     vd.pif = "eth0";
                     vd.vid = 1000;
-                    String vname = OvmVlan.create(c, vd);
+                    final String vname = OvmVlan.create(c, vd);
                     System.out.println(vname);
                 } else if (cmd.equalsIgnoreCase("delVlan")) {
                     OvmVlan.delete(c, args[1]);
                 } else if (cmd.equalsIgnoreCase("delBr")) {
                     OvmBridge.delete(c, args[1]);
                 } else if (cmd.equalsIgnoreCase("getBrs")) {
-                    List<String> brs = OvmBridge.getAllBridges(c);
+                    final List<String> brs = OvmBridge.getAllBridges(c);
                     System.out.println(brs);
                 } else if (cmd.equalsIgnoreCase("getBrDetails")) {
-                    OvmBridge.Details brd = OvmBridge.getDetails(c, args[1]);
+                    final OvmBridge.Details brd = OvmBridge.getDetails(c, args[1]);
                     System.out.println(brd.interfaces);
                 }
 
             }
 
-            List<String> l = new ArrayList<String>();
+            final List<String> l = new ArrayList<String>();
             l.add("4b4d8951-f0b6-36c5-b4f3-a82ff2611c65");
             System.out.println(Coder.toJson(l));
 
-//            Map<String, String> res = OvmHost.getPerformanceStats(c, "xenbr0");
-//            System.out.println(res.toString());
-//            String stxt = "{\"vifs\": [{\"bridge\": \"xenbr0\", \"mac\": \"00:16:3E:5C:B1:D1\", \"type\": \"netfront\"}], \"powerState\": \"RUNNING\", \"disks\": [], \"cpuNum\": 1, \"memory\": 536870912, \"rootDisk\": {\"path\": \"/var/ovs/mount/60D0985974CA425AAF5D01A1F161CC8B/running_pool/MyTest/System.img\", \"type\": \"w\"}}";
-//            OvmVm.Details ddd = Coder.fromJson(stxt, OvmVm.Details.class);
-//            System.out.println(ddd.vifs.size());
-//            System.out.println(ddd.rootDisk.path);
-        } catch (Exception e) {
+            //            Map<String, String> res = OvmHost.getPerformanceStats(c, "xenbr0");
+            //            System.out.println(res.toString());
+            //            String stxt = "{\"vifs\": [{\"bridge\": \"xenbr0\", \"mac\": \"00:16:3E:5C:B1:D1\", \"type\": \"netfront\"}], \"powerState\": \"RUNNING\", \"disks\": [], \"cpuNum\": 1, \"memory\": 536870912, \"rootDisk\": {\"path\": \"/var/ovs/mount/60D0985974CA425AAF5D01A1F161CC8B/running_pool/MyTest/System.img\", \"type\": \"w\"}}";
+            //            OvmVm.Details ddd = Coder.fromJson(stxt, OvmVm.Details.class);
+            //            System.out.println(ddd.vifs.size());
+            //            System.out.println(ddd.rootDisk.path);
+        } catch (final Exception e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }


### PR DESCRIPTION
Fixing issues: 1012719, 1116509, 1116677 and 1116812

I split commit between fixes and code formatting in order to keep the review as smooth as possible.

The fixes include:
* Commenting out an unused variable in the Test.java
* Assigning the ResultSet returned by the prepared statement and closing it in the finally block
* Avoiding catching only Exception. Makes the code too britle.
* Catching the QemuImgException and throwing it to be caught further in the code
* Surrounding the output stream with try/catch and throwing it to be further handled in the code. Closing the output stream quietly.
* Replacing concatenation with optionsBuffer.append(option.getKey()).append('=').append(option.getValue()).append(',');

Full build, including tests, was executed. I will deploy a DC and run VM Life Cycle on KVM and XenServer62. Report will follow.

Cheers,
Wilder