### PR TITLE
CLOUDSTACK-8590 Refactoring NiciraNVP resource

### DIFF
--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpRequestWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpRequestWrapper.java
@@ -16,6 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+
 package com.cloud.network.resource;
 
 import java.util.Hashtable;

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpRequestWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpRequestWrapper.java
@@ -48,9 +48,9 @@ public class NiciraNvpRequestWrapper extends RequestWrapper {
     @SuppressWarnings("rawtypes")
     private void init() {
         // NiciraNvpResource commands
-        final Hashtable<Class<? extends Command>, CommandWrapper> libvirtCommands = processAnnotations(baseSet);
+        final Hashtable<Class<? extends Command>, CommandWrapper> niciraCommands = processAnnotations(baseSet);
 
-        resources.put(NiciraNvpResource.class, libvirtCommands);
+        resources.put(NiciraNvpResource.class, niciraCommands);
     }
 
     public static NiciraNvpRequestWrapper getInstance() {

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpRequestWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpRequestWrapper.java
@@ -1,0 +1,76 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.network.resource;
+
+import java.util.Hashtable;
+import java.util.Set;
+
+import org.reflections.Reflections;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.Command;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.RequestWrapper;
+import com.cloud.resource.ServerResource;
+
+public class NiciraNvpRequestWrapper extends RequestWrapper {
+
+    private static NiciraNvpRequestWrapper instance;
+
+    static {
+        instance = new NiciraNvpRequestWrapper();
+    }
+
+    Reflections baseWrappers = new Reflections("com.cloud.network.resource.wrapper");
+    @SuppressWarnings("rawtypes")
+    Set<Class<? extends CommandWrapper>> baseSet = baseWrappers.getSubTypesOf(CommandWrapper.class);
+
+    private NiciraNvpRequestWrapper() {
+        init();
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void init() {
+        // NiciraNvpResource commands
+        final Hashtable<Class<? extends Command>, CommandWrapper> libvirtCommands = processAnnotations(baseSet);
+
+        resources.put(NiciraNvpResource.class, libvirtCommands);
+    }
+
+    public static NiciraNvpRequestWrapper getInstance() {
+        return instance;
+    }
+
+    @SuppressWarnings({"rawtypes" })
+    @Override
+    public Answer execute(final Command command, final ServerResource serverResource) {
+        final Class<? extends ServerResource> resourceClass = serverResource.getClass();
+
+        final Hashtable<Class<? extends Command>, CommandWrapper> resourceCommands = retrieveResource(command, resourceClass);
+
+        CommandWrapper<Command, Answer, ServerResource> commandWrapper = retrieveCommands(command.getClass(), resourceCommands);
+
+        while (commandWrapper == null) {
+            //Could not find the command in the given resource, will traverse the family tree.
+            commandWrapper = retryWhenAllFails(command, resourceClass, resourceCommands);
+        }
+
+        return commandWrapper.execute(command, serverResource);
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpResource.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpResource.java
@@ -50,8 +50,6 @@ import com.cloud.agent.api.DeleteLogicalSwitchPortAnswer;
 import com.cloud.agent.api.DeleteLogicalSwitchPortCommand;
 import com.cloud.agent.api.FindLogicalSwitchPortAnswer;
 import com.cloud.agent.api.FindLogicalSwitchPortCommand;
-import com.cloud.agent.api.MaintainAnswer;
-import com.cloud.agent.api.MaintainCommand;
 import com.cloud.agent.api.PingCommand;
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.agent.api.StartupNiciraNvpCommand;
@@ -204,9 +202,7 @@ public class NiciraNvpResource implements ServerResource {
             // [TODO] Remove when all the commands are refactored.
         }
 
-        if (cmd instanceof MaintainCommand) {
-            return executeRequest((MaintainCommand)cmd);
-        } else if (cmd instanceof CreateLogicalSwitchCommand) {
+        if (cmd instanceof CreateLogicalSwitchCommand) {
             return executeRequest((CreateLogicalSwitchCommand)cmd, numRetries);
         } else if (cmd instanceof DeleteLogicalSwitchCommand) {
             return executeRequest((DeleteLogicalSwitchCommand)cmd, numRetries);
@@ -648,10 +644,6 @@ public class NiciraNvpResource implements ServerResource {
             }
         }
 
-    }
-
-    private Answer executeRequest(final MaintainCommand cmd) {
-        return new MaintainAnswer(cmd);
     }
 
     private Answer retry(final Command cmd, final int numRetries) {

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpResource.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpResource.java
@@ -40,8 +40,6 @@ import com.cloud.agent.api.CreateLogicalRouterAnswer;
 import com.cloud.agent.api.CreateLogicalRouterCommand;
 import com.cloud.agent.api.DeleteLogicalRouterAnswer;
 import com.cloud.agent.api.DeleteLogicalRouterCommand;
-import com.cloud.agent.api.DeleteLogicalSwitchPortAnswer;
-import com.cloud.agent.api.DeleteLogicalSwitchPortCommand;
 import com.cloud.agent.api.FindLogicalSwitchPortAnswer;
 import com.cloud.agent.api.FindLogicalSwitchPortCommand;
 import com.cloud.agent.api.PingCommand;
@@ -207,9 +205,7 @@ public class NiciraNvpResource implements ServerResource {
             // [TODO] Remove when all the commands are refactored.
         }
 
-        if (cmd instanceof DeleteLogicalSwitchPortCommand) {
-            return executeRequest((DeleteLogicalSwitchPortCommand)cmd, NUM_RETRIES);
-        } else if (cmd instanceof UpdateLogicalSwitchPortCommand) {
+        if (cmd instanceof UpdateLogicalSwitchPortCommand) {
             return executeRequest((UpdateLogicalSwitchPortCommand)cmd, NUM_RETRIES);
         } else if (cmd instanceof FindLogicalSwitchPortCommand) {
             return executeRequest((FindLogicalSwitchPortCommand)cmd, NUM_RETRIES);
@@ -239,16 +235,6 @@ public class NiciraNvpResource implements ServerResource {
 
     @Override
     public void setAgentControl(final IAgentControl agentControl) {
-    }
-
-    private Answer executeRequest(final DeleteLogicalSwitchPortCommand cmd, final int numRetries) {
-        try {
-            niciraNvpApi.deleteLogicalSwitchPort(cmd.getLogicalSwitchUuid(), cmd.getLogicalSwitchPortUuid());
-            return new DeleteLogicalSwitchPortAnswer(cmd, true, "Logical switch port " + cmd.getLogicalSwitchPortUuid() + " deleted");
-        } catch (final NiciraNvpApiException e) {
-            retryUtility.addRetry(cmd, NUM_RETRIES);
-            return retryUtility.retry(cmd, DeleteLogicalSwitchPortAnswer.class, e);
-        }
     }
 
     private Answer executeRequest(final UpdateLogicalSwitchPortCommand cmd, final int numRetries) {

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
@@ -1,0 +1,42 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.network.resource;
+
+import com.cloud.network.nicira.LogicalSwitch;
+
+public class NiciraNvpUtilities {
+
+    private static NiciraNvpUtilities instance;
+
+    static {
+        instance = new NiciraNvpUtilities();
+    }
+
+    private NiciraNvpUtilities() {
+    }
+
+    public static NiciraNvpUtilities getInstance() {
+        return instance;
+    }
+
+    public LogicalSwitch createLogicalSwitch() {
+        final LogicalSwitch logicalSwitch = new LogicalSwitch();
+        return logicalSwitch;
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
@@ -16,6 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+
 package com.cloud.network.resource;
 
 import java.util.ArrayList;

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
@@ -26,6 +26,7 @@ import com.cloud.agent.api.CreateLogicalSwitchPortCommand;
 import com.cloud.network.nicira.LogicalSwitch;
 import com.cloud.network.nicira.LogicalSwitchPort;
 import com.cloud.network.nicira.NiciraNvpTag;
+import com.cloud.network.nicira.VifAttachment;
 
 public class NiciraNvpUtilities {
 
@@ -56,5 +57,9 @@ public class NiciraNvpUtilities {
 
         final LogicalSwitchPort logicalSwitchPort = new LogicalSwitchPort(attachmentUuid, tags, true);
         return logicalSwitchPort;
+    }
+
+    public VifAttachment createVifAttachment(final String attachmentUuid) {
+        return new VifAttachment(attachmentUuid);
     }
 }

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/NiciraNvpUtilities.java
@@ -18,7 +18,13 @@
 //
 package com.cloud.network.resource;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.cloud.agent.api.CreateLogicalSwitchPortCommand;
 import com.cloud.network.nicira.LogicalSwitch;
+import com.cloud.network.nicira.LogicalSwitchPort;
+import com.cloud.network.nicira.NiciraNvpTag;
 
 public class NiciraNvpUtilities {
 
@@ -38,5 +44,16 @@ public class NiciraNvpUtilities {
     public LogicalSwitch createLogicalSwitch() {
         final LogicalSwitch logicalSwitch = new LogicalSwitch();
         return logicalSwitch;
+    }
+
+    public LogicalSwitchPort createLogicalSwitchPort(final CreateLogicalSwitchPortCommand command) {
+        final String attachmentUuid = command.getAttachmentUuid();
+
+        // Tags set to scope cs_account and account name
+        final List<NiciraNvpTag> tags = new ArrayList<NiciraNvpTag>();
+        tags.add(new NiciraNvpTag("cs_account", command.getOwnerName()));
+
+        final LogicalSwitchPort logicalSwitchPort = new LogicalSwitchPort(attachmentUuid, tags, true);
+        return logicalSwitchPort;
     }
 }

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpConfigurePortForwardingRulesCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpConfigurePortForwardingRulesCommandWrapper.java
@@ -1,0 +1,120 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ConfigurePortForwardingRulesOnLogicalRouterAnswer;
+import com.cloud.agent.api.ConfigurePortForwardingRulesOnLogicalRouterCommand;
+import com.cloud.agent.api.to.PortForwardingRuleTO;
+import com.cloud.network.nicira.NatRule;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.nicira.NiciraNvpList;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  ConfigurePortForwardingRulesOnLogicalRouterCommand.class)
+public final class NiciraNvpConfigurePortForwardingRulesCommandWrapper extends CommandWrapper<ConfigurePortForwardingRulesOnLogicalRouterCommand, Answer, NiciraNvpResource> {
+
+    private static final Logger s_logger = Logger.getLogger(NiciraNvpConfigurePortForwardingRulesCommandWrapper.class);
+
+    @Override
+    public Answer execute(final ConfigurePortForwardingRulesOnLogicalRouterCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+        try {
+            final NiciraNvpList<NatRule> existingRules = niciraNvpApi.findNatRulesByLogicalRouterUuid(command.getLogicalRouterUuid());
+            // Rules of the game (also known as assumptions-that-will-make-stuff-break-later-on)
+            // A SourceNat rule with a match other than a /32 cidr is assumed to be the "main" SourceNat rule
+            // Any other SourceNat rule should have a corresponding DestinationNat rule
+
+            for (final PortForwardingRuleTO rule : command.getRules()) {
+                if (rule.isAlreadyAdded() && !rule.revoked()) {
+                    // Don't need to do anything
+                    continue;
+                }
+
+                if (rule.getDstPortRange()[0] != rule.getDstPortRange()[1] || rule.getSrcPortRange()[0] != rule.getSrcPortRange()[1]) {
+                    return new ConfigurePortForwardingRulesOnLogicalRouterAnswer(command, false, "Nicira NVP doesn't support port ranges for port forwarding");
+                }
+
+                final NatRule[] rulepair = niciraNvpResource.generatePortForwardingRulePair(rule.getDstIp(), rule.getDstPortRange(), rule.getSrcIp(), rule.getSrcPortRange(), rule.getProtocol());
+
+                NatRule incoming = null;
+                NatRule outgoing = null;
+
+                for (final NatRule storedRule : existingRules.getResults()) {
+                    if (storedRule.equalsIgnoreUuid(rulepair[1])) {
+                        // The outgoing rule exists
+                        outgoing = storedRule;
+                        s_logger.debug("Found matching outgoing rule " + outgoing.getUuid());
+                        if (incoming != null) {
+                            break;
+                        }
+                    } else if (storedRule.equalsIgnoreUuid(rulepair[0])) {
+                        // The incoming rule exists
+                        incoming = storedRule;
+                        s_logger.debug("Found matching incoming rule " + incoming.getUuid());
+                        if (outgoing != null) {
+                            break;
+                        }
+                    }
+                }
+                if (incoming != null && outgoing != null) {
+                    if (rule.revoked()) {
+                        s_logger.debug("Deleting incoming rule " + incoming.getUuid());
+                        niciraNvpApi.deleteLogicalRouterNatRule(command.getLogicalRouterUuid(), incoming.getUuid());
+
+                        s_logger.debug("Deleting outgoing rule " + outgoing.getUuid());
+                        niciraNvpApi.deleteLogicalRouterNatRule(command.getLogicalRouterUuid(), outgoing.getUuid());
+                    }
+                } else {
+                    if (rule.revoked()) {
+                        s_logger.warn("Tried deleting a rule that does not exist, " + rule.getSrcIp() + " -> " + rule.getDstIp());
+                        break;
+                    }
+
+                    rulepair[0] = niciraNvpApi.createLogicalRouterNatRule(command.getLogicalRouterUuid(), rulepair[0]);
+                    s_logger.debug("Created " + niciraNvpResource.natRuleToString(rulepair[0]));
+
+                    try {
+                        rulepair[1] = niciraNvpApi.createLogicalRouterNatRule(command.getLogicalRouterUuid(), rulepair[1]);
+                        s_logger.debug("Created " + niciraNvpResource.natRuleToString(rulepair[1]));
+                    } catch (final NiciraNvpApiException ex) {
+                        s_logger.warn("NiciraNvpApiException during create call, rolling back previous create");
+                        niciraNvpApi.deleteLogicalRouterNatRule(command.getLogicalRouterUuid(), rulepair[0].getUuid());
+                        throw ex; // Rethrow the original exception
+                    }
+
+                }
+            }
+            return new ConfigurePortForwardingRulesOnLogicalRouterAnswer(command, true, command.getRules().size() + " PortForwarding rules applied");
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, ConfigurePortForwardingRulesOnLogicalRouterAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpConfigurePublicIpsCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpConfigurePublicIpsCommandWrapper.java
@@ -1,0 +1,60 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ConfigurePublicIpsOnLogicalRouterAnswer;
+import com.cloud.agent.api.ConfigurePublicIpsOnLogicalRouterCommand;
+import com.cloud.network.nicira.LogicalRouterPort;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.nicira.NiciraNvpList;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  ConfigurePublicIpsOnLogicalRouterCommand.class)
+public final class NiciraNvpConfigurePublicIpsCommandWrapper extends CommandWrapper<ConfigurePublicIpsOnLogicalRouterCommand, Answer, NiciraNvpResource> {
+
+    @Override
+    public Answer execute(final ConfigurePublicIpsOnLogicalRouterCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+
+        try {
+            final NiciraNvpList<LogicalRouterPort> ports = niciraNvpApi.findLogicalRouterPortByGatewayServiceUuid(command.getLogicalRouterUuid(), command.getL3GatewayServiceUuid());
+            if (ports.getResultCount() != 1) {
+                return new ConfigurePublicIpsOnLogicalRouterAnswer(command, false, "No logical router ports found, unable to set ip addresses");
+            }
+            final LogicalRouterPort lrp = ports.getResults().get(0);
+            lrp.setIpAddresses(command.getPublicCidrs());
+            niciraNvpApi.updateLogicalRouterPort(command.getLogicalRouterUuid(), lrp);
+
+            return new ConfigurePublicIpsOnLogicalRouterAnswer(command, true, "Configured " + command.getPublicCidrs().size() + " ip addresses on logical router uuid " +
+                    command.getLogicalRouterUuid());
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, ConfigurePublicIpsOnLogicalRouterAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpConfigureStaticNatRulesCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpConfigureStaticNatRulesCommandWrapper.java
@@ -1,0 +1,113 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ConfigureStaticNatRulesOnLogicalRouterAnswer;
+import com.cloud.agent.api.ConfigureStaticNatRulesOnLogicalRouterCommand;
+import com.cloud.agent.api.to.StaticNatRuleTO;
+import com.cloud.network.nicira.NatRule;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.nicira.NiciraNvpList;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  ConfigureStaticNatRulesOnLogicalRouterCommand.class)
+public final class NiciraNvpConfigureStaticNatRulesCommandWrapper extends CommandWrapper<ConfigureStaticNatRulesOnLogicalRouterCommand, Answer, NiciraNvpResource> {
+
+    private static final Logger s_logger = Logger.getLogger(NiciraNvpConfigureStaticNatRulesCommandWrapper.class);
+
+    @Override
+    public Answer execute(final ConfigureStaticNatRulesOnLogicalRouterCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+
+        try {
+            final NiciraNvpList<NatRule> existingRules = niciraNvpApi.findNatRulesByLogicalRouterUuid(command.getLogicalRouterUuid());
+            // Rules of the game (also known as assumptions-that-will-make-stuff-break-later-on)
+            // A SourceNat rule with a match other than a /32 cidr is assumed to be the "main" SourceNat rule
+            // Any other SourceNat rule should have a corresponding DestinationNat rule
+
+            for (final StaticNatRuleTO rule : command.getRules()) {
+
+                final NatRule[] rulepair = niciraNvpResource.generateStaticNatRulePair(rule.getDstIp(), rule.getSrcIp());
+
+                NatRule incoming = null;
+                NatRule outgoing = null;
+
+                for (final NatRule storedRule : existingRules.getResults()) {
+                    if (storedRule.equalsIgnoreUuid(rulepair[1])) {
+                        // The outgoing rule exists
+                        outgoing = storedRule;
+                        s_logger.debug("Found matching outgoing rule " + outgoing.getUuid());
+                        if (incoming != null) {
+                            break;
+                        }
+                    } else if (storedRule.equalsIgnoreUuid(rulepair[0])) {
+                        // The incoming rule exists
+                        incoming = storedRule;
+                        s_logger.debug("Found matching incoming rule " + incoming.getUuid());
+                        if (outgoing != null) {
+                            break;
+                        }
+                    }
+                }
+                if (incoming != null && outgoing != null) {
+                    if (rule.revoked()) {
+                        s_logger.debug("Deleting incoming rule " + incoming.getUuid());
+                        niciraNvpApi.deleteLogicalRouterNatRule(command.getLogicalRouterUuid(), incoming.getUuid());
+
+                        s_logger.debug("Deleting outgoing rule " + outgoing.getUuid());
+                        niciraNvpApi.deleteLogicalRouterNatRule(command.getLogicalRouterUuid(), outgoing.getUuid());
+                    }
+                } else {
+                    if (rule.revoked()) {
+                        s_logger.warn("Tried deleting a rule that does not exist, " + rule.getSrcIp() + " -> " + rule.getDstIp());
+                        break;
+                    }
+
+                    rulepair[0] = niciraNvpApi.createLogicalRouterNatRule(command.getLogicalRouterUuid(), rulepair[0]);
+                    s_logger.debug("Created " + niciraNvpResource.natRuleToString(rulepair[0]));
+
+                    try {
+                        rulepair[1] = niciraNvpApi.createLogicalRouterNatRule(command.getLogicalRouterUuid(), rulepair[1]);
+                        s_logger.debug("Created " + niciraNvpResource.natRuleToString(rulepair[1]));
+                    } catch (final NiciraNvpApiException ex) {
+                        s_logger.debug("Failed to create SourceNatRule, rolling back DestinationNatRule");
+                        niciraNvpApi.deleteLogicalRouterNatRule(command.getLogicalRouterUuid(), rulepair[0].getUuid());
+                        throw ex; // Rethrow original exception
+                    }
+
+                }
+            }
+            return new ConfigureStaticNatRulesOnLogicalRouterAnswer(command, true, command.getRules().size() + " StaticNat rules applied");
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, ConfigureStaticNatRulesOnLogicalRouterAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalRouterCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalRouterCommandWrapper.java
@@ -1,0 +1,152 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NAME_MAX_LEN;
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.CreateLogicalRouterAnswer;
+import com.cloud.agent.api.CreateLogicalRouterCommand;
+import com.cloud.network.nicira.L3GatewayAttachment;
+import com.cloud.network.nicira.LogicalRouter;
+import com.cloud.network.nicira.LogicalRouterPort;
+import com.cloud.network.nicira.LogicalSwitchPort;
+import com.cloud.network.nicira.Match;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.nicira.NiciraNvpTag;
+import com.cloud.network.nicira.PatchAttachment;
+import com.cloud.network.nicira.RouterNextHop;
+import com.cloud.network.nicira.SingleDefaultRouteImplicitRoutingConfig;
+import com.cloud.network.nicira.SourceNatRule;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  CreateLogicalRouterCommand.class)
+public final class NiciraNvpCreateLogicalRouterCommandWrapper extends CommandWrapper<CreateLogicalRouterCommand, Answer, NiciraNvpResource> {
+
+    private static final Logger s_logger = Logger.getLogger(NiciraNvpCreateLogicalRouterCommandWrapper.class);
+
+    @Override
+    public Answer execute(final CreateLogicalRouterCommand command, final NiciraNvpResource niciraNvpResource) {
+        final String routerName = command.getName();
+        final String gatewayServiceUuid = command.getGatewayServiceUuid();
+        final String logicalSwitchUuid = command.getLogicalSwitchUuid();
+
+        final List<NiciraNvpTag> tags = new ArrayList<NiciraNvpTag>();
+        tags.add(new NiciraNvpTag("cs_account", command.getOwnerName()));
+
+        final String publicNetworkNextHopIp = command.getPublicNextHop();
+        final String publicNetworkIpAddress = command.getPublicIpCidr();
+        final String internalNetworkAddress = command.getInternalIpCidr();
+
+        s_logger.debug("Creating a logical router with external ip " + publicNetworkIpAddress + " and internal ip " + internalNetworkAddress + "on gateway service " +
+                gatewayServiceUuid);
+
+        final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+
+        try {
+            // Create the Router
+            LogicalRouter lrc = new LogicalRouter();
+            lrc.setDisplayName(niciraNvpResource.truncate(routerName, NAME_MAX_LEN));
+            lrc.setTags(tags);
+            lrc.setRoutingConfig(new SingleDefaultRouteImplicitRoutingConfig(new RouterNextHop(publicNetworkNextHopIp)));
+            lrc = niciraNvpApi.createLogicalRouter(lrc);
+
+            // store the switchport for rollback
+            LogicalSwitchPort lsp = null;
+
+            try {
+                // Create the outside port for the router
+                LogicalRouterPort lrpo = new LogicalRouterPort();
+                lrpo.setAdminStatusEnabled(true);
+                lrpo.setDisplayName(niciraNvpResource.truncate(routerName + "-outside-port", NAME_MAX_LEN));
+                lrpo.setTags(tags);
+                final List<String> outsideIpAddresses = new ArrayList<String>();
+                outsideIpAddresses.add(publicNetworkIpAddress);
+                lrpo.setIpAddresses(outsideIpAddresses);
+                lrpo = niciraNvpApi.createLogicalRouterPort(lrc.getUuid(), lrpo);
+
+                // Attach the outside port to the gateway service on the correct VLAN
+                final L3GatewayAttachment attachment = new L3GatewayAttachment(gatewayServiceUuid);
+                if (command.getVlanId() != 0) {
+                    attachment.setVlanId(command.getVlanId());
+                }
+                niciraNvpApi.updateLogicalRouterPortAttachment(lrc.getUuid(), lrpo.getUuid(), attachment);
+
+                // Create the inside port for the router
+                LogicalRouterPort lrpi = new LogicalRouterPort();
+                lrpi.setAdminStatusEnabled(true);
+                lrpi.setDisplayName(niciraNvpResource.truncate(routerName + "-inside-port", NAME_MAX_LEN));
+                lrpi.setTags(tags);
+                final List<String> insideIpAddresses = new ArrayList<String>();
+                insideIpAddresses.add(internalNetworkAddress);
+                lrpi.setIpAddresses(insideIpAddresses);
+                lrpi = niciraNvpApi.createLogicalRouterPort(lrc.getUuid(), lrpi);
+
+                // Create the inside port on the lswitch
+                lsp = new LogicalSwitchPort(niciraNvpResource.truncate(routerName + "-inside-port", NAME_MAX_LEN), tags, true);
+                lsp = niciraNvpApi.createLogicalSwitchPort(logicalSwitchUuid, lsp);
+
+                // Attach the inside router port to the lswitch port with a PatchAttachment
+                niciraNvpApi.updateLogicalRouterPortAttachment(lrc.getUuid(), lrpi.getUuid(), new PatchAttachment(lsp.getUuid()));
+
+                // Attach the inside lswitch port to the router with a PatchAttachment
+                niciraNvpApi.updateLogicalSwitchPortAttachment(logicalSwitchUuid, lsp.getUuid(), new PatchAttachment(lrpi.getUuid()));
+
+                // Setup the source nat rule
+                final SourceNatRule snr = new SourceNatRule();
+                snr.setToSourceIpAddressMin(publicNetworkIpAddress.split("/")[0]);
+                snr.setToSourceIpAddressMax(publicNetworkIpAddress.split("/")[0]);
+                final Match match = new Match();
+                match.setSourceIpAddresses(internalNetworkAddress);
+                snr.setMatch(match);
+                snr.setOrder(200);
+                niciraNvpApi.createLogicalRouterNatRule(lrc.getUuid(), snr);
+            } catch (final NiciraNvpApiException e) {
+                // We need to destroy the router if we already created it
+                // this will also take care of any router ports and rules
+                try {
+                    niciraNvpApi.deleteLogicalRouter(lrc.getUuid());
+                    if (lsp != null) {
+                        niciraNvpApi.deleteLogicalSwitchPort(logicalSwitchUuid, lsp.getUuid());
+                    }
+                } catch (final NiciraNvpApiException ex) {
+                }
+
+                throw e;
+            }
+
+            return new CreateLogicalRouterAnswer(command, true, "Logical Router created (uuid " + lrc.getUuid() + ")", lrc.getUuid());
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, CreateLogicalRouterAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalSwitchCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalSwitchCommandWrapper.java
@@ -19,6 +19,8 @@
 
 package com.cloud.network.resource.wrapper;
 
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +34,7 @@ import com.cloud.network.nicira.NiciraNvpTag;
 import com.cloud.network.nicira.TransportZoneBinding;
 import com.cloud.network.resource.NiciraNvpResource;
 import com.cloud.network.resource.NiciraNvpUtilities;
+import com.cloud.network.utils.CommandRetryUtility;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
 
@@ -62,12 +65,9 @@ public final class NiciraNvpCreateLogicalSwitchCommandWrapper extends CommandWra
             final String switchUuid = logicalSwitch.getUuid();
             return new CreateLogicalSwitchAnswer(command, true, "Logicalswitch " + switchUuid + " created", switchUuid);
         } catch (final NiciraNvpApiException e) {
-            int numRetries = niciraNvpResource.getNumRetries();
-            if (numRetries > 0) {
-                return niciraNvpResource.retry(command, --numRetries);
-            } else {
-                return new CreateLogicalSwitchAnswer(command, e);
-            }
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, CreateLogicalSwitchAnswer.class, e);
         }
     }
 }

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalSwitchCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalSwitchCommandWrapper.java
@@ -1,0 +1,73 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.CreateLogicalSwitchAnswer;
+import com.cloud.agent.api.CreateLogicalSwitchCommand;
+import com.cloud.network.nicira.LogicalSwitch;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.nicira.NiciraNvpTag;
+import com.cloud.network.nicira.TransportZoneBinding;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.resource.NiciraNvpUtilities;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  CreateLogicalSwitchCommand.class)
+public final class NiciraNvpCreateLogicalSwitchCommandWrapper extends CommandWrapper<CreateLogicalSwitchCommand, Answer, NiciraNvpResource> {
+
+    @Override
+    public Answer execute(final CreateLogicalSwitchCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpUtilities niciraNvpUtilities = niciraNvpResource.getNiciraNvpUtilities();
+
+        LogicalSwitch logicalSwitch = niciraNvpUtilities.createLogicalSwitch();
+        logicalSwitch.setDisplayName(niciraNvpResource.truncate("lswitch-" + command.getName(), NiciraNvpResource.NAME_MAX_LEN));
+        logicalSwitch.setPortIsolationEnabled(false);
+
+        // Set transport binding
+        final List<TransportZoneBinding> ltzb = new ArrayList<TransportZoneBinding>();
+        ltzb.add(new TransportZoneBinding(command.getTransportUuid(), command.getTransportType()));
+        logicalSwitch.setTransportZones(ltzb);
+
+        // Tags set to scope cs_account and account name
+        final List<NiciraNvpTag> tags = new ArrayList<NiciraNvpTag>();
+        tags.add(new NiciraNvpTag("cs_account", command.getOwnerName()));
+        logicalSwitch.setTags(tags);
+
+        try {
+            final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+            logicalSwitch = niciraNvpApi.createLogicalSwitch(logicalSwitch);
+            final String switchUuid = logicalSwitch.getUuid();
+            return new CreateLogicalSwitchAnswer(command, true, "Logicalswitch " + switchUuid + " created", switchUuid);
+        } catch (final NiciraNvpApiException e) {
+            int numRetries = niciraNvpResource.getNumRetries();
+            if (numRetries > 0) {
+                return niciraNvpResource.retry(command, --numRetries);
+            } else {
+                return new CreateLogicalSwitchAnswer(command, e);
+            }
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalSwitchPortCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpCreateLogicalSwitchPortCommandWrapper.java
@@ -1,0 +1,70 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.CreateLogicalSwitchPortAnswer;
+import com.cloud.agent.api.CreateLogicalSwitchPortCommand;
+import com.cloud.network.nicira.LogicalSwitchPort;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.nicira.VifAttachment;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.resource.NiciraNvpUtilities;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  CreateLogicalSwitchPortCommand.class)
+public final class NiciraNvpCreateLogicalSwitchPortCommandWrapper extends CommandWrapper<CreateLogicalSwitchPortCommand, Answer, NiciraNvpResource> {
+
+    private static final Logger s_logger = Logger.getLogger(NiciraNvpCreateLogicalSwitchPortCommandWrapper.class);
+
+    @Override
+    public Answer execute(final CreateLogicalSwitchPortCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpUtilities niciraNvpUtilities = niciraNvpResource.getNiciraNvpUtilities();
+
+        final String logicalSwitchUuid = command.getLogicalSwitchUuid();
+        final String attachmentUuid = command.getAttachmentUuid();
+
+        try {
+            final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+
+            final LogicalSwitchPort logicalSwitchPort = niciraNvpUtilities.createLogicalSwitchPort(command);
+            final LogicalSwitchPort newPort = niciraNvpApi.createLogicalSwitchPort(logicalSwitchUuid, logicalSwitchPort);
+            try {
+                niciraNvpApi.updateLogicalSwitchPortAttachment(command.getLogicalSwitchUuid(), newPort.getUuid(), new VifAttachment(attachmentUuid));
+            } catch (final NiciraNvpApiException ex) {
+                s_logger.warn("modifyLogicalSwitchPort failed after switchport was created, removing switchport");
+                niciraNvpApi.deleteLogicalSwitchPort(command.getLogicalSwitchUuid(), newPort.getUuid());
+                throw ex; // Rethrow the original exception
+            }
+            return new CreateLogicalSwitchPortAnswer(command, true, "Logical switch port " + newPort.getUuid() + " created", newPort.getUuid());
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, CreateLogicalSwitchPortAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpDeleteLogicalRouterCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpDeleteLogicalRouterCommandWrapper.java
@@ -1,0 +1,50 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.DeleteLogicalRouterAnswer;
+import com.cloud.agent.api.DeleteLogicalRouterCommand;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  DeleteLogicalRouterCommand.class)
+public final class NiciraNvpDeleteLogicalRouterCommandWrapper extends CommandWrapper<DeleteLogicalRouterCommand, Answer, NiciraNvpResource> {
+
+    @Override
+    public Answer execute(final DeleteLogicalRouterCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+
+        try {
+            niciraNvpApi.deleteLogicalRouter(command.getLogicalRouterUuid());
+            return new DeleteLogicalRouterAnswer(command, true, "Logical Router deleted (uuid " + command.getLogicalRouterUuid() + ")");
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, DeleteLogicalRouterAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpDeleteLogicalSwitchCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpDeleteLogicalSwitchCommandWrapper.java
@@ -1,0 +1,49 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.DeleteLogicalSwitchAnswer;
+import com.cloud.agent.api.DeleteLogicalSwitchCommand;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  DeleteLogicalSwitchCommand.class)
+public final class NiciraNvpDeleteLogicalSwitchCommandWrapper extends CommandWrapper<DeleteLogicalSwitchCommand, Answer, NiciraNvpResource> {
+
+    @Override
+    public Answer execute(final DeleteLogicalSwitchCommand command, final NiciraNvpResource niciraNvpResource) {
+        try {
+            final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+            niciraNvpApi.deleteLogicalSwitch(command.getLogicalSwitchUuid());
+            return new DeleteLogicalSwitchAnswer(command, true, "Logicalswitch " + command.getLogicalSwitchUuid() + " deleted");
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, DeleteLogicalSwitchAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpDeleteLogicalSwitchPortCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpDeleteLogicalSwitchPortCommandWrapper.java
@@ -1,0 +1,54 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import static com.cloud.network.resource.NiciraNvpResource.NUM_RETRIES;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.DeleteLogicalSwitchPortAnswer;
+import com.cloud.agent.api.DeleteLogicalSwitchPortCommand;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.utils.CommandRetryUtility;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  DeleteLogicalSwitchPortCommand.class)
+public final class NiciraNvpDeleteLogicalSwitchPortCommandWrapper extends CommandWrapper<DeleteLogicalSwitchPortCommand, Answer, NiciraNvpResource> {
+
+    private static final Logger s_logger = Logger.getLogger(NiciraNvpDeleteLogicalSwitchPortCommandWrapper.class);
+
+    @Override
+    public Answer execute(final DeleteLogicalSwitchPortCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpApi niciraNvpApi = niciraNvpResource.getNiciraNvpApi();
+
+        try {
+            niciraNvpApi.deleteLogicalSwitchPort(command.getLogicalSwitchUuid(), command.getLogicalSwitchPortUuid());
+            return new DeleteLogicalSwitchPortAnswer(command, true, "Logical switch port " + command.getLogicalSwitchPortUuid() + " deleted");
+        } catch (final NiciraNvpApiException e) {
+            final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();
+            retryUtility.addRetry(command, NUM_RETRIES);
+            return retryUtility.retry(command, DeleteLogicalSwitchPortAnswer.class, e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpMaintainCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpMaintainCommandWrapper.java
@@ -1,0 +1,36 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.MaintainAnswer;
+import com.cloud.agent.api.MaintainCommand;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  MaintainCommand.class)
+public final class NiciraNvpMaintainCommandWrapper extends CommandWrapper<MaintainCommand, Answer, NiciraNvpResource> {
+
+    @Override
+    public Answer execute(final MaintainCommand command, final NiciraNvpResource niciraNvpResource) {
+        return new MaintainAnswer(command);
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpReadyCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpReadyCommandWrapper.java
@@ -1,0 +1,36 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource.wrapper;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ReadyAnswer;
+import com.cloud.agent.api.ReadyCommand;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles =  ReadyCommand.class)
+public final class NiciraNvpReadyCommandWrapper extends CommandWrapper<ReadyCommand, Answer, NiciraNvpResource> {
+
+    @Override
+    public Answer execute(final ReadyCommand command, final NiciraNvpResource niciraNvpResource) {
+        return new ReadyAnswer(command);
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpUpdateLogicalSwitchPortCommandWrapper.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/resource/wrapper/NiciraNvpUpdateLogicalSwitchPortCommandWrapper.java
@@ -32,6 +32,7 @@ import com.cloud.network.nicira.NiciraNvpApiException;
 import com.cloud.network.nicira.NiciraNvpTag;
 import com.cloud.network.nicira.VifAttachment;
 import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.network.resource.NiciraNvpUtilities;
 import com.cloud.network.utils.CommandRetryUtility;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
@@ -41,6 +42,8 @@ public final class NiciraNvpUpdateLogicalSwitchPortCommandWrapper extends Comman
 
     @Override
     public Answer execute(final UpdateLogicalSwitchPortCommand command, final NiciraNvpResource niciraNvpResource) {
+        final NiciraNvpUtilities niciraNvpUtilities = niciraNvpResource.getNiciraNvpUtilities();
+
         final String logicalSwitchUuid = command.getLogicalSwitchUuid();
         final String logicalSwitchPortUuid = command.getLogicalSwitchPortUuid();
         final String attachmentUuid = command.getAttachmentUuid();
@@ -52,7 +55,9 @@ public final class NiciraNvpUpdateLogicalSwitchPortCommandWrapper extends Comman
             final List<NiciraNvpTag> tags = new ArrayList<NiciraNvpTag>();
             tags.add(new NiciraNvpTag("cs_account", command.getOwnerName()));
 
-            niciraNvpApi.updateLogicalSwitchPortAttachment(logicalSwitchUuid, logicalSwitchPortUuid, new VifAttachment(attachmentUuid));
+            final VifAttachment vifAttachment = niciraNvpUtilities.createVifAttachment(attachmentUuid);
+
+            niciraNvpApi.updateLogicalSwitchPortAttachment(logicalSwitchUuid, logicalSwitchPortUuid, vifAttachment);
             return new UpdateLogicalSwitchPortAnswer(command, true, "Attachment for  " + logicalSwitchPortUuid + " updated", logicalSwitchPortUuid);
         } catch (final NiciraNvpApiException e) {
             final CommandRetryUtility retryUtility = niciraNvpResource.getRetryUtility();

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/utils/CommandRetryUtility.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/utils/CommandRetryUtility.java
@@ -1,0 +1,90 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.network.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.Command;
+import com.cloud.network.resource.NiciraNvpResource;
+import com.cloud.resource.ServerResource;
+import com.cloud.utils.exception.CloudRuntimeException;
+
+public class CommandRetryUtility {
+
+    private static final Logger s_logger = Logger.getLogger(NiciraNvpResource.class);
+
+    private static final int ZERO = 0;
+    private static CommandRetryUtility instance;
+
+    static {
+        instance = new CommandRetryUtility();
+    }
+
+    private final ConcurrentHashMap<Command, Integer> commandsToRetry;
+    private ServerResource serverResource;
+
+    private CommandRetryUtility() {
+        commandsToRetry = new ConcurrentHashMap<Command, Integer>();
+    }
+
+    public static CommandRetryUtility getInstance() {
+        return instance;
+    }
+
+    public void setServerResource(final ServerResource serverResource) {
+        this.serverResource = serverResource;
+    }
+
+    public boolean addRetry(final Command command, final int retries) {
+        if (commandsToRetry.containsKey(command)) {
+            // A retry already exists for this command, do not add it again.
+            // Once all retries are executed, the command will be removed from the map.
+            return false;
+        }
+        commandsToRetry.put(command, retries);
+        return true;
+    }
+
+    public Answer retry(final Command command, final Class<? extends Answer> answerClass, final Exception error) {
+        if (commandsToRetry.containsKey(command)) {
+            Integer numRetries = commandsToRetry.get(command);
+
+            if (numRetries > ZERO) {
+                commandsToRetry.put(command, --numRetries);
+
+                s_logger.warn("Retrying " + command.getClass().getSimpleName() + ". Number of retries remaining: " + numRetries);
+
+                return serverResource.executeRequest(command);
+            } else {
+                commandsToRetry.remove(command);
+            }
+        }
+        try {
+            final Constructor<? extends Answer> answerConstructor = answerClass.getConstructor(Command.class, Exception.class);
+            return answerConstructor.newInstance(command, error);
+        } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new CloudRuntimeException(e);
+        }
+    }
+}

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/utils/CommandRetryUtility.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/utils/CommandRetryUtility.java
@@ -27,13 +27,11 @@ import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
-import com.cloud.network.resource.NiciraNvpResource;
 import com.cloud.resource.ServerResource;
-import com.cloud.utils.exception.CloudRuntimeException;
 
 public class CommandRetryUtility {
 
-    private static final Logger s_logger = Logger.getLogger(NiciraNvpResource.class);
+    private static final Logger s_logger = Logger.getLogger(CommandRetryUtility.class);
 
     private static final int ZERO = 0;
     private static CommandRetryUtility instance;
@@ -85,7 +83,7 @@ public class CommandRetryUtility {
             final Constructor<? extends Answer> answerConstructor = answerClass.getConstructor(Command.class, Exception.class);
             return answerConstructor.newInstance(command, error);
         } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            throw new CloudRuntimeException(e);
+            return Answer.createUnsupportedCommandAnswer(command);
         }
     }
 }

--- a/plugins/network-elements/nicira-nvp/src/com/cloud/network/utils/CommandRetryUtility.java
+++ b/plugins/network-elements/nicira-nvp/src/com/cloud/network/utils/CommandRetryUtility.java
@@ -16,6 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+
 package com.cloud.network.utils;
 
 import java.lang.reflect.Constructor;

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.MaintainCommand;
 import com.cloud.agent.api.ReadyCommand;
 
 public class NiciraNvpRequestWrapperTest {
@@ -37,6 +38,18 @@ public class NiciraNvpRequestWrapperTest {
     @Test
     public void testReadyCommandWrapper() {
         final ReadyCommand command = new ReadyCommand();
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testMaintainCommandWrapper() {
+        final MaintainCommand command = new MaintainCommand();
 
         final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
         assertNotNull(wrapper);

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
@@ -21,14 +21,20 @@ package com.cloud.network.resource;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.CreateLogicalSwitchCommand;
 import com.cloud.agent.api.MaintainCommand;
 import com.cloud.agent.api.ReadyCommand;
+import com.cloud.network.nicira.LogicalSwitch;
+import com.cloud.network.nicira.NiciraNvpApi;
+import com.cloud.network.nicira.NiciraNvpApiException;
 
 public class NiciraNvpRequestWrapperTest {
 
@@ -50,6 +56,41 @@ public class NiciraNvpRequestWrapperTest {
     @Test
     public void testMaintainCommandWrapper() {
         final MaintainCommand command = new MaintainCommand();
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testCreateLogicalSwitchCommandWrapper() {
+        final NiciraNvpApi niciraNvpApi = Mockito.mock(NiciraNvpApi.class);
+        final NiciraNvpUtilities niciraNvpUtilities = Mockito.mock(NiciraNvpUtilities.class);
+        final LogicalSwitch logicalSwitch = Mockito.mock(LogicalSwitch.class);
+
+        final String transportUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+        final String transportType = "stt";
+        final String name = "logicalswitch";
+        final String ownerName = "owner";
+
+        final CreateLogicalSwitchCommand command = new CreateLogicalSwitchCommand(transportUuid, transportType, name, ownerName);
+
+        final String truncated = "lswitch-" + command.getName();
+
+        when(niciraNvpResource.getNiciraNvpUtilities()).thenReturn(niciraNvpUtilities);
+        when(niciraNvpUtilities.createLogicalSwitch()).thenReturn(logicalSwitch);
+        when(niciraNvpResource.truncate("lswitch-" + command.getName(), NiciraNvpResource.NAME_MAX_LEN)).thenReturn(truncated);
+        when(niciraNvpResource.getNiciraNvpApi()).thenReturn(niciraNvpApi);
+
+        try {
+            when(niciraNvpApi.createLogicalSwitch(logicalSwitch)).thenReturn(logicalSwitch);
+            when(logicalSwitch.getUuid()).thenReturn(transportUuid);
+        } catch (final NiciraNvpApiException e) {
+            fail(e.getMessage());
+        }
 
         final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
         assertNotNull(wrapper);

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
@@ -1,0 +1,48 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.network.resource;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ReadyCommand;
+
+public class NiciraNvpRequestWrapperTest {
+
+    @Mock
+    private final NiciraNvpResource niciraNvpResource = Mockito.mock(NiciraNvpResource.class);
+
+    @Test
+    public void testReadyCommandWrapper() {
+        final ReadyCommand command = new ReadyCommand();
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+}

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
@@ -22,6 +22,7 @@ package com.cloud.network.resource;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
@@ -30,6 +31,7 @@ import org.mockito.Mockito;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.CreateLogicalSwitchCommand;
+import com.cloud.agent.api.DeleteLogicalSwitchCommand;
 import com.cloud.agent.api.MaintainCommand;
 import com.cloud.agent.api.ReadyCommand;
 import com.cloud.network.nicira.LogicalSwitch;
@@ -88,6 +90,30 @@ public class NiciraNvpRequestWrapperTest {
         try {
             when(niciraNvpApi.createLogicalSwitch(logicalSwitch)).thenReturn(logicalSwitch);
             when(logicalSwitch.getUuid()).thenReturn(transportUuid);
+        } catch (final NiciraNvpApiException e) {
+            fail(e.getMessage());
+        }
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testDeleteLogicalSwitchCommandWrapper() {
+        final NiciraNvpApi niciraNvpApi = Mockito.mock(NiciraNvpApi.class);
+
+        final String logicalSwitchUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+
+        final DeleteLogicalSwitchCommand command = new DeleteLogicalSwitchCommand(logicalSwitchUuid);
+
+        when(niciraNvpResource.getNiciraNvpApi()).thenReturn(niciraNvpApi);
+
+        try {
+            doNothing().when(niciraNvpApi).deleteLogicalSwitch(command.getLogicalSwitchUuid());
         } catch (final NiciraNvpApiException e) {
             fail(e.getMessage());
         }

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpRequestWrapperTest.java
@@ -25,18 +25,28 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ConfigurePublicIpsOnLogicalRouterCommand;
 import com.cloud.agent.api.CreateLogicalSwitchCommand;
+import com.cloud.agent.api.DeleteLogicalRouterCommand;
 import com.cloud.agent.api.DeleteLogicalSwitchCommand;
+import com.cloud.agent.api.DeleteLogicalSwitchPortCommand;
 import com.cloud.agent.api.MaintainCommand;
 import com.cloud.agent.api.ReadyCommand;
+import com.cloud.agent.api.UpdateLogicalSwitchPortCommand;
+import com.cloud.network.nicira.LogicalRouterPort;
 import com.cloud.network.nicira.LogicalSwitch;
 import com.cloud.network.nicira.NiciraNvpApi;
 import com.cloud.network.nicira.NiciraNvpApiException;
+import com.cloud.network.nicira.NiciraNvpList;
+import com.cloud.network.nicira.VifAttachment;
 
 public class NiciraNvpRequestWrapperTest {
 
@@ -114,6 +124,123 @@ public class NiciraNvpRequestWrapperTest {
 
         try {
             doNothing().when(niciraNvpApi).deleteLogicalSwitch(command.getLogicalSwitchUuid());
+        } catch (final NiciraNvpApiException e) {
+            fail(e.getMessage());
+        }
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testConfigurePublicIpsOnLogicalRouterCommand() {
+        final NiciraNvpApi niciraNvpApi = Mockito.mock(NiciraNvpApi.class);
+        final LogicalRouterPort port1 = Mockito.mock(LogicalRouterPort.class);
+
+        final List<LogicalRouterPort> listPorts = new ArrayList<LogicalRouterPort>();
+        listPorts.add(port1);
+
+        final NiciraNvpList<LogicalRouterPort> ports = new NiciraNvpList<LogicalRouterPort>();
+        ports.setResults(listPorts);
+        ports.setResultCount(1);
+
+        final String logicalRouterUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+        final String l3GatewayServiceUuid  = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+        final List<String> publicCidrs = new ArrayList<String>();
+        publicCidrs.add("10.1.1.0/24");
+
+        final ConfigurePublicIpsOnLogicalRouterCommand command = new ConfigurePublicIpsOnLogicalRouterCommand(logicalRouterUuid, l3GatewayServiceUuid, publicCidrs);
+
+        when(niciraNvpResource.getNiciraNvpApi()).thenReturn(niciraNvpApi);
+
+        try {
+            when(niciraNvpApi.findLogicalRouterPortByGatewayServiceUuid(command.getLogicalRouterUuid(), command.getL3GatewayServiceUuid())).thenReturn(ports);
+            doNothing().when(niciraNvpApi).updateLogicalRouterPort(command.getLogicalRouterUuid(), port1);
+        } catch (final NiciraNvpApiException e) {
+            fail(e.getMessage());
+        }
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testDeleteLogicalSwitchPortCommand() {
+        final NiciraNvpApi niciraNvpApi = Mockito.mock(NiciraNvpApi.class);
+
+        final String logicalSwitchUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+        final String logicalSwitchPortUuid  = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+
+        final DeleteLogicalSwitchPortCommand command = new DeleteLogicalSwitchPortCommand(logicalSwitchUuid, logicalSwitchPortUuid);
+
+        when(niciraNvpResource.getNiciraNvpApi()).thenReturn(niciraNvpApi);
+
+        try {
+            doNothing().when(niciraNvpApi).deleteLogicalSwitchPort(command.getLogicalSwitchUuid(), command.getLogicalSwitchPortUuid());
+        } catch (final NiciraNvpApiException e) {
+            fail(e.getMessage());
+        }
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testDeleteLogicalRouterCommand() {
+        final NiciraNvpApi niciraNvpApi = Mockito.mock(NiciraNvpApi.class);
+
+        final String logicalRouterUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+
+        final DeleteLogicalRouterCommand command = new DeleteLogicalRouterCommand(logicalRouterUuid);
+
+        when(niciraNvpResource.getNiciraNvpApi()).thenReturn(niciraNvpApi);
+
+        try {
+            doNothing().when(niciraNvpApi).deleteLogicalRouter(command.getLogicalRouterUuid());
+        } catch (final NiciraNvpApiException e) {
+            fail(e.getMessage());
+        }
+
+        final NiciraNvpRequestWrapper wrapper = NiciraNvpRequestWrapper.getInstance();
+        assertNotNull(wrapper);
+
+        final Answer answer = wrapper.execute(command, niciraNvpResource);
+
+        assertTrue(answer.getResult());
+    }
+
+    @Test
+    public void testUpdateLogicalSwitchPortCommand() {
+        final NiciraNvpApi niciraNvpApi = Mockito.mock(NiciraNvpApi.class);
+        final NiciraNvpUtilities niciraNvpUtilities = Mockito.mock(NiciraNvpUtilities.class);
+        final VifAttachment vifAttachment = Mockito.mock(VifAttachment.class);
+
+        final String logicalSwitchPortUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+        final String logicalSwitchUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+        final String attachmentUuid = "d2e05a9e-7120-4487-a5fc-414ab36d9345";
+        final String ownerName = "admin";
+        final String nicName = "eth0";
+
+        final UpdateLogicalSwitchPortCommand command = new UpdateLogicalSwitchPortCommand(logicalSwitchPortUuid, logicalSwitchUuid, attachmentUuid, ownerName, nicName);
+
+        when(niciraNvpResource.getNiciraNvpUtilities()).thenReturn(niciraNvpUtilities);
+        when(niciraNvpResource.getNiciraNvpApi()).thenReturn(niciraNvpApi);
+
+        try {
+            when(niciraNvpUtilities.createVifAttachment(attachmentUuid)).thenReturn(vifAttachment);
+            doNothing().when(niciraNvpApi).updateLogicalSwitchPortAttachment(logicalSwitchUuid, logicalSwitchPortUuid, vifAttachment);
         } catch (final NiciraNvpApiException e) {
             fail(e.getMessage());
         }

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpResourceTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpResourceTest.java
@@ -85,11 +85,15 @@ import com.cloud.network.nicira.NiciraNvpApi;
 import com.cloud.network.nicira.NiciraNvpApiException;
 import com.cloud.network.nicira.NiciraNvpList;
 import com.cloud.network.nicira.SourceNatRule;
+import com.cloud.network.utils.CommandRetryUtility;
 
 public class NiciraNvpResourceTest {
     NiciraNvpApi nvpApi = mock(NiciraNvpApi.class);
     NiciraNvpResource resource;
     Map<String, Object> parameters;
+
+    private NiciraNvpUtilities niciraNvpUtilities;
+    private CommandRetryUtility retryUtility;
 
     @Before
     public void setUp() throws ConfigurationException {
@@ -107,6 +111,10 @@ public class NiciraNvpResourceTest {
         parameters.put("guid", "aaaaa-bbbbb-ccccc");
         parameters.put("zoneId", "blublub");
         parameters.put("adminpass", "adminpass");
+
+        niciraNvpUtilities = NiciraNvpUtilities.getInstance();
+        retryUtility = CommandRetryUtility.getInstance();
+        retryUtility.setServerResource(resource);
     }
 
     @Test(expected = ConfigurationException.class)
@@ -295,7 +303,7 @@ public class NiciraNvpResourceTest {
 
         doThrow(new NiciraNvpApiException()).when(nvpApi).updateLogicalSwitchPortAttachment((String)any(), (String)any(), (Attachment)any());
         final UpdateLogicalSwitchPortAnswer dlspa =
-            (UpdateLogicalSwitchPortAnswer)resource.executeRequest(new UpdateLogicalSwitchPortCommand("aaaa", "bbbb", "cccc", "owner", "nicname"));
+                (UpdateLogicalSwitchPortAnswer)resource.executeRequest(new UpdateLogicalSwitchPortCommand("aaaa", "bbbb", "cccc", "owner", "nicname"));
         assertFalse(dlspa.getResult());
     }
 

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpResourceTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpResourceTest.java
@@ -432,8 +432,23 @@ public class NiciraNvpResourceTest {
 
         when(cmd.getLogicalRouterUuid()).thenReturn("aaaaa");
         when(cmd.getL3GatewayServiceUuid()).thenReturn("bbbbb");
-        doThrow(new NiciraNvpApiException()).when(nvpApi).updateLogicalRouterPort((String)any(), (LogicalRouterPort)any());
         when(nvpApi.findLogicalRouterPortByGatewayServiceUuid("aaaaa", "bbbbb")).thenReturn(list);
+        doThrow(new NiciraNvpApiException()).when(nvpApi).updateLogicalRouterPort((String)any(), (LogicalRouterPort)any());
+
+        final ConfigurePublicIpsOnLogicalRouterAnswer answer = (ConfigurePublicIpsOnLogicalRouterAnswer)resource.executeRequest(cmd);
+        assertFalse(answer.getResult());
+
+    }
+
+    @Test
+    public void testConfigurePublicIpsOnLogicalRouterRetry() throws ConfigurationException, NiciraNvpApiException {
+        resource.configure("NiciraNvpResource", parameters);
+
+        final ConfigurePublicIpsOnLogicalRouterCommand cmd = mock(ConfigurePublicIpsOnLogicalRouterCommand.class);
+
+        when(cmd.getLogicalRouterUuid()).thenReturn("aaaaa");
+        when(cmd.getL3GatewayServiceUuid()).thenReturn("bbbbb");
+        when(nvpApi.findLogicalRouterPortByGatewayServiceUuid("aaaaa", "bbbbb")).thenThrow(new NiciraNvpApiException("retry 1")).thenThrow(new NiciraNvpApiException("retry 2"));
 
         final ConfigurePublicIpsOnLogicalRouterAnswer answer = (ConfigurePublicIpsOnLogicalRouterAnswer)resource.executeRequest(cmd);
         assertFalse(answer.getResult());

--- a/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpResourceTest.java
+++ b/plugins/network-elements/nicira-nvp/test/com/cloud/network/resource/NiciraNvpResourceTest.java
@@ -92,7 +92,6 @@ public class NiciraNvpResourceTest {
     NiciraNvpResource resource;
     Map<String, Object> parameters;
 
-    private NiciraNvpUtilities niciraNvpUtilities;
     private CommandRetryUtility retryUtility;
 
     @Before
@@ -112,7 +111,6 @@ public class NiciraNvpResourceTest {
         parameters.put("zoneId", "blublub");
         parameters.put("adminpass", "adminpass");
 
-        niciraNvpUtilities = NiciraNvpUtilities.getInstance();
         retryUtility = CommandRetryUtility.getInstance();
         retryUtility.setServerResource(resource);
     }


### PR DESCRIPTION
Hi there,

The motivation behind the refactor of the NiciraNvpResource class was to decouple the execute of the commands, which was handled into several private methods in the class.

With the refactor, we were able to decouple all the commands by wrapping them with another class. The extra classes are declared with the ResourceWrapper annotation, which makes possible to get all the classes loaded into a map inside the implementation of the  RequestWrapper class, in that case the NiciraNvpRequestWrapper.

New tests were added in order to increase test coverage. The current status is:

* Resource package: 86.7% coverage
* Utils package: 95.1% coverage
* Wrapper package: 97.5% coverage

In addition, the previous retry mechanism has been improved. Instead of having an instance variable to control the retries and the extra methods with the number of retries passed as parameter, we now have a Map which holds the commands and the number of retry. Once the number of retries reaches ZERO, the given command is removed from the Map.

An issue has been created in order to follow up with this refactor: https://issues.apache.org/jira/browse/CLOUDSTACK-8590

The changes do not affect the behaviour of the NiciraNvpResource. As a proof of that, all the existing tests worked without any change. This is a pure structural change on the code.  

This PR consists of 11 commits. I tried to combine the work on the command wrappers, retry mechanism, unit tests and general stuff.

Cheers,
Wilder