### PR TITLE
Fix findbugs high priority warning

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
@@ -1019,7 +1019,6 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
 
     private String getVolumePathInDatastore(DatastoreMO dsMo, String volumeFileName) throws Exception {
         String datastoreVolumePath = dsMo.searchFileInSubFolders(volumeFileName, true);
-        assert (datastoreVolumePath != null) : "Virtual disk file missing from datastore.";
         if (datastoreVolumePath == null) {
             throw new CloudRuntimeException("Unable to find file " + volumeFileName + " in datastore " + dsMo.getName());
         }


### PR DESCRIPTION
VmwareStorageManagerImpl.java:1023, RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE, Priority: High
Redundant nullcheck of datastoreVolumePath, which is known to be non-null in com.cloud.hypervisor.vmware.manager.VmwareStorageManagerImpl.getVolumePathInDatastore(DatastoreMO, String)

Assertion is not used in runtime, correct way is throw and handle exception.
This just gets rid of the warning on the findbugs reports.