### PR TITLE
Fix findbugs warning in LibvirtConsoleProxyLoadCommandWrapper

### DIFF
--- a/agent/src/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
+++ b/agent/src/com/cloud/agent/resource/consoleproxy/ConsoleProxyResource.java
@@ -149,7 +149,7 @@ public class ConsoleProxyResource extends ServerResourceBase implements ServerRe
             final URLConnection conn = url.openConnection();
 
             final InputStream is = conn.getInputStream();
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(is,"UTF-8"));
             final StringBuilder sb2 = new StringBuilder();
             String line = null;
             try {

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConsoleProxyLoadCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtConsoleProxyLoadCommandWrapper.java
@@ -50,7 +50,7 @@ public abstract class LibvirtConsoleProxyLoadCommandWrapper<T extends Command, A
             final URLConnection conn = url.openConnection();
 
             final InputStream is = conn.getInputStream();
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(is,"UTF-8"));
             final StringBuilder sb2 = new StringBuilder();
             String line = null;
             try {

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixConsoleProxyLoadCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixConsoleProxyLoadCommandWrapper.java
@@ -55,7 +55,7 @@ public abstract class CitrixConsoleProxyLoadCommandWrapper<T extends Command, A 
             conn.setReadTimeout(5000);
 
             final InputStream is = conn.getInputStream();
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(is, Charset.defaultCharset()));
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(is,"UTF-8"));
             final StringBuilder sb2 = new StringBuilder();
             String line = null;
             try {

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixConsoleProxyLoadCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixConsoleProxyLoadCommandWrapper.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.charset.Charset;
 
 import org.apache.log4j.Logger;
 

--- a/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxyCmdHandler.java
+++ b/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxyCmdHandler.java
@@ -63,7 +63,7 @@ public class ConsoleProxyCmdHandler implements HttpHandler {
             Headers hds = t.getResponseHeaders();
             hds.set("Content-Type", "text/plain");
             t.sendResponseHeaders(200, 0);
-            OutputStreamWriter os = new OutputStreamWriter(t.getResponseBody());
+            OutputStreamWriter os = new OutputStreamWriter(t.getResponseBody(),"UTF-8");
             statsCollector.getStatsReport(os);
             os.close();
         }


### PR DESCRIPTION
Encoding is now specified in both server and clients for the console proxy getstatus command
For some reason, findbugs did not detect unsafe encoding issue in ConsoleProxyResource.java, is properly specified now though...
CitrixConsoleProxyLoadCommandWrapper was specifying system default encoding for operation, should be ok because default for xenserver is UTF-8 since it's linux based, but it's best to specify exact encoding set on the server end to be consistent