### PR TITLE
Offer a getDurationInMillis() method in the Profiler utility class

### DIFF
--- a/engine/orchestration/src/com/cloud/agent/manager/SynchronousListener.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/SynchronousListener.java
@@ -116,7 +116,7 @@ public class SynchronousListener implements Listener {
         profiler.stop();
 
         if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Synchronized command - sending completed, time: " + profiler.getDuration() + ", answer: " +
+            s_logger.trace("Synchronized command - sending completed, time: " + profiler.getDurationInMillis() + ", answer: " +
                 (_answers != null ? _answers[0].toString() : "null"));
         }
         return _answers;

--- a/framework/db/src/com/cloud/utils/db/GlobalLock.java
+++ b/framework/db/src/com/cloud/utils/db/GlobalLock.java
@@ -139,7 +139,7 @@ public class GlobalLock {
                         }
                         profiler.stop();
 
-                        remainingMilliSeconds -= profiler.getDuration();
+                        remainingMilliSeconds -= profiler.getDurationInMillis();
                         if (remainingMilliSeconds < 0)
                             return false;
 

--- a/framework/db/test/com/cloud/utils/db/GlobalLockTest.java
+++ b/framework/db/test/com/cloud/utils/db/GlobalLockTest.java
@@ -49,7 +49,7 @@ public class GlobalLockTest {
                 p.start();
                 locked = WorkLock.lock(timeoutSeconds);
                 p.stop();
-                System.out.println("Thread " + id + " waited " + p.getDuration() + " ms, locked=" + locked);
+                System.out.println("Thread " + id + " waited " + p.getDurationInMillis() + " ms, locked=" + locked);
                 if (locked) {
                     Thread.sleep(jobDuration * 1000);
                 }

--- a/server/src/com/cloud/network/security/SecurityGroupManagerImpl2.java
+++ b/server/src/com/cloud/network/security/SecurityGroupManagerImpl2.java
@@ -125,7 +125,7 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
         p.stop();
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Security Group Mgr v2: done scheduling ruleset updates for " + workItems.size() + " vms: num new jobs=" + newJobs +
-                " num rows insert or updated=" + updated + " time taken=" + p.getDuration());
+                " num rows insert or updated=" + updated + " time taken=" + p.getDurationInMillis());
         }
     }
 

--- a/server/test/com/cloud/network/security/SecurityGroupManagerImpl2Test.java
+++ b/server/test/com/cloud/network/security/SecurityGroupManagerImpl2Test.java
@@ -61,7 +61,7 @@ public class SecurityGroupManagerImpl2Test extends TestCase {
         _sgMgr.scheduleRulesetUpdateToHosts(work, false, null);
         profiler.stop();
 
-        System.out.println("Done " + numVms + " in " + profiler.getDuration() + " ms");
+        System.out.println("Done " + numVms + " in " + profiler.getDurationInMillis() + " ms");
     }
 
     @Test

--- a/server/test/com/cloud/network/security/SecurityGroupQueueTest.java
+++ b/server/test/com/cloud/network/security/SecurityGroupQueueTest.java
@@ -131,7 +131,7 @@ public class SecurityGroupQueueTest extends TestCase {
             }
         }
         p.stop();
-        System.out.println("Num Vms= " + maxVmId + " Queue size = " + queue.size() + " time=" + p.getDuration() + " ms");
+        System.out.println("Num Vms= " + maxVmId + " Queue size = " + queue.size() + " time=" + p.getDurationInMillis() + " ms");
         assertEquals(maxVmId, queue.size());
     }
 

--- a/utils/src/com/cloud/utils/Profiler.java
+++ b/utils/src/com/cloud/utils/Profiler.java
@@ -46,8 +46,8 @@ public class Profiler {
      */
     public long getDuration() {
         if (startTickNanoSeconds != null && stopTickNanoSeconds != null) {
-            final long timeInMicroSeconds = stopTickNanoSeconds - startTickNanoSeconds;
-            return timeInMicroSeconds;
+            final long timeInNanoSeconds = stopTickNanoSeconds - startTickNanoSeconds;
+            return timeInNanoSeconds;
         }
 
         return -1;

--- a/utils/src/com/cloud/utils/Profiler.java
+++ b/utils/src/com/cloud/utils/Profiler.java
@@ -20,45 +20,72 @@
 package com.cloud.utils;
 
 public class Profiler {
-    private Long startTickInMs;
-    private Long stopTickInMs;
+
+    private static final long MILLIS_FACTOR = 1000l;
+    private static final double EXPONENT = 2d;
+
+
+    private Long startTickNanoSeconds;
+    private Long stopTickNanoSeconds;
 
     public long start() {
-        startTickInMs = System.nanoTime();
-        return startTickInMs.longValue();
+        startTickNanoSeconds = System.nanoTime();
+        return startTickNanoSeconds;
     }
 
     public long stop() {
-        stopTickInMs = System.nanoTime();
-        return stopTickInMs.longValue();
+        stopTickNanoSeconds = System.nanoTime();
+        return stopTickNanoSeconds;
     }
 
+    /**
+     * 1 millisecond = 1e+6 nanoseconds
+     * 1 second = 1000 milliseconds = 1e+9 nanoseconds
+     *
+     * @return the duration in nanoseconds.
+     */
     public long getDuration() {
-        if (startTickInMs != null && stopTickInMs != null) {
-            return stopTickInMs.longValue() - startTickInMs.longValue();
+        if (startTickNanoSeconds != null && stopTickNanoSeconds != null) {
+            final long timeInMicroSeconds = stopTickNanoSeconds - startTickNanoSeconds;
+            return timeInMicroSeconds;
+        }
+
+        return -1;
+    }
+
+    /**
+     * 1 millisecond = 1e+6 nanoseconds
+     * 1 second = 1000 millisecond = 1e+9 nanoseconds
+     *
+     * @return the duration in milliseconds.
+     */
+    public long getDurationInMillis() {
+        if (startTickNanoSeconds != null && stopTickNanoSeconds != null) {
+            final long timeInMillis = (stopTickNanoSeconds - startTickNanoSeconds) / (long)Math.pow(MILLIS_FACTOR, EXPONENT);
+            return timeInMillis;
         }
 
         return -1;
     }
 
     public boolean isStarted() {
-        return startTickInMs != null;
+        return startTickNanoSeconds != null;
     }
 
     public boolean isStopped() {
-        return stopTickInMs != null;
+        return stopTickNanoSeconds != null;
     }
 
     @Override
     public String toString() {
-        if (startTickInMs == null) {
+        if (startTickNanoSeconds == null) {
             return "Not Started";
         }
 
-        if (stopTickInMs == null) {
+        if (stopTickNanoSeconds == null) {
             return "Started but not stopped";
         }
 
-        return "Done. Duration: " + getDuration() + "ms";
+        return "Done. Duration: " + getDurationInMillis() + "ms";
     }
 }

--- a/utils/test/com/cloud/utils/TestProfiler.java
+++ b/utils/test/com/cloud/utils/TestProfiler.java
@@ -28,23 +28,45 @@ import com.cloud.utils.testcase.Log4jEnabledTestCase;
 public class TestProfiler extends Log4jEnabledTestCase {
     protected final static Logger s_logger = Logger.getLogger(TestProfiler.class);
 
+    private static final long MILLIS_FACTOR = 1000l;
+    private static final int MARGIN = 100;
+    private static final double EXPONENT = 3d;
+
     @Test
-    public void testProfiler() {
+    public void testProfilerInMillis() {
         s_logger.info("testProfiler() started");
 
         final Profiler pf = new Profiler();
         pf.start();
         try {
-            Thread.sleep(1000);
+            Thread.sleep(MILLIS_FACTOR);
         } catch (final InterruptedException e) {
         }
         pf.stop();
 
-        s_logger.info("Duration : " + pf.getDuration());
+        final long durationInMillis = pf.getDurationInMillis();
+        s_logger.info("Duration : " + durationInMillis);
 
-        Assert.assertTrue(pf.getDuration() >= 1000);
+        // An error margin in order to cover the time taken by the star/stop calls.
+        // 100 milliseconds margin seems too much, but it will avoid assertion error
+        // and also fail in case a duration in nanoseconds is used instead.
+        Assert.assertTrue(durationInMillis >= MILLIS_FACTOR  &&  durationInMillis <= MILLIS_FACTOR + MARGIN);
 
         s_logger.info("testProfiler() stopped");
+    }
+
+    @Test
+    public void testProfilerInMicro() {
+        final Profiler pf = new Profiler();
+        pf.start();
+        try {
+            Thread.sleep(MILLIS_FACTOR);
+        } catch (final InterruptedException e) {
+        }
+        pf.stop();
+
+        final long duration = pf.getDuration();
+        Assert.assertTrue(duration >= Math.pow(MILLIS_FACTOR, EXPONENT));
     }
 
     @Test
@@ -56,7 +78,7 @@ public class TestProfiler extends Log4jEnabledTestCase {
         }
         pf.stop();
 
-        Assert.assertTrue(pf.getDuration() == -1);
+        Assert.assertTrue(pf.getDurationInMillis() == -1);
         Assert.assertFalse(pf.isStarted());
     }
 
@@ -69,7 +91,7 @@ public class TestProfiler extends Log4jEnabledTestCase {
         } catch (final InterruptedException e) {
         }
 
-        Assert.assertTrue(pf.getDuration() == -1);
+        Assert.assertTrue(pf.getDurationInMillis() == -1);
         Assert.assertFalse(pf.isStopped());
     }
 }

--- a/utils/test/com/cloud/utils/TestProfiler.java
+++ b/utils/test/com/cloud/utils/TestProfiler.java
@@ -94,4 +94,18 @@ public class TestProfiler extends Log4jEnabledTestCase {
         Assert.assertTrue(pf.getDurationInMillis() == -1);
         Assert.assertFalse(pf.isStopped());
     }
+
+    @Test
+    public void testResolution() {
+        long nanoTime1 = 0l;
+        long nanoTime2 = 0l;
+        nanoTime1 = System.nanoTime();
+        nanoTime2 = System.nanoTime();
+        System.out.println("Nano time 1: " + nanoTime1);
+        System.out.println("Nano time 2: " + nanoTime2);
+
+        // We are measuring the elapsed time in 2 consecutive calls of System.nanoTime()
+        // That's the same as 0.002 milliseconds or 2000 nanoseconds.
+        Assert.assertTrue("It took more than 2 microseconds between 2 consecutive calls to System.nanoTime().", nanoTime2 - nanoTime1 <= 2000);
+    }
 }

--- a/utils/test/com/cloud/utils/TestProfiler.java
+++ b/utils/test/com/cloud/utils/TestProfiler.java
@@ -28,6 +28,7 @@ import com.cloud.utils.testcase.Log4jEnabledTestCase;
 public class TestProfiler extends Log4jEnabledTestCase {
     protected final static Logger s_logger = Logger.getLogger(TestProfiler.class);
 
+    private static final long ONE_SECOND = 1000l;
     private static final long MILLIS_FACTOR = 1000l;
     private static final int MARGIN = 100;
     private static final double EXPONENT = 3d;
@@ -39,13 +40,13 @@ public class TestProfiler extends Log4jEnabledTestCase {
         final Profiler pf = new Profiler();
         pf.start();
         try {
-            Thread.sleep(MILLIS_FACTOR);
+            Thread.sleep(ONE_SECOND);
         } catch (final InterruptedException e) {
         }
         pf.stop();
 
         final long durationInMillis = pf.getDurationInMillis();
-        s_logger.info("Duration : " + durationInMillis);
+        s_logger.info("Duration in Millis: " + durationInMillis);
 
         // An error margin in order to cover the time taken by the star/stop calls.
         // 100 milliseconds margin seems too much, but it will avoid assertion error
@@ -56,16 +57,17 @@ public class TestProfiler extends Log4jEnabledTestCase {
     }
 
     @Test
-    public void testProfilerInMicro() {
+    public void testProfilerInNano() {
         final Profiler pf = new Profiler();
         pf.start();
         try {
-            Thread.sleep(MILLIS_FACTOR);
+            Thread.sleep(ONE_SECOND);
         } catch (final InterruptedException e) {
         }
         pf.stop();
 
         final long duration = pf.getDuration();
+        s_logger.info("Duration in Nano: " + duration);
         Assert.assertTrue(duration >= Math.pow(MILLIS_FACTOR, EXPONENT));
     }
 
@@ -101,6 +103,9 @@ public class TestProfiler extends Log4jEnabledTestCase {
         long nanoTime2 = 0l;
         nanoTime1 = System.nanoTime();
         nanoTime2 = System.nanoTime();
+
+        // Using sysout here because is faster than the logger and we don't want to
+        // waste time.
         System.out.println("Nano time 1: " + nanoTime1);
         System.out.println("Nano time 2: " + nanoTime2);
 


### PR DESCRIPTION
Hey @DaanHoogland 

Details about the new implementation we discussed this afternoon and test report.

        - New implementation uses nanoseconds. Due to that, the places where the Profiler is used as a Monitor and/or a stopwatch will suffer with the difference in the return
       - Also added a getDuration(), which returns the time in nanoseconds in case someone wants to use it instead
       - Added an extra test to check if the getDuration() works fine with nanoseconds
       - Fixed the test that checks the time in milliseconds: I added an error margin to cover the test better
       - Testing the elapsed time between 2 consecutive calls to System.nanoTime()

Environment:

Management Server on CentOS 7.1
XenServer 6.2
Isolation Type: VLAN
Shared Storage

test_privategw_acl (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_privategw_acl | Status : SUCCESS ===
ok
Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... SKIP: At least two hosts should be present in the zone for migration
Test destroy(expunge) Virtual Machine ... === TestName: test_09_expunge_vm | Status : SUCCESS ===
ok
Test router internal advanced zone ... === TestName: test_02_router_internal_adv | Status : SUCCESS ===
ok
Test restart network ... === TestName: test_03_restart_network_cleanup | Status : SUCCESS ===
ok
Test router basic setup ... === TestName: test_05_router_basic | Status : SUCCESS ===
ok
Test router advanced setup ... === TestName: test_06_router_advanced | Status : SUCCESS ===
ok
Test stop router ... === TestName: test_07_stop_router | Status : SUCCESS ===
ok
Test start router ... === TestName: test_08_start_router | Status : SUCCESS ===
ok
Test reboot router ... === TestName: test_09_reboot_router | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 18 tests in 1404.594s

OK (SKIP=1)