### PR TITLE
CLOUDSTACK-8582: Skipping unsuitable test cases for simulator

### DIFF
--- a/test/integration/component/test_ps_domain_limits.py
+++ b/test/integration/component/test_ps_domain_limits.py
@@ -194,7 +194,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
             return [FAIL, e, None]
         return [PASS, None, users]
 
-    @attr(tags=["advanced", "selfservice"])
+    @attr(tags=["advanced", "selfservice"], required_hardware="false")
     def test_01_multiple_domains_primary_storage_limits(self):
         """Test primary storage limit of domain and its sub-domains
 
@@ -536,7 +536,7 @@ class TestMultipleChildDomain(cloudstackTestCase):
                 self.fail("Failure: %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced"], required_hardware="true")
     def test_04_create_template_snapshot(self):
         """Test create snapshot and templates from volume
 

--- a/test/integration/component/test_ps_limits.py
+++ b/test/integration/component/test_ps_limits.py
@@ -495,7 +495,7 @@ class TestVolumeLimits(cloudstackTestCase):
 	return
 
     @data(ROOT_DOMAIN_ADMIN, CHILD_DOMAIN_ADMIN)
-    @attr(tags=["advanced"], required_hardware="false")
+    @attr(tags=["advanced"], required_hardware="true")
     def test_create_template_snapshot(self, value):
         """Test create snapshot and templates from volume
 

--- a/test/integration/component/test_templates.py
+++ b/test/integration/component/test_templates.py
@@ -504,7 +504,7 @@ class TestTemplates(cloudstackTestCase):
         return
 
     @attr(speed="slow")
-    @attr(tags=["advanced", "advancedns"], required_hardware="false")
+    @attr(tags=["advanced", "advancedns"], required_hardware="true")
     def test_04_template_from_snapshot(self):
         """Create Template from snapshot
         """

--- a/test/integration/component/test_volumes.py
+++ b/test/integration/component/test_volumes.py
@@ -705,7 +705,7 @@ class TestAttachVolumeISO(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "advancedns"])
+    @attr(tags=["advanced", "advancedns"], required_hardware="true")
     def test_01_volume_iso_attach(self):
         """Test Volumes and ISO attach
         """


### PR DESCRIPTION
Modifying tags for test cases which shouldn't be run on simulator (Test cases requiring download of templates/ISOs and creation of templates from snapshots)