### PR TITLE
CLOUDSTACK-8606: DB performance impacted due to VM sync.

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
@@ -22,6 +22,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.log4j.Logger;
 
@@ -59,6 +61,7 @@ public class Upgrade452to460 implements DbUpgrade {
     @Override
     public void performDataMigration(final Connection conn) {
         updateVMInstanceUserId(conn);
+        addIndexForVMInstance(conn);
     }
 
     public void updateVMInstanceUserId(final Connection conn) {
@@ -133,6 +136,22 @@ public class Upgrade452to460 implements DbUpgrade {
         } catch (final SQLException e) {
             e.printStackTrace();
             throw new CloudRuntimeException("Adding redundancy to vpc, networks and vpc_offerings failed", e);
+        }
+    }
+
+    private void addIndexForVMInstance(Connection conn) {
+        // Drop index if it exists
+        List<String> indexList = new ArrayList<String>();
+        s_logger.debug("Dropping index i_vm_instance__instance_name from vm_instance table if it exists");
+        indexList.add("i_vm_instance__instance_name");
+        DbUpgradeUtils.dropKeysIfExist(conn, "vm_instance", indexList, false);
+
+        // Now add index
+        try (PreparedStatement pstmt = conn.prepareStatement("ALTER TABLE `cloud`.`vm_instance` ADD INDEX `i_vm_instance__instance_name`(`instance_name`)");) {
+            pstmt.executeUpdate();
+            s_logger.debug("Added index i_vm_instance__instance_name to vm_instance table");
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Unable to add index i_vm_instance__instance_name to vm_instance table for the column instance_name", e);
         }
     }
 


### PR DESCRIPTION
VM sync. generates a lot of queries on vm_instance table with 'instance_name' as filter. Since the field is not
indexed, these kind of queries will impact DB performance. Added an index for instance_name field.