### PR TITLE
Fix another findbugs encoding warning in CitrixResourceBase

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -5047,10 +5047,10 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             Process p = Runtime.getRuntime().exec(cmd);
 
             BufferedReader stdInput = new BufferedReader(new
-                    InputStreamReader(p.getInputStream()));
+                    InputStreamReader(p.getInputStream(),Charset.defaultCharset()));
 
             BufferedReader stdError = new BufferedReader(new
-                    InputStreamReader(p.getErrorStream()));
+                    InputStreamReader(p.getErrorStream(),Charset.defaultCharset()));
 
             // read the output from the command
             while ((s = stdInput.readLine()) != null) {


### PR DESCRIPTION
In this case, using default encoding is desired, since the purpose is to read shell command output, which uses the platform's default encoding. This gets rid of the findbugs warning.