### PR TITLE
CLOUDSTACK-8455: Use the correct label to display extractable checkbox

### DIFF
--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -435,7 +435,7 @@
                                     },
 
                                     isExtractable: {
-                                        label: "extractable",
+                                        label: "label.extractable",
                                         docID: 'helpRegisterTemplateExtractable',
                                         isBoolean: true
                                     },
@@ -826,7 +826,7 @@
                                     },
 
                                     isExtractable: {
-                                        label: "extractable",
+                                        label: "label.extractable",
                                         docID: 'helpRegisterTemplateExtractable',
                                         isBoolean: true
                                     },
@@ -1909,7 +1909,7 @@
                                     },
 
                                     isExtractable: {
-                                        label: "extractable",
+                                        label: "label.extractable",
                                         docID: 'helpRegisterISOExtractable',
                                         isBoolean: true
                                     },


### PR DESCRIPTION
Simple fix to use the appropriate label name