### PR TITLE
CLOUDSTACK-8641 - When calling "update hostpassword" API it throws NP…

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/host/UpdateHostPasswordCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/host/UpdateHostPasswordCmd.java
@@ -67,7 +67,7 @@ public class UpdateHostPasswordCmd extends BaseCmd {
     }
 
     public Boolean getUpdatePasswdOnHost() {
-        return updatePasswdOnHost;
+        return updatePasswdOnHost == null ? false : true;
     }
 
     public String getPassword() {

--- a/api/test/org/apache/cloudstack/api/command/test/UpdateHostPasswordCmdTest.java
+++ b/api/test/org/apache/cloudstack/api/command/test/UpdateHostPasswordCmdTest.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import junit.framework.TestCase;
+
+import org.apache.cloudstack.api.ResponseGenerator;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.command.admin.host.UpdateHostPasswordCmd;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.resource.ResourceService;
+import com.cloud.server.ManagementService;
+
+public class UpdateHostPasswordCmdTest extends TestCase {
+
+    private UpdateHostPasswordCmd updateHostPasswordCmd;
+    private ManagementService managementServer;
+    private ResourceService resourceService;
+    private ResponseGenerator responseGenerator;
+
+    @Override
+    @Before
+    public void setUp() {
+        responseGenerator = Mockito.mock(ResponseGenerator.class);
+        managementServer = Mockito.mock(ManagementService.class);
+        resourceService = Mockito.mock(ResourceService.class);
+        updateHostPasswordCmd = new UpdateHostPasswordCmd();
+    }
+
+    @Test
+    public void testExecuteForNullResult() {
+
+        updateHostPasswordCmd._mgr = managementServer;
+        updateHostPasswordCmd._resourceService = resourceService;
+
+        try {
+            Mockito.when(managementServer.updateHostPassword(updateHostPasswordCmd)).thenReturn(false);
+        } catch (final InvalidParameterValueException e) {
+            fail(e.getMessage());
+        } catch (final IllegalArgumentException e) {
+            fail(e.getMessage());
+        }
+
+        try {
+            updateHostPasswordCmd.execute();
+        } catch (final ServerApiException exception) {
+            Assert.assertEquals("Failed to update config", exception.getDescription());
+        }
+
+        assertFalse("The attribute updatePasswdOnHost should be false, but it isn't.", updateHostPasswordCmd.getUpdatePasswdOnHost());
+        verify(managementServer, times(1)).updateHostPassword(updateHostPasswordCmd);
+    }
+
+    @Test
+    public void testCreateSuccess() {
+
+        updateHostPasswordCmd._mgr = managementServer;
+        updateHostPasswordCmd._resourceService = resourceService;
+        updateHostPasswordCmd._responseGenerator = responseGenerator;
+
+        try {
+            Mockito.when(managementServer.updateHostPassword(updateHostPasswordCmd)).thenReturn(true);
+        } catch (final Exception e) {
+            fail("Received exception when success expected " + e.getMessage());
+        }
+
+        try {
+            updateHostPasswordCmd.execute();
+        } catch (final ServerApiException exception) {
+            assertEquals("Failed to update config", exception.getDescription());
+        }
+
+        assertFalse("The attribute updatePasswdOnHost should be false, but it isn't.", updateHostPasswordCmd.getUpdatePasswdOnHost());
+        verify(managementServer, times(1)).updateHostPassword(updateHostPasswordCmd);
+    }
+}


### PR DESCRIPTION
…E if the update_passwd_on_host if not informed

   - On getUpdatePasswdOnHost() method, if updatePasswdOnHost is null then return false.

Apologies for the NPE. This will fix it.

Output of command updating KVM host DB only:

(local) 🐵 > update hostpassword hostid=9ae1d93b-d09c-4e1c-94fa-9082e81cca26 username=root password=admin123
success = true

@DaanHoogland @bhaisaab that's a quick one to review. :)

Cheers,
Wilder