### PR TITLE
CLOUDSTACK-8642: SSO Method not allowed bug fix.

### DIFF
--- a/ui/scripts/cloud.core.callbacks.js
+++ b/ui/scripts/cloud.core.callbacks.js
@@ -65,6 +65,7 @@ $(document).ready(function() {
     if (url != undefined && url != null && url.length > 0) {
         url = unescape(clientApiUrl + "?" + url);
         $.ajax({
+            type: 'POST',
             url: url,
             dataType: "json",
             async: false,


### PR DESCRIPTION
Due to CLOUDSTACK-8505 and commit 1c81b241e7914b24b06c3b7b3ee98bc0d3b4f68b only POST methods are allowed. This needs to be explicitly stated in the AJAX method.