### PR TITLE
Fix another findbugs high priority warning

### DIFF
--- a/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
+++ b/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
@@ -2614,7 +2614,7 @@ public class JuniperSrxResource implements ServerResource {
                 xml = SrxXml.APPLICATION_ADD.getXml();
                 xml = replaceXmlValue(xml, "name", applicationName);
                 xml = replaceXmlValue(xml, "protocol", protocol.toString());
-                if (protocol.toString() == Protocol.icmp.toString()) {
+                if (protocol.toString().equals(Protocol.icmp.toString())) {
                     icmpOrDestPort = "<icmp-type>" + startPort + "</icmp-type>";
                     icmpOrDestPort += "<icmp-code>" + endPort + "</icmp-code>";
                 } else {


### PR DESCRIPTION
JuniperSrxResource.java:2617, ES_COMPARING_STRINGS_WITH_EQ, Priority: High
Comparison of String objects using == or != in com.cloud.network.resource.JuniperSrxResource.manageApplication(JuniperSrxResource$SecurityPolicyType, JuniperSrxResource$SrxCommand, JuniperSrxResource$Protocol, int, int)

This now correctly compares strings