### PR TITLE
Extend wait before retry to states other than 'Starting'

### DIFF
--- a/test/integration/smoke/test_secondary_storage.py
+++ b/test/integration/smoke/test_secondary_storage.py
@@ -153,7 +153,7 @@ class TestSecStorageServices(cloudstackTestCase):
                         )
 
             for ssvm in list_ssvm_response:
-                if ssvm.state == 'Starting':
+                if ssvm.state != 'Running':
                     time.sleep(30)
                     continue
         for ssvm in list_ssvm_response:


### PR DESCRIPTION
https://github.com/apache/cloudstack/pull/493 implemented wait and retry for SSVM state Starting, but today there was as an occurrence of SSVM being in other state (Stopped) in https://travis-ci.org/apache/cloudstack/jobs/67986292 relating to https://github.com/apache/cloudstack/pull/512
This extends the wait before retrying the API call to any state that is not the desired 'Running' state.