### PR TITLE
Allow EC2 to be run from Maven properly

### DIFF
--- a/awsapi/pom.xml
+++ b/awsapi/pom.xml
@@ -204,6 +204,19 @@
       <artifactId>cloud-framework-db</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${cs.mysql.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.ws.xmlschema</groupId>
+      <artifactId>xmlschema-core</artifactId>
+      <version>2.2.1</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
This pull request adds two runtime dependencies to the POM for awsapi so the [developer guide instructions](http://docs.cloudstack.apache.org/en/latest/developer_guide.html) can work. Without these runtime dependencies, the awsapi server fails to start up with "No appropriate JDBC driver found" and a missing method error in regards to the XML Schema Library.