### PR TITLE
Fix findbugs encoding warning in LibvirtCreatePrivateTemplateFromVolu…

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCreatePrivateTemplateFromVolumeCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtCreatePrivateTemplateFromVolumeCommandWrapper.java
@@ -137,7 +137,7 @@ public final class LibvirtCreatePrivateTemplateFromVolumeCommandWrapper extends 
                 templateContent += "snapshot.name=" + dateFormat.format(date) + System.getProperty("line.separator");
 
                 try(FileOutputStream templFo = new FileOutputStream(templateProp);) {
-                    templFo.write(templateContent.getBytes());
+                    templFo.write(templateContent.getBytes("UTF-8"));
                     templFo.flush();
                 }catch(final IOException ex)
                 {


### PR DESCRIPTION
…meCommandWrapper

Libvirt templates should be written in UTF-8, default was already doing that so this just gets rid of the findbugs warning