### PR TITLE
Fix findbugs ClassCastException in ScaleSystemVMCmd.java

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/systemvm/ScaleSystemVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/systemvm/ScaleSystemVMCmd.java
@@ -16,9 +16,6 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.systemvm;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.log4j.Logger;

--- a/api/src/org/apache/cloudstack/api/command/admin/systemvm/ScaleSystemVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/systemvm/ScaleSystemVMCmd.java
@@ -80,18 +80,7 @@ public class ScaleSystemVMCmd extends BaseAsyncCmd {
     }
 
     public Map<String, String> getDetails() {
-        Map<String, String> customparameterMap = new HashMap<String, String>();
-        if (details != null && details.size() != 0) {
-            Collection parameterCollection = details.values();
-            Iterator iter = parameterCollection.iterator();
-            while (iter.hasNext()) {
-                HashMap<String, String> value = (HashMap<String, String>)iter.next();
-                for (Map.Entry<String, String> entry : value.entrySet()) {
-                    customparameterMap.put(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-        return customparameterMap;
+        return details;
     }
 
     /////////////////////////////////////////////////////


### PR DESCRIPTION
getDetails() isn't called anywhere in the code, either way, implementation is wrong since details is a Map\<String, String\> and not a Map\<String, Map\<String,String\>\>
If this piece of could would get run, it would just fail trying to cast String to HashMap\<String,String\> in line 88