### PR TITLE
getUsedBytes should query the SolidFire cluster to acquire the size o…

### DIFF
--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
@@ -307,6 +307,18 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
                     usedSpace += volumeSize;
                 }
+                else {
+                    SolidFireUtil.SolidFireConnection sfConnection = SolidFireUtil.getSolidFireConnection(storagePool.getId(), _storagePoolDetailsDao);
+                    long lVolumeId = Long.valueOf(volume.getFolder());
+
+                    SolidFireUtil.SolidFireVolume sfVolume = SolidFireUtil.getSolidFireVolume(sfConnection, lVolumeId);
+
+                    // SolidFireUtil.VOLUME_SIZE was introduced in 4.5.
+                    // To be backward compatible with releases prior to 4.5, call updateVolumeDetails here.
+                    // That way if SolidFireUtil.VOLUME_SIZE wasn't put in the volume_details table when the
+                    // volume was initially created, it can be placed in volume_details here.
+                    updateVolumeDetails(volume.getId(), sfVolume.getTotalSize());
+                }
             }
         }
 
@@ -417,8 +429,6 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
         if (dataObject.getType() == DataObjectType.VOLUME) {
             VolumeInfo volumeInfo = (VolumeInfo)dataObject;
-            AccountVO account = _accountDao.findById(volumeInfo.getAccountId());
-            String sfAccountName = SolidFireUtil.getSolidFireAccountName(account.getUuid(), account.getAccountId());
 
             long storagePoolId = dataStore.getId();
 
@@ -427,6 +437,8 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
             AccountDetailVO accountDetail = SolidFireUtil.getAccountDetail(volumeInfo.getAccountId(), storagePoolId, _accountDetailsDao);
 
             if (accountDetail == null || accountDetail.getValue() == null) {
+                AccountVO account = _accountDao.findById(volumeInfo.getAccountId());
+                String sfAccountName = SolidFireUtil.getSolidFireAccountName(account.getUuid(), account.getAccountId());
                 SolidFireUtil.SolidFireAccount sfAccount = SolidFireUtil.getSolidFireAccount(sfConnection, sfAccountName);
 
                 if (sfAccount == null) {


### PR DESCRIPTION
…f the given volume if there is no volume_details info for that volume (and then create a volume_details row for this volume so we don't have to make that cluster call for this purpose again)

********************

This only impacts the SolidFire storage plug-in.

In supporting back-end snapshots, I re-wrote how the getUsedBytes method works (which is called by the capacity manager).

The implementation now depends on a new row in the volume_details table for the volume in question that says how large the backend volume that supports your virtual disk is (the virtual disk's size is kept track of in the volumes table).

Since this addition to the volume_details table is new in 4.6 and these kinds of volumes have been created before 4.6, we need to make sure if no applicable volume_details row exits for the volume in question that we go retrieve the necessary info from the applicable SolidFire cluster and create a row in the volume_details table for future reference.