### PR TITLE
Fix findbugs warning in VmwareHelper.java

### DIFF
--- a/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -469,7 +469,7 @@ public class VmwareHelper {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
 
         try {
-            out = new BufferedWriter(new OutputStreamWriter(bos));
+            out = new BufferedWriter(new OutputStreamWriter(bos,"UTF-8"));
 
             out.write("disksInChain=" + disksInChain);
             out.newLine();


### PR DESCRIPTION
Disk descriptors should be written in UTF-8 for Vmware