### PR TITLE
Fix findbugs encoding warning in JuniperSrxResource

### DIFF
--- a/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
+++ b/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
@@ -17,7 +17,7 @@
 package com.cloud.network.resource;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
@@ -191,7 +191,7 @@ public class JuniperSrxResource implements ServerResource {
                     throw new Exception("Failed to find Juniper SRX XML file: " + filename);
                 }
 
-                try(FileReader fr = new FileReader(xmlFilePath);
+                try(InputStreamReader fr = new InputStreamReader(new FileInputStream(xmlFilePath),"UTF-8");
                 BufferedReader br = new BufferedReader(fr);) {
                     String xml = "";
                     String line;


### PR DESCRIPTION
All .xml files contain only utf-8/us-ascii compatible characters. If special characters are added to these files in the future, UTF-8 should be used for cross platform compatibility