### PR TITLE
Using Profiler class, from the utils package, instead of System.currentTimeMillis()

### DIFF
--- a/framework/cluster/src/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/com/cloud/cluster/ClusterManagerImpl.java
@@ -261,11 +261,15 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                                         pdu.getSequenceId() + ", pdu ack seq: " + pdu.getAckSequenceId() + ", json: " + pdu.getJsonPackage());
                             }
 
-                            final long startTick = System.currentTimeMillis();
+                            final Profiler profiler = new Profiler();
+                            profiler.start();
+
                             final String strResult = peerService.execute(pdu);
+                            profiler.stop();
+
                             if (s_logger.isDebugEnabled()) {
                                 s_logger.debug("Cluster PDU " + getSelfPeerName() + " -> " + pdu.getDestPeer() + " completed. time: " +
-                                        (System.currentTimeMillis() - startTick) + "ms. agent: " + pdu.getAgentId() + ", pdu seq: " + pdu.getSequenceId() +
+                                        profiler.getDurationInMillis() + "ms. agent: " + pdu.getAgentId() + ", pdu seq: " + pdu.getSequenceId() +
                                         ", pdu ack seq: " + pdu.getAckSequenceId() + ", json: " + pdu.getJsonPackage());
                             }
 


### PR DESCRIPTION
Yesterday I found out that some methods' execution time are being measured based on System.currentTimeMillis() calls. We have a Profiler class, under the com.cloud.utils package, so I'm trying to make the use of that class consistent.

The PR is split in 2 commits: one for the formatting changes; and the other for applying the Profiler usage.