### PR TITLE
Removed "medium" dictionary from test_data and modified the tests dependen on it

### DIFF
--- a/test/integration/component/maint/test_bugs.py
+++ b/test/integration/component/maint/test_bugs.py
@@ -68,7 +68,7 @@ class Test42xBugsMgmtSvr(cloudstackTestCase):
             # Creating Disk offering, Service Offering and Account
             cls.service_offering = ServiceOffering.create(
                 cls.apiClient,
-                cls.services["service_offerings"]
+                cls.services["service_offerings"]["tiny"]
             )
             cls.account = Account.create(
                 cls.api_client,

--- a/test/integration/component/maint/test_multiple_ip_ranges.py
+++ b/test/integration/component/maint/test_multiple_ip_ranges.py
@@ -111,7 +111,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
         if cls.vr_state is False:
             cls.vm_res = VirtualMachine.create(
                 cls.api_client,
-                cls.testdata["server_without_disk"],
+                cls.testdata["small"],
                 templateid=cls.template.id,
                 accountid=cls.account.name,
                 domainid=cls.testdata["domainid"],
@@ -181,7 +181,7 @@ class TestMultipleIpRanges(cloudstackTestCase):
         try:
             self.virtual_machine = VirtualMachine.create(
                 self.apiclient,
-                self.testdata["server_without_disk"],
+                self.testdata["small"],
                 templateid=self.template.id,
                 accountid=self.account.name,
                 domainid=self.testdata["domainid"],

--- a/test/integration/component/maint/test_zone_level_local_storage_setting.py
+++ b/test/integration/component/maint/test_zone_level_local_storage_setting.py
@@ -107,13 +107,13 @@ def storage_check(self, type, value):
 
 def create_system_so(self, offering_type, storage_type):
     """Create system offerings """
-    self.testdata["service_offerings"]["issystem"] = "true"
-    self.testdata["service_offerings"]["systemvmtype"] = offering_type
-    self.testdata["service_offerings"]["storagetype"] = storage_type
+    self.testdata["service_offerings"]["tiny"]["issystem"] = "true"
+    self.testdata["service_offerings"]["tiny"]["systemvmtype"] = offering_type
+    self.testdata["service_offerings"]["tiny"]["storagetype"] = storage_type
 
     service_offering = ServiceOffering.create(
         self.apiclient,
-        self.testdata["service_offerings"]
+        self.testdata["service_offerings"]["tiny"]
     )
 
     if service_offering is None:
@@ -136,32 +136,32 @@ def create_system_so(self, offering_type, storage_type):
 
     self.assertEqual(
         list_service_response[0].cpunumber,
-        self.testdata["service_offerings"]["cpunumber"],
+        self.testdata["service_offerings"]["tiny"]["cpunumber"],
         "Check server id in createServiceOffering"
     )
     self.assertEqual(
         list_service_response[0].cpuspeed,
-        self.testdata["service_offerings"]["cpuspeed"],
+        self.testdata["service_offerings"]["tiny"]["cpuspeed"],
         "Check cpuspeed in createServiceOffering"
     )
     self.assertEqual(
         list_service_response[0].displaytext,
-        self.testdata["service_offerings"]["displaytext"],
+        self.testdata["service_offerings"]["tiny"]["displaytext"],
         "Check server displaytext in createServiceOfferings"
     )
     self.assertEqual(
         list_service_response[0].memory,
-        self.testdata["service_offerings"]["memory"],
+        self.testdata["service_offerings"]["tiny"]["memory"],
         "Check memory in createServiceOffering"
     )
     self.assertEqual(
         list_service_response[0].name,
-        self.testdata["service_offerings"]["name"],
+        self.testdata["service_offerings"]["tiny"]["name"],
         "Check name in createServiceOffering"
     )
     self.assertEqual(
         list_service_response[0].storagetype,
-        self.testdata["service_offerings"]["storagetype"],
+        self.testdata["service_offerings"]["tiny"]["storagetype"],
         "Check storagetype in createServiceOffering"
     )
     self._cleanup.append(service_offering)

--- a/test/integration/component/maint/testpath_disablestoragepool.py
+++ b/test/integration/component/maint/testpath_disablestoragepool.py
@@ -116,9 +116,9 @@ class TestPathDisableStorage_Basic(cloudstackTestCase):
 
         # Create offerings for local storage if local storage is enabled
         if cls.zone.localstorageenabled:
-            cls.testdata["service_offerings"]["storagetype"] = 'local'
+            cls.testdata["service_offerings"]["tiny"]["storagetype"] = 'local'
             cls.service_offering_local = ServiceOffering.create(cls.apiclient,
-                                                            cls.testdata["service_offerings"]
+                                                            cls.testdata["service_offerings"]["tiny"]
                                                             )
             cls._cleanup.append(cls.service_offering_local)
             cls.testdata["disk_offering"]["storagetype"] = 'local'
@@ -127,7 +127,7 @@ class TestPathDisableStorage_Basic(cloudstackTestCase):
                                                           )
             cls._cleanup.append(cls.disk_offering_local)
             cls.testdata["disk_offering"]["storagetype"] = ' '
-            cls.testdata["service_offerings"]["storagetype"] = ' '
+            cls.testdata["service_offerings"]["tiny"]["storagetype"] = ' '
         else:
             cls.debug("No local storage found")
 
@@ -730,10 +730,10 @@ class TestPathDisableStorage_Maint_Tags(cloudstackTestCase):
 
             # Create offerings for local storage if local storage is enabled
             if cls.zone.localstorageenabled:
-                cls.testdata["service_offerings"]["storagetype"] = 'local'
+                cls.testdata["service_offerings"]["tiny"]["storagetype"] = 'local'
                 cls.debug("Creating local storage offering")
                 cls.service_offering_local = ServiceOffering.create(cls.apiclient,
-                                                                cls.testdata["service_offerings"]
+                                                                cls.testdata["service_offerings"]["tiny"]
                                                                 )
                 cls._cleanup.append(cls.service_offering_local)
                 cls.testdata["disk_offering"]["storagetype"] = 'local'
@@ -743,7 +743,7 @@ class TestPathDisableStorage_Maint_Tags(cloudstackTestCase):
                                                               )
                 cls._cleanup.append(cls.disk_offering_local)
                 cls.testdata["disk_offering"]["storagetype"] = ' '
-                cls.testdata["service_offerings"]["storagetype"] = ' '
+                cls.testdata["service_offerings"]["tiny"]["storagetype"] = ' '
             else:
                 cls.debug("No local storage found")
 
@@ -939,11 +939,11 @@ class TestPathDisableStorage_Maint_Tags(cloudstackTestCase):
         StoragePool.update(self.userapiclient, id=storage_id, tags='disable_prov')
 
         # Step 7: Add tagged service offering
-        self.testdata['service_offerings']['tags'] = 'disable_prov'
-        self.testdata["service_offerings"]["storagetype"] = 'local'
+        self.testdata['service_offerings']['tiny']['tags'] = 'disable_prov'
+        self.testdata["service_offerings"]["tiny"]["storagetype"] = 'local'
         self.tagged_so = ServiceOffering.create(self.userapiclient, self.testdata['service_offerings'])
-        self.testdata['service_offerings']['tags'] = ' '
-        self.testdata["service_offerings"]["storagetype"] = ' '
+        self.testdata['service_offerings']['tiny']['tags'] = ' '
+        self.testdata["service_offerings"]["tiny"]["storagetype"] = ' '
         self.cleanup.append(self.tagged_so)
 
         # Step 8: Enable the pool

--- a/test/integration/component/test_interop_xd_ccp.py
+++ b/test/integration/component/test_interop_xd_ccp.py
@@ -49,7 +49,8 @@ from marvin.lib.common import (get_domain,
                                 get_template,
                                 get_pod,
                                 list_hosts,
-                                get_windows_template
+                                get_windows_template,
+                                list_virtual_machines
                                 )
 
 from marvin.codes import FAILED, PASS
@@ -58,6 +59,7 @@ from nose.plugins.attrib import attr
 import time
 import random
 import string
+import unittest
 
 _multiprocess_shared_ = True
 class TestXDCCPInterop(cloudstackTestCase):
@@ -168,9 +170,6 @@ class TestXDCCPInterop(cloudstackTestCase):
         cls.services["small"]["zoneid"] = cls.zone.id
         cls.services["small"]["template"] = cls.template.id
 
-        cls.services["medium"]["zoneid"] = cls.zone.id
-        cls.services["medium"]["template"] = cls.template.id
-
         user_data = ''.join(random.choice(string.ascii_uppercase + string.digits) for x in range(2500))
         cls.services["virtual_machine"]["userdata"] = user_data
 
@@ -180,7 +179,7 @@ class TestXDCCPInterop(cloudstackTestCase):
 
         cls.virtual_machine = VirtualMachine.create(
             cls.apiclient,
-            cls.services["medium"],
+            cls.services["small"],
             accountid=cls.account.name,
             domainid=cls.account.domainid,
             serviceofferingid=cls.service_offering.id,  
@@ -727,7 +726,7 @@ class TestXDCCPInterop(cloudstackTestCase):
                         )
         restorevm = VirtualMachine.create(
             self.user_api_client,
-            self.services["medium"],
+            self.services["small"],
             accountid=self.account.name,
             domainid=self.account.domainid,
             serviceofferingid=self.service_offering.id,
@@ -862,7 +861,7 @@ class TestXDCCPInterop(cloudstackTestCase):
 
         restorevm = VirtualMachine.create(
             self.user_api_client,
-            self.services["medium"],
+            self.services["small"],
             networkids=vm1network.id,
             accountid=self.account.name,
             domainid=self.account.domainid,
@@ -974,7 +973,7 @@ class TestXDCCPInterop(cloudstackTestCase):
 
         templatevm = VirtualMachine.create(
                                     self.user_api_client,
-                                    self.services["medium"],
+                                    self.services["small"],
                                     templateid=self.template.id,
                                     accountid=self.account.name,
                                     domainid=self.account.domainid,
@@ -1089,7 +1088,7 @@ class TestXDCCPInterop(cloudstackTestCase):
 
         templatevm = VirtualMachine.create(
                                     self.user_api_client,
-                                    self.services["medium"],
+                                    self.services["small"],
                                     templateid=roottemplate.id,
                                     networkids=vm3network.id,
                                     serviceofferingid=self.service_offering.id,
@@ -1227,8 +1226,8 @@ class TestXDCCPInterop(cloudstackTestCase):
 
             vm_1 = VirtualMachine.create(
                                     self.user_api_client,
-                                    self.services["medium"],
-                                    templateid=template.id,
+                                    self.services["small"],
+                                    templateid=self.template.id,
                                     networkids=vm4network.id,
                                     serviceofferingid=self.service_offering.id,
                                     accountid=self.account.name,

--- a/test/integration/smoke/test_affinity_groups.py
+++ b/test/integration/smoke/test_affinity_groups.py
@@ -62,7 +62,7 @@ class TestDeployVmWithAffinityGroup(cloudstackTestCase):
         )
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
 
         cls.ag = AffinityGroup.create(cls.apiclient, cls.services["virtual_machine"]["affinity"],

--- a/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
+++ b/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
@@ -125,11 +125,9 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             domainid=self.domain.id
         )
 
-        self.testdata["vgpu260q"]["zoneid"] = self.zone.id
-        self.testdata["vgpu260q"]["template"] = self.template.id
+        self.testdata["small"]["zoneid"] = self.zone.id
+        self.testdata["small"]["template"] = self.template.id
 
-        self.testdata["vgpu140q"]["zoneid"] = self.zone.id
-        self.testdata["vgpu140q"]["template"] = self.template.id
         self.testdata["service_offerings"]["vgpu260qwin"]["serviceofferingdetails"] = [
             {
                 'pciDevice': 'Group of NVIDIA Corporation GK107GL [GRID K1] GPUs'}, {
@@ -156,7 +154,7 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
         """
         self.virtual_machine = VirtualMachine.create(
             self.apiclient,
-            self.testdata["vgpu260q"],
+            self.testdata["small"],
             accountid=self.account.name,
             domainid=self.account.domainid,
             serviceofferingid=self.service_offering.id,

--- a/test/integration/smoke/test_deploy_vm_with_userdata.py
+++ b/test/integration/smoke/test_deploy_vm_with_userdata.py
@@ -39,10 +39,10 @@ class TestDeployVmWithUserData(cloudstackTestCase):
         cls.zone = get_zone(cls.apiClient, testClient.getZoneForTests())
         if cls.zone.localstorageenabled:
             #For devcloud since localstroage is enabled
-            cls.services["service_offerings"]["storagetype"] = "local"
+            cls.services["service_offerings"]["tiny"]["storagetype"] = "local"
         cls.service_offering = ServiceOffering.create(
             cls.apiClient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.account = Account.create(cls.apiClient, services=cls.services["account"])
         cls.cleanup = [cls.account]

--- a/test/integration/smoke/test_deploy_vms_with_varied_deploymentplanners.py
+++ b/test/integration/smoke/test_deploy_vms_with_varied_deploymentplanners.py
@@ -67,7 +67,7 @@ class TestDeployVmWithVariedPlanners(cloudstackTestCase):
         #FIXME: How do we know that first fit actually happened?
         self.service_offering_firstfit = ServiceOffering.create(
             self.apiclient,
-            self.services["service_offerings"],
+            self.services["service_offerings"]["tiny"],
             deploymentplanner='FirstFitPlanner'
         )
 
@@ -110,7 +110,7 @@ class TestDeployVmWithVariedPlanners(cloudstackTestCase):
         """
         self.service_offering_userdispersing = ServiceOffering.create(
             self.apiclient,
-            self.services["service_offerings"],
+            self.services["service_offerings"]["tiny"],
             deploymentplanner='UserDispersingPlanner'
         )
 
@@ -169,7 +169,7 @@ class TestDeployVmWithVariedPlanners(cloudstackTestCase):
         """
         self.service_offering_userconcentrated = ServiceOffering.create(
             self.apiclient,
-            self.services["service_offerings"],
+            self.services["service_offerings"]["tiny"],
             deploymentplanner='UserConcentratedPodPlanner'
         )
 

--- a/test/integration/smoke/test_internal_lb.py
+++ b/test/integration/smoke/test_internal_lb.py
@@ -39,7 +39,7 @@ class TestInternalLb(cloudstackTestCase):
         cls.domain = get_domain(cls.apiclient)
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.account = Account.create(cls.apiclient, services=cls.services["account"])
         cls.template = get_template(

--- a/test/integration/smoke/test_loadbalance.py
+++ b/test/integration/smoke/test_loadbalance.py
@@ -59,7 +59,7 @@ class TestLoadBalance(cloudstackTestCase):
                             )
         cls.service_offering = ServiceOffering.create(
                                         cls.apiclient,
-                                        cls.services["service_offerings"]
+                                        cls.services["service_offerings"]["tiny"]
                                         )
         cls.vm_1 = VirtualMachine.create(
                                     cls.apiclient,

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -272,7 +272,7 @@ class TestPortForwarding(cloudstackTestCase):
         cls.services["virtual_machine"]["zoneid"] = cls.zone.id
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.virtual_machine = VirtualMachine.create(
             cls.apiclient,
@@ -596,7 +596,7 @@ class TestRebootRouter(cloudstackTestCase):
         )
         self.service_offering = ServiceOffering.create(
             self.apiclient,
-            self.services["service_offerings"]
+            self.services["service_offerings"]["tiny"]
         )
         self.vm_1 = VirtualMachine.create(
             self.apiclient,
@@ -765,7 +765,7 @@ class TestReleaseIP(cloudstackTestCase):
 
         self.service_offering = ServiceOffering.create(
             self.apiclient,
-            self.services["service_offerings"]
+            self.services["service_offerings"]["tiny"]
         )
 
         self.virtual_machine = VirtualMachine.create(
@@ -905,7 +905,7 @@ class TestDeleteAccount(cloudstackTestCase):
         )
         self.service_offering = ServiceOffering.create(
             self.apiclient,
-            self.services["service_offerings"]
+            self.services["service_offerings"]["tiny"]
         )
         self.vm_1 = VirtualMachine.create(
             self.apiclient,
@@ -1050,7 +1050,7 @@ class TestRouterRules(cloudstackTestCase):
         cls.services["virtual_machine"]["zoneid"] = cls.zone.id
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.virtual_machine = VirtualMachine.create(
             cls.apiclient,

--- a/test/integration/smoke/test_network_acl.py
+++ b/test/integration/smoke/test_network_acl.py
@@ -37,7 +37,7 @@ class TestNetworkACL(cloudstackTestCase):
         cls.domain = get_domain(cls.apiclient)
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.account = Account.create(cls.apiclient, services=cls.services["account"])
         cls.template = get_template(

--- a/test/integration/smoke/test_routers.py
+++ b/test/integration/smoke/test_routers.py
@@ -79,7 +79,7 @@ class TestRouterServices(cloudstackTestCase):
         )
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.vm_1 = VirtualMachine.create(
             cls.apiclient,

--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -176,8 +176,6 @@ class TestServiceOfferings(cloudstackTestCase):
         cls.services["small"]["zoneid"] = cls.zone.id
         cls.services["small"]["template"] = template.id
 
-        cls.services["medium"]["zoneid"] = cls.zone.id
-        cls.services["medium"]["template"] = template.id
 
         # Create VMs, NAT Rules etc
         cls.account = Account.create(
@@ -197,7 +195,7 @@ class TestServiceOfferings(cloudstackTestCase):
         )
         cls.medium_virtual_machine = VirtualMachine.create(
             cls.apiclient,
-            cls.services["medium"],
+            cls.services["small"],
             accountid=cls.account.name,
             domainid=cls.account.domainid,
             serviceofferingid=cls.medium_offering.id,

--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -75,7 +75,7 @@ class TestCreateServiceOffering(cloudstackTestCase):
 
         service_offering = ServiceOffering.create(
             self.apiclient,
-            self.services["service_offerings"]
+            self.services["service_offerings"]["tiny"]
         )
         self.cleanup.append(service_offering)
 
@@ -101,27 +101,27 @@ class TestCreateServiceOffering(cloudstackTestCase):
 
         self.assertEqual(
             list_service_response[0].cpunumber,
-            self.services["service_offerings"]["cpunumber"],
+            self.services["service_offerings"]["tiny"]["cpunumber"],
             "Check server id in createServiceOffering"
         )
         self.assertEqual(
             list_service_response[0].cpuspeed,
-            self.services["service_offerings"]["cpuspeed"],
+            self.services["service_offerings"]["tiny"]["cpuspeed"],
             "Check cpuspeed in createServiceOffering"
         )
         self.assertEqual(
             list_service_response[0].displaytext,
-            self.services["service_offerings"]["displaytext"],
+            self.services["service_offerings"]["tiny"]["displaytext"],
             "Check server displaytext in createServiceOfferings"
         )
         self.assertEqual(
             list_service_response[0].memory,
-            self.services["service_offerings"]["memory"],
+            self.services["service_offerings"]["tiny"]["memory"],
             "Check memory in createServiceOffering"
         )
         self.assertEqual(
             list_service_response[0].name,
-            self.services["service_offerings"]["name"],
+            self.services["service_offerings"]["tiny"]["name"],
             "Check name in createServiceOffering"
         )
         return
@@ -157,11 +157,11 @@ class TestServiceOfferings(cloudstackTestCase):
 
         cls.service_offering_1 = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.service_offering_2 = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         template = get_template(
             cls.apiclient,

--- a/test/integration/smoke/test_snapshots.py
+++ b/test/integration/smoke/test_snapshots.py
@@ -75,7 +75,7 @@ class TestSnapshotRootDisk(cloudstackTestCase):
             cls._cleanup.append(cls.account)
             cls.service_offering = ServiceOffering.create(
                 cls.apiclient,
-                cls.services["service_offerings"]
+                cls.services["service_offerings"]["tiny"]
             )
             cls._cleanup.append(cls.service_offering)
             cls.virtual_machine = cls.virtual_machine_with_disk = \

--- a/test/integration/smoke/test_snapshots.py
+++ b/test/integration/smoke/test_snapshots.py
@@ -62,7 +62,7 @@ class TestSnapshotRootDisk(cloudstackTestCase):
                     "ostype"]
 
             cls.services["domainid"] = cls.domain.id
-            cls.services["server_without_disk"]["zoneid"] = cls.zone.id
+            cls.services["small"]["zoneid"] = cls.zone.id
             cls.services["templates"]["ostypeid"] = template.ostypeid
             cls.services["zoneid"] = cls.zone.id
 
@@ -81,7 +81,7 @@ class TestSnapshotRootDisk(cloudstackTestCase):
             cls.virtual_machine = cls.virtual_machine_with_disk = \
                 VirtualMachine.create(
                     cls.apiclient,
-                    cls.services["server_without_disk"],
+                    cls.services["small"],
                     templateid=template.id,
                     accountid=cls.account.name,
                     domainid=cls.account.domainid,

--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -106,7 +106,7 @@ class TestCreateTemplate(cloudstackTestCase):
             cls._cleanup.append(cls.account)
             cls.service_offering = ServiceOffering.create(
                                             cls.apiclient,
-                                            cls.services["service_offerings"]
+                                            cls.services["service_offerings"]["tiny"]
                                             )
             cls._cleanup.append(cls.service_offering)
             #create virtual machine
@@ -268,7 +268,7 @@ class TestTemplates(cloudstackTestCase):
                             )
         cls.service_offering = ServiceOffering.create(
                                             cls.apiclient,
-                                            cls.services["service_offerings"]
+                                            cls.services["service_offerings"]["tiny"]
                                         )
         #create virtual machine
         cls.virtual_machine = VirtualMachine.create(

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -72,8 +72,6 @@ class TestDeployVM(cloudstackTestCase):
         cls.services["small"]["zoneid"] = cls.zone.id
         cls.services["small"]["template"] = template.id
 
-        cls.services["medium"]["zoneid"] = cls.zone.id
-        cls.services["medium"]["template"] = template.id
         cls.services["iso1"]["zoneid"] = cls.zone.id
 
         cls.account = Account.create(
@@ -286,8 +284,6 @@ class TestVMLifeCycle(cloudstackTestCase):
         cls.services["small"]["zoneid"] = cls.zone.id
         cls.services["small"]["template"] = template.id
 
-        cls.services["medium"]["zoneid"] = cls.zone.id
-        cls.services["medium"]["template"] = template.id
         cls.services["iso1"]["zoneid"] = cls.zone.id
 
         # Create VMs, NAT Rules etc
@@ -317,7 +313,7 @@ class TestVMLifeCycle(cloudstackTestCase):
                                         )
         cls.medium_virtual_machine = VirtualMachine.create(
                                        cls.apiclient,
-                                       cls.services["medium"],
+                                       cls.services["small"],
                                        accountid=cls.account.name,
                                        domainid=cls.account.domainid,
                                        serviceofferingid=cls.medium_offering.id,

--- a/test/integration/smoke/test_vm_snapshots.py
+++ b/test/integration/smoke/test_vm_snapshots.py
@@ -60,7 +60,7 @@ class TestVmSnapshot(cloudstackTestCase):
                     with description %s" % cls.services["ostype"]
 
         cls.services["domainid"] = cls.domain.id
-        cls.services["server"]["zoneid"] = cls.zone.id
+        cls.services["small"]["zoneid"] = cls.zone.id
         cls.services["templates"]["ostypeid"] = template.ostypeid
         cls.services["zoneid"] = cls.zone.id
 
@@ -79,7 +79,7 @@ class TestVmSnapshot(cloudstackTestCase):
         cls._cleanup.append(cls.service_offering)
         cls.virtual_machine = VirtualMachine.create(
             cls.apiclient,
-            cls.services["server"],
+            cls.services["small"],
             templateid=template.id,
             accountid=cls.account.name,
             domainid=cls.account.domainid,

--- a/test/integration/smoke/test_vm_snapshots.py
+++ b/test/integration/smoke/test_vm_snapshots.py
@@ -74,7 +74,7 @@ class TestVmSnapshot(cloudstackTestCase):
 
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls._cleanup.append(cls.service_offering)
         cls.virtual_machine = VirtualMachine.create(

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -101,7 +101,7 @@ class TestCreateVolume(cloudstackTestCase):
                             )
         cls.service_offering = ServiceOffering.create(
                                             cls.apiclient,
-                                            cls.services["service_offerings"]
+                                            cls.services["service_offerings"]["tiny"]
                                             )
         cls.virtual_machine = VirtualMachine.create(
                                     cls.apiclient,
@@ -322,7 +322,7 @@ class TestVolumes(cloudstackTestCase):
                             )
         cls.service_offering = ServiceOffering.create(
                                             cls.apiclient,
-                                            cls.services["service_offerings"]
+                                            cls.services["service_offerings"]["tiny"]
                                         )
         cls.virtual_machine = VirtualMachine.create(
                                     cls.apiclient,

--- a/test/integration/smoke/test_vpc_vpn.py
+++ b/test/integration/smoke/test_vpc_vpn.py
@@ -39,7 +39,7 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
         cls.domain = get_domain(cls.apiclient)
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.account = Account.create(cls.apiclient, services=cls.services["account"])
         cls.template = get_template(
@@ -147,7 +147,7 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
         cls.domain = get_domain(cls.apiclient)
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
-            cls.services["service_offerings"]
+            cls.services["service_offerings"]["tiny"]
         )
         cls.account = Account.create(cls.apiclient, services=cls.services["account"])
         cls.template = get_template(

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -81,16 +81,6 @@ test_data = {
         "publicport": 22,
         "protocol": 'TCP',
     },
-    "medium": {
-        "displayname": "testserver",
-        "username": "root",
-        "password": "password",
-        "ssh_port": 22,
-        "hypervisor": 'XenServer',
-        "privateport": 22,
-        "publicport": 22,
-        "protocol": 'TCP',
-    },
     "service_offering": {
         "name": "Tiny Instance",
         "displaytext": "Tiny Instance",

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -370,16 +370,6 @@ test_data = {
         "name": "testvm3",
         "displayname": "Test VM3",
     },
-    "server_without_disk": {
-        "displayname": "Test VM-No Disk",
-        "username": "root",
-        "password": "password",
-        "ssh_port": 22,
-        "hypervisor": 'XenServer',
-        "privateport": 22,
-        "publicport": 22,
-        "protocol": 'TCP',
-    },
     "shared_network": {
         "name": "MySharedNetwork - Test",
         "displaytext": "MySharedNetwork",
@@ -984,16 +974,6 @@ test_data = {
         "gateway": "10.2.1.1",
         "netmask": "255.255.255.192"
     },
-    "server": {
-        "displayname": "TestVM",
-        "username": "root",
-        "password": "password",
-        "ssh_port": 22,
-        "hypervisor": 'XenServer',
-        "privateport": 22,
-        "publicport": 22,
-        "protocol": 'TCP'
-    },
     "privateport": 22,
     "publicport": 22,
     "protocol": 'TCP',
@@ -1104,28 +1084,6 @@ test_data = {
             # ensure unique username generated each time
             "password": "password",
         },
-        "vgpu260q":  # Create a virtual machine instance with vgpu type as 260q
-            {
-                "displayname": "testserver",
-                "username": "root",  # VM creds for SSH
-                "password": "password",
-                "ssh_port": 22,
-                "hypervisor": 'XenServer',
-                "privateport": 22,
-                "publicport": 22,
-                "protocol": 'TCP',
-            },
-        "vgpu140q":  # Create a virtual machine instance with vgpu type as 140q
-            {
-                "displayname": "testserver",
-                "username": "root",
-                "password": "password",
-                "ssh_port": 22,
-                "hypervisor": 'XenServer',
-                "privateport": 22,
-                "publicport": 22,
-                "protocol": 'TCP',
-            },
         "service_offerings":
             {
                 "GRID K260Q":

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -89,12 +89,6 @@ test_data = {
         "memory": 256,  # In MBs
     },
     "service_offerings": {
-        "name": "Tiny Instance",
-        "displaytext": "Tiny Instance",
-        "cpunumber": 1,
-        "cpuspeed": 100,
-        "memory": 128,
-
         "tiny": {
             "name": "Tiny Instance",
             "displaytext": "Tiny Instance",


### PR DESCRIPTION
We have two entried(keys) named "small" and "medium" inside test_data.py to specify the vm properties and access details. However, both contain the same values. So deleted one of them and also modified the tests accordingly.

Ran all the tests and all of them passed.

Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... === TestName: test_08_migrate_vm | Status : SUCCESS ===

Test to create service offering ... === TestName: test_01_create_service_offering | Status : SUCCESS ===
ok
Test to update existing service offering ... === TestName: test_02_edit_service_offering | Status : SUCCESS ===
ok
Test to delete service offering ... === TestName: test_03_delete_service_offering | Status : SUCCESS ===
ok
Test to change service to a small capacity ... === TestName: test_04_change_offering_small | Status : SUCCESS ===
ok

