### PR TITLE
CLOUDSTACK-8567 Migrating primary storage causes name_label field to …

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -850,6 +850,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
                 hypervisorResource.checkForSuccess(conn, task);
                 final VDI destVdi = Types.toVDI(task, conn);
                 final VolumeObjectTO newVol = new VolumeObjectTO();
+                destVdi.setNameLabel(conn, srcVolume.getName());
                 newVol.setPath(destVdi.getUuid(conn));
                 newVol.setSize(srcVolume.getSize());
 


### PR DESCRIPTION
The fix is to set the VDI name-label in XenServer.