### PR TITLE
CLOUDSTACK-8709 No out of band migrate alert for non-routers

### DIFF
--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -2627,7 +2627,7 @@ Configurable, StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 s_logger.info("Schedule a router reboot task as router " + vo.getId() + " is powered-on out-of-band. we need to reboot to refresh network rules");
                 _rebootRouterExecutor.execute(new RebootTask(vo.getId()));
         } else {
-            if (isOutOfBandMigrated(opaque)) {
+            if (isOutOfBandMigrated(opaque) && (vo.getType() == VirtualMachine.Type.DomainRouter)) {
                 final String title = "Router has been migrated out of band: " + vo.getInstanceName();
                 final String context =
                         "An out of band migration of router " + vo.getInstanceName() + "(" + vo.getUuid() + ") was detected. No automated action was performed.";


### PR DESCRIPTION
This prevents the out-of-band migrate alerts being generated for non-routers.