### PR TITLE
Handling Basic Zone scenarios for starting VM in stopped state

### DIFF
--- a/test/integration/component/test_blocker_bugs.py
+++ b/test/integration/component/test_blocker_bugs.py
@@ -663,7 +663,14 @@ class TestRouterRestart(cloudstackTestCase):
         #    all it's services should resume
 
         # Find router associated with user account
-        list_router_response = list_routers(
+        if (self.services['mode'] == "Basic"):
+            list_router_response = list_routers(
+                                    self.apiclient,
+                                    zoneid=self.zone.id,
+                                    listall=True
+                                    )
+        else:
+            list_router_response = list_routers(
                                     self.apiclient,
                                     account=self.account.name,
                                     domainid=self.account.domainid
@@ -702,7 +709,14 @@ class TestRouterRestart(cloudstackTestCase):
         self.apiclient.restartNetwork(cmd)
 
         # Get router details after restart
-        list_router_response = list_routers(
+        if (self.services['mode'] == "Basic"):
+            list_router_response = list_routers(
+                                    self.apiclient,
+                                    zoneid=self.zone.id,
+                                    listall=True
+                                    )
+        else:
+            list_router_response = list_routers(
                                     self.apiclient,
                                     account=self.account.name,
                                     domainid=self.account.domainid

--- a/test/integration/component/test_project_limits.py
+++ b/test/integration/component/test_project_limits.py
@@ -1052,7 +1052,7 @@ class TestMaxProjectNetworks(cloudstackTestCase):
         return
 
     @attr(tags=["advanced", "advancedns", "simulator",
-                "api", "eip"])
+                "api"])
     def test_maxAccountNetworks(self):
         """Test Limit number of guest account specific networks
         """

--- a/test/integration/component/test_resource_limits.py
+++ b/test/integration/component/test_resource_limits.py
@@ -1448,7 +1448,7 @@ class TestMaxAccountNetworks(cloudstackTestCase):
         return
 
     @attr(tags=["advanced", "advancedns", "simulator",
-                "api", "eip"])
+                "api"])
     def test_maxAccountNetworks(self):
         """Test Limit number of guest account specific networks
         """

--- a/test/integration/component/test_stopped_vm.py
+++ b/test/integration/component/test_stopped_vm.py
@@ -1067,18 +1067,20 @@ class TestRouterStateAfterDeploy(cloudstackTestCase):
             self.apiclient,
             VirtualMachine.STOPPED)
         self.assertEqual(response[0], PASS, response[1])
-        self.debug("Checking the router state after VM deployment")
-        routers = Router.list(
-            self.apiclient,
-            account=self.account.name,
-            domainid=self.account.domainid,
-            listall=True
-        )
-        self.assertEqual(
-            routers,
-            None,
-            "List routers should return empty response"
-        )
+
+        if(self.zone.networktype == "Advanced"):
+            self.debug("Checking the router state after VM deployment")
+            routers = Router.list(
+                self.apiclient,
+                account=self.account.name,
+                domainid=self.account.domainid,
+                listall=True
+            )
+            self.assertEqual(
+                routers,
+                None,
+                "List routers should return empty response"
+            )
         self.debug(
             "Deploying another instance (startvm=true) in the account: %s" %
             self.account.name)
@@ -1097,12 +1099,19 @@ class TestRouterStateAfterDeploy(cloudstackTestCase):
             VirtualMachine.RUNNING)
         self.assertEqual(response[0], PASS, response[1])
         self.debug("Checking the router state after VM deployment")
-        routers = Router.list(
-            self.apiclient,
-            account=self.account.name,
-            domainid=self.account.domainid,
-            listall=True
-        )
+        if (self.zone.networktype == "Basic"):
+            routers = Router.list(
+                                  self.apiclient,
+                                  zoneid=self.zone.id,
+                                  listall=True
+                                 )
+        else:
+            routers = Router.list(
+                self.apiclient,
+                account=self.account.name,
+                domainid=self.account.domainid,
+                listall=True
+            )
         self.assertEqual(
             isinstance(routers, list),
             True,
@@ -1118,17 +1127,18 @@ class TestRouterStateAfterDeploy(cloudstackTestCase):
         self.debug("Destroying the running VM:%s" %
                    self.virtual_machine_2.name)
         self.virtual_machine_2.delete(self.apiclient, expunge=True)
-        routers = Router.list(
-            self.apiclient,
-            account=self.account.name,
-            domainid=self.account.domainid,
-            listall=True
-        )
-        self.assertNotEqual(
-            routers,
-            None,
-            "Router should get deleted after expunge delay+wait"
-        )
+        if(self.zone.networktype == "Advanced"):
+            routers = Router.list(
+                self.apiclient,
+                account=self.account.name,
+                domainid=self.account.domainid,
+                listall=True
+            )
+            self.assertNotEqual(
+                routers,
+                None,
+                "Router should get deleted after expunge delay+wait"
+            )
         return
 
 


### PR DESCRIPTION
Basic Zone result:

Test Deploy Virtual Machine with no startVM parameter ... === TestName: test_01_deploy_vm_no_startvm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 41.609s

OK


Advanced Zone result:

Test Deploy Virtual Machine with no startVM parameter ... === TestName: test_01_deploy_vm_no_startvm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 139.844s

OK
