### PR TITLE
Findbugs issues with instance acces to static fields

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -96,8 +96,8 @@ import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.CpuModeDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.CpuTuneDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DevicesDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
-import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef.deviceType;
-import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef.diskProtocol;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef.DeviceType;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef.DiskProtocol;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.FeaturesDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.FilesystemDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.GraphicDef;
@@ -105,7 +105,7 @@ import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.GuestDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.GuestResourceDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InputDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef;
-import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef.guestNetType;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef.GuestNetType;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.SerialDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.TermPolicy;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.VideoDef;
@@ -1841,10 +1841,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         if (HypervisorType.LXC == _hypervisorType && VirtualMachine.Type.User == vmTO.getType()) {
             // LXC domain is only valid for user VMs. Use KVM for system VMs.
-            guest.setGuestType(GuestDef.guestType.LXC);
+            guest.setGuestType(GuestDef.GuestType.LXC);
             vm.setHvsType(HypervisorType.LXC.toString().toLowerCase());
         } else {
-            guest.setGuestType(GuestDef.guestType.KVM);
+            guest.setGuestType(GuestDef.GuestType.KVM);
             vm.setHvsType(HypervisorType.KVM.toString().toLowerCase());
             vm.setLibvirtVersion(_hypervisorLibvirtVersion);
             vm.setQemuVersion(_hypervisorQemuVersion);
@@ -1852,8 +1852,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         guest.setGuestArch(vmTO.getArch());
         guest.setMachineType("pc");
         guest.setUuid(uuid);
-        guest.setBootOrder(GuestDef.bootOrder.CDROM);
-        guest.setBootOrder(GuestDef.bootOrder.HARDISK);
+        guest.setBootOrder(GuestDef.BootOrder.CDROM);
+        guest.setBootOrder(GuestDef.BootOrder.HARDISK);
 
         vm.addComp(guest);
 
@@ -2036,12 +2036,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             }
 
             // if params contains a rootDiskController key, use its value (this is what other HVs are doing)
-            DiskDef.diskBus diskBusType = null;
+            DiskDef.DiskBus diskBusType = null;
             final Map <String, String> params = vmSpec.getDetails();
             if (params != null && params.get("rootDiskController") != null && !params.get("rootDiskController").isEmpty()) {
                 final String rootDiskController = params.get("rootDiskController");
                 s_logger.debug("Passed custom disk bus " + rootDiskController);
-                for (final DiskDef.diskBus bus : DiskDef.diskBus.values()) {
+                for (final DiskDef.DiskBus bus : DiskDef.DiskBus.values()) {
                     if (bus.toString().equalsIgnoreCase(rootDiskController)) {
                         s_logger.debug("Found matching enum for disk bus " + rootDiskController);
                         diskBusType = bus;
@@ -2071,20 +2071,20 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                             we pass the pool's UUID as the authSecret
                      */
                     disk.defNetworkBasedDisk(physicalDisk.getPath().replace("rbd:", ""), pool.getSourceHost(), pool.getSourcePort(), pool.getAuthUserName(),
-                            pool.getUuid(), devId, diskBusType, diskProtocol.RBD, DiskDef.diskFmtType.RAW);
+                            pool.getUuid(), devId, diskBusType, DiskProtocol.RBD, DiskDef.DiskFmtType.RAW);
                 } else if (pool.getType() == StoragePoolType.Gluster) {
                     final String mountpoint = pool.getLocalPath();
                     final String path = physicalDisk.getPath();
                     final String glusterVolume = pool.getSourceDir().replace("/", "");
                     disk.defNetworkBasedDisk(glusterVolume + path.replace(mountpoint, ""), pool.getSourceHost(), pool.getSourcePort(), null,
-                            null, devId, diskBusType, diskProtocol.GLUSTER, DiskDef.diskFmtType.QCOW2);
+                            null, devId, diskBusType, DiskProtocol.GLUSTER, DiskDef.DiskFmtType.QCOW2);
                 } else if (pool.getType() == StoragePoolType.CLVM || physicalDisk.getFormat() == PhysicalDiskFormat.RAW) {
                     disk.defBlockBasedDisk(physicalDisk.getPath(), devId, diskBusType);
                 } else {
                     if (volume.getType() == Volume.Type.DATADISK) {
-                        disk.defFileBasedDisk(physicalDisk.getPath(), devId, DiskDef.diskBus.VIRTIO, DiskDef.diskFmtType.QCOW2);
+                        disk.defFileBasedDisk(physicalDisk.getPath(), devId, DiskDef.DiskBus.VIRTIO, DiskDef.DiskFmtType.QCOW2);
                     } else {
-                        disk.defFileBasedDisk(physicalDisk.getPath(), devId, diskBusType, DiskDef.diskFmtType.QCOW2);
+                        disk.defFileBasedDisk(physicalDisk.getPath(), devId, diskBusType, DiskDef.DiskFmtType.QCOW2);
                     }
 
                 }
@@ -2106,7 +2106,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                     disk.setIopsWriteRate(volumeObjectTO.getIopsWriteRate());
                 }
                 if (volumeObjectTO.getCacheMode() != null) {
-                    disk.setCacheMode(DiskDef.diskCacheMode.valueOf(volumeObjectTO.getCacheMode().toString().toUpperCase()));
+                    disk.setCacheMode(DiskDef.DiskCacheMode.valueOf(volumeObjectTO.getCacheMode().toString().toUpperCase()));
                 }
             }
             vm.getDevices().addDevice(disk);
@@ -2138,7 +2138,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                         if (device != null) {
                             s_logger.debug("RBD device on host is: " + device);
                             final DiskDef diskdef = new DiskDef();
-                            diskdef.defBlockBasedDisk(device, devId, DiskDef.diskBus.VIRTIO);
+                            diskdef.defBlockBasedDisk(device, devId, DiskDef.DiskBus.VIRTIO);
                             diskdef.setQemuDriver(false);
                             vm.getDevices().addDevice(diskdef);
                         } else {
@@ -2199,7 +2199,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         final String result = attachOrDetachDevice(conn, true, vmName, isoXml);
         if (result == null && !isAttach) {
             for (final DiskDef disk : disks) {
-                if (disk.getDeviceType() == DiskDef.deviceType.CDROM) {
+                if (disk.getDeviceType() == DiskDef.DeviceType.CDROM) {
                     cleanupDisk(disk);
                 }
             }
@@ -2237,14 +2237,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 diskdef = new DiskDef();
                 if (attachingPool.getType() == StoragePoolType.RBD) {
                     diskdef.defNetworkBasedDisk(attachingDisk.getPath(), attachingPool.getSourceHost(), attachingPool.getSourcePort(), attachingPool.getAuthUserName(),
-                            attachingPool.getUuid(), devId, DiskDef.diskBus.VIRTIO, diskProtocol.RBD, DiskDef.diskFmtType.RAW);
+                            attachingPool.getUuid(), devId, DiskDef.DiskBus.VIRTIO, DiskProtocol.RBD, DiskDef.DiskFmtType.RAW);
                 } else if (attachingPool.getType() == StoragePoolType.Gluster) {
                     diskdef.defNetworkBasedDisk(attachingDisk.getPath(), attachingPool.getSourceHost(), attachingPool.getSourcePort(), null,
-                            null, devId, DiskDef.diskBus.VIRTIO, diskProtocol.GLUSTER, DiskDef.diskFmtType.QCOW2);
+                            null, devId, DiskDef.DiskBus.VIRTIO, DiskProtocol.GLUSTER, DiskDef.DiskFmtType.QCOW2);
                 } else if (attachingDisk.getFormat() == PhysicalDiskFormat.QCOW2) {
-                    diskdef.defFileBasedDisk(attachingDisk.getPath(), devId, DiskDef.diskBus.VIRTIO, DiskDef.diskFmtType.QCOW2);
+                    diskdef.defFileBasedDisk(attachingDisk.getPath(), devId, DiskDef.DiskBus.VIRTIO, DiskDef.DiskFmtType.QCOW2);
                 } else if (attachingDisk.getFormat() == PhysicalDiskFormat.RAW) {
-                    diskdef.defBlockBasedDisk(attachingDisk.getPath(), devId, DiskDef.diskBus.VIRTIO);
+                    diskdef.defBlockBasedDisk(attachingDisk.getPath(), devId, DiskDef.DiskBus.VIRTIO);
                 }
                 if (bytesReadRate != null && bytesReadRate > 0) {
                     diskdef.setBytesReadRate(bytesReadRate);
@@ -2260,7 +2260,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 }
 
                 if (cacheMode != null) {
-                    diskdef.setCacheMode(DiskDef.diskCacheMode.valueOf(cacheMode.toUpperCase()));
+                    diskdef.setCacheMode(DiskDef.DiskCacheMode.valueOf(cacheMode.toUpperCase()));
                 }
             }
 
@@ -2619,7 +2619,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             final LibvirtDomainXMLParser parser = new LibvirtDomainXMLParser();
             parser.parseDomainXML(vmDef);
             for (final InterfaceDef nic : parser.getInterfaces()) {
-                if (nic.getNetType() == guestNetType.BRIDGE && nic.getBrName().startsWith("cloudVirBr")) {
+                if (nic.getNetType() == GuestNetType.BRIDGE && nic.getBrName().startsWith("cloudVirBr")) {
                     try {
                         final int vnetId = Integer.parseInt(nic.getBrName().replaceFirst("cloudVirBr", ""));
                         final String pifName = getPif(_guestBridgeName);
@@ -2838,11 +2838,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
     }
 
-    private DiskDef.diskBus getGuestDiskModel(final String platformEmulator) {
+    private DiskDef.DiskBus getGuestDiskModel(final String platformEmulator) {
         if (isGuestPVEnabled(platformEmulator)) {
-            return DiskDef.diskBus.VIRTIO;
+            return DiskDef.DiskBus.VIRTIO;
         } else {
-            return DiskDef.diskBus.IDE;
+            return DiskDef.DiskBus.IDE;
         }
     }
 
@@ -2921,7 +2921,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             final List<DiskDef> disks = getDisks(conn, vmName);
 
             for (final DiskDef disk : disks) {
-                if (disk.getDeviceType() != deviceType.DISK) {
+                if (disk.getDeviceType() != DeviceType.DISK) {
                     break;
                 }
                 final DomainBlockStats blockStats = dm.blockStats(disk.getDiskLabel());

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParser.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParser.java
@@ -35,7 +35,7 @@ import org.xml.sax.SAXException;
 
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef;
-import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef.nicModel;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef.NicModel;
 
 public class LibvirtDomainXMLParser {
     private static final Logger s_logger = Logger.getLogger(LibvirtDomainXMLParser.class);
@@ -75,15 +75,15 @@ public class LibvirtDomainXMLParser {
                     String diskLabel = getAttrValue("target", "dev", disk);
                     String bus = getAttrValue("target", "bus", disk);
 
-                    DiskDef.diskFmtType fmt = null;
+                    DiskDef.DiskFmtType fmt = null;
                     if (diskFmtType != null) {
-                        fmt = DiskDef.diskFmtType.valueOf(diskFmtType.toUpperCase());
+                        fmt = DiskDef.DiskFmtType.valueOf(diskFmtType.toUpperCase());
                     }
 
                     def.defNetworkBasedDisk(diskPath, host, port, authUserName, poolUuid, diskLabel,
-                        DiskDef.diskBus.valueOf(bus.toUpperCase()),
-                        DiskDef.diskProtocol.valueOf(protocol.toUpperCase()), fmt);
-                    def.setCacheMode(DiskDef.diskCacheMode.valueOf(diskCacheMode.toUpperCase()));
+                        DiskDef.DiskBus.valueOf(bus.toUpperCase()),
+                        DiskDef.DiskProtocol.valueOf(protocol.toUpperCase()), fmt);
+                    def.setCacheMode(DiskDef.DiskCacheMode.valueOf(diskCacheMode.toUpperCase()));
                 } else {
                     String diskFmtType = getAttrValue("driver", "type", disk);
                     String diskCacheMode = getAttrValue("driver", "cache", disk);
@@ -96,20 +96,20 @@ public class LibvirtDomainXMLParser {
 
                     if (type.equalsIgnoreCase("file")) {
                         if (device.equalsIgnoreCase("disk")) {
-                            DiskDef.diskFmtType fmt = null;
+                            DiskDef.DiskFmtType fmt = null;
                             if (diskFmtType != null) {
-                                fmt = DiskDef.diskFmtType.valueOf(diskFmtType.toUpperCase());
+                                fmt = DiskDef.DiskFmtType.valueOf(diskFmtType.toUpperCase());
                             }
-                            def.defFileBasedDisk(diskFile, diskLabel, DiskDef.diskBus.valueOf(bus.toUpperCase()), fmt);
+                            def.defFileBasedDisk(diskFile, diskLabel, DiskDef.DiskBus.valueOf(bus.toUpperCase()), fmt);
                         } else if (device.equalsIgnoreCase("cdrom")) {
                             def.defISODisk(diskFile);
                         }
                     } else if (type.equalsIgnoreCase("block")) {
                         def.defBlockBasedDisk(diskDev, diskLabel,
-                            DiskDef.diskBus.valueOf(bus.toUpperCase()));
+                            DiskDef.DiskBus.valueOf(bus.toUpperCase()));
                     }
                     if (diskCacheMode != null) {
-                        def.setCacheMode(DiskDef.diskCacheMode.valueOf(diskCacheMode.toUpperCase()));
+                        def.setCacheMode(DiskDef.DiskCacheMode.valueOf(diskCacheMode.toUpperCase()));
                     }
                 }
 
@@ -160,13 +160,13 @@ public class LibvirtDomainXMLParser {
                 }
                 if (type.equalsIgnoreCase("network")) {
                     String network = getAttrValue("source", "network", nic);
-                    def.defPrivateNet(network, dev, mac, nicModel.valueOf(model.toUpperCase()), networkRateKBps);
+                    def.defPrivateNet(network, dev, mac, NicModel.valueOf(model.toUpperCase()), networkRateKBps);
                 } else if (type.equalsIgnoreCase("bridge")) {
                     String bridge = getAttrValue("source", "bridge", nic);
-                    def.defBridgeNet(bridge, dev, mac, nicModel.valueOf(model.toUpperCase()), networkRateKBps);
+                    def.defBridgeNet(bridge, dev, mac, NicModel.valueOf(model.toUpperCase()), networkRateKBps);
                 } else if (type.equalsIgnoreCase("ethernet")) {
                     String scriptPath = getAttrValue("script", "path", nic);
-                    def.defEthernet(dev, mac, nicModel.valueOf(model.toUpperCase()), scriptPath, networkRateKBps);
+                    def.defEthernet(dev, mac, NicModel.valueOf(model.toUpperCase()), scriptPath, networkRateKBps);
                 }
                 interfaces.add(def);
             }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -34,15 +34,15 @@ public class LibvirtVMDef {
     private final Map<String, Object> components = new HashMap<String, Object>();
 
     public static class GuestDef {
-        enum guestType {
+        enum GuestType {
             KVM, XEN, EXE, LXC
         }
 
-        enum bootOrder {
+        enum BootOrder {
             HARDISK("hd"), CDROM("cdrom"), FLOPPY("fd"), NETWORK("network");
             String _order;
 
-            bootOrder(String order) {
+            BootOrder(String order) {
                 _order = order;
             }
 
@@ -52,7 +52,7 @@ public class LibvirtVMDef {
             }
         }
 
-        private guestType _type;
+        private GuestType _type;
         private String _arch;
         private String _loader;
         private String _kernel;
@@ -60,14 +60,14 @@ public class LibvirtVMDef {
         private String _root;
         private String _cmdline;
         private String _uuid;
-        private final List<bootOrder> _bootdevs = new ArrayList<bootOrder>();
+        private final List<BootOrder> _bootdevs = new ArrayList<BootOrder>();
         private String _machine;
 
-        public void setGuestType(guestType type) {
+        public void setGuestType(GuestType type) {
             _type = type;
         }
 
-        public guestType getGuestType() {
+        public GuestType getGuestType() {
             return _type;
         }
 
@@ -90,7 +90,7 @@ public class LibvirtVMDef {
             _cmdline = cmdline;
         }
 
-        public void setBootOrder(bootOrder order) {
+        public void setBootOrder(BootOrder order) {
             _bootdevs.add(order);
         }
 
@@ -100,7 +100,7 @@ public class LibvirtVMDef {
 
         @Override
         public String toString() {
-            if (_type == guestType.KVM) {
+            if (_type == GuestType.KVM) {
                 StringBuilder guestDef = new StringBuilder();
 
                 guestDef.append("<sysinfo type='smbios'>\n");
@@ -121,14 +121,14 @@ public class LibvirtVMDef {
                 }
                 guestDef.append(">hvm</type>\n");
                 if (!_bootdevs.isEmpty()) {
-                    for (bootOrder bo : _bootdevs) {
+                    for (BootOrder bo : _bootdevs) {
                         guestDef.append("<boot dev='" + bo + "'/>\n");
                     }
                 }
                 guestDef.append("<smbios mode='sysinfo'/>\n");
                 guestDef.append("</os>\n");
                 return guestDef.toString();
-            } else if (_type == guestType.LXC) {
+            } else if (_type == GuestType.LXC) {
                 StringBuilder guestDef = new StringBuilder();
                 guestDef.append("<os>\n");
                 guestDef.append("<type>exe</type>\n");
@@ -353,7 +353,7 @@ public class LibvirtVMDef {
 
     public static class DevicesDef {
         private String _emulator;
-        private GuestDef.guestType _guestType;
+        private GuestDef.GuestType _guestType;
         private final Map<String, List<?>> devices = new HashMap<String, List<?>>();
 
         public boolean addDevice(Object device) {
@@ -373,7 +373,7 @@ public class LibvirtVMDef {
             _emulator = emulator;
         }
 
-        public void setGuestType(GuestDef.guestType guestType) {
+        public void setGuestType(GuestDef.GuestType guestType) {
             _guestType = guestType;
         }
 
@@ -387,7 +387,7 @@ public class LibvirtVMDef {
 
             for (List<?> devs : devices.values()) {
                 for (Object dev : devs) {
-                    if (_guestType == GuestDef.guestType.LXC) {
+                    if (_guestType == GuestDef.GuestType.LXC) {
                         if (dev instanceof GraphicDef || dev instanceof InputDef) {
                             continue;
                         }
@@ -418,11 +418,11 @@ public class LibvirtVMDef {
     }
 
     public static class DiskDef {
-        public enum deviceType {
+        public enum DeviceType {
             FLOPPY("floppy"), DISK("disk"), CDROM("cdrom");
             String _type;
 
-            deviceType(String type) {
+            DeviceType(String type) {
                 _type = type;
             }
 
@@ -432,11 +432,11 @@ public class LibvirtVMDef {
             }
         }
 
-        enum diskType {
+        enum DiskType {
             FILE("file"), BLOCK("block"), DIRECTROY("dir"), NETWORK("network");
             String _diskType;
 
-            diskType(String type) {
+            DiskType(String type) {
                 _diskType = type;
             }
 
@@ -446,11 +446,11 @@ public class LibvirtVMDef {
             }
         }
 
-        public enum diskProtocol {
+        public enum DiskProtocol {
             RBD("rbd"), SHEEPDOG("sheepdog"), GLUSTER("gluster");
             String _diskProtocol;
 
-            diskProtocol(String protocol) {
+            DiskProtocol(String protocol) {
                 _diskProtocol = protocol;
             }
 
@@ -460,11 +460,11 @@ public class LibvirtVMDef {
             }
         }
 
-        public enum diskBus {
+        public enum DiskBus {
             IDE("ide"), SCSI("scsi"), VIRTIO("virtio"), XEN("xen"), USB("usb"), UML("uml"), FDC("fdc");
             String _bus;
 
-            diskBus(String bus) {
+            DiskBus(String bus) {
                 _bus = bus;
             }
 
@@ -474,11 +474,11 @@ public class LibvirtVMDef {
             }
         }
 
-        public enum diskFmtType {
+        public enum DiskFmtType {
             RAW("raw"), QCOW2("qcow2");
             String _fmtType;
 
-            diskFmtType(String fmt) {
+            DiskFmtType(String fmt) {
                 _fmtType = fmt;
             }
 
@@ -488,11 +488,11 @@ public class LibvirtVMDef {
             }
         }
 
-        public enum diskCacheMode {
+        public enum DiskCacheMode {
             NONE("none"), WRITEBACK("writeback"), WRITETHROUGH("writethrough");
             String _diskCacheMode;
 
-            diskCacheMode(String cacheMode) {
+            DiskCacheMode(String cacheMode) {
                 _diskCacheMode = cacheMode;
             }
 
@@ -505,17 +505,17 @@ public class LibvirtVMDef {
             }
         }
 
-        private deviceType _deviceType; /* floppy, disk, cdrom */
-        private diskType _diskType;
-        private diskProtocol _diskProtocol;
+        private DeviceType _deviceType; /* floppy, disk, cdrom */
+        private DiskType _diskType;
+        private DiskProtocol _diskProtocol;
         private String _sourcePath;
         private String _sourceHost;
         private int _sourcePort;
         private String _authUserName;
         private String _authSecretUUID;
         private String _diskLabel;
-        private diskBus _bus;
-        private diskFmtType _diskFmtType; /* qcow2, raw etc. */
+        private DiskBus _bus;
+        private DiskFmtType _diskFmtType; /* qcow2, raw etc. */
         private boolean _readonly = false;
         private boolean _shareable = false;
         private boolean _deferAttach = false;
@@ -523,17 +523,17 @@ public class LibvirtVMDef {
         private Long _bytesWriteRate;
         private Long _iopsReadRate;
         private Long _iopsWriteRate;
-        private diskCacheMode _diskCacheMode;
+        private DiskCacheMode _diskCacheMode;
         private boolean qemuDriver = true;
 
-        public void setDeviceType(deviceType deviceType) {
+        public void setDeviceType(DeviceType deviceType) {
             _deviceType = deviceType;
         }
 
-        public void defFileBasedDisk(String filePath, String diskLabel, diskBus bus, diskFmtType diskFmtType) {
-            _diskType = diskType.FILE;
-            _deviceType = deviceType.DISK;
-            _diskCacheMode = diskCacheMode.NONE;
+        public void defFileBasedDisk(String filePath, String diskLabel, DiskBus bus, DiskFmtType diskFmtType) {
+            _diskType = DiskType.FILE;
+            _deviceType = DeviceType.DISK;
+            _diskCacheMode = DiskCacheMode.NONE;
             _sourcePath = filePath;
             _diskLabel = diskLabel;
             _diskFmtType = diskFmtType;
@@ -542,26 +542,26 @@ public class LibvirtVMDef {
         }
 
         /* skip iso label */
-        private String getDevLabel(int devId, diskBus bus) {
+        private String getDevLabel(int devId, DiskBus bus) {
             if (devId == 2) {
                 devId++;
             }
 
             char suffix = (char)('a' + devId);
-            if (bus == diskBus.SCSI) {
+            if (bus == DiskBus.SCSI) {
                 return "sd" + suffix;
-            } else if (bus == diskBus.VIRTIO) {
+            } else if (bus == DiskBus.VIRTIO) {
                 return "vd" + suffix;
             }
             return "hd" + suffix;
 
         }
 
-        public void defFileBasedDisk(String filePath, int devId, diskBus bus, diskFmtType diskFmtType) {
+        public void defFileBasedDisk(String filePath, int devId, DiskBus bus, DiskFmtType diskFmtType) {
 
-            _diskType = diskType.FILE;
-            _deviceType = deviceType.DISK;
-            _diskCacheMode = diskCacheMode.NONE;
+            _diskType = DiskType.FILE;
+            _deviceType = DeviceType.DISK;
+            _diskCacheMode = DiskCacheMode.NONE;
             _sourcePath = filePath;
             _diskLabel = getDevLabel(devId, bus);
             _diskFmtType = diskFmtType;
@@ -570,41 +570,41 @@ public class LibvirtVMDef {
         }
 
         public void defISODisk(String volPath) {
-            _diskType = diskType.FILE;
-            _deviceType = deviceType.CDROM;
+            _diskType = DiskType.FILE;
+            _deviceType = DeviceType.CDROM;
             _sourcePath = volPath;
             _diskLabel = "hdc";
-            _diskFmtType = diskFmtType.RAW;
-            _diskCacheMode = diskCacheMode.NONE;
-            _bus = diskBus.IDE;
+            _diskFmtType = DiskFmtType.RAW;
+            _diskCacheMode = DiskCacheMode.NONE;
+            _bus = DiskBus.IDE;
         }
 
-        public void defBlockBasedDisk(String diskName, int devId, diskBus bus) {
-            _diskType = diskType.BLOCK;
-            _deviceType = deviceType.DISK;
-            _diskFmtType = diskFmtType.RAW;
-            _diskCacheMode = diskCacheMode.NONE;
+        public void defBlockBasedDisk(String diskName, int devId, DiskBus bus) {
+            _diskType = DiskType.BLOCK;
+            _deviceType = DeviceType.DISK;
+            _diskFmtType = DiskFmtType.RAW;
+            _diskCacheMode = DiskCacheMode.NONE;
             _sourcePath = diskName;
             _diskLabel = getDevLabel(devId, bus);
             _bus = bus;
         }
 
-        public void defBlockBasedDisk(String diskName, String diskLabel, diskBus bus) {
-            _diskType = diskType.BLOCK;
-            _deviceType = deviceType.DISK;
-            _diskFmtType = diskFmtType.RAW;
-            _diskCacheMode = diskCacheMode.NONE;
+        public void defBlockBasedDisk(String diskName, String diskLabel, DiskBus bus) {
+            _diskType = DiskType.BLOCK;
+            _deviceType = DeviceType.DISK;
+            _diskFmtType = DiskFmtType.RAW;
+            _diskCacheMode = DiskCacheMode.NONE;
             _sourcePath = diskName;
             _diskLabel = diskLabel;
             _bus = bus;
         }
 
-        public void defNetworkBasedDisk(String diskName, String sourceHost, int sourcePort, String authUserName, String authSecretUUID, int devId, diskBus bus,
-                diskProtocol protocol, diskFmtType diskFmtType) {
-            _diskType = diskType.NETWORK;
-            _deviceType = deviceType.DISK;
+        public void defNetworkBasedDisk(String diskName, String sourceHost, int sourcePort, String authUserName, String authSecretUUID, int devId, DiskBus bus,
+                DiskProtocol protocol, DiskFmtType diskFmtType) {
+            _diskType = DiskType.NETWORK;
+            _deviceType = DeviceType.DISK;
             _diskFmtType = diskFmtType;
-            _diskCacheMode = diskCacheMode.NONE;
+            _diskCacheMode = DiskCacheMode.NONE;
             _sourcePath = diskName;
             _sourceHost = sourceHost;
             _sourcePort = sourcePort;
@@ -615,12 +615,12 @@ public class LibvirtVMDef {
             _diskProtocol = protocol;
         }
 
-        public void defNetworkBasedDisk(String diskName, String sourceHost, int sourcePort, String authUserName, String authSecretUUID, String diskLabel, diskBus bus,
-                diskProtocol protocol, diskFmtType diskFmtType) {
-            _diskType = diskType.NETWORK;
-            _deviceType = deviceType.DISK;
+        public void defNetworkBasedDisk(String diskName, String sourceHost, int sourcePort, String authUserName, String authSecretUUID, String diskLabel, DiskBus bus,
+                DiskProtocol protocol, DiskFmtType diskFmtType) {
+            _diskType = DiskType.NETWORK;
+            _deviceType = DeviceType.DISK;
             _diskFmtType = diskFmtType;
-            _diskCacheMode = diskCacheMode.NONE;
+            _diskCacheMode = DiskCacheMode.NONE;
             _sourcePath = diskName;
             _sourceHost = sourceHost;
             _sourcePort = sourcePort;
@@ -655,11 +655,11 @@ public class LibvirtVMDef {
             return _diskLabel;
         }
 
-        public diskType getDiskType() {
+        public DiskType getDiskType() {
             return _diskType;
         }
 
-        public deviceType getDeviceType() {
+        public DeviceType getDeviceType() {
             return _deviceType;
         }
 
@@ -667,11 +667,11 @@ public class LibvirtVMDef {
             _sourcePath = volPath;
         }
 
-        public diskBus getBusType() {
+        public DiskBus getBusType() {
             return _bus;
         }
 
-        public diskFmtType getDiskFormatType() {
+        public DiskFmtType getDiskFormatType() {
             return _diskFmtType;
         }
 
@@ -696,11 +696,11 @@ public class LibvirtVMDef {
             _iopsWriteRate = iopsWriteRate;
         }
 
-        public void setCacheMode(diskCacheMode cacheMode) {
+        public void setCacheMode(DiskCacheMode cacheMode) {
             _diskCacheMode = cacheMode;
         }
 
-        public diskCacheMode getCacheMode() {
+        public DiskCacheMode getCacheMode() {
             return _diskCacheMode;
         }
 
@@ -722,21 +722,21 @@ public class LibvirtVMDef {
                         + "' cache='" + _diskCacheMode + "' " + "/>\n");
             }
 
-            if (_diskType == diskType.FILE) {
+            if (_diskType == DiskType.FILE) {
                 diskBuilder.append("<source ");
                 if (_sourcePath != null) {
                     diskBuilder.append("file='" + _sourcePath + "'");
-                } else if (_deviceType == deviceType.CDROM) {
+                } else if (_deviceType == DeviceType.CDROM) {
                     diskBuilder.append("file=''");
                 }
                 diskBuilder.append("/>\n");
-            } else if (_diskType == diskType.BLOCK) {
+            } else if (_diskType == DiskType.BLOCK) {
                 diskBuilder.append("<source");
                 if (_sourcePath != null) {
                     diskBuilder.append(" dev='" + _sourcePath + "'");
                 }
                 diskBuilder.append("/>\n");
-            } else if (_diskType == diskType.NETWORK) {
+            } else if (_diskType == DiskType.NETWORK) {
                 diskBuilder.append("<source ");
                 diskBuilder.append(" protocol='" + _diskProtocol + "'");
                 diskBuilder.append(" name='" + _sourcePath + "'");
@@ -761,7 +761,7 @@ public class LibvirtVMDef {
             }
             diskBuilder.append("/>\n");
 
-            if ((_deviceType != deviceType.CDROM) &&
+            if ((_deviceType != DeviceType.CDROM) &&
                     (s_libvirtVersion >= 9008) &&
                     (s_qemuVersion >= 1001000) &&
                     (((_bytesReadRate != null) && (_bytesReadRate > 0)) || ((_bytesWriteRate != null) && (_bytesWriteRate > 0)) ||
@@ -784,11 +784,11 @@ public class LibvirtVMDef {
     }
 
     public static class InterfaceDef {
-        enum guestNetType {
+        enum GuestNetType {
             BRIDGE("bridge"), DIRECT("direct"), NETWORK("network"), USER("user"), ETHERNET("ethernet"), INTERNAL("internal");
             String _type;
 
-            guestNetType(String type) {
+            GuestNetType(String type) {
                 _type = type;
             }
 
@@ -798,11 +798,11 @@ public class LibvirtVMDef {
             }
         }
 
-        enum nicModel {
+        enum NicModel {
             E1000("e1000"), VIRTIO("virtio"), RTL8139("rtl8139"), NE2KPCI("ne2k_pci"), VMXNET3("vmxnet3");
             String _model;
 
-            nicModel(String model) {
+            NicModel(String model) {
                 _model = model;
             }
 
@@ -812,34 +812,34 @@ public class LibvirtVMDef {
             }
         }
 
-        enum hostNicType {
+        enum HostNicType {
             DIRECT_ATTACHED_WITHOUT_DHCP, DIRECT_ATTACHED_WITH_DHCP, VNET, VLAN;
         }
 
-        private guestNetType _netType; /*
+        private GuestNetType _netType; /*
          * bridge, ethernet, network, user,
          * internal
          */
-        private hostNicType _hostNetType; /* Only used by agent java code */
+        private HostNicType _hostNetType; /* Only used by agent java code */
         private String _netSourceMode;
         private String _sourceName;
         private String _networkName;
         private String _macAddr;
         private String _ipAddr;
         private String _scriptPath;
-        private nicModel _model;
+        private NicModel _model;
         private Integer _networkRateKBps;
         private String _virtualPortType;
         private String _virtualPortInterfaceId;
         private int _vlanTag = -1;
         private boolean _pxeDisable = false;
 
-        public void defBridgeNet(String brName, String targetBrName, String macAddr, nicModel model) {
+        public void defBridgeNet(String brName, String targetBrName, String macAddr, NicModel model) {
             defBridgeNet(brName, targetBrName, macAddr, model, 0);
         }
 
-        public void defBridgeNet(String brName, String targetBrName, String macAddr, nicModel model, Integer networkRateKBps) {
-            _netType = guestNetType.BRIDGE;
+        public void defBridgeNet(String brName, String targetBrName, String macAddr, NicModel model, Integer networkRateKBps) {
+            _netType = GuestNetType.BRIDGE;
             _sourceName = brName;
             _networkName = targetBrName;
             _macAddr = macAddr;
@@ -847,12 +847,12 @@ public class LibvirtVMDef {
             _networkRateKBps = networkRateKBps;
         }
 
-        public void defDirectNet(String sourceName, String targetName, String macAddr, nicModel model, String sourceMode) {
+        public void defDirectNet(String sourceName, String targetName, String macAddr, NicModel model, String sourceMode) {
             defDirectNet(sourceName, targetName, macAddr, model, sourceMode, 0);
         }
 
-        public void defDirectNet(String sourceName, String targetName, String macAddr, nicModel model, String sourceMode, Integer networkRateKBps) {
-            _netType = guestNetType.DIRECT;
+        public void defDirectNet(String sourceName, String targetName, String macAddr, NicModel model, String sourceMode, Integer networkRateKBps) {
+            _netType = GuestNetType.DIRECT;
             _netSourceMode = sourceMode;
             _sourceName = sourceName;
             _networkName = targetName;
@@ -861,12 +861,12 @@ public class LibvirtVMDef {
             _networkRateKBps = networkRateKBps;
         }
 
-        public void defPrivateNet(String networkName, String targetName, String macAddr, nicModel model) {
+        public void defPrivateNet(String networkName, String targetName, String macAddr, NicModel model) {
             defPrivateNet(networkName, targetName, macAddr, model, 0);
         }
 
-        public void defPrivateNet(String networkName, String targetName, String macAddr, nicModel model, Integer networkRateKBps) {
-            _netType = guestNetType.NETWORK;
+        public void defPrivateNet(String networkName, String targetName, String macAddr, NicModel model, Integer networkRateKBps) {
+            _netType = GuestNetType.NETWORK;
             _sourceName = networkName;
             _networkName = targetName;
             _macAddr = macAddr;
@@ -874,12 +874,12 @@ public class LibvirtVMDef {
             _networkRateKBps = networkRateKBps;
         }
 
-        public void defEthernet(String targetName, String macAddr, nicModel model, String scriptPath) {
+        public void defEthernet(String targetName, String macAddr, NicModel model, String scriptPath) {
             defEthernet(targetName, macAddr, model, scriptPath, 0);
         }
 
-        public void defEthernet(String targetName, String macAddr, nicModel model, String scriptPath, Integer networkRateKBps) {
-            _netType = guestNetType.ETHERNET;
+        public void defEthernet(String targetName, String macAddr, NicModel model, String scriptPath, Integer networkRateKBps) {
+            _netType = GuestNetType.ETHERNET;
             _networkName = targetName;
             _sourceName = targetName;
             _macAddr = macAddr;
@@ -888,15 +888,15 @@ public class LibvirtVMDef {
             _networkRateKBps = networkRateKBps;
         }
 
-        public void defEthernet(String targetName, String macAddr, nicModel model) {
+        public void defEthernet(String targetName, String macAddr, NicModel model) {
             defEthernet(targetName, macAddr, model, null);
         }
 
-        public void setHostNetType(hostNicType hostNetType) {
+        public void setHostNetType(HostNicType hostNetType) {
             _hostNetType = hostNetType;
         }
 
-        public hostNicType getHostNetType() {
+        public HostNicType getHostNetType() {
             return _hostNetType;
         }
 
@@ -908,7 +908,7 @@ public class LibvirtVMDef {
             return _sourceName;
         }
 
-        public guestNetType getNetType() {
+        public GuestNetType getNetType() {
             return _netType;
         }
 
@@ -924,7 +924,7 @@ public class LibvirtVMDef {
             return _macAddr;
         }
 
-        public nicModel getModel() {
+        public NicModel getModel() {
             return _model;
         }
 
@@ -956,11 +956,11 @@ public class LibvirtVMDef {
         public String toString() {
             StringBuilder netBuilder = new StringBuilder();
             netBuilder.append("<interface type='" + _netType + "'>\n");
-            if (_netType == guestNetType.BRIDGE) {
+            if (_netType == GuestNetType.BRIDGE) {
                 netBuilder.append("<source bridge='" + _sourceName + "'/>\n");
-            } else if (_netType == guestNetType.NETWORK) {
+            } else if (_netType == GuestNetType.NETWORK) {
                 netBuilder.append("<source network='" + _sourceName + "'/>\n");
-            } else if (_netType == guestNetType.DIRECT) {
+            } else if (_netType == GuestNetType.DIRECT) {
                 netBuilder.append("<source dev='" + _sourceName + "' mode='" + _netSourceMode + "'/>\n");
             }
             if (_networkName != null) {

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1275,12 +1275,20 @@ public class LibvirtVMDef {
         return _hvsType;
     }
 
-    public void setLibvirtVersion(long libvirtVersion) {
+    public static void setGlobalLibvirtVersion(long libvirtVersion) {
         s_libvirtVersion = libvirtVersion;
     }
 
-    public void setQemuVersion(long qemuVersion) {
+    public void setLibvirtVersion(long libvirtVersion) {
+        setGlobalLibvirtVersion(libvirtVersion);
+    }
+
+    public static void setGlobalQemuVersion(long qemuVersion) {
         s_qemuVersion = qemuVersion;
+    }
+
+    public void setQemuVersion(long qemuVersion) {
+        setGlobalQemuVersion(qemuVersion);
     }
 
     public void setDomainName(String domainName) {

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/VifDriverBase.java
@@ -47,10 +47,10 @@ public abstract class VifDriverBase implements VifDriver {
     @Override
     public abstract void unplug(LibvirtVMDef.InterfaceDef iface);
 
-    protected LibvirtVMDef.InterfaceDef.nicModel getGuestNicModel(String platformEmulator, String nicAdapter) {
+    protected LibvirtVMDef.InterfaceDef.NicModel getGuestNicModel(String platformEmulator, String nicAdapter) {
         // if nicAdapter is found in ENUM, use it. Otherwise, match guest OS type as before
         if (nicAdapter != null && !nicAdapter.isEmpty()) {
-            for (LibvirtVMDef.InterfaceDef.nicModel model : LibvirtVMDef.InterfaceDef.nicModel.values()) {
+            for (LibvirtVMDef.InterfaceDef.NicModel model : LibvirtVMDef.InterfaceDef.NicModel.values()) {
                 if (model.toString().equalsIgnoreCase(nicAdapter)) {
                     return model;
                 }
@@ -58,9 +58,9 @@ public abstract class VifDriverBase implements VifDriver {
         }
 
         if (_libvirtComputingResource.isGuestPVEnabled(platformEmulator)) {
-            return LibvirtVMDef.InterfaceDef.nicModel.VIRTIO;
+            return LibvirtVMDef.InterfaceDef.NicModel.VIRTIO;
         } else {
-            return LibvirtVMDef.InterfaceDef.nicModel.E1000;
+            return LibvirtVMDef.InterfaceDef.NicModel.E1000;
         }
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -84,7 +84,7 @@ import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
 import com.cloud.hypervisor.kvm.resource.LibvirtConnection;
 import com.cloud.hypervisor.kvm.resource.LibvirtDomainXMLParser;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
-import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef.diskProtocol;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef.DiskProtocol;
 import com.cloud.storage.JavaStorageLayer;
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.Storage.StoragePoolType;
@@ -863,7 +863,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         final String result = attachOrDetachDevice(conn, true, vmName, isoXml);
         if (result == null && !isAttach) {
             for (final DiskDef disk : disks) {
-                if (disk.getDeviceType() == DiskDef.deviceType.CDROM) {
+                if (disk.getDeviceType() == DiskDef.DeviceType.CDROM) {
                     resource.cleanupDisk(disk);
                 }
             }
@@ -992,24 +992,24 @@ public class KVMStorageProcessor implements StorageProcessor {
                         final String device = resource.mapRbdDevice(attachingDisk);
                         if (device != null) {
                             s_logger.debug("RBD device on host is: "+device);
-                            diskdef.defBlockBasedDisk(device, devId, DiskDef.diskBus.VIRTIO);
+                            diskdef.defBlockBasedDisk(device, devId, DiskDef.DiskBus.VIRTIO);
                         } else {
                             throw new InternalErrorException("Error while mapping disk "+attachingDisk.getPath()+" on host");
                         }
                     } else {
                         diskdef.defNetworkBasedDisk(attachingDisk.getPath(), attachingPool.getSourceHost(), attachingPool.getSourcePort(), attachingPool.getAuthUserName(),
-                                attachingPool.getUuid(), devId, DiskDef.diskBus.VIRTIO, diskProtocol.RBD, DiskDef.diskFmtType.RAW);
+                                attachingPool.getUuid(), devId, DiskDef.DiskBus.VIRTIO, DiskProtocol.RBD, DiskDef.DiskFmtType.RAW);
                     }
                 } else if (attachingPool.getType() == StoragePoolType.Gluster) {
                     final String mountpoint = attachingPool.getLocalPath();
                     final String path = attachingDisk.getPath();
                     final String glusterVolume = attachingPool.getSourceDir().replace("/", "");
                     diskdef.defNetworkBasedDisk(glusterVolume + path.replace(mountpoint, ""), attachingPool.getSourceHost(), attachingPool.getSourcePort(), null,
-                            null, devId, DiskDef.diskBus.VIRTIO, diskProtocol.GLUSTER, DiskDef.diskFmtType.QCOW2);
+                            null, devId, DiskDef.DiskBus.VIRTIO, DiskProtocol.GLUSTER, DiskDef.DiskFmtType.QCOW2);
                 } else if (attachingDisk.getFormat() == PhysicalDiskFormat.QCOW2) {
-                    diskdef.defFileBasedDisk(attachingDisk.getPath(), devId, DiskDef.diskBus.VIRTIO, DiskDef.diskFmtType.QCOW2);
+                    diskdef.defFileBasedDisk(attachingDisk.getPath(), devId, DiskDef.DiskBus.VIRTIO, DiskDef.DiskFmtType.QCOW2);
                 } else if (attachingDisk.getFormat() == PhysicalDiskFormat.RAW) {
-                    diskdef.defBlockBasedDisk(attachingDisk.getPath(), devId, DiskDef.diskBus.VIRTIO);
+                    diskdef.defBlockBasedDisk(attachingDisk.getPath(), devId, DiskDef.DiskBus.VIRTIO);
                 }
             }
 

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
@@ -29,14 +29,14 @@ public class LibvirtDomainXMLParserTest extends TestCase {
     public void testDomainXMLParser() {
         int vncPort = 5900;
 
-        DiskDef.diskBus diskBus = DiskDef.diskBus.VIRTIO;
-        DiskDef.diskType diskType = DiskDef.diskType.FILE;
-        DiskDef.deviceType deviceType = DiskDef.deviceType.DISK;
-        DiskDef.diskFmtType diskFormat = DiskDef.diskFmtType.QCOW2;
-        DiskDef.diskCacheMode diskCache = DiskDef.diskCacheMode.NONE;
+        DiskDef.DiskBus diskBus = DiskDef.DiskBus.VIRTIO;
+        DiskDef.DiskType diskType = DiskDef.DiskType.FILE;
+        DiskDef.DeviceType deviceType = DiskDef.DeviceType.DISK;
+        DiskDef.DiskFmtType diskFormat = DiskDef.DiskFmtType.QCOW2;
+        DiskDef.DiskCacheMode diskCache = DiskDef.DiskCacheMode.NONE;
 
-        InterfaceDef.nicModel ifModel = InterfaceDef.nicModel.VIRTIO;
-        InterfaceDef.guestNetType ifType = InterfaceDef.guestNetType.BRIDGE;
+        InterfaceDef.NicModel ifModel = InterfaceDef.NicModel.VIRTIO;
+        InterfaceDef.GuestNetType ifType = InterfaceDef.GuestNetType.BRIDGE;
 
         String diskLabel ="vda";
         String diskPath = "/var/lib/libvirt/images/my-test-image.qcow2";

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
@@ -27,7 +27,7 @@ public class LibvirtVMDefTest extends TestCase {
 
     public void testInterfaceEtehrnet() {
         LibvirtVMDef.InterfaceDef ifDef = new LibvirtVMDef.InterfaceDef();
-        ifDef.defEthernet("targetDeviceName", "00:11:22:aa:bb:dd", LibvirtVMDef.InterfaceDef.nicModel.VIRTIO);
+        ifDef.defEthernet("targetDeviceName", "00:11:22:aa:bb:dd", LibvirtVMDef.InterfaceDef.NicModel.VIRTIO);
 
         String expected =
             "<interface type='ethernet'>\n" + "<target dev='targetDeviceName'/>\n" + "<mac address='00:11:22:aa:bb:dd'/>\n" + "<model type='virtio'/>\n"
@@ -38,10 +38,10 @@ public class LibvirtVMDefTest extends TestCase {
 
     public void testInterfaceDirectNet() {
         LibvirtVMDef.InterfaceDef ifDef = new LibvirtVMDef.InterfaceDef();
-        ifDef.defDirectNet("targetDeviceName", null, "00:11:22:aa:bb:dd", LibvirtVMDef.InterfaceDef.nicModel.VIRTIO, "private");
+        ifDef.defDirectNet("targetDeviceName", null, "00:11:22:aa:bb:dd", LibvirtVMDef.InterfaceDef.NicModel.VIRTIO, "private");
 
         String expected =
-            "<interface type='" + LibvirtVMDef.InterfaceDef.guestNetType.DIRECT + "'>\n" + "<source dev='targetDeviceName' mode='private'/>\n" +
+            "<interface type='" + LibvirtVMDef.InterfaceDef.GuestNetType.DIRECT + "'>\n" + "<source dev='targetDeviceName' mode='private'/>\n" +
                 "<mac address='00:11:22:aa:bb:dd'/>\n" + "<model type='virtio'/>\n" + "</interface>\n";
 
         assertEquals(expected, ifDef.toString());
@@ -72,9 +72,9 @@ public class LibvirtVMDefTest extends TestCase {
         String diskLabel = "vda";
 
         DiskDef disk = new DiskDef();
-        DiskDef.diskBus bus = DiskDef.diskBus.VIRTIO;
-        DiskDef.diskFmtType type = DiskDef.diskFmtType.QCOW2;
-        DiskDef.diskCacheMode cacheMode = DiskDef.diskCacheMode.WRITEBACK;
+        DiskDef.DiskBus bus = DiskDef.DiskBus.VIRTIO;
+        DiskDef.DiskFmtType type = DiskDef.DiskFmtType.QCOW2;
+        DiskDef.DiskCacheMode cacheMode = DiskDef.DiskCacheMode.WRITEBACK;
 
         disk.defFileBasedDisk(filePath, diskLabel, bus, type);
         disk.setCacheMode(cacheMode);
@@ -82,7 +82,7 @@ public class LibvirtVMDefTest extends TestCase {
         assertEquals(filePath, disk.getDiskPath());
         assertEquals(diskLabel, disk.getDiskLabel());
         assertEquals(bus, disk.getBusType());
-        assertEquals(DiskDef.deviceType.DISK, disk.getDeviceType());
+        assertEquals(DiskDef.DeviceType.DISK, disk.getDeviceType());
 
         String xmlDef = disk.toString();
         String expectedXml = "<disk  device='disk' type='file'>\n<driver name='qemu' type='" + type.toString() + "' cache='" + cacheMode.toString() + "' />\n" +


### PR DESCRIPTION
I wonder if these fields are used solely on the host or on the management server as well.
If the code is running on both it is not right that these fields are static as multiple versions of KVM may be deployed in a cloud. the use of the fields is static so this wrapper function is needed to negate the findbugs warning.