### PR TITLE
Fix findbugs warning in NetscalerResource.java

### DIFF
--- a/plugins/network-elements/netscaler/src/com/cloud/network/resource/NetscalerResource.java
+++ b/plugins/network-elements/netscaler/src/com/cloud/network/resource/NetscalerResource.java
@@ -457,7 +457,7 @@ public class NetscalerResource implements ServerResource {
         try {
             IpAddressTO[] ips = cmd.getIpAddresses();
             for (IpAddressTO ip : ips) {
-                long guestVlanTag = Long.valueOf(ip.getBroadcastUri());
+                long guestVlanTag = Long.parseLong(ip.getBroadcastUri());
                 String vlanSelfIp = ip.getVlanGateway();
                 String vlanNetmask = ip.getVlanNetmask();
 


### PR DESCRIPTION
Unnecessary boxing/unboxing of primitive value