### PR TITLE
CLOUDSTACK-8603: Random list VM failures at scale (more than 1000 VMs…

### DIFF
--- a/server/src/com/cloud/api/query/dao/ResourceTagJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/ResourceTagJoinDaoImpl.java
@@ -149,20 +149,24 @@ public class ResourceTagJoinDaoImpl extends GenericDaoBase<ResourceTagJoinVO, Lo
     public ResourceTagJoinVO searchById(Long id) {
         SearchCriteria<ResourceTagJoinVO> sc = tagIdSearch.create();
         sc.setParameters("id", id);
-        List<ResourceTagJoinVO> vms = searchIncludingRemoved(sc, null, null, false);
-        assert vms != null && vms.size() == 1 : "No tag found for tag id " + id;
-        return vms.get(0);
+        List<ResourceTagJoinVO> tags = searchIncludingRemoved(sc, null, null, false);
+        if (tags != null && tags.size() > 0) {
+            return tags.get(0);
+        } else {
+            return null;
+        }
     }
 
     @Override
     public ResourceTagJoinVO newResourceTagView(ResourceTag vr) {
-
         SearchCriteria<ResourceTagJoinVO> sc = tagIdSearch.create();
         sc.setParameters("id", vr.getId());
-        List<ResourceTagJoinVO> vms = searchIncludingRemoved(sc, null, null, false);
-        assert vms != null && vms.size() == 1 : "No tag found for tag id " + vr.getId();
-        return vms.get(0);
-
+        List<ResourceTagJoinVO> tags = searchIncludingRemoved(sc, null, null, false);
+        if (tags != null && tags.size() > 0) {
+            return tags.get(0);
+        } else {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
…) when VM has resource tags

There is no 'removed' field on the resource_tags table. So 'id' based search may return a record or null in case record is deleted.
Added a check for null or empty in search resource tags based on 'id'.