### PR TITLE
Fix findbugs ClassCastException in UpgradeSystemVMCmd.java

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/systemvm/UpgradeSystemVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/systemvm/UpgradeSystemVMCmd.java
@@ -75,18 +75,7 @@ public class UpgradeSystemVMCmd extends BaseCmd {
     }
 
     public Map<String, String> getDetails() {
-        Map<String, String> customparameterMap = new HashMap<String, String>();
-        if (details != null && details.size() != 0) {
-            Collection parameterCollection = details.values();
-            Iterator iter = parameterCollection.iterator();
-            while (iter.hasNext()) {
-                HashMap<String, String> value = (HashMap<String, String>)iter.next();
-                for (Map.Entry<String,String>entry : value.entrySet()) {
-                    customparameterMap.put(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-        return customparameterMap;
+        return details;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/org/apache/cloudstack/api/command/admin/systemvm/UpgradeSystemVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/systemvm/UpgradeSystemVMCmd.java
@@ -16,9 +16,6 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.systemvm;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.log4j.Logger;


### PR DESCRIPTION
UpgradeVMCmd.getDetails() is called from ManagementServerImpl.upgradeSystemVM() and would fail to run, as it would try to cast String to HashMap\<String,String\>