### PR TITLE
findbugs: String to byt[] conversion

### DIFF
--- a/server/src/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/com/cloud/network/NetworkModelImpl.java
@@ -2292,7 +2292,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         final List<String[]> vmData = new ArrayList<String[]>();
 
         if (userData != null) {
-            vmData.add(new String[]{"userdata", "user-data", new String(Base64.decodeBase64(userData.getBytes()))});
+            vmData.add(new String[]{"userdata", "user-data", new String(Base64.decodeBase64(userData))});
         }
         vmData.add(new String[]{"metadata", "service-offering", StringUtils.unicodeEscape(serviceOffering)});
         vmData.add(new String[]{"metadata", "availability-zone", StringUtils.unicodeEscape(zoneName)});


### PR DESCRIPTION
decodeBase64() can work on String so the unsafe conversion is not needed