### PR TITLE
Fix findbugs encoding warning, all .xml files contain only utf-8/us-a…

### DIFF
--- a/plugins/network-elements/cisco-vnmc/src/com/cloud/network/cisco/CiscoVnmcConnectionImpl.java
+++ b/plugins/network-elements/cisco-vnmc/src/com/cloud/network/cisco/CiscoVnmcConnectionImpl.java
@@ -129,7 +129,7 @@ public class CiscoVnmcConnectionImpl implements CiscoVnmcConnection {
                     throw new Exception("Failed to find Cisco VNMC XML file: " + filename);
                 }
 
-                FileReader fr = new FileReader(xmlFilePath);
+                InputStreamReader fr = new InputStreamReader(new FileInputStream(xmlFilePath),"UTF-8");
                 BufferedReader br = new BufferedReader(fr);
 
                 String xml = "";

--- a/plugins/network-elements/cisco-vnmc/src/com/cloud/network/cisco/CiscoVnmcConnectionImpl.java
+++ b/plugins/network-elements/cisco-vnmc/src/com/cloud/network/cisco/CiscoVnmcConnectionImpl.java
@@ -17,7 +17,8 @@
 package com.cloud.network.cisco;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
Fix findbugs encoding warning, all .xml files contain only utf-8/us-ascii compatible characters. If special characters are added to these files in the future, UTF-8 should be used for cross platform compatibility