### PR TITLE
CLOUDSTACK-8598. CS reports migration as successful but the volume is…

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -3347,7 +3347,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     }
 
     private int getVirtualDiskInfo(VirtualMachineMO vmMo, String srcDiskName) throws Exception {
-        Pair<VirtualDisk, String> deviceInfo = vmMo.getDiskDevice(srcDiskName, false);
+        Pair<VirtualDisk, String> deviceInfo = vmMo.getDiskDevice(srcDiskName, true);
         if (deviceInfo == null) {
             throw new Exception("No such disk device: " + srcDiskName);
         }


### PR DESCRIPTION
… not migrated in vCenter.

During migration, CS should do an exact disk match between volume path and vCenter disk name.