### PR TITLE
Fix findbugs encoding warning in HttpNfcLeaseMO

### DIFF
--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/HttpNfcLeaseMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/HttpNfcLeaseMO.java
@@ -121,7 +121,7 @@ public class HttpNfcLeaseMO extends BaseMO {
 
     public static String readOvfContent(String ovfFilePath) throws IOException {
         StringBuffer strContent = new StringBuffer();
-        BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(ovfFilePath)));
+        BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(ovfFilePath),"UTF-8"));
         String lineStr;
         while ((lineStr = in.readLine()) != null) {
             strContent.append(lineStr);


### PR DESCRIPTION
VMWare ovf files are utf-8 encoded. Relying on default encoding in some platforms such as windows would cause erroneous characters from being read on some fields like description, and could also cause the import to fail, depending on the characters.