### PR TITLE
CLOUDSTACK-3317 - DVS does not support management\storage network

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
@@ -268,14 +268,6 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
                     throw new InvalidParameterValueException(msg);
                 }
             }
-        } else {
-            // Distributed virtual switch is not supported in Basic zone for now.
-            // Private / Management network traffic is not yet supported over distributed virtual switch.
-            if (guestTrafficLabelObj.getVirtualSwitchType() != VirtualSwitchType.StandardVirtualSwitch) {
-                String msg = "Detected that Guest traffic is over Distributed virtual switch in Basic zone. Only Standard vSwitch is supported in Basic zone.";
-                s_logger.error(msg);
-                throw new DiscoveredWithErrorException(msg);
-            }
         }
 
         privateTrafficLabel = _netmgr.getDefaultManagementTrafficLabel(dcId, HypervisorType.VMware);
@@ -414,7 +406,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
         } catch (DiscoveredWithErrorException e) {
             throw e;
         } catch (Exception e) {
-            s_logger.warn("Unable to connect to Vmware vSphere server. service address: " + url.getHost());
+            s_logger.warn("Unable to connect to Vmware vSphere server. service address: " + url.getHost() + ". " + e);
             return null;
         } finally {
             if (context != null)

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2463,6 +2463,13 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         } else if (nicTo.getBroadcastType() == BroadcastDomainType.Lswitch) {
             // We don't need to set any VLAN id for an NVP logical switch
             return null;
+        } else if (nicTo.getBroadcastType() == BroadcastDomainType.Storage) {
+            URI broadcastUri = nicTo.getBroadcastUri();
+            if (broadcastUri != null) {
+                String vlanId = BroadcastDomainType.getValue(broadcastUri);
+                s_logger.debug("Using VLAN [" + vlanId + "] from broadcast uri [" + broadcastUri + "]");
+                return vlanId;
+            }
         }
 
         s_logger.warn("Unrecognized broadcast type in VmwareResource, type: " + nicTo.getBroadcastType().toString() + ". Use vlan info from labeling: " + defaultVlan);
@@ -2525,24 +2532,18 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
         String switchName = null;
         VirtualSwitchType switchType = VirtualSwitchType.StandardVirtualSwitch;
-        String vlanToken = Vlan.UNTAGGED;
+        String vlanId = Vlan.UNTAGGED;
 
-        // Get switch details from the nicTO object
         if(nicTo.getName() != null && !nicTo.getName().isEmpty()) {
-            String[] tokens = nicTo.getName().split(",");
             // Format of network traffic label is <VSWITCH>,<VLANID>,<VSWITCHTYPE>
             // If all 3 fields are mentioned then number of tokens would be 3.
             // If only <VSWITCH>,<VLANID> are mentioned then number of tokens would be 2.
-            switchName = tokens[0];
-            if(tokens.length == 2 || tokens.length == 3) {
-                vlanToken = tokens[1];
-                if (vlanToken.isEmpty()) {
-                    vlanToken = Vlan.UNTAGGED;
-                }
-                if (tokens.length == 3) {
-                    switchType = VirtualSwitchType.getType(tokens[2]);
-                }
-            }
+            // Get switch details from the nicTO object
+            String networkName = nicTo.getName();
+            VmwareTrafficLabel mgmtTrafficLabelObj = new VmwareTrafficLabel(networkName, trafficType);
+            switchName = mgmtTrafficLabelObj.getVirtualSwitchName();
+            vlanId = mgmtTrafficLabelObj.getVlanId();
+            switchType = mgmtTrafficLabelObj.getVirtualSwitchType();
         } else {
             if (trafficType == TrafficType.Guest && _guestTrafficInfo != null) {
                 switchType = _guestTrafficInfo.getVirtualSwitchType();
@@ -2558,7 +2559,15 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             switchName = _privateNetworkVSwitchName;
         }
 
-        return new Ternary<String,String,String>(switchName, switchType.toString(), vlanToken);
+        if (switchType == VirtualSwitchType.NexusDistributedVirtualSwitch) {
+            if (trafficType == TrafficType.Management || trafficType == TrafficType.Storage) {
+                throw new CloudException("Unable to configure NIC " + nicTo.toString() + " as traffic type " + trafficType.toString() +
+                        " is not supported over virtual switch type " + switchType +
+                        ". Please specify only supported type of virtual switches i.e. {vmwaresvs, vmwaredvs} in physical network traffic label.");
+            }
+        }
+
+        return new Ternary<String, String, String>(switchName, switchType.toString(), vlanId);
     }
 
     private String getNetworkNamePrefix(NicTO nicTo) throws Exception {

--- a/plugins/hypervisors/vmware/src/com/cloud/network/VmwareTrafficLabel.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/network/VmwareTrafficLabel.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.network;
 
+import com.cloud.dc.Vlan;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.hypervisor.vmware.mo.VirtualSwitchType;
 import com.cloud.network.Networks.TrafficType;
@@ -32,7 +33,7 @@ public class VmwareTrafficLabel implements TrafficLabel {
     TrafficType _trafficType = TrafficType.None;
     VirtualSwitchType _vSwitchType = VirtualSwitchType.StandardVirtualSwitch;
     String _vSwitchName = DEFAULT_VSWITCH_NAME;
-    String _vlanId = null;
+    String _vlanId = Vlan.UNTAGGED;
 
     public VmwareTrafficLabel(String networkLabel, TrafficType trafficType, VirtualSwitchType defVswitchType) {
         _trafficType = trafficType;

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
@@ -681,7 +681,7 @@ public class HypervisorHostHelper {
         VmwareDistributedVirtualSwitchVlanSpec vlanSpec = null;
         VmwareDistributedVirtualSwitchPvlanSpec pvlanSpec = null;
         VMwareDVSPortSetting dvsPortSetting = null;
-        DVPortgroupConfigSpec dvPortGroupSpec;
+        DVPortgroupConfigSpec newDvPortGroupSpec;
 
         // Next, create the port group. For this, we need to create a VLAN spec.
         // NOTE - VmwareDistributedVirtualSwitchPvlanSpec extends VmwareDistributedVirtualSwitchVlanSpec.
@@ -701,38 +701,145 @@ public class HypervisorHostHelper {
             dvsPortSetting = createVmwareDVPortSettingSpec(shapingPolicy, secPolicy, pvlanSpec);
         }
 
-        dvPortGroupSpec = createDvPortGroupSpec(networkName, dvsPortSetting, numPorts, autoExpandSupported);
+        newDvPortGroupSpec = createDvPortGroupSpec(networkName, dvsPortSetting, numPorts, autoExpandSupported);
         if (portGroupPolicy != null)
         {
-            dvPortGroupSpec.setPolicy(portGroupPolicy);
+            newDvPortGroupSpec.setPolicy(portGroupPolicy);
         }
 
         if (!dataCenterMo.hasDvPortGroup(networkName)) {
             s_logger.info("Distributed Virtual Port group " + networkName + " not found.");
             // TODO(sateesh): Handle Exceptions
             try {
-                dvSwitchMo.createDVPortGroup(dvPortGroupSpec);
+                dvSwitchMo.createDVPortGroup(newDvPortGroupSpec);
             } catch (Exception e) {
                 String msg = "Failed to create distributed virtual port group " + networkName + " on dvSwitch " + physicalNetwork;
+                msg += ". " + VmwareHelper.getExceptionMessage(e);
                 throw new Exception(msg);
             }
         } else {
             s_logger.info("Found Distributed Virtual Port group " + networkName);
-            // TODO(sateesh): Handle Exceptions
-            DVPortgroupConfigInfo dvPortgroupInfo = dataCenterMo.getDvPortGroupSpec(networkName);
-            if (!isSpecMatch(dvPortgroupInfo, vid, shapingPolicy)) {
+            DVPortgroupConfigInfo currentDvPortgroupInfo = dataCenterMo.getDvPortGroupSpec(networkName);
+            if (!isSpecMatch(currentDvPortgroupInfo, newDvPortGroupSpec)) {
                 s_logger.info("Updating Distributed Virtual Port group " + networkName);
-                dvPortGroupSpec.setDefaultPortConfig(dvsPortSetting);
-                dvPortGroupSpec.setConfigVersion(dvPortgroupInfo.getConfigVersion());
+                newDvPortGroupSpec.setDefaultPortConfig(dvsPortSetting);
+                newDvPortGroupSpec.setConfigVersion(currentDvPortgroupInfo.getConfigVersion());
                 ManagedObjectReference morDvPortGroup = dataCenterMo.getDvPortGroupMor(networkName);
                 try {
-                    dvSwitchMo.updateDvPortGroup(morDvPortGroup, dvPortGroupSpec);
+                    dvSwitchMo.updateDvPortGroup(morDvPortGroup, newDvPortGroupSpec);
                 } catch (Exception e) {
                     String msg = "Failed to update distributed virtual port group " + networkName + " on dvSwitch " + physicalNetwork;
+                    msg += ". " + VmwareHelper.getExceptionMessage(e);
                     throw new Exception(msg);
                 }
             }
         }
+    }
+
+    public static boolean isSpecMatch(DVPortgroupConfigInfo currentDvPortgroupInfo, DVPortgroupConfigSpec newDvPortGroupSpec) {
+        String dvPortGroupName = newDvPortGroupSpec.getName();
+        s_logger.debug("Checking if configuration of dvPortGroup [" + dvPortGroupName + "] has changed.");
+        boolean specMatches = true;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy;
+        currentTrafficShapingPolicy = currentDvPortgroupInfo.getDefaultPortConfig().getInShapingPolicy();
+
+        assert (currentTrafficShapingPolicy != null);
+
+        LongPolicy oldAverageBandwidthPolicy = currentTrafficShapingPolicy.getAverageBandwidth();
+        LongPolicy oldBurstSizePolicy = currentTrafficShapingPolicy.getBurstSize();
+        LongPolicy oldPeakBandwidthPolicy = currentTrafficShapingPolicy.getPeakBandwidth();
+        BoolPolicy oldIsEnabledPolicy = currentTrafficShapingPolicy.getEnabled();
+        Long oldAverageBandwidth = null;
+        Long oldBurstSize = null;
+        Long oldPeakBandwidth = null;
+        Boolean oldIsEnabled = null;
+
+        if (oldAverageBandwidthPolicy != null) {
+            oldAverageBandwidth = oldAverageBandwidthPolicy.getValue();
+        }
+        if (oldBurstSizePolicy != null) {
+            oldBurstSize = oldBurstSizePolicy.getValue();
+        }
+        if (oldPeakBandwidthPolicy != null) {
+            oldPeakBandwidth = oldPeakBandwidthPolicy.getValue();
+        }
+        if (oldIsEnabledPolicy != null) {
+            oldIsEnabled = oldIsEnabledPolicy.isValue();
+        }
+
+        DVSTrafficShapingPolicy newTrafficShapingPolicyInbound = newDvPortGroupSpec.getDefaultPortConfig().getInShapingPolicy();
+        LongPolicy newAverageBandwidthPolicy = newTrafficShapingPolicyInbound.getAverageBandwidth();
+        LongPolicy newBurstSizePolicy = newTrafficShapingPolicyInbound.getBurstSize();
+        LongPolicy newPeakBandwidthPolicy = newTrafficShapingPolicyInbound.getPeakBandwidth();
+        BoolPolicy newIsEnabledPolicy = newTrafficShapingPolicyInbound.getEnabled();
+        Long newAverageBandwidth = null;
+        Long newBurstSize = null;
+        Long newPeakBandwidth = null;
+        Boolean newIsEnabled = null;
+        if (newAverageBandwidthPolicy != null) {
+            newAverageBandwidth = newAverageBandwidthPolicy.getValue();
+        }
+        if (newBurstSizePolicy != null) {
+            newBurstSize = newBurstSizePolicy.getValue();
+        }
+        if (newPeakBandwidthPolicy != null) {
+            newPeakBandwidth = newPeakBandwidthPolicy.getValue();
+        }
+        if (newIsEnabledPolicy != null) {
+            newIsEnabled = newIsEnabledPolicy.isValue();
+        }
+
+        if (!oldIsEnabled.equals(newIsEnabled)) {
+            s_logger.info("Detected change in state of shaping policy (enabled/disabled) [" + newIsEnabled + "]");
+            specMatches = false;
+        }
+
+        if (oldIsEnabled || newIsEnabled) {
+            if (oldAverageBandwidth != null && !oldAverageBandwidth.equals(newAverageBandwidth)) {
+                s_logger.info("Average bandwidth setting in new shaping policy doesn't match the existing setting.");
+                specMatches = false;
+            } else if (oldBurstSize != null && !oldBurstSize.equals(newBurstSize)) {
+                s_logger.info("Burst size setting in new shaping policy doesn't match the existing setting.");
+                specMatches = false;
+            } else if (oldPeakBandwidth != null && !oldPeakBandwidth.equals(newPeakBandwidth)) {
+                s_logger.info("Peak bandwidth setting in new shaping policy doesn't match the existing setting.");
+                specMatches = false;
+            }
+        }
+
+        boolean oldAutoExpandSetting = currentDvPortgroupInfo.isAutoExpand();
+        boolean autoExpandEnabled = newDvPortGroupSpec.isAutoExpand();
+        if (oldAutoExpandSetting != autoExpandEnabled) {
+            specMatches = false;
+        }
+        if (!autoExpandEnabled) {
+            // Allow update of number of dvports per dvPortGroup is auto expand is not enabled.
+            int oldNumPorts = currentDvPortgroupInfo.getNumPorts();
+            int newNumPorts = newDvPortGroupSpec.getNumPorts();
+            if (oldNumPorts < newNumPorts) {
+                s_logger.info("Need to update the number of dvports for dvPortGroup :[" + dvPortGroupName +
+                            "] from existing number of dvports " + oldNumPorts + " to " + newNumPorts);
+                specMatches = false;
+            } else if (oldNumPorts > newNumPorts) {
+                s_logger.warn("Detected that new number of dvports [" + newNumPorts + "] in dvPortGroup [" + dvPortGroupName +
+                        "] is less than existing number of dvports [" + oldNumPorts + "]. Attempt to update this dvPortGroup may fail!");
+                specMatches = false;
+            }
+        }
+
+        VmwareDistributedVirtualSwitchVlanIdSpec oldVlanSpec = (VmwareDistributedVirtualSwitchVlanIdSpec)((
+                VMwareDVSPortSetting)currentDvPortgroupInfo.getDefaultPortConfig()).getVlan();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanSpec = (VmwareDistributedVirtualSwitchVlanIdSpec)((
+                VMwareDVSPortSetting)newDvPortGroupSpec.getDefaultPortConfig()).getVlan();
+        int oldVlanId = oldVlanSpec.getVlanId();
+        int newVlanId = newVlanSpec.getVlanId();
+        if (oldVlanId != newVlanId) {
+            s_logger.info("Detected that new VLAN [" + newVlanId + "] of dvPortGroup [" + dvPortGroupName +
+                        "] is different from current VLAN [" + oldVlanId + "]");
+            specMatches = false;
+        }
+
+        return specMatches;
     }
 
     public static ManagedObjectReference waitForDvPortGroupReady(DatacenterMO dataCenterMo, String dvPortGroupName, long timeOutMs) throws Exception {
@@ -811,11 +918,12 @@ public class HypervisorHostHelper {
 
     public static DVSTrafficShapingPolicy getDVSShapingPolicy(Integer networkRateMbps) {
         DVSTrafficShapingPolicy shapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy isEnabled = new BoolPolicy();
         if (networkRateMbps == null || networkRateMbps.intValue() <= 0) {
+            isEnabled.setValue(false);
+            shapingPolicy.setEnabled(isEnabled);
             return shapingPolicy;
         }
-        shapingPolicy = new DVSTrafficShapingPolicy();
-        BoolPolicy isEnabled = new BoolPolicy();
         LongPolicy averageBandwidth = new LongPolicy();
         LongPolicy peakBandwidth = new LongPolicy();
         LongPolicy burstSize = new LongPolicy();

--- a/vmware-base/test/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 package com.cloud.hypervisor.vmware.mo;
 
 import static org.junit.Assert.assertEquals;

--- a/vmware-base/test/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package com.cloud.hypervisor.vmware.mo;
 
 import static org.junit.Assert.assertEquals;

--- a/vmware-base/test/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/mo/HypervisorHostHelperTest.java
@@ -1,0 +1,544 @@
+package com.cloud.hypervisor.vmware.mo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.vmware.vim25.AboutInfo;
+import com.vmware.vim25.BoolPolicy;
+import com.vmware.vim25.DVPortgroupConfigInfo;
+import com.vmware.vim25.DVPortgroupConfigSpec;
+import com.vmware.vim25.DVSTrafficShapingPolicy;
+import com.vmware.vim25.LongPolicy;
+import com.vmware.vim25.ServiceContent;
+import com.vmware.vim25.VMwareDVSPortSetting;
+import com.vmware.vim25.VmwareDistributedVirtualSwitchVlanIdSpec;
+
+import com.cloud.hypervisor.vmware.util.VmwareContext;
+
+public class HypervisorHostHelperTest {
+    @Mock
+    VmwareContext context;
+    @Mock
+    DVPortgroupConfigInfo currentDvPortgroupInfo;
+    @Mock
+    DVPortgroupConfigSpec dvPortgroupConfigSpec;
+    @Mock
+    ServiceContent serviceContent;
+    @Mock
+    AboutInfo aboutInfo;
+
+    String vSwitchName;
+    Integer networkRateMbps;
+    String vlanId;
+    String prefix;
+    String svlanId = null;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(context.getServiceContent()).thenReturn(serviceContent);
+        when(serviceContent.getAbout()).thenReturn(aboutInfo);
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testGetPublicNetworkNamePrefixUnTaggedVlan() throws Exception {
+        vlanId = "untagged";
+        String publicNetworkPrefix = HypervisorHostHelper.getPublicNetworkNamePrefix(vlanId);
+        assertEquals("cloud.public.untagged", publicNetworkPrefix);
+    }
+
+    @Test
+    public void testGetVcenterApiVersion() throws Exception {
+        when(aboutInfo.getApiVersion()).thenReturn("5.5");
+        assertEquals("5.5", HypervisorHostHelper.getVcenterApiVersion(context));
+        verify(aboutInfo).getApiVersion();
+        verify(serviceContent).getAbout();
+        verify(context).getServiceContent();
+    }
+
+    @Test
+    public void testGetVcenterApiVersionWithNullContextObject() throws Exception {
+        assertNull(HypervisorHostHelper.getVcenterApiVersion(null));
+        verifyZeroInteractions(aboutInfo);
+        verifyZeroInteractions(serviceContent);
+    }
+
+    @Test
+    public void testIsFeatureSupportedInVcenterApiVersionUnSupported() throws Exception {
+        when(aboutInfo.getApiVersion()).thenReturn("5.0");
+        String featureRequiresVersion = "6.0";
+        String actualVersion = HypervisorHostHelper.getVcenterApiVersion(context);
+        Boolean featureSupportedVersion = HypervisorHostHelper.isFeatureSupportedInVcenterApiVersion(
+                actualVersion, featureRequiresVersion);
+        assertFalse(featureSupportedVersion);
+        verify(aboutInfo).getApiVersion();
+        verify(serviceContent).getAbout();
+        verify(context).getServiceContent();
+    }
+
+    @Test
+    public void testIsFeatureSupportedInVcenterApiVersionSupported() throws Exception {
+        when(aboutInfo.getApiVersion()).thenReturn("5.5");
+        String featureRequiresVersion = "5.0";
+        String actualVersion = HypervisorHostHelper.getVcenterApiVersion(context);
+        boolean featureSupportedVersion = HypervisorHostHelper.isFeatureSupportedInVcenterApiVersion(
+                actualVersion, featureRequiresVersion);
+        assertTrue(featureSupportedVersion);
+        verify(aboutInfo).getApiVersion();
+        verify(serviceContent).getAbout();
+        verify(context).getServiceContent();
+    }
+
+    @Test
+    public void testIsSpecMatch() throws Exception {
+        int currentNumPorts = 256;
+        int currentvlanId = 100;
+        boolean currentAutoExpand = true;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy currentIsEnabled = new BoolPolicy();
+        currentIsEnabled.setValue(true);
+        LongPolicy currentAvgBw = new LongPolicy();
+        currentAvgBw.setValue(200L);
+        LongPolicy currentBurstSize = new LongPolicy();
+        currentBurstSize.setValue(400L);
+        LongPolicy currentPeakBw = new LongPolicy();
+        currentPeakBw.setValue(2000L);
+
+        VMwareDVSPortSetting currentVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec currentVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        currentVlanIdSpec.setVlanId(currentvlanId);
+        currentVmwareDvsPortSetting.setVlan(currentVlanIdSpec);
+        currentTrafficShapingPolicy.setAverageBandwidth(currentAvgBw);
+        currentTrafficShapingPolicy.setBurstSize(currentBurstSize);
+        currentTrafficShapingPolicy.setPeakBandwidth(currentPeakBw);
+        currentTrafficShapingPolicy.setEnabled(currentIsEnabled);
+        currentVmwareDvsPortSetting.setInShapingPolicy(currentTrafficShapingPolicy);
+
+        when(currentDvPortgroupInfo.getNumPorts()).thenReturn(currentNumPorts);
+        when(currentDvPortgroupInfo.isAutoExpand()).thenReturn(currentAutoExpand);
+        when(currentDvPortgroupInfo.getDefaultPortConfig()).thenReturn(currentVmwareDvsPortSetting);
+
+        int newNumPorts = 256;
+        int newvlanId = 100;
+        boolean newAutoExpand = true;
+        DVSTrafficShapingPolicy newTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy newIsEnabled = new BoolPolicy();
+        newIsEnabled.setValue(true);
+        LongPolicy newAvgBw = new LongPolicy();
+        newAvgBw.setValue(200L);
+        LongPolicy newBurstSize = new LongPolicy();
+        newBurstSize.setValue(400L);
+        LongPolicy newPeakBw = new LongPolicy();
+        newPeakBw.setValue(2000L);
+        VMwareDVSPortSetting newVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        newVlanIdSpec.setVlanId(newvlanId);
+        newVmwareDvsPortSetting.setVlan(newVlanIdSpec);
+        newTrafficShapingPolicy.setAverageBandwidth(newAvgBw);
+        newTrafficShapingPolicy.setBurstSize(newBurstSize);
+        newTrafficShapingPolicy.setPeakBandwidth(newPeakBw);
+        newTrafficShapingPolicy.setEnabled(newIsEnabled);
+        newVmwareDvsPortSetting.setInShapingPolicy(newTrafficShapingPolicy);
+
+        when(dvPortgroupConfigSpec.getNumPorts()).thenReturn(newNumPorts);
+        when(dvPortgroupConfigSpec.isAutoExpand()).thenReturn(newAutoExpand);
+        when(dvPortgroupConfigSpec.getDefaultPortConfig()).thenReturn(newVmwareDvsPortSetting);
+
+        boolean specCompareResult = HypervisorHostHelper.isSpecMatch(currentDvPortgroupInfo, dvPortgroupConfigSpec);
+        assertTrue(specCompareResult);
+    }
+
+    @Test
+    public void testIsSpecMatchConfigSpecWithHighBandwidthShapingPolicy() throws Exception {
+        // Tests case of network offering upgrade in terms of bandwidth
+        int currentNumPorts = 256;
+        int currentvlanId = 100;
+        boolean currentAutoExpand = true;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy currentIsEnabled = new BoolPolicy();
+        currentIsEnabled.setValue(true);
+        LongPolicy currentAvgBw = new LongPolicy();
+        currentAvgBw.setValue(200L);
+        LongPolicy currentBurstSize = new LongPolicy();
+        currentBurstSize.setValue(400L);
+        LongPolicy currentPeakBw = new LongPolicy();
+        currentPeakBw.setValue(2000L);
+
+        VMwareDVSPortSetting currentVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec currentVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        currentVlanIdSpec.setVlanId(currentvlanId);
+        currentVmwareDvsPortSetting.setVlan(currentVlanIdSpec);
+        currentTrafficShapingPolicy.setAverageBandwidth(currentAvgBw);
+        currentTrafficShapingPolicy.setBurstSize(currentBurstSize);
+        currentTrafficShapingPolicy.setPeakBandwidth(currentPeakBw);
+        currentTrafficShapingPolicy.setEnabled(currentIsEnabled);
+        currentVmwareDvsPortSetting.setInShapingPolicy(currentTrafficShapingPolicy);
+
+        when(currentDvPortgroupInfo.getNumPorts()).thenReturn(currentNumPorts);
+        when(currentDvPortgroupInfo.isAutoExpand()).thenReturn(currentAutoExpand);
+        when(currentDvPortgroupInfo.getDefaultPortConfig()).thenReturn(currentVmwareDvsPortSetting);
+
+        int newNumPorts = 256;
+        int newvlanId = 100;
+        boolean newAutoExpand = true;
+        DVSTrafficShapingPolicy newTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy newIsEnabled = new BoolPolicy();
+        newIsEnabled.setValue(true);
+        LongPolicy newAvgBw = new LongPolicy();
+        newAvgBw.setValue(400L);
+        LongPolicy newBurstSize = new LongPolicy();
+        newBurstSize.setValue(800L);
+        LongPolicy newPeakBw = new LongPolicy();
+        newPeakBw.setValue(4000L);
+        VMwareDVSPortSetting newVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        newVlanIdSpec.setVlanId(newvlanId);
+        newVmwareDvsPortSetting.setVlan(newVlanIdSpec);
+        newTrafficShapingPolicy.setAverageBandwidth(newAvgBw);
+        newTrafficShapingPolicy.setBurstSize(newBurstSize);
+        newTrafficShapingPolicy.setPeakBandwidth(newPeakBw);
+        newTrafficShapingPolicy.setEnabled(newIsEnabled);
+        newVmwareDvsPortSetting.setInShapingPolicy(newTrafficShapingPolicy);
+
+        when(dvPortgroupConfigSpec.getNumPorts()).thenReturn(newNumPorts);
+        when(dvPortgroupConfigSpec.isAutoExpand()).thenReturn(newAutoExpand);
+        when(dvPortgroupConfigSpec.getDefaultPortConfig()).thenReturn(newVmwareDvsPortSetting);
+
+        boolean specCompareResult = HypervisorHostHelper.isSpecMatch(currentDvPortgroupInfo, dvPortgroupConfigSpec);
+        assertFalse(specCompareResult);
+    }
+
+    @Test
+    public void testIsSpecMatchConfigSpecWithMoreDvPortsAndAutoExpandEnabled() throws Exception {
+        int currentNumPorts = 512;
+        int currentvlanId = 100;
+        boolean currentAutoExpand = true;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy currentIsEnabled = new BoolPolicy();
+        currentIsEnabled.setValue(true);
+        LongPolicy currentAvgBw = new LongPolicy();
+        currentAvgBw.setValue(200L);
+        LongPolicy currentBurstSize = new LongPolicy();
+        currentBurstSize.setValue(400L);
+        LongPolicy currentPeakBw = new LongPolicy();
+        currentPeakBw.setValue(2000L);
+
+        VMwareDVSPortSetting currentVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec currentVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        currentVlanIdSpec.setVlanId(currentvlanId);
+        currentVmwareDvsPortSetting.setVlan(currentVlanIdSpec);
+        currentTrafficShapingPolicy.setAverageBandwidth(currentAvgBw);
+        currentTrafficShapingPolicy.setBurstSize(currentBurstSize);
+        currentTrafficShapingPolicy.setPeakBandwidth(currentPeakBw);
+        currentTrafficShapingPolicy.setEnabled(currentIsEnabled);
+        currentVmwareDvsPortSetting.setInShapingPolicy(currentTrafficShapingPolicy);
+
+        when(currentDvPortgroupInfo.getNumPorts()).thenReturn(currentNumPorts);
+        when(currentDvPortgroupInfo.isAutoExpand()).thenReturn(currentAutoExpand);
+        when(currentDvPortgroupInfo.getDefaultPortConfig()).thenReturn(currentVmwareDvsPortSetting);
+
+        int newNumPorts = 256;
+        int newvlanId = 100;
+        boolean newAutoExpand = true;
+        DVSTrafficShapingPolicy newTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy newIsEnabled = new BoolPolicy();
+        newIsEnabled.setValue(true);
+        LongPolicy newAvgBw = new LongPolicy();
+        newAvgBw.setValue(200L);
+        LongPolicy newBurstSize = new LongPolicy();
+        newBurstSize.setValue(400L);
+        LongPolicy newPeakBw = new LongPolicy();
+        newPeakBw.setValue(2000L);
+        VMwareDVSPortSetting newVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        newVlanIdSpec.setVlanId(newvlanId);
+        newVmwareDvsPortSetting.setVlan(newVlanIdSpec);
+        newTrafficShapingPolicy.setAverageBandwidth(newAvgBw);
+        newTrafficShapingPolicy.setBurstSize(newBurstSize);
+        newTrafficShapingPolicy.setPeakBandwidth(newPeakBw);
+        newTrafficShapingPolicy.setEnabled(newIsEnabled);
+        newVmwareDvsPortSetting.setInShapingPolicy(newTrafficShapingPolicy);
+
+        when(dvPortgroupConfigSpec.getNumPorts()).thenReturn(newNumPorts);
+        when(dvPortgroupConfigSpec.isAutoExpand()).thenReturn(newAutoExpand);
+        when(dvPortgroupConfigSpec.getDefaultPortConfig()).thenReturn(newVmwareDvsPortSetting);
+
+        boolean specCompareResult = HypervisorHostHelper.isSpecMatch(currentDvPortgroupInfo, dvPortgroupConfigSpec);
+        assertTrue(specCompareResult);
+    }
+
+    @Test
+    public void testIsSpecMatchConfigSpecWithMoreDvPortsAndAutoExpandDisabled() throws Exception {
+        int currentNumPorts = 512;
+        int currentvlanId = 100;
+        boolean currentAutoExpand = false;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy currentIsEnabled = new BoolPolicy();
+        currentIsEnabled.setValue(true);
+        LongPolicy currentAvgBw = new LongPolicy();
+        currentAvgBw.setValue(200L);
+        LongPolicy currentBurstSize = new LongPolicy();
+        currentBurstSize.setValue(400L);
+        LongPolicy currentPeakBw = new LongPolicy();
+        currentPeakBw.setValue(2000L);
+
+        VMwareDVSPortSetting currentVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec currentVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        currentVlanIdSpec.setVlanId(currentvlanId);
+        currentVmwareDvsPortSetting.setVlan(currentVlanIdSpec);
+        currentTrafficShapingPolicy.setAverageBandwidth(currentAvgBw);
+        currentTrafficShapingPolicy.setBurstSize(currentBurstSize);
+        currentTrafficShapingPolicy.setPeakBandwidth(currentPeakBw);
+        currentTrafficShapingPolicy.setEnabled(currentIsEnabled);
+        currentVmwareDvsPortSetting.setInShapingPolicy(currentTrafficShapingPolicy);
+
+        when(currentDvPortgroupInfo.getNumPorts()).thenReturn(currentNumPorts);
+        when(currentDvPortgroupInfo.isAutoExpand()).thenReturn(currentAutoExpand);
+        when(currentDvPortgroupInfo.getDefaultPortConfig()).thenReturn(currentVmwareDvsPortSetting);
+
+        int newNumPorts = 256;
+        int newvlanId = 100;
+        boolean newAutoExpand = false;
+        DVSTrafficShapingPolicy newTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy newIsEnabled = new BoolPolicy();
+        newIsEnabled.setValue(true);
+        LongPolicy newAvgBw = new LongPolicy();
+        newAvgBw.setValue(200L);
+        LongPolicy newBurstSize = new LongPolicy();
+        newBurstSize.setValue(400L);
+        LongPolicy newPeakBw = new LongPolicy();
+        newPeakBw.setValue(2000L);
+        VMwareDVSPortSetting newVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        newVlanIdSpec.setVlanId(newvlanId);
+        newVmwareDvsPortSetting.setVlan(newVlanIdSpec);
+        newTrafficShapingPolicy.setAverageBandwidth(newAvgBw);
+        newTrafficShapingPolicy.setBurstSize(newBurstSize);
+        newTrafficShapingPolicy.setPeakBandwidth(newPeakBw);
+        newTrafficShapingPolicy.setEnabled(newIsEnabled);
+        newVmwareDvsPortSetting.setInShapingPolicy(newTrafficShapingPolicy);
+
+        when(dvPortgroupConfigSpec.getNumPorts()).thenReturn(newNumPorts);
+        when(dvPortgroupConfigSpec.isAutoExpand()).thenReturn(newAutoExpand);
+        when(dvPortgroupConfigSpec.getDefaultPortConfig()).thenReturn(newVmwareDvsPortSetting);
+
+        boolean specCompareResult = HypervisorHostHelper.isSpecMatch(currentDvPortgroupInfo, dvPortgroupConfigSpec);
+        assertFalse(specCompareResult);
+    }
+
+    @Test
+    public void testIsSpecMatchConfigSpecWithAutoExpandUpdate() throws Exception {
+        int currentNumPorts = 512;
+        int currentvlanId = 100;
+        boolean currentAutoExpand = false;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy currentIsEnabled = new BoolPolicy();
+        currentIsEnabled.setValue(true);
+        LongPolicy currentAvgBw = new LongPolicy();
+        currentAvgBw.setValue(200L);
+        LongPolicy currentBurstSize = new LongPolicy();
+        currentBurstSize.setValue(400L);
+        LongPolicy currentPeakBw = new LongPolicy();
+        currentPeakBw.setValue(2000L);
+
+        VMwareDVSPortSetting currentVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec currentVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        currentVlanIdSpec.setVlanId(currentvlanId);
+        currentVmwareDvsPortSetting.setVlan(currentVlanIdSpec);
+        currentTrafficShapingPolicy.setAverageBandwidth(currentAvgBw);
+        currentTrafficShapingPolicy.setBurstSize(currentBurstSize);
+        currentTrafficShapingPolicy.setPeakBandwidth(currentPeakBw);
+        currentTrafficShapingPolicy.setEnabled(currentIsEnabled);
+        currentVmwareDvsPortSetting.setInShapingPolicy(currentTrafficShapingPolicy);
+
+        when(currentDvPortgroupInfo.getNumPorts()).thenReturn(currentNumPorts);
+        when(currentDvPortgroupInfo.isAutoExpand()).thenReturn(currentAutoExpand);
+        when(currentDvPortgroupInfo.getDefaultPortConfig()).thenReturn(currentVmwareDvsPortSetting);
+
+        int newNumPorts = 256;
+        int newvlanId = 100;
+        boolean newAutoExpand = true;
+        DVSTrafficShapingPolicy newTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy newIsEnabled = new BoolPolicy();
+        newIsEnabled.setValue(true);
+        LongPolicy newAvgBw = new LongPolicy();
+        newAvgBw.setValue(200L);
+        LongPolicy newBurstSize = new LongPolicy();
+        newBurstSize.setValue(400L);
+        LongPolicy newPeakBw = new LongPolicy();
+        newPeakBw.setValue(2000L);
+        VMwareDVSPortSetting newVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        newVlanIdSpec.setVlanId(newvlanId);
+        newVmwareDvsPortSetting.setVlan(newVlanIdSpec);
+        newTrafficShapingPolicy.setAverageBandwidth(newAvgBw);
+        newTrafficShapingPolicy.setBurstSize(newBurstSize);
+        newTrafficShapingPolicy.setPeakBandwidth(newPeakBw);
+        newTrafficShapingPolicy.setEnabled(newIsEnabled);
+        newVmwareDvsPortSetting.setInShapingPolicy(newTrafficShapingPolicy);
+
+        when(dvPortgroupConfigSpec.getNumPorts()).thenReturn(newNumPorts);
+        when(dvPortgroupConfigSpec.isAutoExpand()).thenReturn(newAutoExpand);
+        when(dvPortgroupConfigSpec.getDefaultPortConfig()).thenReturn(newVmwareDvsPortSetting);
+
+        boolean specCompareResult = HypervisorHostHelper.isSpecMatch(currentDvPortgroupInfo, dvPortgroupConfigSpec);
+        assertFalse(specCompareResult);
+    }
+
+    @Test
+    public void testIsSpecMatchConfigSpecWithCurrentShapingPolicyDisabled() throws Exception {
+        int currentNumPorts = 512;
+        int currentvlanId = 100;
+        boolean currentAutoExpand = true;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy currentIsEnabled = new BoolPolicy();
+        currentIsEnabled.setValue(false);
+
+        VMwareDVSPortSetting currentVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec currentVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        currentVlanIdSpec.setVlanId(currentvlanId);
+        currentVmwareDvsPortSetting.setVlan(currentVlanIdSpec);
+        currentTrafficShapingPolicy.setEnabled(currentIsEnabled);
+        currentVmwareDvsPortSetting.setInShapingPolicy(currentTrafficShapingPolicy);
+
+        when(currentDvPortgroupInfo.getNumPorts()).thenReturn(currentNumPorts);
+        when(currentDvPortgroupInfo.isAutoExpand()).thenReturn(currentAutoExpand);
+        when(currentDvPortgroupInfo.getDefaultPortConfig()).thenReturn(currentVmwareDvsPortSetting);
+
+        int newNumPorts = 256;
+        int newvlanId = 100;
+        boolean newAutoExpand = true;
+        DVSTrafficShapingPolicy newTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy newIsEnabled = new BoolPolicy();
+        newIsEnabled.setValue(true);
+        LongPolicy newAvgBw = new LongPolicy();
+        newAvgBw.setValue(200L);
+        LongPolicy newBurstSize = new LongPolicy();
+        newBurstSize.setValue(400L);
+        LongPolicy newPeakBw = new LongPolicy();
+        newPeakBw.setValue(2000L);
+        VMwareDVSPortSetting newVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        newVlanIdSpec.setVlanId(newvlanId);
+        newVmwareDvsPortSetting.setVlan(newVlanIdSpec);
+        newTrafficShapingPolicy.setAverageBandwidth(newAvgBw);
+        newTrafficShapingPolicy.setBurstSize(newBurstSize);
+        newTrafficShapingPolicy.setPeakBandwidth(newPeakBw);
+        newTrafficShapingPolicy.setEnabled(newIsEnabled);
+        newVmwareDvsPortSetting.setInShapingPolicy(newTrafficShapingPolicy);
+
+        when(dvPortgroupConfigSpec.getNumPorts()).thenReturn(newNumPorts);
+        when(dvPortgroupConfigSpec.isAutoExpand()).thenReturn(newAutoExpand);
+        when(dvPortgroupConfigSpec.getDefaultPortConfig()).thenReturn(newVmwareDvsPortSetting);
+
+        boolean specCompareResult = HypervisorHostHelper.isSpecMatch(currentDvPortgroupInfo, dvPortgroupConfigSpec);
+        assertFalse(specCompareResult);
+    }
+
+    @Test
+    public void testIsSpecMatchConfigSpecWithCurrentShapingPolicyAndNewShapingPolicyDisabled() throws Exception {
+        int currentNumPorts = 512;
+        int currentvlanId = 100;
+        boolean currentAutoExpand = true;
+        DVSTrafficShapingPolicy currentTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy currentIsEnabled = new BoolPolicy();
+        currentIsEnabled.setValue(false);
+        VMwareDVSPortSetting currentVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec currentVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        currentVlanIdSpec.setVlanId(currentvlanId);
+        currentVmwareDvsPortSetting.setVlan(currentVlanIdSpec);
+        currentTrafficShapingPolicy.setEnabled(currentIsEnabled);
+        currentVmwareDvsPortSetting.setInShapingPolicy(currentTrafficShapingPolicy);
+
+        when(currentDvPortgroupInfo.getNumPorts()).thenReturn(currentNumPorts);
+        when(currentDvPortgroupInfo.isAutoExpand()).thenReturn(currentAutoExpand);
+        when(currentDvPortgroupInfo.getDefaultPortConfig()).thenReturn(currentVmwareDvsPortSetting);
+
+        int newNumPorts = 256;
+        int newvlanId = 100;
+        boolean newAutoExpand = true;
+        DVSTrafficShapingPolicy newTrafficShapingPolicy = new DVSTrafficShapingPolicy();
+        BoolPolicy newIsEnabled = new BoolPolicy();
+        newIsEnabled.setValue(false);
+        VMwareDVSPortSetting newVmwareDvsPortSetting = new VMwareDVSPortSetting();
+        VmwareDistributedVirtualSwitchVlanIdSpec newVlanIdSpec = new VmwareDistributedVirtualSwitchVlanIdSpec();
+        newVlanIdSpec.setVlanId(newvlanId);
+        newVmwareDvsPortSetting.setVlan(newVlanIdSpec);
+        newTrafficShapingPolicy.setEnabled(newIsEnabled);
+        newVmwareDvsPortSetting.setInShapingPolicy(newTrafficShapingPolicy);
+
+        when(dvPortgroupConfigSpec.getNumPorts()).thenReturn(newNumPorts);
+        when(dvPortgroupConfigSpec.isAutoExpand()).thenReturn(newAutoExpand);
+        when(dvPortgroupConfigSpec.getDefaultPortConfig()).thenReturn(newVmwareDvsPortSetting);
+
+        boolean specCompareResult = HypervisorHostHelper.isSpecMatch(currentDvPortgroupInfo, dvPortgroupConfigSpec);
+        assertTrue(specCompareResult);
+    }
+
+    @Test
+    public void testGetPublicNetworkNamePrefixTaggedVlan() throws Exception {
+        vlanId = "1234";
+        String publicNetworkPrefix = HypervisorHostHelper.getPublicNetworkNamePrefix(vlanId);
+        assertEquals("cloud.public.1234", publicNetworkPrefix);
+    }
+
+    @Test
+    public void testComposeCloudNetworkNameTaggedVlanPublicTraffic() throws Exception {
+        vlanId = "100";
+        networkRateMbps = 200;
+        prefix = "cloud.public";
+        vSwitchName = "vSwitch0";
+        String cloudNetworkName = HypervisorHostHelper.composeCloudNetworkName(prefix, vlanId, svlanId, networkRateMbps, vSwitchName);
+        assertEquals("cloud.public.100.200.1-vSwitch0", cloudNetworkName);
+    }
+
+    @Test
+    public void testComposeCloudNetworkNameUnTaggedVlanStorageTraffic() throws Exception {
+        vlanId = null;
+        networkRateMbps = null;
+        prefix = "cloud.storage";
+        vSwitchName = "vSwitch1";
+        String cloudNetworkName = HypervisorHostHelper.composeCloudNetworkName(prefix, vlanId, svlanId, networkRateMbps, vSwitchName);
+        assertEquals("cloud.storage.untagged.0.1-vSwitch1", cloudNetworkName);
+    }
+
+    @Test
+    public void testComposeCloudNetworkNameUnTaggedVlanGuestTraffic() throws Exception {
+        vlanId = "400";
+        svlanId = "123";
+        networkRateMbps = 512;
+        prefix = "cloud.guest";
+        vSwitchName = "vSwitch2";
+        String cloudNetworkName = HypervisorHostHelper.composeCloudNetworkName(prefix, vlanId, svlanId, networkRateMbps, vSwitchName);
+        assertEquals("cloud.guest.400.s123.512.1-vSwitch2", cloudNetworkName);
+    }
+}


### PR DESCRIPTION
Added support for Management and Storage Network traffic over VMware DVS in CloudStack deployments. Also added support for storage VLAN over dvPortGroup.

Signed-off-by: Sateesh Chodapuneedi <sateesh@apache.org>

CLOUDSTACK-3317 - DVS does not support management\storage network

Use non-zero dvport count while updating dvportgroups of system traffic.
Updated configuration compare logic to avoid update dvportgroup operation unless required.
This would help improve speed in vm/network deployment as the update calls would reduce. Also improved logging.

Signed-off-by: Sateesh Chodapuneedi <sateesh@apache.org>

Added unit tests covering the code changes in this branch/feature development
Integration tests are already present in master branch
Signed-off-by: Sateesh Chodapuneedi <sateesh@apache.org>