### PR TITLE
VM deployments from ISO and attaching ISOs to vm are not supported in LXC

### DIFF
--- a/test/integration/smoke/test_iso.py
+++ b/test/integration/smoke/test_iso.py
@@ -41,6 +41,9 @@ class TestCreateIso(cloudstackTestCase):
         self.services = self.testClient.getParsedTestDataConfig()
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
+        self.hypervisor = self.testClient.getHypervisorInfo()
+        if self.hypervisor.lower() in ['lxc']:
+            self.skipTest("ISOs are not supported on %s" % self.hypervisor)
         # Get Zone, Domain and templates
         self.domain = get_domain(self.apiclient)
         self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
@@ -150,7 +153,7 @@ class TestISO(cloudstackTestCase):
         cls._cleanup = []
         cls.unsupportedHypervisor = False
         cls.hypervisor = get_hypervisor_type(cls.apiclient)
-        if cls.hypervisor.lower() == "simulator":
+        if cls.hypervisor.lower() in ["simulator", "lxc"]:
             cls.unsupportedHypervisor = True
             return
 
@@ -230,7 +233,6 @@ class TestISO(cloudstackTestCase):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
-
         if self.unsupportedHypervisor:
             self.skipTest("Skipping test because unsupported hypervisor\
                     %s" % self.hypervisor)


### PR DESCRIPTION
So no point in running iso tests for LXC. Anyway we are using KVM system-template for LXC, all the tests we are performing as part of this suite are being run on KVM.

Test create public & private ISO ... SKIP: ISOs are not supported on LXC
Test Edit ISO ... SKIP: Skipping test because unsupported hypervisor                    LXC
Test delete ISO ... SKIP: Skipping test because unsupported hypervisor                    LXC
Test for extract ISO ... SKIP: Skipping test because unsupported hypervisor                    LXC
Update & Test for ISO permissions ... SKIP: Skipping test because unsupported hypervisor                    LXC
Test for copy ISO from one zone to another ... SKIP: Skipping test because unsupported hypervisor                    LXC
Test delete ISO ... SKIP: Skipping test because unsupported hypervisor                    LXC

----------------------------------------------------------------------
Ran 7 tests in 0.435s

OK (SKIP=7) 
