### PR TITLE
ui: Allow UI plugins to be shown on navigation bar

### DIFF
--- a/ui/plugins/testPlugin/testPlugin.js
+++ b/ui/plugins/testPlugin/testPlugin.js
@@ -19,6 +19,7 @@
     plugin.ui.addSection({
       id: 'testPlugin',
       title: 'TestPlugin',
+      showOnNavigation: true,
       preFilter: function(args) {
         return isAdmin();
       },

--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -31,9 +31,12 @@
                 sections = ["dashboard", "instances", "storage", "network", "templates", "accounts", "events", "regions", "affinityGroups"];
             }
 
-            if (cloudStack.plugins.length) {
-                sections.push('plugins');
-            }
+            $.each(cloudStack.plugins, function(idx, plugin) {
+                if (cloudStack.sections.hasOwnProperty(plugin) && !cloudStack.sections[plugin].showOnNavigation) {
+                    sections.push('plugins');
+                    return false;
+                }
+            });
 
             return sections;
         },

--- a/ui/scripts/ui/core.js
+++ b/ui/scripts/ui/core.js
@@ -61,7 +61,7 @@
                 );
             }
 
-            if (args.isPlugin) {
+            if (args.isPlugin && !args.showOnNavigation) {
                 $li.hide();
             }
 
@@ -88,7 +88,7 @@
             return $(this).hasClass(sectionID);
         });
         var data = args.sections[sectionID];
-        var isPlugin = data.isPlugin;
+        var isPlugin = data.isPlugin && !data.showOnNavigation;
 
         data.$browser = $browser;
 


### PR DESCRIPTION
Introduces a boolean option in UI plugins setting it to 'true' would display
the UI plugin on the left navigation bar.

Signed-off-by: Rohit Yadav <rohit.yadav@shapeblue.com>