### PR TITLE
CLOUDSTACK-8633: Changing file permissions from 755 to 440

### DIFF
--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -301,6 +301,7 @@ install -D packaging/centos63/cloud-management.sysconfig ${RPM_BUILD_ROOT}%{_sys
 install -D server/target/conf/cloudstack-sudoers ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 install -D packaging/centos63/tomcat.sh ${RPM_BUILD_ROOT}%{_initrddir}/tomcat.sh
 
+chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina
 chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost
 chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -278,6 +278,7 @@ install -D packaging/centos7/cloud-management.service ${RPM_BUILD_ROOT}%{_unitdi
 install -D packaging/centos7/cloud.limits ${RPM_BUILD_ROOT}%{_sysconfdir}/security/limits.d/cloud
 touch ${RPM_BUILD_ROOT}%{_localstatedir}/run/%{name}-management.pid
 
+chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina
 chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost
 chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina/localhost/client


### PR DESCRIPTION
With 0755 permissions on /etc/sudoers.d/cloudstack-management we are getting following error in bringing up CS:
Failed to start bean 'cloudStackLifeCycle'; nested exception is com.cloud.utils.exception.CloudRuntimeException: Failed to inject generated public key into systemvm iso sudo: /etc/sudoers.d/cloudstack-management is mode 0755, should be 0440sudo: sorry, you must have a tty to run sudo”

So I have changed the permissions to 440.