### PR TITLE
CLOUDSTACK-8668: VR type in shared network is dhcpsrvr. Ips are being removed due to this issue

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -182,6 +182,9 @@ class updateDataBag:
             self.processCLItem('2', "public")
         elif (self.qFile.data['cmd_line']['type'] == "vpcrouter"):
             self.processCLItem('0', "control")
+        elif (self.qFile.data['cmd_line']['type'] == "dhcpsrvr"):
+            self.processCLItem('0', "guest")
+            self.processCLItem('1', "control")
         return cs_cmdline.merge(dbag, self.qFile.data)
 
     def processCLItem(self, num, nw_type):


### PR DESCRIPTION
- VR IP config is loaded from /var/cache/cloud/cmdline
- For shared network VR type is "dhcpserver" in /var/cache/cloud/cmdline
- after VR refactor, merge.py is considering VR types "router" and "vpcrouter" only
-  Fixed by adding dhcpserver VR type

Testing:
- VR successfully started on shared network. All IPs are configured properly.