### PR TITLE
CLOUDSTACK-8666: Put host in Alert state only after alert.wait timeout

### DIFF
--- a/server/src/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -220,7 +220,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
             }
         }
 
-        return Status.Alert;
+        return hostState;
     }
 
     @Override


### PR DESCRIPTION
Instead of putting the host to Alert state immediately, the investigators should be allowed to run for some time based on alert.wait global config.
At the end of this interval if the host state still cannot be determined then put the host in Alert. Also updated some of the log messages.

Refer to the bug for the detailed description.

Since these scenarios are difficult to simulate, haven't written any tests. If anyone has suggestions on some tests please let me know.
