### PR TITLE
Fix findbugs warning HE_EQUALS_USE_HASHCODE in Ip4Address.java

### DIFF
--- a/utils/src/com/cloud/utils/net/Ip4Address.java
+++ b/utils/src/com/cloud/utils/net/Ip4Address.java
@@ -64,4 +64,8 @@ public class Ip4Address {
             return false;
         }
     }
+    @Override
+    public int hashCode(){
+        return (int)(_mac.hashCode()*_addr.hashCode());
+    }~
 }

--- a/utils/src/com/cloud/utils/net/Ip4Address.java
+++ b/utils/src/com/cloud/utils/net/Ip4Address.java
@@ -67,5 +67,5 @@ public class Ip4Address {
     @Override
     public int hashCode(){
         return (int)(_mac.hashCode()*_addr.hashCode());
-    }~
+    }
 }


### PR DESCRIPTION
When overriding equals(), hashCode() must also be overriden do comply with the directive that equal objects must have equal hashcodes
Without this implementation, usage of these kinds of objects in hashmaps for example, will be broken