### PR TITLE
Fix findbugs warning in PaloAltoResource.java

### DIFF
--- a/plugins/network-elements/palo-alto/src/com/cloud/network/resource/PaloAltoResource.java
+++ b/plugins/network-elements/palo-alto/src/com/cloud/network/resource/PaloAltoResource.java
@@ -1612,7 +1612,7 @@ public class PaloAltoResource implements ServerResource {
     }
 
     private String getPrivateSubnet(String vlan) throws ExecutionException {
-        String _interfaceName = genPrivateInterfaceName(Long.valueOf(vlan).longValue());
+        String _interfaceName = genPrivateInterfaceName(Long.parseLong(vlan));
         Map<String, String> params = new HashMap<String, String>();
         params.put("type", "config");
         params.put("action", "get");


### PR DESCRIPTION
Unnecessary boxing/unboxing of primitive value