### PR TITLE
CLOUDSTACK-8582: Tagging test cases which should not be run on simulator accordingly

### DIFF
--- a/test/integration/component/test_accounts.py
+++ b/test/integration/component/test_accounts.py
@@ -869,7 +869,7 @@ class TestTemplateHierarchy(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "basic", "eip", "advancedns", "sg"])
+    @attr(tags=["advanced", "basic", "eip", "advancedns", "sg"], required_hardware="true")
     def test_01_template_hierarchy(self):
         """Test to verify template at same level in hierarchy"""
 

--- a/test/integration/component/test_project_limits.py
+++ b/test/integration/component/test_project_limits.py
@@ -883,7 +883,7 @@ class TestResourceLimitsProject(cloudstackTestCase):
                         )
         return
 
-    @attr(tags=["advanced", "basic", "sg", "eip", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "sg", "eip", "advancedns"], required_hardware="true")
     def test_07_templates_per_project(self):
         """Test Templates limit per project
         """

--- a/test/integration/component/test_project_usage.py
+++ b/test/integration/component/test_project_usage.py
@@ -790,7 +790,7 @@ class TestTemplateUsage(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "basic", "sg", "eip", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "sg", "eip", "advancedns"], required_hardware="true")
     def test_01_template_usage(self):
         """Test Upload/ delete a template and verify correct usage is generated
             for the template uploaded
@@ -998,7 +998,7 @@ class TestISOUsage(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "basic", "sg", "eip", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "basic", "sg", "eip", "advancedns"], required_hardware="true")
     def test_01_ISO_usage(self):
         """Test Create/Delete a ISO and verify its usage is generated correctly
         """

--- a/test/integration/component/test_stopped_vm.py
+++ b/test/integration/component/test_stopped_vm.py
@@ -419,7 +419,7 @@ class TestDeployVM(cloudstackTestCase):
             "advancedns",
             "basic",
             "sg"],
-        required_hardware="false")
+        required_hardware="true")
     def test_07_deploy_startvm_attach_iso(self):
         """Test Deploy Virtual Machine with startVM=false and attach ISO
         """

--- a/test/integration/component/test_usage.py
+++ b/test/integration/component/test_usage.py
@@ -930,7 +930,7 @@ class TestISOUsage(cloudstackTestCase):
             "sg",
             "eip",
             "advancedns"],
-        required_hardware="false")
+        required_hardware="true")
     def test_01_ISO_usage(self):
         """Test Create/Delete a ISO and verify its usage is generated correctly
         """


### PR DESCRIPTION
Template and ISO download test cases should not be run on simulator as they require SSVM and secondary storage to be present.

On SImulator we are only testing management server code.

Added the tags accordingly.