### PR TITLE
CLOUDSTACK-8579: Fix cleanup operation in few test cases

### DIFF
--- a/test/integration/component/test_blocker_bugs.py
+++ b/test/integration/component/test_blocker_bugs.py
@@ -743,11 +743,11 @@ class TestTemplates(cloudstackTestCase):
                             cls.services["ostype"]
                             )
         cls.templateSupported = True
+        cls._cleanup = []
         if cls.hypervisor.lower() in ['lxc']:
             cls.templateSupported = False
             return
         cls.services["virtual_machine"]["zoneid"] = cls.zone.id
-        cls._cleanup = []
         try:
             cls.account = Account.create(
                             cls.api_client,
@@ -1024,6 +1024,7 @@ class TestDataPersistency(cloudstackTestCase):
         cls.domain = get_domain(cls.api_client)
         cls.services['mode'] = cls.zone.networktype
         cls.templateSupported = True
+        cls.cleanup = []
         template = get_template(
                             cls.api_client,
                             cls.zone.id,

--- a/test/integration/component/test_project_usage.py
+++ b/test/integration/component/test_project_usage.py
@@ -512,6 +512,7 @@ class TestVolumeUsage(cloudstackTestCase):
         cls.services['mode'] = cls.zone.networktype
         cls.hypervisor = cls.testClient.getHypervisorInfo()
         cls.rbdStorageFound = True
+        cls._cleanup = []
         if cls.hypervisor.lower() == 'lxc':
             if not find_storage_pool_type(cls.api_client, storagetype='rbd'):
                 cls.rbdStorageFound = False
@@ -1265,6 +1266,7 @@ class TestSnapshotUsage(cloudstackTestCase):
         cls.api_client = cls.testClient.getApiClient()
         cls.hypervisor = cls.testClient.getHypervisorInfo()
         cls.snapshotSupported = True
+        cls._cleanup = []
         if cls.hypervisor.lower() in ['hyperv', 'lxc']:
             cls.snapshotSupported = False
             return


### PR DESCRIPTION
Cleanup list should be declared before returning from setUpClass() so that tearDownClass() works properly.

Currently the test cases are failing with "Class does not have cleanup attribute".

Tested with passing LXC as hypervisor and test cases skipped successfully without giving any error.


Test the timing issue of root disk data sync ... SKIP: Template creation from root volume is not supported in LXC
TS_BUG_009-Test the size of template created from root disk ... SKIP: Template creation from root volume is not supported in LXC
TS_BUG_010-Test check size of snapshot and template ... SKIP: Template creation from root volume is not supported in LXC
TS_BUG_011-Test Reusing deleted template name ... SKIP: Template creation from root volume is not supported in LXC

----------------------------------------------------------------------
Ran 4 tests in 28.247s

OK (SKIP=4)



Test Create/Delete a manual snap shot and verify ... SKIP: Snapshots are not supported on LXC
Test Create/delete a volume and verify correct usage is recorded ... SKIP

----------------------------------------------------------------------
Ran 2 tests in 10.303s

OK (SKIP=2)