### PR TITLE
CLOUDSTACK-8683: process cmd_line.json for shared network VR in cloud-early-config

### DIFF
--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -1339,6 +1339,10 @@ start() {
      dhcpsrvr)
          [ "$NAME" == "" ] && NAME=dhcpsrvr
          setup_dhcpsrvr
+         if [ -x /opt/cloud/bin/update_config.py ]
+         then
+	         /opt/cloud/bin/update_config.py cmd_line.json
+         fi
 	  ;;
      secstorage)
          [ "$NAME" == "" ] && NAME=secstorage


### PR DESCRIPTION
- SSH access on link_local_ip is blocked for shared VR
- MS is unable to program rules on VR. Vm deployment also fails as the DHCP entries cannot be added.
- Fixed by processing cmd_line.json in cloud-early-config similar to isolated VR

Test:
- Deploy Vm successful
- Can access VR from host via ssh on link_local_ip on port 3922
