### PR TITLE
CLOUDSTACK-8620 :skip test cases if rbd storage is not available in l…

### DIFF
--- a/test/integration/component/test_ps_resize_volume.py
+++ b/test/integration/component/test_ps_resize_volume.py
@@ -91,9 +91,9 @@ class TestResizeVolume(cloudstackTestCase):
             cls.hypervisor = str(get_hypervisor_type(cls.api_client)).lower()
 
             # Creating service offering with normal config
-            cls.service_offering = ServiceOffering.create(cls.api_client,
-                                                          cls.services["\
-                                                          service_offering"])
+            cls.service_offering = ServiceOffering.create(
+                cls.api_client,
+                cls.services["service_offering"])
             cls._cleanup.append(cls.service_offering)
 
             cls.services["disk_offering"]["disksize"] = 5

--- a/test/integration/component/test_ps_resize_volume.py
+++ b/test/integration/component/test_ps_resize_volume.py
@@ -15,14 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-""" P1 tests for testing resize volume functionality with primary storage limit constraints on
-    account/domain
+""" P1 tests for testing resize volume functionality with primary storage
+    imit constraints on account/domain
 
-    Test Plan: https://cwiki.apache.org/confluence/display/CLOUDSTACK/Limit+Resources+to+domain+or+accounts
+    Test Plan: https://cwiki.apache.org/confluence/display/CLOUDSTACK/
+    Limit+Resources+to+domain+or+accounts
 
     Issue Link: https://issues.apache.org/jira/browse/CLOUDSTACK-1466
 
-    Feature Specifications: https://cwiki.apache.org/confluence/display/CLOUDSTACK/Limit+Resources+to+domains+and+accounts
+    Feature Specifications: https://cwiki.apache.org/confluence/display/
+    CLOUDSTACK/Limit+Resources+to+domains+and+accounts
 """
 # Import Local Modules
 from nose.plugins.attrib import attr
@@ -38,7 +40,8 @@ from marvin.lib.common import (get_domain,
                                get_zone,
                                get_template,
                                matchResourceCount,
-                               isDomainResourceCountEqualToExpectedCount)
+                               isDomainResourceCountEqualToExpectedCount,
+                               find_storage_pool_type)
 from marvin.lib.utils import (cleanup_resources,
                               get_hypervisor_type)
 from marvin.codes import (PASS,
@@ -48,59 +51,69 @@ from marvin.codes import (PASS,
                           RESOURCE_SECONDARY_STORAGE,
                           XEN_SERVER)
 
+
 class TestResizeVolume(cloudstackTestCase):
 
     @classmethod
     def setUpClass(cls):
         cloudstackTestClient = super(TestResizeVolume,
-                               cls).getClsTestClient()
+                                     cls).getClsTestClient()
         cls.api_client = cloudstackTestClient.getApiClient()
+        cls.hypervisor = cloudstackTestClient.getHypervisorInfo()
         # Fill services from the external config file
         cls.services = cloudstackTestClient.getParsedTestDataConfig()
         # Get Zone, Domain and templates
         cls.domain = get_domain(cls.api_client)
-        cls.zone = get_zone(cls.api_client, cloudstackTestClient.getZoneForTests())
+        cls.zone = get_zone(
+            cls.api_client,
+            cloudstackTestClient.getZoneForTests())
         cls.services["mode"] = cls.zone.networktype
+        cls._cleanup = []
+        cls.unsupportedStorageType = False
+        if cls.hypervisor.lower() == 'lxc':
+            if not find_storage_pool_type(cls.api_client, storagetype='rbd'):
+                cls.unsupportedStorageType = True
+                return
         cls.resourcetypemapping = {RESOURCE_PRIMARY_STORAGE: 10,
                                    RESOURCE_SECONDARY_STORAGE: 11}
 
-
-
         cls.template = get_template(
-                            cls.api_client,
-                            cls.zone.id,
-                            cls.services["ostype"]
-                            )
+            cls.api_client,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
 
         cls.services["virtual_machine"]["zoneid"] = cls.zone.id
         cls.services["virtual_machine"]["template"] = cls.template.id
         cls.services["volume"]["zoneid"] = cls.zone.id
 
-        cls._cleanup = []
         try:
             cls.hypervisor = str(get_hypervisor_type(cls.api_client)).lower()
 
             # Creating service offering with normal config
             cls.service_offering = ServiceOffering.create(cls.api_client,
-                                            cls.services["service_offering"])
+                                                          cls.services["\
+                                                          service_offering"])
             cls._cleanup.append(cls.service_offering)
 
             cls.services["disk_offering"]["disksize"] = 5
             cls.disk_offering_5_GB = DiskOffering.create(
-                                    cls.api_client,
-                                    cls.services["disk_offering"]
-                                    )
+                cls.api_client,
+                cls.services["disk_offering"]
+            )
             cls._cleanup.append(cls.disk_offering_5_GB)
 
             cls.services["disk_offering"]["disksize"] = 20
             cls.disk_offering_20_GB = DiskOffering.create(
-                                    cls.api_client,
-                                    cls.services["disk_offering"]
-                                    )
+                cls.api_client,
+                cls.services["disk_offering"]
+            )
             cls._cleanup.append(cls.disk_offering_20_GB)
         except Exception as e:
             cls.tearDownClass()
-            raise unittest.SkipTest("Failure while creating disk offering: %s" % e)
+            raise unittest.SkipTest(
+                "Failure while creating disk offering: %s" %
+                e)
         return
 
     @classmethod
@@ -113,6 +126,9 @@ class TestResizeVolume(cloudstackTestCase):
         return
 
     def setUp(self):
+        if self.unsupportedStorageType:
+            self.skipTest(
+                "unsupported storage type")
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
         self.cleanup = []
@@ -133,15 +149,17 @@ class TestResizeVolume(cloudstackTestCase):
 
         try:
             if domainLimit:
-                #Update resource limit for domain
+                # Update resource limit for domain
                 Resources.updateLimit(self.apiclient, resourcetype=10,
-                              max=domainLimit,
-                              domainid=self.parent_domain.id)
+                                      max=domainLimit,
+                                      domainid=self.parent_domain.id)
             if accountLimit:
-                #Update resource limit for domain
-                Resources.updateLimit(self.apiclient, resourcetype=10,
-                              max=accountLimit, account=self.parentd_admin.name,
-                              domainid=self.parent_domain.id)
+                # Update resource limit for domain
+                Resources.updateLimit(self.apiclient,
+                                      resourcetype=10,
+                                      max=accountLimit,
+                                      account=self.parentd_admin.name,
+                                      domainid=self.parent_domain.id)
         except Exception as e:
             return [FAIL, e]
         return [PASS, None]
@@ -149,10 +167,13 @@ class TestResizeVolume(cloudstackTestCase):
     def setupAccounts(self):
         try:
             self.parent_domain = Domain.create(self.apiclient,
-                                        services=self.services["domain"],
-                                        parentdomainid=self.domain.id)
-            self.parentd_admin = Account.create(self.apiclient, self.services["account"],
-                                            admin=True, domainid=self.parent_domain.id)
+                                               services=self.services[
+                                                   "domain"],
+                                               parentdomainid=self.domain.id)
+            self.parentd_admin = Account.create(self.apiclient,
+                                                self.services["account"],
+                                                admin=True,
+                                                domainid=self.parent_domain.id)
 
             # Cleanup the resources created at end of test
             self.cleanup.append(self.parentd_admin)
@@ -163,24 +184,26 @@ class TestResizeVolume(cloudstackTestCase):
 
     @attr(tags=["advanced"], required_hardware="true")
     def test_01_increase_volume_size_within_account_limit(self):
-	"""Test increasing volume size within the account limit and verify primary storage usage
+        """Test increasing volume size within the account limit and verify
+           primary storage usage
 
         # Validate the following
         # 1. Create a domain and its admin account
-        # 2. Set account primary storage limit well beyond (20 GB volume + template size of VM)
+        # 2. Set account primary storage limit well beyond (20 GB volume +
+        #    template size of VM)
         # 3. Deploy a VM without any disk offering (only root disk)
         # 4. Create a volume of 5 GB in the account and attach it to the VM
         # 5. Increase (resize) the volume to 20 GB
-        # 6. Resize opearation should be successful and primary storage counnt for
-        #    account should be updated successfully"""
+        # 6. Resize operation should be successful and primary storage count
+        #    for account should be updated successfully"""
 
         # Setting up account and domain hierarchy
         result = self.setupAccounts()
         self.assertEqual(result[0], PASS, result[1])
 
         apiclient = self.testClient.getUserApiClient(
-                        UserName=self.parentd_admin.name,
-                        DomainName=self.parentd_admin.domain)
+            UserName=self.parentd_admin.name,
+            DomainName=self.parentd_admin.domain)
         self.assertNotEqual(apiclient, FAILED, "Failed to get api client\
                             of account: %s" % self.parentd_admin.name)
 
@@ -190,35 +213,40 @@ class TestResizeVolume(cloudstackTestCase):
         self.assertEqual(response[0], PASS, response[1])
         try:
             virtualMachine = VirtualMachine.create(
-                    apiclient, self.services["virtual_machine"],
-                    accountid=self.parentd_admin.name, domainid=self.parent_domain.id,
-                    serviceofferingid=self.service_offering.id
-                    )
+                apiclient, self.services["virtual_machine"],
+                accountid=self.parentd_admin.name,
+                domainid=self.parent_domain.id,
+                serviceofferingid=self.service_offering.id
+            )
 
             volume = Volume.create(
-                    apiclient,self.services["volume"],zoneid=self.zone.id,
-                    account=self.parentd_admin.name,domainid=self.parent_domain.id,
-                    diskofferingid=self.disk_offering_5_GB.id)
+                apiclient, self.services["volume"],
+                zoneid=self.zone.id,
+                account=self.parentd_admin.name,
+                domainid=self.parent_domain.id,
+                diskofferingid=self.disk_offering_5_GB.id)
 
             virtualMachine.attach_volume(apiclient, volume=volume)
 
             expectedCount = (templateSize + self.disk_offering_5_GB.disksize)
             response = matchResourceCount(
-                        self.apiclient, expectedCount,
-                        RESOURCE_PRIMARY_STORAGE,
-                        accountid=self.parentd_admin.id)
+                self.apiclient, expectedCount,
+                RESOURCE_PRIMARY_STORAGE,
+                accountid=self.parentd_admin.id)
             if response[0] == FAIL:
                 raise Exception(response[1])
 
             if self.hypervisor == str(XEN_SERVER).lower():
                 virtualMachine.stop(self.apiclient)
-            volume.resize(apiclient, diskofferingid=self.disk_offering_20_GB.id)
+            volume.resize(
+                apiclient,
+                diskofferingid=self.disk_offering_20_GB.id)
 
             expectedCount = (templateSize + self.disk_offering_20_GB.disksize)
             response = matchResourceCount(
-                        self.apiclient, expectedCount,
-                        RESOURCE_PRIMARY_STORAGE,
-                        accountid=self.parentd_admin.id)
+                self.apiclient, expectedCount,
+                RESOURCE_PRIMARY_STORAGE,
+                accountid=self.parentd_admin.id)
             if response[0] == FAIL:
                 raise Exception(response[1])
         except Exception as e:
@@ -227,12 +255,13 @@ class TestResizeVolume(cloudstackTestCase):
 
     @attr(tags=["advanced"], required_hardware="true")
     def test_02_increase_volume_size_above_account_limit(self):
-	"""Test increasing volume size above the account limit
+        """Test increasing volume size above the account limit
 
         # Validate the following
         # 1. Create a domain and its admin account
-        # 2. Set account primary storage limit more than (5 GB volume + template size of VM)
-        #    and less than (20 GB volume+ template size of VM)
+        # 2. Set account primary storage limit more than (5 GB volume +
+        #    template size of VM) and less than (20 GB volume+ template
+        #    size of VM)
         # 3. Deploy a VM without any disk offering (only root disk)
         # 4. Create a volume of 5 GB in the account and attach it to the VM
         # 5. Try to (resize) the volume to 20 GB
@@ -248,30 +277,33 @@ class TestResizeVolume(cloudstackTestCase):
         self.assertEqual(response[0], PASS, response[1])
 
         apiclient = self.testClient.getUserApiClient(
-                        UserName=self.parentd_admin.name,
-                        DomainName=self.parentd_admin.domain)
+            UserName=self.parentd_admin.name,
+            DomainName=self.parentd_admin.domain)
         self.assertNotEqual(apiclient, FAILED, "Failed to get api client\
                             of account: %s" % self.parentd_admin.name)
 
         try:
             virtualMachine = VirtualMachine.create(
-                    apiclient, self.services["virtual_machine"],
-                    accountid=self.parentd_admin.name, domainid=self.parent_domain.id,
-                    serviceofferingid=self.service_offering.id
-                    )
+                apiclient, self.services["virtual_machine"],
+                accountid=self.parentd_admin.name,
+                domainid=self.parent_domain.id,
+                serviceofferingid=self.service_offering.id
+            )
 
             volume = Volume.create(
-                    apiclient,self.services["volume"],zoneid=self.zone.id,
-                    account=self.parentd_admin.name,domainid=self.parent_domain.id,
-                    diskofferingid=self.disk_offering_5_GB.id)
+                apiclient, self.services["volume"],
+                zoneid=self.zone.id,
+                account=self.parentd_admin.name,
+                domainid=self.parent_domain.id,
+                diskofferingid=self.disk_offering_5_GB.id)
 
             virtualMachine.attach_volume(apiclient, volume=volume)
 
             expectedCount = (templateSize + self.disk_offering_5_GB.disksize)
             response = matchResourceCount(
-                        self.apiclient, expectedCount,
-                        RESOURCE_PRIMARY_STORAGE,
-                        accountid=self.parentd_admin.id)
+                self.apiclient, expectedCount,
+                RESOURCE_PRIMARY_STORAGE,
+                accountid=self.parentd_admin.id)
             if response[0] == FAIL:
                 raise Exception(response[1])
         except Exception as e:
@@ -280,17 +312,20 @@ class TestResizeVolume(cloudstackTestCase):
         if self.hypervisor == str(XEN_SERVER).lower():
             virtualMachine.stop(self.apiclient)
         with self.assertRaises(Exception):
-            volume.resize(apiclient, diskofferingid=self.disk_offering_20_GB.id)
+            volume.resize(
+                apiclient,
+                diskofferingid=self.disk_offering_20_GB.id)
         return
 
     @attr(tags=["advanced"], required_hardware="true")
     def test_03_increase_volume_size_above_domain_limit(self):
-	"""Test increasing volume size above the domain limit
+        """Test increasing volume size above the domain limit
 
         # Validate the following
         # 1. Create a domain and its admin account
-        # 2. Set domain primary storage limit more than (5 GB volume + template size of VM)
-        #    and less than (20 GB volume+ template size of VM)
+        # 2. Set domain primary storage limit more than (5 GB volume +
+        #    template size of VM) and less than (20 GB volume+
+        #    template size of VM)
         # 3. Deploy a VM without any disk offering (only root disk)
         # 4. Create a volume of 5 GB in the account and attach it to the VM
         # 5. Try to (resize) the volume to 20 GB
@@ -306,29 +341,32 @@ class TestResizeVolume(cloudstackTestCase):
         self.assertEqual(response[0], PASS, response[1])
 
         apiclient = self.testClient.getUserApiClient(
-                        UserName=self.parentd_admin.name,
-                        DomainName=self.parentd_admin.domain)
+            UserName=self.parentd_admin.name,
+            DomainName=self.parentd_admin.domain)
         self.assertNotEqual(apiclient, FAILED, "Failed to get api client\
                             of account: %s" % self.parentd_admin.name)
 
         try:
             virtualMachine = VirtualMachine.create(
-                    apiclient, self.services["virtual_machine"],
-                    accountid=self.parentd_admin.name, domainid=self.parent_domain.id,
-                    serviceofferingid=self.service_offering.id
-                    )
+                apiclient, self.services["virtual_machine"],
+                accountid=self.parentd_admin.name,
+                domainid=self.parent_domain.id,
+                serviceofferingid=self.service_offering.id
+            )
 
             volume = Volume.create(
-                    apiclient,self.services["volume"],zoneid=self.zone.id,
-                    account=self.parentd_admin.name,domainid=self.parent_domain.id,
-                    diskofferingid=self.disk_offering_5_GB.id)
+                apiclient, self.services["volume"],
+                zoneid=self.zone.id,
+                account=self.parentd_admin.name,
+                domainid=self.parent_domain.id,
+                diskofferingid=self.disk_offering_5_GB.id)
 
             virtualMachine.attach_volume(apiclient, volume=volume)
 
             expectedCount = (templateSize + self.disk_offering_5_GB.disksize)
             result = isDomainResourceCountEqualToExpectedCount(
-                        self.apiclient, self.parent_domain.id,
-                        expectedCount, RESOURCE_PRIMARY_STORAGE)
+                self.apiclient, self.parent_domain.id,
+                expectedCount, RESOURCE_PRIMARY_STORAGE)
             self.assertFalse(result[0], result[1])
             self.assertTrue(result[2], "Resource count does not match")
         except Exception as e:
@@ -337,5 +375,7 @@ class TestResizeVolume(cloudstackTestCase):
         if self.hypervisor == str(XEN_SERVER).lower():
             virtualMachine.stop(self.apiclient)
         with self.assertRaises(Exception):
-            volume.resize(apiclient, diskofferingid=self.disk_offering_20_GB.id)
+            volume.resize(
+                apiclient,
+                diskofferingid=self.disk_offering_20_GB.id)
         return


### PR DESCRIPTION
skipping tests based on storage for lxc hype and fixing pep8 issues 
test result
=========
Test increasing volume size within the account limit and verify primary storage usage ... SKIP: unsupported storage type
Test increasing volume size above the account limit ... SKIP: unsupported storage type
Test increasing volume size above the domain limit ... SKIP: unsupported storage type

----------------------------------------------------------------------
Ran 3 tests in 2.236s

OK (SKIP=3)
