### PR TITLE
Fix last ocurrence of unnecessary boxing detected by findbugs

### DIFF
--- a/plugins/network-elements/cisco-vnmc/src/com/cloud/network/resource/CiscoVnmcResource.java
+++ b/plugins/network-elements/cisco-vnmc/src/com/cloud/network/resource/CiscoVnmcResource.java
@@ -263,7 +263,7 @@ public class CiscoVnmcResource implements ServerResource {
         String[] result = new String[2];
         String[] cidrData = cidr.split("\\/");
         assert (cidrData.length == 2) : "Something is wrong with source cidr " + cidr;
-        long size = Long.valueOf(cidrData[1]);
+        long size = Long.parseLong(cidrData[1]);
         result[0] = cidrData[0];
         result[1] = cidrData[0];
         if (size < 32) {


### PR DESCRIPTION
CiscoVnmcResource.java:266, DM_BOXED_PRIMITIVE_FOR_PARSING, Priority: High
Boxing/unboxing to parse a primitive com.cloud.network.resource.CiscoVnmcResource.getIpRangeFromCidr(String)