### PR TITLE
CLOUDSTACK-8582: Modifying tag for test cases which should not be run on simulator

### DIFF
--- a/test/integration/component/test_VirtualRouter_alerts.py
+++ b/test/integration/component/test_VirtualRouter_alerts.py
@@ -112,7 +112,7 @@ class TestVRServiceFailureAlerting(cloudstackTestCase):
         return
 
     @attr(hypervisor="xenserver")
-    @attr(tags=["advanced", "basic"])
+    @attr(tags=["advanced", "basic"], required_hardware="true")
     def test_01_VRServiceFailureAlerting(self):
 
         if self.zone.networktype == "Basic":


### PR DESCRIPTION
The test case tries to ssh to router through host and take down the services. This is not a right candidate to run on simulator.