### PR TITLE
CLOUDSTACK-8554: Fixed string conversion issue in few netscaler test cases

### DIFF
--- a/test/integration/component/test_netscaler_lb_algo.py
+++ b/test/integration/component/test_netscaler_lb_algo.py
@@ -78,7 +78,7 @@ class TestLbWithRoundRobin(cloudstackTestCase):
                 cls.testdata["service_offering"]
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:
@@ -296,7 +296,7 @@ class TestLbWithLeastConn(cloudstackTestCase):
             )
             cls._cleanup.append(cls.service_offering)
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:
@@ -523,7 +523,7 @@ class TestLbWithSourceIp(cloudstackTestCase):
             )
             cls._cleanup.append(cls.service_offering)
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:
@@ -774,7 +774,7 @@ class TestLbAlgoRrLc(cloudstackTestCase):
                 networkid=cls.network.id
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:
@@ -995,7 +995,7 @@ class TestLbAlgoLcRr(cloudstackTestCase):
                 networkid=cls.network.id
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:
@@ -1214,7 +1214,7 @@ class TestLbAlgoRrSb(cloudstackTestCase):
                 networkid=cls.network.id
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:
@@ -1437,7 +1437,7 @@ class TestLbAlgoSbRr(cloudstackTestCase):
                 networkid=cls.network.id
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:
@@ -1661,7 +1661,7 @@ class TestLbAlgoSbLc(cloudstackTestCase):
                 networkid=cls.network.id
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg =e 
             else:
@@ -1884,7 +1884,7 @@ class TestLbAlgoLcSb(cloudstackTestCase):
                 networkid=cls.network.id
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:

--- a/test/integration/component/test_netscaler_lb_sticky.py
+++ b/test/integration/component/test_netscaler_lb_sticky.py
@@ -112,7 +112,7 @@ class TestLbStickyPolicy(cloudstackTestCase):
                 networkid=cls.network.id
             )
         except Exception as e:
-            if cls.exception_string.lower() in e.lower():
+            if cls.exception_string.lower() in str(e).lower():
                 cls.skiptest = True
                 cls.exception_msg = e
             else:


### PR DESCRIPTION
Fixed issue "Exception object is directly converted to lower without converting it to string."


Logs:
Test edit LB rule from least conn to round robin algo ... SKIP: Connection limit to CFE exceeded
Test edit LB rule from round robin to source algo ... SKIP: Connection limit to CFE exceeded
Test edit LB rule from round robin to least connection algo ... SKIP: Connection limit to CFE exceeded
Test edit LB rule from round robin to source algo ... SKIP: Connection limit to CFE exceeded
Test edit LB rule from source to least conn algo ... SKIP: Connection limit to CFE exceeded
Test edit LB rule from source to round robin algo ... SKIP: Connection limit to CFE exceeded
Test Create LB rule with least connection algorithm ... SKIP: Connection limit to CFE exceeded
Test Create LB rule with round robin algorithm ... SKIP: Connection limit to CFE exceeded
Test Create LB rule with source Ip algorithm ... SKIP: Connection limit to CFE exceeded

----------------------------------------------------------------------
Ran 9 tests in 33.583s

OK (SKIP=9)