### PR TITLE
VM Snapshot Usage for DATA disk is reported as the size of the DATA d…

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -3162,6 +3162,15 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
     }
 
     public long getVMSnapshotChainSize(final Connection conn, final VolumeObjectTO volumeTo, final String vmName) throws BadServerResponse, XenAPIException, XmlRpcException {
+        if (volumeTo.getVolumeType() == Volume.Type.DATADISK) {
+            VDI dataDisk = VDI.getByUuid(conn, volumeTo.getPath());
+            if (dataDisk != null) {
+                String dataDiskName = dataDisk.getNameLabel(conn);
+                if (dataDiskName != null && !dataDiskName.isEmpty()) {
+                    volumeTo.setName(dataDiskName);
+                }
+            }
+        }
         final Set<VDI> allvolumeVDIs = VDI.getByNameLabel(conn, volumeTo.getName());
         long size = 0;
         for (final VDI vdi : allvolumeVDIs) {


### PR DESCRIPTION
VM Snapshot Usage for DATA disk is reported as the size of the DATA disk instead of the actual snapshot size.
