### PR TITLE
Fix site-to-site VPN feature

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -425,9 +425,9 @@ class CsSite2SiteVpn(CsDataBag):
         CsHelper.execute("ipsec auto --rereadall")
 
     def configure_iptables(self, dev, obj):
-        self.fw.append(["", "front", "-A INPUT -i %s -p udp -m udp --dport 500 -j ACCEPT" % dev])
-        self.fw.append(["", "front", "-A INPUT -i %s -p udp -m udp --dport 4500 -j ACCEPT" % dev])
-        self.fw.append(["", "front", "-A INPUT -i %s -p esp -j ACCEPT" % dev])
+        self.fw.append(["", "front", "-A INPUT -i %s -p udp -m udp --dport 500 -s %s -d %s -j ACCEPT" % (dev, obj['peer_gateway_ip'], obj['local_public_ip'])])
+        self.fw.append(["", "front", "-A INPUT -i %s -p udp -m udp --dport 4500 -s %s -d %s -j ACCEPT" % (dev, obj['peer_gateway_ip'], obj['local_public_ip'])])
+        self.fw.append(["", "front", "-A INPUT -i %s -p esp -s %s -d %s -j ACCEPT" % (dev, obj['peer_gateway_ip'], obj['local_public_ip'])])
         self.fw.append(["nat", "front", "-A POSTROUTING -t nat -o %s -m mark --mark 0x525 -j ACCEPT" % dev])
         for net in obj['peer_guest_cidr_list'].lstrip().rstrip().split(','):
             self.fw.append(["mangle", "front",

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -428,7 +428,7 @@ class CsSite2SiteVpn(CsDataBag):
         self.fw.append(["", "front", "-A INPUT -i %s -p udp -m udp --dport 500 -j ACCEPT" % dev])
         self.fw.append(["", "front", "-A INPUT -i %s -p udp -m udp --dport 4500 -j ACCEPT" % dev])
         self.fw.append(["", "front", "-A INPUT -i %s -p esp -j ACCEPT" % dev])
-        self.fw.append(["nat", "front", "-A POSTROUTING -t nat -o %s-m mark --set-xmark 0x525/0xffffffff -j ACCEPT" % dev])
+        self.fw.append(["nat", "front", "-A POSTROUTING -t nat -o %s -m mark --mark 0x525 -j ACCEPT" % dev])
         for net in obj['peer_guest_cidr_list'].lstrip().rstrip().split(','):
             self.fw.append(["mangle", "front",
                             "-A FORWARD -s %s -d %s -j MARK --set-xmark 0x525/0xffffffff" % (obj['local_guest_cidr'], net)])
@@ -453,7 +453,7 @@ class CsSite2SiteVpn(CsDataBag):
         file.addeq(" leftsubnet=%s" % obj['local_guest_cidr'])
         file.addeq(" leftnexthop=%s" % obj['local_public_gateway'])
         file.addeq(" right=%s" % rightpeer)
-        file.addeq(" rightsubnets=%s" % peerlist)
+        file.addeq(" rightsubnets={%s}" % peerlist)
         file.addeq(" type=tunnel")
         file.addeq(" authby=secret")
         file.addeq(" keyexchange=ike")
@@ -463,7 +463,7 @@ class CsSite2SiteVpn(CsDataBag):
         file.addeq(" salifetime=%s" % self.convert_sec_to_h(obj['esp_lifetime']))
         file.addeq(" pfs=%s" % CsHelper.bool_to_yn(obj['dpd']))
         file.addeq(" keyingtries=2")
-        file.addeq(" auto=add")
+        file.addeq(" auto=start")
         if obj['dpd']:
             file.addeq("  dpddelay=30")
             file.addeq("  dpdtimeout=120")

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
@@ -114,7 +114,10 @@ class CsFile:
 
     def search(self, search, replace):
         found = False
-        logging.debug("Searching for %s and replacing with %s" % (search, replace))
+        replace_filtered = replace
+        if re.search("PSK \"", replace):
+            replace_filtered = re.sub(r'".*"', '"****"', replace)
+        logging.debug("Searching for %s and replacing with %s" % (search, replace_filtered))
         for index, line in enumerate(self.new_config):
             if line.lstrip().startswith("#"):
                 continue


### PR DESCRIPTION
This is work done together with @jayapalu on fixing the site2site VPN. The first part was done in PR #690 by @jayapalu. On top of that, some other fixes were needed and those are added in this PR. It made sense to make a new PR which includes all fixes so we can actually test it. 

The original PR #690 is already merged into this one, so can be closed. Since the commit ids are kept the same, merging this will close both.

I closely compared the 4.4/4.5 implementation with the new 4.6 one. I did not only make it work, but also added some security improvements (some of which were also in 4.4/4.5). I noticed the pre shared key was being logged, so removed that as well.

This is how I tested and verified it:
https://github.com/schubergphilis/MCT-shared/tree/master/helper_scripts/cloudstack/vpn_tests
When I have some time available, I'll write a Marvin test for it that we can include in the repo.

It now works(tm) with one manual step due to CLOUDSTACK-8685: 
We need a default gateway before site-to-site VPN will actually work. It will connect, but not forward packets. The reason for this, is due to the iptables setup. VM1 has router1 as gateway, but router1 does not know the route to VM2 so it will give up. With a default gateway, the packets are about to be forwarded to the default gateway but when they reach eth1 the public nic, iptables kicks in, does some magic and forwards it through the ipsec tunnel. So, you need a default gw set to upstream.

Workaround for now is setting the route manually:
``route add default gw 1.2.3.4``  or  ``ip route add default via 1.2.3.4``

In other words, we need to fix CLOUDSTACK-8685 soon, too.

Thanks to @snuf @jayapalu!
 
@jayapalu @snuf could you please review this?