### PR TITLE
Fix findbugs warning in ClusterManagerImpl.java

### DIFF
--- a/framework/cluster/src/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/com/cloud/cluster/ClusterManagerImpl.java
@@ -413,7 +413,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
     @Override
     public ManagementServerHostVO getPeer(String mgmtServerId) {
-        return _mshostDao.findByMsid(Long.valueOf(mgmtServerId));
+        return _mshostDao.findByMsid(Long.parseLong(mgmtServerId));
     }
 
     @Override


### PR DESCRIPTION
ManagementServerHostDao.findByMsid takes long as input, and a boxed Long was being created for it