### PR TITLE
Implemented condition that only admin or owner of the template can change its permissions

### DIFF
--- a/server/src/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/com/cloud/template/TemplateManagerImpl.java
@@ -1324,6 +1324,11 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             throw new InvalidParameterValueException("Update template permissions is an invalid operation on template " + template.getName());
         }
 
+        //Only admin or owner of the template should be able to change its permissions
+        if (caller.getId() != ownerId && !isAdmin) {
+            throw new InvalidParameterValueException("Unable to grant permission to account " + caller.getAccountName() + " as it is neither admin nor owner or the template");
+        }
+
         VMTemplateVO updatedTemplate = _tmpltDao.createForUpdate();
 
         if (isPublic != null) {


### PR DESCRIPTION
 ..... using updateTemplatePermissions API

Consider this scenario :
In a domain, there are three User Accounts UA1, UA2,UA3
A private template is registered by UA1
Through the updateTemplatePermissions API, UA1 gives permission to both UA2 and UA3
Now, UA2, having been shared the template, can remove the permission of UA3(or add permissions to another account).
EXPECTED BEHAVIOR :
UA2 should not be able to to add/remove permissions of other accounts.
