### PR TITLE
Default to notify only script to handle non-CLVM/QCOW cases.

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtResizeVolumeCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtResizeVolumeCommandWrapper.java
@@ -69,9 +69,10 @@ public final class LibvirtResizeVolumeCommandWrapper extends CommandWrapper<Resi
 
             final KVMPhysicalDisk vol = pool.getPhysicalDisk(volid);
             final String path = vol.getPath();
-            String type = libvirtComputingResource.getResizeScriptType(pool, vol);
+            String type = notifyOnlyType;
 
             if (pool.getType() != StoragePoolType.RBD) {
+                type = libvirtComputingResource.getResizeScriptType(pool, vol);
                 if (type.equals("QCOW2") && shrinkOk) {
                     return new ResizeVolumeAnswer(command, false, "Unable to shrink volumes of type " + type);
                 }
@@ -99,7 +100,6 @@ public final class LibvirtResizeVolumeCommandWrapper extends CommandWrapper<Resi
                     }
 
                     v.resize(newSize, flags);
-                    type = notifyOnlyType;
                 } catch (final LibvirtException e) {
                     return new ResizeVolumeAnswer(command, false, e.toString());
                 }


### PR DESCRIPTION
This relates to [CLOUDSTACK-8732](https://issues.apache.org/jira/browse/CLOUDSTACK-8732)

Before this commit the call to `getResizeScriptType` would throw an exception (earlier versions returned `null`, which was fine) - this caused the RBD case to fail. By changing the default to notify only we fix the case for any non-CLVM and non-QCOW cases, too.

This is RBD for now, but this should extend to new storage types supported by Libvirt natively in future.

This is my first attempted contribution: I can see a case for adding RBD logic to the actual getResizeScriptType call, too, but I felt that putting it `LibvirtResizeVolumeCommandWrapper.java` kept the special-casing of RBD (and comments about that) in one place.

### Caveat:

With Libvirt 1.2.2 this actually doesn't do the right thing - but it does do what the documentation *says* should be the right thing, so I'm going to test if this is a Libvirt bug which is fixed in a later version.

(To make it work I need to execute something like:

    virsh blockresize --path vda --size 100G i-7-44-VM

where vda is the path as far as the *guest* is concerned, and not an `rbd/` path - which *should* work, but doesn't.)