### PR TITLE
get rid of useless out-of-band alerts

### DIFF
--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -2626,13 +2626,6 @@ Configurable, StateListener<State, VirtualMachine.Event, VirtualMachine> {
             (newState == State.Running)) {
                 s_logger.info("Schedule a router reboot task as router " + vo.getId() + " is powered-on out-of-band. we need to reboot to refresh network rules");
                 _rebootRouterExecutor.execute(new RebootTask(vo.getId()));
-        } else {
-            if (isOutOfBandMigrated(opaque) && (vo.getType() == VirtualMachine.Type.DomainRouter)) {
-                final String title = "Router has been migrated out of band: " + vo.getInstanceName();
-                final String context =
-                        "An out of band migration of router " + vo.getInstanceName() + "(" + vo.getUuid() + ") was detected. No automated action was performed.";
-                _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_DOMAIN_ROUTER, vo.getDataCenterId(), vo.getPodIdToDeployIn(), title, context);
-            }
         }
 
         return true;


### PR DESCRIPTION
These alerts are generating a lot of false positives. Try spinning
a new router, or migrate one using the API (not out-of-band) and
you'll get alerts anyway.

I just removed the alert below. We might consider ditching the
functionality completely, as route VMs in master are designed
to be persistent anyway.

Let's at least remove the alerts.

@dahn @snuf & others, what do you think?