### PR TITLE
CLOUDSTACK-8658: make initializer static instead of default

### DIFF
--- a/utils/src/com/cloud/utils/StringUtils.java
+++ b/utils/src/com/cloud/utils/StringUtils.java
@@ -35,7 +35,7 @@ public class StringUtils {
 
     private static Charset preferredACSCharset;
 
-    {
+    static {
         String preferredCharset = "UTF-8";
         if (Charset.isSupported(preferredCharset)) {
             preferredACSCharset = Charset.forName(preferredCharset);

--- a/utils/test/com/cloud/utils/StringUtilsTest.java
+++ b/utils/test/com/cloud/utils/StringUtilsTest.java
@@ -21,6 +21,7 @@ package com.cloud.utils;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -29,6 +30,16 @@ import junit.framework.Assert;
 import org.junit.Test;
 
 public class StringUtilsTest {
+    @Test
+    public void testGetPrefferedCharset() {
+        assertEquals(StringUtils.getPreferredCharset(),Charset.forName("UTF-8"));
+    }
+
+    @Test
+    public void testGetDefaultCharset() {
+        assertEquals(StringUtils.getPreferredCharset(),Charset.defaultCharset());
+    }
+
     @Test
     public void testCleanPasswordFromJsonObjectAtEnd() {
         String input = "{\"foo\":\"bar\",\"password\":\"test\"}";


### PR DESCRIPTION
bad bug: ommision of the static keyword on initializer leaves data uninitialized :{