### PR TITLE
Fix 3 findbugs encoding warnings

### DIFF
--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -21,7 +21,7 @@ import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.URLEncoder;
@@ -1523,7 +1523,7 @@ public class VirtualMachineMO extends BaseMO {
                         String ovfPath = exportDir + File.separator + exportName + ".ovf";
                         fileNames.add(ovfPath);
 
-                        FileWriter out = new FileWriter(ovfPath);
+                        OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(ovfPath),"UTF-8");
                         out.write(ovfCreateDescriptorResult.getOvfDescriptor());
                         out.close();
 
@@ -1592,8 +1592,8 @@ public class VirtualMachineMO extends BaseMO {
 
         boolean replaced = false;
         try {
-            in = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(vmxContent)));
-            out = new BufferedWriter(new OutputStreamWriter(bos));
+            in = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(vmxContent),"UTF-8"));
+            out = new BufferedWriter(new OutputStreamWriter(bos,"UTF-8"));
             String line;
             while ((line = in.readLine()) != null) {
                 if (line.startsWith("workingDir")) {

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/VmdkFileDescriptor.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/VmdkFileDescriptor.java
@@ -39,7 +39,7 @@ public class VmdkFileDescriptor {
     public void parse(byte[] vmdkFileContent) throws IOException {
         BufferedReader in = null;
         try {
-            in = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(vmdkFileContent)));
+            in = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(vmdkFileContent),"UTF-8"));
             String line;
             while ((line = in.readLine()) != null) {
                 // ignore empty and comment lines
@@ -93,8 +93,8 @@ public class VmdkFileDescriptor {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
 
         try {
-            in = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(vmdkContent)));
-            out = new BufferedWriter(new OutputStreamWriter(bos));
+            in = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(vmdkContent),"UTF-8"));
+            out = new BufferedWriter(new OutputStreamWriter(bos,"UTF-8"));
             String line;
             while ((line = in.readLine()) != null) {
                 // ignore empty and comment lines


### PR DESCRIPTION
Vmdk descriptor files used by ESX should be UTF-8 encoded