### PR TITLE
BUG-ID:CLOUDSTACK-7472: kvmclock fix for LXC is not required after fixing CLOUDSTACK-8177

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -783,9 +783,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         value = (String) params.get("kvmclock.disable");
         if (Boolean.parseBoolean(value)) {
             _noKvmClock = true;
-        } else if(HypervisorType.LXC.equals(_hypervisorType) && value == null){
-            //Disable kvmclock by default for LXC
-            _noKvmClock = true;
         }
 
         LibvirtConnection.initialize(_hypervisorURI);


### PR DESCRIPTION
kvmclock fix for LXC is not required after fixing CLOUDSTACK-8177