### PR TITLE
Allow some time for the SSVM to start before throwing a failure

### DIFF
--- a/test/integration/smoke/test_secondary_storage.py
+++ b/test/integration/smoke/test_secondary_storage.py
@@ -134,7 +134,7 @@ class TestSecStorageServices(cloudstackTestCase):
                         'Up',
                         "Check state of primary storage pools is Up or not"
                         )
-        for _ in range(4):
+        for _ in range(2):
             list_ssvm_response = list_ssvms(
                                     self.apiclient,
                                     systemvmtype='secondarystoragevm',
@@ -154,10 +154,10 @@ class TestSecStorageServices(cloudstackTestCase):
 
             for ssvm in list_ssvm_response:
                 if ssvm.state == 'Starting':
-                    time.sleep(15)
+                    time.sleep(30)
                     continue
-            for ssvm in list_ssvm_response:
-                self.assertEqual(
+        for ssvm in list_ssvm_response:
+            self.assertEqual(
                             ssvm.state,
                             'Running',
                             "Check whether state of SSVM is running"

--- a/test/integration/smoke/test_secondary_storage.py
+++ b/test/integration/smoke/test_secondary_storage.py
@@ -134,30 +134,35 @@ class TestSecStorageServices(cloudstackTestCase):
                         'Up',
                         "Check state of primary storage pools is Up or not"
                         )
-
-        list_ssvm_response = list_ssvms(
+        for _ in range(4):
+            list_ssvm_response = list_ssvms(
                                     self.apiclient,
                                     systemvmtype='secondarystoragevm',
                                     )
 
-        self.assertEqual(
+            self.assertEqual(
                             isinstance(list_ssvm_response, list),
                             True,
                             "Check list response returns a valid list"
                         )
-        #Verify SSVM response
-        self.assertNotEqual(
+            #Verify SSVM response
+            self.assertNotEqual(
                             len(list_ssvm_response),
                             0,
                             "Check list System VMs response"
                         )
 
-        for ssvm in list_ssvm_response:
-            self.assertEqual(
+            for ssvm in list_ssvm_response:
+                if ssvm.state == 'Starting':
+                    time.sleep(15)
+                    continue
+            for ssvm in list_ssvm_response:
+                self.assertEqual(
                             ssvm.state,
                             'Running',
                             "Check whether state of SSVM is running"
                         )
+        
         return
 
     @attr(tags = ["advanced", "advancedns", "smoke", "basic", "eip", "sg"], required_hardware="false")


### PR DESCRIPTION
This fixes the old issue with intermittently failing marvin test on travis

Example output:

==== Marvin Init Successful ====
=== TestName: test_01_sys_vm_start | Status : FAILED ===
=== TestName: test_02_sys_template_ready | Status : EXCEPTION ===
===final results are now copied to: /tmp//MarvinLogs/test_secondary_storage_KYYYZV===
+----------------------------+---------+
| Test | Result |
+============================+=========+
| test_01_sys_vm_start | Failure |
+----------------------------+---------+
| test_02_sys_template_ready | Success |
+----------------------------+---------+