### PR TITLE
CLOUDSTACK-8649: Fixed unnecessary double url decoding in registerSSHKeyPair.

### DIFF
--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -16,9 +16,7 @@
 // under the License.
 package com.cloud.server;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -3617,11 +3615,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
         String name = cmd.getName();
         String key = cmd.getPublicKey();
-        try {
-            key = URLDecoder.decode(key, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            s_logger.warn("key decoding tried invain: " + e.getLocalizedMessage());
-        }
+
         String publicKey = getPublicKeyFromKeyKeyMaterial(key);
         String fingerprint = getFingerprint(publicKey);
 


### PR DESCRIPTION
The method cmd.getPublicKey() already returns a decoded string. So when we try to decode it again the plus "+" signs are being decoded to white spaces. In a next step the key is cut at the spaces and only the first two parts are being saved in the DB.