### PR TITLE
Fix findbugs encoding issue in MemStat.java

### DIFF
--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/linux/MemStat.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/utils/linux/MemStat.java
@@ -51,7 +51,7 @@ public class MemStat {
 
     public void refresh() {
         File f = new File(MEMINFO_FILE);
-        try (Scanner scanner = new Scanner(f)) {
+        try (Scanner scanner = new Scanner(f,"UTF-8")) {
             parseFromScanner(scanner);
         } catch (FileNotFoundException ex) {
             throw new RuntimeException("File " + MEMINFO_FILE + " not found:" + ex.toString());


### PR DESCRIPTION
Was safe either way as this piece of code should only run in linux and only contains safe characters, this just gets rid of the findbugs warning