### PR TITLE
Reduce the lowest hypervisor snapshot reserve value from 50% to 10%

### DIFF
--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
@@ -77,6 +77,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
     private static final Logger s_logger = Logger.getLogger(SolidFirePrimaryDataStoreDriver.class);
     private static final int s_lockTimeInSeconds = 300;
+    private static final int s_lowestHypervisorSnapshotReserve = 10;
 
     @Inject private AccountDao _accountDao;
     @Inject private AccountDetailsDao _accountDetailsDao;
@@ -352,9 +353,7 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
         Integer hypervisorSnapshotReserve = volume.getHypervisorSnapshotReserve();
 
         if (hypervisorSnapshotReserve != null) {
-            if (hypervisorSnapshotReserve < 50) {
-                hypervisorSnapshotReserve = 50;
-            }
+            hypervisorSnapshotReserve = Math.max(hypervisorSnapshotReserve, s_lowestHypervisorSnapshotReserve);
 
             volumeSize += volumeSize * (hypervisorSnapshotReserve / 100f);
         }


### PR DESCRIPTION
If the admin specifies a hypervisor snapshot reserve value that is below a particular number, we want to just use that number.

For example, if the admin specifies 5% for hypervisor snapshot reserve, we want to use - at least - 10% now (it used to be 50%, but that can make the backend volume overly large in certain situations).

This only impacts the SolidFire storage plug-in.