### PR TITLE
CLOUDSTACK-8696: Create Region fails with exception

### DIFF
--- a/setup/db/db/schema-452to460.sql
+++ b/setup/db/db/schema-452to460.sql
@@ -398,3 +398,7 @@ CREATE TABLE `cloud`.`external_bigswitch_bcf_devices` (
   CONSTRAINT `fk_external_bigswitch_bcf_devices__host_id` FOREIGN KEY (`host_id`) REFERENCES `host`(`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_external_bigswitch_bcf_devices__physical_network_id` FOREIGN KEY (`physical_network_id`) REFERENCES `physical_network`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+SET foreign_key_checks = 0;
+ALTER TABLE `cloud`.`region` MODIFY `id` int unsigned UNIQUE NOT NULL;
+SET foreign_key_checks = 1;


### PR DESCRIPTION
'id' in the region table should not be an autoincrement unlike other
tables. This is because, region ids must be in sync across installs and
hence is accepted as input to the addRegions api.

It is not a good practise to override id for this purpose. another
column 'regionId' has to be created and used(CLOUDSTACK-8706). until it
is fixed, id should never be autoincrement in regions table.

@kishankavala @bhaisaab @DaanHoogland please review