### PR TITLE
travis: don't force M2_HOME, let Travis use the bundled maven3

### DIFF
--- a/tools/travis/before_script.sh
+++ b/tools/travis/before_script.sh
@@ -37,7 +37,6 @@ fi
 
 export CATALINA_BASE=/opt/tomcat
 export CATALINA_HOME=/opt/tomcat
-export M2_HOME="/usr/local/maven-3.2.1/"
 export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=500m"
 
 mvn -Dsimulator -pl :cloud-client-ui jetty:run 2>&1 > /dev/null &

--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -36,7 +36,6 @@ fi
 
 export CATALINA_BASE=/opt/tomcat
 export CATALINA_HOME=/opt/tomcat
-export M2_HOME="/usr/local/maven-3.2.1/"
 export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=500m"
 
 if [ $TEST_SEQUENCE_NUMBER -eq 1 ]; then


### PR DESCRIPTION
This PR would test is M2_HOME option overriding is causing for the 4.5 Travis failures