### PR TITLE
CLOUDSTACK-8583 : fixing issue related to script test/integration/com…

### DIFF
--- a/test/integration/component/test_stopped_vm.py
+++ b/test/integration/component/test_stopped_vm.py
@@ -141,7 +141,6 @@ class TestDeployVM(cloudstackTestCase):
             accountid=self.account.name,
             domainid=self.account.domainid,
             serviceofferingid=self.service_offering.id,
-            diskofferingid=self.disk_offering.id,
             mode=self.zone.networktype
         )
 
@@ -1061,7 +1060,6 @@ class TestRouterStateAfterDeploy(cloudstackTestCase):
             accountid=self.account.name,
             domainid=self.account.domainid,
             serviceofferingid=self.service_offering.id,
-            diskofferingid=self.disk_offering.id,
             startvm=False
         )
 


### PR DESCRIPTION
issue
-------
Few testcases are failing  because of unsupported storage type .Deploy vm with data disk is failing.

solution
----------
Deploying vm without data disk for the test cases which does not required data disk. 