### PR TITLE
findbugs equals(obj) implementations go against the contract

### DIFF
--- a/engine/storage/src/org/apache/cloudstack/storage/BaseType.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/BaseType.java
@@ -23,18 +23,23 @@ public abstract class BaseType {
     public boolean equals(Object that) {
         if (this == that) {
             return true;
-        }
-        if (that instanceof String) {
-            if (this.toString().equalsIgnoreCase((String)that)) {
-                return true;
-            }
         } else if (that instanceof BaseType) {
             BaseType th = (BaseType)that;
             if (this.toString().equalsIgnoreCase(th.toString())) {
                 return true;
             }
-        } else {
-            return false;
+        }
+        return false;
+    }
+
+    public boolean isSameTypeAs(Object that) {
+        if (this.equals(that)){
+            return true;
+        }
+        if (that instanceof String) {
+            if (this.toString().equalsIgnoreCase((String)that)) {
+                return true;
+            }
         }
         return false;
     }

--- a/engine/storage/src/org/apache/cloudstack/storage/BaseType.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/BaseType.java
@@ -25,19 +25,24 @@ public abstract class BaseType {
             return true;
         } else if (that instanceof BaseType) {
             BaseType th = (BaseType)that;
-            if (this.toString().equalsIgnoreCase(th.toString())) {
+            if (toString().equalsIgnoreCase(th.toString())) {
                 return true;
             }
         }
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return toString().toLowerCase().hashCode();
+    }
+
     public boolean isSameTypeAs(Object that) {
-        if (this.equals(that)){
+        if (equals(that)){
             return true;
         }
         if (that instanceof String) {
-            if (this.toString().equalsIgnoreCase((String)that)) {
+            if (toString().equalsIgnoreCase((String)that)) {
                 return true;
             }
         }

--- a/engine/storage/test/org/apache/cloudstack/storage/BaseTypeTest.java
+++ b/engine/storage/test/org/apache/cloudstack/storage/BaseTypeTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.storage;
 
 import org.junit.Assert;

--- a/engine/storage/test/org/apache/cloudstack/storage/BaseTypeTest.java
+++ b/engine/storage/test/org/apache/cloudstack/storage/BaseTypeTest.java
@@ -1,0 +1,32 @@
+package org.apache.cloudstack.storage;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.testing.EqualsTester;
+
+public class BaseTypeTest {
+    @Test
+    public void testEquals() {
+        new EqualsTester()
+                .addEqualityGroup(new TestType("a"), new TestType("A"))
+                .addEqualityGroup(new TestType("Bd"), new TestType("bD"))
+                .testEquals();
+    }
+
+    @Test
+    public void testIsSameTypeAs() {
+        Assert.assertTrue("'a' and 'A' should be considdered the same type", new TestType("a").isSameTypeAs("A"));
+        Assert.assertTrue("'B' and 'b' should be considdered the same address", new TestType("B").isSameTypeAs(new TestType("b")));
+    }
+    class TestType extends BaseType {
+        String content;
+        public TestType(String t) {
+            content = t;
+        }
+        @Override
+        public String toString() {
+            return content;
+        }
+    }
+}

--- a/framework/config/src/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -122,6 +122,13 @@ public class ConfigKey<T> {
         if (obj instanceof ConfigKey) {
             ConfigKey<?> that = (ConfigKey<?>)obj;
             return this._name.equals(that._name);
+        }
+        return false;
+    }
+
+    public boolean isSameKeyAs(Object obj) {
+        if(this.equals(obj)) {
+            return true;
         } else if (obj instanceof String) {
             String key = (String)obj;
             return key.equals(_name);

--- a/framework/config/test/org/apache/cloudstack/framework/config/ConfigKeyTest.java
+++ b/framework/config/test/org/apache/cloudstack/framework/config/ConfigKeyTest.java
@@ -1,0 +1,34 @@
+package org.apache.cloudstack.framework.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.testing.EqualsTester;
+
+import org.apache.cloudstack.framework.config.ConfigKey.Scope;
+
+import com.cloud.utils.exception.CloudRuntimeException;
+
+public class ConfigKeyTest {
+    @Test
+    public void testEquals() {
+        new EqualsTester()
+                .addEqualityGroup(new ConfigKey("cat", String.class, "naam", "nick", "bijnaam", true, Scope.Cluster),
+                        new ConfigKey("hond", Boolean.class, "naam", "truus", "thrown name", false),
+                        new ConfigKey(Long.class, "naam", "vis", "goud", "zwemt", true, Scope.Account, 3L)
+                )
+                .testEquals();
+    }
+
+    @Test
+    public void testIsSameKeyAs() {
+        ConfigKey key = new ConfigKey("cat", String.class, "naam", "nick", "bijnaam", true, Scope.Cluster);
+        Assert.assertTrue("1 and one should be considdered the same address", key.isSameKeyAs("naam"));
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testIsSameKeyAsThrowingCloudRuntimeException() {
+        ConfigKey key = new ConfigKey("hond", Boolean.class, "naam", "truus", "thrown name", false);
+        Assert.assertFalse("zero and 0L should be considdered the same address", key.isSameKeyAs(0L));
+    }
+}

--- a/framework/config/test/org/apache/cloudstack/framework/config/ConfigKeyTest.java
+++ b/framework/config/test/org/apache/cloudstack/framework/config/ConfigKeyTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.framework.config;
 
 import org.junit.Assert;

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <cs.trilead.version>1.0.0-build217</cs.trilead.version>
     <cs.ehcache.version>2.6.9</cs.ehcache.version>
     <cs.gson.version>1.7.2</cs.gson.version>
+    <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
     <cs.guava.version>18.0</cs.guava.version>
     <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
     <cs.httpclient.version>4.3.6</cs.httpclient.version>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -162,6 +162,11 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <version>${cs.guava-testlib.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/utils/src/com/cloud/utils/net/Ip.java
+++ b/utils/src/com/cloud/utils/net/Ip.java
@@ -75,6 +75,13 @@ public class Ip implements Serializable, Comparable<Ip> {
     public boolean equals(Object obj) {
         if (obj instanceof Ip) {
             return ip == ((Ip)obj).ip;
+        }
+        return false;
+    }
+
+    public boolean isSameAddressAs(Object obj) {
+        if (this.equals(obj)) {
+            return true;
         } else if (obj instanceof String) {
             return ip == NetUtils.ip2Long((String)obj);
         } else if (obj instanceof Long) {

--- a/utils/src/com/cloud/utils/net/Ip4Address.java
+++ b/utils/src/com/cloud/utils/net/Ip4Address.java
@@ -55,15 +55,23 @@ public class Ip4Address {
 
     @Override
     public boolean equals(Object that) {
-        if (that instanceof String) { // Assume that is an ip4 address in String form
-            return _addr.equals(that);
-        } else if (that instanceof Ip4Address) {
+
+        if (that instanceof Ip4Address) {
             Ip4Address ip4 = (Ip4Address)that;
             return this._addr.equals(ip4._addr) && (this._mac == ip4._mac || this._mac.equals(ip4._mac));
         } else {
             return false;
         }
     }
+
+    public boolean isSameAddressAs(Object other) {
+        if (other instanceof String) { // Assume that is an ip4 address in String form
+            return _addr.equals(other);
+        } else {
+            return this.equals(other);
+        }
+    }
+
     @Override
     public int hashCode(){
         return (int)(_mac.hashCode()*_addr.hashCode());

--- a/utils/src/com/cloud/utils/net/Ip4Address.java
+++ b/utils/src/com/cloud/utils/net/Ip4Address.java
@@ -22,6 +22,7 @@ package com.cloud.utils.net;
 public class Ip4Address {
     String _addr;
     String _mac;
+    static final String s_empty_mac = "00:00:00:00:00:00";
 
     public Ip4Address(String addr, String mac) {
         _addr = addr;
@@ -34,11 +35,11 @@ public class Ip4Address {
     }
 
     public Ip4Address(String addr) {
-        this(addr, null);
+        this(addr, s_empty_mac);
     }
 
     public Ip4Address(long addr) {
-        this(NetUtils.long2Ip(addr), null);
+        this(NetUtils.long2Ip(addr), s_empty_mac);
     }
 
     public String ip4() {
@@ -58,7 +59,7 @@ public class Ip4Address {
 
         if (that instanceof Ip4Address) {
             Ip4Address ip4 = (Ip4Address)that;
-            return this._addr.equals(ip4._addr) && (this._mac == ip4._mac || this._mac.equals(ip4._mac));
+            return _addr.equals(ip4._addr) && (_mac == ip4._mac || _mac.equals(ip4._mac));
         } else {
             return false;
         }
@@ -68,12 +69,12 @@ public class Ip4Address {
         if (other instanceof String) { // Assume that is an ip4 address in String form
             return _addr.equals(other);
         } else {
-            return this.equals(other);
+            return equals(other);
         }
     }
 
     @Override
     public int hashCode(){
-        return (int)(_mac.hashCode()*_addr.hashCode());
+        return _mac.hashCode()*_addr.hashCode();
     }
 }

--- a/utils/test/com/cloud/utils/net/Ip4AddressTest.java
+++ b/utils/test/com/cloud/utils/net/Ip4AddressTest.java
@@ -1,0 +1,24 @@
+package com.cloud.utils.net;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.testing.EqualsTester;
+
+public class Ip4AddressTest {
+
+    @Test
+    public void testEquals() throws Exception {
+        new EqualsTester()
+                .addEqualityGroup(new Ip4Address("0.0.0.1", "00:00:00:00:00:02"), new Ip4Address(1L, 2L))
+                .addEqualityGroup(new Ip4Address("0.0.0.1", "00:00:00:00:00:00"), new Ip4Address(1L, 0L), new Ip4Address(1L, 0L), new Ip4Address(1L), new Ip4Address("0.0.0.1"))
+                .testEquals();
+    }
+
+    @Test
+    public void testIsSameAddressAs() {
+        Assert.assertTrue("1 and one should be considdered the same address", new Ip4Address(1L, 5L).isSameAddressAs("0.0.0.1"));
+        Assert.assertFalse("zero and 0L should be considdered the same address but a Long won't be accepted", new Ip4Address("0.0.0.0", "00:00:00:00:00:08").isSameAddressAs(0L));
+    }
+
+}

--- a/utils/test/com/cloud/utils/net/Ip4AddressTest.java
+++ b/utils/test/com/cloud/utils/net/Ip4AddressTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.utils.net;
 
 import org.junit.Assert;

--- a/utils/test/com/cloud/utils/net/IpTest.java
+++ b/utils/test/com/cloud/utils/net/IpTest.java
@@ -21,7 +21,10 @@ package com.cloud.utils.net;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.common.testing.EqualsTester;
 
 public class IpTest {
 
@@ -41,6 +44,20 @@ public class IpTest {
     public void testStart() {
         Ip min = new Ip(0);
         assertEquals("Minimal address not created", "0.0.0.0", min.addr());
+    }
+
+    @Test
+    public void testEquals() {
+        new EqualsTester()
+                .addEqualityGroup(new Ip("0.0.0.1"), new Ip(1L))
+                .addEqualityGroup(new Ip("0.0.0.0"), new Ip(0L))
+                .testEquals();
+    }
+
+    @Test
+    public void testIsSameAddressAs() {
+        Assert.assertTrue("1 and one should be considdered the same address", new Ip(1L).isSameAddressAs("0.0.0.1"));
+        Assert.assertTrue("zero and 0L should be considdered the same address", new Ip("0.0.0.0").isSameAddressAs(0L));
     }
 
 }


### PR DESCRIPTION
  these are removed from the call into separate calls
This might very well spectacularly fail in integration tests. really looking forward to see that;)