### PR TITLE
CLOUDSTACK-8650: Fix securitygroups ingress FW for protocol any and 0.0.0.0/0

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -860,7 +860,7 @@ def add_network_rules(vm_name, vm_id, vm_ip, signature, seqno, vmMac, rules, vif
                 for ip in ips:
                     execute("iptables -I " + vmchain + " -p icmp --icmp-type " + range + " " + direction + " " + ip + " -j "+ action)
 
-        if allow_any
+        if allow_any:
             if protocol == 'all':
                 execute("iptables -I " + vmchain + " -m state --state NEW " + direction + " 0.0.0.0/0 -j "+action)
             elif protocol != 'icmp':

--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -860,8 +860,10 @@ def add_network_rules(vm_name, vm_id, vm_ip, signature, seqno, vmMac, rules, vif
                 for ip in ips:
                     execute("iptables -I " + vmchain + " -p icmp --icmp-type " + range + " " + direction + " " + ip + " -j "+ action)
 
-        if allow_any and protocol != 'all':
-            if protocol != 'icmp':
+        if allow_any
+            if protocol == 'all':
+                execute("iptables -I " + vmchain + " -m state --state NEW " + direction + " 0.0.0.0/0 -j "+action)
+            elif protocol != 'icmp':
                 execute("iptables -I " + vmchain + " -p " + protocol + " -m " + protocol + " --dport " + range + " -m state --state NEW -j "+ action)
             else:
                 range = start + "/" + end


### PR DESCRIPTION
When using security groups, adding an ingress rule for protocol "any" with source address 0.0.0.0/0, resulted in no action (as the 0.0.0.0/0 entry was stripped from the array of source ips, but unlike icmp/tcp/udp, no special action was set for the handling of the allow_any flag.

This oneliner only removes 0.0.0.0/0 from the list if the protocol isn't any...