### PR TITLE
Fix findbugs SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING…

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade30xBase.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade30xBase.java
@@ -32,12 +32,13 @@ public abstract class Upgrade30xBase implements DbUpgrade {
     final static Logger s_logger = Logger.getLogger(Upgrade30xBase.class);
 
     protected String getNetworkLabelFromConfig(Connection conn, String name) {
-        String sql = "SELECT value FROM `cloud`.`configuration` where name = '" + name + "'";
+        String sql = "SELECT value FROM `cloud`.`configuration` where name = ?";
         String networkLabel = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         try {
             pstmt = conn.prepareStatement(sql);
+            pstmt.setString(1,name);
             rs = pstmt.executeQuery();
             if (rs.next()) {
                 networkLabel = rs.getString(1);


### PR DESCRIPTION
… warning in Upgrade30xBase.java

There was no risk of sql injection here, nor any need to use PreparedStatement, still, this fixes the warning