### PR TITLE
Fix another case of unnecessary boxing

### DIFF
--- a/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
+++ b/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
@@ -1277,8 +1277,8 @@ public class JuniperSrxResource implements ServerResource {
         for (String[] destNatRule : destNatRules) {
             String publicIp = destNatRule[0];
             String privateIp = destNatRule[1];
-            int srcPort = Integer.valueOf(destNatRule[2]);
-            int destPort = Integer.valueOf(destNatRule[3]);
+            int srcPort = Integer.parseInt(destNatRule[2]);
+            int destPort = Integer.parseInt(destNatRule[3]);
 
             Long publicVlanTag = null;
             if (publicVlanTags.containsKey(publicIp)) {


### PR DESCRIPTION
JuniperSrxResource.java:1280, DM_BOXED_PRIMITIVE_FOR_PARSING, Priority: High
Boxing/unboxing to parse a primitive com.cloud.network.resource.JuniperSrxResource.removeDestinationNatRules(Long, Map, List)