### PR TITLE
CLOUDSTACK-8626 :[Automation]fixing test/integration/component/test_p…

### DIFF
--- a/test/integration/component/test_ps_max_limits.py
+++ b/test/integration/component/test_ps_max_limits.py
@@ -208,7 +208,6 @@ class TestMaxPrimaryStorageLimits(cloudstackTestCase):
 
         self.virtualMachine = VirtualMachine.create(self.api_client, self.services["virtual_machine"],
                             accountid=self.child_do_admin.name, domainid=self.child_do_admin.domainid,
-                            diskofferingid=self.disk_offering.id,
                             serviceofferingid=self.service_offering.id)
 
         accounts = Account.list(self.apiclient, id=self.child_do_admin.id)
@@ -259,7 +258,6 @@ class TestMaxPrimaryStorageLimits(cloudstackTestCase):
 
         self.virtualMachine = VirtualMachine.create(self.api_client, self.services["virtual_machine"],
                             projectid=self.project.id,
-                            diskofferingid=self.disk_offering.id,
                             serviceofferingid=self.service_offering.id)
 
         try:


### PR DESCRIPTION
…s_max_limits.py for lxc hypervisor

test results
========
Test Try to deploy VM with admin account where account has used ... === TestName: test_02_deploy_vm_account_limit_reached | Status : SUCCESS ===
ok
Test TTry to deploy VM with admin account where account has not used ... === TestName: test_03_deploy_vm_project_limit_reached | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 2 tests in 579.271s

OK
