### PR TITLE
Removed double encoding of Public Key from JS.

### DIFF
--- a/ui/scripts/accounts.js
+++ b/ui/scripts/accounts.js
@@ -1813,7 +1813,7 @@
 
                                 if (args.data.publickey != null && args.data.publickey.length > 0) {
                                     $.extend(data, {
-                                        publickey: encodeURIComponent(args.data.publickey)
+                                        publickey: args.data.publickey
                                     });
                                     $.ajax({
                                         url: createURL('registerSSHKeyPair'),


### PR DESCRIPTION
See Cloudstack issue CLOUDSTACK-8742 & CLOUDSTACK-8649 for information.