### PR TITLE
CLOUDSTACK-8738: Added the two methods for enable and cancel maintena…

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -2638,6 +2638,22 @@ class StoragePool:
         return apiclient.enableStorageMaintenance(cmd)
 
     @classmethod
+    def enableMaintenance(cls, apiclient, id):
+        """enables maintenance mode Storage pool"""
+
+        cmd = enableStorageMaintenance.enableStorageMaintenanceCmd()
+        cmd.id = id
+        return apiclient.enableStorageMaintenance(cmd)
+
+    @classmethod
+    def cancelMaintenance(cls, apiclient, id):
+        """Cancels maintenance mode Host"""
+
+        cmd = cancelStorageMaintenance.cancelStorageMaintenanceCmd()
+        cmd.id = id
+        return apiclient.cancelStorageMaintenance(cmd)
+
+    @classmethod
     def list(cls, apiclient, **kwargs):
         """List all storage pools matching criteria"""
 


### PR DESCRIPTION
Added the two methods for enable and cancel maintenance used in testpath_disablestoragepool

Test results:
Test Steps: ... === TestName: test_01_disable_enable_pool_1_host | Status : SUCCESS ===
ok
Test Steps: ... === TestName: test_01_disable_enable_pool_2_CLUSTER | Status : SUCCESS ===
ok
Test Steps: ... SKIP: No ZONE  storage pools found
Test Steps: ... === TestName: test_02_vm_operations_on_disabled_pool_1_host | Status : SUCCESS ===
ok
Test Steps: ... === TestName: test_02_vm_operations_on_disabled_pool_2_CLUSTER | Status : SUCCESS ===
ok
Test Steps: ... SKIP: No ZONE wide storage pools found
Test Steps: ... === TestName: test_01_cross_cluster_attach_disk | Status : SUCCESS ===
ok
