### PR TITLE
Fix findbugs encoding warning in VmwareServerDiscoverer.java

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
@@ -398,7 +398,11 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
             }
 
             // place a place holder guid derived from cluster ID
-            cluster.setGuid(UUID.nameUUIDFromBytes(String.valueOf(clusterId).getBytes()).toString());
+            try{
+                cluster.setGuid(UUID.nameUUIDFromBytes(String.valueOf(clusterId).getBytes("UTF-8")).toString());
+            }catch(UnsupportedEncodingException e){
+                throw new DiscoveredWithErrorException("Unable to create UUID based on string " + String.valueOf(clusterId) + ". Bad clusterId or UTF-8 encoding error.");
+            }
             _clusterDao.update(clusterId, cluster);
             // Flag cluster discovery success
             failureInClusterDiscovery = false;


### PR DESCRIPTION
Input string should only contain safe characters, since it's derived from a Long object. This just gets rid of the findbugs warning