### PR TITLE
CLOUDSTACK-8669: create volume failed due to null charset

### DIFF
--- a/utils/src/com/cloud/utils/StringUtils.java
+++ b/utils/src/com/cloud/utils/StringUtils.java
@@ -52,7 +52,7 @@ public class StringUtils {
         return Charset.isSupported(UTF8);
     }
 
-    public static Charset getDefaultCharset() {
+    protected static Charset getDefaultCharset() {
         return Charset.defaultCharset();
     }
 

--- a/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareContext.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareContext.java
@@ -19,6 +19,7 @@ package com.cloud.hypervisor.vmware.util;
 import com.cloud.hypervisor.vmware.mo.DatacenterMO;
 import com.cloud.hypervisor.vmware.mo.DatastoreFile;
 import com.cloud.utils.ActionDelegate;
+import com.cloud.utils.StringUtils;
 import com.vmware.vim25.ManagedObjectReference;
 import com.vmware.vim25.ObjectContent;
 import com.vmware.vim25.ObjectSpec;
@@ -50,6 +51,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -357,7 +359,7 @@ public class VmwareContext {
             }
             out.flush();
 
-            br = new BufferedReader(new InputStreamReader(conn.getInputStream(),conn.getContentEncoding()));
+            br = new BufferedReader(new InputStreamReader(conn.getInputStream(), getCharSetFromConnection(conn)));
             String line;
             while ((line = br.readLine()) != null) {
                 if (s_logger.isTraceEnabled())
@@ -373,6 +375,18 @@ public class VmwareContext {
             if (br != null)
                 br.close();
         }
+    }
+
+    private Charset getCharSetFromConnection(HttpURLConnection conn) {
+        String charsetName = conn.getContentEncoding();
+        Charset charset;
+        try {
+            charset = Charset.forName(charsetName);
+        } catch (IllegalArgumentException e) {
+            s_logger.warn("Illegal/unsupported/null charset name from connection. charsetname from connection is " + charsetName);
+            charset = StringUtils.getPreferredCharset();
+        }
+        return charset;
     }
 
     public void uploadVmdkFile(String httpMethod, String urlString, String localFileName, long totalBytesUpdated, ActionDelegate<Long> progressUpdater) throws Exception {
@@ -483,9 +497,9 @@ public class VmwareContext {
         out.write(content);
         out.flush();
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(),conn.getContentEncoding()));
+        BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), getCharSetFromConnection(conn)));
         String line;
-        while ((line = in.readLine()) != null) {
+        while ((in.ready()) && (line = in.readLine()) != null) {
             if (s_logger.isTraceEnabled())
                 s_logger.trace("Upload " + urlString + " response: " + line);
         }

--- a/vmware-base/test/com/cloud/hypervisor/vmware/util/VmwareContextTest.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/util/VmwareContextTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.cloud.hypervisor.vmware.util;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VmwareContextTest {
+
+    @Test
+    public void testUploadResourceContentCharsetException() throws Exception {
+        VmwareClient client = Mockito.mock(VmwareClient.class);
+        String address = "10.1.1.1";
+        VmwareContext vmwareContext = Mockito.spy(new VmwareContext(client, address));
+        HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
+        Mockito.doReturn(Mockito.mock(OutputStream.class)).when(conn).getOutputStream();
+        Mockito.doReturn(Mockito.mock(InputStream.class)).when(conn).getInputStream();
+        Mockito.doReturn(conn).when(vmwareContext).getHTTPConnection("http://example.com", "PUT");
+        //This method should not throw any exception. Ref: CLOUDSTACK-8669
+        vmwareContext.uploadResourceContent("http://example.com", "content".getBytes());
+    }
+
+}


### PR DESCRIPTION
Added a new private method getCharSetFromConnection() which checks if
the connection charset is null and if it is null, returns
StringUtils.getPreferredCharset

regression caused by commit f03411ca0436c8b52f5e60b0c8820fd1d1ba2ff6