### PR TITLE
CLOUDSTACK-8553:Unable to launch VM from template because of permission issue

### DIFF
--- a/test/integration/testpaths/testpath_volume_snapshot.py
+++ b/test/integration/testpaths/testpath_volume_snapshot.py
@@ -394,7 +394,7 @@ class TestVolumeSnapshot(cloudstackTestCase):
         )
 
         vm_from_temp = VirtualMachine.create(
-            self.userapiclient,
+            self.apiclient,
             self.testdata["small"],
             templateid=templateFromSnapshot.id,
             accountid=self.account.name,


### PR DESCRIPTION
Non-root user failed to create VM from a template created by Root user