### PR TITLE
CLOUDSTACK-8630: Fix for missing Firewall service parameter in test script

### DIFF
--- a/test/integration/component/test_project_usage.py
+++ b/test/integration/component/test_project_usage.py
@@ -109,6 +109,7 @@ class Services:
                                    "name": "SSH",
                                    "alg": "roundrobin",
                                    # Algorithm used for load balancing
+                                   "openfirewall":"false",
                                    "privateport": 22,
                                    "publicport": 2222,
                                 },
@@ -1171,7 +1172,7 @@ class TestLBRuleUsage(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "eip", "advancedns", "simulator"], required_hardware="false")
+    @attr(tags=["advanced", "eip", "advancedns", "simulator","bpk"], required_hardware="false")
     def test_01_lb_usage(self):
         """Test Create/Delete a LB rule and verify correct usage is recorded
         """

--- a/test/integration/component/test_project_usage.py
+++ b/test/integration/component/test_project_usage.py
@@ -1172,7 +1172,7 @@ class TestLBRuleUsage(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced", "eip", "advancedns", "simulator","bpk"], required_hardware="false")
+    @attr(tags=["advanced", "eip", "advancedns", "simulator"], required_hardware="false")
     def test_01_lb_usage(self):
         """Test Create/Delete a LB rule and verify correct usage is recorded
         """

--- a/test/integration/component/test_usage.py
+++ b/test/integration/component/test_usage.py
@@ -104,6 +104,7 @@ class Services:
                 "name": "SSH",
                 "alg": "roundrobin",
                 # Algorithm used for load balancing
+                "openfirewall":"false",
                 "privateport": 22,
                 "publicport": 2222,
             },
@@ -1089,7 +1090,7 @@ class TestLBRuleUsage(cloudstackTestCase):
             "advanced",
             "eip",
             "advancedns",
-            "simulator"],
+            "simulator","bpk"],
         required_hardware="false")
     def test_01_lb_usage(self):
         """Test Create/Delete a LB rule and verify correct usage is recorded

--- a/test/integration/component/test_usage.py
+++ b/test/integration/component/test_usage.py
@@ -1090,7 +1090,7 @@ class TestLBRuleUsage(cloudstackTestCase):
             "advanced",
             "eip",
             "advancedns",
-            "simulator","bpk"],
+            "simulator"],
         required_hardware="false")
     def test_01_lb_usage(self):
         """Test Create/Delete a LB rule and verify correct usage is recorded


### PR DESCRIPTION
Test Create/Delete a LB rule and verify correct usage is recorded ... === TestName: test_01_lb_usage | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 50.564s

OK
