### PR TITLE
CLOUDSTACK-8640: Revert to AWS SDK 1.3.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <org.springframework.version>3.2.12.RELEASE</org.springframework.version>
     <cs.mockito.version>1.9.5</cs.mockito.version>
     <cs.powermock.version>1.5.3</cs.powermock.version>
-    <cs.aws.sdk.version>1.9.8</cs.aws.sdk.version>
+    <cs.aws.sdk.version>1.3.22</cs.aws.sdk.version>
     <cs.lang.version>2.6</cs.lang.version>
     <cs.lang3.version>3.4</cs.lang3.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>

--- a/utils/src/com/cloud/utils/S3Utils.java
+++ b/utils/src/com/cloud/utils/S3Utils.java
@@ -103,17 +103,19 @@ public final class S3Utils {
         }
 
         if (clientOptions.getUseTCPKeepAlive() != null) {
-            configuration.setUseTcpKeepAlive(clientOptions.getUseTCPKeepAlive());
+            //configuration.setUseTcpKeepAlive(clientOptions.getUseTCPKeepAlive());
+            LOGGER.debug("useTCPKeepAlive not supported by old AWS SDK");
         }
 
         if (clientOptions.getConnectionTtl() != null) {
-            configuration.setConnectionTTL(clientOptions.getConnectionTtl());
+            //configuration.setConnectionTTL(clientOptions.getConnectionTtl());
+            LOGGER.debug("connectionTtl not supported by old AWS SDK");
         }
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(format("Creating S3 client with configuration: [protocol: %1$s, connectionTimeOut: " + "%2$s, maxErrorRetry: %3$s, socketTimeout: %4$s, useTCPKeepAlive: %5$s, connectionTtl: %6$s]",
                 configuration.getProtocol(), configuration.getConnectionTimeout(), configuration.getMaxErrorRetry(), configuration.getSocketTimeout(),
-                configuration.useTcpKeepAlive(), configuration.getConnectionTTL()));
+                -1, -1));
         }
 
         final AmazonS3Client client = new AmazonS3Client(credentials, configuration);


### PR DESCRIPTION
The newer SDKs API changed which causes our S3 Template Downloader to never complete.

Although we should fix the Template Downloader we can revert to the old AWS SDK for now.

The fix on the longer run will be rewriting the S3 Template Downloader.

Two methods had to be disabled for now since the old SDK does not support them. They can
be re-enabled when the Template Downloader has been fixed.