### PR TITLE
CLOUDSTACK-8622:  Reinstate working sessions in browser

### DIFF
--- a/api/src/org/apache/cloudstack/api/auth/APIAuthenticationType.java
+++ b/api/src/org/apache/cloudstack/api/auth/APIAuthenticationType.java
@@ -17,5 +17,5 @@
 package org.apache.cloudstack.api.auth;
 
 public enum APIAuthenticationType {
-    LOGIN_API, LOGOUT_API
+    LOGIN_API, LOGOUT_API, READONLY_API
 }

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/GetServiceProviderMetaDataCmd.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/GetServiceProviderMetaDataCmd.java
@@ -255,7 +255,7 @@ public class GetServiceProviderMetaDataCmd extends BaseCmd implements APIAuthent
 
     @Override
     public APIAuthenticationType getAPIType() {
-        return APIAuthenticationType.LOGIN_API;
+        return APIAuthenticationType.READONLY_API;
     }
 
     @Override

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/ListIdpsCmd.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/ListIdpsCmd.java
@@ -97,7 +97,7 @@ public class ListIdpsCmd extends BaseCmd implements APIAuthenticator {
 
     @Override
     public APIAuthenticationType getAPIType() {
-        return APIAuthenticationType.LOGIN_API;
+        return APIAuthenticationType.READONLY_API;
     }
 
     @Override

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmd.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmd.java
@@ -326,13 +326,13 @@ public class SAML2LoginAPIAuthenticatorCmd extends BaseCmd implements APIAuthent
                             resp.addCookie(new Cookie("domainid", URLEncoder.encode(loginResponse.getDomainId(), HttpUtils.UTF_8)));
                             resp.addCookie(new Cookie("role", URLEncoder.encode(loginResponse.getType(), HttpUtils.UTF_8)));
                             resp.addCookie(new Cookie("username", URLEncoder.encode(loginResponse.getUsername(), HttpUtils.UTF_8)));
-                            resp.addCookie(new Cookie(ApiConstants.SESSIONKEY, URLEncoder.encode(loginResponse.getSessionKey(), HttpUtils.UTF_8)));
                             resp.addCookie(new Cookie("account", URLEncoder.encode(loginResponse.getAccount(), HttpUtils.UTF_8)));
                             String timezone = loginResponse.getTimeZone();
                             if (timezone != null) {
                                 resp.addCookie(new Cookie("timezone", URLEncoder.encode(timezone, HttpUtils.UTF_8)));
                             }
                             resp.addCookie(new Cookie("userfullname", URLEncoder.encode(loginResponse.getFirstName() + " " + loginResponse.getLastName(), HttpUtils.UTF_8).replace("+", "%20")));
+                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly", ApiConstants.SESSIONKEY, loginResponse.getSessionKey()));
                             resp.sendRedirect(SAML2AuthManager.SAMLCloudStackRedirectionUrl.value());
                             return ApiResponseSerializer.toSerializedString(loginResponse, responseType);
                         }

--- a/plugins/user-authenticators/saml2/test/org/apache/cloudstack/GetServiceProviderMetaDataCmdTest.java
+++ b/plugins/user-authenticators/saml2/test/org/apache/cloudstack/GetServiceProviderMetaDataCmdTest.java
@@ -97,6 +97,6 @@ public class GetServiceProviderMetaDataCmdTest {
 
     @Test
     public void testGetAPIType() {
-        Assert.assertTrue(new GetServiceProviderMetaDataCmd().getAPIType() == APIAuthenticationType.LOGIN_API);
+        Assert.assertTrue(new GetServiceProviderMetaDataCmd().getAPIType() == APIAuthenticationType.READONLY_API);
     }
 }

--- a/plugins/user-authenticators/saml2/test/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmdTest.java
+++ b/plugins/user-authenticators/saml2/test/org/apache/cloudstack/api/command/SAML2LoginAPIAuthenticatorCmdTest.java
@@ -196,6 +196,6 @@ public class SAML2LoginAPIAuthenticatorCmdTest {
 
     @Test
     public void testGetAPIType() {
-        Assert.assertTrue(new GetServiceProviderMetaDataCmd().getAPIType() == APIAuthenticationType.LOGIN_API);
+        Assert.assertTrue(new SAML2LoginAPIAuthenticatorCmd().getAPIType() == APIAuthenticationType.LOGIN_API);
     }
 }

--- a/server/src/com/cloud/api/ApiServlet.java
+++ b/server/src/com/cloud/api/ApiServlet.java
@@ -16,19 +16,13 @@
 // under the License.
 package com.cloud.api;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.inject.Inject;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
+import com.cloud.user.Account;
+import com.cloud.user.AccountService;
+import com.cloud.user.User;
+import com.cloud.utils.HttpUtils;
+import com.cloud.utils.StringUtils;
+import com.cloud.utils.db.EntityManager;
+import com.cloud.utils.net.NetUtils;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiServerService;
 import org.apache.cloudstack.api.ServerApiException;
@@ -41,13 +35,18 @@ import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
-import com.cloud.user.Account;
-import com.cloud.user.AccountService;
-import com.cloud.user.User;
-import com.cloud.utils.HttpUtils;
-import com.cloud.utils.StringUtils;
-import com.cloud.utils.db.EntityManager;
-import com.cloud.utils.net.NetUtils;
+import javax.inject.Inject;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component("apiServlet")
 @SuppressWarnings("serial")
@@ -180,7 +179,7 @@ public class ApiServlet extends HttpServlet {
                         }
                         session = req.getSession(true);
                         if (ApiServer.isSecureSessionCookieEnabled()) {
-                            resp.setHeader("SET-COOKIE", "JSESSIONID=" + session.getId() + ";Secure;Path=/client");
+                            resp.setHeader("SET-COOKIE", String.format("JSESSIONID=%s;Secure;HttpOnly;Path=/client", session.getId()));
                             if (s_logger.isDebugEnabled()) {
                                 if (s_logger.isDebugEnabled()) {
                                     s_logger.debug("Session cookie is marked secure!");
@@ -191,11 +190,15 @@ public class ApiServlet extends HttpServlet {
 
                     try {
                         responseString = apiAuthenticator.authenticate(command, params, session, remoteAddress, responseType, auditTrailSb, req, resp);
+                        if (session != null && session.getAttribute(ApiConstants.SESSIONKEY) != null) {
+                            resp.addHeader("SET-COOKIE", String.format("%s=%s;HttpOnly", ApiConstants.SESSIONKEY, session.getAttribute(ApiConstants.SESSIONKEY)));
+                        }
                     } catch (ServerApiException e) {
                         httpResponseCode = e.getErrorCode().getHttpCode();
                         responseString = e.getMessage();
                         s_logger.debug("Authentication failure: " + e.getMessage());
                     }
+
                     if (apiAuthenticator.getAPIType() == APIAuthenticationType.LOGOUT_API) {
                         if (session != null) {
                             final Long userId = (Long) session.getAttribute("userid");
@@ -213,6 +216,9 @@ public class ApiServlet extends HttpServlet {
                             } catch (final IllegalStateException ignored) {
                             }
                         }
+                        Cookie sessionKeyCookie = new Cookie(ApiConstants.SESSIONKEY, "");
+                        sessionKeyCookie.setMaxAge(0);
+                        resp.addCookie(sessionKeyCookie);
                     }
                     HttpUtils.writeHttpResponse(resp, responseString, httpResponseCode, responseType, ApiServer.getJSONContentType());
                     return;
@@ -229,11 +235,15 @@ public class ApiServlet extends HttpServlet {
 
             if (!isNew) {
                 userId = (Long)session.getAttribute("userid");
-                final String account = (String)session.getAttribute("account");
+                final String account = (String) session.getAttribute("account");
                 final Object accountObj = session.getAttribute("accountobj");
-                final String sessionKey = (String)session.getAttribute(ApiConstants.SESSIONKEY);
-                final String[] sessionKeyParam = (String[])params.get(ApiConstants.SESSIONKEY);
-                if ((sessionKeyParam == null) || (sessionKey == null) || !sessionKey.equals(sessionKeyParam[0])) {
+                final String sessionKey = (String) session.getAttribute(ApiConstants.SESSIONKEY);
+                final String sessionKeyFromCookie = HttpUtils.findCookie(req.getCookies(), ApiConstants.SESSIONKEY);
+                final String[] sessionKeyFromParams = (String[]) params.get(ApiConstants.SESSIONKEY);
+                if ((sessionKey == null)
+                        || (sessionKeyFromParams == null && sessionKeyFromCookie == null)
+                        || (sessionKeyFromParams != null && !sessionKey.equals(sessionKeyFromParams[0]))
+                        || (sessionKeyFromCookie != null && !sessionKey.equals(sessionKeyFromCookie))) {
                     try {
                         session.invalidate();
                     } catch (final IllegalStateException ise) {

--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -107,28 +107,11 @@
             // Use this for checking the session, to bypass login screen
             bypassLoginCheck: function(args) { //determine to show or bypass login screen
                 if (g_loginResponse == null) { //show login screen
-                    /*
-                     * Since we no longer store sessionKey in cookie, opening the
-                     * 2nd browser window (of the same domain) will show login screen (i.e. user has to
-                     * enter credentials again) and will cause the 1st browser window session timeout.
-                     */
                     var unBoxCookieValue = function (cookieName) {
-                        var cookieValue = $.cookie(cookieName);
-                        if (cookieValue && cookieValue.length > 2 && cookieValue[0] === '"' && cookieValue[cookieValue.length-1] === '"') {
-                            cookieValue = cookieValue.slice(1, cookieValue.length-1);
-                            $.cookie(cookieName, cookieValue, { expires: 1 });
-                        }
-                        return decodeURIComponent(cookieValue);
+                        return decodeURIComponent($.cookie(cookieName)).replace(/"([^"]+(?="))"/g, '$1');
                     };
-                    unBoxCookieValue('sessionkey');
-                    // if sessionkey cookie exists use this to set g_sessionKey
-                    // and destroy sessionkey cookie
-                    if ($.cookie('sessionkey')) {
-                        g_sessionKey = $.cookie('sessionkey');
-                        $.cookie('sessionkey', null);
-                    } else {
-                        g_sessionKey = unBoxCookieValue('JSESSIONID');
-                    }
+                    // sessionkey is a HttpOnly cookie now, no need to pass as API param
+                    g_sessionKey = null;
                     g_role = unBoxCookieValue('role');
                     g_userid = unBoxCookieValue('userid');
                     g_domainid = unBoxCookieValue('domainid');
@@ -136,7 +119,7 @@
                     g_username = unBoxCookieValue('username');
                     g_userfullname = unBoxCookieValue('userfullname');
                     g_timezone = unBoxCookieValue('timezone');
-                } else { //single-sign-on	(bypass login screen)
+                } else { //single-sign-on (bypass login screen)
                     g_sessionKey = encodeURIComponent(g_loginResponse.sessionkey);
                     g_role = g_loginResponse.type;
                     g_username = g_loginResponse.username;
@@ -144,7 +127,7 @@
                     g_account = g_loginResponse.account;
                     g_domainid = g_loginResponse.domainid;
                     g_userfullname = g_loginResponse.firstname + ' ' + g_loginResponse.lastname;
-                    g_timezone = g_loginResponse.timezone;                    
+                    g_timezone = g_loginResponse.timezone;
                 }
 
                 var userValid = false;
@@ -180,7 +163,25 @@
                         return true;
                     }
                 });
-               
+
+                // Populate IDP list
+                $.ajax({
+                    type: 'GET',
+                    url: createURL('listIdps'),
+                    dataType: 'json',
+                    async: false,
+                    success: function(data, textStatus, xhr) {
+                        if (data && data.listidpsresponse && data.listidpsresponse.idp) {
+                            var idpList = data.listidpsresponse.idp.sort(function (a, b) {
+                                return a.orgName.localeCompare(b.orgName);
+                            });
+                            g_idpList = idpList;
+                        }
+                    },
+                    error: function(xhr) {
+                    },
+                });
+
                 return userValid ? {
                     user: {
                         userid: g_userid,
@@ -227,14 +228,16 @@
                     async: false,
                     success: function(json) {
                         var loginresponse = json.loginresponse;
-                        
-                        g_sessionKey = encodeURIComponent(loginresponse.sessionkey);
+                        // sessionkey is recevied as a HttpOnly cookie
+                        // therefore reset any g_sessionKey value, an explicit
+                        // param in the API call is no longer needed
+                        g_sessionKey = null;
                         g_role = loginresponse.type;
                         g_username = loginresponse.username;
                         g_userid = loginresponse.userid;
                         g_account = loginresponse.account;
                         g_domainid = loginresponse.domainid;
-                        g_timezone = loginresponse.timezone;                        
+                        g_timezone = loginresponse.timezone;
                         g_userfullname = loginresponse.firstname + ' ' + loginresponse.lastname;
 
                         $.cookie('username', g_username, {
@@ -320,7 +323,7 @@
                 $.ajax({
                     url: createURL('logout'),
                     async: false,
-                    success: function() {                        
+                    success: function() {
                         g_sessionKey = null;
                         g_username = null;
                         g_account = null;
@@ -331,15 +334,16 @@
                         g_kvmsnapshotenabled = null;
                         g_regionsecondaryenabled = null;
                         g_loginCmdText = null;
-                        
-                        $.cookie('JSESSIONID', null);
-                        $.cookie('sessionkey', null);
-                        $.cookie('username', null);
-                        $.cookie('account', null);
-                        $.cookie('domainid', null);
-                        $.cookie('role', null);  
-                        $.cookie('timezone', null);
-                        
+
+                        // Remove any cookies
+                        var cookies = document.cookie.split(";");
+                        for (var i = 0; i < cookies.length; i++) {
+                            var cookieName = $.trim(cookies[i].split("=")[0]);
+                            if (['login-option', 'lang'].indexOf(cookieName) < 0) {
+                                $.cookie(cookieName, null);
+                            }
+                        }
+
                         if (onLogoutCallback()) { //onLogoutCallback() will set g_loginResponse(single-sign-on variable) to null, then bypassLoginCheck() will show login screen.
                             document.location.reload(); //when onLogoutCallback() returns true, reload the current document.
                         }
@@ -367,13 +371,15 @@
                 g_regionsecondaryenabled = null;
                 g_loginCmdText = null;
 
-                $.cookie('JSESSIONID', null);
-                $.cookie('sessionkey', null);
-                $.cookie('username', null);
-                $.cookie('account', null);
-                $.cookie('domainid', null);
-                $.cookie('role', null);
-                $.cookie('timezone', null);
+                // Remove any cookies
+                var cookies = document.cookie.split(";");
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookieName = $.trim(cookies[i].split("=")[0]);
+                    if (['login-option', 'lang'].indexOf(cookieName) < 0) {
+                        $.cookie(cookieName, null);
+                    }
+                }
+
                 var url = 'samlSso';
                 if (args.data.idpid) {
                     url = url + '&idpid=' + args.data.idpid;

--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -170,7 +170,10 @@ var pollAsyncJobResult = function(args) {
 
     function createURL(apiName, options) {
         if (!options) options = {};
-        var urlString = clientApiUrl + "?" + "command=" + apiName + "&response=json&sessionkey=" + g_sessionKey;
+        var urlString = clientApiUrl + "?" + "command=" + apiName + "&response=json";
+        if (g_sessionKey) {
+            urlString += "&sessionkey=" + g_sessionKey;
+        }
 
         if (cloudStack.context && cloudStack.context.projects && !options.ignoreProject) {
             urlString = urlString + '&projectid=' + cloudStack.context.projects[0].id;

--- a/ui/scripts/ui-custom/login.js
+++ b/ui/scripts/ui-custom/login.js
@@ -129,10 +129,6 @@
             return false;
         });
 
-        // Show SAML button if only SP is configured
-        $login.find('#login-dropdown').hide();
-        $login.find('#saml-login').hide();
-        $login.find('#cloudstack-login').hide();
 
         var toggleLoginView = function (selectedOption) {
             $login.find('#login-submit').show();
@@ -160,55 +156,43 @@
             }
         });
 
-        $.ajax({
-            type: 'GET',
-            url: createURL('listIdps'),
-            dataType: 'json',
-            async: false,
-            success: function(data, textStatus, xhr) {
-                if (xhr.status === 200) {
-                    $login.find('#login-dropdown').show();
-                    $login.find('#login-submit').hide();
-                } else {
-                    $login.find('#cloudstack-login').show();
-                    $login.find('#login-submit').show();
-                    return;
-                }
+        // By Default hide login option dropdown
+        $login.find('#login-dropdown').hide();
+        $login.find('#login-submit').show();
+        $login.find('#cloudstack-login').show();
+        $login.find('#saml-login').hide();
 
+        // If any IdP servers were set, SAML is enabled
+        if (g_idpList && g_idpList.length > 0) {
+            $login.find('#login-dropdown').show();
+            $login.find('#login-submit').hide();
+            $login.find('#cloudstack-login').hide();
+            $login.find('#saml-login').hide();
+
+            $login.find('#login-options')
+                .append($('<option>', {
+                    value: '',
+                    text: '--- Select Identity Provider -- ',
+                    selected: true
+                }));
+
+            $.each(g_idpList, function(index, idp) {
                 $login.find('#login-options')
                     .append($('<option>', {
-                        value: '',
-                        text: '--- Select Identity Provider -- ',
-                        selected: true
+                        value: idp.id,
+                        text: idp.orgName
                     }));
+            });
 
-                if (data.listidpsresponse && data.listidpsresponse.idp) {
-                    var idpList = data.listidpsresponse.idp.sort(function (a, b) {
-                        return a.orgName.localeCompare(b.orgName);
-                    });
-                    g_idpList = idpList;
-                    $.each(idpList, function(index, idp) {
-                        $login.find('#login-options')
-                            .append($('<option>', {
-                                value: idp.id,
-                                text: idp.orgName
-                            }));
-                    });
+            var loginOption = $.cookie('login-option');
+            if (loginOption) {
+                var option = $login.find('#login-options option[value="' + loginOption + '"]');
+                if (option.length > 0) {
+                    option.prop('selected', true);
+                    toggleLoginView(loginOption);
                 }
-
-                var loginOption = $.cookie('login-option');
-                if (loginOption) {
-                    var option = $login.find('#login-options option[value="' + loginOption + '"]');
-                    if (option.length > 0) {
-                        option.prop('selected', true);
-                        toggleLoginView(loginOption);
-                    }
-                }
-            },
-            error: function(xhr) {
-                $login.find('#cloudstack-login').show();
-            },
-        });
+            }
+        }
 
         // Select language
         var $languageSelect = $login.find('select[name=language]');

--- a/utils/src/com/cloud/utils/HttpUtils.java
+++ b/utils/src/com/cloud/utils/HttpUtils.java
@@ -51,6 +51,7 @@ public class HttpUtils {
     }
 
     public static String findCookie(final Cookie[] cookies, final String key) {
+        if (cookies == null || key == null) return null;
         for (Cookie cookie: cookies) {
             if (cookie != null && cookie.getName().equals(key)) {
                 return cookie.getValue();


### PR DESCRIPTION
- Login is based on sessionkey HttpOnly Cookie
- ApiServlet does login verification using sessionKey from both the request cookies
  and the API parameters. In both cases, if either or both are passed they should
  match the sessionKey stored in the current session of the HttpRequest
- UI: it no longer needs to read or set sessionkey cookie
- UI: it no longer needs to return g_sessionKey value in the API requests, though
  to support a sso mechanism it is not removed for that specific case
- UI: on logout, all cookies are removed (though this won't remove httponly ones)
- Secure jsessionid cookie is set to be HttpOnly and Secure
- SAML login should also set HttpOnly cookie before redirecting to UI
- SAML: ListIdps API is made a readonly API that won't destroy an existing session

Performed tests (login, saml login if applicable, page refreshes, opening
multiple tabs, logout) with following combinations:
- SAML disabled, normal auth as admin, domain-admin and user
- SAML enabled, normal auth as admin, domain-admin and user; and saml sso as
  admin, domain-admin and user