### PR TITLE
fix systemvm64template build, fix .deb package creation.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,7 +6,7 @@ cloudstack (4.6.0-SNAPSHOT) unstable; urgency=low
   [ Rafael da Fonseca ]
   * Switch to dpkg-source 3.0 (native) format
 
- -- Rafael da Fonseca <rsafonseca@gmail.com>  Fri, 22 May 2015 16:03:55 +0200
+ -- the Apache CloudStack project <dev@cloudstack.apache.org>  Thu, 18 Jun 2015 11:17:09 +0200
 
 cloudstack (4.5.0-snapshot) unstable; urgency=low
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-VERSION := $(shell mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v "\[")
+VERSION := $(shell cat pom.xml |sed '22!d'| cut -d'>' -f2 |cut -d'<' -f1)
 PACKAGE = $(shell dh_listpackages|head -n 1|cut -d '-' -f 1)
 SYSCONFDIR = "/etc"
 DESTDIR = "debian/tmp"

--- a/tools/appliance/definitions/systemvmtemplate/install_systemvm_packages.sh
+++ b/tools/appliance/definitions/systemvmtemplate/install_systemvm_packages.sh
@@ -65,7 +65,7 @@ function install_packages() {
     xl2tpd bcrelay ppp ipsec-tools tdb-tools \
     openswan=1:2.6.37-3 \
     xenstore-utils libxenstore3.0 \
-    conntrackd ipvsadm libnetfilter-conntrack3 libnl1 \
+    conntrackd ipvsadm libnetfilter-conntrack3 libnl-3-200 libnl-genl-3-200 \
     ipcalc \
     openjdk-7-jre-headless \
     iptables-persistent \


### PR DESCRIPTION
- build .deb package job must be change for ``dpkg-buildpackage -uc -us`` ubuntu 14.04 enforce signature of package. CLOUDSTACK-8675

- @wilderrodrigues: this fix dependency for keepalived on building systemvm64template. Changing ``libnl1`` by ``libnl-3-200 libnl-genl-3-200`` seams resolve the build problem.

For unknown reason the default way to retrieve version ``mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v "\["`` does not work in package creation, it return a null value.