### PR TITLE
Fix findbugs warning in HypervDirectConnectResource.java

### DIFF
--- a/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
@@ -2081,8 +2081,8 @@ public class HypervDirectConnectResource extends ServerResourceBase implements S
                 String[] splitResult = result.split(":");
                 int i = 0;
                 while (i < splitResult.length - 1) {
-                    stats[0] += (new Long(splitResult[i++])).longValue();
-                    stats[1] += (new Long(splitResult[i++])).longValue();
+                    stats[0] += Long.parseLong(splitResult[i++]);
+                    stats[1] += Long.parseLong(splitResult[i++]);
                 }
             } catch (Throwable e) {
                 s_logger.warn("Unable to parse return from script return of network usage command: " + e.toString(), e);


### PR DESCRIPTION
Two boxed Longs were being created instead of simple long