### PR TITLE
Add git status output to debug git fetch failures

### DIFF
--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -49,6 +49,9 @@ javac -version
 echo -e "\nMaven Version: "
 mvn -v
 
+echo -e "\nCheck Git status"
+git status
+
 echo -e "\nUpdating the system: "
 sudo apt-get -q -y update > /dev/null
 


### PR DESCRIPTION
The purpose of this is to visualize the git status output after git fetch, to identify possible problems that are stalling the build.
On a recent travis build stall, got this message from the downloadDeps.sh script plugin runs:

[ERROR] 
org.eclipse.jgit.errors.RevWalkException: Walk failure.
Caused by: org.eclipse.jgit.errors.MissingObjectException: Missing commit 6e068551d60b68288dd69e8248bcc5043e8e97e8

If fetching is actually having problems on some runs, the output of git status should provide more insight on it.