### PR TITLE
CLOUDSTACK-8610. Unable to attach 7th Disk to Windows Server 2012 R2 …

### DIFF
--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -1928,6 +1928,20 @@ public class VirtualMachineMO extends BaseMO {
         throw new Exception("SCSI Controller Not Found");
     }
 
+    public int getGenericScsiDeviceControllerKeyNoException() throws Exception {
+        List<VirtualDevice> devices = _context.getVimClient().getDynamicProperty(_mor, "config.hardware.device");
+
+        if (devices != null && devices.size() > 0) {
+            for (VirtualDevice device : devices) {
+                if (device instanceof VirtualSCSIController) {
+                    return device.getKey();
+                }
+            }
+        }
+
+        return -1;
+    }
+
     public int getScsiDeviceControllerKeyNoException() throws Exception {
         List<VirtualDevice> devices = _context.getVimClient().getDynamicProperty(_mor, "config.hardware.device");
 
@@ -2377,7 +2391,7 @@ public class VirtualMachineMO extends BaseMO {
 
         List<Integer> existingUnitNumbers = new ArrayList<Integer>();
         int deviceNumber = 0;
-        int scsiControllerKey = getScsiDeviceControllerKeyNoException();
+        int scsiControllerKey = getGenericScsiDeviceControllerKeyNoException();
         if (devices != null && devices.size() > 0) {
             for (VirtualDevice device : devices) {
                 if (device.getControllerKey() != null && device.getControllerKey().intValue() == controllerKey) {


### PR DESCRIPTION
…instance.

During disk attach, while trying to obtain the controller key for SCSI controller, look for device with the generic SCSI controller type i.e. VirtualSCSIController.

While trying to obtain the SCSI id to attach a disk to, CS should ignore the reserved SCSI id 7. But this is not being honored in case of VMs with SCSI controller of type 'VirtualLsiLogicSASController'. And so in case of Windows 2012 R2 VMs, CS chooses to attach the 7th disk on the reserved SCSI id and this fails on vCenter.