### PR TITLE
Cloudstack 8612

### DIFF
--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/SyncQueueItemDao.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/SyncQueueItemDao.java
@@ -30,7 +30,7 @@ public interface SyncQueueItemDao extends GenericDao<SyncQueueItemVO, Long> {
 
     public List<SyncQueueItemVO> getActiveQueueItems(Long msid, boolean exclusive);
 
-    public List<SyncQueueItemVO> getBlockedQueueItems(long thresholdMs, boolean exclusive);
+    public List<SyncQueueItemVO> getBlockedQueueItems(long thresholdMs, long snapshotThresholdMs, String jobCmd, boolean exclusive);
 
     public Long getQueueItemIdByContentIdAndType(long contentId, String contentType);
 }

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -92,6 +92,8 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
     private static final ConfigKey<Integer> VmJobLockTimeout = new ConfigKey<Integer>("Advanced",
             Integer.class, "vm.job.lock.timeout", "1800",
             "Time in seconds to wait in acquiring lock to submit a vm worker job", false);
+    private static final ConfigKey<Long> VolumeSnapshotJobCancelThreshold = new ConfigKey<Long>("Advanced", Long.class, "volume.snapshot.job.cancel.threshold", "60",
+            "Time (in minutes) for volume snapshot async-job to be forcefully cancelled if it has been in process for long", true, ConfigKey.Scope.Global);
 
     private static final Logger s_logger = Logger.getLogger(AsyncJobManagerImpl.class);
 
@@ -133,7 +135,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {JobExpireMinutes, JobCancelThresholdMinutes, VmJobLockTimeout};
+        return new ConfigKey<?>[] {JobExpireMinutes, JobCancelThresholdMinutes, VmJobLockTimeout, VolumeSnapshotJobCancelThreshold};
     }
 
     @Override
@@ -792,7 +794,8 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                     s_logger.info("Begin cleanup expired async-jobs");
 
                     // forcefully cancel blocking queue items if they've been staying there for too long
-                    List<SyncQueueItemVO> blockItems = _queueMgr.getBlockedQueueItems(JobCancelThresholdMinutes.value() * 60000, false);
+                    List<SyncQueueItemVO> blockItems = _queueMgr.getBlockedQueueItems(JobCancelThresholdMinutes.value() * 60000, VolumeSnapshotJobCancelThreshold.value() * 60000,
+                            "VmWorkTakeVolumeSnapshot", false);
                     if (blockItems != null && blockItems.size() > 0) {
                         for (SyncQueueItemVO item : blockItems) {
                             try {

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/SyncQueueManager.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/SyncQueueManager.java
@@ -33,7 +33,7 @@ public interface SyncQueueManager extends Manager {
 
     public List<SyncQueueItemVO> getActiveQueueItems(Long msid, boolean exclusive);
 
-    public List<SyncQueueItemVO> getBlockedQueueItems(long thresholdMs, boolean exclusive);
+    public List<SyncQueueItemVO> getBlockedQueueItems(long thresholdMs, long snapshotThresholdMs, String jobCmd, boolean exclusive);
 
     void purgeAsyncJobQueueItemId(long asyncJobId);
 

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/SyncQueueManagerImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/SyncQueueManagerImpl.java
@@ -237,8 +237,8 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
     }
 
     @Override
-    public List<SyncQueueItemVO> getBlockedQueueItems(long thresholdMs, boolean exclusive) {
-        return _syncQueueItemDao.getBlockedQueueItems(thresholdMs, exclusive);
+    public List<SyncQueueItemVO> getBlockedQueueItems(long thresholdMs, long snapshotThresholdMs, String jobCmd, boolean exclusive) {
+        return _syncQueueItemDao.getBlockedQueueItems(thresholdMs, snapshotThresholdMs, jobCmd, exclusive);
     }
 
     private boolean queueReadyToProcess(SyncQueueVO queueVO) {

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -447,7 +447,19 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
             _cmdExecLogDao.persist(execLog);
             cmd.setContextParam("execid", String.valueOf(execLog.getId()));
             cmd.setContextParam("noderuninfo", String.format("%d-%d", _clusterMgr.getManagementNodeId(), _clusterMgr.getCurrentRunId()));
-            cmd.setContextParam("vCenterSessionTimeout", String.valueOf(_vmwareMgr.getVcenterSessionTimeout()));
+            if (cmd instanceof CopyCommand) { // Snapshot backup
+                CopyCommand cpyCommand = (CopyCommand)cmd;
+                DataTO srcData = cpyCommand.getSrcTO();
+                DataTO destData = cpyCommand.getDestTO();
+                if (srcData.getObjectType() == DataObjectType.SNAPSHOT && destData.getObjectType() == DataObjectType.SNAPSHOT &&
+                        srcData.getDataStore().getRole() == DataStoreRole.Primary) {
+                    cmd.setContextParam("vCenterSessionTimeout", String.valueOf(_vmwareMgr.getSnapshotBackupSessionTimeout()));
+                } else {
+                    cmd.setContextParam("vCenterSessionTimeout", String.valueOf(_vmwareMgr.getVcenterSessionTimeout()));
+                }
+            } else {
+                cmd.setContextParam("vCenterSessionTimeout", String.valueOf(_vmwareMgr.getVcenterSessionTimeout()));
+            }
 
             if (cmd instanceof BackupSnapshotCommand || cmd instanceof CreatePrivateTemplateFromVolumeCommand ||
                 cmd instanceof CreatePrivateTemplateFromSnapshotCommand || cmd instanceof CopyVolumeCommand || cmd instanceof CopyCommand ||

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
@@ -314,7 +314,8 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
 
         VmwareContext context = null;
         try {
-            context = VmwareContextFactory.create(url.getHost(), username, password);
+            int sessionTimeout = _vmwareMgr.getVcenterSessionTimeout();
+            context = VmwareContextFactory.create(url.getHost(), username, password, sessionTimeout);
             if (privateTrafficLabel != null)
                 context.registerStockObject("privateTrafficLabel", privateTrafficLabel);
 

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManager.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManager.java
@@ -79,4 +79,7 @@ public interface VmwareManager {
     boolean isLegacyZone(long dcId);
 
     boolean hasNexusVSM(Long clusterId);
+
+    public int getSnapshotBackupSessionTimeout();
+
 }

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -185,6 +185,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
     private int _additionalPortRangeSize;
     private int _routerExtraPublicNics = 2;
     private int _vCenterSessionTimeout = 1200000; // Timeout in milliseconds
+    private int _snapshotBackupSessionTimeout = 1200000; // Timeout in milliseconds
 
     private String _rootDiskController = DiskControllerType.ide.toString();
 
@@ -282,6 +283,9 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
 
         _vCenterSessionTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.VmwareVcenterSessionTimeout.key()), 1200) * 1000;
         s_logger.info("VmwareManagerImpl config - vmware.vcenter.session.timeout: " + _vCenterSessionTimeout);
+
+        _snapshotBackupSessionTimeout = NumbersUtil.parseInt(_configDao.getValue(Config.VmwareSnapshotBackupSessionTimeout.key()), 1200) * 1000;
+        s_logger.info("VmwareManagerImpl config - vmware.snapshot.backup.session.timeout: " + _snapshotBackupSessionTimeout);
 
         _recycleHungWorker = _configDao.getValue(Config.VmwareRecycleHungWorker.key());
         if (_recycleHungWorker == null || _recycleHungWorker.isEmpty()) {
@@ -487,6 +491,8 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         params.put("vmware.root.disk.controller", _rootDiskController);
         params.put("vmware.recycle.hung.wokervm", _recycleHungWorker);
         params.put("ports.per.dvportgroup", _portsPerDvPortGroup);
+        params.put("vmware.vcenter.session.timeout", _vCenterSessionTimeout);
+        params.put("vmware.snapshot.backup.session.timeout", _snapshotBackupSessionTimeout);
     }
 
     @Override
@@ -943,6 +949,11 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
     }
 
     @Override
+    public int getSnapshotBackupSessionTimeout(){
+        return _snapshotBackupSessionTimeout;
+    }
+
+    @Override
     public List<Class<?>> getCommands() {
         List<Class<?>> cmdList = new ArrayList<Class<?>>();
         cmdList.add(AddVmwareDcCmd.class);
@@ -1022,7 +1033,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         String guid;
         ManagedObjectReference dcMor;
         try {
-            context = VmwareContextFactory.create(vCenterHost, userName, password);
+            context = VmwareContextFactory.create(vCenterHost, userName, password, _vCenterSessionTimeout);
 
             // Check if DC exists on vCenter
             dcMo = new DatacenterMO(context, vmwareDcName);
@@ -1119,7 +1130,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         // Construct context
         VmwareContext context = null;
         try {
-            context = VmwareContextFactory.create(vCenterHost, userName, password);
+            context = VmwareContextFactory.create(vCenterHost, userName, password, _vCenterSessionTimeout);
 
             // Check if DC exists on vCenter
             try {

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareContextFactory.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareContextFactory.java
@@ -55,7 +55,7 @@ public class VmwareContextFactory {
         s_clusterMgr = _clusterMgr;
     }
 
-    public static VmwareContext create(String vCenterAddress, String vCenterUserName, String vCenterPassword) throws Exception {
+    public static VmwareContext create(String vCenterAddress, String vCenterUserName, String vCenterPassword, int sessionTimeout) throws Exception {
         assert (vCenterAddress != null);
         assert (vCenterUserName != null);
         assert (vCenterPassword != null);
@@ -66,7 +66,7 @@ public class VmwareContextFactory {
                 StringUtils.getMaskedPasswordForDisplay(vCenterPassword));
 
         VmwareClient vimClient = new VmwareClient(vCenterAddress + "-" + s_seq++);
-        vimClient.setVcenterSessionTimeout(s_vmwareMgr.getVcenterSessionTimeout());
+        vimClient.setVcenterSessionTimeout(sessionTimeout);
         vimClient.connect(serviceUrl, vCenterUserName, vCenterPassword);
 
         VmwareContext context = new VmwareContext(vimClient, vCenterAddress);
@@ -76,22 +76,22 @@ public class VmwareContextFactory {
         context.registerStockObject("manageportgroup", s_vmwareMgr.getManagementPortGroupName());
         context.registerStockObject("noderuninfo", String.format("%d-%d", s_clusterMgr.getManagementNodeId(), s_clusterMgr.getCurrentRunId()));
 
-        context.setPoolInfo(s_pool, VmwareContextPool.composePoolKey(vCenterAddress, vCenterUserName));
+        context.setPoolInfo(s_pool, VmwareContextPool.composePoolKey(vCenterAddress, vCenterUserName, sessionTimeout));
         s_pool.registerOutstandingContext(context);
 
         return context;
     }
 
-    public static VmwareContext getContext(String vCenterAddress, String vCenterUserName, String vCenterPassword) throws Exception {
-        VmwareContext context = s_pool.getContext(vCenterAddress, vCenterUserName);
+    public static VmwareContext getContext(String vCenterAddress, String vCenterUserName, String vCenterPassword, int sessionTimeout) throws Exception {
+        VmwareContext context = s_pool.getContext(vCenterAddress, vCenterUserName, sessionTimeout);
         if (context == null) {
-            context = create(vCenterAddress, vCenterUserName, vCenterPassword);
+            context = create(vCenterAddress, vCenterUserName, vCenterPassword, sessionTimeout);
         } else {
             // Validate current context and verify if vCenter session timeout value of the context matches the timeout value set by Admin
-            if (!context.validate() || (context.getVimClient().getVcenterSessionTimeout() != s_vmwareMgr.getVcenterSessionTimeout())) {
+            if (!context.validate()) {
                 s_logger.info("Validation of the context failed, dispose and create a new one");
                 context.close();
-                context = create(vCenterAddress, vCenterUserName, vCenterPassword);
+                context = create(vCenterAddress, vCenterUserName, vCenterPassword, sessionTimeout);
             }
         }
 

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -308,7 +308,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     protected int _portsPerDvPortGroup;
     protected boolean _fullCloneFlag = false;
     protected boolean _instanceNameFlag = false;
-
+    protected int _vCenterSessionTimeout = 1200000; // Timeout in milliseconds
     protected boolean _recycleHungWorker = false;
     protected DiskControllerType _rootDiskController = DiskControllerType.ide;
 
@@ -4983,6 +4983,10 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 _instanceNameFlag = false;
             }
 
+            Integer sessionTimeout = (Integer) params.get("vmware.vcenter.session.timeout");
+            if (sessionTimeout != null)
+                _vCenterSessionTimeout = sessionTimeout.intValue();
+
             value = (String)params.get("scripts.timeout");
             int timeout = NumbersUtil.parseInt(value, 1440) * 1000;
             _storageProcessor = new VmwareStorageProcessor((VmwareHostService)this, _fullCloneFlag, (VmwareStorageMount)mgr, timeout, this, _shutdownWaitMs, null);
@@ -5035,9 +5039,16 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     @Override
     public VmwareContext getServiceContext(Command cmd) {
         VmwareContext context = null;
+        int vCenterSessionTimeout;
+        if (cmd != null && cmd.getContextParam("vCenterSessionTimeout") != null) {
+            vCenterSessionTimeout = NumbersUtil.parseInt(cmd.getContextParam("vCenterSessionTimeout"), 1200000);
+        } else {
+            vCenterSessionTimeout = _vCenterSessionTimeout;
+        }
+
         if(s_serviceContext.get() != null) {
             context = s_serviceContext.get();
-            String poolKey = VmwareContextPool.composePoolKey(_vCenterAddress, _username);
+            String poolKey = VmwareContextPool.composePoolKey(_vCenterAddress, _username, vCenterSessionTimeout);
             // Before re-using the thread local context, ensure it corresponds to the right vCenter API session and that it is valid to make calls.
             if(context.getPoolKey().equals(poolKey)) {
                 if (context.validate()) {
@@ -5051,11 +5062,11 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 }
             } else {
                 // Exisitng ThreadLocal context corresponds to a different vCenter API session. Why has it not been recycled?
-                s_logger.warn("ThreadLocal VMware context: " + poolKey + " doesn't correspond to the right vCenter. Expected VMware context: " + context.getPoolKey());
+                s_logger.warn("ThreadLocal VMware context: " + poolKey + ". Expected VMware context: " + context.getPoolKey());
             }
         }
         try {
-            context = VmwareContextFactory.getContext(_vCenterAddress, _username, _password);
+            context = VmwareContextFactory.getContext(_vCenterAddress, _username, _password, vCenterSessionTimeout);
             s_serviceContext.set(context);
         } catch (Exception e) {
             s_logger.error("Unable to connect to vSphere server: " + _vCenterAddress, e);

--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -1247,6 +1247,7 @@ public enum Config {
             "When set to true this will enable nested virtualization when this is supported by the hypervisor",
             null),
     VmwareVcenterSessionTimeout("Advanced", ManagementServer.class, Long.class, "vmware.vcenter.session.timeout", "1200", "VMware client timeout in seconds", null),
+    VmwareSnapshotBackupSessionTimeout("Advanced", ManagementServer.class, Long.class, "vmware.snapshot.backup.session.timeout", "1200", "VMware client timeout in seconds for snapshot backup", null),
 
     // Midonet
     MidoNetAPIServerAddress(

--- a/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareContextPool.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareContextPool.java
@@ -72,8 +72,8 @@ public class VmwareContextPool {
         }
     }
 
-    public VmwareContext getContext(String vCenterAddress, String vCenterUserName) {
-        String poolKey = composePoolKey(vCenterAddress, vCenterUserName);
+    public VmwareContext getContext(String vCenterAddress, String vCenterUserName, int vCenterSessionTimeout) {
+        String poolKey = composePoolKey(vCenterAddress, vCenterUserName, vCenterSessionTimeout);
         synchronized (this) {
             List<VmwareContext> l = _pool.get(poolKey);
             if (l == null)
@@ -162,9 +162,10 @@ public class VmwareContextPool {
         }
     }
 
-    public static String composePoolKey(String vCenterAddress, String vCenterUserName) {
+    public static String composePoolKey(String vCenterAddress, String vCenterUserName, int vCenterSessionTimeout) {
         assert (vCenterUserName != null);
         assert (vCenterAddress != null);
-        return vCenterUserName + "@" + vCenterAddress;
+        int sessionTimeoutInSeconds = vCenterSessionTimeout/1000;
+        return vCenterUserName + "@" + vCenterAddress + ";" + String.valueOf(sessionTimeoutInSeconds);
     }
 }

--- a/vmware-base/test/com/cloud/hypervisor/vmware/mo/TestVmwareContextFactory.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/mo/TestVmwareContextFactory.java
@@ -37,7 +37,7 @@ public class TestVmwareContextFactory {
         s_pool = new VmwareContextPool();
     }
 
-    public static VmwareContext create(String vCenterAddress, String vCenterUserName, String vCenterPassword) throws Exception {
+    public static VmwareContext create(String vCenterAddress, String vCenterUserName, String vCenterPassword, int sessionTimeout) throws Exception {
         assert (vCenterAddress != null);
         assert (vCenterUserName != null);
         assert (vCenterPassword != null);
@@ -49,20 +49,20 @@ public class TestVmwareContextFactory {
                 StringUtils.getMaskedPasswordForDisplay(vCenterPassword));
 
         VmwareClient vimClient = new VmwareClient(vCenterAddress + "-" + s_seq++);
-        vimClient.setVcenterSessionTimeout(1200000);
+        vimClient.setVcenterSessionTimeout(sessionTimeout);
         vimClient.connect(serviceUrl, vCenterUserName, vCenterPassword);
 
         VmwareContext context = new VmwareContext(vimClient, vCenterAddress);
         return context;
     }
 
-    public static VmwareContext getContext(String vCenterAddress, String vCenterUserName, String vCenterPassword) throws Exception {
-        VmwareContext context = s_pool.getContext(vCenterAddress, vCenterUserName);
+    public static VmwareContext getContext(String vCenterAddress, String vCenterUserName, String vCenterPassword, int sessionTimeout) throws Exception {
+        VmwareContext context = s_pool.getContext(vCenterAddress, vCenterUserName, sessionTimeout);
         if (context == null)
-            context = create(vCenterAddress, vCenterUserName, vCenterPassword);
+            context = create(vCenterAddress, vCenterUserName, vCenterPassword, sessionTimeout);
 
         if (context != null) {
-            context.setPoolInfo(s_pool, VmwareContextPool.composePoolKey(vCenterAddress, vCenterUserName));
+            context.setPoolInfo(s_pool, VmwareContextPool.composePoolKey(vCenterAddress, vCenterUserName, sessionTimeout));
         }
 
         return context;


### PR DESCRIPTION
To ensure that setting a high timeout value for snapshot backup operation will not affect vCenter connections made for any other operations besides volume snapshot, split the existing vCenter session timeout configuration into two configurations,
1. To tune timeout value for CS's session vCenter during snapshot backup operation - 'vmware.snapshot.backup.session.timeout' (new; default: 20 minutes)
2. For all other operations - 'vmware.vcenter.session.timeout' (existing; default: 20 minutes)

Additional change -
Users could potentially run into a timeout issue while trying to snapshot large VMs. There is a timeout for async-jobs that ensures that any job that has been in process for too long is cancelled by CS MS. This timeout is configurable using a global configuration ‘job.cancel.threshold.minutes’ and it defaults to 1 hour.
Now for large volumes even though users configure other snapshot timeout values (‘vmware.snapshot.backup.session.timeout’ and ‘backup.snapshot.wait‘) to a very high value, the snapshot operation will still fail because the job will be cancelled in 1 hour.
Hence proposing a configuration that will allow admins to separate out the job cancellation timeout for ‘volume snapshot’ jobs from other vm work jobs - 'volume.snapshot.job.cancel.threshold'.
