### PR TITLE
Replace System.currentTimeMillis() by System.nanoTime()

### DIFF
--- a/utils/src/com/cloud/utils/Profiler.java
+++ b/utils/src/com/cloud/utils/Profiler.java
@@ -23,24 +23,20 @@ public class Profiler {
     private Long startTickInMs;
     private Long stopTickInMs;
 
-    public Profiler() {
-        startTickInMs = null;
-        stopTickInMs = null;
-    }
-
     public long start() {
-        startTickInMs = System.currentTimeMillis();
+        startTickInMs = System.nanoTime();
         return startTickInMs.longValue();
     }
 
     public long stop() {
-        stopTickInMs = System.currentTimeMillis();
+        stopTickInMs = System.nanoTime();
         return stopTickInMs.longValue();
     }
 
     public long getDuration() {
-        if (startTickInMs != null && stopTickInMs != null)
+        if (startTickInMs != null && stopTickInMs != null) {
             return stopTickInMs.longValue() - startTickInMs.longValue();
+        }
 
         return -1;
     }
@@ -55,11 +51,13 @@ public class Profiler {
 
     @Override
     public String toString() {
-        if (startTickInMs == null)
+        if (startTickInMs == null) {
             return "Not Started";
+        }
 
-        if (stopTickInMs == null)
+        if (stopTickInMs == null) {
             return "Started but not stopped";
+        }
 
         return "Done. Duration: " + getDuration() + "ms";
     }

--- a/utils/test/com/cloud/utils/TestProfiler.java
+++ b/utils/test/com/cloud/utils/TestProfiler.java
@@ -32,11 +32,11 @@ public class TestProfiler extends Log4jEnabledTestCase {
     public void testProfiler() {
         s_logger.info("testProfiler() started");
 
-        Profiler pf = new Profiler();
+        final Profiler pf = new Profiler();
         pf.start();
         try {
             Thread.sleep(1000);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
         }
         pf.stop();
 
@@ -45,5 +45,31 @@ public class TestProfiler extends Log4jEnabledTestCase {
         Assert.assertTrue(pf.getDuration() >= 1000);
 
         s_logger.info("testProfiler() stopped");
+    }
+
+    @Test
+    public void testProfilerNoStart() {
+        final Profiler pf = new Profiler();
+        try {
+            Thread.sleep(20);
+        } catch (final InterruptedException e) {
+        }
+        pf.stop();
+
+        Assert.assertTrue(pf.getDuration() == -1);
+        Assert.assertFalse(pf.isStarted());
+    }
+
+    @Test
+    public void testProfilerNoStop() {
+        final Profiler pf = new Profiler();
+        pf.start();
+        try {
+            Thread.sleep(20);
+        } catch (final InterruptedException e) {
+        }
+
+        Assert.assertTrue(pf.getDuration() == -1);
+        Assert.assertFalse(pf.isStopped());
     }
 }


### PR DESCRIPTION
   - System.nanoTime() is the best way to measure elapsed time in Java.
   - It gives a resolution on the order of microseconds
   - The System.currentTimeMillis() is used when calculating absolut time.

Add unit tests to cover negative cases
   - Cover when the profile is not started/stopped

Test Environment
  - Management Server: CentOS 7.1
  - KVM

Tests successfully executed:

> nosetests --with-marvin --marvin-config=/data/shared/marvin/mct-zone2-kvm2-ISOLATED.cfg -s -a tags=advanced,required_hardware=false \
>     smoke/test_vm_life_cycle.py smoke/test_routers.py smoke/test_vpc_vpn.py smoke/test_reset_vm_on_reboot.py smoke/test_service_offerings.py \
>     component/test_vpc_offerings.py smoke/test_privategw_acl.py smoke/test_network_acl.py