### PR TITLE
CLOUDSTACK-8457: SAML UI Dialog fixes to use local $form

### DIFF
--- a/ui/scripts/accounts.js
+++ b/ui/scripts/accounts.js
@@ -1099,21 +1099,21 @@
                                         },
                                         select: function(args) {
                                             var samlChecked = false;
-                                            var idpUrl = "";
+                                            var idpUrl = args.$form.find('select[name=samlEntity]').children(':selected').val();
                                             var appendDomainToUsername = function() {
                                                 if (!g_appendIdpDomain) {
                                                     return;
                                                 }
-                                                var username = $('input[name=username]').val();
+                                                var username = args.$form.find('input[name=username]').val();
                                                 if (username) {
                                                     username = username.split('@')[0];
                                                 }
                                                 if (samlChecked) {
                                                     var link = document.createElement('a');
                                                     link.setAttribute('href', idpUrl);
-                                                    $('input[name=username]').val(username + "@" + link.host.split('.').splice(-2).join('.'));
+                                                    args.$form.find('input[name=username]').val(username + "@" + link.host.split('.').splice(-2).join('.'));
                                                 } else {
-                                                    $('input[name=username]').val(username);
+                                                    args.$form.find('input[name=username]').val(username);
                                                 }
                                             };
                                             args.$form.find('select[name=samlEntity]').change(function() {

--- a/ui/scripts/accountsWizard.js
+++ b/ui/scripts/accountsWizard.js
@@ -179,33 +179,6 @@
                     required: false
                 },
                 select: function(args) {
-                    var samlChecked = false;
-                    var idpUrl = "";
-                    var appendDomainToUsername = function() {
-                        if (!g_appendIdpDomain) {
-                            return;
-                        }
-                        var username = $('input[name=username]').val();
-                        if (username) {
-                            username = username.split('@')[0];
-                        }
-                        if (samlChecked) {
-                            var link = document.createElement('a');
-                            link.setAttribute('href', idpUrl);
-                            $('input[name=username]').val(username + "@" + link.host.split('.').splice(-2).join('.'));
-                        } else {
-                            $('input[name=username]').val(username);
-                        }
-                    };
-                    args.$form.find('select[name=samlEntity]').change(function() {
-                        idpUrl = $(this).children(':selected').val();
-                        appendDomainToUsername();
-                    });
-                    args.$form.find('input[name=samlEnable]').change(function() {
-                        samlChecked = $(this).context.checked;
-                        appendDomainToUsername();
-                    });
-
                     var items = [];
                     $(g_idpList).each(function() {
                         items.push({

--- a/ui/scripts/ui-custom/accountsWizard.js
+++ b/ui/scripts/ui-custom/accountsWizard.js
@@ -293,6 +293,35 @@
                 }
                 $wizard.find('.manual-account-details').append(informationNotInLdapForm);
 
+                if (g_idpList && g_appendIdpDomain && !ldapStatus) {
+                    var samlChecked = false;
+                    var idpUrl = $wizard.find('select[name=samlEntity]').children(':selected').val();
+                    var appendDomainToUsername = function() {
+                        if (!g_appendIdpDomain) {
+                            return;
+                        }
+                        var username = $wizard.find('input[name=username]').val();
+                        if (username) {
+                            username = username.split('@')[0];
+                        }
+                        if (samlChecked) {
+                            var link = document.createElement('a');
+                            link.setAttribute('href', idpUrl);
+                            $wizard.find('input[name=username]').val(username + "@" + link.host.split('.').splice(-2).join('.'));
+                        } else {
+                            $wizard.find('input[name=username]').val(username);
+                        }
+                    };
+                    $wizard.find('select[name=samlEntity]').change(function() {
+                        idpUrl = $(this).children(':selected').val();
+                        appendDomainToUsername();
+                    });
+                    $wizard.find('input[name=samlEnable]').change(function() {
+                        samlChecked = $(this).context.checked;
+                        appendDomainToUsername();
+                    });
+                }
+
                 return $wizard.dialog({
                     title: ldapStatus ? _l('Add LDAP Account') : _l('label.add.account'),
                     width: ldapStatus ? 800 : 330,


### PR DESCRIPTION
This uses local selector to access the DOM elements, the previous commit
would find a global element which is not in the context and fail changing the
element in the opened dialog.

Signed-off-by: Rohit Yadav <rohit.yadav@shapeblue.com>