### PR TITLE
CLOUDSTACK-8616: Redundant VPC with both routers as Master

### DIFF
--- a/systemvm/patches/debian/buildsystemvm.sh
+++ b/systemvm/patches/debian/buildsystemvm.sh
@@ -376,7 +376,7 @@ packages() {
   #xenstore utils
   chroot . apt-get --no-install-recommends -q -y --force-yes install xenstore-utils libxenstore3.0
   #keepalived - install version 1.2.13 from wheezy backports
-  chroot . apt-get --no-install-recommends -t wheezy-backports -q -y --force-yes install keepalived
+  chroot . apt-get --no-install-recommends -q -y --force-yes -t wheezy-backports install keepalived
   #conntrackd
   chroot . apt-get --no-install-recommends -q -y --force-yes install conntrackd ipvsadm libnetfilter-conntrack3 libnl1
   #ipcalc

--- a/systemvm/patches/debian/buildsystemvm.sh
+++ b/systemvm/patches/debian/buildsystemvm.sh
@@ -347,6 +347,12 @@ vpn_config() {
   cp -r ${scriptdir}/vpn/* ./
 }
 
+#
+# IMPORTANT REMARK
+# Package intallation is no longer done via this script. We are not removing the code yet, but we want to 
+# make sure that everybody willing to install/update packages should refer to the file:
+#   ==> cloud-tools/appliance/definitions/systemvmtemplate/install_systemvm_packages.sh
+#
 packages() {
   DEBIAN_FRONTEND=noninteractive
   DEBIAN_PRIORITY=critical

--- a/systemvm/patches/debian/buildsystemvm.sh
+++ b/systemvm/patches/debian/buildsystemvm.sh
@@ -375,8 +375,10 @@ packages() {
   chroot . apt-get --no-install-recommends -q -y --force-yes install open-vm-tools
   #xenstore utils
   chroot . apt-get --no-install-recommends -q -y --force-yes install xenstore-utils libxenstore3.0
-  #keepalived and conntrackd
-  chroot . apt-get --no-install-recommends -q -y --force-yes install keepalived conntrackd ipvsadm libnetfilter-conntrack3 libnl1
+  #keepalived - install version 1.2.13 from wheezy backports
+  chroot . apt-get --no-install-recommends -t wheezy-backports -q -y --force-yes install keepalived
+  #conntrackd
+  chroot . apt-get --no-install-recommends -q -y --force-yes install conntrackd ipvsadm libnetfilter-conntrack3 libnl1
   #ipcalc
   chroot . apt-get --no-install-recommends -q -y --force-yes install ipcalc
   #irqbalance from wheezy-backports

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -133,10 +133,6 @@ class CsInterface:
             return self.get_attr("gateway")
         else:
             return self.config.cmdline().get_guest_gw()
-#             if self.config.cmdline().is_redundant():
-#                 return self.config.cmdline().get_guest_gw()
-#             else:
-#                 return self.get_ip()
 
     def ip_in_subnet(self, ip):
         ipo = IPAddress(ip)
@@ -410,10 +406,6 @@ class CsIP:
                             ])
 
         if self.get_type() in ["public"]:
-            # self.fw.append(["nat", "front",
-                            # "-A POSTROUTING -o %s -j SNAT --to-source %s" %
-                           # (self.dev, self.address['public_ip'])
-                            # ])
             self.fw.append(["", "front",
                             "-A FORWARD -o %s -d %s -j ACL_INBOUND_%s" % (self.dev, self.address['network'], self.dev)
                             ])
@@ -457,7 +449,6 @@ class CsIP:
                 vpccidr = self.config.cmdline().get_vpccidr()
                 self.fw.append(["filter", "", "-A FORWARD -s %s ! -d %s -j ACCEPT" % (vpccidr, vpccidr)])
                 self.fw.append(["nat", "", "-A POSTROUTING -j SNAT -o %s --to-source %s" % (self.dev, self.address['public_ip'])])
-        # route.flush()
 
     def list(self):
         self.iplist = {}

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
@@ -57,11 +57,6 @@ class CsCmdLine(CsDataBag):
             self.dbag['config'] = {}
         return self.dbag['config']
 
-    def get_priority(self):
-        if "router_pr" in self.idata():
-            return self.idata()['router_pr']
-        return 99
-
     def set_guest_gw(self, val):
         self.idata()['guestgw'] = val
 
@@ -69,9 +64,6 @@ class CsCmdLine(CsDataBag):
         if "guestgw" in self.idata():
             return self.idata()['guestgw']
         return False
-
-    def set_priority(self, val):
-        self.idata()['router_pr'] = val
 
     def is_redundant(self):
         if "redundant_router" in self.idata():

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
@@ -35,10 +35,9 @@ class CsFile:
                 self.new_config.append(line)
         except IOError:
             logging.debug("File %s does not exist" % self.filename)
-            return
         else:
             logging.debug("Reading file %s" % self.filename)
-            self.config = copy.deepcopy(self.new_config)
+            self.config = list(self.new_config)
 
     def is_changed(self):
         if set(self.config) != set(self.new_config):
@@ -58,6 +57,7 @@ class CsFile:
 
     def commit(self):
         if not self.is_changed():
+            logging.info("Nothing to commit. The %s file did not change" % self.filename)
             return
         handle = open(self.filename, "w+")
         for line in self.new_config:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -139,13 +139,20 @@ class CsRedundant(object):
         heartbeat_cron.add("* * * * * root $SHELL %s/check_heartbeat.sh 2>&1 > /dev/null" % self.CS_ROUTER_DIR, -1)
         heartbeat_cron.add("* * * * * root sleep 30; $SHELL %s/check_heartbeat.sh 2>&1 > /dev/null" % self.CS_ROUTER_DIR, -1)
         heartbeat_cron.commit()
-        
+
         # Configure KeepaliveD cron job - runs at every reboot
         keepalived_cron = CsFile("/etc/cron.d/keepalived")
         keepalived_cron.add("SHELL=/bin/bash", 0)
         keepalived_cron.add("PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin", 1)
         keepalived_cron.add("@reboot root service keepalived start", -1)
         keepalived_cron.commit()
+
+        # Configure ConntrackD cron job - runs at every reboot
+        conntrackd_cron = CsFile("/etc/cron.d/conntrackd")
+        conntrackd_cron.add("SHELL=/bin/bash", 0)
+        conntrackd_cron.add("PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin", 1)
+        conntrackd_cron.add("@reboot root service conntrackd start", -1)
+        conntrackd_cron.commit()
 
         proc = CsProcess(['/usr/sbin/keepalived', '--vrrp'])
         if not proc.find() or keepalived_conf.is_changed():

--- a/systemvm/patches/debian/config/opt/cloud/bin/master.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/master.py
@@ -51,3 +51,6 @@ if options.master:
 
 if options.backup:
     red.set_backup()
+
+if options.fault:
+    red.set_fault()

--- a/systemvm/patches/debian/config/opt/cloud/templates/check_heartbeat.sh.templ
+++ b/systemvm/patches/debian/config/opt/cloud/templates/check_heartbeat.sh.templ
@@ -22,11 +22,11 @@ STRIKE_FILE="$ROUTER_BIN_PATH/keepalived.strikes"
 
 if [ -e $ROUTER_BIN_PATH/keepalived.ts2 ]
 then
-    lasttime=$(cat $ROUTER_BIN_PATH/keepalived.ts2)
     thistime=$(cat $ROUTER_BIN_PATH/keepalived.ts)
-    diff=$(($thistime - $lasttime))
+    lasttime=$(cat $ROUTER_BIN_PATH/keepalived.ts2)
+    diff=$(($lasttime - $thistime))
     s=0
-    if [ $diff -lt 30 ]
+    if [ $diff -ge 10 ]
     then
         if [ -e $STRIKE_FILE ]
         then
@@ -47,13 +47,14 @@ then
     if [ $s -gt 2 ]
     then
         echo Keepalived process is dead! >> $ROUTER_LOG
-        $ROUTER_BIN_PATH/services.sh stop >> $ROUTER_LOG 2>&1
-        $ROUTER_BIN_PATH/disable_pubip.sh >> $ROUTER_LOG 2>&1
-        $ROUTER_BIN_PATH/primary-backup.sh fault >> $ROUTER_LOG 2>&1
         service keepalived stop >> $ROUTER_LOG 2>&1
         service conntrackd stop >> $ROUTER_LOG 2>&1
-	pkill -9 keepalived >> $ROUTER_LOG 2>&1
-	pkill -9 conntrackd >> $ROUTER_LOG 2>&1
+        
+        #Set fault so we have the same effect as a KeepaliveD fault.
+        python /opt/cloud/bin/master.py --fault
+        
+        pkill -9 keepalived >> $ROUTER_LOG 2>&1
+        pkill -9 conntrackd >> $ROUTER_LOG 2>&1
         echo Status: FAULT \(keepalived process is dead\) >> $ROUTER_LOG
         exit
     fi

--- a/systemvm/patches/debian/config/opt/cloud/templates/keepalived.conf.templ
+++ b/systemvm/patches/debian/config/opt/cloud/templates/keepalived.conf.templ
@@ -21,15 +21,14 @@ global_defs {
 
 vrrp_script heartbeat {
     script "[RROUTER_BIN_PATH]/heartbeat.sh"
-    interval 10
+    interval 5
 }
 
 vrrp_instance inside_network {
-    state BACKUP
+    state EQUAL
     interface eth0
     virtual_router_id 51
-    priority [PRIORITY]
-		nopreempt
+    nopreempt
 
     advert_int 1
     authentication {
@@ -46,7 +45,7 @@ vrrp_instance inside_network {
     }
 
     !That's the correct path of the master.py file.
-    notify_master "/opt/cloud/bin/master.py --master"
     notify_backup "/opt/cloud/bin/master.py --backup"
+    notify_master "/opt/cloud/bin/master.py --master"
     notify_fault "/opt/cloud/bin/master.py --fault"
 }

--- a/systemvm/test/python/TestCsCmdLine.py
+++ b/systemvm/test/python/TestCsCmdLine.py
@@ -32,13 +32,6 @@ class TestCsCmdLine(unittest.TestCase):
     def test_idata(self):
         self.assertTrue(self.cscmdline.idata() == {})
 
-    def test_get_priority(self):
-        self.assertTrue(self.cscmdline.get_priority() == 99)
-
-    def test_set_priority(self):
-        self.cscmdline.set_priority(100)
-        self.assertTrue(self.cscmdline.get_priority() == 100)
-
     def test_is_redundant(self):
         self.assertTrue(self.cscmdline.is_redundant() is False)
         self.cscmdline.set_redundant()

--- a/test/integration/component/test_vpc_redundant.py
+++ b/test/integration/component/test_vpc_redundant.py
@@ -283,7 +283,8 @@ class TestVPCRedundancy(cloudstackTestCase):
         cnts = [0, 0, 0]
         self.query_routers(count, showall)
         for router in self.routers:
-            cnts[vals.index(router.redundantstate)] += 1
+            if router.state == "Running":
+                cnts[vals.index(router.redundantstate)] += 1
         if cnts[vals.index('MASTER')] != 1:
             self.fail("No Master or too many master routers found %s" % cnts[vals.index('MASTER')])
         # if cnts[vals.index('UNKNOWN')] > 0:
@@ -431,6 +432,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.do_vpc_test(False)
 
         self.stop_router("MASTER")
+        # wait for the backup router to transit to master state
         time.sleep(30)
         self.check_master_status(1)
         self.do_vpc_test(False)
@@ -441,7 +443,6 @@ class TestVPCRedundancy(cloudstackTestCase):
 
         self.start_router()
         self.add_nat_rules()
-        time.sleep(60)
         self.check_master_status(2)
         self.do_vpc_test(False)
 
@@ -459,6 +460,7 @@ class TestVPCRedundancy(cloudstackTestCase):
                     vm.set_ip(self.acquire_publicip(o.get_net()))
                 if vm.get_nat() is None:
                     vm.set_nat(self.create_natrule(vm.get_vm(), vm.get_ip(), o.get_net()))
+                    time.sleep(5)
 
     def do_vpc_test(self, expectFail):
         retries = 20

--- a/tools/appliance/definitions/systemvmtemplate/install_systemvm_packages.sh
+++ b/tools/appliance/definitions/systemvmtemplate/install_systemvm_packages.sh
@@ -65,7 +65,7 @@ function install_packages() {
     xl2tpd bcrelay ppp ipsec-tools tdb-tools \
     openswan=1:2.6.37-3 \
     xenstore-utils libxenstore3.0 \
-    keepalived conntrackd ipvsadm libnetfilter-conntrack3 libnl1 \
+    conntrackd ipvsadm libnetfilter-conntrack3 libnl1 \
     ipcalc \
     openjdk-7-jre-headless \
     iptables-persistent \
@@ -75,7 +75,7 @@ function install_packages() {
     radvd \
     sharutils
 
-  ${apt_get} -t wheezy-backports install irqbalance open-vm-tools
+  ${apt_get} -t wheezy-backports install keepalived irqbalance open-vm-tools
 
   # hold on installed openswan version, upgrade rest of the packages (if any)
   apt-mark hold openswan


### PR DESCRIPTION
This PR contains some refactoring of the Python code used by the redundant routers and also a fix for the intermittent problem when running the rVPC component tests.

To summarise it:

* If the KeepaloiveD configuration file changes, restart the service instead of reloading it.
* Since we are configuring KeepaliveD/VRRP in no-preemptive mode, we no longer need priorities. As a matter of fact, the Management Server was not sending priorities to the routers anymore. The value used in the old configuration was defaulted to 99 in the Python code.
* KeepaliveD and ConntractD, once configured in a router, will have a cronjob that will run on reboot. So, the services will be restarted without the need to wait for the management server to send some configuration and force a restart.
* Installing KeepaliveD from Wheezy-Backports in order to have a newer version available.

I already squashed few commits of this PR so we wouldn't have to go through simple fixes/typos that happened during the tryouts. When opening the commits for review please note that the commit messages also contain the messages of the squashed commits.

Adding the cronjob to restart the KeepaliveD service on reboot helped to get a 60% success rate with the tests. Before that, the tests were failing very often: 4 out of 5 times.

I then added the "restart" when configuration changes instead of "reload". Once the change was applied, I successfully executed the tests 13 times. That gives confidence.

Tests can be executed with the following command:

nosetests --with-marvin --marvin-config=[your_configuration_file] -s -a tags=advanced,required_hardware=true component/test_vpc_redundant.py

Since there were changes on marvin/base.py - in the previous PR, you will need to build/upgrade your Marvin installation.

@DaanHoogland @bhaisaab @remibergsma, could you please have a look at this PR?

Cheers,
Wilder
