### PR TITLE
Fix 2 findbugs ClassCastExceptions

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
@@ -81,22 +81,8 @@ public class ScaleVMCmd extends BaseAsyncCmd {
         return serviceOfferingId;
     }
 
-    //instead of reading a map directly we are using collections.
-    //it is because details.values() cannot be cast to a map.
-    //it gives a exception
     public Map<String, String> getDetails() {
-        Map<String, String> customparameterMap = new HashMap<String, String>();
-        if (details != null && details.size() != 0) {
-            Collection parameterCollection = details.values();
-            Iterator iter = parameterCollection.iterator();
-            while (iter.hasNext()) {
-                HashMap<String, String> value = (HashMap<String, String>)iter.next();
-                for (String key : value.keySet()) {
-                    customparameterMap.put(key, value.get(key));
-                }
-            }
-        }
-        return customparameterMap;
+        return details;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
@@ -16,9 +16,6 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.vm;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 

--- a/api/src/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
@@ -16,9 +16,6 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.vm;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.log4j.Logger;

--- a/api/src/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
@@ -80,18 +80,7 @@ public class UpgradeVMCmd extends BaseCmd {
     }
 
     public Map<String, String> getDetails() {
-        Map<String, String> customparameterMap = new HashMap<String, String>();
-        if (details != null && details.size() != 0) {
-            Collection parameterCollection = details.values();
-            Iterator iter = parameterCollection.iterator();
-            while (iter.hasNext()) {
-                HashMap<String, String> value = (HashMap<String, String>)iter.next();
-                for (String key : value.keySet()) {
-                    customparameterMap.put(key, value.get(key));
-                }
-            }
-        }
-        return customparameterMap;
+        return details;
     }
 
     /////////////////////////////////////////////////////


### PR DESCRIPTION
ScaleVMCmd.getDetails() isn't called anywhere in the code, either way, implementation is wrong since details is a Map\<String, String\> and not a Map\<String, Map\<String,String\>\>
UpgradeVMCmd.getDetails() is called from UserVmManagerImpl.upgradeVirtualMachine() and would fail to run, as it would try to cast String to HashMap\<String,String\>
Removed nonsense comment about casting a Collection to a Map obviously giving exception