### PR TITLE
Fix performance issue reported by findbugs (unnescessary boxing/unbox…

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -690,8 +690,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 String[] splitResult = result.split(":");
                 int i = 0;
                 while (i < splitResult.length - 1) {
-                    stats[0] += (new Long(splitResult[i++])).longValue();
-                    stats[1] += (new Long(splitResult[i++])).longValue();
+                    stats[0] += Long.parseLong(splitResult[i++]);
+                    stats[1] += Long.parseLong(splitResult[i++]);
                 }
                 return new NetworkUsageAnswer(cmd, "success", stats[0], stats[1]);
             }
@@ -4766,8 +4766,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 String[] splitResult = result.split(":");
                 int i = 0;
                 while (i < splitResult.length - 1) {
-                    stats[0] += (new Long(splitResult[i++])).longValue();
-                    stats[1] += (new Long(splitResult[i++])).longValue();
+                    stats[0] += Long.parseLong(splitResult[i++]);
+                    stats[1] += Long.parseLong(splitResult[i++]);
                 }
             } catch (Throwable e) {
                 s_logger.warn("Unable to parse return from script return of network usage command: " + e.toString(), e);


### PR DESCRIPTION
…ing)

VmwareResource.java:693, DM_BOXED_PRIMITIVE_FOR_PARSING, Priority: High
VmwareResource.java:4769, DM_BOXED_PRIMITIVE_FOR_PARSING, Priority: High
Boxing/unboxing to parse a primitive com.cloud.hypervisor.vmware.resource.VmwareResource.getNetworkStats(String)

Now op is faster and takes up less memory