### PR TITLE
CLOUDSTACK-8639:fixing calculation mistakes in component/test_ss_doma…

### DIFF
--- a/test/integration/component/test_ss_domain_limits.py
+++ b/test/integration/component/test_ss_domain_limits.py
@@ -559,7 +559,9 @@ class TestDeleteAccount(cloudstackTestCase):
         self.assertFalse(result[0], result[1])
         self.assertTrue(result[2], "Resource count does not match")
 
-        expectedCount *= 2
+        self.templateSize = int((int(templates[0].size)*2) / (1024**3))
+
+        expectedCount = self.templateSize
         result = isDomainResourceCountEqualToExpectedCount(
                                     self.apiclient, self.parent_domain.id,
                                     expectedCount, RESOURCE_SECONDARY_STORAGE)


### PR DESCRIPTION
test result
=========
Test secondary storage limit of domain and its sub-domains ... === TestName: test_04_create_template_delete_account | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 175.563s

OK