### PR TITLE
Changed variable s_logger to non-static and fixed its name in “com.cloud.utils.component.ComponentLifecycleBase” and its subclasses

### DIFF
--- a/core/src/com/cloud/storage/template/IsoProcessor.java
+++ b/core/src/com/cloud/storage/template/IsoProcessor.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.StorageLayer;
@@ -33,21 +32,20 @@ import com.cloud.utils.component.AdapterBase;
 
 @Local(value = Processor.class)
 public class IsoProcessor extends AdapterBase implements Processor {
-    private static final Logger s_logger = Logger.getLogger(IsoProcessor.class);
 
     StorageLayer _storage;
 
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
         if (format != null) {
-            s_logger.debug("We don't handle conversion from " + format + " to ISO.");
+            logger.debug("We don't handle conversion from " + format + " to ISO.");
             return null;
         }
 
         String isoPath = templatePath + File.separator + templateName + "." + ImageFormat.ISO.getFileExtension();
 
         if (!_storage.exists(isoPath)) {
-            s_logger.debug("Unable to find the iso file: " + isoPath);
+            logger.debug("Unable to find the iso file: " + isoPath);
             return null;
         }
 

--- a/core/src/com/cloud/storage/template/OVAProcessor.java
+++ b/core/src/com/cloud/storage/template/OVAProcessor.java
@@ -26,7 +26,6 @@ import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -38,39 +37,38 @@ import com.cloud.utils.script.Script;
 
 @Local(value = Processor.class)
 public class OVAProcessor extends AdapterBase implements Processor {
-    private static final Logger s_logger = Logger.getLogger(OVAProcessor.class);
 
     StorageLayer _storage;
 
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
         if (format != null) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("We currently don't handle conversion from " + format + " to OVA.");
+            if (logger.isInfoEnabled()) {
+                logger.info("We currently don't handle conversion from " + format + " to OVA.");
             }
             return null;
         }
 
-        s_logger.info("Template processing. templatePath: " + templatePath + ", templateName: " + templateName);
+        logger.info("Template processing. templatePath: " + templatePath + ", templateName: " + templateName);
         String templateFilePath = templatePath + File.separator + templateName + "." + ImageFormat.OVA.getFileExtension();
         if (!_storage.exists(templateFilePath)) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Unable to find the vmware template file: " + templateFilePath);
+            if (logger.isInfoEnabled()) {
+                logger.info("Unable to find the vmware template file: " + templateFilePath);
             }
             return null;
         }
 
-        s_logger.info("Template processing - untar OVA package. templatePath: " + templatePath + ", templateName: " + templateName);
+        logger.info("Template processing - untar OVA package. templatePath: " + templatePath + ", templateName: " + templateName);
         String templateFileFullPath = templatePath + File.separator + templateName + "." + ImageFormat.OVA.getFileExtension();
         File templateFile = new File(templateFileFullPath);
 
-        Script command = new Script("tar", 0, s_logger);
+        Script command = new Script("tar", 0, logger);
         command.add("--no-same-owner");
         command.add("-xf", templateFileFullPath);
         command.setWorkDir(templateFile.getParent());
         String result = command.execute();
         if (result != null) {
-            s_logger.info("failed to untar OVA package due to " + result + ". templatePath: " + templatePath + ", templateName: " + templateName);
+            logger.info("failed to untar OVA package due to " + result + ". templatePath: " + templatePath + ", templateName: " + templateName);
             return null;
         }
 
@@ -91,7 +89,7 @@ public class OVAProcessor extends AdapterBase implements Processor {
             long size = getTemplateVirtualSize(file.getParent(), file.getName());
             return size;
         } catch (Exception e) {
-            s_logger.info("[ignored]"
+            logger.info("[ignored]"
                     + "failed to get virtual template size for ova: " + e.getLocalizedMessage());
         }
         return file.length();
@@ -105,7 +103,7 @@ public class OVAProcessor extends AdapterBase implements Processor {
         String ovfFileName = getOVFFilePath(templateFileFullPath);
         if (ovfFileName == null) {
             String msg = "Unable to locate OVF file in template package directory: " + templatePath;
-            s_logger.error(msg);
+            logger.error(msg);
             throw new InternalErrorException(msg);
         }
         try {
@@ -130,7 +128,7 @@ public class OVAProcessor extends AdapterBase implements Processor {
             return virtualSize;
         } catch (Exception e) {
             String msg = "Unable to parse OVF XML document to get the virtual disk size due to" + e;
-            s_logger.error(msg);
+            logger.error(msg);
             throw new InternalErrorException(msg);
         }
     }

--- a/core/src/com/cloud/storage/template/QCOW2Processor.java
+++ b/core/src/com/cloud/storage/template/QCOW2Processor.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.StorageLayer;
@@ -36,7 +35,6 @@ import com.cloud.utils.component.AdapterBase;
 
 @Local(value = Processor.class)
 public class QCOW2Processor extends AdapterBase implements Processor {
-    private static final Logger s_logger = Logger.getLogger(QCOW2Processor.class);
     private static final int VIRTUALSIZE_HEADER_LOCATION = 24;
 
     private StorageLayer _storage;
@@ -44,14 +42,14 @@ public class QCOW2Processor extends AdapterBase implements Processor {
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
         if (format != null) {
-            s_logger.debug("We currently don't handle conversion from " + format + " to QCOW2.");
+            logger.debug("We currently don't handle conversion from " + format + " to QCOW2.");
             return null;
         }
 
         String qcow2Path = templatePath + File.separator + templateName + "." + ImageFormat.QCOW2.getFileExtension();
 
         if (!_storage.exists(qcow2Path)) {
-            s_logger.debug("Unable to find the qcow2 file: " + qcow2Path);
+            logger.debug("Unable to find the qcow2 file: " + qcow2Path);
             return null;
         }
 
@@ -66,7 +64,7 @@ public class QCOW2Processor extends AdapterBase implements Processor {
         try {
             info.virtualSize = getVirtualSize(qcow2File);
         } catch (IOException e) {
-            s_logger.error("Unable to get virtual size from " + qcow2File.getName());
+            logger.error("Unable to get virtual size from " + qcow2File.getName());
             return null;
         }
 

--- a/core/src/com/cloud/storage/template/RawImageProcessor.java
+++ b/core/src/com/cloud/storage/template/RawImageProcessor.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.exception.InternalErrorException;
 import com.cloud.storage.Storage.ImageFormat;
@@ -34,7 +33,6 @@ import com.cloud.utils.component.AdapterBase;
 
 @Local(value = Processor.class)
 public class RawImageProcessor extends AdapterBase implements Processor {
-    private static final Logger s_logger = Logger.getLogger(RawImageProcessor.class);
     StorageLayer _storage;
 
     @Override
@@ -50,13 +48,13 @@ public class RawImageProcessor extends AdapterBase implements Processor {
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
         if (format != null) {
-            s_logger.debug("We currently don't handle conversion from " + format + " to raw image.");
+            logger.debug("We currently don't handle conversion from " + format + " to raw image.");
             return null;
         }
 
         String imgPath = templatePath + File.separator + templateName + "." + ImageFormat.RAW.getFileExtension();
         if (!_storage.exists(imgPath)) {
-            s_logger.debug("Unable to find raw image:" + imgPath);
+            logger.debug("Unable to find raw image:" + imgPath);
             return null;
         }
         FormatInfo info = new FormatInfo();
@@ -64,7 +62,7 @@ public class RawImageProcessor extends AdapterBase implements Processor {
         info.filename = templateName + "." + ImageFormat.RAW.getFileExtension();
         info.size = _storage.getSize(imgPath);
         info.virtualSize = info.size;
-        s_logger.debug("Process raw image " + info.filename + " successfully");
+        logger.debug("Process raw image " + info.filename + " successfully");
         return info;
     }
 

--- a/core/src/com/cloud/storage/template/TARProcessor.java
+++ b/core/src/com/cloud/storage/template/TARProcessor.java
@@ -22,7 +22,6 @@ package com.cloud.storage.template;
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.StorageLayer;
 import com.cloud.utils.component.AdapterBase;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
@@ -31,21 +30,20 @@ import java.util.Map;
 
 @Local(value = Processor.class)
 public class TARProcessor extends AdapterBase implements Processor {
-    private static final Logger s_logger = Logger.getLogger(TARProcessor.class);
 
     private StorageLayer _storage;
 
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
         if (format != null) {
-            s_logger.debug("We currently don't handle conversion from " + format + " to TAR.");
+            logger.debug("We currently don't handle conversion from " + format + " to TAR.");
             return null;
         }
 
         String tarPath = templatePath + File.separator + templateName + "." + ImageFormat.TAR.getFileExtension();
 
         if (!_storage.exists(tarPath)) {
-            s_logger.debug("Unable to find the tar file: " + tarPath);
+            logger.debug("Unable to find the tar file: " + tarPath);
             return null;
         }
 

--- a/core/src/com/cloud/storage/template/VhdProcessor.java
+++ b/core/src/com/cloud/storage/template/VhdProcessor.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.StorageLayer;
@@ -43,7 +42,6 @@ import com.cloud.utils.component.AdapterBase;
 @Local(value = Processor.class)
 public class VhdProcessor extends AdapterBase implements Processor {
 
-    private static final Logger s_logger = Logger.getLogger(VhdProcessor.class);
     StorageLayer _storage;
     private int vhdFooterSize = 512;
     private int vhdFooterCreatorAppOffset = 28;
@@ -54,13 +52,13 @@ public class VhdProcessor extends AdapterBase implements Processor {
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
         if (format != null) {
-            s_logger.debug("We currently don't handle conversion from " + format + " to VHD.");
+            logger.debug("We currently don't handle conversion from " + format + " to VHD.");
             return null;
         }
 
         String vhdPath = templatePath + File.separator + templateName + "." + ImageFormat.VHD.getFileExtension();
         if (!_storage.exists(vhdPath)) {
-            s_logger.debug("Unable to find the vhd file: " + vhdPath);
+            logger.debug("Unable to find the vhd file: " + vhdPath);
             return null;
         }
 
@@ -74,7 +72,7 @@ public class VhdProcessor extends AdapterBase implements Processor {
         try {
             info.virtualSize = getVirtualSize(vhdFile);
         } catch (IOException e) {
-            s_logger.error("Unable to get the virtual size for " + vhdPath);
+            logger.error("Unable to get the virtual size for " + vhdPath);
             return null;
         }
 

--- a/core/src/com/cloud/storage/template/VmdkProcessor.java
+++ b/core/src/com/cloud/storage/template/VmdkProcessor.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.exception.InternalErrorException;
 import com.cloud.storage.Storage.ImageFormat;
@@ -40,24 +39,23 @@ import com.cloud.utils.component.AdapterBase;
 
 @Local(value = Processor.class)
 public class VmdkProcessor extends AdapterBase implements Processor {
-    private static final Logger s_logger = Logger.getLogger(VmdkProcessor.class);
 
     StorageLayer _storage;
 
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
         if (format != null) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("We currently don't handle conversion from " + format + " to VMDK.");
+            if (logger.isInfoEnabled()) {
+                logger.info("We currently don't handle conversion from " + format + " to VMDK.");
             }
             return null;
         }
 
-        s_logger.info("Template processing. templatePath: " + templatePath + ", templateName: " + templateName);
+        logger.info("Template processing. templatePath: " + templatePath + ", templateName: " + templateName);
         String templateFilePath = templatePath + File.separator + templateName + "." + ImageFormat.VMDK.getFileExtension();
         if (!_storage.exists(templateFilePath)) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Unable to find the vmware template file: " + templateFilePath);
+            if (logger.isInfoEnabled()) {
+                logger.info("Unable to find the vmware template file: " + templateFilePath);
             }
             return null;
         }
@@ -77,7 +75,7 @@ public class VmdkProcessor extends AdapterBase implements Processor {
             long size = getTemplateVirtualSize(file.getParent(), file.getName());
             return size;
         } catch (Exception e) {
-            s_logger.info("[ignored]"
+            logger.info("[ignored]"
                     + "failed to get template virtual size for vmdk: " + e.getLocalizedMessage());
         }
         return file.length();
@@ -103,15 +101,15 @@ public class VmdkProcessor extends AdapterBase implements Processor {
             }
         } catch(FileNotFoundException ex) {
             String msg = "Unable to open file '" + templateFileFullPath + "' " + ex.toString();
-            s_logger.error(msg);
+            logger.error(msg);
             throw new InternalErrorException(msg);
         } catch(IOException ex) {
             String msg = "Unable read open file '" + templateFileFullPath + "' " + ex.toString();
-            s_logger.error(msg);
+            logger.error(msg);
             throw new InternalErrorException(msg);
         }
 
-        s_logger.debug("vmdk file had size="+virtualSize);
+        logger.debug("vmdk file had size="+virtualSize);
         return virtualSize;
     }
 

--- a/engine/orchestration/src/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
@@ -43,10 +43,6 @@ import javax.naming.ConfigurationException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
-import org.apache.log4j.Logger;
-
-import com.google.gson.Gson;
-
 import org.apache.cloudstack.framework.config.ConfigDepot;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -95,10 +91,10 @@ import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.nio.Link;
 import com.cloud.utils.nio.Task;
+import com.google.gson.Gson;
 
 @Local(value = {AgentManager.class, ClusteredAgentRebalanceService.class})
 public class ClusteredAgentManagerImpl extends AgentManagerImpl implements ClusterManagerListener, ClusteredAgentRebalanceService {
-    final static Logger s_logger = Logger.getLogger(ClusteredAgentManagerImpl.class);
     private static final ScheduledExecutorService s_transferExecutor = Executors.newScheduledThreadPool(2, new NamedThreadFactory("Cluster-AgentRebalancingExecutor"));
     private final long rebalanceTimeOut = 300000; // 5 mins - after this time remove the agent from the transfer list
 
@@ -144,7 +140,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         _sslEngines = new HashMap<String, SSLEngine>(7);
         _nodeId = ManagementServerNode.getManagementServerId();
 
-        s_logger.info("Configuring ClusterAgentManagerImpl. management server node id(msid): " + _nodeId);
+        logger.info("Configuring ClusterAgentManagerImpl. management server node id(msid): " + _nodeId);
 
         ClusteredAgentAttache.initialize(this);
 
@@ -162,8 +158,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             return false;
         }
         _timer.schedule(new DirectAgentScanTimerTask(), STARTUP_DELAY, ScanInterval.value());
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Scheduled direct agent scan task to run at an interval of " + ScanInterval.value() + " seconds");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Scheduled direct agent scan task to run at an interval of " + ScanInterval.value() + " seconds");
         }
 
         // Schedule tasks for agent rebalancing
@@ -177,8 +173,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
     public void scheduleHostScanTask() {
         _timer.schedule(new DirectAgentScanTimerTask(), 0);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Scheduled a direct agent scan task");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Scheduled a direct agent scan task");
         }
     }
 
@@ -187,8 +183,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     }
 
     private void scanDirectAgentToLoad() {
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Begin scanning directly connected hosts");
+        if (logger.isTraceEnabled()) {
+            logger.trace("Begin scanning directly connected hosts");
         }
 
         // for agents that are self-managed, threshold to be considered as disconnected after pingtimeout
@@ -196,18 +192,18 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         List<HostVO> hosts = _hostDao.findAndUpdateDirectAgentToLoad(cutSeconds, LoadSize.value().longValue(), _nodeId);
         List<HostVO> appliances = _hostDao.findAndUpdateApplianceToLoad(cutSeconds, _nodeId);
 
-       if (hosts != null) {
+        if (hosts != null) {
             hosts.addAll(appliances);
             if (hosts.size() > 0) {
-                s_logger.debug("Found " + hosts.size() + " unmanaged direct hosts, processing connect for them...");
+                logger.debug("Found " + hosts.size() + " unmanaged direct hosts, processing connect for them...");
                 for (HostVO host : hosts) {
                     try {
                         AgentAttache agentattache = findAttache(host.getId());
                         if (agentattache != null) {
                             // already loaded, skip
                             if (agentattache.forForward()) {
-                                if (s_logger.isInfoEnabled()) {
-                                    s_logger.info(host + " is detected down, but we have a forward attache running, disconnect this one before launching the host");
+                                if (logger.isInfoEnabled()) {
+                                    logger.info(host + " is detected down, but we have a forward attache running, disconnect this one before launching the host");
                                 }
                                 removeAgent(agentattache, Status.Disconnected);
                             } else {
@@ -215,18 +211,18 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                             }
                         }
 
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Loading directly connected host " + host.getId() + "(" + host.getName() + ")");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Loading directly connected host " + host.getId() + "(" + host.getName() + ")");
                         }
                         loadDirectlyConnectedHost(host, false);
                     } catch (Throwable e) {
-                        s_logger.warn(" can not load directly connected host " + host.getId() + "(" + host.getName() + ") due to ", e);
+                        logger.warn(" can not load directly connected host " + host.getId() + "(" + host.getName() + ") due to ", e);
                     }
                 }
             }
         }
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("End scanning directly connected hosts");
+        if (logger.isTraceEnabled()) {
+            logger.trace("End scanning directly connected hosts");
         }
     }
 
@@ -236,7 +232,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             try {
                 runDirectAgentScanTimerTask();
             } catch (Throwable e) {
-                s_logger.error("Unexpected exception " + e.getMessage(), e);
+                logger.error("Unexpected exception " + e.getMessage(), e);
             }
         }
     }
@@ -247,7 +243,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     }
 
     protected AgentAttache createAttache(long id) {
-        s_logger.debug("create forwarding ClusteredAgentAttache for " + id);
+        logger.debug("create forwarding ClusteredAgentAttache for " + id);
         HostVO host = _hostDao.findById(id);
         final AgentAttache attache = new ClusteredAgentAttache(this, id, host.getName());
         AgentAttache old = null;
@@ -256,8 +252,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             _agents.put(id, attache);
         }
         if (old != null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Remove stale agent attache from current management server");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Remove stale agent attache from current management server");
             }
             removeAgent(old, Status.Removed);
         }
@@ -266,7 +262,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
     @Override
     protected AgentAttache createAttacheForConnect(HostVO host, Link link) {
-        s_logger.debug("create ClusteredAgentAttache for " + host.getId());
+        logger.debug("create ClusteredAgentAttache for " + host.getId());
         final AgentAttache attache = new ClusteredAgentAttache(this, host.getId(), host.getName(), link, host.isInMaintenanceStates());
         link.attach(attache);
         AgentAttache old = null;
@@ -282,7 +278,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
     @Override
     protected AgentAttache createAttacheForDirectConnect(Host host, ServerResource resource) {
-        s_logger.debug("create ClusteredDirectAgentAttache for " + host.getId());
+        logger.debug("create ClusteredDirectAgentAttache for " + host.getId());
         final DirectAgentAttache attache = new ClusteredDirectAgentAttache(this, host.getId(), host.getName(), _nodeId, resource, host.isInMaintenanceStates());
         AgentAttache old = null;
         synchronized (_agents) {
@@ -326,8 +322,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     @Override
     public boolean executeUserRequest(long hostId, Event event) throws AgentUnavailableException {
         if (event == Event.AgentDisconnected) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Received agent disconnect event for host " + hostId);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Received agent disconnect event for host " + hostId);
             }
             AgentAttache attache = findAttache(hostId);
             if (attache != null) {
@@ -336,7 +332,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                     HostTransferMapVO transferVO = _hostTransferDao.findById(hostId);
                     if (transferVO != null) {
                         if (transferVO.getFutureOwner() == _nodeId && transferVO.getState() == HostTransferState.TransferStarted) {
-                            s_logger.debug("Not processing " + Event.AgentDisconnected + " event for the host id=" + hostId + " as the host is being connected to " +
+                            logger.debug("Not processing " + Event.AgentDisconnected + " event for the host id=" + hostId + " as the host is being connected to " +
                                     _nodeId);
                             return true;
                         }
@@ -346,7 +342,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 // don't process disconnect if the disconnect came for the host via delayed cluster notification,
                 // but the host has already reconnected to the current management server
                 if (!attache.forForward()) {
-                    s_logger.debug("Not processing " + Event.AgentDisconnected + " event for the host id=" + hostId +
+                    logger.debug("Not processing " + Event.AgentDisconnected + " event for the host id=" + hostId +
                             " as the host is directly connected to the current management server " + _nodeId);
                     return true;
                 }
@@ -369,7 +365,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 return result;
             }
         } catch (AgentUnavailableException e) {
-            s_logger.debug("cannot propagate agent reconnect because agent is not available", e);
+            logger.debug("cannot propagate agent reconnect because agent is not available", e);
             return false;
         }
 
@@ -377,32 +373,27 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     }
 
     public void notifyNodesInCluster(AgentAttache attache) {
-        s_logger.debug("Notifying other nodes of to disconnect");
+        logger.debug("Notifying other nodes of to disconnect");
         Command[] cmds = new Command[] {new ChangeAgentCommand(attache.getId(), Event.AgentDisconnected)};
         _clusterMgr.broadcast(attache.getId(), _gson.toJson(cmds));
     }
 
     // notifies MS peers to schedule a host scan task immediately, triggered during addHost operation
     public void notifyNodesInClusterToScheduleHostScanTask() {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Notifying other MS nodes to run host scan task");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Notifying other MS nodes to run host scan task");
         }
         Command[] cmds = new Command[] {new ScheduleHostScanTaskCommand()};
         _clusterMgr.broadcast(0, _gson.toJson(cmds));
     }
 
-    protected static void logT(byte[] bytes, final String msg) {
-        s_logger.trace("Seq " + Request.getAgentId(bytes) + "-" + Request.getSequence(bytes) + ": MgmtId " + Request.getManagementServerId(bytes) + ": " +
+    protected void logD(byte[] bytes, final String msg) {
+        logger.debug("Seq " + Request.getAgentId(bytes) + "-" + Request.getSequence(bytes) + ": MgmtId " + Request.getManagementServerId(bytes) + ": " +
                 (Request.isRequest(bytes) ? "Req: " : "Resp: ") + msg);
     }
 
-    protected static void logD(byte[] bytes, final String msg) {
-        s_logger.debug("Seq " + Request.getAgentId(bytes) + "-" + Request.getSequence(bytes) + ": MgmtId " + Request.getManagementServerId(bytes) + ": " +
-                (Request.isRequest(bytes) ? "Req: " : "Resp: ") + msg);
-    }
-
-    protected static void logI(byte[] bytes, final String msg) {
-        s_logger.info("Seq " + Request.getAgentId(bytes) + "-" + Request.getSequence(bytes) + ": MgmtId " + Request.getManagementServerId(bytes) + ": " +
+    protected void logI(byte[] bytes, final String msg) {
+        logger.info("Seq " + Request.getAgentId(bytes) + "-" + Request.getSequence(bytes) + ": MgmtId " + Request.getManagementServerId(bytes) + ": " +
                 (Request.isRequest(bytes) ? "Req: " : "Resp: ") + msg);
     }
 
@@ -427,7 +418,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 return false;
             }
             try {
-                if (s_logger.isDebugEnabled()) {
+                if (logger.isDebugEnabled()) {
                     logD(bytes, "Routing to peer");
                 }
                 Link.write(ch, new ByteBuffer[] {ByteBuffer.wrap(bytes)}, sslEngine);
@@ -467,7 +458,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 try {
                     ch.close();
                 } catch (IOException e) {
-                    s_logger.warn("Unable to close peer socket connection to " + peerName);
+                    logger.warn("Unable to close peer socket connection to " + peerName);
                 }
             }
             _peers.remove(peerName);
@@ -483,14 +474,14 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 try {
                     prevCh.close();
                 } catch (Exception e) {
-                    s_logger.info("[ignored]"
+                    logger.info("[ignored]"
                             + "failed to get close resource for previous channel Socket: " + e.getLocalizedMessage());
                 }
             }
             if (ch == null || ch == prevCh) {
                 ManagementServerHost ms = _clusterMgr.getPeer(peerName);
                 if (ms == null) {
-                    s_logger.info("Unable to find peer: " + peerName);
+                    logger.info("Unable to find peer: " + peerName);
                     return null;
                 }
                 String ip = ms.getServiceIP();
@@ -513,13 +504,13 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                         sslEngine.setEnabledProtocols(SSLUtils.getSupportedProtocols(sslEngine.getEnabledProtocols()));
 
                         Link.doHandshake(ch1, sslEngine, true);
-                        s_logger.info("SSL: Handshake done");
+                        logger.info("SSL: Handshake done");
                     } catch (Exception e) {
                         ch1.close();
                         throw new IOException("SSL: Fail to init SSL! " + e);
                     }
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Connection to peer opened: " + peerName + ", ip: " + ip);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Connection to peer opened: " + peerName + ", ip: " + ip);
                     }
                     _peers.put(peerName, ch1);
                     _sslEngines.put(peerName, sslEngine);
@@ -528,15 +519,15 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                     try {
                         ch1.close();
                     } catch (IOException ex) {
-                        s_logger.error("failed to close failed peer socket: " + ex);
+                        logger.error("failed to close failed peer socket: " + ex);
                     }
-                    s_logger.warn("Unable to connect to peer management server: " + peerName + ", ip: " + ip + " due to " + e.getMessage(), e);
+                    logger.warn("Unable to connect to peer management server: " + peerName + ", ip: " + ip + " due to " + e.getMessage(), e);
                     return null;
                 }
             }
 
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("Found open channel for peer: " + peerName);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Found open channel for peer: " + peerName);
             }
             return ch;
         }
@@ -562,8 +553,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         AgentAttache agent = findAttache(hostId);
         if (agent == null || !agent.forForward()) {
             if (isHostOwnerSwitched(host)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host " + hostId + " has switched to another management server, need to update agent map with a forwarding agent attache");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Host " + hostId + " has switched to another management server, need to update agent map with a forwarding agent attache");
                 }
                 agent = createAttache(hostId);
             }
@@ -582,10 +573,10 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         if (_peers != null) {
             for (SocketChannel ch : _peers.values()) {
                 try {
-                    s_logger.info("Closing: " + ch.toString());
+                    logger.info("Closing: " + ch.toString());
                     ch.close();
                 } catch (IOException e) {
-                    s_logger.info("[ignored] error on closing channel: " +ch.toString(), e);
+                    logger.info("[ignored] error on closing channel: " +ch.toString(), e);
                 }
             }
         }
@@ -622,7 +613,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 final byte[] data = task.getData();
                 Version ver = Request.getVersion(data);
                 if (ver.ordinal() != Version.v1.ordinal() && ver.ordinal() != Version.v3.ordinal()) {
-                    s_logger.warn("Wrong version for clustered agent request");
+                    logger.warn("Wrong version for clustered agent request");
                     super.doTask(task);
                     return;
                 }
@@ -642,7 +633,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                         Request req = Request.parse(data);
                         Command[] cmds = req.getCommands();
                         CancelCommand cancel = (CancelCommand)cmds[0];
-                        if (s_logger.isDebugEnabled()) {
+                        if (logger.isDebugEnabled()) {
                             logD(data, "Cancel request received");
                         }
                         agent.cancel(cancel.getSequence());
@@ -690,7 +681,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                             AgentAttache attache = (AgentAttache)link.attachment();
                             if (attache != null) {
                                 attache.sendNext(Request.getSequence(data));
-                            } else if (s_logger.isDebugEnabled()) {
+                            } else if (logger.isDebugEnabled()) {
                                 logD(data, "No attache to process " + Request.parse(data).toString());
                             }
                         }
@@ -703,11 +694,11 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                             final Response response = Response.parse(data);
                             AgentAttache attache = findAttache(response.getAgentId());
                             if (attache == null) {
-                                s_logger.info("SeqA " + response.getAgentId() + "-" + response.getSequence() + "Unable to find attache to forward " + response.toString());
+                                logger.info("SeqA " + response.getAgentId() + "-" + response.getSequence() + "Unable to find attache to forward " + response.toString());
                                 return;
                             }
                             if (!attache.processAnswers(response.getSequence(), response)) {
-                                s_logger.info("SeqA " + attache.getId() + "-" + response.getSequence() + ": Response is not processed: " + response.toString());
+                                logger.info("SeqA " + attache.getId() + "-" + response.getSequence() + ": Response is not processed: " + response.toString());
                             }
                         }
                         return;
@@ -726,10 +717,10 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     @Override
     public void onManagementNodeLeft(List<? extends ManagementServerHost> nodeList, long selfNodeId) {
         for (ManagementServerHost vo : nodeList) {
-            s_logger.info("Marking hosts as disconnected on Management server" + vo.getMsid());
+            logger.info("Marking hosts as disconnected on Management server" + vo.getMsid());
             long lastPing = (System.currentTimeMillis() >> 10) - getTimeout();
             _hostDao.markHostsAsDisconnected(vo.getMsid(), lastPing);
-            s_logger.info("Deleting entries from op_host_transfer table for Management server " + vo.getMsid());
+            logger.info("Deleting entries from op_host_transfer table for Management server " + vo.getMsid());
             cleanupTransferMap(vo.getMsid());
         }
     }
@@ -757,7 +748,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             try {
                 result = rebalanceHost(agentId, currentOwnerId, futureOwnerId);
             } catch (Exception e) {
-                s_logger.warn("Unable to rebalance host id=" + agentId, e);
+                logger.warn("Unable to rebalance host id=" + agentId, e);
             }
         }
         return result;
@@ -772,14 +763,14 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         protected volatile boolean cancelled = false;
 
         public AgentLoadBalancerTask() {
-            s_logger.debug("Agent load balancer task created");
+            logger.debug("Agent load balancer task created");
         }
 
         @Override
         public synchronized boolean cancel() {
             if (!cancelled) {
                 cancelled = true;
-                s_logger.debug("Agent load balancer task cancelled");
+                logger.debug("Agent load balancer task cancelled");
                 return super.cancel();
             }
             return true;
@@ -790,19 +781,19 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             try {
                 if (!cancelled) {
                     startRebalanceAgents();
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("The agent load balancer task is now being cancelled");
+                    if (logger.isInfoEnabled()) {
+                        logger.info("The agent load balancer task is now being cancelled");
                     }
                     cancelled = true;
                 }
             } catch (Throwable e) {
-                s_logger.error("Unexpected exception " + e.toString(), e);
+                logger.error("Unexpected exception " + e.toString(), e);
             }
         }
     }
 
     public void startRebalanceAgents() {
-        s_logger.debug("Management server " + _nodeId + " is asking other peers to rebalance their agents");
+        logger.debug("Management server " + _nodeId + " is asking other peers to rebalance their agents");
         List<ManagementServerHostVO> allMS = _mshostDao.listBy(ManagementServerHost.State.Up);
         QueryBuilder<HostVO> sc = QueryBuilder.create(HostVO.class);
         sc.and(sc.entity().getManagementServerId(), Op.NNULL);
@@ -814,16 +805,16 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         if (!allManagedAgents.isEmpty() && !allMS.isEmpty()) {
             avLoad = allManagedAgents.size() / allMS.size();
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("There are no hosts to rebalance in the system. Current number of active management server nodes in the system is " + allMS.size() +
+            if (logger.isDebugEnabled()) {
+                logger.debug("There are no hosts to rebalance in the system. Current number of active management server nodes in the system is " + allMS.size() +
                         "; number of managed agents is " + allManagedAgents.size());
             }
             return;
         }
 
         if (avLoad == 0L) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("As calculated average load is less than 1, rounding it to 1");
+            if (logger.isDebugEnabled()) {
+                logger.debug("As calculated average load is less than 1, rounding it to 1");
             }
             avLoad = 1;
         }
@@ -837,19 +828,19 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                     if (hostsToRebalance != null && !hostsToRebalance.isEmpty()) {
                         break;
                     } else {
-                        s_logger.debug("Agent load balancer planner " + lbPlanner.getName() + " found no hosts to be rebalanced from management server " + node.getMsid());
+                        logger.debug("Agent load balancer planner " + lbPlanner.getName() + " found no hosts to be rebalanced from management server " + node.getMsid());
                     }
                 }
 
                 if (hostsToRebalance != null && !hostsToRebalance.isEmpty()) {
-                    s_logger.debug("Found " + hostsToRebalance.size() + " hosts to rebalance from management server " + node.getMsid());
+                    logger.debug("Found " + hostsToRebalance.size() + " hosts to rebalance from management server " + node.getMsid());
                     for (HostVO host : hostsToRebalance) {
                         long hostId = host.getId();
-                        s_logger.debug("Asking management server " + node.getMsid() + " to give away host id=" + hostId);
+                        logger.debug("Asking management server " + node.getMsid() + " to give away host id=" + hostId);
                         boolean result = true;
 
                         if (_hostTransferDao.findById(hostId) != null) {
-                            s_logger.warn("Somebody else is already rebalancing host id: " + hostId);
+                            logger.warn("Somebody else is already rebalancing host id: " + hostId);
                             continue;
                         }
 
@@ -858,18 +849,18 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                             transfer = _hostTransferDao.startAgentTransfering(hostId, node.getMsid(), _nodeId);
                             Answer[] answer = sendRebalanceCommand(node.getMsid(), hostId, node.getMsid(), _nodeId, Event.RequestAgentRebalance);
                             if (answer == null) {
-                                s_logger.warn("Failed to get host id=" + hostId + " from management server " + node.getMsid());
+                                logger.warn("Failed to get host id=" + hostId + " from management server " + node.getMsid());
                                 result = false;
                             }
                         } catch (Exception ex) {
-                            s_logger.warn("Failed to get host id=" + hostId + " from management server " + node.getMsid(), ex);
+                            logger.warn("Failed to get host id=" + hostId + " from management server " + node.getMsid(), ex);
                             result = false;
                         } finally {
                             if (transfer != null) {
                                 HostTransferMapVO transferState = _hostTransferDao.findByIdAndFutureOwnerId(transfer.getId(), _nodeId);
                                 if (!result && transferState != null && transferState.getState() == HostTransferState.TransferRequested) {
-                                    if (s_logger.isDebugEnabled()) {
-                                        s_logger.debug("Removing mapping from op_host_transfer as it failed to be set to transfer mode");
+                                    if (logger.isDebugEnabled()) {
+                                        logger.debug("Removing mapping from op_host_transfer as it failed to be set to transfer mode");
                                     }
                                     // just remove the mapping (if exists) as nothing was done on the peer management
 // server yet
@@ -879,7 +870,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                         }
                     }
                 } else {
-                    s_logger.debug("Found no hosts to rebalance from the management server " + node.getMsid());
+                    logger.debug("Found no hosts to rebalance from the management server " + node.getMsid());
                 }
             }
         }
@@ -893,8 +884,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         Command[] cmds = commands.toCommands();
 
         try {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Forwarding " + cmds[0].toString() + " to " + peer);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Forwarding " + cmds[0].toString() + " to " + peer);
             }
             String peerName = Long.toString(peer);
             String cmdStr = _gson.toJson(cmds);
@@ -902,7 +893,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             Answer[] answers = _gson.fromJson(ansStr, Answer[].class);
             return answers;
         } catch (Exception e) {
-            s_logger.warn("Caught exception while talking to " + currentOwnerId, e);
+            logger.warn("Caught exception while talking to " + currentOwnerId, e);
             return null;
         }
     }
@@ -926,8 +917,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             return null;
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Propagating agent change request event:" + event.toString() + " to agent:" + agentId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Propagating agent change request event:" + event.toString() + " to agent:" + agentId);
         }
         Command[] cmds = new Command[1];
         cmds[0] = new ChangeAgentCommand(agentId, event);
@@ -939,8 +930,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
         Answer[] answers = _gson.fromJson(ansStr, Answer[].class);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Result for agent change is " + answers[0].getResult());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Result for agent change is " + answers[0].getResult());
         }
 
         return answers[0].getResult();
@@ -951,12 +942,12 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             @Override
             protected void runInContext() {
                 try {
-                    if (s_logger.isTraceEnabled()) {
-                        s_logger.trace("Clustered agent transfer scan check, management server id:" + _nodeId);
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Clustered agent transfer scan check, management server id:" + _nodeId);
                     }
                     synchronized (_agentToTransferIds) {
                         if (_agentToTransferIds.size() > 0) {
-                            s_logger.debug("Found " + _agentToTransferIds.size() + " agents to transfer");
+                            logger.debug("Found " + _agentToTransferIds.size() + " agents to transfer");
                             // for (Long hostId : _agentToTransferIds) {
                             for (Iterator<Long> iterator = _agentToTransferIds.iterator(); iterator.hasNext();) {
                                 Long hostId = iterator.next();
@@ -973,14 +964,14 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                                         _hostTransferDao.findActiveHostTransferMapByHostId(hostId, new Date(cutTime.getTime() - rebalanceTimeOut));
 
                                 if (transferMap == null) {
-                                    s_logger.debug("Timed out waiting for the host id=" + hostId + " to be ready to transfer, skipping rebalance for the host");
+                                    logger.debug("Timed out waiting for the host id=" + hostId + " to be ready to transfer, skipping rebalance for the host");
                                     iterator.remove();
                                     _hostTransferDao.completeAgentTransfer(hostId);
                                     continue;
                                 }
 
                                 if (transferMap.getInitialOwner() != _nodeId || attache == null || attache.forForward()) {
-                                    s_logger.debug("Management server " + _nodeId + " doesn't own host id=" + hostId + " any more, skipping rebalance for the host");
+                                    logger.debug("Management server " + _nodeId + " doesn't own host id=" + hostId + " any more, skipping rebalance for the host");
                                     iterator.remove();
                                     _hostTransferDao.completeAgentTransfer(hostId);
                                     continue;
@@ -988,7 +979,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
                                 ManagementServerHostVO ms = _mshostDao.findByMsid(transferMap.getFutureOwner());
                                 if (ms != null && ms.getState() != ManagementServerHost.State.Up) {
-                                    s_logger.debug("Can't transfer host " + hostId + " as it's future owner is not in UP state: " + ms +
+                                    logger.debug("Can't transfer host " + hostId + " as it's future owner is not in UP state: " + ms +
                                             ", skipping rebalance for the host");
                                     iterator.remove();
                                     _hostTransferDao.completeAgentTransfer(hostId);
@@ -1000,31 +991,31 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                                     try {
                                         _executor.execute(new RebalanceTask(hostId, transferMap.getInitialOwner(), transferMap.getFutureOwner()));
                                     } catch (RejectedExecutionException ex) {
-                                        s_logger.warn("Failed to submit rebalance task for host id=" + hostId + "; postponing the execution");
+                                        logger.warn("Failed to submit rebalance task for host id=" + hostId + "; postponing the execution");
                                         continue;
                                     }
 
                                 } else {
-                                    s_logger.debug("Agent " + hostId + " can't be transfered yet as its request queue size is " + attache.getQueueSize() +
+                                    logger.debug("Agent " + hostId + " can't be transfered yet as its request queue size is " + attache.getQueueSize() +
                                             " and listener queue size is " + attache.getNonRecurringListenersSize());
                                 }
                             }
                         } else {
-                            if (s_logger.isTraceEnabled()) {
-                                s_logger.trace("Found no agents to be transfered by the management server " + _nodeId);
+                            if (logger.isTraceEnabled()) {
+                                logger.trace("Found no agents to be transfered by the management server " + _nodeId);
                             }
                         }
                     }
 
                 } catch (Throwable e) {
-                    s_logger.error("Problem with the clustered agent transfer scan check!", e);
+                    logger.error("Problem with the clustered agent transfer scan check!", e);
                 }
             }
         };
     }
 
     private boolean setToWaitForRebalance(final long hostId, long currentOwnerId, long futureOwnerId) {
-        s_logger.debug("Adding agent " + hostId + " to the list of agents to transfer");
+        logger.debug("Adding agent " + hostId + " to the list of agents to transfer");
         synchronized (_agentToTransferIds) {
             return _agentToTransferIds.add(hostId);
         }
@@ -1035,7 +1026,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         boolean result = true;
         if (currentOwnerId == _nodeId) {
             if (!startRebalance(hostId)) {
-                s_logger.debug("Failed to start agent rebalancing");
+                logger.debug("Failed to start agent rebalancing");
                 finishRebalance(hostId, futureOwnerId, Event.RebalanceFailed);
                 return false;
             }
@@ -1046,23 +1037,23 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 }
 
             } catch (Exception ex) {
-                s_logger.warn("Host " + hostId + " failed to connect to the management server " + futureOwnerId + " as a part of rebalance process", ex);
+                logger.warn("Host " + hostId + " failed to connect to the management server " + futureOwnerId + " as a part of rebalance process", ex);
                 result = false;
             }
 
             if (result) {
-                s_logger.debug("Successfully transfered host id=" + hostId + " to management server " + futureOwnerId);
+                logger.debug("Successfully transfered host id=" + hostId + " to management server " + futureOwnerId);
                 finishRebalance(hostId, futureOwnerId, Event.RebalanceCompleted);
             } else {
-                s_logger.warn("Failed to transfer host id=" + hostId + " to management server " + futureOwnerId);
+                logger.warn("Failed to transfer host id=" + hostId + " to management server " + futureOwnerId);
                 finishRebalance(hostId, futureOwnerId, Event.RebalanceFailed);
             }
 
         } else if (futureOwnerId == _nodeId) {
             HostVO host = _hostDao.findById(hostId);
             try {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Disconnecting host " + host.getId() + "(" + host.getName() + " as a part of rebalance process without notification");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Disconnecting host " + host.getId() + "(" + host.getName() + " as a part of rebalance process without notification");
                 }
 
                 AgentAttache attache = findAttache(hostId);
@@ -1071,26 +1062,26 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 }
 
                 if (result) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Loading directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Loading directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
                                 " as a part of rebalance process");
                     }
                     result = loadDirectlyConnectedHost(host, true);
                 } else {
-                    s_logger.warn("Failed to disconnect " + host.getId() + "(" + host.getName() + " as a part of rebalance process without notification");
+                    logger.warn("Failed to disconnect " + host.getId() + "(" + host.getName() + " as a part of rebalance process without notification");
                 }
 
             } catch (Exception ex) {
-                s_logger.warn("Failed to load directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
+                logger.warn("Failed to load directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
                         " as a part of rebalance process due to:", ex);
                 result = false;
             }
 
             if (result) {
-                s_logger.debug("Successfully loaded directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
+                logger.debug("Successfully loaded directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
                         " as a part of rebalance process");
             } else {
-                s_logger.warn("Failed to load directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
+                logger.warn("Failed to load directly connected host " + host.getId() + "(" + host.getName() + ") to the management server " + _nodeId +
                         " as a part of rebalance process");
             }
         }
@@ -1101,13 +1092,13 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     protected void finishRebalance(final long hostId, long futureOwnerId, Event event) {
 
         boolean success = (event == Event.RebalanceCompleted) ? true : false;
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Finishing rebalancing for the agent " + hostId + " with event " + event);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Finishing rebalancing for the agent " + hostId + " with event " + event);
         }
 
         AgentAttache attache = findAttache(hostId);
         if (attache == null || !(attache instanceof ClusteredAgentAttache)) {
-            s_logger.debug("Unable to find forward attache for the host id=" + hostId + ", assuming that the agent disconnected already");
+            logger.debug("Unable to find forward attache for the host id=" + hostId + ", assuming that the agent disconnected already");
             _hostTransferDao.completeAgentTransfer(hostId);
             return;
         }
@@ -1122,7 +1113,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             // 2) Get all transfer requests and route them to peer
             Request requestToTransfer = forwardAttache.getRequestToTransfer();
             while (requestToTransfer != null) {
-                s_logger.debug("Forwarding request " + requestToTransfer.getSequence() + " held in transfer attache " + hostId + " from the management server " +
+                logger.debug("Forwarding request " + requestToTransfer.getSequence() + " held in transfer attache " + hostId + " from the management server " +
                         _nodeId + " to " + futureOwnerId);
                 boolean routeResult = routeToPeer(Long.toString(futureOwnerId), requestToTransfer.getBytes());
                 if (!routeResult) {
@@ -1132,23 +1123,23 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 requestToTransfer = forwardAttache.getRequestToTransfer();
             }
 
-            s_logger.debug("Management server " + _nodeId + " completed agent " + hostId + " rebalance to " + futureOwnerId);
+            logger.debug("Management server " + _nodeId + " completed agent " + hostId + " rebalance to " + futureOwnerId);
 
         } else {
             failRebalance(hostId);
         }
 
-        s_logger.debug("Management server " + _nodeId + " completed agent " + hostId + " rebalance");
+        logger.debug("Management server " + _nodeId + " completed agent " + hostId + " rebalance");
         _hostTransferDao.completeAgentTransfer(hostId);
     }
 
     protected void failRebalance(final long hostId) {
         try {
-            s_logger.debug("Management server " + _nodeId + " failed to rebalance agent " + hostId);
+            logger.debug("Management server " + _nodeId + " failed to rebalance agent " + hostId);
             _hostTransferDao.completeAgentTransfer(hostId);
             handleDisconnectWithoutInvestigation(findAttache(hostId), Event.RebalanceFailed, true, true);
         } catch (Exception ex) {
-            s_logger.warn("Failed to reconnect host id=" + hostId + " as a part of failed rebalance task cleanup");
+            logger.warn("Failed to reconnect host id=" + hostId + " as a part of failed rebalance task cleanup");
         }
     }
 
@@ -1156,7 +1147,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         HostVO host = _hostDao.findById(hostId);
 
         if (host == null || host.getRemoved() != null) {
-            s_logger.warn("Unable to find host record, fail start rebalancing process");
+            logger.warn("Unable to find host record, fail start rebalancing process");
             return false;
         }
 
@@ -1166,17 +1157,17 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 handleDisconnectWithoutInvestigation(attache, Event.StartAgentRebalance, true, true);
                 ClusteredAgentAttache forwardAttache = (ClusteredAgentAttache)createAttache(hostId);
                 if (forwardAttache == null) {
-                    s_logger.warn("Unable to create a forward attache for the host " + hostId + " as a part of rebalance process");
+                    logger.warn("Unable to create a forward attache for the host " + hostId + " as a part of rebalance process");
                     return false;
                 }
-                s_logger.debug("Putting agent id=" + hostId + " to transfer mode");
+                logger.debug("Putting agent id=" + hostId + " to transfer mode");
                 forwardAttache.setTransferMode(true);
                 _agents.put(hostId, forwardAttache);
             } else {
                 if (attache == null) {
-                    s_logger.warn("Attache for the agent " + hostId + " no longer exists on management server " + _nodeId + ", can't start host rebalancing");
+                    logger.warn("Attache for the agent " + hostId + " no longer exists on management server " + _nodeId + ", can't start host rebalancing");
                 } else {
-                    s_logger.warn("Attache for the agent " + hostId + " has request queue size= " + attache.getQueueSize() + " and listener queue size " +
+                    logger.warn("Attache for the agent " + hostId + " has request queue size= " + attache.getQueueSize() + " and listener queue size " +
                             attache.getNonRecurringListenersSize() + ", can't start host rebalancing");
                 }
                 return false;
@@ -1213,19 +1204,19 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         @Override
         protected void runInContext() {
             try {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Rebalancing host id=" + hostId);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Rebalancing host id=" + hostId);
                 }
                 rebalanceHost(hostId, currentOwnerId, futureOwnerId);
             } catch (Exception e) {
-                s_logger.warn("Unable to rebalance host id=" + hostId, e);
+                logger.warn("Unable to rebalance host id=" + hostId, e);
             }
         }
     }
 
     private String handleScheduleHostScanTaskCommand(ScheduleHostScanTaskCommand cmd) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Intercepting resource manager command: " + _gson.toJson(cmd));
+        if (logger.isDebugEnabled()) {
+            logger.debug("Intercepting resource manager command: " + _gson.toJson(cmd));
         }
 
         try {
@@ -1233,7 +1224,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         } catch (Exception e) {
             // Scheduling host scan task in peer MS is a best effort operation during host add, regular host scan
             // happens at fixed intervals anyways. So handling any exceptions that may be thrown
-            s_logger.warn("Exception happened while trying to schedule host scan task on mgmt server " + _clusterMgr.getSelfPeerName() +
+            logger.warn("Exception happened while trying to schedule host scan task on mgmt server " + _clusterMgr.getSelfPeerName() +
                     ", ignoring as regular host scan happens at fixed interval anyways", e);
             return null;
         }
@@ -1260,8 +1251,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         @Override
         public String dispatch(ClusterServicePdu pdu) {
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Dispatch ->" + pdu.getAgentId() + ", json: " + pdu.getJsonPackage());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Dispatch ->" + pdu.getAgentId() + ", json: " + pdu.getJsonPackage());
             }
 
             Command[] cmds = null;
@@ -1269,24 +1260,24 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                 cmds = _gson.fromJson(pdu.getJsonPackage(), Command[].class);
             } catch (Throwable e) {
                 assert (false);
-                s_logger.error("Excection in gson decoding : ", e);
+                logger.error("Excection in gson decoding : ", e);
             }
 
             if (cmds.length == 1 && cmds[0] instanceof ChangeAgentCommand) { // intercepted
                 ChangeAgentCommand cmd = (ChangeAgentCommand)cmds[0];
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Intercepting command for agent change: agent " + cmd.getAgentId() + " event: " + cmd.getEvent());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Intercepting command for agent change: agent " + cmd.getAgentId() + " event: " + cmd.getEvent());
                 }
                 boolean result = false;
                 try {
                     result = executeAgentUserRequest(cmd.getAgentId(), cmd.getEvent());
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Result is " + result);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Result is " + result);
                     }
 
                 } catch (AgentUnavailableException e) {
-                    s_logger.warn("Agent is unavailable", e);
+                    logger.warn("Agent is unavailable", e);
                     return null;
                 }
 
@@ -1296,21 +1287,21 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             } else if (cmds.length == 1 && cmds[0] instanceof TransferAgentCommand) {
                 TransferAgentCommand cmd = (TransferAgentCommand)cmds[0];
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Intercepting command for agent rebalancing: agent " + cmd.getAgentId() + " event: " + cmd.getEvent());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Intercepting command for agent rebalancing: agent " + cmd.getAgentId() + " event: " + cmd.getEvent());
                 }
                 boolean result = false;
                 try {
                     result = rebalanceAgent(cmd.getAgentId(), cmd.getEvent(), cmd.getCurrentOwner(), cmd.getFutureOwner());
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Result is " + result);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Result is " + result);
                     }
 
                 } catch (AgentUnavailableException e) {
-                    s_logger.warn("Agent is unavailable", e);
+                    logger.warn("Agent is unavailable", e);
                     return null;
                 } catch (OperationTimedoutException e) {
-                    s_logger.warn("Operation timed out", e);
+                    logger.warn("Operation timed out", e);
                     return null;
                 }
                 Answer[] answers = new Answer[1];
@@ -1319,14 +1310,14 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             } else if (cmds.length == 1 && cmds[0] instanceof PropagateResourceEventCommand) {
                 PropagateResourceEventCommand cmd = (PropagateResourceEventCommand)cmds[0];
 
-                s_logger.debug("Intercepting command to propagate event " + cmd.getEvent().name() + " for host " + cmd.getHostId());
+                logger.debug("Intercepting command to propagate event " + cmd.getEvent().name() + " for host " + cmd.getHostId());
 
                 boolean result = false;
                 try {
                     result = _resourceMgr.executeUserRequest(cmd.getHostId(), cmd.getEvent());
-                    s_logger.debug("Result is " + result);
+                    logger.debug("Result is " + result);
                 } catch (AgentUnavailableException ex) {
-                    s_logger.warn("Agent is unavailable", ex);
+                    logger.warn("Agent is unavailable", ex);
                     return null;
                 }
 
@@ -1341,30 +1332,30 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
 
             try {
                 long startTick = System.currentTimeMillis();
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Dispatch -> " + pdu.getAgentId() + ", json: " + pdu.getJsonPackage());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Dispatch -> " + pdu.getAgentId() + ", json: " + pdu.getJsonPackage());
                 }
 
                 Answer[] answers = sendToAgent(pdu.getAgentId(), cmds, pdu.isStopOnError());
                 if (answers != null) {
                     String jsonReturn = _gson.toJson(answers);
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Completed dispatching -> " + pdu.getAgentId() + ", json: " + pdu.getJsonPackage() + " in " +
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Completed dispatching -> " + pdu.getAgentId() + ", json: " + pdu.getJsonPackage() + " in " +
                                 (System.currentTimeMillis() - startTick) + " ms, return result: " + jsonReturn);
                     }
 
                     return jsonReturn;
                 } else {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Completed dispatching -> " + pdu.getAgentId() + ", json: " + pdu.getJsonPackage() + " in " +
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Completed dispatching -> " + pdu.getAgentId() + ", json: " + pdu.getJsonPackage() + " in " +
                                 (System.currentTimeMillis() - startTick) + " ms, return null result");
                     }
                 }
             } catch (AgentUnavailableException e) {
-                s_logger.warn("Agent is unavailable", e);
+                logger.warn("Agent is unavailable", e);
             } catch (OperationTimedoutException e) {
-                s_logger.warn("Timed Out", e);
+                logger.warn("Timed Out", e);
             }
 
             return null;
@@ -1389,8 +1380,8 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
             @Override
             protected void runInContext() {
                 try {
-                    if (s_logger.isTraceEnabled()) {
-                        s_logger.trace("Agent rebalance task check, management server id:" + _nodeId);
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Agent rebalance task check, management server id:" + _nodeId);
                     }
                     // initiate agent lb task will be scheduled and executed only once, and only when number of agents
 // loaded exceeds _connectedAgentsThreshold
@@ -1408,18 +1399,18 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
                         if (allHostsCount > 0.0) {
                             double load = managedHostsCount / allHostsCount;
                             if (load >= ConnectedAgentThreshold.value()) {
-                                s_logger.debug("Scheduling agent rebalancing task as the average agent load " + load + " is more than the threshold " +
+                                logger.debug("Scheduling agent rebalancing task as the average agent load " + load + " is more than the threshold " +
                                         ConnectedAgentThreshold.value());
                                 scheduleRebalanceAgents();
                                 _agentLbHappened = true;
                             } else {
-                                s_logger.debug("Not scheduling agent rebalancing task as the averages load " + load + " is less than the threshold " +
+                                logger.debug("Not scheduling agent rebalancing task as the averages load " + load + " is less than the threshold " +
                                         ConnectedAgentThreshold.value());
                             }
                         }
                     }
                 } catch (Throwable e) {
-                    s_logger.error("Problem with the clustered agent transfer scan check!", e);
+                    logger.error("Problem with the clustered agent transfer scan check!", e);
                 }
             }
         };
@@ -1428,13 +1419,13 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     @Override
     public void rescan() {
         // schedule a scan task immediately
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Scheduling a host scan task");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Scheduling a host scan task");
         }
         // schedule host scan task on current MS
         scheduleHostScanTask();
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Notifying all peer MS to schedule host scan task");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Notifying all peer MS to schedule host scan task");
         }
     }
 

--- a/engine/orchestration/src/com/cloud/cluster/agentlb/ClusterBasedAgentLoadBalancerPlanner.java
+++ b/engine/orchestration/src/com/cloud/cluster/agentlb/ClusterBasedAgentLoadBalancerPlanner.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.host.Host;
@@ -41,7 +40,6 @@ import com.cloud.utils.db.SearchCriteria.Op;
 @Component
 @Local(value = AgentLoadBalancerPlanner.class)
 public class ClusterBasedAgentLoadBalancerPlanner extends AdapterBase implements AgentLoadBalancerPlanner {
-    private static final Logger s_logger = Logger.getLogger(AgentLoadBalancerPlanner.class);
 
     @Inject
     HostDao _hostDao = null;
@@ -54,7 +52,7 @@ public class ClusterBasedAgentLoadBalancerPlanner extends AdapterBase implements
         List<HostVO> allHosts = sc.list();
 
         if (allHosts.size() <= avLoad) {
-            s_logger.debug("Agent load = " + allHosts.size() + " for management server " + msId + " doesn't exceed average system agent load = " + avLoad +
+            logger.debug("Agent load = " + allHosts.size() + " for management server " + msId + " doesn't exceed average system agent load = " + avLoad +
                 "; so it doesn't participate in agent rebalancing process");
             return null;
         }
@@ -66,7 +64,7 @@ public class ClusterBasedAgentLoadBalancerPlanner extends AdapterBase implements
         List<HostVO> directHosts = sc.list();
 
         if (directHosts.isEmpty()) {
-            s_logger.debug("No direct agents in status " + Status.Up + " exist for the management server " + msId +
+            logger.debug("No direct agents in status " + Status.Up + " exist for the management server " + msId +
                 "; so it doesn't participate in agent rebalancing process");
             return null;
         }
@@ -92,23 +90,23 @@ public class ClusterBasedAgentLoadBalancerPlanner extends AdapterBase implements
         int hostsLeft = directHosts.size();
         List<HostVO> hostsToReturn = new ArrayList<HostVO>();
 
-        s_logger.debug("Management server " + msId + " can give away " + hostsToGive + " as it currently owns " + allHosts.size() +
+        logger.debug("Management server " + msId + " can give away " + hostsToGive + " as it currently owns " + allHosts.size() +
             " and the average agent load in the system is " + avLoad + "; finalyzing list of hosts to give away...");
         for (Long cluster : hostToClusterMap.keySet()) {
             List<HostVO> hostsInCluster = hostToClusterMap.get(cluster);
             hostsLeft = hostsLeft - hostsInCluster.size();
             if (hostsToReturn.size() < hostsToGive) {
-                s_logger.debug("Trying cluster id=" + cluster);
+                logger.debug("Trying cluster id=" + cluster);
 
                 if (hostsInCluster.size() > hostsLeftToGive) {
-                    s_logger.debug("Skipping cluster id=" + cluster + " as it has more hosts than we need: " + hostsInCluster.size() + " vs " + hostsLeftToGive);
+                    logger.debug("Skipping cluster id=" + cluster + " as it has more hosts than we need: " + hostsInCluster.size() + " vs " + hostsLeftToGive);
                     if (hostsLeft >= hostsLeftToGive) {
                         continue;
                     } else {
                         break;
                     }
                 } else {
-                    s_logger.debug("Taking all " + hostsInCluster.size() + " hosts: " + hostsInCluster + " from cluster id=" + cluster);
+                    logger.debug("Taking all " + hostsInCluster.size() + " hosts: " + hostsInCluster + " from cluster id=" + cluster);
                     hostsToReturn.addAll(hostsInCluster);
                     hostsLeftToGive = hostsLeftToGive - hostsInCluster.size();
                 }
@@ -117,7 +115,7 @@ public class ClusterBasedAgentLoadBalancerPlanner extends AdapterBase implements
             }
         }
 
-        s_logger.debug("Management server " + msId + " is ready to give away " + hostsToReturn.size() + " hosts");
+        logger.debug("Management server " + msId + " is ready to give away " + hostsToReturn.size() + " hosts");
         return hostsToReturn;
     }
 

--- a/engine/orchestration/src/com/cloud/vm/VmWorkJobDispatcher.java
+++ b/engine/orchestration/src/com/cloud/vm/VmWorkJobDispatcher.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.jobs.AsyncJob;
@@ -34,7 +33,6 @@ import com.cloud.utils.component.AdapterBase;
 import com.cloud.vm.dao.VMInstanceDao;
 
 public class VmWorkJobDispatcher extends AdapterBase implements AsyncJobDispatcher {
-    private static final Logger s_logger = Logger.getLogger(VmWorkJobDispatcher.class);
 
     @Inject private VirtualMachineManagerImpl _vmMgr;
     @Inject
@@ -65,23 +63,23 @@ public class VmWorkJobDispatcher extends AdapterBase implements AsyncJobDispatch
             try {
                 workClz = Class.forName(job.getCmd());
             } catch (ClassNotFoundException e) {
-                s_logger.error("VM work class " + cmd + " is not found" + ", job origin: " + job.getRelated(), e);
+                logger.error("VM work class " + cmd + " is not found" + ", job origin: " + job.getRelated(), e);
                 _asyncJobMgr.completeAsyncJob(job.getId(), JobInfo.Status.FAILED, 0, e.getMessage());
                 return;
             }
 
             work = VmWorkSerializer.deserialize(workClz, job.getCmdInfo());
             if(work == null) {
-                s_logger.error("Unable to deserialize VM work " + job.getCmd() + ", job info: " + job.getCmdInfo() + ", job origin: " + job.getRelated());
+                logger.error("Unable to deserialize VM work " + job.getCmd() + ", job info: " + job.getCmdInfo() + ", job origin: " + job.getRelated());
                 _asyncJobMgr.completeAsyncJob(job.getId(), JobInfo.Status.FAILED, 0, "Unable to deserialize VM work");
                 return;
             }
 
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Run VM work job: " + cmd + " for VM " + work.getVmId() + ", job origin: " + job.getRelated());
+            if (logger.isDebugEnabled())
+                logger.debug("Run VM work job: " + cmd + " for VM " + work.getVmId() + ", job origin: " + job.getRelated());
             try {
                 if (_handlers == null || _handlers.isEmpty()) {
-                    s_logger.error("Invalid startup configuration, no work job handler is found. cmd: " + job.getCmd() + ", job info: " + job.getCmdInfo()
+                    logger.error("Invalid startup configuration, no work job handler is found. cmd: " + job.getCmd() + ", job info: " + job.getCmdInfo()
                             + ", job origin: " + job.getRelated());
                     _asyncJobMgr.completeAsyncJob(job.getId(), JobInfo.Status.FAILED, 0, "Invalid startup configuration. no job handler is found");
                     return;
@@ -90,7 +88,7 @@ public class VmWorkJobDispatcher extends AdapterBase implements AsyncJobDispatch
                 VmWorkJobHandler handler = _handlers.get(work.getHandlerName());
 
                 if (handler == null) {
-                    s_logger.error("Unable to find work job handler. handler name: " + work.getHandlerName() + ", job cmd: " + job.getCmd()
+                    logger.error("Unable to find work job handler. handler name: " + work.getHandlerName() + ", job cmd: " + job.getCmd()
                             + ", job info: " + job.getCmdInfo() + ", job origin: " + job.getRelated());
                     _asyncJobMgr.completeAsyncJob(job.getId(), JobInfo.Status.FAILED, 0, "Unable to find work job handler");
                     return;
@@ -105,14 +103,14 @@ public class VmWorkJobDispatcher extends AdapterBase implements AsyncJobDispatch
                     CallContext.unregister();
                 }
             } finally {
-                if (s_logger.isDebugEnabled())
-                    s_logger.debug("Done with run of VM work job: " + cmd + " for VM " + work.getVmId() + ", job origin: " + job.getRelated());
+                if (logger.isDebugEnabled())
+                    logger.debug("Done with run of VM work job: " + cmd + " for VM " + work.getVmId() + ", job origin: " + job.getRelated());
             }
         } catch(InvalidParameterValueException e) {
-            s_logger.error("Unable to complete " + job + ", job origin:" + job.getRelated());
+            logger.error("Unable to complete " + job + ", job origin:" + job.getRelated());
             _asyncJobMgr.completeAsyncJob(job.getId(), JobInfo.Status.FAILED, 0, _asyncJobMgr.marshallResultObject(e));
         } catch(Throwable e) {
-            s_logger.error("Unable to complete " + job + ", job origin:" + job.getRelated(), e);
+            logger.error("Unable to complete " + job + ", job origin:" + job.getRelated(), e);
 
             //RuntimeException ex = new RuntimeException("Job failed due to exception " + e.getMessage());
             _asyncJobMgr.completeAsyncJob(job.getId(), JobInfo.Status.FAILED, 0, _asyncJobMgr.marshallResultObject(e));

--- a/engine/orchestration/src/com/cloud/vm/VmWorkJobWakeupDispatcher.java
+++ b/engine/orchestration/src/com/cloud/vm/VmWorkJobWakeupDispatcher.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.jobs.AsyncJob;
@@ -47,7 +46,6 @@ import com.cloud.vm.dao.VMInstanceDao;
  * Current code base uses blocking calls to wait for job completion
  */
 public class VmWorkJobWakeupDispatcher extends AdapterBase implements AsyncJobDispatcher {
-    private static final Logger s_logger = Logger.getLogger(VmWorkJobWakeupDispatcher.class);
 
     @Inject
     private VmWorkJobDao _workjobDao;
@@ -69,7 +67,7 @@ public class VmWorkJobWakeupDispatcher extends AdapterBase implements AsyncJobDi
         try {
             List<AsyncJobJoinMapVO> joinRecords = _joinMapDao.listJoinRecords(job.getId());
             if (joinRecords.size() != 1) {
-                s_logger.warn("AsyncJob-" + job.getId()
+                logger.warn("AsyncJob-" + job.getId()
                         + " received wakeup call with un-supported joining job number: " + joinRecords.size());
 
                 // if we fail wakeup-execution for any reason, avoid release sync-source if there is any
@@ -84,7 +82,7 @@ public class VmWorkJobWakeupDispatcher extends AdapterBase implements AsyncJobDi
             try {
                 workClz = Class.forName(job.getCmd());
             } catch (ClassNotFoundException e) {
-                s_logger.error("VM work class " + job.getCmd() + " is not found", e);
+                logger.error("VM work class " + job.getCmd() + " is not found", e);
                 return;
             }
 
@@ -105,14 +103,14 @@ public class VmWorkJobWakeupDispatcher extends AdapterBase implements AsyncJobDi
                     handler.invoke(_vmMgr);
                 } else {
                     assert (false);
-                    s_logger.error("Unable to find wakeup handler " + joinRecord.getWakeupHandler() +
+                    logger.error("Unable to find wakeup handler " + joinRecord.getWakeupHandler() +
                             " when waking up job-" + job.getId());
                 }
             } finally {
                 CallContext.unregister();
             }
         } catch (Throwable e) {
-            s_logger.warn("Unexpected exception in waking up job-" + job.getId());
+            logger.warn("Unexpected exception in waking up job-" + job.getId());
 
             // if we fail wakeup-execution for any reason, avoid release sync-source if there is any
             job.setSyncSource(null);
@@ -132,11 +130,11 @@ public class VmWorkJobWakeupDispatcher extends AdapterBase implements AsyncJobDi
                 method.setAccessible(true);
             } catch (SecurityException e) {
                 assert (false);
-                s_logger.error("Unexpected exception", e);
+                logger.error("Unexpected exception", e);
                 return null;
             } catch (NoSuchMethodException e) {
                 assert (false);
-                s_logger.error("Unexpected exception", e);
+                logger.error("Unexpected exception", e);
                 return null;
             }
 

--- a/engine/orchestration/src/org/apache/cloudstack/engine/datacenter/entity/api/db/dao/EngineClusterDaoImpl.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/datacenter/entity/api/db/dao/EngineClusterDaoImpl.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.datacenter.entity.api.DataCenterResourceEntity;
@@ -53,7 +52,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component(value = "EngineClusterDao")
 @Local(value = EngineClusterDao.class)
 public class EngineClusterDaoImpl extends GenericDaoBase<EngineClusterVO, Long> implements EngineClusterDao {
-    private static final Logger s_logger = Logger.getLogger(EngineClusterDaoImpl.class);
 
     protected final SearchBuilder<EngineClusterVO> PodSearch;
     protected final SearchBuilder<EngineClusterVO> HyTypeWithoutGuidSearch;
@@ -274,7 +272,7 @@ public class EngineClusterDaoImpl extends GenericDaoBase<EngineClusterVO, Long> 
 
         int rows = update(vo, sc);
 
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             EngineClusterVO dbCluster = findByIdIncludingRemoved(vo.getId());
             if (dbCluster != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -301,7 +299,7 @@ public class EngineClusterDaoImpl extends GenericDaoBase<EngineClusterVO, Long> 
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update dataCenter: id=" + vo.getId() + ", as there is no such dataCenter exists in the database anymore");
+                logger.debug("Unable to update dataCenter: id=" + vo.getId() + ", as there is no such dataCenter exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/schema/src/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -28,7 +28,6 @@ import java.util.Map.Entry;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
@@ -52,7 +51,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {CapacityDao.class})
 public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements CapacityDao {
-    private static final Logger s_logger = Logger.getLogger(CapacityDaoImpl.class);
 
     private static final String ADD_ALLOCATED_SQL = "UPDATE `cloud`.`op_host_capacity` SET used_capacity = used_capacity + ? WHERE host_id = ? AND capacity_type = ?";
     private static final String SUBTRACT_ALLOCATED_SQL =
@@ -523,7 +521,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Exception updating capacity for host: " + hostId, e);
+            logger.warn("Exception updating capacity for host: " + hostId, e);
         }
     }
 
@@ -988,7 +986,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             }
             pstmt.executeUpdate();
         } catch (Exception e) {
-            s_logger.warn("Error updating CapacityVO", e);
+            logger.warn("Error updating CapacityVO", e);
         }
     }
 
@@ -1008,7 +1006,7 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
                 return rs.getFloat(1);
             }
         } catch (Exception e) {
-            s_logger.warn("Error checking cluster threshold", e);
+            logger.warn("Error checking cluster threshold", e);
         }
         return 0;
     }

--- a/engine/schema/src/com/cloud/certificate/dao/CertificateDaoImpl.java
+++ b/engine/schema/src/com/cloud/certificate/dao/CertificateDaoImpl.java
@@ -18,7 +18,6 @@ package com.cloud.certificate.dao;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.certificate.CertificateVO;
@@ -30,7 +29,6 @@ import com.cloud.utils.db.GenericDaoBase;
 @DB
 public class CertificateDaoImpl extends GenericDaoBase<CertificateVO, Long> implements CertificateDao {
 
-    private static final Logger s_logger = Logger.getLogger(CertificateDaoImpl.class);
 
     public CertificateDaoImpl() {
 
@@ -44,7 +42,7 @@ public class CertificateDaoImpl extends GenericDaoBase<CertificateVO, Long> impl
             update(cert.getId(), cert);
             return cert.getId();
         } catch (Exception e) {
-            s_logger.warn("Unable to read the certificate: " + e);
+            logger.warn("Unable to read the certificate: " + e);
             return new Long(0);
         }
     }

--- a/engine/schema/src/com/cloud/cluster/agentlb/dao/HostTransferMapDaoImpl.java
+++ b/engine/schema/src/com/cloud/cluster/agentlb/dao/HostTransferMapDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.cluster.agentlb.HostTransferMapVO;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Local(value = {HostTransferMapDao.class})
 @DB
 public class HostTransferMapDaoImpl extends GenericDaoBase<HostTransferMapVO, Long> implements HostTransferMapDao {
-    private static final Logger s_logger = Logger.getLogger(HostTransferMapDaoImpl.class);
 
     protected SearchBuilder<HostTransferMapVO> AllFieldsSearch;
     protected SearchBuilder<HostTransferMapVO> IntermediateStateSearch;

--- a/engine/schema/src/com/cloud/dc/dao/DataCenterDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/DataCenterDaoImpl.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 import javax.persistence.TableGenerator;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.DataCenterDetailVO;
@@ -58,7 +57,6 @@ import com.cloud.utils.net.NetUtils;
 @Component
 @Local(value = {DataCenterDao.class})
 public class DataCenterDaoImpl extends GenericDaoBase<DataCenterVO, Long> implements DataCenterDao {
-    private static final Logger s_logger = Logger.getLogger(DataCenterDaoImpl.class);
 
     protected SearchBuilder<DataCenterVO> NameSearch;
     protected SearchBuilder<DataCenterVO> ListZonesByDomainIdSearch;
@@ -412,7 +410,7 @@ public class DataCenterDaoImpl extends GenericDaoBase<DataCenterVO, Long> implem
                     Long dcId = Long.parseLong(tokenOrIdOrName);
                     return findById(dcId);
                 } catch (NumberFormatException nfe) {
-                    s_logger.debug("Cannot parse " + tokenOrIdOrName + " into long. " + nfe);
+                    logger.debug("Cannot parse " + tokenOrIdOrName + " into long. " + nfe);
                 }
             }
         }

--- a/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.DataCenterIpAddressVO;
@@ -41,7 +40,6 @@ import com.cloud.utils.net.NetUtils;
 @Local(value = {DataCenterIpAddressDao.class})
 @DB
 public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddressVO, Long> implements DataCenterIpAddressDao {
-    private static final Logger s_logger = Logger.getLogger(DataCenterIpAddressDaoImpl.class);
 
     private final SearchBuilder<DataCenterIpAddressVO> AllFieldsSearch;
     private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllIpCount;
@@ -144,8 +142,8 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
 
     @Override
     public void releaseIpAddress(String ipAddress, long dcId, Long instanceId) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing ip address: " + ipAddress + " data center " + dcId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing ip address: " + ipAddress + " data center " + dcId);
         }
         SearchCriteria<DataCenterIpAddressVO> sc = AllFieldsSearch.create();
         sc.setParameters("ip", ipAddress);
@@ -162,8 +160,8 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
 
     @Override
     public void releaseIpAddress(long nicId, String reservationId) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing ip address for reservationId=" + reservationId + ", instance=" + nicId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing ip address for reservationId=" + reservationId + ", instance=" + nicId);
         }
         SearchCriteria<DataCenterIpAddressVO> sc = AllFieldsSearch.create();
         sc.setParameters("instance", nicId);
@@ -178,8 +176,8 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
 
     @Override
     public void releaseIpAddress(long nicId) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing ip address for instance=" + nicId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing ip address for instance=" + nicId);
         }
         SearchCriteria<DataCenterIpAddressVO> sc = AllFieldsSearch.create();
         sc.setParameters("instance", nicId);

--- a/engine/schema/src/com/cloud/dc/dao/DataCenterLinkLocalIpAddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/DataCenterLinkLocalIpAddressDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.DataCenterLinkLocalIpAddressVO;
@@ -43,7 +42,6 @@ import com.cloud.utils.net.NetUtils;
 @Local(value = {DataCenterLinkLocalIpAddressDaoImpl.class})
 @DB
 public class DataCenterLinkLocalIpAddressDaoImpl extends GenericDaoBase<DataCenterLinkLocalIpAddressVO, Long> implements DataCenterLinkLocalIpAddressDao {
-    private static final Logger s_logger = Logger.getLogger(DataCenterLinkLocalIpAddressDaoImpl.class);
 
     private final SearchBuilder<DataCenterLinkLocalIpAddressVO> AllFieldsSearch;
     private final GenericSearchBuilder<DataCenterLinkLocalIpAddressVO, Integer> AllIpCount;
@@ -107,8 +105,8 @@ public class DataCenterLinkLocalIpAddressDaoImpl extends GenericDaoBase<DataCent
 
     @Override
     public void releaseIpAddress(String ipAddress, long dcId, long instanceId) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing ip address: " + ipAddress + " data center " + dcId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing ip address: " + ipAddress + " data center " + dcId);
         }
         SearchCriteria<DataCenterLinkLocalIpAddressVO> sc = AllFieldsSearch.create();
         sc.setParameters("ip", ipAddress);

--- a/engine/schema/src/com/cloud/dc/dao/HostPodDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/HostPodDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.HostPodVO;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {HostPodDao.class})
 public class HostPodDaoImpl extends GenericDaoBase<HostPodVO, Long> implements HostPodDao {
-    private static final Logger s_logger = Logger.getLogger(HostPodDaoImpl.class);
 
     protected SearchBuilder<HostPodVO> DataCenterAndNameSearch;
     protected SearchBuilder<HostPodVO> DataCenterIdSearch;
@@ -102,7 +100,7 @@ public class HostPodDaoImpl extends GenericDaoBase<HostPodVO, Long> implements H
                 currentPodCidrSubnets.put(podId, cidrPair);
             }
         } catch (SQLException ex) {
-            s_logger.warn("DB exception " + ex.getMessage(), ex);
+            logger.warn("DB exception " + ex.getMessage(), ex);
             return null;
         }
 

--- a/engine/schema/src/com/cloud/domain/dao/DomainDaoImpl.java
+++ b/engine/schema/src/com/cloud/domain/dao/DomainDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.domain.Domain;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {DomainDao.class})
 public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements DomainDao {
-    private static final Logger s_logger = Logger.getLogger(DomainDaoImpl.class);
 
     protected SearchBuilder<DomainVO> DomainNameLikeSearch;
     protected SearchBuilder<DomainVO> ParentDomainNameLikeSearch;
@@ -112,7 +110,7 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
 
         DomainVO parentDomain = findById(parent);
         if (parentDomain == null) {
-            s_logger.error("Unable to load parent domain: " + parent);
+            logger.error("Unable to load parent domain: " + parent);
             return null;
         }
 
@@ -122,7 +120,7 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
 
             parentDomain = this.lockRow(parent, true);
             if (parentDomain == null) {
-                s_logger.error("Unable to lock parent domain: " + parent);
+                logger.error("Unable to lock parent domain: " + parent);
                 return null;
             }
 
@@ -137,7 +135,7 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
             txn.commit();
             return domain;
         } catch (Exception e) {
-            s_logger.error("Unable to create domain due to " + e.getMessage(), e);
+            logger.error("Unable to create domain due to " + e.getMessage(), e);
             txn.rollback();
             return null;
         }
@@ -148,23 +146,23 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
     public boolean remove(Long id) {
         // check for any active users / domains assigned to the given domain id and don't remove the domain if there are any
         if (id != null && id.longValue() == Domain.ROOT_DOMAIN) {
-            s_logger.error("Can not remove domain " + id + " as it is ROOT domain");
+            logger.error("Can not remove domain " + id + " as it is ROOT domain");
             return false;
         } else {
             if(id == null) {
-                s_logger.error("Can not remove domain without id.");
+                logger.error("Can not remove domain without id.");
                 return false;
             }
         }
 
         DomainVO domain = findById(id);
         if (domain == null) {
-            s_logger.info("Unable to remove domain as domain " + id + " no longer exists");
+            logger.info("Unable to remove domain as domain " + id + " no longer exists");
             return true;
         }
 
         if (domain.getParent() == null) {
-            s_logger.error("Invalid domain " + id + ", orphan?");
+            logger.error("Invalid domain " + id + ", orphan?");
             return false;
         }
 
@@ -177,7 +175,7 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
             txn.start();
             DomainVO parentDomain = super.lockRow(domain.getParent(), true);
             if (parentDomain == null) {
-                s_logger.error("Unable to load parent domain: " + domain.getParent());
+                logger.error("Unable to load parent domain: " + domain.getParent());
                 return false;
             }
 
@@ -198,7 +196,7 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
             txn.commit();
         } catch (SQLException ex) {
             success = false;
-            s_logger.error("error removing domain: " + id, ex);
+            logger.error("error removing domain: " + id, ex);
             txn.rollback();
         }
         return success;

--- a/engine/schema/src/com/cloud/event/dao/EventDaoImpl.java
+++ b/engine/schema/src/com/cloud/event/dao/EventDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.event.Event.State;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {EventDao.class})
 public class EventDaoImpl extends GenericDaoBase<EventVO, Long> implements EventDao {
-    public static final Logger s_logger = Logger.getLogger(EventDaoImpl.class.getName());
     protected final SearchBuilder<EventVO> CompletedEventSearch;
     protected final SearchBuilder<EventVO> ToArchiveOrDeleteEventSearch;
 

--- a/engine/schema/src/com/cloud/event/dao/UsageEventDaoImpl.java
+++ b/engine/schema/src/com/cloud/event/dao/UsageEventDaoImpl.java
@@ -26,7 +26,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.Vlan;
@@ -44,7 +43,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {UsageEventDao.class})
 public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implements UsageEventDao {
-    public static final Logger s_logger = Logger.getLogger(UsageEventDaoImpl.class.getName());
 
     private final SearchBuilder<UsageEventVO> latestEventsSearch;
     private final SearchBuilder<UsageEventVO> IpeventsSearch;
@@ -103,8 +101,8 @@ public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implem
         // Copy events from cloud db to usage db
         String sql = COPY_EVENTS;
         if (recentEventId == 0) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("no recent event date, copying all events");
+            if (logger.isDebugEnabled()) {
+                logger.debug("no recent event date, copying all events");
             }
             sql = COPY_ALL_EVENTS;
         }
@@ -122,7 +120,7 @@ public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implem
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error copying events from cloud db to usage db", ex);
+            logger.error("error copying events from cloud db to usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         } finally {
             txn.close();
@@ -131,8 +129,8 @@ public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implem
         // Copy event details from cloud db to usage db
         sql = COPY_EVENT_DETAILS;
         if (recentEventId == 0) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("no recent event date, copying all event detailss");
+            if (logger.isDebugEnabled()) {
+                logger.debug("no recent event date, copying all event detailss");
             }
             sql = COPY_ALL_EVENT_DETAILS;
         }
@@ -150,7 +148,7 @@ public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implem
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error copying event details from cloud db to usage db", ex);
+            logger.error("error copying event details from cloud db to usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         } finally {
             txn.close();
@@ -173,7 +171,7 @@ public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implem
             }
             return 0;
         } catch (Exception ex) {
-            s_logger.error("error getting most recent event id", ex);
+            logger.error("error getting most recent event id", ex);
             throw new CloudRuntimeException(ex.getMessage());
         } finally {
             txn.close();
@@ -185,7 +183,7 @@ public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implem
         try {
             return listLatestEvents(endDate);
         } catch (Exception ex) {
-            s_logger.error("error getting most recent event date", ex);
+            logger.error("error getting most recent event date", ex);
             throw new CloudRuntimeException(ex.getMessage());
         } finally {
             txn.close();
@@ -205,7 +203,7 @@ public class UsageEventDaoImpl extends GenericDaoBase<UsageEventVO, Long> implem
             }
             return 0;
         } catch (Exception ex) {
-            s_logger.error("error getting max event id", ex);
+            logger.error("error getting max event id", ex);
             throw new CloudRuntimeException(ex.getMessage());
         } finally {
             txn.close();

--- a/engine/schema/src/com/cloud/event/dao/UsageEventDetailsDaoImpl.java
+++ b/engine/schema/src/com/cloud/event/dao/UsageEventDetailsDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.event.UsageEventDetailsVO;
@@ -33,7 +32,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageEventDetailsDao.class})
 public class UsageEventDetailsDaoImpl extends GenericDaoBase<UsageEventDetailsVO, Long> implements UsageEventDetailsDao {
-    public static final Logger s_logger = Logger.getLogger(UsageEventDetailsDaoImpl.class.getName());
 
     protected final SearchBuilder<UsageEventDetailsVO> EventDetailsSearch;
     protected final SearchBuilder<UsageEventDetailsVO> DetailSearch;

--- a/engine/schema/src/com/cloud/gpu/dao/HostGpuGroupsDaoImpl.java
+++ b/engine/schema/src/com/cloud/gpu/dao/HostGpuGroupsDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.gpu.HostGpuGroupsVO;
@@ -32,7 +31,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = HostGpuGroupsDao.class)
 public class HostGpuGroupsDaoImpl extends GenericDaoBase<HostGpuGroupsVO, Long> implements HostGpuGroupsDao {
-    private static final Logger s_logger = Logger.getLogger(HostGpuGroupsDaoImpl.class);
 
     private final SearchBuilder<HostGpuGroupsVO> _hostIdGroupNameSearch;
     private final SearchBuilder<HostGpuGroupsVO> _searchByHostId;

--- a/engine/schema/src/com/cloud/gpu/dao/VGPUTypesDaoImpl.java
+++ b/engine/schema/src/com/cloud/gpu/dao/VGPUTypesDaoImpl.java
@@ -28,7 +28,6 @@ import java.util.Map.Entry;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.VgpuTypesInfo;
@@ -43,7 +42,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = VGPUTypesDao.class)
 public class VGPUTypesDaoImpl extends GenericDaoBase<VGPUTypesVO, Long> implements VGPUTypesDao {
-    private static final Logger s_logger = Logger.getLogger(VGPUTypesDaoImpl.class);
 
     private final SearchBuilder<VGPUTypesVO> _searchByGroupId;
     private final SearchBuilder<VGPUTypesVO> _searchByGroupIdVGPUType;

--- a/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
@@ -31,7 +31,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.persistence.TableGenerator;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.VgpuTypesInfo;
@@ -71,9 +70,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @DB
 @TableGenerator(name = "host_req_sq", table = "op_host", pkColumnName = "id", valueColumnName = "sequence", allocationSize = 1)
 public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao { //FIXME: , ExternalIdDao {
-    private static final Logger s_logger = Logger.getLogger(HostDaoImpl.class);
-    private static final Logger status_logger = Logger.getLogger(Status.class);
-    private static final Logger state_logger = Logger.getLogger(ResourceState.class);
 
     protected SearchBuilder<HostVO> TypePodDcStatusSearch;
 
@@ -289,7 +285,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         try {
             HostTransferSearch = _hostTransferDao.createSearchBuilder();
         } catch (Throwable e) {
-            s_logger.debug("error", e);
+            logger.debug("error", e);
         }
         HostTransferSearch.and("id", HostTransferSearch.entity().getId(), SearchCriteria.Op.NULL);
         UnmanagedDirectConnectSearch.join("hostTransferSearch", HostTransferSearch, HostTransferSearch.entity().getId(), UnmanagedDirectConnectSearch.entity().getId(),
@@ -445,8 +441,8 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             sb.append(" ");
         }
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Following hosts got reset: " + sb.toString());
+        if (logger.isTraceEnabled()) {
+            logger.trace("Following hosts got reset: " + sb.toString());
         }
     }
 
@@ -505,19 +501,19 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         TransactionLegacy txn = TransactionLegacy.currentTxn();
 
         txn.start();
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Resetting hosts suitable for reconnect");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Resetting hosts suitable for reconnect");
         }
         // reset hosts that are suitable candidates for reconnect
         resetHosts(managementServerId, lastPingSecondsAfter);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Completed resetting hosts suitable for reconnect");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Completed resetting hosts suitable for reconnect");
         }
 
         List<HostVO> assignedHosts = new ArrayList<HostVO>();
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Acquiring hosts for clusters already owned by this management server");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Acquiring hosts for clusters already owned by this management server");
         }
         List<Long> clusters = findClustersOwnedByManagementServer(managementServerId);
         if (clusters.size() > 0) {
@@ -535,17 +531,17 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
                 sb.append(host.getId());
                 sb.append(" ");
             }
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("Following hosts got acquired for clusters already owned: " + sb.toString());
+            if (logger.isTraceEnabled()) {
+                logger.trace("Following hosts got acquired for clusters already owned: " + sb.toString());
             }
         }
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Completed acquiring hosts for clusters already owned by this management server");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Completed acquiring hosts for clusters already owned by this management server");
         }
 
         if (assignedHosts.size() < limit) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Acquiring hosts for clusters not owned by any management server");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Acquiring hosts for clusters not owned by any management server");
             }
             // for remaining hosts not owned by any MS check if they can be owned (by owning full cluster)
             clusters = findClustersForHostsNotOwnedByAnyManagementServer();
@@ -585,12 +581,12 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
                         break;
                     }
                 }
-                if (s_logger.isTraceEnabled()) {
-                    s_logger.trace("Following hosts got acquired from newly owned clusters: " + sb.toString());
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Following hosts got acquired from newly owned clusters: " + sb.toString());
                 }
             }
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Completed acquiring hosts for clusters not owned by any management server");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Completed acquiring hosts for clusters not owned by any management server");
             }
         }
         txn.commit();
@@ -754,7 +750,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
                 }
             }
         } catch (SQLException e) {
-            s_logger.warn("Exception: ", e);
+            logger.warn("Exception: ", e);
         }
         return result;
     }
@@ -865,15 +861,15 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
                 l.add(info);
             }
         } catch (SQLException e) {
-            s_logger.debug("SQLException caught", e);
+            logger.debug("SQLException caught", e);
         }
         return l;
     }
 
     @Override
     public long getNextSequence(long hostId) {
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("getNextSequence(), hostId: " + hostId);
+        if (logger.isTraceEnabled()) {
+            logger.trace("getNextSequence(), hostId: " + hostId);
         }
 
         TableGenerator tg = _tgs.get("host_req_sq");
@@ -953,7 +949,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             HostVO ho = findById(host.getId());
             assert ho != null : "How how how? : " + host.getId();
 
-            if (status_logger.isDebugEnabled()) {
+            if (logger.isDebugEnabled()) {
 
                 StringBuilder str = new StringBuilder("Unable to update host for event:").append(event.toString());
                 str.append(". Name=").append(host.getName());
@@ -975,7 +971,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
                         .append(":old update count=")
                         .append(oldUpdateCount)
                         .append("]");
-                status_logger.debug(str.toString());
+                logger.debug(str.toString());
             } else {
                 StringBuilder msg = new StringBuilder("Agent status update: [");
                 msg.append("id = " + host.getId());
@@ -985,11 +981,11 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
                 msg.append("; new status = " + newStatus);
                 msg.append("; old update count = " + oldUpdateCount);
                 msg.append("; new update count = " + newUpdateCount + "]");
-                status_logger.debug(msg.toString());
+                logger.debug(msg.toString());
             }
 
             if (ho.getState() == newStatus) {
-                status_logger.debug("Host " + ho.getName() + " state has already been updated to " + newStatus);
+                logger.debug("Host " + ho.getName() + " state has already been updated to " + newStatus);
                 return true;
             }
         }
@@ -1015,7 +1011,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         int result = update(ub, sc, null);
         assert result <= 1 : "How can this update " + result + " rows? ";
 
-        if (state_logger.isDebugEnabled() && result == 0) {
+        if (logger.isDebugEnabled() && result == 0) {
             HostVO ho = findById(host.getId());
             assert ho != null : "How how how? : " + host.getId();
 
@@ -1025,7 +1021,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             str.append("; old state = " + oldState);
             str.append("; event = " + event);
             str.append("; new state = " + newState + "]");
-            state_logger.debug(str.toString());
+            logger.debug(str.toString());
         } else {
             StringBuilder msg = new StringBuilder("Resource state update: [");
             msg.append("id = " + host.getId());
@@ -1033,7 +1029,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             msg.append("; old state = " + oldState);
             msg.append("; event = " + event);
             msg.append("; new state = " + newState + "]");
-            state_logger.debug(msg.toString());
+            logger.debug(msg.toString());
         }
 
         return result > 0;

--- a/engine/schema/src/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
+++ b/engine/schema/src/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
@@ -33,7 +32,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Local(value = HypervisorCapabilitiesDao.class)
 public class HypervisorCapabilitiesDaoImpl extends GenericDaoBase<HypervisorCapabilitiesVO, Long> implements HypervisorCapabilitiesDao {
 
-    private static final Logger s_logger = Logger.getLogger(HypervisorCapabilitiesDaoImpl.class);
 
     protected final SearchBuilder<HypervisorCapabilitiesVO> HypervisorTypeSearch;
     protected final SearchBuilder<HypervisorCapabilitiesVO> HypervisorTypeAndVersionSearch;

--- a/engine/schema/src/com/cloud/network/dao/FirewallRulesCidrsDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/FirewallRulesCidrsDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.DB;
@@ -33,7 +32,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = FirewallRulesCidrsDao.class)
 public class FirewallRulesCidrsDaoImpl extends GenericDaoBase<FirewallRulesCidrsVO, Long> implements FirewallRulesCidrsDao {
-    private static final Logger s_logger = Logger.getLogger(FirewallRulesCidrsDaoImpl.class);
     protected final SearchBuilder<FirewallRulesCidrsVO> CidrsSearch;
 
     protected FirewallRulesCidrsDaoImpl() {

--- a/engine/schema/src/com/cloud/network/dao/IPAddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/IPAddressDaoImpl.java
@@ -26,7 +26,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.resourcedetail.dao.UserIpAddressDetailsDao;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.Vlan.VlanType;
@@ -50,7 +49,6 @@ import com.cloud.utils.net.Ip;
 @Local(value = {IPAddressDao.class})
 @DB
 public class IPAddressDaoImpl extends GenericDaoBase<IPAddressVO, Long> implements IPAddressDao {
-    private static final Logger s_logger = Logger.getLogger(IPAddressDaoImpl.class);
 
     protected SearchBuilder<IPAddressVO> AllFieldsSearch;
     protected SearchBuilder<IPAddressVO> VlanDbIdSearchUnallocated;
@@ -322,7 +320,7 @@ public class IPAddressDaoImpl extends GenericDaoBase<IPAddressVO, Long> implemen
                 ipCount = rs.getInt(1);
             }
         } catch (Exception e) {
-            s_logger.warn("Exception counting IP addresses", e);
+            logger.warn("Exception counting IP addresses", e);
         }
 
         return ipCount;

--- a/engine/schema/src/com/cloud/network/dao/PortProfileDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/PortProfileDaoImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.DB;
@@ -38,7 +37,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Local(value = PortProfileDao.class)
 @DB()
 public class PortProfileDaoImpl extends GenericDaoBase<PortProfileVO, Long> implements PortProfileDao {
-    protected static final Logger s_logger = Logger.getLogger(PortProfileDaoImpl.class);
 
     final SearchBuilder<PortProfileVO> nameSearch;
     final SearchBuilder<PortProfileVO> accessVlanSearch;

--- a/engine/schema/src/com/cloud/network/dao/RemoteAccessVpnDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/RemoteAccessVpnDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.network.RemoteAccessVpn;
@@ -31,7 +30,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {RemoteAccessVpnDao.class})
 public class RemoteAccessVpnDaoImpl extends GenericDaoBase<RemoteAccessVpnVO, Long> implements RemoteAccessVpnDao {
-    private static final Logger s_logger = Logger.getLogger(RemoteAccessVpnDaoImpl.class);
 
     private final SearchBuilder<RemoteAccessVpnVO> AllFieldsSearch;
 

--- a/engine/schema/src/com/cloud/network/dao/Site2SiteVpnConnectionDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/Site2SiteVpnConnectionDaoImpl.java
@@ -22,7 +22,6 @@ import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.GenericDaoBase;
@@ -33,7 +32,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {Site2SiteVpnConnectionDao.class})
 public class Site2SiteVpnConnectionDaoImpl extends GenericDaoBase<Site2SiteVpnConnectionVO, Long> implements Site2SiteVpnConnectionDao {
-    private static final Logger s_logger = Logger.getLogger(Site2SiteVpnConnectionDaoImpl.class);
 
     @Inject
     protected IPAddressDao _addrDao;

--- a/engine/schema/src/com/cloud/network/dao/Site2SiteVpnGatewayDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/Site2SiteVpnGatewayDaoImpl.java
@@ -19,7 +19,6 @@ package com.cloud.network.dao;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.GenericDaoBase;
@@ -32,7 +31,6 @@ public class Site2SiteVpnGatewayDaoImpl extends GenericDaoBase<Site2SiteVpnGatew
     @Inject
     protected IPAddressDao _addrDao;
 
-    private static final Logger s_logger = Logger.getLogger(Site2SiteVpnGatewayDaoImpl.class);
 
     private final SearchBuilder<Site2SiteVpnGatewayVO> AllFieldsSearch;
 

--- a/engine/schema/src/com/cloud/network/dao/UserIpv6AddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/UserIpv6AddressDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.network.UserIpv6AddressVO;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.SearchCriteria.Op;
 @Component
 @Local(value = UserIpv6AddressDao.class)
 public class UserIpv6AddressDaoImpl extends GenericDaoBase<UserIpv6AddressVO, Long> implements UserIpv6AddressDao {
-    private static final Logger s_logger = Logger.getLogger(IPAddressDaoImpl.class);
 
     protected final SearchBuilder<UserIpv6AddressVO> AllFieldsSearch;
     protected GenericSearchBuilder<UserIpv6AddressVO, Long> CountFreePublicIps;

--- a/engine/schema/src/com/cloud/network/security/dao/VmRulesetLogDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/security/dao/VmRulesetLogDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.network.security.VmRulesetLogVO;
@@ -39,7 +38,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {VmRulesetLogDao.class})
 public class VmRulesetLogDaoImpl extends GenericDaoBase<VmRulesetLogVO, Long> implements VmRulesetLogDao {
-    protected static final Logger s_logger = Logger.getLogger(VmRulesetLogDaoImpl.class);
     private SearchBuilder<VmRulesetLogVO> VmIdSearch;
     private String InsertOrUpdateSQl = "INSERT INTO op_vm_ruleset_log (instance_id, created, logsequence) "
         + " VALUES(?, now(), 1) ON DUPLICATE KEY UPDATE logsequence=logsequence+1";
@@ -100,19 +98,19 @@ public class VmRulesetLogDaoImpl extends GenericDaoBase<VmRulesetLogVO, Long> im
             } catch (SQLTransactionRollbackException e1) {
                 if (i < maxTries - 1) {
                     int delayMs = (i + 1) * 1000;
-                    s_logger.debug("Caught a deadlock exception while inserting security group rule log, retrying in " + delayMs);
+                    logger.debug("Caught a deadlock exception while inserting security group rule log, retrying in " + delayMs);
                     try {
                         Thread.sleep(delayMs);
                     } catch (InterruptedException ie) {
-                        s_logger.debug("[ignored] interupted while inserting security group rule log.");
+                        logger.debug("[ignored] interupted while inserting security group rule logger.");
                     }
                 } else
-                    s_logger.warn("Caught another deadlock exception while retrying inserting security group rule log, giving up");
+                    logger.warn("Caught another deadlock exception while retrying inserting security group rule log, giving up");
 
             }
         }
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Inserted or updated " + numUpdated + " rows");
+        if (logger.isTraceEnabled()) {
+            logger.trace("Inserted or updated " + numUpdated + " rows");
         }
         return numUpdated;
     }
@@ -136,8 +134,8 @@ public class VmRulesetLogDaoImpl extends GenericDaoBase<VmRulesetLogVO, Long> im
                             vmIds.add(vmId);
                         }
                         int numUpdated = executeWithRetryOnDeadlock(txn, pstmt, vmIds);
-                        if (s_logger.isTraceEnabled()) {
-                            s_logger.trace("Inserted or updated " + numUpdated + " rows");
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Inserted or updated " + numUpdated + " rows");
                         }
                         if (numUpdated > 0)
                             count += stmtSize;
@@ -147,7 +145,7 @@ public class VmRulesetLogDaoImpl extends GenericDaoBase<VmRulesetLogVO, Long> im
 
             }
         } catch (SQLException sqe) {
-            s_logger.warn("Failed to execute multi insert ", sqe);
+            logger.warn("Failed to execute multi insert ", sqe);
         }
 
         return count;
@@ -175,10 +173,10 @@ public class VmRulesetLogDaoImpl extends GenericDaoBase<VmRulesetLogVO, Long> im
             queryResult = stmtInsert.executeBatch();
 
             txn.commit();
-            if (s_logger.isTraceEnabled())
-                s_logger.trace("Updated or inserted " + workItems.size() + " log items");
+            if (logger.isTraceEnabled())
+                logger.trace("Updated or inserted " + workItems.size() + " log items");
         } catch (SQLException e) {
-            s_logger.warn("Failed to execute batch update statement for ruleset log: ", e);
+            logger.warn("Failed to execute batch update statement for ruleset log: ", e);
             txn.rollback();
             success = false;
         }
@@ -187,7 +185,7 @@ public class VmRulesetLogDaoImpl extends GenericDaoBase<VmRulesetLogVO, Long> im
             workItems.toArray(arrayItems);
             for (int i = 0; i < queryResult.length; i++) {
                 if (queryResult[i] < 0) {
-                    s_logger.debug("Batch query update failed for vm " + arrayItems[i]);
+                    logger.debug("Batch query update failed for vm " + arrayItems[i]);
                 }
             }
         }

--- a/engine/schema/src/com/cloud/network/vpc/dao/NetworkACLItemCidrsDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/vpc/dao/NetworkACLItemCidrsDaoImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.network.vpc.NetworkACLItemCidrsDao;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = NetworkACLItemCidrsDao.class)
 public class NetworkACLItemCidrsDaoImpl extends GenericDaoBase<NetworkACLItemCidrsVO, Long> implements NetworkACLItemCidrsDao {
-    private static final Logger s_logger = Logger.getLogger(NetworkACLItemCidrsDaoImpl.class);
     protected final SearchBuilder<NetworkACLItemCidrsVO> cidrsSearch;
 
     protected NetworkACLItemCidrsDaoImpl() {

--- a/engine/schema/src/com/cloud/network/vpc/dao/NetworkACLItemDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/vpc/dao/NetworkACLItemDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.network.vpc.NetworkACLItem.State;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Local(value = NetworkACLItemDao.class)
 @DB()
 public class NetworkACLItemDaoImpl extends GenericDaoBase<NetworkACLItemVO, Long> implements NetworkACLItemDao {
-    private static final Logger s_logger = Logger.getLogger(NetworkACLItemDaoImpl.class);
 
     protected final SearchBuilder<NetworkACLItemVO> AllFieldsSearch;
     protected final SearchBuilder<NetworkACLItemVO> NotRevokedSearch;

--- a/engine/schema/src/com/cloud/network/vpc/dao/PrivateIpDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/vpc/dao/PrivateIpDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.network.vpc.PrivateIpVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Local(value = PrivateIpDao.class)
 @DB()
 public class PrivateIpDaoImpl extends GenericDaoBase<PrivateIpVO, Long> implements PrivateIpDao {
-    private static final Logger s_logger = Logger.getLogger(PrivateIpDaoImpl.class);
 
     private final SearchBuilder<PrivateIpVO> AllFieldsSearch;
     private final GenericSearchBuilder<PrivateIpVO, Integer> CountAllocatedByNetworkId;
@@ -92,8 +90,8 @@ public class PrivateIpDaoImpl extends GenericDaoBase<PrivateIpVO, Long> implemen
 
     @Override
     public void releaseIpAddress(String ipAddress, long networkId) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing private ip address: " + ipAddress + " network id " + networkId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing private ip address: " + ipAddress + " network id " + networkId);
         }
         SearchCriteria<PrivateIpVO> sc = AllFieldsSearch.create();
         sc.setParameters("ip", ipAddress);

--- a/engine/schema/src/com/cloud/projects/dao/ProjectAccountDaoImpl.java
+++ b/engine/schema/src/com/cloud/projects/dao/ProjectAccountDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.projects.ProjectAccount;
@@ -39,7 +38,6 @@ public class ProjectAccountDaoImpl extends GenericDaoBase<ProjectAccountVO, Long
     final GenericSearchBuilder<ProjectAccountVO, Long> AdminSearch;
     final GenericSearchBuilder<ProjectAccountVO, Long> ProjectAccountSearch;
     final GenericSearchBuilder<ProjectAccountVO, Long> CountByRoleSearch;
-    public static final Logger s_logger = Logger.getLogger(ProjectAccountDaoImpl.class.getName());
 
     protected ProjectAccountDaoImpl() {
         AllFieldsSearch = createSearchBuilder();
@@ -150,7 +148,7 @@ public class ProjectAccountDaoImpl extends GenericDaoBase<ProjectAccountVO, Long
 
         int rowsRemoved = remove(sc);
         if (rowsRemoved > 0) {
-            s_logger.debug("Removed account id=" + accountId + " from " + rowsRemoved + " projects");
+            logger.debug("Removed account id=" + accountId + " from " + rowsRemoved + " projects");
         }
     }
 

--- a/engine/schema/src/com/cloud/projects/dao/ProjectDaoImpl.java
+++ b/engine/schema/src/com/cloud/projects/dao/ProjectDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.projects.Project;
@@ -39,7 +38,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {ProjectDao.class})
 public class ProjectDaoImpl extends GenericDaoBase<ProjectVO, Long> implements ProjectDao {
-    private static final Logger s_logger = Logger.getLogger(ProjectDaoImpl.class);
     protected final SearchBuilder<ProjectVO> AllFieldsSearch;
     protected GenericSearchBuilder<ProjectVO, Long> CountByDomain;
     protected GenericSearchBuilder<ProjectVO, Long> ProjectAccountSearch;
@@ -79,7 +77,7 @@ public class ProjectDaoImpl extends GenericDaoBase<ProjectVO, Long> implements P
         ProjectVO projectToRemove = findById(projectId);
         projectToRemove.setName(null);
         if (!update(projectId, projectToRemove)) {
-            s_logger.warn("Failed to reset name for the project id=" + projectId + " as a part of project remove");
+            logger.warn("Failed to reset name for the project id=" + projectId + " as a part of project remove");
             return false;
         }
 

--- a/engine/schema/src/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
+++ b/engine/schema/src/com/cloud/projects/dao/ProjectInvitationDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.projects.ProjectInvitation.State;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {ProjectInvitationDao.class})
 public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO, Long> implements ProjectInvitationDao {
-    private static final Logger s_logger = Logger.getLogger(ProjectInvitationDaoImpl.class);
     protected final SearchBuilder<ProjectInvitationVO> AllFieldsSearch;
     protected final SearchBuilder<ProjectInvitationVO> InactiveSearch;
 
@@ -91,7 +89,7 @@ public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO
         for (ProjectInvitationVO invitationToExpire : invitationsToExpire) {
             invitationToExpire.setState(State.Expired);
             if (!update(invitationToExpire.getId(), invitationToExpire)) {
-                s_logger.warn("Fail to expire invitation " + invitationToExpire.toString());
+                logger.warn("Fail to expire invitation " + invitationToExpire.toString());
                 success = false;
             }
         }
@@ -113,7 +111,7 @@ public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO
         sc.setParameters("id", id);
 
         if (findOneBy(sc) == null) {
-            s_logger.warn("Unable to find project invitation by id " + id);
+            logger.warn("Unable to find project invitation by id " + id);
             return false;
         }
 
@@ -165,7 +163,7 @@ public class ProjectInvitationDaoImpl extends GenericDaoBase<ProjectInvitationVO
         sc.setParameters("projectId", projectId);
 
         int numberRemoved = remove(sc);
-        s_logger.debug("Removed " + numberRemoved + " invitations for project id=" + projectId);
+        logger.debug("Removed " + numberRemoved + " invitations for project id=" + projectId);
     }
 
 }

--- a/engine/schema/src/com/cloud/storage/dao/LaunchPermissionDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/LaunchPermissionDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.storage.LaunchPermissionVO;
@@ -41,7 +40,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {LaunchPermissionDao.class})
 public class LaunchPermissionDaoImpl extends GenericDaoBase<LaunchPermissionVO, Long> implements LaunchPermissionDao {
-    private static final Logger s_logger = Logger.getLogger(LaunchPermissionDaoImpl.class);
     private static final String REMOVE_LAUNCH_PERMISSION = "DELETE FROM `cloud`.`launch_permission`" + "  WHERE template_id = ? AND account_id = ?";
 
     private static final String LIST_PERMITTED_TEMPLATES =
@@ -82,7 +80,7 @@ public class LaunchPermissionDaoImpl extends GenericDaoBase<LaunchPermissionVO, 
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error removing launch permissions", e);
+            logger.warn("Error removing launch permissions", e);
             throw new CloudRuntimeException("Error removing launch permissions", e);
         }
     }
@@ -147,7 +145,7 @@ public class LaunchPermissionDaoImpl extends GenericDaoBase<LaunchPermissionVO, 
                 permittedTemplates.add(template);
             }
         } catch (Exception e) {
-            s_logger.warn("Error listing permitted templates", e);
+            logger.warn("Error listing permitted templates", e);
         }
         return permittedTemplates;
     }

--- a/engine/schema/src/com/cloud/storage/dao/SnapshotDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/SnapshotDaoImpl.java
@@ -24,7 +24,6 @@ import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.server.ResourceTag.ResourceObjectType;
@@ -53,7 +52,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Component
 @Local(value = {SnapshotDao.class})
 public class SnapshotDaoImpl extends GenericDaoBase<SnapshotVO, Long> implements SnapshotDao {
-    public static final Logger s_logger = Logger.getLogger(SnapshotDaoImpl.class.getName());
     // TODO: we should remove these direct sqls
     private static final String GET_LAST_SNAPSHOT =
         "SELECT snapshots.id FROM snapshot_store_ref, snapshots where snapshots.id = snapshot_store_ref.snapshot_id AND snapshosts.volume_id = ? AND snapshot_store_ref.role = ? ORDER BY created DESC";
@@ -208,7 +206,7 @@ public class SnapshotDaoImpl extends GenericDaoBase<SnapshotVO, Long> implements
                 return rs.getLong(1);
             }
         } catch (Exception ex) {
-            s_logger.info("[ignored]"
+            logger.info("[ignored]"
                     + "caught something while getting sec. host id: " + ex.getLocalizedMessage());
         }
         return null;
@@ -228,7 +226,7 @@ public class SnapshotDaoImpl extends GenericDaoBase<SnapshotVO, Long> implements
                 return rs.getLong(1);
             }
         } catch (Exception ex) {
-            s_logger.error("error getting last snapshot", ex);
+            logger.error("error getting last snapshot", ex);
         }
         return 0;
     }
@@ -246,7 +244,7 @@ public class SnapshotDaoImpl extends GenericDaoBase<SnapshotVO, Long> implements
             pstmt.executeUpdate();
             return 1;
         } catch (Exception ex) {
-            s_logger.error("error getting last snapshot", ex);
+            logger.error("error getting last snapshot", ex);
         }
         return 0;
     }
@@ -263,7 +261,7 @@ public class SnapshotDaoImpl extends GenericDaoBase<SnapshotVO, Long> implements
             pstmt.executeUpdate();
             return 1;
         } catch (Exception ex) {
-            s_logger.error("error set secondary storage host id", ex);
+            logger.error("error set secondary storage host id", ex);
         }
         return 0;
     }

--- a/engine/schema/src/com/cloud/storage/dao/StoragePoolHostDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/StoragePoolHostDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.host.Status;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {StoragePoolHostDao.class})
 public class StoragePoolHostDaoImpl extends GenericDaoBase<StoragePoolHostVO, Long> implements StoragePoolHostDao {
-    public static final Logger s_logger = Logger.getLogger(StoragePoolHostDaoImpl.class.getName());
 
     protected final SearchBuilder<StoragePoolHostVO> PoolSearch;
     protected final SearchBuilder<StoragePoolHostVO> HostSearch;
@@ -115,10 +113,10 @@ public class StoragePoolHostDaoImpl extends GenericDaoBase<StoragePoolHostVO, Lo
                     result.add(findById(id));
                 }
             }catch (SQLException e) {
-                s_logger.warn("listByHostStatus:Exception: ", e);
+                logger.warn("listByHostStatus:Exception: ", e);
             }
         } catch (Exception e) {
-            s_logger.warn("listByHostStatus:Exception: ", e);
+            logger.warn("listByHostStatus:Exception: ", e);
         }
         return result;
     }
@@ -138,7 +136,7 @@ public class StoragePoolHostDaoImpl extends GenericDaoBase<StoragePoolHostVO, Lo
                 l.add(new Pair<Long, Integer>(rs.getLong(1), rs.getInt(2)));
             }
         } catch (SQLException e) {
-            s_logger.debug("SQLException: ", e);
+            logger.debug("SQLException: ", e);
         }
         return l;
     }

--- a/engine/schema/src/com/cloud/storage/dao/UploadDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/UploadDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.storage.Upload.Mode;
@@ -33,7 +32,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {UploadDao.class})
 public class UploadDaoImpl extends GenericDaoBase<UploadVO, Long> implements UploadDao {
-    public static final Logger s_logger = Logger.getLogger(UploadDaoImpl.class.getName());
     protected final SearchBuilder<UploadVO> typeUploadStatusSearch;
     protected final SearchBuilder<UploadVO> typeHostAndUploadStatusSearch;
     protected final SearchBuilder<UploadVO> typeModeAndStatusSearch;

--- a/engine/schema/src/com/cloud/storage/dao/VMTemplateDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VMTemplateDaoImpl.java
@@ -30,7 +30,6 @@ import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.dao.DataCenterDao;
@@ -65,7 +64,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {VMTemplateDao.class})
 public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implements VMTemplateDao {
-    private static final Logger s_logger = Logger.getLogger(VMTemplateDaoImpl.class);
 
     @Inject
     VMTemplateZoneDao _templateZoneDao;
@@ -234,7 +232,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
                 l.add(rs.getLong(1));
             }
         } catch (SQLException e) {
-            s_logger.debug("Exception: ", e);
+            logger.debug("Exception: ", e);
         }
         return l;
     }
@@ -288,7 +286,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
 
         routerTmpltName = (String)params.get("routing.uniquename");
 
-        s_logger.debug("Found parameter routing unique name " + routerTmpltName);
+        logger.debug("Found parameter routing unique name " + routerTmpltName);
         if (routerTmpltName == null) {
             routerTmpltName = "routing";
         }
@@ -297,8 +295,8 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
         if (consoleProxyTmpltName == null) {
             consoleProxyTmpltName = "routing";
         }
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Use console proxy template : " + consoleProxyTmpltName);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Use console proxy template : " + consoleProxyTmpltName);
         }
 
         UniqueNameSearch = createSearchBuilder();
@@ -512,10 +510,10 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
      * (rs.next()) { Pair<Long, Long> templateZonePair = new Pair<Long,
      * Long>(rs.getLong(1), -1L); templateZonePairList.add(templateZonePair); }
      *
-     * } catch (Exception e) { s_logger.warn("Error listing templates", e); }
+     * } catch (Exception e) { logger.warn("Error listing templates", e); }
      * finally { try { if (rs != null) { rs.close(); } if (pstmt != null) {
      * pstmt.close(); } txn.commit(); } catch (SQLException sqle) {
-     * s_logger.warn("Error in cleaning up", sqle); } }
+     * logger.warn("Error in cleaning up", sqle); } }
      *
      * return templateZonePairList; }
      *
@@ -696,9 +694,9 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
      * null)); continue; } else if (keyword == null && name == null){
      * templateZonePairList.add(new Pair<Long,Long>(publicIsos.get(i).getId(),
      * null)); } } } } } catch (Exception e) {
-     * s_logger.warn("Error listing templates", e); } finally { try { if (rs !=
+     * logger.warn("Error listing templates", e); } finally { try { if (rs !=
      * null) { rs.close(); } if (pstmt != null) { pstmt.close(); } txn.commit();
-     * } catch( SQLException sqle) { s_logger.warn("Error in cleaning up",
+     * } catch( SQLException sqle) { logger.warn("Error in cleaning up",
      * sqle); } }
      *
      * return templateZonePairList; }
@@ -1021,7 +1019,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
      * while (rs.next()) { final Pair<Long, Long> templateZonePair = new
      * Pair<Long, Long>( rs.getLong(1), -1L);
      * templateZonePairList.add(templateZonePair); } txn.commit(); } catch
-     * (Exception e) { s_logger.warn("Error listing S3 templates", e); if (txn
+     * (Exception e) { logger.warn("Error listing S3 templates", e); if (txn
      * != null) { txn.rollback(); } } finally { closeResources(pstmt, rs); if
      * (txn != null) { txn.close(); } }
      *
@@ -1050,7 +1048,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
         builder.set(vo, "updated", new Date());
 
         int rows = update((VMTemplateVO)vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             VMTemplateVO dbTemplate = findByIdIncludingRemoved(vo.getId());
             if (dbTemplate != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -1083,7 +1081,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update template: id=" + vo.getId() + ", as no such template exists in the database anymore");
+                logger.debug("Unable to update template: id=" + vo.getId() + ", as no such template exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/schema/src/com/cloud/storage/dao/VMTemplateHostDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VMTemplateHostDaoImpl.java
@@ -29,7 +29,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObjectInStore;
@@ -53,7 +52,6 @@ import com.cloud.utils.db.UpdateBuilder;
 @Component
 @Local(value = {VMTemplateHostDao.class})
 public class VMTemplateHostDaoImpl extends GenericDaoBase<VMTemplateHostVO, Long> implements VMTemplateHostDao {
-    public static final Logger s_logger = Logger.getLogger(VMTemplateHostDaoImpl.class.getName());
     @Inject
     HostDao _hostDao;
     protected final SearchBuilder<VMTemplateHostVO> HostSearch;
@@ -172,7 +170,7 @@ public class VMTemplateHostDaoImpl extends GenericDaoBase<VMTemplateHostVO, Long
             pstmt.setLong(8, instance.getTemplateId());
             pstmt.executeUpdate();
         } catch (Exception e) {
-            s_logger.warn("Exception: ", e);
+            logger.warn("Exception: ", e);
         }
     }
 
@@ -241,7 +239,7 @@ public class VMTemplateHostDaoImpl extends GenericDaoBase<VMTemplateHostVO, Long
                 result.add(toEntityBean(rs, false));
             }
         } catch (Exception e) {
-            s_logger.warn("Exception: ", e);
+            logger.warn("Exception: ", e);
         }
         return result;
     }
@@ -273,10 +271,10 @@ public class VMTemplateHostDaoImpl extends GenericDaoBase<VMTemplateHostVO, Long
                     result.add(findById(id));
                 }
             }catch (SQLException e) {
-                s_logger.warn("listByTemplateStatus:Exception: "+e.getMessage(), e);
+                logger.warn("listByTemplateStatus:Exception: "+e.getMessage(), e);
             }
         } catch (Exception e) {
-            s_logger.warn("listByTemplateStatus:Exception: "+e.getMessage(), e);
+            logger.warn("listByTemplateStatus:Exception: "+e.getMessage(), e);
         }
         return result;
 
@@ -391,7 +389,7 @@ public class VMTemplateHostDaoImpl extends GenericDaoBase<VMTemplateHostVO, Long
         builder.set(vo, "updated", new Date());
 
         int rows = update((VMTemplateHostVO)vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             VMTemplateHostVO dbVol = findByIdIncludingRemoved(templateHost.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -424,7 +422,7 @@ public class VMTemplateHostDaoImpl extends GenericDaoBase<VMTemplateHostVO, Long
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update objectIndatastore: id=" + templateHost.getId() + ", as there is no such object exists in the database anymore");
+                logger.debug("Unable to update objectIndatastore: id=" + templateHost.getId() + ", as there is no such object exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/schema/src/com/cloud/storage/dao/VMTemplatePoolDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VMTemplatePoolDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObjectInStore;
@@ -44,7 +43,6 @@ import com.cloud.utils.db.UpdateBuilder;
 @Component
 @Local(value = {VMTemplatePoolDao.class})
 public class VMTemplatePoolDaoImpl extends GenericDaoBase<VMTemplateStoragePoolVO, Long> implements VMTemplatePoolDao {
-    public static final Logger s_logger = Logger.getLogger(VMTemplatePoolDaoImpl.class.getName());
 
     protected final SearchBuilder<VMTemplateStoragePoolVO> PoolSearch;
     protected final SearchBuilder<VMTemplateStoragePoolVO> TemplateSearch;
@@ -160,7 +158,7 @@ public class VMTemplatePoolDaoImpl extends GenericDaoBase<VMTemplateStoragePoolV
                 result.add(toEntityBean(rs, false));
             }
         } catch (Exception e) {
-            s_logger.warn("Exception: ", e);
+            logger.warn("Exception: ", e);
         }
         return result;
 
@@ -184,10 +182,10 @@ public class VMTemplatePoolDaoImpl extends GenericDaoBase<VMTemplateStoragePoolV
                     result.add(findById(id));
                 }
             }catch (Exception e) {
-                s_logger.warn("Exception: ", e);
+                logger.warn("Exception: ", e);
             }
         } catch (Exception e) {
-            s_logger.warn("Exception: ", e);
+            logger.warn("Exception: ", e);
         }
         return result;
 
@@ -208,10 +206,10 @@ public class VMTemplatePoolDaoImpl extends GenericDaoBase<VMTemplateStoragePoolV
                     result.add(findById(id));
                 }
             }catch (Exception e) {
-                s_logger.warn("Exception: ", e);
+                logger.warn("Exception: ", e);
             }
         } catch (Exception e) {
-            s_logger.warn("Exception: ", e);
+            logger.warn("Exception: ", e);
         }
         return result;
 
@@ -259,7 +257,7 @@ public class VMTemplatePoolDaoImpl extends GenericDaoBase<VMTemplateStoragePoolV
         builder.set(vo, "updated", new Date());
 
         int rows = update((VMTemplateStoragePoolVO)vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             VMTemplateStoragePoolVO dbVol = findByIdIncludingRemoved(templatePool.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -292,7 +290,7 @@ public class VMTemplatePoolDaoImpl extends GenericDaoBase<VMTemplateStoragePoolV
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update objectIndatastore: id=" + templatePool.getId() + ", as there is no such object exists in the database anymore");
+                logger.debug("Unable to update objectIndatastore: id=" + templatePool.getId() + ", as there is no such object exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/schema/src/com/cloud/storage/dao/VMTemplateZoneDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VMTemplateZoneDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.storage.VMTemplateZoneVO;
@@ -32,7 +31,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {VMTemplateZoneDao.class})
 public class VMTemplateZoneDaoImpl extends GenericDaoBase<VMTemplateZoneVO, Long> implements VMTemplateZoneDao {
-    public static final Logger s_logger = Logger.getLogger(VMTemplateZoneDaoImpl.class.getName());
 
     protected final SearchBuilder<VMTemplateZoneVO> ZoneSearch;
     protected final SearchBuilder<VMTemplateZoneVO> TemplateSearch;

--- a/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -26,7 +26,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.exception.InvalidParameterValueException;
@@ -55,7 +54,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = VolumeDao.class)
 public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements VolumeDao {
-    private static final Logger s_logger = Logger.getLogger(VolumeDaoImpl.class);
     protected final SearchBuilder<VolumeVO> DetachedAccountIdSearch;
     protected final SearchBuilder<VolumeVO> TemplateZoneSearch;
     protected final GenericSearchBuilder<VolumeVO, SumCount> TotalSizeByPoolSearch;
@@ -268,7 +266,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
                 else if (scope == ScopeType.ZONE)
                     sql = SELECT_HYPERTYPE_FROM_ZONE_VOLUME;
                 else
-                    s_logger.error("Unhandled scope type '" + scope + "' when running getHypervisorType on volume id " + volumeId);
+                    logger.error("Unhandled scope type '" + scope + "' when running getHypervisorType on volume id " + volumeId);
 
                 pstmt = txn.prepareAutoCloseStatement(sql);
                 pstmt.setLong(1, volumeId);
@@ -297,7 +295,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
         } else if (type.equals(HypervisorType.VMware)) {
             return ImageFormat.OVA;
         } else {
-            s_logger.warn("Do not support hypervisor " + type.toString());
+            logger.warn("Do not support hypervisor " + type.toString());
             return null;
         }
     }
@@ -483,7 +481,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
         builder.set(vo, "updated", new Date());
 
         int rows = update((VolumeVO)vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             VolumeVO dbVol = findByIdIncludingRemoved(vo.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -516,7 +514,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update volume: id=" + vo.getId() + ", as there is no such volume exists in the database anymore");
+                logger.debug("Unable to update volume: id=" + vo.getId() + ", as there is no such volume exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/schema/src/com/cloud/storage/dao/VolumeHostDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeHostDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObjectInStore;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.UpdateBuilder;
 @Component
 @Local(value = {VolumeHostDao.class})
 public class VolumeHostDaoImpl extends GenericDaoBase<VolumeHostVO, Long> implements VolumeHostDao {
-    private static final Logger s_logger = Logger.getLogger(VolumeHostDaoImpl.class);
     protected final SearchBuilder<VolumeHostVO> HostVolumeSearch;
     protected final SearchBuilder<VolumeHostVO> ZoneVolumeSearch;
     protected final SearchBuilder<VolumeHostVO> VolumeSearch;
@@ -141,7 +139,7 @@ public class VolumeHostDaoImpl extends GenericDaoBase<VolumeHostVO, Long> implem
         builder.set(vo, "updated", new Date());
 
         int rows = update((VolumeHostVO)vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             VolumeHostVO dbVol = findByIdIncludingRemoved(volHost.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -174,7 +172,7 @@ public class VolumeHostDaoImpl extends GenericDaoBase<VolumeHostVO, Long> implem
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update objectIndatastore: id=" + volHost.getId() + ", as there is no such object exists in the database anymore");
+                logger.debug("Unable to update objectIndatastore: id=" + volHost.getId() + ", as there is no such object exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/schema/src/com/cloud/upgrade/DatabaseIntegrityChecker.java
+++ b/engine/schema/src/com/cloud/upgrade/DatabaseIntegrityChecker.java
@@ -24,7 +24,6 @@ import java.sql.SQLException;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.maint.Version;
@@ -39,7 +38,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {SystemIntegrityChecker.class})
 public class DatabaseIntegrityChecker extends AdapterBase implements SystemIntegrityChecker {
-    private static final Logger s_logger = Logger.getLogger(DatabaseIntegrityChecker.class);
 
     @Inject
     VersionDao _dao;
@@ -103,32 +101,32 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
                                 }
                                 catch (Exception e)
                                 {
-                                    s_logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
+                                    logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
                                     throw new CloudRuntimeException("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage(),e);
                                 }
                         }
                         catch (Exception e)
                         {
-                                s_logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
+                                logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
                                 throw new CloudRuntimeException("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage(),e);
                         }
                     }
                     if (noDuplicate) {
-                        s_logger.debug("No duplicate hosts with the same local storage found in database");
+                        logger.debug("No duplicate hosts with the same local storage found in database");
                     } else {
-                        s_logger.error(helpInfo.toString());
+                        logger.error(helpInfo.toString());
                     }
                     txn.commit();
                     return noDuplicate;
             }catch (Exception e)
             {
-                  s_logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
+                  logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
                   throw new CloudRuntimeException("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage(),e);
             }
         }
         catch (Exception e)
         {
-            s_logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
+            logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage());
             throw new CloudRuntimeException("checkDuplicateHostWithTheSameLocalStorage: Exception :" + e.getMessage(),e);
         }
         finally
@@ -139,7 +137,7 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
                 }
             }catch(Exception e)
             {
-                s_logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception:"+ e.getMessage());
+                logger.error("checkDuplicateHostWithTheSameLocalStorage: Exception:"+ e.getMessage());
             }
         }
     }
@@ -152,7 +150,7 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
                 String tableName = rs.getString(1);
                 if (tableName.equalsIgnoreCase("usage_event") || tableName.equalsIgnoreCase("usage_port_forwarding") || tableName.equalsIgnoreCase("usage_network_offering")) {
                     num++;
-                    s_logger.debug("Checking 21to22PremiumUprage table " + tableName + " found");
+                    logger.debug("Checking 21to22PremiumUprage table " + tableName + " found");
                 }
                 if (num == 3) {
                     return true;
@@ -168,7 +166,7 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
             boolean found = false;
             while (rs.next()) {
                 if (column.equalsIgnoreCase(rs.getString(1))) {
-                    s_logger.debug(String.format("Column %1$s.%2$s.%3$s found", dbName, tableName, column));
+                    logger.debug(String.format("Column %1$s.%2$s.%3$s found", dbName, tableName, column));
                     found = true;
                     break;
                 }
@@ -225,33 +223,33 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
                     }
                 }
                 if (!hasUsage) {
-                    s_logger.debug("No cloud_usage found in database, no need to check missed premium upgrade");
+                    logger.debug("No cloud_usage found in database, no need to check missed premium upgrade");
                     txn.commit();
                     return true;
                 }
                 if (!check21to22PremiumUprage(conn)) {
-                    s_logger.error("21to22 premium upgrade missed");
+                    logger.error("21to22 premium upgrade missed");
                     txn.commit();
                     return false;
                 }
                 if (!check221to222PremiumUprage(conn)) {
-                    s_logger.error("221to222 premium upgrade missed");
+                    logger.error("221to222 premium upgrade missed");
                     txn.commit();
                     return false;
                 }
                 if (!check222to224PremiumUpgrade(conn)) {
-                    s_logger.error("222to224 premium upgrade missed");
+                    logger.error("222to224 premium upgrade missed");
                     txn.commit();
                     return false;
                 }
                 txn.commit();
                 return true;
             } catch (Exception e) {
-                s_logger.error("checkMissedPremiumUpgradeFor228: Exception:" + e.getMessage());
+                logger.error("checkMissedPremiumUpgradeFor228: Exception:" + e.getMessage());
                 throw new CloudRuntimeException("checkMissedPremiumUpgradeFor228: Exception:" + e.getMessage(), e);
             }
         }catch (Exception e) {
-            s_logger.error("checkMissedPremiumUpgradeFor228: Exception:"+ e.getMessage());
+            logger.error("checkMissedPremiumUpgradeFor228: Exception:"+ e.getMessage());
             throw new CloudRuntimeException("checkMissedPremiumUpgradeFor228: Exception:" + e.getMessage(),e);
         }
         finally
@@ -262,7 +260,7 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
                 }
             }catch(Exception e)
             {
-                s_logger.error("checkMissedPremiumUpgradeFor228: Exception:"+ e.getMessage());
+                logger.error("checkMissedPremiumUpgradeFor228: Exception:"+ e.getMessage());
             }
         }
     }
@@ -271,19 +269,19 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
     public void check() {
         GlobalLock lock = GlobalLock.getInternLock("DatabaseIntegrity");
         try {
-            s_logger.info("Grabbing lock to check for database integrity.");
+            logger.info("Grabbing lock to check for database integrity.");
             if (!lock.lock(20 * 60)) {
                 throw new CloudRuntimeException("Unable to acquire lock to check for database integrity.");
             }
 
             try {
-                s_logger.info("Performing database integrity check");
+                logger.info("Performing database integrity check");
                 if (!checkDuplicateHostWithTheSameLocalStorage()) {
                     throw new CloudRuntimeException("checkDuplicateHostWithTheSameLocalStorage detected error");
                 }
 
                 if (!checkMissedPremiumUpgradeFor228()) {
-                    s_logger.error("Your current database version is 2.2.8, management server detected some missed premium upgrade, please contact CloudStack support and attach log file. Thank you!");
+                    logger.error("Your current database version is 2.2.8, management server detected some missed premium upgrade, please contact CloudStack support and attach log file. Thank you!");
                     throw new CloudRuntimeException("Detected missed premium upgrade");
                 }
             } finally {
@@ -299,7 +297,7 @@ public class DatabaseIntegrityChecker extends AdapterBase implements SystemInteg
         try {
             check();
         } catch (Exception e) {
-            s_logger.error("System integrity check exception", e);
+            logger.error("System integrity check exception", e);
             System.exit(1);
         }
         return true;

--- a/engine/schema/src/com/cloud/upgrade/dao/VersionDaoImpl.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/VersionDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.upgrade.dao.VersionVO.Step;
@@ -42,7 +41,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Local(value = VersionDao.class)
 @DB()
 public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements VersionDao {
-    private static final Logger s_logger = Logger.getLogger(VersionDaoImpl.class);
 
     final GenericSearchBuilder<VersionVO, String> CurrentVersionSearch;
     final SearchBuilder<VersionVO> AllFieldsSearch;
@@ -76,7 +74,7 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
     @DB
     public String getCurrentVersion() {
         try (Connection conn = TransactionLegacy.getStandaloneConnection();) {
-            s_logger.debug("Checking to see if the database is at a version before it was the version table is created");
+            logger.debug("Checking to see if the database is at a version before it was the version table is created");
 
             try (
                     PreparedStatement pstmt = conn.prepareStatement("SHOW TABLES LIKE 'version'");
@@ -91,8 +89,8 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                                 pstmt_domain.executeQuery();
                                 return "2.1.8";
                             } catch (final SQLException e) {
-                                s_logger.debug("Assuming the exception means domain_id is not there.");
-                                s_logger.debug("No version table and no nics table, returning 2.1.7");
+                                logger.debug("Assuming the exception means domain_id is not there.");
+                                logger.debug("No version table and no nics table, returning 2.1.7");
                                 return "2.1.7";
                             }
                         } else {
@@ -100,7 +98,7 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                                  ResultSet rs_static_nat = pstmt_static_nat.executeQuery();){
                                 return "2.2.1";
                             } catch (final SQLException e) {
-                                s_logger.debug("Assuming the exception means static_nat field doesn't exist in firewall_rules table, returning version 2.2.2");
+                                logger.debug("Assuming the exception means static_nat field doesn't exist in firewall_rules table, returning version 2.2.2");
                                 return "2.2.2";
                             }
                         }
@@ -127,7 +125,7 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                 }
 
                 // Use nics table information and is_static_nat field from firewall_rules table to determine version information
-                s_logger.debug("Version table exists, but it's empty; have to confirm that version is 2.2.2");
+                logger.debug("Version table exists, but it's empty; have to confirm that version is 2.2.2");
                 try (PreparedStatement pstmt = conn.prepareStatement("SHOW TABLES LIKE 'nics'");
                      ResultSet rs = pstmt.executeQuery();){
                     if (!rs.next()) {
@@ -138,7 +136,7 @@ public class VersionDaoImpl extends GenericDaoBase<VersionVO, Long> implements V
                             throw new CloudRuntimeException("Unable to determine the current version, version table exists and empty, " +
                                     "nics table doesn't exist, is_static_nat field exists in firewall_rules table");
                         } catch (final SQLException e) {
-                            s_logger.debug("Assuming the exception means static_nat field doesn't exist in firewall_rules table, returning version 2.2.2");
+                            logger.debug("Assuming the exception means static_nat field doesn't exist in firewall_rules table, returning version 2.2.2");
                             return "2.2.2";
                         }
                     }

--- a/engine/schema/src/com/cloud/usage/dao/UsageDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageDaoImpl.java
@@ -27,7 +27,6 @@ import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.exception.CloudRuntimeException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import javax.ejb.Local;
@@ -42,7 +41,6 @@ import java.util.TimeZone;
 @Component
 @Local(value = {UsageDao.class})
 public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements UsageDao {
-    public static final Logger s_logger = Logger.getLogger(UsageDaoImpl.class.getName());
     private static final String DELETE_ALL = "DELETE FROM cloud_usage";
     private static final String DELETE_ALL_BY_ACCOUNTID = "DELETE FROM cloud_usage WHERE account_id = ?";
     private static final String DELETE_ALL_BY_INTERVAL = "DELETE FROM cloud_usage WHERE end_date < DATE_SUB(CURRENT_DATE(), INTERVAL ? DAY)";
@@ -92,7 +90,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error retrieving usage vm instances for account id: " + accountId);
+            logger.error("error retrieving usage vm instances for account id: " + accountId);
         } finally {
             txn.close();
         }
@@ -132,7 +130,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving account to cloud_usage db", ex);
+            logger.error("error saving account to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
     }
@@ -162,7 +160,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving account to cloud_usage db", ex);
+            logger.error("error saving account to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
     }
@@ -203,7 +201,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving user stats to cloud_usage db", ex);
+            logger.error("error saving user stats to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
     }
@@ -230,7 +228,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving user stats to cloud_usage db", ex);
+            logger.error("error saving user stats to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
     }
@@ -247,7 +245,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
                 return Long.valueOf(rs.getLong(1));
             }
         } catch (Exception ex) {
-            s_logger.error("error getting last account id", ex);
+            logger.error("error getting last account id", ex);
         }
         return null;
     }
@@ -264,7 +262,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
                 return Long.valueOf(rs.getLong(1));
             }
         } catch (Exception ex) {
-            s_logger.error("error getting last user stats id", ex);
+            logger.error("error getting last user stats id", ex);
         }
         return null;
     }
@@ -283,7 +281,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
                 templateList.add(Long.valueOf(rs.getLong(1)));
             }
         } catch (Exception ex) {
-            s_logger.error("error listing public templates", ex);
+            logger.error("error listing public templates", ex);
         }
         return templateList;
     }
@@ -300,7 +298,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
                 return Long.valueOf(rs.getLong(1));
             }
         } catch (Exception ex) {
-            s_logger.error("error getting last vm disk stats id", ex);
+            logger.error("error getting last vm disk stats id", ex);
         }
         return null;
     }
@@ -333,7 +331,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving vm disk stats to cloud_usage db", ex);
+            logger.error("error saving vm disk stats to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
 
@@ -379,7 +377,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving vm disk stats to cloud_usage db", ex);
+            logger.error("error saving vm disk stats to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
 
@@ -446,7 +444,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving usage records to cloud_usage db", ex);
+            logger.error("error saving usage records to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
     }
@@ -464,7 +462,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error removing old cloud_usage records for interval: " + days);
+            logger.error("error removing old cloud_usage records for interval: " + days);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageIPAddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageIPAddressDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageIPAddressVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageIPAddressDao.class})
 public class UsageIPAddressDaoImpl extends GenericDaoBase<UsageIPAddressVO, Long> implements UsageIPAddressDao {
-    public static final Logger s_logger = Logger.getLogger(UsageIPAddressDaoImpl.class.getName());
 
     protected static final String UPDATE_RELEASED = "UPDATE usage_ip_address SET released = ? WHERE account_id = ? AND public_ip_address = ? and released IS NULL";
     protected static final String GET_USAGE_RECORDS_BY_ACCOUNT =
@@ -77,7 +75,7 @@ public class UsageIPAddressDaoImpl extends GenericDaoBase<UsageIPAddressVO, Long
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.error("Error updating usageIPAddressVO:"+e.getMessage(), e);
+            logger.error("Error updating usageIPAddressVO:"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -142,7 +140,7 @@ public class UsageIPAddressDaoImpl extends GenericDaoBase<UsageIPAddressVO, Long
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageJobDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageJobDaoImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageJobVO;
@@ -36,7 +35,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {UsageJobDao.class})
 public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements UsageJobDao {
-    private static final Logger s_logger = Logger.getLogger(UsageJobDaoImpl.class.getName());
 
     private static final String GET_LAST_JOB_SUCCESS_DATE_MILLIS =
         "SELECT end_millis FROM cloud_usage.usage_job WHERE end_millis > 0 and success = 1 ORDER BY end_millis DESC LIMIT 1";
@@ -53,7 +51,7 @@ public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements
                 return rs.getLong(1);
             }
         } catch (Exception ex) {
-            s_logger.error("error getting last usage job success date", ex);
+            logger.error("error getting last usage job success date", ex);
         } finally {
             txn.close();
         }
@@ -79,7 +77,7 @@ public class UsageJobDaoImpl extends GenericDaoBase<UsageJobVO, Long> implements
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error updating job success date", ex);
+            logger.error("error updating job success date", ex);
             throw new CloudRuntimeException(ex.getMessage());
         } finally {
             txn.close();

--- a/engine/schema/src/com/cloud/usage/dao/UsageLoadBalancerPolicyDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageLoadBalancerPolicyDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageLoadBalancerPolicyVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageLoadBalancerPolicyDao.class})
 public class UsageLoadBalancerPolicyDaoImpl extends GenericDaoBase<UsageLoadBalancerPolicyVO, Long> implements UsageLoadBalancerPolicyDao {
-    public static final Logger s_logger = Logger.getLogger(UsageLoadBalancerPolicyDaoImpl.class.getName());
 
     protected static final String REMOVE_BY_USERID_LBID = "DELETE FROM usage_load_balancer_policy WHERE account_id = ? AND id = ?";
     protected static final String UPDATE_DELETED = "UPDATE usage_load_balancer_policy SET deleted = ? WHERE account_id = ? AND id = ? and deleted IS NULL";
@@ -66,7 +64,7 @@ public class UsageLoadBalancerPolicyDaoImpl extends GenericDaoBase<UsageLoadBala
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error removing UsageLoadBalancerPolicyVO", e);
+            logger.warn("Error removing UsageLoadBalancerPolicyVO", e);
         } finally {
             txn.close();
         }
@@ -92,7 +90,7 @@ public class UsageLoadBalancerPolicyDaoImpl extends GenericDaoBase<UsageLoadBala
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error updating UsageLoadBalancerPolicyVO"+e.getMessage(), e);
+            logger.warn("Error updating UsageLoadBalancerPolicyVO"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -161,7 +159,7 @@ public class UsageLoadBalancerPolicyDaoImpl extends GenericDaoBase<UsageLoadBala
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageNetworkDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageNetworkDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageNetworkVO;
@@ -35,7 +34,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {UsageNetworkDao.class})
 public class UsageNetworkDaoImpl extends GenericDaoBase<UsageNetworkVO, Long> implements UsageNetworkDao {
-    private static final Logger s_logger = Logger.getLogger(UsageVMInstanceDaoImpl.class.getName());
     private static final String SELECT_LATEST_STATS =
         "SELECT u.account_id, u.zone_id, u.host_id, u.host_type, u.network_id, u.bytes_sent, u.bytes_received, u.agg_bytes_received, u.agg_bytes_sent, u.event_time_millis "
             + "FROM cloud_usage.usage_network u INNER JOIN (SELECT netusage.account_id as acct_id, netusage.zone_id as z_id, max(netusage.event_time_millis) as max_date "
@@ -79,7 +77,7 @@ public class UsageNetworkDaoImpl extends GenericDaoBase<UsageNetworkVO, Long> im
             }
             return returnMap;
         } catch (Exception ex) {
-            s_logger.error("error getting recent usage network stats", ex);
+            logger.error("error getting recent usage network stats", ex);
         } finally {
             txn.close();
         }
@@ -99,7 +97,7 @@ public class UsageNetworkDaoImpl extends GenericDaoBase<UsageNetworkVO, Long> im
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error deleting old usage network stats", ex);
+            logger.error("error deleting old usage network stats", ex);
         }
     }
 
@@ -128,7 +126,7 @@ public class UsageNetworkDaoImpl extends GenericDaoBase<UsageNetworkVO, Long> im
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving usage_network to cloud_usage db", ex);
+            logger.error("error saving usage_network to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
     }

--- a/engine/schema/src/com/cloud/usage/dao/UsageNetworkOfferingDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageNetworkOfferingDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageNetworkOfferingVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageNetworkOfferingDao.class})
 public class UsageNetworkOfferingDaoImpl extends GenericDaoBase<UsageNetworkOfferingVO, Long> implements UsageNetworkOfferingDao {
-    public static final Logger s_logger = Logger.getLogger(UsageNetworkOfferingDaoImpl.class.getName());
 
     protected static final String UPDATE_DELETED =
         "UPDATE usage_network_offering SET deleted = ? WHERE account_id = ? AND vm_instance_id = ? AND network_offering_id = ? and deleted IS NULL";
@@ -76,7 +74,7 @@ public class UsageNetworkOfferingDaoImpl extends GenericDaoBase<UsageNetworkOffe
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error updating UsageNetworkOfferingVO:"+e.getMessage(), e);
+            logger.warn("Error updating UsageNetworkOfferingVO:"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -148,7 +146,7 @@ public class UsageNetworkOfferingDaoImpl extends GenericDaoBase<UsageNetworkOffe
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsagePortForwardingRuleDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsagePortForwardingRuleDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsagePortForwardingRuleVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsagePortForwardingRuleDao.class})
 public class UsagePortForwardingRuleDaoImpl extends GenericDaoBase<UsagePortForwardingRuleVO, Long> implements UsagePortForwardingRuleDao {
-    public static final Logger s_logger = Logger.getLogger(UsagePortForwardingRuleDaoImpl.class.getName());
 
     protected static final String REMOVE_BY_USERID_PFID = "DELETE FROM usage_port_forwarding WHERE account_id = ? AND id = ?";
     protected static final String UPDATE_DELETED = "UPDATE usage_port_forwarding SET deleted = ? WHERE account_id = ? AND id = ? and deleted IS NULL";
@@ -66,7 +64,7 @@ public class UsagePortForwardingRuleDaoImpl extends GenericDaoBase<UsagePortForw
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error removing UsagePortForwardingRuleVO", e);
+            logger.warn("Error removing UsagePortForwardingRuleVO", e);
         } finally {
             txn.close();
         }
@@ -92,7 +90,7 @@ public class UsagePortForwardingRuleDaoImpl extends GenericDaoBase<UsagePortForw
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error updating UsagePortForwardingRuleVO:"+e.getMessage(), e);
+            logger.warn("Error updating UsagePortForwardingRuleVO:"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -161,7 +159,7 @@ public class UsagePortForwardingRuleDaoImpl extends GenericDaoBase<UsagePortForw
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageSecurityGroupDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageSecurityGroupDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageSecurityGroupVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageSecurityGroupDao.class})
 public class UsageSecurityGroupDaoImpl extends GenericDaoBase<UsageSecurityGroupVO, Long> implements UsageSecurityGroupDao {
-    public static final Logger s_logger = Logger.getLogger(UsageSecurityGroupDaoImpl.class.getName());
 
     protected static final String UPDATE_DELETED =
         "UPDATE usage_security_group SET deleted = ? WHERE account_id = ? AND vm_instance_id = ? AND security_group_id = ? and deleted IS NULL";
@@ -76,7 +74,7 @@ public class UsageSecurityGroupDaoImpl extends GenericDaoBase<UsageSecurityGroup
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error updating UsageSecurityGroupVO:"+e.getMessage(), e);
+            logger.warn("Error updating UsageSecurityGroupVO:"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -144,7 +142,7 @@ public class UsageSecurityGroupDaoImpl extends GenericDaoBase<UsageSecurityGroup
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records:"+e.getMessage(), e);
+            logger.warn("Error getting usage records:"+e.getMessage(), e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageStorageDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageStorageDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageStorageVO;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageStorageDao.class})
 public class UsageStorageDaoImpl extends GenericDaoBase<UsageStorageVO, Long> implements UsageStorageDao {
-    public static final Logger s_logger = Logger.getLogger(UsageStorageDaoImpl.class.getName());
 
     protected static final String REMOVE_BY_USERID_STORAGEID = "DELETE FROM usage_storage WHERE account_id = ? AND id = ? AND storage_type = ?";
     protected static final String UPDATE_DELETED = "UPDATE usage_storage SET deleted = ? WHERE account_id = ? AND id = ? AND storage_type = ? and deleted IS NULL";
@@ -108,7 +106,7 @@ public class UsageStorageDaoImpl extends GenericDaoBase<UsageStorageVO, Long> im
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.error("Error removing usageStorageVO", e);
+            logger.error("Error removing usageStorageVO", e);
         } finally {
             txn.close();
         }
@@ -136,7 +134,7 @@ public class UsageStorageDaoImpl extends GenericDaoBase<UsageStorageVO, Long> im
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.error("Error updating UsageStorageVO:"+e.getMessage(), e);
+            logger.error("Error updating UsageStorageVO:"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -210,7 +208,7 @@ public class UsageStorageDaoImpl extends GenericDaoBase<UsageStorageVO, Long> im
             }
         }catch (Exception e) {
             txn.rollback();
-            s_logger.error("getUsageRecords:Exception:"+e.getMessage(), e);
+            logger.error("getUsageRecords:Exception:"+e.getMessage(), e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageVMInstanceDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageVMInstanceDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.TimeZone;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageVMInstanceVO;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageVMInstanceDao.class})
 public class UsageVMInstanceDaoImpl extends GenericDaoBase<UsageVMInstanceVO, Long> implements UsageVMInstanceDao {
-    public static final Logger s_logger = Logger.getLogger(UsageVMInstanceDaoImpl.class.getName());
 
     protected static final String UPDATE_USAGE_INSTANCE_SQL = "UPDATE usage_vm_instance SET end_date = ? "
         + "WHERE account_id = ? and vm_instance_id = ? and usage_type = ? and end_date IS NULL";
@@ -64,7 +62,7 @@ public class UsageVMInstanceDaoImpl extends GenericDaoBase<UsageVMInstanceVO, Lo
             pstmt.executeUpdate();
             txn.commit();
         } catch (Exception e) {
-            s_logger.warn(e);
+            logger.warn(e);
         } finally {
             txn.close();
         }
@@ -85,7 +83,7 @@ public class UsageVMInstanceDaoImpl extends GenericDaoBase<UsageVMInstanceVO, Lo
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error deleting usage vm instance with vmId: " + instance.getVmInstanceId() + ", for account with id: " + instance.getAccountId());
+            logger.error("error deleting usage vm instance with vmId: " + instance.getVmInstanceId() + ", for account with id: " + instance.getAccountId());
         } finally {
             txn.close();
         }
@@ -143,7 +141,7 @@ public class UsageVMInstanceDaoImpl extends GenericDaoBase<UsageVMInstanceVO, Lo
                 usageInstances.add(usageInstance);
             }
         } catch (Exception ex) {
-            s_logger.error("error retrieving usage vm instances for account id: " + accountId, ex);
+            logger.error("error retrieving usage vm instances for account id: " + accountId, ex);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageVMSnapshotDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageVMSnapshotDaoImpl.java
@@ -26,7 +26,6 @@ import java.util.TimeZone;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageVMSnapshotVO;
@@ -37,7 +36,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageVMSnapshotDao.class})
 public class UsageVMSnapshotDaoImpl extends GenericDaoBase<UsageVMSnapshotVO, Long> implements UsageVMSnapshotDao {
-    public static final Logger s_logger = Logger.getLogger(UsageVMSnapshotDaoImpl.class.getName());
     protected static final String GET_USAGE_RECORDS_BY_ACCOUNT = "SELECT id, zone_id, account_id, domain_id, vm_id, disk_offering_id, size, created, processed "
         + " FROM usage_vmsnapshot" + " WHERE account_id = ? " + " AND ( (created BETWEEN ? AND ?) OR "
         + "      (created < ? AND processed is NULL) ) ORDER BY created asc";
@@ -62,7 +60,7 @@ public class UsageVMSnapshotDaoImpl extends GenericDaoBase<UsageVMSnapshotVO, Lo
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error updating UsageVMSnapshotVO", e);
+            logger.warn("Error updating UsageVMSnapshotVO", e);
         } finally {
             txn.close();
         }
@@ -112,7 +110,7 @@ public class UsageVMSnapshotDaoImpl extends GenericDaoBase<UsageVMSnapshotVO, Lo
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }
@@ -163,7 +161,7 @@ public class UsageVMSnapshotDaoImpl extends GenericDaoBase<UsageVMSnapshotVO, Lo
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageVPNUserDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageVPNUserDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageVPNUserVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageVPNUserDao.class})
 public class UsageVPNUserDaoImpl extends GenericDaoBase<UsageVPNUserVO, Long> implements UsageVPNUserDao {
-    public static final Logger s_logger = Logger.getLogger(UsageVPNUserDaoImpl.class.getName());
 
     protected static final String UPDATE_DELETED = "UPDATE usage_vpn_user SET deleted = ? WHERE account_id = ? AND user_id = ? and deleted IS NULL";
     protected static final String GET_USAGE_RECORDS_BY_ACCOUNT = "SELECT zone_id, account_id, domain_id, user_id, user_name, created, deleted " + "FROM usage_vpn_user "
@@ -71,7 +69,7 @@ public class UsageVPNUserDaoImpl extends GenericDaoBase<UsageVPNUserVO, Long> im
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.error("Error updating UsageVPNUserVO:"+e.getMessage(), e);
+            logger.error("Error updating UsageVPNUserVO:"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -141,7 +139,7 @@ public class UsageVPNUserDaoImpl extends GenericDaoBase<UsageVPNUserVO, Long> im
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/usage/dao/UsageVmDiskDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageVmDiskDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageVmDiskVO;
@@ -35,7 +34,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {UsageVmDiskDao.class})
 public class UsageVmDiskDaoImpl extends GenericDaoBase<UsageVmDiskVO, Long> implements UsageVmDiskDao {
-    private static final Logger s_logger = Logger.getLogger(UsageVmDiskDaoImpl.class.getName());
     private static final String SELECT_LATEST_STATS =
         "SELECT uvd.account_id, uvd.zone_id, uvd.vm_id, uvd.volume_id, uvd.io_read, uvd.io_write, uvd.agg_io_read, uvd.agg_io_write, "
             + "uvd.bytes_read, uvd.bytes_write, uvd.agg_bytes_read, uvd.agg_bytes_write, uvd.event_time_millis "
@@ -83,7 +81,7 @@ public class UsageVmDiskDaoImpl extends GenericDaoBase<UsageVmDiskVO, Long> impl
             }
             return returnMap;
         } catch (Exception ex) {
-            s_logger.error("error getting recent usage disk stats", ex);
+            logger.error("error getting recent usage disk stats", ex);
         } finally {
             txn.close();
         }
@@ -103,7 +101,7 @@ public class UsageVmDiskDaoImpl extends GenericDaoBase<UsageVmDiskVO, Long> impl
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error deleting old usage disk stats", ex);
+            logger.error("error deleting old usage disk stats", ex);
         }
     }
 
@@ -135,7 +133,7 @@ public class UsageVmDiskDaoImpl extends GenericDaoBase<UsageVmDiskVO, Long> impl
             txn.commit();
         } catch (Exception ex) {
             txn.rollback();
-            s_logger.error("error saving usage_vm_disk to cloud_usage db", ex);
+            logger.error("error saving usage_vm_disk to cloud_usage db", ex);
             throw new CloudRuntimeException(ex.getMessage());
         }
     }

--- a/engine/schema/src/com/cloud/usage/dao/UsageVolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageVolumeDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.ejb.Local;
 
 import com.cloud.exception.CloudException;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.usage.UsageVolumeVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageVolumeDao.class})
 public class UsageVolumeDaoImpl extends GenericDaoBase<UsageVolumeVO, Long> implements UsageVolumeDao {
-    public static final Logger s_logger = Logger.getLogger(UsageVolumeDaoImpl.class.getName());
 
     protected static final String REMOVE_BY_USERID_VOLID = "DELETE FROM usage_volume WHERE account_id = ? AND id = ?";
     protected static final String UPDATE_DELETED = "UPDATE usage_volume SET deleted = ? WHERE account_id = ? AND id = ? and deleted IS NULL";
@@ -71,7 +69,7 @@ public class UsageVolumeDaoImpl extends GenericDaoBase<UsageVolumeVO, Long> impl
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error removing usageVolumeVO:"+e.getMessage(), e);
+            logger.warn("Error removing usageVolumeVO:"+e.getMessage(), e);
         } finally {
             txn.close();
         }
@@ -93,7 +91,7 @@ public class UsageVolumeDaoImpl extends GenericDaoBase<UsageVolumeVO, Long> impl
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error updating UsageVolumeVO", e);
+            logger.warn("Error updating UsageVolumeVO", e);
         } finally {
             txn.close();
         }
@@ -171,7 +169,7 @@ public class UsageVolumeDaoImpl extends GenericDaoBase<UsageVolumeVO, Long> impl
             }
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Error getting usage records", e);
+            logger.warn("Error getting usage records", e);
         } finally {
             txn.close();
         }

--- a/engine/schema/src/com/cloud/user/dao/AccountDaoImpl.java
+++ b/engine/schema/src/com/cloud/user/dao/AccountDaoImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.user.Account;
@@ -44,7 +43,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {AccountDao.class})
 public class AccountDaoImpl extends GenericDaoBase<AccountVO, Long> implements AccountDao {
-    private static final Logger s_logger = Logger.getLogger(AccountDaoImpl.class);
     private static final String FIND_USER_ACCOUNT_BY_API_KEY = "SELECT u.id, u.username, u.account_id, u.secret_key, u.state, "
         + "a.id, a.account_name, a.type, a.domain_id, a.state " + "FROM `cloud`.`user` u, `cloud`.`account` a "
         + "WHERE u.account_id = a.id AND u.api_key = ? and u.removed IS NULL";
@@ -148,7 +146,7 @@ public class AccountDaoImpl extends GenericDaoBase<AccountVO, Long> implements A
                 userAcctPair = new Pair<User, Account>(u, a);
             }
         } catch (Exception e) {
-            s_logger.warn("Exception finding user/acct by api key: " + apiKey, e);
+            logger.warn("Exception finding user/acct by api key: " + apiKey, e);
         }
         return userAcctPair;
     }
@@ -266,7 +264,7 @@ public class AccountDaoImpl extends GenericDaoBase<AccountVO, Long> implements A
         if (!account.getNeedsCleanup()) {
             account.setNeedsCleanup(true);
             if (!update(accountId, account)) {
-                s_logger.warn("Failed to mark account id=" + accountId + " for cleanup");
+                logger.warn("Failed to mark account id=" + accountId + " for cleanup");
             }
         }
     }
@@ -286,7 +284,7 @@ public class AccountDaoImpl extends GenericDaoBase<AccountVO, Long> implements A
             domain_id = account_vo.getDomainId();
         }
         catch (Exception e) {
-            s_logger.warn("getDomainIdForGivenAccountId: Exception :" + e.getMessage());
+            logger.warn("getDomainIdForGivenAccountId: Exception :" + e.getMessage());
         }
         finally {
             return domain_id;

--- a/engine/schema/src/com/cloud/user/dao/UserStatisticsDaoImpl.java
+++ b/engine/schema/src/com/cloud/user/dao/UserStatisticsDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.TimeZone;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.user.UserStatisticsVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UserStatisticsDao.class})
 public class UserStatisticsDaoImpl extends GenericDaoBase<UserStatisticsVO, Long> implements UserStatisticsDao {
-    private static final Logger s_logger = Logger.getLogger(UserStatisticsDaoImpl.class);
     private static final String ACTIVE_AND_RECENTLY_DELETED_SEARCH =
         "SELECT us.id, us.data_center_id, us.account_id, us.public_ip_address, us.device_id, us.device_type, us.network_id, us.agg_bytes_received, us.agg_bytes_sent "
             + "FROM user_statistics us, account a " + "WHERE us.account_id = a.id AND (a.removed IS NULL OR a.removed >= ?) " + "ORDER BY us.id";
@@ -111,7 +109,7 @@ public class UserStatisticsDaoImpl extends GenericDaoBase<UserStatisticsVO, Long
                 userStats.add(toEntityBean(rs, false));
             }
         } catch (Exception ex) {
-            s_logger.error("error saving user stats to cloud_usage db", ex);
+            logger.error("error saving user stats to cloud_usage db", ex);
         }
         return userStats;
     }
@@ -129,7 +127,7 @@ public class UserStatisticsDaoImpl extends GenericDaoBase<UserStatisticsVO, Long
                 userStats.add(toEntityBean(rs, false));
             }
         } catch (Exception ex) {
-            s_logger.error("error lisitng updated user stats", ex);
+            logger.error("error lisitng updated user stats", ex);
         }
         return userStats;
     }

--- a/engine/schema/src/com/cloud/user/dao/VmDiskStatisticsDaoImpl.java
+++ b/engine/schema/src/com/cloud/user/dao/VmDiskStatisticsDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.TimeZone;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.user.VmDiskStatisticsVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {VmDiskStatisticsDao.class})
 public class VmDiskStatisticsDaoImpl extends GenericDaoBase<VmDiskStatisticsVO, Long> implements VmDiskStatisticsDao {
-    private static final Logger s_logger = Logger.getLogger(VmDiskStatisticsDaoImpl.class);
     private static final String ACTIVE_AND_RECENTLY_DELETED_SEARCH =
         "SELECT bcf.id, bcf.data_center_id, bcf.account_id, bcf.vm_id, bcf.volume_id, bcf.agg_io_read, bcf.agg_io_write, bcf.agg_bytes_read, bcf.agg_bytes_write "
             + "FROM vm_disk_statistics bcf, account a " + "WHERE bcf.account_id = a.id AND (a.removed IS NULL OR a.removed >= ?) " + "ORDER BY bcf.id";
@@ -106,7 +104,7 @@ public class VmDiskStatisticsDaoImpl extends GenericDaoBase<VmDiskStatisticsVO, 
                 vmDiskStats.add(toEntityBean(rs, false));
             }
         } catch (Exception ex) {
-            s_logger.error("error saving vm disk stats to cloud_usage db", ex);
+            logger.error("error saving vm disk stats to cloud_usage db", ex);
         }
         return vmDiskStats;
     }
@@ -124,7 +122,7 @@ public class VmDiskStatisticsDaoImpl extends GenericDaoBase<VmDiskStatisticsVO, 
                 vmDiskStats.add(toEntityBean(rs, false));
             }
         } catch (Exception ex) {
-            s_logger.error("error lisitng updated vm disk stats", ex);
+            logger.error("error lisitng updated vm disk stats", ex);
         }
         return vmDiskStats;
     }

--- a/engine/schema/src/com/cloud/vm/dao/ConsoleProxyDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/ConsoleProxyDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.info.ConsoleProxyLoadInfo;
@@ -42,7 +41,6 @@ import com.cloud.vm.VirtualMachine.State;
 @Component
 @Local(value = {ConsoleProxyDao.class})
 public class ConsoleProxyDaoImpl extends GenericDaoBase<ConsoleProxyVO, Long> implements ConsoleProxyDao {
-    private static final Logger s_logger = Logger.getLogger(ConsoleProxyDaoImpl.class);
 
     //
     // query SQL for returnning console proxy assignment info as following
@@ -217,7 +215,7 @@ public class ConsoleProxyDaoImpl extends GenericDaoBase<ConsoleProxyVO, Long> im
                 l.add(new Pair<Long, Integer>(rs.getLong(1), rs.getInt(2)));
             }
         } catch (SQLException e) {
-            s_logger.debug("Caught SQLException: ", e);
+            logger.debug("Caught SQLException: ", e);
         }
         return l;
     }
@@ -242,7 +240,7 @@ public class ConsoleProxyDaoImpl extends GenericDaoBase<ConsoleProxyVO, Long> im
                 l.add(new Pair<Long, Integer>(rs.getLong(1), rs.getInt(2)));
             }
         } catch (SQLException e) {
-            s_logger.debug("Caught SQLException: ", e);
+            logger.debug("Caught SQLException: ", e);
         }
         return l;
     }
@@ -261,7 +259,7 @@ public class ConsoleProxyDaoImpl extends GenericDaoBase<ConsoleProxyVO, Long> im
                 return rs.getInt(1);
             }
         } catch (SQLException e) {
-            s_logger.debug("Caught SQLException: ", e);
+            logger.debug("Caught SQLException: ", e);
         }
         return 0;
     }
@@ -279,7 +277,7 @@ public class ConsoleProxyDaoImpl extends GenericDaoBase<ConsoleProxyVO, Long> im
                 return rs.getInt(1);
             }
         } catch (SQLException e) {
-            s_logger.debug("Caught SQLException: ", e);
+            logger.debug("Caught SQLException: ", e);
         }
         return 0;
     }
@@ -301,7 +299,7 @@ public class ConsoleProxyDaoImpl extends GenericDaoBase<ConsoleProxyVO, Long> im
                 l.add(info);
             }
         } catch (SQLException e) {
-            s_logger.debug("Exception: ", e);
+            logger.debug("Exception: ", e);
         }
         return l;
     }
@@ -323,7 +321,7 @@ public class ConsoleProxyDaoImpl extends GenericDaoBase<ConsoleProxyVO, Long> im
                 l.add(rs.getLong(1));
             }
         } catch (SQLException e) {
-            s_logger.debug("Caught SQLException: ", e);
+            logger.debug("Caught SQLException: ", e);
         }
         return l;
     }

--- a/engine/schema/src/com/cloud/vm/dao/UserVmCloneSettingDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/UserVmCloneSettingDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.DB;
@@ -35,7 +34,6 @@ import com.cloud.vm.UserVmCloneSettingVO;
 @Local(value = {UserVmCloneSettingDao.class})
 @DB()
 public class UserVmCloneSettingDaoImpl extends GenericDaoBase<UserVmCloneSettingVO, Long> implements UserVmCloneSettingDao {
-    public static final Logger s_logger = Logger.getLogger(UserVmCloneSettingDaoImpl.class);
 
     protected SearchBuilder<UserVmCloneSettingVO> vmIdSearch;
     protected SearchBuilder<UserVmCloneSettingVO> cloneTypeSearch;

--- a/engine/schema/src/com/cloud/vm/dao/UserVmDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/UserVmDaoImpl.java
@@ -30,7 +30,6 @@ import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.server.ResourceTag.ResourceObjectType;
 import com.cloud.tags.dao.ResourceTagDao;
@@ -55,7 +54,6 @@ import com.cloud.vm.dao.UserVmData.SecurityGroupData;
 
 @Local(value = {UserVmDao.class})
 public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements UserVmDao {
-    public static final Logger s_logger = Logger.getLogger(UserVmDaoImpl.class);
 
     protected SearchBuilder<UserVmVO> AccountPodSearch;
     protected SearchBuilder<UserVmVO> AccountDataCenterSearch;
@@ -378,13 +376,13 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
                 }
             }
             catch (Exception e) {
-                s_logger.error("listPodIdsHavingVmsforAccount:Exception: " +  e.getMessage());
+                logger.error("listPodIdsHavingVmsforAccount:Exception: " +  e.getMessage());
                 throw new CloudRuntimeException("listPodIdsHavingVmsforAccount:Exception: " + e.getMessage(), e);
             }
             txn.commit();
             return result;
         } catch (Exception e) {
-            s_logger.error("listPodIdsHavingVmsforAccount:Exception : " +  e.getMessage());
+            logger.error("listPodIdsHavingVmsforAccount:Exception : " +  e.getMessage());
             throw new CloudRuntimeException("listPodIdsHavingVmsforAccount:Exception: " + e.getMessage(), e);
         }
         finally {
@@ -396,7 +394,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
             }
             catch (Exception e)
             {
-                s_logger.error("listVmDetails:Exception:" + e.getMessage());
+                logger.error("listVmDetails:Exception:" + e.getMessage());
             }
         }
 
@@ -433,7 +431,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
                         }
                         catch (Exception e)
                         {
-                            s_logger.error("listVmDetails:Exception:" + e.getMessage());
+                            logger.error("listVmDetails:Exception:" + e.getMessage());
                             throw new CloudRuntimeException("listVmDetails: Exception:" + e.getMessage(),e);
                         }
                         curr_index += VM_DETAILS_BATCH_SIZE;
@@ -441,7 +439,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
                 }
                 catch (Exception e)
                 {
-                    s_logger.error("listVmDetails:Exception:" + e.getMessage());
+                    logger.error("listVmDetails:Exception:" + e.getMessage());
                     throw new CloudRuntimeException("listVmDetails: Exception:" + e.getMessage(),e);
                 }
             }
@@ -469,20 +467,20 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
                     }
                     catch (Exception e)
                     {
-                        s_logger.error("listVmDetails: Exception:" + e.getMessage());
+                        logger.error("listVmDetails: Exception:" + e.getMessage());
                         throw new CloudRuntimeException("listVmDetails: Exception:" + e.getMessage(),e);
                     }
                 }
                 catch (Exception e)
                 {
-                    s_logger.error("listVmDetails:Exception:" + e.getMessage());
+                    logger.error("listVmDetails:Exception:" + e.getMessage());
                     throw new CloudRuntimeException("listVmDetails: Exception:" + e.getMessage(),e);
                 }
             }
             txn.commit();
             return userVmDataHash;
         } catch (Exception e) {
-            s_logger.error("listVmDetails:Exception:" + e.getMessage());
+            logger.error("listVmDetails:Exception:" + e.getMessage());
             throw new CloudRuntimeException("listVmDetails:Exception : ", e);
         }
         finally {
@@ -494,7 +492,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
             }
             catch (Exception e)
             {
-                s_logger.error("listVmDetails:Exception:" + e.getMessage());
+                logger.error("listVmDetails:Exception:" + e.getMessage());
             }
         }
 
@@ -656,7 +654,7 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
                 }
             }
         } catch (SQLException e) {
-            s_logger.error("GetVmsDetailsByNames: Exception in sql: " + e.getMessage());
+            logger.error("GetVmsDetailsByNames: Exception in sql: " + e.getMessage());
             throw new CloudRuntimeException("GetVmsDetailsByNames: Exception: " + e.getMessage());
         }
 

--- a/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -29,7 +29,6 @@ import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.host.HostVO;
@@ -66,7 +65,6 @@ import com.cloud.vm.VirtualMachine.Type;
 @Local(value = {VMInstanceDao.class})
 public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implements VMInstanceDao {
 
-    public static final Logger s_logger = Logger.getLogger(VMInstanceDaoImpl.class);
     private static final int MAX_CONSECUTIVE_SAME_STATE_UPDATE_COUNT = 3;
 
     protected SearchBuilder<VMInstanceVO> VMClusterSearch;
@@ -439,8 +437,8 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
     @Override
     public boolean updateState(State oldState, Event event, State newState, VirtualMachine vm, Object opaque) {
         if (newState == null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("There's no way to transition from old state: " + oldState.toString() + " event: " + event.toString());
+            if (logger.isDebugEnabled()) {
+                logger.debug("There's no way to transition from old state: " + oldState.toString() + " event: " + event.toString());
             }
             return false;
         }
@@ -479,7 +477,7 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         if (result == 0) {
             VMInstanceVO vo = findByIdIncludingRemoved(vm.getId());
 
-            if (s_logger.isDebugEnabled()) {
+            if (logger.isDebugEnabled()) {
                 if (vo != null) {
                     StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
                     str.append(": DB Data={Host=").append(vo.getHostId()).append("; State=").append(vo.getState().toString()).append("; updated=").append(vo.getUpdated())
@@ -488,16 +486,16 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
                             .append("; time=").append(vo.getUpdateTime());
                     str.append("} Stale Data: {Host=").append(oldHostId).append("; State=").append(oldState).append("; updated=").append(oldUpdated).append("; time=")
                             .append(oldUpdateDate).append("}");
-                    s_logger.debug(str.toString());
+                    logger.debug(str.toString());
 
                 } else {
-                    s_logger.debug("Unable to update the vm id=" + vm.getId() + "; the vm either doesn't exist or already removed");
+                    logger.debug("Unable to update the vm id=" + vm.getId() + "; the vm either doesn't exist or already removed");
                 }
             }
 
             if (vo != null && vo.getState() == newState) {
                 // allow for concurrent update if target state has already been matched
-                s_logger.debug("VM " + vo.getInstanceName() + " state has been already been updated to " + newState);
+                logger.debug("VM " + vo.getInstanceName() + " state has been already been updated to " + newState);
                 return true;
             }
         }

--- a/engine/schema/src/com/cloud/vm/snapshot/dao/VMSnapshotDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/snapshot/dao/VMSnapshotDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.GenericDaoBase;
@@ -38,7 +37,6 @@ import com.cloud.vm.snapshot.VMSnapshotVO;
 @Component
 @Local(value = {VMSnapshotDao.class})
 public class VMSnapshotDaoImpl extends GenericDaoBase<VMSnapshotVO, Long> implements VMSnapshotDao {
-    private static final Logger s_logger = Logger.getLogger(VMSnapshotDaoImpl.class);
     private final SearchBuilder<VMSnapshotVO> SnapshotSearch;
     private final SearchBuilder<VMSnapshotVO> ExpungingSnapshotSearch;
     private final SearchBuilder<VMSnapshotVO> SnapshotStatusSearch;
@@ -145,7 +143,7 @@ public class VMSnapshotDaoImpl extends GenericDaoBase<VMSnapshotVO, Long> implem
         builder.set(vo, "updated", new Date());
 
         int rows = update((VMSnapshotVO)vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             VMSnapshotVO dbVol = findByIdIncludingRemoved(vo.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -178,7 +176,7 @@ public class VMSnapshotDaoImpl extends GenericDaoBase<VMSnapshotVO, Long> implem
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update VM snapshot: id=" + vo.getId() + ", as there is no such snapshot exists in the database anymore");
+                logger.debug("Unable to update VM snapshot: id=" + vo.getId() + ", as there is no such snapshot exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/schema/src/org/apache/cloudstack/engine/cloud/entity/api/db/dao/VMEntityDaoImpl.java
+++ b/engine/schema/src/org/apache/cloudstack/engine/cloud/entity/api/db/dao/VMEntityDaoImpl.java
@@ -23,7 +23,6 @@ import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.cloud.entity.api.db.VMEntityVO;
@@ -39,7 +38,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Local(value = {VMEntityDao.class})
 public class VMEntityDaoImpl extends GenericDaoBase<VMEntityVO, Long> implements VMEntityDao {
 
-    public static final Logger s_logger = Logger.getLogger(VMEntityDaoImpl.class);
 
     @Inject
     protected VMReservationDao _vmReservationDao;

--- a/engine/schema/src/org/apache/cloudstack/region/dao/RegionDaoImpl.java
+++ b/engine/schema/src/org/apache/cloudstack/region/dao/RegionDaoImpl.java
@@ -18,7 +18,6 @@ package org.apache.cloudstack.region.dao;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.region.RegionVO;
@@ -30,7 +29,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {RegionDao.class})
 public class RegionDaoImpl extends GenericDaoBase<RegionVO, Integer> implements RegionDao {
-    private static final Logger s_logger = Logger.getLogger(RegionDaoImpl.class);
     protected SearchBuilder<RegionVO> NameSearch;
     protected SearchBuilder<RegionVO> AllFieldsSearch;
 

--- a/engine/storage/integration-test/test/org/apache/cloudstack/storage/test/DirectAgentManagerSimpleImpl.java
+++ b/engine/storage/integration-test/test/org/apache/cloudstack/storage/test/DirectAgentManagerSimpleImpl.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.Listener;
@@ -60,7 +59,6 @@ import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateMachine2;
 
 public class DirectAgentManagerSimpleImpl extends ManagerBase implements AgentManager {
-    private static final Logger logger = Logger.getLogger(DirectAgentManagerSimpleImpl.class);
     private final Map<Long, ServerResource> hostResourcesMap = new HashMap<Long, ServerResource>();
     @Inject
     HostDao hostDao;

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
 import org.apache.cloudstack.engine.subsystem.api.storage.VMSnapshotOptions;
@@ -71,7 +70,6 @@ import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 
 public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshotStrategy {
-    private static final Logger s_logger = Logger.getLogger(DefaultVMSnapshotStrategy.class);
     @Inject
     VMSnapshotHelper vmSnapshotHelper;
     @Inject
@@ -148,7 +146,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
             answer = (CreateVMSnapshotAnswer)agentMgr.send(hostId, ccmd);
             if (answer != null && answer.getResult()) {
                 processAnswer(vmSnapshotVO, userVm, answer, hostId);
-                s_logger.debug("Create vm snapshot " + vmSnapshot.getName() + " succeeded for vm: " + userVm.getInstanceName());
+                logger.debug("Create vm snapshot " + vmSnapshot.getName() + " succeeded for vm: " + userVm.getInstanceName());
                 result = true;
 
                 for (VolumeObjectTO volumeTo : answer.getVolumeTOs()) {
@@ -159,21 +157,21 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
                 String errMsg = "Creating VM snapshot: " + vmSnapshot.getName() + " failed";
                 if (answer != null && answer.getDetails() != null)
                     errMsg = errMsg + " due to " + answer.getDetails();
-                s_logger.error(errMsg);
+                logger.error(errMsg);
                 throw new CloudRuntimeException(errMsg);
             }
         } catch (OperationTimedoutException e) {
-            s_logger.debug("Creating VM snapshot: " + vmSnapshot.getName() + " failed: " + e.toString());
+            logger.debug("Creating VM snapshot: " + vmSnapshot.getName() + " failed: " + e.toString());
             throw new CloudRuntimeException("Creating VM snapshot: " + vmSnapshot.getName() + " failed: " + e.toString());
         } catch (AgentUnavailableException e) {
-            s_logger.debug("Creating VM snapshot: " + vmSnapshot.getName() + " failed", e);
+            logger.debug("Creating VM snapshot: " + vmSnapshot.getName() + " failed", e);
             throw new CloudRuntimeException("Creating VM snapshot: " + vmSnapshot.getName() + " failed: " + e.toString());
         } finally {
             if (!result) {
                 try {
                     vmSnapshotHelper.vmSnapshotStateTransitTo(vmSnapshot, VMSnapshot.Event.OperationFailed);
                 } catch (NoTransitionException e1) {
-                    s_logger.error("Cannot set vm snapshot state due to: " + e1.getMessage());
+                    logger.error("Cannot set vm snapshot state due to: " + e1.getMessage());
                 }
             }
         }
@@ -186,7 +184,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
         try {
             vmSnapshotHelper.vmSnapshotStateTransitTo(vmSnapshot, VMSnapshot.Event.ExpungeRequested);
         } catch (NoTransitionException e) {
-            s_logger.debug("Failed to change vm snapshot state with event ExpungeRequested");
+            logger.debug("Failed to change vm snapshot state with event ExpungeRequested");
             throw new CloudRuntimeException("Failed to change vm snapshot state with event ExpungeRequested: " + e.getMessage());
         }
 
@@ -214,7 +212,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
                 return true;
             } else {
                 String errMsg = (answer == null) ? null : answer.getDetails();
-                s_logger.error("Delete vm snapshot " + vmSnapshot.getName() + " of vm " + userVm.getInstanceName() + " failed due to " + errMsg);
+                logger.error("Delete vm snapshot " + vmSnapshot.getName() + " of vm " + userVm.getInstanceName() + " failed due to " + errMsg);
                 throw new CloudRuntimeException("Delete vm snapshot " + vmSnapshot.getName() + " of vm " + userVm.getInstanceName() + " failed due to " + errMsg);
             }
         } catch (OperationTimedoutException e) {
@@ -247,7 +245,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
             });
         } catch (Exception e) {
             String errMsg = "Error while process answer: " + as.getClass() + " due to " + e.getMessage();
-            s_logger.error(errMsg, e);
+            logger.error(errMsg, e);
             throw new CloudRuntimeException(errMsg);
         }
     }
@@ -367,21 +365,21 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
                 String errMsg = "Revert VM: " + userVm.getInstanceName() + " to snapshot: " + vmSnapshotVO.getName() + " failed";
                 if (answer != null && answer.getDetails() != null)
                     errMsg = errMsg + " due to " + answer.getDetails();
-                s_logger.error(errMsg);
+                logger.error(errMsg);
                 throw new CloudRuntimeException(errMsg);
             }
         } catch (OperationTimedoutException e) {
-            s_logger.debug("Failed to revert vm snapshot", e);
+            logger.debug("Failed to revert vm snapshot", e);
             throw new CloudRuntimeException(e.getMessage());
         } catch (AgentUnavailableException e) {
-            s_logger.debug("Failed to revert vm snapshot", e);
+            logger.debug("Failed to revert vm snapshot", e);
             throw new CloudRuntimeException(e.getMessage());
         } finally {
             if (!result) {
                 try {
                     vmSnapshotHelper.vmSnapshotStateTransitTo(vmSnapshot, VMSnapshot.Event.OperationFailed);
                 } catch (NoTransitionException e1) {
-                    s_logger.error("Cannot set vm snapshot state due to: " + e1.getMessage());
+                    logger.error("Cannot set vm snapshot state due to: " + e1.getMessage());
                 }
             }
         }

--- a/engine/storage/src/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import com.cloud.storage.Storage;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
@@ -54,7 +53,6 @@ import com.cloud.vm.DiskProfile;
 import com.cloud.vm.VirtualMachineProfile;
 
 public abstract class AbstractStoragePoolAllocator extends AdapterBase implements StoragePoolAllocator {
-    private static final Logger s_logger = Logger.getLogger(AbstractStoragePoolAllocator.class);
     @Inject
     StorageManager storageMgr;
     protected @Inject
@@ -116,8 +114,8 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
         }
 
         List<Long> poolIdsByCapacity = _capacityDao.orderHostsByFreeCapacity(clusterId, capacityType);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("List of pools in descending order of free capacity: "+ poolIdsByCapacity);
+        if (logger.isDebugEnabled()) {
+            logger.debug("List of pools in descending order of free capacity: "+ poolIdsByCapacity);
         }
 
       //now filter the given list of Pools by this ordered list
@@ -146,8 +144,8 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
         Long clusterId = plan.getClusterId();
 
         List<Long> poolIdsByVolCount = _volumeDao.listPoolIdsByVolumeCount(dcId, podId, clusterId, account.getAccountId());
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("List of pools in ascending order of number of volumes for account id: " + account.getAccountId() + " is: " + poolIdsByVolCount);
+        if (logger.isDebugEnabled()) {
+            logger.debug("List of pools in ascending order of number of volumes for account id: " + account.getAccountId() + " is: " + poolIdsByVolCount);
         }
 
         // now filter the given list of Pools by this ordered list
@@ -189,12 +187,12 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
 
     protected boolean filter(ExcludeList avoid, StoragePool pool, DiskProfile dskCh, DeploymentPlan plan) {
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Checking if storage pool is suitable, name: " + pool.getName() + " ,poolId: " + pool.getId());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Checking if storage pool is suitable, name: " + pool.getName() + " ,poolId: " + pool.getId());
         }
         if (avoid.shouldAvoid(pool)) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("StoragePool is in avoid set, skipping this pool");
+            if (logger.isDebugEnabled()) {
+                logger.debug("StoragePool is in avoid set, skipping this pool");
             }
             return false;
         }
@@ -203,14 +201,14 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
         if (clusterId != null) {
             ClusterVO cluster = _clusterDao.findById(clusterId);
             if (!(cluster.getHypervisorType() == dskCh.getHypervisorType())) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("StoragePool's Cluster does not have required hypervisorType, skipping this pool");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("StoragePool's Cluster does not have required hypervisorType, skipping this pool");
                 }
                 return false;
             }
         } else if (pool.getHypervisor() != null && !pool.getHypervisor().equals(HypervisorType.Any) && !(pool.getHypervisor() == dskCh.getHypervisorType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("StoragePool does not have required hypervisorType, skipping this pool");
+            if (logger.isDebugEnabled()) {
+                logger.debug("StoragePool does not have required hypervisorType, skipping this pool");
             }
             return false;
         }
@@ -235,13 +233,13 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
                 //LXC ROOT disks supports NFS and local storage pools only
                 if(!(Storage.StoragePoolType.NetworkFilesystem.equals(poolType) ||
                         Storage.StoragePoolType.Filesystem.equals(poolType)) ){
-                    s_logger.debug("StoragePool does not support LXC ROOT disk, skipping this pool");
+                    logger.debug("StoragePool does not support LXC ROOT disk, skipping this pool");
                     return false;
                 }
             } else if (Volume.Type.DATADISK.equals(volType)){
                 //LXC DATA disks supports RBD storage pool only
                 if(!Storage.StoragePoolType.RBD.equals(poolType)){
-                    s_logger.debug("StoragePool does not support LXC DATA disk, skipping this pool");
+                    logger.debug("StoragePool does not support LXC DATA disk, skipping this pool");
                     return false;
                 }
             }

--- a/engine/storage/src/org/apache/cloudstack/storage/allocator/GarbageCollectingStoragePoolAllocator.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/allocator/GarbageCollectingStoragePoolAllocator.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -38,7 +37,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = StoragePoolAllocator.class)
 public class GarbageCollectingStoragePoolAllocator extends AbstractStoragePoolAllocator {
-    private static final Logger s_logger = Logger.getLogger(GarbageCollectingStoragePoolAllocator.class);
 
     StoragePoolAllocator _firstFitStoragePoolAllocator;
     StoragePoolAllocator _localStoragePoolAllocator;
@@ -50,9 +48,9 @@ public class GarbageCollectingStoragePoolAllocator extends AbstractStoragePoolAl
 
     @Override
     public List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
-        s_logger.debug("GarbageCollectingStoragePoolAllocator looking for storage pool");
+        logger.debug("GarbageCollectingStoragePoolAllocator looking for storage pool");
         if (!_storagePoolCleanupEnabled) {
-            s_logger.debug("Storage pool cleanup is not enabled, so GarbageCollectingStoragePoolAllocator is being skipped.");
+            logger.debug("Storage pool cleanup is not enabled, so GarbageCollectingStoragePoolAllocator is being skipped.");
             return null;
         }
 

--- a/engine/storage/src/org/apache/cloudstack/storage/allocator/LocalStoragePoolAllocator.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/allocator/LocalStoragePoolAllocator.java
@@ -28,7 +28,6 @@ import javax.naming.ConfigurationException;
 import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.capacity.dao.CapacityDao;
@@ -47,7 +46,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Component
 @Local(value = StoragePoolAllocator.class)
 public class LocalStoragePoolAllocator extends AbstractStoragePoolAllocator {
-    private static final Logger s_logger = Logger.getLogger(LocalStoragePoolAllocator.class);
 
     @Inject
     StoragePoolHostDao _poolHostDao;
@@ -64,18 +62,18 @@ public class LocalStoragePoolAllocator extends AbstractStoragePoolAllocator {
 
     @Override
     protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
-        s_logger.debug("LocalStoragePoolAllocator trying to find storage pool to fit the vm");
+        logger.debug("LocalStoragePoolAllocator trying to find storage pool to fit the vm");
 
         if (!dskCh.useLocalStorage()) {
             return null;
         }
 
-        if (s_logger.isTraceEnabled()) {
+        if (logger.isTraceEnabled()) {
             // Log the pools details that are ignored because they are in disabled state
             List<StoragePoolVO> disabledPools = _storagePoolDao.findDisabledPoolsByScope(plan.getDataCenterId(), plan.getPodId(), plan.getClusterId(), ScopeType.HOST);
             if (disabledPools != null && !disabledPools.isEmpty()) {
                 for (StoragePoolVO pool : disabledPools) {
-                    s_logger.trace("Ignoring pool " + pool + " as it is in disabled state.");
+                    logger.trace("Ignoring pool " + pool + " as it is in disabled state.");
                 }
             }
         }
@@ -89,7 +87,7 @@ public class LocalStoragePoolAllocator extends AbstractStoragePoolAllocator {
                 if (pool != null && pool.isLocal()) {
                     StoragePool storagePool = (StoragePool)this.dataStoreMgr.getPrimaryDataStore(pool.getId());
                     if (filter(avoid, storagePool, dskCh, plan)) {
-                        s_logger.debug("Found suitable local storage pool " + pool.getId() + ", adding to list");
+                        logger.debug("Found suitable local storage pool " + pool.getId() + ", adding to list");
                         suitablePools.add(storagePool);
                     } else {
                         avoid.addPool(pool.getId());
@@ -128,8 +126,8 @@ public class LocalStoragePoolAllocator extends AbstractStoragePoolAllocator {
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("LocalStoragePoolAllocator returning " + suitablePools.size() + " suitable storage pools");
+        if (logger.isDebugEnabled()) {
+            logger.debug("LocalStoragePoolAllocator returning " + suitablePools.size() + " suitable storage pools");
         }
 
         return suitablePools;

--- a/engine/storage/src/org/apache/cloudstack/storage/allocator/ZoneWideStoragePoolAllocator.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/allocator/ZoneWideStoragePoolAllocator.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -41,7 +40,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Component
 public class ZoneWideStoragePoolAllocator extends AbstractStoragePoolAllocator {
-    private static final Logger s_logger = Logger.getLogger(ZoneWideStoragePoolAllocator.class);
     @Inject
     PrimaryDataStoreDao _storagePoolDao;
     @Inject
@@ -50,18 +48,18 @@ public class ZoneWideStoragePoolAllocator extends AbstractStoragePoolAllocator {
 
     @Override
     protected List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
-        s_logger.debug("ZoneWideStoragePoolAllocator to find storage pool");
+        logger.debug("ZoneWideStoragePoolAllocator to find storage pool");
 
         if (dskCh.useLocalStorage()) {
             return null;
         }
 
-        if (s_logger.isTraceEnabled()) {
+        if (logger.isTraceEnabled()) {
             // Log the pools details that are ignored because they are in disabled state
             List<StoragePoolVO> disabledPools = _storagePoolDao.findDisabledPoolsByScope(plan.getDataCenterId(), null, null, ScopeType.ZONE);
             if (disabledPools != null && !disabledPools.isEmpty()) {
                 for (StoragePoolVO pool : disabledPools) {
-                    s_logger.trace("Ignoring pool " + pool + " as it is in disabled state.");
+                    logger.trace("Ignoring pool " + pool + " as it is in disabled state.");
                 }
             }
         }
@@ -114,8 +112,8 @@ public class ZoneWideStoragePoolAllocator extends AbstractStoragePoolAllocator {
         long dcId = plan.getDataCenterId();
 
         List<Long> poolIdsByVolCount = _volumeDao.listZoneWidePoolIdsByVolumeCount(dcId, account.getAccountId());
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("List of pools in ascending order of number of volumes for account id: " + account.getAccountId() + " is: " + poolIdsByVolCount);
+        if (logger.isDebugEnabled()) {
+            logger.debug("List of pools in ascending order of number of volumes for account id: " + account.getAccountId() + " is: " + poolIdsByVolCount);
         }
 
         // now filter the given list of Pools by this ordered list

--- a/engine/storage/src/org/apache/cloudstack/storage/datastore/provider/DataStoreProviderManagerImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/datastore/provider/DataStoreProviderManagerImpl.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.StorageProviderResponse;
@@ -48,7 +47,6 @@ import com.cloud.utils.component.Registry;
 
 @Component
 public class DataStoreProviderManagerImpl extends ManagerBase implements DataStoreProviderManager, Registry<DataStoreProvider> {
-    private static final Logger s_logger = Logger.getLogger(DataStoreProviderManagerImpl.class);
 
     List<DataStoreProvider> providers;
     protected Map<String, DataStoreProvider> providerMap = new ConcurrentHashMap<String, DataStoreProvider>();
@@ -123,18 +121,18 @@ public class DataStoreProviderManagerImpl extends ManagerBase implements DataSto
 
         String providerName = provider.getName();
         if (providerMap.get(providerName) != null) {
-            s_logger.debug("Did not register data store provider, provider name: " + providerName + " is not unique");
+            logger.debug("Did not register data store provider, provider name: " + providerName + " is not unique");
             return false;
         }
 
-        s_logger.debug("registering data store provider:" + provider.getName());
+        logger.debug("registering data store provider:" + provider.getName());
 
         providerMap.put(providerName, provider);
         try {
             boolean registrationResult = provider.configure(copyParams);
             if (!registrationResult) {
                 providerMap.remove(providerName);
-                s_logger.debug("Failed to register data store provider: " + providerName);
+                logger.debug("Failed to register data store provider: " + providerName);
                 return false;
             }
 
@@ -146,7 +144,7 @@ public class DataStoreProviderManagerImpl extends ManagerBase implements DataSto
                 imageStoreProviderMgr.registerDriver(provider.getName(), (ImageStoreDriver)provider.getDataStoreDriver());
             }
         } catch (Exception e) {
-            s_logger.debug("configure provider failed", e);
+            logger.debug("configure provider failed", e);
             providerMap.remove(providerName);
             return false;
         }

--- a/engine/storage/src/org/apache/cloudstack/storage/db/ObjectInDataStoreDaoImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/db/ObjectInDataStoreDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObjectInStore;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.UpdateBuilder;
 
 @Component
 public class ObjectInDataStoreDaoImpl extends GenericDaoBase<ObjectInDataStoreVO, Long> implements ObjectInDataStoreDao {
-    private static final Logger s_logger = Logger.getLogger(ObjectInDataStoreDaoImpl.class);
     private SearchBuilder<ObjectInDataStoreVO> updateStateSearch;
 
     @Override
@@ -69,7 +67,7 @@ public class ObjectInDataStoreDaoImpl extends GenericDaoBase<ObjectInDataStoreVO
         builder.set(vo, "updated", new Date());
 
         int rows = update(vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             ObjectInDataStoreVO dbVol = findByIdIncludingRemoved(vo.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -102,7 +100,7 @@ public class ObjectInDataStoreDaoImpl extends GenericDaoBase<ObjectInDataStoreVO
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update objectIndatastore: id=" + vo.getId() + ", as there is no such object exists in the database anymore");
+                logger.debug("Unable to update objectIndatastore: id=" + vo.getId() + ", as there is no such object exists in the database anymore");
             }
         }
         return rows > 0;

--- a/engine/storage/src/org/apache/cloudstack/storage/image/db/SnapshotDataStoreDaoImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/db/SnapshotDataStoreDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObjectInStore;
@@ -46,7 +45,6 @@ import com.cloud.utils.db.UpdateBuilder;
 
 @Component
 public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO, Long> implements SnapshotDataStoreDao {
-    private static final Logger s_logger = Logger.getLogger(SnapshotDataStoreDaoImpl.class);
     private SearchBuilder<SnapshotDataStoreVO> updateStateSearch;
     private SearchBuilder<SnapshotDataStoreVO> storeSearch;
     private SearchBuilder<SnapshotDataStoreVO> destroyedSearch;
@@ -140,7 +138,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
         builder.set(dataObj, "updated", new Date());
 
         int rows = update(dataObj, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             SnapshotDataStoreVO dbVol = findByIdIncludingRemoved(dataObj.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(dataObj.toString());
@@ -173,7 +171,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update objectIndatastore: id=" + dataObj.getId() + ", as there is no such object exists in the database anymore");
+                logger.debug("Unable to update objectIndatastore: id=" + dataObj.getId() + ", as there is no such object exists in the database anymore");
             }
         }
         return rows > 0;
@@ -234,7 +232,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
                 }
             }
         } catch (SQLException e) {
-            s_logger.debug("Failed to find latest snapshot for volume: " + volumeId + " due to: "  + e.toString());
+            logger.debug("Failed to find latest snapshot for volume: " + volumeId + " due to: "  + e.toString());
         }
         return null;
     }
@@ -255,7 +253,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
                 }
             }
         } catch (SQLException e) {
-            s_logger.debug("Failed to find oldest snapshot for volume: " + volumeId + " due to: "  + e.toString());
+            logger.debug("Failed to find oldest snapshot for volume: " + volumeId + " due to: "  + e.toString());
         }
         return null;
     }
@@ -278,7 +276,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
                 }
             }
         } catch (SQLException e) {
-            s_logger.debug("Failed to find parent snapshot: " + e.toString());
+            logger.debug("Failed to find parent snapshot: " + e.toString());
         }
         return null;
     }
@@ -326,14 +324,14 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
         List<SnapshotDataStoreVO> snapshots = listBy(sc);
         // create an entry for each record, but with empty install path since the content is not yet on region-wide store yet
         if (snapshots != null) {
-            s_logger.info("Duplicate " + snapshots.size() + " snapshot cache store records to region store");
+            logger.info("Duplicate " + snapshots.size() + " snapshot cache store records to region store");
             for (SnapshotDataStoreVO snap : snapshots) {
                 SnapshotDataStoreVO snapStore = findByStoreSnapshot(DataStoreRole.Image, storeId, snap.getSnapshotId());
                 if (snapStore != null) {
-                    s_logger.info("There is already entry for snapshot " + snap.getSnapshotId() + " on region store " + storeId);
+                    logger.info("There is already entry for snapshot " + snap.getSnapshotId() + " on region store " + storeId);
                     continue;
                 }
-                s_logger.info("Persisting an entry for snapshot " + snap.getSnapshotId() + " on region store " + storeId);
+                logger.info("Persisting an entry for snapshot " + snap.getSnapshotId() + " on region store " + storeId);
                 SnapshotDataStoreVO ss = new SnapshotDataStoreVO();
                 ss.setSnapshotId(snap.getSnapshotId());
                 ss.setDataStoreId(storeId);
@@ -377,7 +375,7 @@ public class SnapshotDataStoreDaoImpl extends GenericDaoBase<SnapshotDataStoreVO
         sc.setParameters("destroyed", false);
         List<SnapshotDataStoreVO> snaps = listBy(sc);
         if (snaps != null) {
-            s_logger.info("Update to cache store role for " + snaps.size() + " entries in snapshot_store_ref");
+            logger.info("Update to cache store role for " + snaps.size() + " entries in snapshot_store_ref");
             for (SnapshotDataStoreVO snap : snaps) {
                 snap.setRole(DataStoreRole.ImageCache);
                 update(snap.getId(), snap);

--- a/engine/storage/src/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/db/TemplateDataStoreDaoImpl.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObjectInStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -56,7 +55,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
 public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO, Long> implements TemplateDataStoreDao {
-    private static final Logger s_logger = Logger.getLogger(TemplateDataStoreDaoImpl.class);
     private SearchBuilder<TemplateDataStoreVO> updateStateSearch;
     private SearchBuilder<TemplateDataStoreVO> storeSearch;
     private SearchBuilder<TemplateDataStoreVO> cacheSearch;
@@ -174,7 +172,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
         }
 
         int rows = update(dataObj, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             TemplateDataStoreVO dbVol = findByIdIncludingRemoved(dataObj.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(dataObj.toString());
@@ -207,7 +205,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update objectIndatastore: id=" + dataObj.getId() + ", as there is no such object exists in the database anymore");
+                logger.debug("Unable to update objectIndatastore: id=" + dataObj.getId() + ", as there is no such object exists in the database anymore");
             }
         }
         return rows > 0;
@@ -457,7 +455,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
         List<TemplateDataStoreVO> tmpls = listBy(sc);
         // create an entry for each template record, but with empty install path since the content is not yet on region-wide store yet
         if (tmpls != null) {
-            s_logger.info("Duplicate " + tmpls.size() + " template cache store records to region store");
+            logger.info("Duplicate " + tmpls.size() + " template cache store records to region store");
             for (TemplateDataStoreVO tmpl : tmpls) {
                 long templateId = tmpl.getTemplateId();
                 VMTemplateVO template = _tmpltDao.findById(templateId);
@@ -465,15 +463,15 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
                     throw new CloudRuntimeException("No template is found for template id: " + templateId);
                 }
                 if (template.getTemplateType() == TemplateType.SYSTEM) {
-                    s_logger.info("No need to duplicate system template since it will be automatically downloaded while adding region store");
+                    logger.info("No need to duplicate system template since it will be automatically downloaded while adding region store");
                     continue;
                 }
                 TemplateDataStoreVO tmpStore = findByStoreTemplate(storeId, tmpl.getTemplateId());
                 if (tmpStore != null) {
-                    s_logger.info("There is already entry for template " + tmpl.getTemplateId() + " on region store " + storeId);
+                    logger.info("There is already entry for template " + tmpl.getTemplateId() + " on region store " + storeId);
                     continue;
                 }
-                s_logger.info("Persisting an entry for template " + tmpl.getTemplateId() + " on region store " + storeId);
+                logger.info("Persisting an entry for template " + tmpl.getTemplateId() + " on region store " + storeId);
                 TemplateDataStoreVO ts = new TemplateDataStoreVO();
                 ts.setTemplateId(tmpl.getTemplateId());
                 ts.setDataStoreId(storeId);
@@ -508,7 +506,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
         sc.setParameters("destroyed", false);
         List<TemplateDataStoreVO> tmpls = listBy(sc);
         if (tmpls != null) {
-            s_logger.info("Update to cache store role for " + tmpls.size() + " entries in template_store_ref");
+            logger.info("Update to cache store role for " + tmpls.size() + " entries in template_store_ref");
             for (TemplateDataStoreVO tmpl : tmpls) {
                 tmpl.setDataStoreRole(DataStoreRole.ImageCache);
                 update(tmpl.getId(), tmpl);
@@ -537,7 +535,7 @@ public class TemplateDataStoreDaoImpl extends GenericDaoBase<TemplateDataStoreVO
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Failed expiring download urls for dcId: " + dcId, e);
+            logger.warn("Failed expiring download urls for dcId: " + dcId, e);
         }
 
     }

--- a/engine/storage/src/org/apache/cloudstack/storage/image/db/VolumeDataStoreDaoImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/db/VolumeDataStoreDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObjectInStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -48,7 +47,6 @@ import com.cloud.utils.db.UpdateBuilder;
 
 @Component
 public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Long> implements VolumeDataStoreDao {
-    private static final Logger s_logger = Logger.getLogger(VolumeDataStoreDaoImpl.class);
     private SearchBuilder<VolumeDataStoreVO> updateStateSearch;
     private SearchBuilder<VolumeDataStoreVO> volumeSearch;
     private SearchBuilder<VolumeDataStoreVO> storeSearch;
@@ -141,7 +139,7 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
         }
 
         int rows = update(dataObj, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             VolumeDataStoreVO dbVol = findByIdIncludingRemoved(dataObj.getId());
             if (dbVol != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(dataObj.toString());
@@ -174,7 +172,7 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update objectIndatastore: id=" + dataObj.getId() + ", as there is no such object exists in the database anymore");
+                logger.debug("Unable to update objectIndatastore: id=" + dataObj.getId() + ", as there is no such object exists in the database anymore");
             }
         }
         return rows > 0;
@@ -281,14 +279,14 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
         }
         // create an entry for each record, but with empty install path since the content is not yet on region-wide store yet
         if (vols != null) {
-            s_logger.info("Duplicate " + vols.size() + " volume cache store records to region store");
+            logger.info("Duplicate " + vols.size() + " volume cache store records to region store");
             for (VolumeDataStoreVO vol : vols) {
                 VolumeDataStoreVO volStore = findByStoreVolume(storeId, vol.getVolumeId());
                 if (volStore != null) {
-                    s_logger.info("There is already entry for volume " + vol.getVolumeId() + " on region store " + storeId);
+                    logger.info("There is already entry for volume " + vol.getVolumeId() + " on region store " + storeId);
                     continue;
                 }
-                s_logger.info("Persisting an entry for volume " + vol.getVolumeId() + " on region store " + storeId);
+                logger.info("Persisting an entry for volume " + vol.getVolumeId() + " on region store " + storeId);
                 VolumeDataStoreVO vs = new VolumeDataStoreVO();
                 vs.setVolumeId(vol.getVolumeId());
                 vs.setDataStoreId(storeId);
@@ -337,7 +335,7 @@ public class VolumeDataStoreDaoImpl extends GenericDaoBase<VolumeDataStoreVO, Lo
             txn.commit();
         } catch (Exception e) {
             txn.rollback();
-            s_logger.warn("Failed expiring download urls for dcId: " + dcId, e);
+            logger.warn("Failed expiring download urls for dcId: " + dcId, e);
         }
 
     }

--- a/engine/storage/src/org/apache/cloudstack/storage/volume/db/TemplatePrimaryDataStoreDaoImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/volume/db/TemplatePrimaryDataStoreDaoImpl.java
@@ -20,7 +20,6 @@ package org.apache.cloudstack.storage.volume.db;
 
 import java.util.Date;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.UpdateBuilder;
 
 @Component
 public class TemplatePrimaryDataStoreDaoImpl extends GenericDaoBase<TemplatePrimaryDataStoreVO, Long> implements TemplatePrimaryDataStoreDao {
-    private static final Logger s_logger = Logger.getLogger(TemplatePrimaryDataStoreDaoImpl.class);
     protected final SearchBuilder<TemplatePrimaryDataStoreVO> updateSearchBuilder;
 
     public TemplatePrimaryDataStoreDaoImpl() {
@@ -81,7 +79,7 @@ public class TemplatePrimaryDataStoreDaoImpl extends GenericDaoBase<TemplatePrim
         builder.set(vo, "lastUpdated", new Date());
 
         int rows = update(vo, sc);
-        if (rows == 0 && s_logger.isDebugEnabled()) {
+        if (rows == 0 && logger.isDebugEnabled()) {
             TemplatePrimaryDataStoreVO template = findByIdIncludingRemoved(vo.getId());
             if (template != null) {
                 StringBuilder str = new StringBuilder("Unable to update ").append(vo.toString());
@@ -114,7 +112,7 @@ public class TemplatePrimaryDataStoreDaoImpl extends GenericDaoBase<TemplatePrim
                     .append("; updatedTime=")
                     .append(oldUpdatedTime);
             } else {
-                s_logger.debug("Unable to update template: id=" + vo.getId() + ", as there is no such template exists in the database anymore");
+                logger.debug("Unable to update template: id=" + vo.getId() + ", as there is no such template exists in the database anymore");
             }
         }
         return rows > 0;

--- a/framework/cluster/src/com/cloud/cluster/ClusterFenceManagerImpl.java
+++ b/framework/cluster/src/com/cloud/cluster/ClusterFenceManagerImpl.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.component.ManagerBase;
@@ -31,7 +30,6 @@ import com.cloud.utils.component.ManagerBase;
 @Component
 @Local(value = {ClusterFenceManager.class})
 public class ClusterFenceManagerImpl extends ManagerBase implements ClusterFenceManager, ClusterManagerListener {
-    private static final Logger s_logger = Logger.getLogger(ClusterFenceManagerImpl.class);
 
     @Inject
     ClusterManager _clusterMgr;
@@ -52,7 +50,7 @@ public class ClusterFenceManagerImpl extends ManagerBase implements ClusterFence
 
     @Override
     public void onManagementNodeIsolated() {
-        s_logger.error("Received node isolation notification, will perform self-fencing and shut myself down");
+        logger.error("Received node isolation notification, will perform self-fencing and shut myself down");
         System.exit(SELF_FENCING_EXIT_CODE);
     }
 }

--- a/framework/cluster/src/com/cloud/cluster/ClusterManagerImpl.java
+++ b/framework/cluster/src/com/cloud/cluster/ClusterManagerImpl.java
@@ -46,7 +46,6 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
-import org.apache.log4j.Logger;
 
 import com.cloud.cluster.dao.ManagementServerHostDao;
 import com.cloud.cluster.dao.ManagementServerHostPeerDao;
@@ -70,7 +69,6 @@ import com.cloud.utils.net.NetUtils;
 
 @Local(value = {ClusterManager.class})
 public class ClusterManagerImpl extends ManagerBase implements ClusterManager, Configurable {
-    private static final Logger s_logger = Logger.getLogger(ClusterManagerImpl.class);
 
     private static final int EXECUTOR_SHUTDOWN_TIMEOUT = 1000; // 1 second
     private static final int DEFAULT_OUTGOING_WORKERS = 5;
@@ -167,7 +165,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         }
 
         for (final ClusterServiceRequestPdu pdu : candidates) {
-            s_logger.warn("Cancel cluster request PDU to peer: " + strPeer + ", pdu: " + pdu.getJsonPackage());
+            logger.warn("Cancel cluster request PDU to peer: " + strPeer + ", pdu: " + pdu.getJsonPackage());
             synchronized (pdu) {
                 pdu.notifyAll();
             }
@@ -251,13 +249,13 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                     try {
                         peerService = getPeerService(pdu.getDestPeer());
                     } catch (final RemoteException e) {
-                        s_logger.error("Unable to get cluster service on peer : " + pdu.getDestPeer());
+                        logger.error("Unable to get cluster service on peer : " + pdu.getDestPeer());
                     }
 
                     if (peerService != null) {
                         try {
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Cluster PDU " + getSelfPeerName() + " -> " + pdu.getDestPeer() + ". agent: " + pdu.getAgentId() + ", pdu seq: " +
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Cluster PDU " + getSelfPeerName() + " -> " + pdu.getDestPeer() + ". agent: " + pdu.getAgentId() + ", pdu seq: " +
                                         pdu.getSequenceId() + ", pdu ack seq: " + pdu.getAckSequenceId() + ", json: " + pdu.getJsonPackage());
                             }
 
@@ -267,8 +265,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                             final String strResult = peerService.execute(pdu);
                             profiler.stop();
 
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Cluster PDU " + getSelfPeerName() + " -> " + pdu.getDestPeer() + " completed. time: " +
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Cluster PDU " + getSelfPeerName() + " -> " + pdu.getDestPeer() + " completed. time: " +
                                         profiler.getDurationInMillis() + "ms. agent: " + pdu.getAgentId() + ", pdu seq: " + pdu.getSequenceId() +
                                         ", pdu ack seq: " + pdu.getAckSequenceId() + ", json: " + pdu.getJsonPackage());
                             }
@@ -279,15 +277,15 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
                         } catch (final RemoteException e) {
                             invalidatePeerService(pdu.getDestPeer());
-                            if (s_logger.isInfoEnabled()) {
-                                s_logger.info("Exception on remote execution, peer: " + pdu.getDestPeer() + ", iteration: " + i + ", exception message :" +
+                            if (logger.isInfoEnabled()) {
+                                logger.info("Exception on remote execution, peer: " + pdu.getDestPeer() + ", iteration: " + i + ", exception message :" +
                                         e.getMessage());
                             }
                         }
                     }
                 }
             } catch (final Throwable e) {
-                s_logger.error("Unexcpeted exception: ", e);
+                logger.error("Unexcpeted exception: ", e);
             }
         }
     }
@@ -311,7 +309,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                                     requestPdu.notifyAll();
                                 }
                             } else {
-                                s_logger.warn("Original request has already been cancelled. pdu: " + pdu.getJsonPackage());
+                                logger.warn("Original request has already been cancelled. pdu: " + pdu.getJsonPackage());
                             }
                         } else {
                             String result = _dispatcher.dispatch(pdu);
@@ -333,7 +331,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                     }
                 });
             } catch (final Throwable e) {
-                s_logger.error("Unexcpeted exception: ", e);
+                logger.error("Unexcpeted exception: ", e);
             }
         }
     }
@@ -366,12 +364,12 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 continue; // Skip myself.
             }
             try {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Forwarding " + cmds + " to " + peer.getMsid());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Forwarding " + cmds + " to " + peer.getMsid());
                 }
                 executeAsync(peerName, agentId, cmds, true);
             } catch (final Exception e) {
-                s_logger.warn("Caught exception while talkign to " + peer.getMsid());
+                logger.warn("Caught exception while talkign to " + peer.getMsid());
             }
         }
     }
@@ -388,8 +386,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
     @Override
     public String execute(final String strPeer, final long agentId, final String cmds, final boolean stopOnError) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug(getSelfPeerName() + " -> " + strPeer + "." + agentId + " " + cmds);
+        if (logger.isDebugEnabled()) {
+            logger.debug(getSelfPeerName() + " -> " + strPeer + "." + agentId + " " + cmds);
         }
 
         final ClusterServiceRequestPdu pdu = new ClusterServiceRequestPdu();
@@ -408,8 +406,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug(getSelfPeerName() + " -> " + strPeer + "." + agentId + " completed. result: " + pdu.getResponseResult());
+        if (logger.isDebugEnabled()) {
+            logger.debug(getSelfPeerName() + " -> " + strPeer + "." + agentId + " completed. result: " + pdu.getResponseResult());
         }
 
         if (pdu.getResponseResult() != null && pdu.getResponseResult().length() > 0) {
@@ -438,7 +436,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         // Note : we don't check duplicates
         synchronized (_listeners) {
 
-            s_logger.info("register cluster listener " + listener.getClass());
+            logger.info("register cluster listener " + listener.getClass());
 
             _listeners.add(listener);
         }
@@ -447,18 +445,18 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
     @Override
     public void unregisterListener(final ClusterManagerListener listener) {
         synchronized (_listeners) {
-            s_logger.info("unregister cluster listener " + listener.getClass());
+            logger.info("unregister cluster listener " + listener.getClass());
 
             _listeners.remove(listener);
         }
     }
 
     public void notifyNodeJoined(final List<ManagementServerHostVO> nodeList) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Notify management server node join to listeners.");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Notify management server node join to listeners.");
 
             for (final ManagementServerHostVO mshost : nodeList) {
-                s_logger.debug("Joining node, IP: " + mshost.getServiceIP() + ", msid: " + mshost.getMsid());
+                logger.debug("Joining node, IP: " + mshost.getServiceIP() + ", msid: " + mshost.getMsid());
             }
         }
 
@@ -472,13 +470,13 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
     }
 
     public void notifyNodeLeft(final List<ManagementServerHostVO> nodeList) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Notify management server node left to listeners.");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Notify management server node left to listeners.");
         }
 
         for (final ManagementServerHostVO mshost : nodeList) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Leaving node, IP: " + mshost.getServiceIP() + ", msid: " + mshost.getMsid());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Leaving node, IP: " + mshost.getServiceIP() + ", msid: " + mshost.getMsid());
             }
             cancelClusterRequestToPeer(String.valueOf(mshost.getMsid()));
         }
@@ -493,8 +491,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
     }
 
     public void notifyNodeIsolated() {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Notify management server node isolation to listeners");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Notify management server node isolation to listeners");
         }
 
         synchronized (_listeners) {
@@ -549,16 +547,16 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
                         profilerHeartbeatUpdate.start();
                         txn.transitToUserManagedConnection(getHeartbeatConnection());
-                        if (s_logger.isTraceEnabled()) {
-                            s_logger.trace("Cluster manager heartbeat update, id:" + _mshostId);
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Cluster manager heartbeat update, id:" + _mshostId);
                         }
 
                         _mshostDao.update(_mshostId, _runId, DateUtil.currentGMTTime());
                         profilerHeartbeatUpdate.stop();
 
                         profilerPeerScan.start();
-                        if (s_logger.isTraceEnabled()) {
-                            s_logger.trace("Cluster manager peer-scan, id:" + _mshostId);
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Cluster manager peer-scan, id:" + _mshostId);
                         }
 
                         if (!_peerScanInited) {
@@ -573,18 +571,18 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                         profiler.stop();
 
                         if (profiler.getDurationInMillis() >= HeartbeatInterval.value()) {
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Management server heartbeat takes too long to finish. profiler: " + profiler.toString() + ", profilerHeartbeatUpdate: " +
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Management server heartbeat takes too long to finish. profiler: " + profiler.toString() + ", profilerHeartbeatUpdate: " +
                                         profilerHeartbeatUpdate.toString() + ", profilerPeerScan: " + profilerPeerScan.toString());
                             }
                         }
                     }
 
                 } catch (final CloudRuntimeException e) {
-                    s_logger.error("Runtime DB exception ", e.getCause());
+                    logger.error("Runtime DB exception ", e.getCause());
 
                     if (e.getCause() instanceof ClusterInvalidSessionException) {
-                        s_logger.error("Invalid cluster session found, fence it");
+                        logger.error("Invalid cluster session found, fence it");
                         queueNotification(new ClusterManagerMessage(ClusterManagerMessage.MessageType.nodeIsolated));
                     }
 
@@ -594,7 +592,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 } catch (final ActiveFencingException e) {
                     queueNotification(new ClusterManagerMessage(ClusterManagerMessage.MessageType.nodeIsolated));
                 } catch (final Throwable e) {
-                    s_logger.error("Unexpected exception in cluster heartbeat", e);
+                    logger.error("Unexpected exception in cluster heartbeat", e);
                     if (isRootCauseConnectionRelated(e.getCause())) {
                         invalidHeartbeatConnection();
                     }
@@ -633,7 +631,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
             if (conn != null) {
                 _heartbeatConnection.reset(conn);
             } else {
-                s_logger.error("DB communication problem detected, fence it");
+                logger.error("DB communication problem detected, fence it");
                 queueNotification(new ClusterManagerMessage(ClusterManagerMessage.MessageType.nodeIsolated));
             }
             // The stand-alone connection does not have to be closed here because there will be another reference to it.
@@ -666,11 +664,11 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
                                     profiler.stop();
                                     if (profiler.getDurationInMillis() > 1000) {
-                                        if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Notifying management server join event took " + profiler.getDurationInMillis() + " ms");
+                                        if (logger.isDebugEnabled()) {
+                                            logger.debug("Notifying management server join event took " + profiler.getDurationInMillis() + " ms");
                                         }
                                     } else {
-                                        s_logger.warn("Notifying management server join event took " + profiler.getDurationInMillis() + " ms");
+                                        logger.warn("Notifying management server join event took " + profiler.getDurationInMillis() + " ms");
                                     }
                                 }
                                 break;
@@ -684,11 +682,11 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
                                     profiler.stop();
                                     if (profiler.getDurationInMillis() > 1000) {
-                                        if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Notifying management server leave event took " + profiler.getDurationInMillis() + " ms");
+                                        if (logger.isDebugEnabled()) {
+                                            logger.debug("Notifying management server leave event took " + profiler.getDurationInMillis() + " ms");
                                         }
                                     } else {
-                                        s_logger.warn("Notifying management server leave event took " + profiler.getDurationInMillis() + " ms");
+                                        logger.warn("Notifying management server leave event took " + profiler.getDurationInMillis() + " ms");
                                     }
                                 }
                                 break;
@@ -703,7 +701,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                             }
 
                         } catch (final Throwable e) {
-                            s_logger.warn("Unexpected exception during cluster notification. ", e);
+                            logger.warn("Unexpected exception during cluster notification. ", e);
                         }
                     }
 
@@ -770,18 +768,18 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         if (orphanList.size() > 0) {
             for (final Long orphanMsid : orphanList) {
                 // construct fake ManagementServerHostVO based on orphan MSID
-                s_logger.info("Add orphan management server msid found in host table to initial clustering notification, orphan msid: " + orphanMsid);
+                logger.info("Add orphan management server msid found in host table to initial clustering notification, orphan msid: " + orphanMsid);
                 inactiveList.add(new ManagementServerHostVO(orphanMsid, 0, "orphan", 0, new Date()));
             }
         } else {
-            s_logger.info("We are good, no orphan management server msid in host table is found");
+            logger.info("We are good, no orphan management server msid in host table is found");
         }
 
         if (inactiveList.size() > 0) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Found " + inactiveList.size() + " inactive management server node based on timestamp");
+            if (logger.isInfoEnabled()) {
+                logger.info("Found " + inactiveList.size() + " inactive management server node based on timestamp");
                 for (final ManagementServerHostVO host : inactiveList) {
-                    s_logger.info("management server node msid: " + host.getMsid() + ", name: " + host.getName() + ", service ip: " + host.getServiceIP() +
+                    logger.info("management server node msid: " + host.getMsid() + ", name: " + host.getName() + ", service ip: " + host.getServiceIP() +
                             ", version: " + host.getVersion());
                 }
             }
@@ -789,7 +787,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
             final List<ManagementServerHostVO> downHostList = new ArrayList<ManagementServerHostVO>();
             for (final ManagementServerHostVO host : inactiveList) {
                 if (!pingManagementNode(host)) {
-                    s_logger.warn("Management node " + host.getId() + " is detected inactive by timestamp and also not pingable");
+                    logger.warn("Management node " + host.getId() + " is detected inactive by timestamp and also not pingable");
                     downHostList.add(host);
                 }
             }
@@ -798,7 +796,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 queueNotification(new ClusterManagerMessage(ClusterManagerMessage.MessageType.nodeRemoved, downHostList));
             }
         } else {
-            s_logger.info("No inactive management server node found");
+            logger.info("No inactive management server node found");
         }
     }
 
@@ -823,7 +821,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
             if (_mshostPeerDao.countStateSeenInPeers(_mshostId, _runId, ManagementServerHost.State.Down) > 0) {
                 final String msg =
                         "We have detected that at least one management server peer reports that this management server is down, perform active fencing to avoid split-brain situation";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ActiveFencingException(msg);
             }
 
@@ -833,24 +831,24 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 final ManagementServerHostVO current = getInListById(entry.getKey(), currentList);
                 if (current == null) {
                     if (entry.getKey().longValue() != _mshostId.longValue()) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Detected management node left, id:" + entry.getKey() + ", nodeIP:" + entry.getValue().getServiceIP());
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Detected management node left, id:" + entry.getKey() + ", nodeIP:" + entry.getValue().getServiceIP());
                         }
                         removedNodeList.add(entry.getValue());
                     }
                 } else {
                     if (current.getRunid() == 0) {
                         if (entry.getKey().longValue() != _mshostId.longValue()) {
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Detected management node left because of invalidated session, id:" + entry.getKey() + ", nodeIP:" +
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Detected management node left because of invalidated session, id:" + entry.getKey() + ", nodeIP:" +
                                         entry.getValue().getServiceIP());
                             }
                             invalidatedNodeList.add(entry.getValue());
                         }
                     } else {
                         if (entry.getValue().getRunid() != current.getRunid()) {
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Detected management node left and rejoined quickly, id:" + entry.getKey() + ", nodeIP:" + entry.getValue().getServiceIP());
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Detected management node left and rejoined quickly, id:" + entry.getKey() + ", nodeIP:" + entry.getValue().getServiceIP());
                             }
 
                             entry.getValue().setRunid(current.getRunid());
@@ -870,7 +868,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 try {
                     JmxUtil.unregisterMBean("ClusterManager", "Node " + mshost.getId());
                 } catch (final Exception e) {
-                    s_logger.warn("Unable to deregiester cluster node from JMX monitoring due to exception " + e.toString());
+                    logger.warn("Unable to deregiester cluster node from JMX monitoring due to exception " + e.toString());
                 }
             }
 
@@ -885,15 +883,15 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         while (it.hasNext()) {
             final ManagementServerHostVO mshost = it.next();
             if (!pingManagementNode(mshost)) {
-                s_logger.warn("Management node " + mshost.getId() + " is detected inactive by timestamp and also not pingable");
+                logger.warn("Management node " + mshost.getId() + " is detected inactive by timestamp and also not pingable");
                 _activePeers.remove(mshost.getId());
                 try {
                     JmxUtil.unregisterMBean("ClusterManager", "Node " + mshost.getId());
                 } catch (final Exception e) {
-                    s_logger.warn("Unable to deregiester cluster node from JMX monitoring due to exception " + e.toString());
+                    logger.warn("Unable to deregiester cluster node from JMX monitoring due to exception " + e.toString());
                 }
             } else {
-                s_logger.info("Management node " + mshost.getId() + " is detected inactive by timestamp but is pingable");
+                logger.info("Management node " + mshost.getId() + " is detected inactive by timestamp but is pingable");
                 it.remove();
             }
         }
@@ -908,15 +906,15 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
             if (!_activePeers.containsKey(mshost.getId())) {
                 _activePeers.put(mshost.getId(), mshost);
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Detected management node joined, id:" + mshost.getId() + ", nodeIP:" + mshost.getServiceIP());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Detected management node joined, id:" + mshost.getId() + ", nodeIP:" + mshost.getServiceIP());
                 }
                 newNodeList.add(mshost);
 
                 try {
                     JmxUtil.registerMBean("ClusterManager", "Node " + mshost.getId(), new ClusterManagerMBeanImpl(this, mshost));
                 } catch (final Exception e) {
-                    s_logger.warn("Unable to regiester cluster node into JMX monitoring due to exception " + ExceptionUtil.toString(e));
+                    logger.warn("Unable to regiester cluster node into JMX monitoring due to exception " + ExceptionUtil.toString(e));
                 }
             }
         }
@@ -928,8 +926,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         profiler.stop();
 
         if (profiler.getDurationInMillis() >= HeartbeatInterval.value()) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Peer scan takes too long to finish. profiler: " + profiler.toString() + ", profilerQueryActiveList: " +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Peer scan takes too long to finish. profiler: " + profiler.toString() + ", profilerQueryActiveList: " +
                         profilerQueryActiveList.toString() + ", profilerSyncClusterInfo: " + profilerSyncClusterInfo.toString() + ", profilerInvalidatedNodeList: " +
                         profilerInvalidatedNodeList.toString() + ", profilerRemovedList: " + profilerRemovedList.toString());
             }
@@ -948,8 +946,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
     @Override
     @DB
     public boolean start() {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Starting Cluster manager, msid : " + _msId);
+        if (logger.isInfoEnabled()) {
+            logger.info("Starting Cluster manager, msid : " + _msId);
         }
 
         final ManagementServerHostVO mshost = Transaction.execute(new TransactionCallback<ManagementServerHostVO>() {
@@ -973,14 +971,14 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                     mshost.setAlertCount(0);
                     mshost.setState(ManagementServerHost.State.Up);
                     _mshostDao.persist(mshost);
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("New instance of management server msid " + _msId + ", runId " + _runId + " is being started");
+                    if (logger.isInfoEnabled()) {
+                        logger.info("New instance of management server msid " + _msId + ", runId " + _runId + " is being started");
                     }
                 } else {
                     _mshostDao.update(mshost.getId(), _runId, NetUtils.getHostName(), version, _clusterNodeIP, _currentServiceAdapter.getServicePort(),
                             DateUtil.currentGMTTime());
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("Management server " + _msId + ", runId " + _runId + " is being started");
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Management server " + _msId + ", runId " + _runId + " is being started");
                     }
                 }
 
@@ -989,8 +987,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         });
 
         _mshostId = mshost.getId();
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Management server (host id : " + _mshostId + ") is being started at " + _clusterNodeIP + ":" + _currentServiceAdapter.getServicePort());
+        if (logger.isInfoEnabled()) {
+            logger.info("Management server (host id : " + _mshostId + ") is being started at " + _clusterNodeIP + ":" + _currentServiceAdapter.getServicePort());
         }
 
         _mshostPeerDao.clearPeerInfo(_mshostId);
@@ -999,8 +997,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         _heartbeatScheduler.scheduleAtFixedRate(getHeartbeatTask(), HeartbeatInterval.value(), HeartbeatInterval.value(), TimeUnit.MILLISECONDS);
         _notificationExecutor.submit(getNotificationTask());
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Cluster manager was started successfully");
+        if (logger.isInfoEnabled()) {
+            logger.info("Cluster manager was started successfully");
         }
 
         return true;
@@ -1009,8 +1007,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
     @Override
     @DB
     public boolean stop() {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Stopping Cluster manager, msid : " + _msId);
+        if (logger.isInfoEnabled()) {
+            logger.info("Stopping Cluster manager, msid : " + _msId);
         }
 
         if (_mshostId != null) {
@@ -1028,8 +1026,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         } catch (final InterruptedException e) {
         }
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Cluster manager is stopped");
+        if (logger.isInfoEnabled()) {
+            logger.info("Cluster manager is stopped");
         }
 
         return true;
@@ -1037,8 +1035,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
     @Override
     public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Start configuring cluster manager : " + name);
+        if (logger.isInfoEnabled()) {
+            logger.info("Start configuring cluster manager : " + name);
         }
 
         final Properties dbProps = DbProperties.getDbProperties();
@@ -1048,8 +1046,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         }
         _clusterNodeIP = _clusterNodeIP.trim();
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Cluster node IP : " + _clusterNodeIP);
+        if (logger.isInfoEnabled()) {
+            logger.info("Cluster node IP : " + _clusterNodeIP);
         }
 
         if (!NetUtils.isLocalAddress(_clusterNodeIP)) {
@@ -1074,8 +1072,8 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
         checkConflicts();
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Cluster manager is configured.");
+        if (logger.isInfoEnabled()) {
+            logger.info("Cluster manager is configured.");
         }
         return true;
     }
@@ -1133,7 +1131,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
 
         final String targetIp = mshost.getServiceIP();
         if ("127.0.0.1".equals(targetIp) || "0.0.0.0".equals(targetIp)) {
-            s_logger.info("ping management node cluster service can not be performed on self");
+            logger.info("ping management node cluster service can not be performed on self");
             return false;
         }
 
@@ -1141,7 +1139,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
         while (--retry > 0) {
             SocketChannel sch = null;
             try {
-                s_logger.info("Trying to connect to " + targetIp);
+                logger.info("Trying to connect to " + targetIp);
                 sch = SocketChannel.open();
                 sch.configureBlocking(true);
                 sch.socket().setSoTimeout(5000);
@@ -1151,7 +1149,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 return true;
             } catch (final IOException e) {
                 if (e instanceof ConnectException) {
-                    s_logger.error("Unable to ping management server at " + targetIp + ":" + mshost.getServicePort() + " due to ConnectException", e);
+                    logger.error("Unable to ping management server at " + targetIp + ":" + mshost.getServicePort() + " due to ConnectException", e);
                     return false;
                 }
             } finally {
@@ -1169,7 +1167,7 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
             }
         }
 
-        s_logger.error("Unable to ping management server at " + targetIp + ":" + mshost.getServicePort() + " after retries");
+        logger.error("Unable to ping management server at " + targetIp + ":" + mshost.getServicePort() + " after retries");
         return false;
     }
 
@@ -1186,25 +1184,25 @@ public class ClusterManagerImpl extends ManagerBase implements ClusterManager, C
                 if ("127.0.0.1".equals(_clusterNodeIP)) {
                     if (pingManagementNode(peer.getMsid())) {
                         final String msg = "Detected another management node with localhost IP is already running, please check your cluster configuration";
-                        s_logger.error(msg);
+                        logger.error(msg);
                         throw new ConfigurationException(msg);
                     } else {
                         final String msg =
                                 "Detected another management node with localhost IP is considered as running in DB, however it is not pingable, we will continue cluster initialization with this management server node";
-                        s_logger.info(msg);
+                        logger.info(msg);
                     }
                 } else {
                     if (pingManagementNode(peer.getMsid())) {
                         final String msg =
                                 "Detected that another management node with the same IP " + peer.getServiceIP() +
                                 " is already running, please check your cluster configuration";
-                        s_logger.error(msg);
+                        logger.error(msg);
                         throw new ConfigurationException(msg);
                     } else {
                         final String msg =
                                 "Detected that another management node with the same IP " + peer.getServiceIP() +
                                 " is considered as running in DB, however it is not pingable, we will continue cluster initialization with this management server node";
-                        s_logger.info(msg);
+                        logger.info(msg);
                     }
                 }
             }

--- a/framework/cluster/src/com/cloud/cluster/ClusterServiceServletAdapter.java
+++ b/framework/cluster/src/com/cloud/cluster/ClusterServiceServletAdapter.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.apache.cloudstack.framework.config.ConfigDepot;
 
 import com.cloud.cluster.dao.ManagementServerHostDao;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.DbProperties;
 
 public class ClusterServiceServletAdapter extends AdapterBase implements ClusterServiceAdapter {
 
-    private static final Logger s_logger = Logger.getLogger(ClusterServiceServletAdapter.class);
     private static final int DEFAULT_SERVICE_PORT = 9090;
     private static final int DEFAULT_REQUEST_TIMEOUT = 300;            // 300 seconds
 
@@ -59,7 +57,7 @@ public class ClusterServiceServletAdapter extends AdapterBase implements Cluster
         try {
             init();
         } catch (ConfigurationException e) {
-            s_logger.error("Unable to init ClusterServiceServletAdapter");
+            logger.error("Unable to init ClusterServiceServletAdapter");
             throw new RemoteException("Unable to init ClusterServiceServletAdapter");
         }
 
@@ -75,7 +73,7 @@ public class ClusterServiceServletAdapter extends AdapterBase implements Cluster
         try {
             init();
         } catch (ConfigurationException e) {
-            s_logger.error("Unable to init ClusterServiceServletAdapter");
+            logger.error("Unable to init ClusterServiceServletAdapter");
             return null;
         }
 
@@ -126,7 +124,7 @@ public class ClusterServiceServletAdapter extends AdapterBase implements Cluster
         Properties dbProps = DbProperties.getDbProperties();
 
         _clusterServicePort = NumbersUtil.parseInt(dbProps.getProperty("cluster.servlet.port"), DEFAULT_SERVICE_PORT);
-        if (s_logger.isInfoEnabled())
-            s_logger.info("Cluster servlet port : " + _clusterServicePort);
+        if (logger.isInfoEnabled())
+            logger.info("Cluster servlet port : " + _clusterServicePort);
     }
 }

--- a/framework/cluster/src/com/cloud/cluster/dao/ManagementServerHostDaoImpl.java
+++ b/framework/cluster/src/com/cloud/cluster/dao/ManagementServerHostDaoImpl.java
@@ -26,7 +26,6 @@ import java.util.TimeZone;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.cluster.ClusterInvalidSessionException;
 import com.cloud.cluster.ManagementServerHost;
@@ -43,7 +42,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 
 @Local(value = {ManagementServerHostDao.class})
 public class ManagementServerHostDaoImpl extends GenericDaoBase<ManagementServerHostVO, Long> implements ManagementServerHostDao {
-    private static final Logger s_logger = Logger.getLogger(ManagementServerHostDaoImpl.class);
 
     private final SearchBuilder<ManagementServerHostVO> MsIdSearch;
     private final SearchBuilder<ManagementServerHostVO> ActiveSearch;
@@ -100,7 +98,7 @@ public class ManagementServerHostDaoImpl extends GenericDaoBase<ManagementServer
             pstmt.executeUpdate();
             txn.commit();
         } catch (Exception e) {
-            s_logger.warn("Unexpected exception, ", e);
+            logger.warn("Unexpected exception, ", e);
             throw new RuntimeException(e.getMessage(), e);
         }
     }
@@ -120,7 +118,7 @@ public class ManagementServerHostDaoImpl extends GenericDaoBase<ManagementServer
             txn.commit();
             return true;
         } catch (Exception e) {
-            s_logger.warn("Unexpected exception, ", e);
+            logger.warn("Unexpected exception, ", e);
             throw new RuntimeException(e.getMessage(), e);
         }
     }
@@ -142,11 +140,11 @@ public class ManagementServerHostDaoImpl extends GenericDaoBase<ManagementServer
             txn.commit();
 
             if (count < 1) {
-                s_logger.info("Invalid cluster session detected, runId " + runid + " is no longer valid");
+                logger.info("Invalid cluster session detected, runId " + runid + " is no longer valid");
                 throw new CloudRuntimeException("Invalid cluster session detected, runId " + runid + " is no longer valid", new ClusterInvalidSessionException("runId " + runid + " is no longer valid"));
             }
         } catch (Exception e) {
-            s_logger.warn("Unexpected exception, ", e);
+            logger.warn("Unexpected exception, ", e);
             throw new RuntimeException(e.getMessage(), e);
         }
     }
@@ -182,7 +180,7 @@ public class ManagementServerHostDaoImpl extends GenericDaoBase<ManagementServer
             changedRows = pstmt.executeUpdate();
             txn.commit();
         } catch (Exception e) {
-            s_logger.warn("Unexpected exception, ", e);
+            logger.warn("Unexpected exception, ", e);
             throw new RuntimeException(e.getMessage(), e);
         }
 
@@ -223,7 +221,7 @@ public class ManagementServerHostDaoImpl extends GenericDaoBase<ManagementServer
             int count = pstmt.executeUpdate();
 
             if (count < 1) {
-                s_logger.info("Invalid cluster session detected, runId " + runId + " is no longer valid");
+                logger.info("Invalid cluster session detected, runId " + runId + " is no longer valid");
                 throw new CloudRuntimeException("Invalid cluster session detected, runId " + runId + " is no longer valid", new ClusterInvalidSessionException("runId " + runId + " is no longer valid"));
             }
         } catch (SQLException e) {

--- a/framework/cluster/src/com/cloud/cluster/dao/ManagementServerHostPeerDaoImpl.java
+++ b/framework/cluster/src/com/cloud/cluster/dao/ManagementServerHostPeerDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.cluster.ManagementServerHost;
 import com.cloud.cluster.ManagementServerHostPeerVO;
@@ -32,7 +31,6 @@ import com.cloud.utils.db.TransactionLegacy;
 
 @Local(value = {ManagementServerHostPeerDao.class})
 public class ManagementServerHostPeerDaoImpl extends GenericDaoBase<ManagementServerHostPeerVO, Long> implements ManagementServerHostPeerDao {
-    private static final Logger s_logger = Logger.getLogger(ManagementServerHostPeerDaoImpl.class);
 
     private final SearchBuilder<ManagementServerHostPeerVO> ClearPeerSearch;
     private final SearchBuilder<ManagementServerHostPeerVO> FindForUpdateSearch;
@@ -87,7 +85,7 @@ public class ManagementServerHostPeerDaoImpl extends GenericDaoBase<ManagementSe
             }
             txn.commit();
         } catch (Exception e) {
-            s_logger.warn("Unexpected exception, ", e);
+            logger.warn("Unexpected exception, ", e);
             txn.rollback();
         }
     }

--- a/framework/config/src/org/apache/cloudstack/framework/config/dao/ConfigurationDaoImpl.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/dao/ConfigurationDaoImpl.java
@@ -26,7 +26,6 @@ import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.component.ComponentLifecycle;
@@ -41,7 +40,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {ConfigurationDao.class})
 public class ConfigurationDaoImpl extends GenericDaoBase<ConfigurationVO, String> implements ConfigurationDao {
-    private static final Logger s_logger = Logger.getLogger(ConfigurationDaoImpl.class);
     private Map<String, String> _configs = null;
     private boolean _premium;
 
@@ -148,7 +146,7 @@ public class ConfigurationDaoImpl extends GenericDaoBase<ConfigurationVO, String
             stmt.executeUpdate();
             return true;
         } catch (Exception e) {
-            s_logger.warn("Unable to update Configuration Value", e);
+            logger.warn("Unable to update Configuration Value", e);
         }
         return false;
     }
@@ -165,7 +163,7 @@ public class ConfigurationDaoImpl extends GenericDaoBase<ConfigurationVO, String
                 return true;
             }
         } catch (Exception e) {
-            s_logger.warn("Unable to update Configuration Value", e);
+            logger.warn("Unable to update Configuration Value", e);
         }
         return false;
     }
@@ -199,7 +197,7 @@ public class ConfigurationDaoImpl extends GenericDaoBase<ConfigurationVO, String
             }
             return returnValue;
         } catch (Exception e) {
-            s_logger.warn("Unable to update Configuration Value", e);
+            logger.warn("Unable to update Configuration Value", e);
             throw new CloudRuntimeException("Unable to initialize configuration variable: " + name);
 
         }

--- a/framework/db/src/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/com/cloud/utils/db/GenericDaoBase.java
@@ -65,7 +65,6 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.utils.DateUtil;
 import com.cloud.utils.NumbersUtil;
@@ -115,7 +114,6 @@ import com.cloud.utils.net.NetUtils;
  **/
 @DB
 public abstract class GenericDaoBase<T, ID extends Serializable> extends ComponentLifecycleBase implements GenericDao<T, ID>, ComponentMethodInterceptable {
-    private final static Logger s_logger = Logger.getLogger(GenericDaoBase.class);
 
     protected final static TimeZone s_gmtTimeZone = TimeZone.getTimeZone("GMT");
 
@@ -255,26 +253,26 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
         _searchEnhancer.setSuperclass(_entityBeanType);
         _searchEnhancer.setCallback(new UpdateBuilder(this));
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Select SQL: " + _partialSelectSql.first().toString());
-            s_logger.trace("Remove SQL: " + (_removeSql != null ? _removeSql.first() : "No remove sql"));
-            s_logger.trace("Select by Id SQL: " + _selectByIdSql);
-            s_logger.trace("Table References: " + _tables);
-            s_logger.trace("Insert SQLs:");
+        if (logger.isTraceEnabled()) {
+            logger.trace("Select SQL: " + _partialSelectSql.first().toString());
+            logger.trace("Remove SQL: " + (_removeSql != null ? _removeSql.first() : "No remove sql"));
+            logger.trace("Select by Id SQL: " + _selectByIdSql);
+            logger.trace("Table References: " + _tables);
+            logger.trace("Insert SQLs:");
             for (final Pair<String, Attribute[]> insertSql : _insertSqls) {
-                s_logger.trace(insertSql.first());
+                logger.trace(insertSql.first());
             }
 
-            s_logger.trace("Delete SQLs");
+            logger.trace("Delete SQLs");
             for (final Pair<String, Attribute[]> deletSql : _deleteSqls) {
-                s_logger.trace(deletSql.first());
+                logger.trace(deletSql.first());
             }
 
-            s_logger.trace("Collection SQLs");
+            logger.trace("Collection SQLs");
             for (Attribute attr : _ecAttributes) {
                 EcInfo info = (EcInfo)attr.attache;
-                s_logger.trace(info.insertSql);
-                s_logger.trace(info.selectSql);
+                logger.trace(info.insertSql);
+                logger.trace(info.selectSql);
             }
         }
 
@@ -413,7 +411,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
                 }
             }
 
-            if (s_logger.isDebugEnabled() && lock != null) {
+            if (logger.isDebugEnabled() && lock != null) {
                 txn.registerLock(pstmt.toString());
             }
             final ResultSet rs = pstmt.executeQuery();
@@ -778,8 +776,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
         }
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("join search statement is " + pstmt);
+        if (logger.isTraceEnabled()) {
+            logger.trace("join search statement is " + pstmt);
         }
         return count;
     }
@@ -1597,7 +1595,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             try {
                 _cache.put(new Element(_idField.get(entity), entity));
             } catch (final Exception e) {
-                s_logger.debug("Can't put it in the cache", e);
+                logger.debug("Can't put it in the cache", e);
             }
         }
 
@@ -1619,7 +1617,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             try {
                 _cache.put(new Element(_idField.get(entity), entity));
             } catch (final Exception e) {
-                s_logger.debug("Can't put it in the cache", e);
+                logger.debug("Can't put it in the cache", e);
             }
         }
 
@@ -1798,7 +1796,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             final int idle = NumbersUtil.parseInt((String)params.get("cache.time.to.idle"), 300);
             _cache = new Cache(getName(), maxElements, false, live == -1, live == -1 ? Integer.MAX_VALUE : live, idle);
             cm.addCache(_cache);
-            s_logger.info("Cache created: " + _cache.toString());
+            logger.info("Cache created: " + _cache.toString());
         } else {
             _cache = null;
         }

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/AsyncJobDaoImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/AsyncJobDaoImpl.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.impl.AsyncJobVO;
 import org.apache.cloudstack.jobs.JobInfo;
@@ -35,7 +34,6 @@ import com.cloud.utils.db.SearchCriteria.Op;
 import com.cloud.utils.db.TransactionLegacy;
 
 public class AsyncJobDaoImpl extends GenericDaoBase<AsyncJobVO, Long> implements AsyncJobDao {
-    private static final Logger s_logger = Logger.getLogger(AsyncJobDaoImpl.class.getName());
 
     private final SearchBuilder<AsyncJobVO> pendingAsyncJobSearch;
     private final SearchBuilder<AsyncJobVO> pendingAsyncJobsSearch;
@@ -105,7 +103,7 @@ public class AsyncJobDaoImpl extends GenericDaoBase<AsyncJobVO, Long> implements
         List<AsyncJobVO> l = listIncludingRemovedBy(sc);
         if (l != null && l.size() > 0) {
             if (l.size() > 1) {
-                s_logger.warn("Instance " + instanceType + "-" + instanceId + " has multiple pending async-job");
+                logger.warn("Instance " + instanceType + "-" + instanceId + " has multiple pending async-job");
             }
 
             return l.get(0);
@@ -192,9 +190,9 @@ public class AsyncJobDaoImpl extends GenericDaoBase<AsyncJobVO, Long> implements
             pstmt.setLong(6, msid);
             pstmt.execute();
         } catch (SQLException e) {
-            s_logger.warn("Unable to reset job status for management server " + msid, e);
+            logger.warn("Unable to reset job status for management server " + msid, e);
         } catch (Throwable e) {
-            s_logger.warn("Unable to reset job status for management server " + msid, e);
+            logger.warn("Unable to reset job status for management server " + msid, e);
         }
     }
 

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/AsyncJobJoinMapDaoImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/AsyncJobJoinMapDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.impl.AsyncJobJoinMapVO;
 import org.apache.cloudstack.jobs.JobInfo;
@@ -39,7 +38,6 @@ import com.cloud.utils.db.UpdateBuilder;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 public class AsyncJobJoinMapDaoImpl extends GenericDaoBase<AsyncJobJoinMapVO, Long> implements AsyncJobJoinMapDao {
-    public static final Logger s_logger = Logger.getLogger(AsyncJobJoinMapDaoImpl.class);
 
     private final SearchBuilder<AsyncJobJoinMapVO> RecordSearch;
     private final SearchBuilder<AsyncJobJoinMapVO> RecordSearchByOwner;
@@ -202,7 +200,7 @@ public class AsyncJobJoinMapDaoImpl extends GenericDaoBase<AsyncJobJoinMapVO, Lo
 //
 //            txn.commit();
 //        } catch (SQLException e) {
-//            s_logger.error("Unexpected exception", e);
+//            logger.error("Unexpected exception", e);
 //        }
 //
 //        return standaloneList;

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/SyncQueueDaoImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/SyncQueueDaoImpl.java
@@ -22,7 +22,6 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.impl.SyncQueueVO;
 
@@ -33,7 +32,6 @@ import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.TransactionLegacy;
 
 public class SyncQueueDaoImpl extends GenericDaoBase<SyncQueueVO, Long> implements SyncQueueDao {
-    private static final Logger s_logger = Logger.getLogger(SyncQueueDaoImpl.class.getName());
 
     SearchBuilder<SyncQueueVO> TypeIdSearch = createSearchBuilder();
 
@@ -60,9 +58,9 @@ public class SyncQueueDaoImpl extends GenericDaoBase<SyncQueueVO, Long> implemen
             pstmt.setString(4, DateUtil.getDateDisplayString(TimeZone.getTimeZone("GMT"), dt));
             pstmt.execute();
         } catch (SQLException e) {
-            s_logger.warn("Unable to create sync queue " + syncObjType + "-" + syncObjId + ":" + e.getMessage(), e);
+            logger.warn("Unable to create sync queue " + syncObjType + "-" + syncObjId + ":" + e.getMessage(), e);
         } catch (Throwable e) {
-            s_logger.warn("Unable to create sync queue " + syncObjType + "-" + syncObjId + ":" + e.getMessage(), e);
+            logger.warn("Unable to create sync queue " + syncObjType + "-" + syncObjId + ":" + e.getMessage(), e);
         }
     }
 

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/SyncQueueItemDaoImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/SyncQueueItemDaoImpl.java
@@ -25,7 +25,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.impl.SyncQueueItemVO;
 
@@ -42,7 +41,6 @@ import com.cloud.utils.db.TransactionLegacy;
 
 @DB
 public class SyncQueueItemDaoImpl extends GenericDaoBase<SyncQueueItemVO, Long> implements SyncQueueItemDao {
-    private static final Logger s_logger = Logger.getLogger(SyncQueueItemDaoImpl.class);
     final GenericSearchBuilder<SyncQueueItemVO, Long> queueIdSearch;
     final GenericSearchBuilder<SyncQueueItemVO, Integer> queueActiveItemSearch;
 
@@ -116,9 +114,9 @@ public class SyncQueueItemDaoImpl extends GenericDaoBase<SyncQueueItemVO, Long> 
                 l.add(item);
             }
         } catch (SQLException e) {
-            s_logger.error("Unexpected sql exception, ", e);
+            logger.error("Unexpected sql exception, ", e);
         } catch (Throwable e) {
-            s_logger.error("Unexpected exception, ", e);
+            logger.error("Unexpected exception, ", e);
         }
         return l;
     }

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/VmWorkJobDaoImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/dao/VmWorkJobDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.impl.VmWorkJobVO;
 import org.apache.cloudstack.framework.jobs.impl.VmWorkJobVO.Step;
@@ -43,7 +42,6 @@ import com.cloud.utils.db.TransactionStatus;
 import com.cloud.vm.VirtualMachine;
 
 public class VmWorkJobDaoImpl extends GenericDaoBase<VmWorkJobVO, Long> implements VmWorkJobDao {
-    private static final Logger s_logger = Logger.getLogger(VmWorkJobDaoImpl.class);
 
     protected SearchBuilder<VmWorkJobVO> PendingWorkJobSearch;
     protected SearchBuilder<VmWorkJobVO> PendingWorkJobByCommandSearch;
@@ -145,8 +143,8 @@ public class VmWorkJobDaoImpl extends GenericDaoBase<VmWorkJobVO, Long> implemen
         sc.setParameters("dispatcher", "VmWorkJobDispatcher");
         List<VmWorkJobVO> expungeList = listBy(sc);
         for (VmWorkJobVO job : expungeList) {
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Expunge completed work job-" + job.getId());
+            if (logger.isDebugEnabled())
+                logger.debug("Expunge completed work job-" + job.getId());
             expunge(job.getId());
             _baseJobDao.expunge(job.getId());
         }
@@ -176,10 +174,10 @@ public class VmWorkJobDaoImpl extends GenericDaoBase<VmWorkJobVO, Long> implemen
 
                     pstmt.execute();
                 } catch (SQLException e) {
-                    s_logger.info("[ignored]"
+                    logger.info("[ignored]"
                             + "SQL failed to delete vm work job: " + e.getLocalizedMessage());
                 } catch (Throwable e) {
-                    s_logger.info("[ignored]"
+                    logger.info("[ignored]"
                             + "caught an error during delete vm work job: " + e.getLocalizedMessage());
                 }
 
@@ -191,10 +189,10 @@ public class VmWorkJobDaoImpl extends GenericDaoBase<VmWorkJobVO, Long> implemen
 
                     pstmt.execute();
                 } catch (SQLException e) {
-                    s_logger.info("[ignored]"
+                    logger.info("[ignored]"
                             + "SQL failed to delete async job: " + e.getLocalizedMessage());
                 } catch (Throwable e) {
-                    s_logger.info("[ignored]"
+                    logger.info("[ignored]"
                             + "caught an error during delete async job: " + e.getLocalizedMessage());
                 }
             }

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobMonitor.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobMonitor.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.AsyncJob;
 import org.apache.cloudstack.framework.jobs.AsyncJobManager;
@@ -37,7 +36,6 @@ import org.apache.cloudstack.managed.context.ManagedContextTimerTask;
 import com.cloud.utils.component.ManagerBase;
 
 public class AsyncJobMonitor extends ManagerBase {
-    public static final Logger s_logger = Logger.getLogger(AsyncJobMonitor.class);
 
     @Inject private MessageBus _messageBus;
 
@@ -86,7 +84,7 @@ public class AsyncJobMonitor extends ManagerBase {
         synchronized (this) {
             for (Map.Entry<Long, ActiveTaskRecord> entry : _activeTasks.entrySet()) {
                 if (entry.getValue().millisSinceLastJobHeartbeat() > _inactivityWarningThresholdMs) {
-                    s_logger.warn("Task (job-" + entry.getValue().getJobId() + ") has been pending for "
+                    logger.warn("Task (job-" + entry.getValue().getJobId() + ") has been pending for "
                             + entry.getValue().millisSinceLastJobHeartbeat() / 1000 + " seconds");
                 }
             }
@@ -110,7 +108,7 @@ public class AsyncJobMonitor extends ManagerBase {
 
     public void registerActiveTask(long runNumber, long jobId) {
         synchronized (this) {
-            s_logger.info("Add job-" + jobId + " into job monitoring");
+            logger.info("Add job-" + jobId + " into job monitoring");
 
             assert (_activeTasks.get(runNumber) == null);
 
@@ -130,7 +128,7 @@ public class AsyncJobMonitor extends ManagerBase {
             ActiveTaskRecord record = _activeTasks.get(runNumber);
             assert (record != null);
             if (record != null) {
-                s_logger.info("Remove job-" + record.getJobId() + " from job monitoring");
+                logger.info("Remove job-" + record.getJobId() + " from job monitoring");
 
                 if (record.isPoolThread())
                     _activePoolThreads.decrementAndGet();
@@ -148,7 +146,7 @@ public class AsyncJobMonitor extends ManagerBase {
             while (it.hasNext()) {
                 Map.Entry<Long, ActiveTaskRecord> entry = it.next();
                 if (entry.getValue().getJobId() == jobId) {
-                    s_logger.info("Remove Job-" + entry.getValue().getJobId() + " from job monitoring due to job cancelling");
+                    logger.info("Remove Job-" + entry.getValue().getJobId() + " from job monitoring due to job cancelling");
 
                     if (entry.getValue().isPoolThread())
                         _activePoolThreads.decrementAndGet();

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/SyncQueueManagerImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/SyncQueueManagerImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.dao.SyncQueueDao;
 import org.apache.cloudstack.framework.jobs.dao.SyncQueueItemDao;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManager {
-    public static final Logger s_logger = Logger.getLogger(SyncQueueManagerImpl.class.getName());
 
     @Inject
     private SyncQueueDao _syncQueueDao;
@@ -70,7 +68,7 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
                 }
             });
         } catch (Exception e) {
-            s_logger.error("Unexpected exception: ", e);
+            logger.error("Unexpected exception: ", e);
         }
         return null;
     }
@@ -84,7 +82,7 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
                 public SyncQueueItemVO doInTransaction(TransactionStatus status) {
                     SyncQueueVO queueVO = _syncQueueDao.findById(queueId);
                     if(queueVO == null) {
-                        s_logger.error("Sync queue(id: " + queueId + ") does not exist");
+                        logger.error("Sync queue(id: " + queueId + ") does not exist");
                         return null;
                     }
 
@@ -109,19 +107,19 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
 
                             return itemVO;
                         } else {
-                            if (s_logger.isDebugEnabled())
-                                s_logger.debug("Sync queue (" + queueId + ") is currently empty");
+                            if (logger.isDebugEnabled())
+                                logger.debug("Sync queue (" + queueId + ") is currently empty");
                         }
                     } else {
-                        if (s_logger.isDebugEnabled())
-                            s_logger.debug("There is a pending process in sync queue(id: " + queueId + ")");
+                        if (logger.isDebugEnabled())
+                            logger.debug("There is a pending process in sync queue(id: " + queueId + ")");
                     }
 
                     return null;
                 }
             });
         } catch (Exception e) {
-            s_logger.error("Unexpected exception: ", e);
+            logger.error("Unexpected exception: ", e);
         }
 
         return null;
@@ -169,7 +167,7 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
 
             return resultList;
         } catch (Exception e) {
-            s_logger.error("Unexpected exception: ", e);
+            logger.error("Unexpected exception: ", e);
         }
 
         return null;
@@ -200,14 +198,14 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
                 }
             });
         } catch (Exception e) {
-            s_logger.error("Unexpected exception: ", e);
+            logger.error("Unexpected exception: ", e);
         }
     }
 
     @Override
     @DB
     public void returnItem(final long queueItemId) {
-        s_logger.info("Returning queue item " + queueItemId + " back to queue for second try in case of DB deadlock");
+        logger.info("Returning queue item " + queueItemId + " back to queue for second try in case of DB deadlock");
         try {
             Transaction.execute(new TransactionCallbackNoReturn() {
                 @Override
@@ -228,7 +226,7 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
                 }
             });
         } catch (Exception e) {
-            s_logger.error("Unexpected exception: ", e);
+            logger.error("Unexpected exception: ", e);
         }
     }
 
@@ -247,8 +245,8 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
         if (nActiveItems < queueVO.getQueueSizeLimit())
             return true;
 
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("Queue (queue id, sync type, sync id) - (" + queueVO.getId()
+        if (logger.isDebugEnabled())
+            logger.debug("Queue (queue id, sync type, sync id) - (" + queueVO.getId()
                     + "," + queueVO.getSyncObjType() + ", " + queueVO.getSyncObjId()
                     + ") is reaching concurrency limit " + queueVO.getQueueSizeLimit());
         return false;
@@ -266,8 +264,8 @@ public class SyncQueueManagerImpl extends ManagerBase implements SyncQueueManage
     public void cleanupActiveQueueItems(Long msid, boolean exclusive) {
         List<SyncQueueItemVO> l = getActiveQueueItems(msid, false);
         for (SyncQueueItemVO item : l) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Discard left-over queue item: " + item.toString());
+            if (logger.isInfoEnabled()) {
+                logger.info("Discard left-over queue item: " + item.toString());
             }
             purgeItem(item.getId());
         }

--- a/framework/jobs/test/org/apache/cloudstack/framework/jobs/AsyncJobTestDispatcher.java
+++ b/framework/jobs/test/org/apache/cloudstack/framework/jobs/AsyncJobTestDispatcher.java
@@ -20,15 +20,12 @@ import java.util.Random;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.jobs.JobInfo.Status;
 
 import com.cloud.utils.component.AdapterBase;
 
 public class AsyncJobTestDispatcher extends AdapterBase implements AsyncJobDispatcher {
-    private static final Logger s_logger =
-            Logger.getLogger(AsyncJobTestDispatcher.class);
 
     @Inject
     private AsyncJobManager _asyncJobMgr;
@@ -45,14 +42,14 @@ public class AsyncJobTestDispatcher extends AdapterBase implements AsyncJobDispa
     public void runJob(final AsyncJob job) {
         _testDashboard.increaseConcurrency();
 
-        s_logger.info("Execute job " + job.getId() + ", current concurrency " + _testDashboard.getConcurrencyCount());
+        logger.info("Execute job " + job.getId() + ", current concurrency " + _testDashboard.getConcurrencyCount());
 
         int interval = 3000;
 
         try {
             Thread.sleep(interval);
         } catch (InterruptedException e) {
-            s_logger.debug("[ignored] .");
+            logger.debug("[ignored] .");
         }
 
         _asyncJobMgr.completeAsyncJob(job.getId(), Status.SUCCEEDED, 0, null);

--- a/framework/security/src/org/apache/cloudstack/framework/security/keystore/KeystoreManagerImpl.java
+++ b/framework/security/src/org/apache/cloudstack/framework/security/keystore/KeystoreManagerImpl.java
@@ -32,7 +32,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.Ternary;
@@ -43,7 +42,6 @@ import com.cloud.utils.security.CertificateHelper;
 @Component
 @Local(value = KeystoreManager.class)
 public class KeystoreManagerImpl extends ManagerBase implements KeystoreManager {
-    private static final Logger s_logger = Logger.getLogger(KeystoreManagerImpl.class);
 
     @Inject
     private KeystoreDao _ksDao;
@@ -51,7 +49,7 @@ public class KeystoreManagerImpl extends ManagerBase implements KeystoreManager 
     @Override
     public boolean validateCertificate(String certificate, String key, String domainSuffix) {
         if (certificate == null || certificate.isEmpty() || key == null || key.isEmpty() || domainSuffix == null || domainSuffix.isEmpty()) {
-            s_logger.error("Invalid parameter found in (certificate, key, domainSuffix) tuple for domain: " + domainSuffix);
+            logger.error("Invalid parameter found in (certificate, key, domainSuffix) tuple for domain: " + domainSuffix);
             return false;
         }
 
@@ -62,9 +60,9 @@ public class KeystoreManagerImpl extends ManagerBase implements KeystoreManager 
             if (ks != null)
                 return true;
 
-            s_logger.error("Unabled to construct keystore for domain: " + domainSuffix);
+            logger.error("Unabled to construct keystore for domain: " + domainSuffix);
         } catch (Exception e) {
-            s_logger.error("Certificate validation failed due to exception for domain: " + domainSuffix, e);
+            logger.error("Certificate validation failed due to exception for domain: " + domainSuffix, e);
         }
         return false;
     }
@@ -110,15 +108,15 @@ public class KeystoreManagerImpl extends ManagerBase implements KeystoreManager 
         try {
             return CertificateHelper.buildAndSaveKeystore(certs, storePassword);
         } catch (KeyStoreException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to KeyStoreException");
+            logger.warn("Unable to build keystore for " + name + " due to KeyStoreException");
         } catch (CertificateException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to CertificateException");
+            logger.warn("Unable to build keystore for " + name + " due to CertificateException");
         } catch (NoSuchAlgorithmException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to NoSuchAlgorithmException");
+            logger.warn("Unable to build keystore for " + name + " due to NoSuchAlgorithmException");
         } catch (InvalidKeySpecException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to InvalidKeySpecException");
+            logger.warn("Unable to build keystore for " + name + " due to InvalidKeySpecException");
         } catch (IOException e) {
-            s_logger.warn("Unable to build keystore for " + name + " due to IOException");
+            logger.warn("Unable to build keystore for " + name + " due to IOException");
         }
         return null;
     }

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/DumpRegistry.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/DumpRegistry.java
@@ -22,16 +22,11 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.cloud.utils.component.ComponentLifecycleBase;
 import com.cloud.utils.component.Named;
 import com.cloud.utils.component.Registry;
 
 public class DumpRegistry extends ComponentLifecycleBase {
-
-    private static final Logger log = LoggerFactory.getLogger(DumpRegistry.class);
 
     List<Registry<?>> registries;
 
@@ -55,10 +50,8 @@ public class DumpRegistry extends ComponentLifecycleBase {
 
                 buffer.append(getName(o));
             }
-
-            log.info("Registry [{}] contains [{}]", registry.getName(), buffer);
+            logger.info(String.format("Registry [%s] contains [%s]", registry.getName(), buffer));
         }
-
         return super.start();
     }
 

--- a/plugins/acl/static-role-based/src/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/static-role-based/src/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
@@ -26,7 +26,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
 
@@ -43,7 +42,6 @@ import com.cloud.utils.component.PluggableService;
 @Local(value = APIChecker.class)
 public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIChecker {
 
-    protected static final Logger s_logger = Logger.getLogger(StaticRoleBasedAPIAccessChecker.class);
 
     Set<String> commandPropertyFiles = new HashSet<String>();
     Set<String> commandsPropertiesOverrides = new HashSet<String>();
@@ -118,7 +116,7 @@ public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIC
                         commandsPropertiesRoleBasedApisMap.get(roleType).add(apiName);
                 }
             } catch (NumberFormatException nfe) {
-                s_logger.info("Malformed key=value pair for entry: " + entry.toString());
+                logger.info("Malformed key=value pair for entry: " + entry.toString());
             }
         }
     }

--- a/plugins/affinity-group-processors/explicit-dedication/src/org/apache/cloudstack/affinity/ExplicitDedicationProcessor.java
+++ b/plugins/affinity-group-processors/explicit-dedication/src/org/apache/cloudstack/affinity/ExplicitDedicationProcessor.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.ClusterVO;
 import com.cloud.dc.DataCenter;
@@ -58,7 +57,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Local(value = AffinityGroupProcessor.class)
 public class ExplicitDedicationProcessor extends AffinityProcessorBase implements AffinityGroupProcessor {
 
-    private static final Logger s_logger = Logger.getLogger(ExplicitDedicationProcessor.class);
     @Inject
     protected UserVmDao _vmDao;
     @Inject
@@ -98,8 +96,8 @@ public class ExplicitDedicationProcessor extends AffinityProcessorBase implement
 
             for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
                 if (vmGroupMapping != null) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Processing affinity group " + vmGroupMapping.getAffinityGroupId() + "of type 'ExplicitDedication' for VM Id: " + vm.getId());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Processing affinity group " + vmGroupMapping.getAffinityGroupId() + "of type 'ExplicitDedication' for VM Id: " + vm.getId());
                     }
 
                     long affinityGroupId = vmGroupMapping.getAffinityGroupId();
@@ -236,13 +234,13 @@ public class ExplicitDedicationProcessor extends AffinityProcessorBase implement
                     avoid = updateAvoidList(resourceList, avoid, dc);
                 } else {
                     avoid.addDataCenter(dc.getId());
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("No dedicated resources available for this domain or account under this group");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("No dedicated resources available for this domain or account under this group");
                     }
                 }
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("ExplicitDedicationProcessor returns Avoid List as: Deploy avoids pods: " + avoid.getPodsToAvoid() + ", clusters: " +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("ExplicitDedicationProcessor returns Avoid List as: Deploy avoids pods: " + avoid.getPodsToAvoid() + ", clusters: " +
                         avoid.getClustersToAvoid() + ", hosts: " + avoid.getHostsToAvoid());
                 }
             }
@@ -409,8 +407,8 @@ public class ExplicitDedicationProcessor extends AffinityProcessorBase implement
         if (group != null) {
             List<DedicatedResourceVO> dedicatedResources = _dedicatedDao.listByAffinityGroupId(group.getId());
             if (!dedicatedResources.isEmpty()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Releasing the dedicated resources under group: " + group);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Releasing the dedicated resources under group: " + group);
                 }
 
                 Transaction.execute(new TransactionCallbackNoReturn() {
@@ -427,8 +425,8 @@ public class ExplicitDedicationProcessor extends AffinityProcessorBase implement
                     }
                 });
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("No dedicated resources to releease under group: " + group);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("No dedicated resources to releease under group: " + group);
                 }
             }
         }

--- a/plugins/affinity-group-processors/host-anti-affinity/src/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-anti-affinity/src/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
@@ -47,7 +46,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Local(value = AffinityGroupProcessor.class)
 public class HostAntiAffinityProcessor extends AffinityProcessorBase implements AffinityGroupProcessor {
 
-    private static final Logger s_logger = Logger.getLogger(HostAntiAffinityProcessor.class);
     @Inject
     protected UserVmDao _vmDao;
     @Inject
@@ -72,8 +70,8 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
             if (vmGroupMapping != null) {
                 AffinityGroupVO group = _affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Processing affinity group " + group.getName() + " for VM Id: " + vm.getId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Processing affinity group " + group.getName() + " for VM Id: " + vm.getId());
                 }
 
                 List<Long> groupVMIds = _affinityGroupVMMapDao.listVmIdsByAffinityGroup(group.getId());
@@ -84,15 +82,15 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
                     if (groupVM != null && !groupVM.isRemoved()) {
                         if (groupVM.getHostId() != null) {
                             avoid.addHost(groupVM.getHostId());
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Added host " + groupVM.getHostId() + " to avoid set, since VM " + groupVM.getId() + " is present on the host");
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Added host " + groupVM.getHostId() + " to avoid set, since VM " + groupVM.getId() + " is present on the host");
                             }
                         } else if (VirtualMachine.State.Stopped.equals(groupVM.getState()) && groupVM.getLastHostId() != null) {
                             long secondsSinceLastUpdate = (DateUtil.currentGMTTime().getTime() - groupVM.getUpdateTime().getTime()) / 1000;
                             if (secondsSinceLastUpdate < _vmCapacityReleaseInterval) {
                                 avoid.addHost(groupVM.getLastHostId());
-                                if (s_logger.isDebugEnabled()) {
-                                    s_logger.debug("Added host " + groupVM.getLastHostId() + " to avoid set, since VM " + groupVM.getId() +
+                                if (logger.isDebugEnabled()) {
+                                    logger.debug("Added host " + groupVM.getLastHostId() + " to avoid set, since VM " + groupVM.getId() +
                                         " is present on the host, in Stopped state but has reserved capacity");
                                 }
                             }
@@ -132,8 +130,8 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
             for (Long groupVMId : groupVMIds) {
                 VMReservationVO vmReservation = _reservationDao.findByVmId(groupVMId);
                 if (vmReservation != null && vmReservation.getHostId() != null && vmReservation.getHostId().equals(plannedHostId)) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Planned destination for VM " + vm.getId() + " conflicts with an existing VM " + vmReservation.getVmId() +
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Planned destination for VM " + vm.getId() + " conflicts with an existing VM " + vmReservation.getVmId() +
                             " reserved on the same host " + plannedHostId);
                     }
                     return false;

--- a/plugins/api/discovery/src/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
+++ b/plugins/api/discovery/src/org/apache/cloudstack/discovery/ApiDiscoveryServiceImpl.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.annotations.SerializedName;
@@ -55,7 +54,6 @@ import com.cloud.utils.component.PluggableService;
 @Component
 @Local(value = ApiDiscoveryService.class)
 public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements ApiDiscoveryService {
-    private static final Logger s_logger = Logger.getLogger(ApiDiscoveryServiceImpl.class);
 
     List<APIChecker> _apiAccessCheckers = null;
     List<PluggableService> _services = null;
@@ -72,13 +70,13 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
             s_apiNameDiscoveryResponseMap = new HashMap<String, ApiDiscoveryResponse>();
             Set<Class<?>> cmdClasses = new HashSet<Class<?>>();
             for (PluggableService service : _services) {
-                s_logger.debug(String.format("getting api commands of service: %s", service.getClass().getName()));
+                logger.debug(String.format("getting api commands of service: %s", service.getClass().getName()));
                 cmdClasses.addAll(service.getCommands());
             }
             cmdClasses.addAll(this.getCommands());
             cacheResponseMap(cmdClasses);
             long endTime = System.nanoTime();
-            s_logger.info("Api Discovery Service: Annotation, docstrings, api relation graph processed in " + (endTime - startTime) / 1000000.0 + " ms");
+            logger.info("Api Discovery Service: Annotation, docstrings, api relation graph processed in " + (endTime - startTime) / 1000000.0 + " ms");
         }
 
         return true;
@@ -97,8 +95,8 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
             }
 
             String apiName = apiCmdAnnotation.name();
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("Found api: " + apiName);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Found api: " + apiName);
             }
             ApiDiscoveryResponse response = getCmdRequestMap(cmdClass, apiCmdAnnotation);
 
@@ -227,7 +225,7 @@ public class ApiDiscoveryServiceImpl extends ComponentLifecycleBase implements A
                 try {
                     apiChecker.checkAccess(user, name);
                 } catch (Exception ex) {
-                    s_logger.debug("API discovery access check failed for " + name + " with " + ex.getMessage());
+                    logger.debug("API discovery access check failed for " + name + " with " + ex.getMessage());
                     return null;
                 }
             }

--- a/plugins/api/rate-limit/src/org/apache/cloudstack/ratelimit/ApiRateLimitServiceImpl.java
+++ b/plugins/api/rate-limit/src/org/apache/cloudstack/ratelimit/ApiRateLimitServiceImpl.java
@@ -27,7 +27,6 @@ import javax.naming.ConfigurationException;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.acl.APIChecker;
@@ -47,7 +46,6 @@ import com.cloud.utils.component.AdapterBase;
 @Component
 @Local(value = APIChecker.class)
 public class ApiRateLimitServiceImpl extends AdapterBase implements APIChecker, ApiRateLimitService {
-    private static final Logger s_logger = Logger.getLogger(ApiRateLimitServiceImpl.class);
 
     /**
      * True if api rate limiting is enabled
@@ -100,7 +98,7 @@ public class ApiRateLimitServiceImpl extends AdapterBase implements APIChecker, 
             CacheManager cm = CacheManager.create();
             Cache cache = new Cache("api-limit-cache", maxElements, false, false, timeToLive, timeToLive);
             cm.addCache(cache);
-            s_logger.info("Limit Cache created with timeToLive=" + timeToLive + ", maxAllowed=" + maxAllowed + ", maxElements=" + maxElements);
+            logger.info("Limit Cache created with timeToLive=" + timeToLive + ", maxAllowed=" + maxAllowed + ", maxElements=" + maxElements);
             cacheStore.setCache(cache);
             _store = cacheStore;
 
@@ -165,13 +163,13 @@ public class ApiRateLimitServiceImpl extends AdapterBase implements APIChecker, 
         int current = entry.incrementAndGet();
 
         if (current <= maxAllowed) {
-            s_logger.trace("account (" + account.getAccountId() + "," + account.getAccountName() + ") has current count = " + current);
+            logger.trace("account (" + account.getAccountId() + "," + account.getAccountName() + ") has current count = " + current);
             return true;
         } else {
             long expireAfter = entry.getExpireDuration();
             // for this exception, we can just show the same message to user and admin users.
             String msg = "The given user has reached his/her account api limit, please retry after " + expireAfter + " ms.";
-            s_logger.warn(msg);
+            logger.warn(msg);
             throw new RequestLimitException(msg);
         }
     }

--- a/plugins/deployment-planners/implicit-dedication/src/com/cloud/deploy/ImplicitDedicationPlanner.java
+++ b/plugins/deployment-planners/implicit-dedication/src/com/cloud/deploy/ImplicitDedicationPlanner.java
@@ -26,7 +26,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.exception.InsufficientServerCapacityException;
@@ -44,7 +43,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Local(value = DeploymentPlanner.class)
 public class ImplicitDedicationPlanner extends FirstFitPlanner implements DeploymentClusterPlanner {
 
-    private static final Logger s_logger = Logger.getLogger(ImplicitDedicationPlanner.class);
 
     @Inject
     private ServiceOfferingDao serviceOfferingDao;
@@ -159,12 +157,12 @@ public class ImplicitDedicationPlanner extends FirstFitPlanner implements Deploy
 
         for (VMInstanceVO vm : allVmsOnHost) {
             if (vm.getAccountId() != accountId) {
-                s_logger.info("Host " + vm.getHostId() + " found to be unsuitable for implicit dedication as it is " + "running instances of another account");
+                logger.info("Host " + vm.getHostId() + " found to be unsuitable for implicit dedication as it is " + "running instances of another account");
                 suitable = false;
                 break;
             } else {
                 if (!isImplicitPlannerUsedByOffering(vm.getServiceOfferingId())) {
-                    s_logger.info("Host " + vm.getHostId() + " found to be unsuitable for implicit dedication as it " +
+                    logger.info("Host " + vm.getHostId() + " found to be unsuitable for implicit dedication as it " +
                         "is running instances of this account which haven't been created using implicit dedication.");
                     suitable = false;
                     break;
@@ -180,11 +178,11 @@ public class ImplicitDedicationPlanner extends FirstFitPlanner implements Deploy
             return false;
         for (VMInstanceVO vm : allVmsOnHost) {
             if (!isImplicitPlannerUsedByOffering(vm.getServiceOfferingId())) {
-                s_logger.info("Host " + vm.getHostId() + " found to be running a vm created by a planner other" + " than implicit.");
+                logger.info("Host " + vm.getHostId() + " found to be running a vm created by a planner other" + " than implicit.");
                 createdByImplicitStrict = false;
                 break;
             } else if (isServiceOfferingUsingPlannerInPreferredMode(vm.getServiceOfferingId())) {
-                s_logger.info("Host " + vm.getHostId() + " found to be running a vm created by an implicit planner" + " in preferred mode.");
+                logger.info("Host " + vm.getHostId() + " found to be running a vm created by an implicit planner" + " in preferred mode.");
                 createdByImplicitStrict = false;
                 break;
             }
@@ -196,7 +194,7 @@ public class ImplicitDedicationPlanner extends FirstFitPlanner implements Deploy
         boolean implicitPlannerUsed = false;
         ServiceOfferingVO offering = serviceOfferingDao.findByIdIncludingRemoved(offeringId);
         if (offering == null) {
-            s_logger.error("Couldn't retrieve the offering by the given id : " + offeringId);
+            logger.error("Couldn't retrieve the offering by the given id : " + offeringId);
         } else {
             String plannerName = offering.getDeploymentPlanner();
             if (plannerName == null) {

--- a/plugins/deployment-planners/user-concentrated-pod/src/com/cloud/deploy/UserConcentratedPodPlanner.java
+++ b/plugins/deployment-planners/user-concentrated-pod/src/com/cloud/deploy/UserConcentratedPodPlanner.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.utils.Pair;
 import com.cloud.vm.VirtualMachineProfile;
@@ -30,7 +29,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Local(value = DeploymentPlanner.class)
 public class UserConcentratedPodPlanner extends FirstFitPlanner implements DeploymentClusterPlanner {
 
-    private static final Logger s_logger = Logger.getLogger(UserConcentratedPodPlanner.class);
 
     /**
      * This method should reorder the given list of Cluster Ids by applying any necessary heuristic
@@ -64,14 +62,14 @@ public class UserConcentratedPodPlanner extends FirstFitPlanner implements Deplo
 
     private List<Long> reorderClustersByPods(List<Long> clusterIds, List<Long> podIds) {
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Reordering cluster list as per pods ordered by user concentration");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Reordering cluster list as per pods ordered by user concentration");
         }
 
         Map<Long, List<Long>> podClusterMap = _clusterDao.getPodClusterIdMap(clusterIds);
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Pod To cluster Map is: " + podClusterMap);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Pod To cluster Map is: " + podClusterMap);
         }
 
         List<Long> reorderedClusters = new ArrayList<Long>();
@@ -90,22 +88,22 @@ public class UserConcentratedPodPlanner extends FirstFitPlanner implements Deplo
         }
         reorderedClusters.addAll(clusterIds);
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Reordered cluster list: " + reorderedClusters);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Reordered cluster list: " + reorderedClusters);
         }
         return reorderedClusters;
     }
 
     protected List<Long> listPodsByUserConcentration(long zoneId, long accountId) {
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Applying UserConcentratedPod heuristic for account: " + accountId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Applying UserConcentratedPod heuristic for account: " + accountId);
         }
 
         List<Long> prioritizedPods = _vmDao.listPodIdsHavingVmsforAccount(zoneId, accountId);
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("List of pods to be considered, after applying UserConcentratedPod heuristic: " + prioritizedPods);
+        if (logger.isTraceEnabled()) {
+            logger.trace("List of pods to be considered, after applying UserConcentratedPod heuristic: " + prioritizedPods);
         }
 
         return prioritizedPods;

--- a/plugins/deployment-planners/user-dispersing/src/com/cloud/deploy/UserDispersingPlanner.java
+++ b/plugins/deployment-planners/user-dispersing/src/com/cloud/deploy/UserDispersingPlanner.java
@@ -26,7 +26,6 @@ import java.util.TreeMap;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.utils.NumbersUtil;
@@ -36,7 +35,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Local(value = DeploymentPlanner.class)
 public class UserDispersingPlanner extends FirstFitPlanner implements DeploymentClusterPlanner {
 
-    private static final Logger s_logger = Logger.getLogger(UserDispersingPlanner.class);
 
     /**
      * This method should reorder the given list of Cluster Ids by applying any necessary heuristic
@@ -99,8 +97,8 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
     }
 
     protected Pair<List<Long>, Map<Long, Double>> listClustersByUserDispersion(long id, boolean isZone, long accountId) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Applying Userdispersion heuristic to clusters for account: " + accountId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Applying Userdispersion heuristic to clusters for account: " + accountId);
         }
         Pair<List<Long>, Map<Long, Double>> clusterIdsVmCountInfo;
         if (isZone) {
@@ -108,19 +106,19 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
         } else {
             clusterIdsVmCountInfo = _vmInstanceDao.listClusterIdsInPodByVmCount(id, accountId);
         }
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("List of clusters in ascending order of number of VMs: " + clusterIdsVmCountInfo.first());
+        if (logger.isTraceEnabled()) {
+            logger.trace("List of clusters in ascending order of number of VMs: " + clusterIdsVmCountInfo.first());
         }
         return clusterIdsVmCountInfo;
     }
 
     protected Pair<List<Long>, Map<Long, Double>> listPodsByUserDispersion(long dataCenterId, long accountId) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Applying Userdispersion heuristic to pods for account: " + accountId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Applying Userdispersion heuristic to pods for account: " + accountId);
         }
         Pair<List<Long>, Map<Long, Double>> podIdsVmCountInfo = _vmInstanceDao.listPodIdsInZoneByVmCount(dataCenterId, accountId);
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("List of pods in ascending order of number of VMs: " + podIdsVmCountInfo.first());
+        if (logger.isTraceEnabled()) {
+            logger.trace("List of pods in ascending order of number of VMs: " + podIdsVmCountInfo.first());
         }
 
         return podIdsVmCountInfo;
@@ -132,25 +130,25 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
         Map<Long, Double> capacityMap = capacityInfo.second();
         Map<Long, Double> vmCountMap = vmCountInfo.second();
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Capacity Id list: " + capacityOrderedIds + " , capacityMap:" + capacityMap);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Capacity Id list: " + capacityOrderedIds + " , capacityMap:" + capacityMap);
         }
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Vm Count Id list: " + vmCountOrderedIds + " , vmCountMap:" + vmCountMap);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Vm Count Id list: " + vmCountOrderedIds + " , vmCountMap:" + vmCountMap);
         }
 
         List<Long> idsReorderedByWeights = new ArrayList<Long>();
         float capacityWeight = (1.0f - _userDispersionWeight);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Applying userDispersionWeight: " + _userDispersionWeight);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Applying userDispersionWeight: " + _userDispersionWeight);
         }
         //normalize the vmCountMap
         LinkedHashMap<Long, Double> normalisedVmCountIdMap = new LinkedHashMap<Long, Double>();
 
         Long totalVmsOfAccount = _vmInstanceDao.countRunningByAccount(accountId);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Total VMs for account: " + totalVmsOfAccount);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Total VMs for account: " + totalVmsOfAccount);
         }
         for (Long id : vmCountOrderedIds) {
             Double normalisedCount = vmCountMap.get(id) / totalVmsOfAccount;
@@ -179,8 +177,8 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
             idsReorderedByWeights.addAll(idList);
         }
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Reordered Id list: " + idsReorderedByWeights);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Reordered Id list: " + idsReorderedByWeights);
         }
 
         return idsReorderedByWeights;

--- a/plugins/event-bus/inmemory/src/org/apache/cloudstack/mom/inmemory/InMemoryEventBus.java
+++ b/plugins/event-bus/inmemory/src/org/apache/cloudstack/mom/inmemory/InMemoryEventBus.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.events.Event;
 import org.apache.cloudstack.framework.events.EventBus;
@@ -40,7 +39,6 @@ import com.cloud.utils.component.ManagerBase;
 @Local(value = EventBus.class)
 public class InMemoryEventBus extends ManagerBase implements EventBus {
 
-    private static final Logger s_logger = Logger.getLogger(InMemoryEventBus.class);
 
     private final static Map<UUID, Pair<EventTopic, EventSubscriber>> subscribers;
 

--- a/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
+++ b/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.events.Event;
 import org.apache.cloudstack.framework.events.EventBus;
@@ -52,7 +51,6 @@ public class KafkaEventBus extends ManagerBase implements EventBus {
 
     private String _topic = null;
     private Producer<String,String> _producer;
-    private static final Logger s_logger = Logger.getLogger(KafkaEventBus.class);
 
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {

--- a/plugins/event-bus/rabbitmq/src/org/apache/cloudstack/mom/rabbitmq/RabbitMQEventBus.java
+++ b/plugins/event-bus/rabbitmq/src/org/apache/cloudstack/mom/rabbitmq/RabbitMQEventBus.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executors;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;
@@ -93,7 +92,6 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
 
     private ExecutorService executorService;
     private static DisconnectHandler disconnectHandler;
-    private static final Logger s_logger = Logger.getLogger(RabbitMQEventBus.class);
 
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
@@ -235,9 +233,9 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
             s_subscribers.put(queueName, queueDetails);
 
         } catch (AlreadyClosedException closedException) {
-            s_logger.warn("Connection to AMQP service is lost. Subscription:" + queueName + " will be active after reconnection");
+            logger.warn("Connection to AMQP service is lost. Subscription:" + queueName + " will be active after reconnection");
         } catch (ConnectException connectException) {
-            s_logger.warn("Connection to AMQP service is lost. Subscription:" + queueName + " will be active after reconnection");
+            logger.warn("Connection to AMQP service is lost. Subscription:" + queueName + " will be active after reconnection");
         } catch (Exception e) {
             throw new EventBusException("Failed to subscribe to event due to " + e.getMessage());
         }
@@ -357,7 +355,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
             try {
                 return createConnection();
             } catch (Exception e) {
-                s_logger.error("Failed to create a connection to AMQP server due to " + e.getMessage());
+                logger.error("Failed to create a connection to AMQP server due to " + e.getMessage());
                 throw e;
             }
         } else {
@@ -397,7 +395,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
                 s_connection.close();
             }
         } catch (Exception e) {
-            s_logger.warn("Failed to close connection to AMQP server due to " + e.getMessage());
+            logger.warn("Failed to close connection to AMQP server due to " + e.getMessage());
         }
         s_connection = null;
     }
@@ -409,7 +407,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
         try {
             s_connection.abort();
         } catch (Exception e) {
-            s_logger.warn("Failed to abort connection due to " + e.getMessage());
+            logger.warn("Failed to abort connection due to " + e.getMessage());
         }
         s_connection = null;
     }
@@ -426,7 +424,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
         try {
             return connection.createChannel();
         } catch (java.io.IOException exception) {
-            s_logger.warn("Failed to create a channel due to " + exception.getMessage());
+            logger.warn("Failed to create a channel due to " + exception.getMessage());
             throw exception;
         }
     }
@@ -435,7 +433,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
         try {
             channel.exchangeDeclare(exchangeName, "topic", true);
         } catch (java.io.IOException exception) {
-            s_logger.error("Failed to create exchange" + exchangeName + " on RabbitMQ server");
+            logger.error("Failed to create exchange" + exchangeName + " on RabbitMQ server");
             throw exception;
         }
     }
@@ -445,7 +443,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
             byte[] messageBodyBytes = eventDescription.getBytes();
             channel.basicPublish(exchangeName, routingKey, MessageProperties.PERSISTENT_TEXT_PLAIN, messageBodyBytes);
         } catch (Exception e) {
-            s_logger.error("Failed to publish event " + routingKey + " on exchange " + exchangeName + "  of message broker due to " + e.getMessage());
+            logger.error("Failed to publish event " + routingKey + " on exchange " + exchangeName + "  of message broker due to " + e.getMessage());
             throw e;
         }
     }
@@ -498,7 +496,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
                     channel.queueDelete(queueName);
                     channel.abort();
                 } catch (IOException ioe) {
-                    s_logger.warn("Failed to delete queue: " + queueName + " on AMQP server due to " + ioe.getMessage());
+                    logger.warn("Failed to delete queue: " + queueName + " on AMQP server due to " + ioe.getMessage());
                 }
             }
         }
@@ -521,7 +519,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
                 }
 
                 abortConnection(); // disconnected to AMQP server, so abort the connection and channels
-                s_logger.warn("Connection has been shutdown by AMQP server. Attempting to reconnect.");
+                logger.warn("Connection has been shutdown by AMQP server. Attempting to reconnect.");
 
                 // initiate re-connect process
                 ReconnectionTask reconnect = new ReconnectionTask();
@@ -599,7 +597,7 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
                         s_subscribers.put(subscriberId, subscriberDetails);
                     }
                 } catch (Exception e) {
-                    s_logger.warn("Failed to recreate queues and binding for the subscribers due to " + e.getMessage());
+                    logger.warn("Failed to recreate queues and binding for the subscribers due to " + e.getMessage());
                 }
             }
             return;

--- a/plugins/file-systems/netapp/src/com/cloud/netapp/NetappManagerImpl.java
+++ b/plugins/file-systems/netapp/src/com/cloud/netapp/NetappManagerImpl.java
@@ -35,7 +35,6 @@ import netapp.manage.NaElement;
 import netapp.manage.NaException;
 import netapp.manage.NaServer;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.commands.netapp.AssociateLunCmd;
@@ -68,7 +67,6 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
         roundrobin, leastfull
     }
 
-    public static final Logger s_logger = Logger.getLogger(NetappManagerImpl.class.getName());
     @Inject
     public VolumeDao _volumeDao;
     @Inject
@@ -85,8 +83,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
 
     @Override
     public void createPool(String poolName, String algorithm) throws InvalidParameterValueException {
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("Request --> createPool ");
+        if (logger.isDebugEnabled())
+            logger.debug("Request --> createPool ");
 
         PoolVO pool = null;
         validAlgorithm(algorithm);
@@ -94,8 +92,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             pool = new PoolVO(poolName, algorithm);
             _poolDao.persist(pool);
 
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Response --> createPool:success");
+            if (logger.isDebugEnabled())
+                logger.debug("Response --> createPool:success");
 
         } catch (CloudRuntimeException cre) {
             pool = _poolDao.findPool(poolName);
@@ -174,8 +172,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
 
     @Override
     public void deletePool(String poolName) throws InvalidParameterValueException, ResourceInUseException {
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("Request --> deletePool ");
+        if (logger.isDebugEnabled())
+            logger.debug("Request --> deletePool ");
 
         PoolVO pool = _poolDao.findPool(poolName);
         if (pool == null) {
@@ -186,8 +184,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
 
         if (volCount == 0) {
             _poolDao.remove(pool.getId());
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Request --> deletePool: Success ");
+            if (logger.isDebugEnabled())
+                logger.debug("Request --> deletePool: Success ");
 
         } else {
             throw new ResourceInUseException("Cannot delete non-empty pool");
@@ -218,14 +216,14 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
         volume = _volumeDao.findVolume(ipAddress, aggrName, volName);
 
         if (volume == null) {
-            s_logger.warn("The volume does not exist in our system");
+            logger.warn("The volume does not exist in our system");
             throw new InvalidParameterValueException("The given tuple:" + ipAddress + "," + aggrName + "," + volName + " doesn't exist in our system");
         }
 
         List<LunVO> lunsOnVol = _lunDao.listLunsByVolId(volume.getId());
 
         if (lunsOnVol != null && lunsOnVol.size() > 0) {
-            s_logger.warn("There are luns on the volume");
+            logger.warn("There are luns on the volume");
             throw new ResourceInUseException("There are luns on the volume");
         }
 
@@ -258,12 +256,12 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             txn.commit();
 
         } catch (UnknownHostException uhe) {
-            s_logger.warn("Unable to delete volume on filer ", uhe);
+            logger.warn("Unable to delete volume on filer ", uhe);
             throw new ServerException("Unable to delete volume on filer", uhe);
         } catch (NaAPIFailedException naf) {
-            s_logger.warn("Unable to delete volume on filer ", naf);
+            logger.warn("Unable to delete volume on filer ", naf);
             if (naf.getErrno() == 13040) {
-                s_logger.info("Deleting the volume: " + volName);
+                logger.info("Deleting the volume: " + volName);
                 _volumeDao.remove(volume.getId());
                 txn.commit();
             }
@@ -271,11 +269,11 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             throw new ServerException("Unable to delete volume on filer", naf);
         } catch (NaException nae) {
             txn.rollback();
-            s_logger.warn("Unable to delete volume on filer ", nae);
+            logger.warn("Unable to delete volume on filer ", nae);
             throw new ServerException("Unable to delete volume on filer", nae);
         } catch (IOException ioe) {
             txn.rollback();
-            s_logger.warn("Unable to delete volume on filer ", ioe);
+            logger.warn("Unable to delete volume on filer ", ioe);
             throw new ServerException("Unable to delete volume on filer", ioe);
         } finally {
             if (pool != null) {
@@ -306,8 +304,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
     public void createVolumeOnFiler(String ipAddress, String aggName, String poolName, String volName, String volSize, String snapshotPolicy,
         Integer snapshotReservation, String username, String password) throws UnknownHostException, ServerException, InvalidParameterValueException {
 
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("Request --> createVolume " + "serverIp:" + ipAddress);
+        if (logger.isDebugEnabled())
+            logger.debug("Request --> createVolume " + "serverIp:" + ipAddress);
 
         boolean snapPolicy = false;
         boolean snapshotRes = false;
@@ -394,7 +392,7 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
         }
         pool = _poolDao.acquireInLockTable(pool.getId());
         if (pool == null) {
-            s_logger.warn("Failed to acquire lock on pool " + poolName);
+            logger.warn("Failed to acquire lock on pool " + poolName);
             throw new ConcurrentModificationException("Failed to acquire lock on pool " + poolName);
         }
         volume = new NetappVolumeVO(ipAddress, aggName, pool.getId(), volName, volSize, "", 0, username, password, 0, pool.getName());
@@ -419,34 +417,34 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             txn.commit();
         } catch (NaException nae) {
             //zapi call failed, log and throw e
-            s_logger.warn("Failed to create volume on the netapp filer:", nae);
+            logger.warn("Failed to create volume on the netapp filer:", nae);
             txn.rollback();
             if (volumeCreated) {
                 try {
                     deleteRogueVolume(volName, s);//deletes created volume on filer
                 } catch (NaException e) {
-                    s_logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
+                    logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
                     throw new ServerException("Unable to create volume via cloudtools."
                         + "Failed to cleanup created volume on netapp filer whilst rolling back on the cloud db:", e);
                 } catch (IOException e) {
-                    s_logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
+                    logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
                     throw new ServerException("Unable to create volume via cloudtools."
                         + "Failed to cleanup created volume on netapp filer whilst rolling back on the cloud db:", e);
                 }
             }
             throw new ServerException("Unable to create volume", nae);
         } catch (IOException ioe) {
-            s_logger.warn("Failed to create volume on the netapp filer:", ioe);
+            logger.warn("Failed to create volume on the netapp filer:", ioe);
             txn.rollback();
             if (volumeCreated) {
                 try {
                     deleteRogueVolume(volName, s);//deletes created volume on filer
                 } catch (NaException e) {
-                    s_logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
+                    logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
                     throw new ServerException("Unable to create volume via cloudtools."
                         + "Failed to cleanup created volume on netapp filer whilst rolling back on the cloud db:", e);
                 } catch (IOException e) {
-                    s_logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
+                    logger.warn("Failed to cleanup created volume whilst rolling back on the netapp filer:", e);
                     throw new ServerException("Unable to create volume via cloudtools."
                         + "Failed to cleanup created volume on netapp filer whilst rolling back on the cloud db:", e);
                 }
@@ -497,7 +495,7 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
                 vol.setSnapshotPolicy(snapScheduleOnFiler);
 
             } catch (ServerException e) {
-                s_logger.warn("Error trying to get snapshot schedule for volume" + vol.getVolumeName());
+                logger.warn("Error trying to get snapshot schedule for volume" + vol.getVolumeName());
             }
         }
         return vols;
@@ -538,10 +536,10 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
                 .append(whichMinutes);
             return sB.toString();
         } catch (NaException nae) {
-            s_logger.warn("Failed to get volume size ", nae);
+            logger.warn("Failed to get volume size ", nae);
             throw new ServerException("Failed to get volume size", nae);
         } catch (IOException ioe) {
-            s_logger.warn("Failed to get volume size ", ioe);
+            logger.warn("Failed to get volume size ", ioe);
             throw new ServerException("Failed to get volume size", ioe);
         } finally {
             if (s != null)
@@ -597,10 +595,10 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             }
 
         } catch (NaException nae) {
-            s_logger.warn("Failed to get volume size ", nae);
+            logger.warn("Failed to get volume size ", nae);
             throw new ServerException("Failed to get volume size", nae);
         } catch (IOException ioe) {
-            s_logger.warn("Failed to get volume size ", ioe);
+            logger.warn("Failed to get volume size ", ioe);
             throw new ServerException("Failed to get volume size", ioe);
         } finally {
             if (s != null)
@@ -646,7 +644,7 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
         }
         pool = _poolDao.acquireInLockTable(pool.getId());
         if (pool == null) {
-            s_logger.warn("Failed to acquire lock on the pool " + poolName);
+            logger.warn("Failed to acquire lock on the pool " + poolName);
             return result;
         }
         NaServer s = null;
@@ -663,8 +661,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
                 throw new ServerException("Could not find a suitable volume to create lun on");
             }
 
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Request --> createLun " + "serverIp:" + selectedVol.getIpAddress());
+            if (logger.isDebugEnabled())
+                logger.debug("Request --> createLun " + "serverIp:" + selectedVol.getIpAddress());
 
             StringBuilder exportPath = new StringBuilder("/vol/");
             exportPath.append(selectedVol.getVolumeName());
@@ -715,7 +713,7 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             } catch (NaAPIFailedException e) {
                 if (e.getErrno() == 9004) {
                     //igroup already exists hence no error
-                    s_logger.warn("Igroup already exists");
+                    logger.warn("Igroup already exists");
                 }
             }
 
@@ -794,15 +792,15 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
 
         NetappVolumeVO vol = _volumeDao.acquireInLockTable(lun.getVolumeId());
         if (vol == null) {
-            s_logger.warn("Failed to lock volume id= " + lun.getVolumeId());
+            logger.warn("Failed to lock volume id= " + lun.getVolumeId());
             return;
         }
         NaServer s = null;
         try {
             s = getServer(vol.getIpAddress(), vol.getUsername(), vol.getPassword());
 
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Request --> destroyLun " + ":serverIp:" + vol.getIpAddress());
+            if (logger.isDebugEnabled())
+                logger.debug("Request --> destroyLun " + ":serverIp:" + vol.getIpAddress());
 
             try {
                 //Unmap lun
@@ -812,7 +810,7 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
                 s.invokeElem(xi2);
             } catch (NaAPIFailedException naf) {
                 if (naf.getErrno() == 9016)
-                    s_logger.warn("no map exists excpn 9016 caught in deletelun, continuing with delete");
+                    logger.warn("no map exists excpn 9016 caught in deletelun, continuing with delete");
             }
 
             //destroy lun
@@ -831,30 +829,30 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             txn.commit();
         } catch (UnknownHostException uhe) {
             txn.rollback();
-            s_logger.warn("Failed to delete lun", uhe);
+            logger.warn("Failed to delete lun", uhe);
             throw new ServerException("Failed to delete lun", uhe);
         } catch (IOException ioe) {
             txn.rollback();
-            s_logger.warn("Failed to delete lun", ioe);
+            logger.warn("Failed to delete lun", ioe);
             throw new ServerException("Failed to delete lun", ioe);
         } catch (NaAPIFailedException naf) {
             if (naf.getErrno() == 9017) {//no such group exists excpn
-                s_logger.warn("no such group exists excpn 9017 caught in deletelun, continuing with delete");
+                logger.warn("no such group exists excpn 9017 caught in deletelun, continuing with delete");
                 _lunDao.remove(lun.getId());
                 txn.commit();
             } else if (naf.getErrno() == 9029) {//LUN maps for this initiator group exist
-                s_logger.warn("LUN maps for this initiator group exist errno 9029 caught in deletelun, continuing with delete");
+                logger.warn("LUN maps for this initiator group exist errno 9029 caught in deletelun, continuing with delete");
                 _lunDao.remove(lun.getId());
                 txn.commit();
             } else {
                 txn.rollback();
-                s_logger.warn("Failed to delete lun", naf);
+                logger.warn("Failed to delete lun", naf);
                 throw new ServerException("Failed to delete lun", naf);
             }
 
         } catch (NaException nae) {
             txn.rollback();
-            s_logger.warn("Failed to delete lun", nae);
+            logger.warn("Failed to delete lun", nae);
             throw new ServerException("Failed to delete lun", nae);
         } finally {
             if (vol != null) {
@@ -875,8 +873,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
      */
     @Override
     public List<LunVO> listLunsOnFiler(String poolName) {
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("Request --> listLunsOnFiler ");
+        if (logger.isDebugEnabled())
+            logger.debug("Request --> listLunsOnFiler ");
 
         List<LunVO> luns = new ArrayList<LunVO>();
 
@@ -886,8 +884,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
             luns.addAll(_lunDao.listLunsByVolId(vol.getId()));
         }
 
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("Response --> listLunsOnFiler:success");
+        if (logger.isDebugEnabled())
+            logger.debug("Response --> listLunsOnFiler:success");
 
         return luns;
     }
@@ -910,8 +908,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
         try {
             s = getServer(vol.getIpAddress(), vol.getUsername(), vol.getPassword());
 
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Request --> disassociateLun " + ":serverIp:" + vol.getIpAddress());
+            if (logger.isDebugEnabled())
+                logger.debug("Request --> disassociateLun " + ":serverIp:" + vol.getIpAddress());
 
             xi = new NaElement("igroup-remove");
             xi.addNewChild("force", "true");
@@ -972,8 +970,8 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
         try {
             s = getServer(vol.getIpAddress(), vol.getUsername(), vol.getPassword());
 
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Request --> associateLun " + ":serverIp:" + vol.getIpAddress());
+            if (logger.isDebugEnabled())
+                logger.debug("Request --> associateLun " + ":serverIp:" + vol.getIpAddress());
 
             //add iqn to the group
             xi2 = new NaElement("igroup-add");
@@ -984,19 +982,19 @@ public class NetappManagerImpl extends ManagerBase implements NetappManager {
 
             return returnVal;
         } catch (UnknownHostException uhe) {
-            s_logger.warn("Unable to associate LUN ", uhe);
+            logger.warn("Unable to associate LUN ", uhe);
             throw new ServerException("Unable to associate LUN", uhe);
         } catch (NaAPIFailedException naf) {
             if (naf.getErrno() == 9008) { //initiator group already contains node
                 return returnVal;
             }
-            s_logger.warn("Unable to associate LUN ", naf);
+            logger.warn("Unable to associate LUN ", naf);
             throw new ServerException("Unable to associate LUN", naf);
         } catch (NaException nae) {
-            s_logger.warn("Unable to associate LUN ", nae);
+            logger.warn("Unable to associate LUN ", nae);
             throw new ServerException("Unable to associate LUN", nae);
         } catch (IOException ioe) {
-            s_logger.warn("Unable to associate LUN ", ioe);
+            logger.warn("Unable to associate LUN ", ioe);
             throw new ServerException("Unable to associate LUN", ioe);
         } finally {
             if (s != null)

--- a/plugins/file-systems/netapp/src/com/cloud/netapp/dao/LunDaoImpl.java
+++ b/plugins/file-systems/netapp/src/com/cloud/netapp/dao/LunDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.netapp.LunVO;
@@ -32,7 +31,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {LunDao.class})
 public class LunDaoImpl extends GenericDaoBase<LunVO, Long> implements LunDao {
-    private static final Logger s_logger = Logger.getLogger(PoolDaoImpl.class);
 
     protected final SearchBuilder<LunVO> LunSearch;
     protected final SearchBuilder<LunVO> LunNameSearch;

--- a/plugins/file-systems/netapp/src/com/cloud/netapp/dao/PoolDaoImpl.java
+++ b/plugins/file-systems/netapp/src/com/cloud/netapp/dao/PoolDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.netapp.PoolVO;
@@ -31,7 +30,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {PoolDao.class})
 public class PoolDaoImpl extends GenericDaoBase<PoolVO, Long> implements PoolDao {
-    private static final Logger s_logger = Logger.getLogger(PoolDaoImpl.class);
 
     protected final SearchBuilder<PoolVO> PoolSearch;
 

--- a/plugins/file-systems/netapp/src/com/cloud/netapp/dao/VolumeDaoImpl.java
+++ b/plugins/file-systems/netapp/src/com/cloud/netapp/dao/VolumeDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.netapp.NetappVolumeVO;
@@ -32,7 +31,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component(value = "netappVolumeDaoImpl")
 @Local(value = {VolumeDao.class})
 public class VolumeDaoImpl extends GenericDaoBase<NetappVolumeVO, Long> implements VolumeDao {
-    private static final Logger s_logger = Logger.getLogger(VolumeDaoImpl.class);
 
     protected final SearchBuilder<NetappVolumeVO> NetappVolumeSearch;
     protected final SearchBuilder<NetappVolumeVO> NetappListVolumeSearch;

--- a/plugins/ha-planners/skip-heurestics/src/com/cloud/deploy/SkipHeuresticsPlanner.java
+++ b/plugins/ha-planners/skip-heurestics/src/com/cloud/deploy/SkipHeuresticsPlanner.java
@@ -17,7 +17,6 @@
 package com.cloud.deploy;
 
 import com.cloud.vm.VirtualMachineProfile;
-import org.apache.log4j.Logger;
 
 
 import javax.ejb.Local;
@@ -27,7 +26,6 @@ import java.util.Map;
 
 @Local(value=HAPlanner.class)
 public class SkipHeuresticsPlanner extends FirstFitPlanner implements HAPlanner {
-    private static final Logger s_logger = Logger.getLogger(SkipHeuresticsPlanner.class);
 
 
     /**
@@ -39,8 +37,8 @@ public class SkipHeuresticsPlanner extends FirstFitPlanner implements HAPlanner 
     @Override
     protected void removeClustersCrossingThreshold(List<Long> clusterListForVmAllocation, ExcludeList avoid,
                                                    VirtualMachineProfile vmProfile, DeploymentPlan plan){
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deploying vm during HA process, so skipping disable threshold check");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deploying vm during HA process, so skipping disable threshold check");
         }
         return;
     }

--- a/plugins/host-allocators/random/src/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
+++ b/plugins/host-allocators/random/src/com/cloud/agent/manager/allocator/impl/RandomAllocator.java
@@ -23,7 +23,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.manager.allocator.HostAllocator;
@@ -42,7 +41,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Component
 @Local(value = HostAllocator.class)
 public class RandomAllocator extends AdapterBase implements HostAllocator {
-    private static final Logger s_logger = Logger.getLogger(RandomAllocator.class);
     @Inject
     private HostDao _hostDao;
     @Inject
@@ -69,9 +67,9 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
 
         String hostTag = offering.getHostTag();
         if (hostTag != null) {
-            s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId + " having host tag:" + hostTag);
+            logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId + " having host tag:" + hostTag);
         } else {
-            s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
+            logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
         }
 
         // list all computing hosts, regardless of whether they support routing...it's random after all
@@ -81,7 +79,7 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
             hostsCopy.retainAll(_resourceMgr.listAllUpAndEnabledHosts(type, clusterId, podId, dcId));
         }
 
-        s_logger.debug("Random Allocator found " + hostsCopy.size() + "  hosts");
+        logger.debug("Random Allocator found " + hostsCopy.size() + "  hosts");
         if (hostsCopy.size() == 0) {
             return suitableHosts;
         }
@@ -95,14 +93,14 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
             if (!avoid.shouldAvoid(host)) {
                 suitableHosts.add(host);
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, " + "skipping this and trying other available hosts");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, " + "skipping this and trying other available hosts");
                 }
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Random Host Allocator returning " + suitableHosts.size() + " suitable hosts");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Random Host Allocator returning " + suitableHosts.size() + " suitable hosts");
         }
 
         return suitableHosts;
@@ -124,9 +122,9 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
 
         String hostTag = offering.getHostTag();
         if (hostTag != null) {
-            s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId + " having host tag:" + hostTag);
+            logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId + " having host tag:" + hostTag);
         } else {
-            s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
+            logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
         }
 
         // list all computing hosts, regardless of whether they support routing...it's random after all
@@ -137,7 +135,7 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
             hosts = _resourceMgr.listAllUpAndEnabledHosts(type, clusterId, podId, dcId);
         }
 
-        s_logger.debug("Random Allocator found " + hosts.size() + "  hosts");
+        logger.debug("Random Allocator found " + hosts.size() + "  hosts");
 
         if (hosts.size() == 0) {
             return suitableHosts;
@@ -152,13 +150,13 @@ public class RandomAllocator extends AdapterBase implements HostAllocator {
             if (!avoid.shouldAvoid(host)) {
                 suitableHosts.add(host);
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, skipping this and trying other available hosts");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, skipping this and trying other available hosts");
                 }
             }
         }
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Random Host Allocator returning " + suitableHosts.size() + " suitable hosts");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Random Host Allocator returning " + suitableHosts.size() + " suitable hosts");
         }
         return suitableHosts;
     }

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalDiscoverer.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalDiscoverer.java
@@ -34,7 +34,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.api.ApiConstants;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.agent.api.StartupRoutingCommand;
@@ -63,7 +62,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 @Local(value = Discoverer.class)
 public class BareMetalDiscoverer extends DiscovererBase implements Discoverer, ResourceStateAdapter {
-    protected static final Logger s_logger = Logger.getLogger(BareMetalDiscoverer.class);
     @Inject
     protected VMInstanceDao _vmDao = null;
 
@@ -94,25 +92,25 @@ public class BareMetalDiscoverer extends DiscovererBase implements Discoverer, R
 
         if (!url.getScheme().equals("http")) {
             String msg = "urlString is not http so we're not taking care of the discovery for this: " + url;
-            s_logger.debug(msg);
+            logger.debug(msg);
             return null;
         }
         if (clusterId == null) {
             String msg = "must specify cluster Id when add host";
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new RuntimeException(msg);
         }
 
         if (podId == null) {
             String msg = "must specify pod Id when add host";
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new RuntimeException(msg);
         }
 
         ClusterVO cluster = _clusterDao.findById(clusterId);
         if (cluster == null || (cluster.getHypervisorType() != HypervisorType.BareMetal)) {
-            if (s_logger.isInfoEnabled())
-                s_logger.info("invalid cluster id or cluster is not for Bare Metal hosts");
+            if (logger.isInfoEnabled())
+                logger.info("invalid cluster id or cluster is not for Bare Metal hosts");
             return null;
         }
 
@@ -134,14 +132,14 @@ public class BareMetalDiscoverer extends DiscovererBase implements Discoverer, R
                         + injectScript);
             }
 
-            final Script2 command = new Script2(scriptPath, s_logger);
+            final Script2 command = new Script2(scriptPath, logger);
             command.add("ping");
             command.add("hostname="+ipmiIp);
             command.add("usrname="+username);
             command.add("password="+password, ParamType.PASSWORD);
             final String result = command.execute();
             if (result != null) {
-                s_logger.warn(String.format("Can not set up ipmi connection(ip=%1$s, username=%2$s, password=%3$s, args) because %4$s", ipmiIp, username, "******", result));
+                logger.warn(String.format("Can not set up ipmi connection(ip=%1$s, username=%2$s, password=%3$s, args) because %4$s", ipmiIp, username, "******", result));
                 return null;
             }
 
@@ -207,11 +205,11 @@ public class BareMetalDiscoverer extends DiscovererBase implements Discoverer, R
             zone.setDhcpProvider(Network.Provider.ExternalDhcpServer.getName());
             _dcDao.update(zone.getId(), zone);
 
-            s_logger.debug(String.format("Discover Bare Metal host successfully(ip=%1$s, username=%2$s, password=%3%s," +
+            logger.debug(String.format("Discover Bare Metal host successfully(ip=%1$s, username=%2$s, password=%3%s," +
                     "cpuNum=%4$s, cpuCapacity-%5$s, memCapacity=%6$s)", ipmiIp, username, "******", cpuNum, cpuCapacity, memCapacity));
             return resources;
         } catch (Exception e) {
-            s_logger.warn("Can not set up bare metal agent", e);
+            logger.warn("Can not set up bare metal agent", e);
         }
 
         return null;

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalGuru.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalGuru.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.host.dao.HostDao;
@@ -43,7 +42,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 @Local(value = HypervisorGuru.class)
 public class BareMetalGuru extends HypervisorGuruBase implements HypervisorGuru {
-    private static final Logger s_logger = Logger.getLogger(BareMetalGuru.class);
     @Inject
     GuestOSDao _guestOsDao;
     @Inject

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalPlanner.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalPlanner.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 
@@ -53,7 +52,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = DeploymentPlanner.class)
 public class BareMetalPlanner extends AdapterBase implements DeploymentPlanner {
-    private static final Logger s_logger = Logger.getLogger(BareMetalPlanner.class);
     @Inject
     protected DataCenterDao _dcDao;
     @Inject
@@ -84,7 +82,7 @@ public class BareMetalPlanner extends AdapterBase implements DeploymentPlanner {
             DataCenter dc = _dcDao.findById(h.getDataCenterId());
             Pod pod = _podDao.findById(h.getPodId());
             Cluster c = _clusterDao.findById(h.getClusterId());
-            s_logger.debug("Start baremetal vm " + vm.getId() + " on last stayed host " + h.getId());
+            logger.debug("Start baremetal vm " + vm.getId() + " on last stayed host " + h.getId());
             return new DeployDestination(dc, pod, c, h);
         }
 
@@ -116,7 +114,7 @@ public class BareMetalPlanner extends AdapterBase implements DeploymentPlanner {
         }
 
         if (target == null) {
-            s_logger.warn("Cannot find host with tag " + hostTag + " use capacity from service offering");
+            logger.warn("Cannot find host with tag " + hostTag + " use capacity from service offering");
             cpu_requested = offering.getCpu() * offering.getSpeed();
             ram_requested = offering.getRamSize() * 1024L * 1024L;
         } else {
@@ -128,7 +126,7 @@ public class BareMetalPlanner extends AdapterBase implements DeploymentPlanner {
             if (haVmTag == null) {
                 hosts = _resourceMgr.listAllUpAndEnabledNonHAHosts(Host.Type.Routing, cluster.getId(), cluster.getPodId(), cluster.getDataCenterId());
             } else {
-                s_logger.warn("Cannot find HA host with tag " + haVmTag + " in cluster id=" + cluster.getId() + ", pod id=" + cluster.getPodId() + ", data center id=" +
+                logger.warn("Cannot find HA host with tag " + haVmTag + " in cluster id=" + cluster.getId() + ", pod id=" + cluster.getPodId() + ", data center id=" +
                     cluster.getDataCenterId());
                 return null;
             }
@@ -140,7 +138,7 @@ public class BareMetalPlanner extends AdapterBase implements DeploymentPlanner {
                 Float memoryOvercommitRatio = Float.parseFloat(cluster_detail_ram.getValue());
 
                 if (_capacityMgr.checkIfHostHasCapacity(h.getId(), cpu_requested, ram_requested, false, cpuOvercommitRatio, memoryOvercommitRatio, true)) {
-                    s_logger.debug("Find host " + h.getId() + " has enough capacity");
+                    logger.debug("Find host " + h.getId() + " has enough capacity");
                     DataCenter dc = _dcDao.findById(h.getDataCenterId());
                     Pod pod = _podDao.findById(h.getPodId());
                     return new DeployDestination(dc, pod, cluster, h);
@@ -148,7 +146,7 @@ public class BareMetalPlanner extends AdapterBase implements DeploymentPlanner {
             }
         }
 
-        s_logger.warn(String.format("Cannot find enough capacity(requested cpu=%1$s memory=%2$s)", cpu_requested, ram_requested));
+        logger.warn(String.format("Cannot find enough capacity(requested cpu=%1$s memory=%2$s)", cpu_requested, ram_requested));
         return null;
     }
 

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalTemplateAdapter.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BareMetalTemplateAdapter.java
@@ -44,7 +44,6 @@ import org.apache.cloudstack.api.command.user.iso.RegisterIsoCmd;
 import org.apache.cloudstack.api.command.user.template.RegisterTemplateCmd;
 import org.apache.cloudstack.storage.command.TemplateOrVolumePostUploadCommand;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.inject.Inject;
@@ -53,7 +52,6 @@ import java.util.List;
 
 @Local(value = TemplateAdapter.class)
 public class BareMetalTemplateAdapter extends TemplateAdapterBase implements TemplateAdapter {
-    private final static Logger s_logger = Logger.getLogger(BareMetalTemplateAdapter.class);
     @Inject
     HostDao _hostDao;
     @Inject
@@ -131,7 +129,7 @@ public class BareMetalTemplateAdapter extends TemplateAdapterBase implements Tem
             zoneName = "all zones";
         }
 
-        s_logger.debug("Attempting to mark template host refs for template: " + template.getName() + " as destroyed in zone: " + zoneName);
+        logger.debug("Attempting to mark template host refs for template: " + template.getName() + " as destroyed in zone: " + zoneName);
         Account account = _accountDao.findByIdIncludingRemoved(template.getAccountId());
         String eventType = EventTypes.EVENT_TEMPLATE_DELETE;
         List<TemplateDataStoreVO> templateHostVOs = this._tmpltStoreDao.listByTemplate(templateId);
@@ -141,7 +139,7 @@ public class BareMetalTemplateAdapter extends TemplateAdapterBase implements Tem
             try {
                 lock = _tmpltStoreDao.acquireInLockTable(vo.getId());
                 if (lock == null) {
-                    s_logger.debug("Failed to acquire lock when deleting templateDataStoreVO with ID: " + vo.getId());
+                    logger.debug("Failed to acquire lock when deleting templateDataStoreVO with ID: " + vo.getId());
                     success = false;
                     break;
                 }
@@ -173,7 +171,7 @@ public class BareMetalTemplateAdapter extends TemplateAdapterBase implements Tem
             _tmpltZoneDao.remove(templateZone.getId());
         }
 
-        s_logger.debug("Successfully marked template host refs for template: " + template.getName() + " as destroyed in zone: " + zoneName);
+        logger.debug("Successfully marked template host refs for template: " + template.getName() + " as destroyed in zone: " + zoneName);
 
         // If there are no more non-destroyed template host entries for this template, delete it
         if (success && (_tmpltStoreDao.listByTemplate(templateId).size() == 0)) {
@@ -183,7 +181,7 @@ public class BareMetalTemplateAdapter extends TemplateAdapterBase implements Tem
 
             try {
                 if (lock == null) {
-                    s_logger.debug("Failed to acquire lock when deleting template with ID: " + templateId);
+                    logger.debug("Failed to acquire lock when deleting template with ID: " + templateId);
                     success = false;
                 } else if (_tmpltDao.remove(templateId)) {
                     // Decrement the number of templates and total secondary storage space used by the account.
@@ -196,7 +194,7 @@ public class BareMetalTemplateAdapter extends TemplateAdapterBase implements Tem
                     _tmpltDao.releaseFromLockTable(lock.getId());
                 }
             }
-            s_logger.debug("Removed template: " + template.getName() + " because all of its template host refs were marked as destroyed.");
+            logger.debug("Removed template: " + template.getName() + " because all of its template host refs were marked as destroyed.");
         }
 
         return success;

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BaremetalManagerImpl.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/manager/BaremetalManagerImpl.java
@@ -33,7 +33,6 @@ import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.dao.VMInstanceDao;
 import org.apache.cloudstack.api.BaremetalProvisionDoneNotificationCmd;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.AddBaremetalHostCmd;
 
@@ -48,7 +47,6 @@ import com.cloud.vm.VirtualMachine.State;
 
 @Local(value = {BaremetalManager.class})
 public class BaremetalManagerImpl extends ManagerBase implements BaremetalManager, StateListener<State, VirtualMachine.Event, VirtualMachine> {
-    private static final Logger s_logger = Logger.getLogger(BaremetalManagerImpl.class);
 
     @Inject
     protected HostDao _hostDao;
@@ -95,17 +93,17 @@ public class BaremetalManagerImpl extends ManagerBase implements BaremetalManage
 
       HostVO host = _hostDao.findById(vo.getHostId());
       if (host == null) {
-        s_logger.debug("Skip oldState " + oldState + " to " + "newState " + newState + " transimtion");
+        logger.debug("Skip oldState " + oldState + " to " + "newState " + newState + " transimtion");
         return true;
       }
       _hostDao.loadDetails(host);
 
       if (newState == State.Starting) {
         host.setDetail("vmName", vo.getInstanceName());
-        s_logger.debug("Add vmName " + host.getDetail("vmName") + " to host " + host.getId() + " details");
+        logger.debug("Add vmName " + host.getDetail("vmName") + " to host " + host.getId() + " details");
       } else {
         if (host.getDetail("vmName") != null && host.getDetail("vmName").equalsIgnoreCase(vo.getInstanceName())) {
-          s_logger.debug("Remove vmName " + host.getDetail("vmName") + " from host " + host.getId() + " details");
+          logger.debug("Remove vmName " + host.getDetail("vmName") + " from host " + host.getId() + " details");
           host.getDetails().remove("vmName");
         }
       }
@@ -152,7 +150,7 @@ public class BaremetalManagerImpl extends ManagerBase implements BaremetalManage
         vm.setState(State.Running);
         vm.setLastHostId(vm.getHostId());
         vmDao.update(vm.getId(), vm);
-        s_logger.debug(String.format("received baremetal provision done notification for vm[id:%s name:%s] running on host[mac:%s, ip:%s]",
+        logger.debug(String.format("received baremetal provision done notification for vm[id:%s name:%s] running on host[mac:%s, ip:%s]",
                 vm.getId(), vm.getInstanceName(), host.getPrivateMacAddress(), host.getPrivateIpAddress()));
     }
 }

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BareMetalPingServiceImpl.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BareMetalPingServiceImpl.java
@@ -33,7 +33,6 @@ import javax.inject.Inject;
 import org.apache.cloudstack.api.AddBaremetalPxeCmd;
 import org.apache.cloudstack.api.AddBaremetalPxePingServerCmd;
 import org.apache.cloudstack.api.ListBaremetalPxeServersCmd;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.baremetal.IpmISetBootDevCommand;
@@ -70,7 +69,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = BaremetalPxeService.class)
 public class BareMetalPingServiceImpl extends BareMetalPxeServiceBase implements BaremetalPxeService {
-    private static final Logger s_logger = Logger.getLogger(BareMetalPingServiceImpl.class);
     @Inject
     ResourceManager _resourceMgr;
     @Inject
@@ -109,19 +107,19 @@ public class BareMetalPingServiceImpl extends BareMetalPxeServiceBase implements
                 new PreparePxeServerCommand(ip, mac, mask, gateway, dns, tpl, profile.getVirtualMachine().getInstanceName(), dest.getHost().getName());
             PreparePxeServerAnswer ans = (PreparePxeServerAnswer)_agentMgr.send(pxeServerId, cmd);
             if (!ans.getResult()) {
-                s_logger.warn("Unable tot program PXE server: " + pxeVo.getId() + " because " + ans.getDetails());
+                logger.warn("Unable tot program PXE server: " + pxeVo.getId() + " because " + ans.getDetails());
                 return false;
             }
 
             IpmISetBootDevCommand bootCmd = new IpmISetBootDevCommand(BootDev.pxe);
             Answer anw = _agentMgr.send(dest.getHost().getId(), bootCmd);
             if (!anw.getResult()) {
-                s_logger.warn("Unable to set host: " + dest.getHost().getId() + " to PXE boot because " + anw.getDetails());
+                logger.warn("Unable to set host: " + dest.getHost().getId() + " to PXE boot because " + anw.getDetails());
             }
 
             return anw.getResult();
         } catch (Exception e) {
-            s_logger.warn("Cannot prepare PXE server", e);
+            logger.warn("Cannot prepare PXE server", e);
             return false;
         }
     }
@@ -152,7 +150,7 @@ public class BareMetalPingServiceImpl extends BareMetalPxeServiceBase implements
             Answer ans = _agentMgr.send(pxeServerId, cmd);
             return ans.getResult();
         } catch (Exception e) {
-            s_logger.debug("Prepare for creating baremetal template failed", e);
+            logger.debug("Prepare for creating baremetal template failed", e);
             return false;
         }
     }
@@ -221,7 +219,7 @@ public class BareMetalPingServiceImpl extends BareMetalPxeServiceBase implements
         try {
             uri = new URI(cmd.getUrl());
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             throw new IllegalArgumentException(e.getMessage());
         }
         String ipAddress = uri.getHost();
@@ -246,7 +244,7 @@ public class BareMetalPingServiceImpl extends BareMetalPxeServiceBase implements
         try {
             resource.configure("PING PXE resource", params);
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             throw new CloudRuntimeException(e.getMessage());
         }
 

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BareMetalResourceBase.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BareMetalResourceBase.java
@@ -72,7 +72,6 @@ import com.cloud.vm.VirtualMachine.PowerState;
 import com.cloud.vm.dao.VMInstanceDao;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
@@ -83,7 +82,6 @@ import java.util.concurrent.TimeUnit;
 
 @Local(value = ServerResource.class)
 public class BareMetalResourceBase extends ManagerBase implements ServerResource {
-    private static final Logger s_logger = Logger.getLogger(BareMetalResourceBase.class);
     protected String _uuid;
     protected String _zone;
     protected String _pod;
@@ -176,20 +174,20 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         try {
             ipmiIface = configDao.getValue(Config.BaremetalIpmiLanInterface.key());
         } catch (Exception e) {
-            s_logger.debug(e.getMessage(), e);
+            logger.debug(e.getMessage(), e);
         }
 
         try {
             ipmiRetryTimes = Integer.parseInt(configDao.getValue(Config.BaremetalIpmiRetryTimes.key()));
         } catch (Exception e) {
-            s_logger.debug(e.getMessage(), e);
+            logger.debug(e.getMessage(), e);
         }
 
         try {
             provisionDoneNotificationOn = Boolean.valueOf(configDao.getValue(Config.BaremetalProvisionDoneNotificationEnabled.key()));
             isProvisionDoneNotificationTimeout = Integer.parseInt(configDao.getValue(Config.BaremetalProvisionDoneNotificationTimeout.key()));
         } catch (Exception e) {
-            s_logger.debug(e.getMessage(), e);
+            logger.debug(e.getMessage(), e);
         }
 
         String injectScript = "scripts/util/ipmi.py";
@@ -198,7 +196,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
             throw new ConfigurationException("Cannot find ping script " + scriptPath);
         }
         String pythonPath = "/usr/bin/python";
-        _pingCommand = new Script2(pythonPath, s_logger);
+        _pingCommand = new Script2(pythonPath, logger);
         _pingCommand.add(scriptPath);
         _pingCommand.add("ping");
         _pingCommand.add("interface=" + ipmiIface);
@@ -206,7 +204,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _pingCommand.add("usrname=" + _username);
         _pingCommand.add("password=" + _password, ParamType.PASSWORD);
 
-        _setPxeBootCommand = new Script2(pythonPath, s_logger);
+        _setPxeBootCommand = new Script2(pythonPath, logger);
         _setPxeBootCommand.add(scriptPath);
         _setPxeBootCommand.add("boot_dev");
         _setPxeBootCommand.add("interface=" + ipmiIface);
@@ -215,7 +213,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _setPxeBootCommand.add("password=" + _password, ParamType.PASSWORD);
         _setPxeBootCommand.add("dev=pxe");
 
-        _setDiskBootCommand = new Script2(pythonPath, s_logger);
+        _setDiskBootCommand = new Script2(pythonPath, logger);
         _setDiskBootCommand.add(scriptPath);
         _setDiskBootCommand.add("boot_dev");
         _setDiskBootCommand.add("interface=" + ipmiIface);
@@ -224,7 +222,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _setDiskBootCommand.add("password=" + _password, ParamType.PASSWORD);
         _setDiskBootCommand.add("dev=disk");
 
-        _rebootCommand = new Script2(pythonPath, s_logger);
+        _rebootCommand = new Script2(pythonPath, logger);
         _rebootCommand.add(scriptPath);
         _rebootCommand.add("reboot");
         _rebootCommand.add("interface=" + ipmiIface);
@@ -232,7 +230,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _rebootCommand.add("usrname=" + _username);
         _rebootCommand.add("password=" + _password, ParamType.PASSWORD);
 
-        _getStatusCommand = new Script2(pythonPath, s_logger);
+        _getStatusCommand = new Script2(pythonPath, logger);
         _getStatusCommand.add(scriptPath);
         _getStatusCommand.add("ping");
         _getStatusCommand.add("interface=" + ipmiIface);
@@ -240,7 +238,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _getStatusCommand.add("usrname=" + _username);
         _getStatusCommand.add("password=" + _password, ParamType.PASSWORD);
 
-        _powerOnCommand = new Script2(pythonPath, s_logger);
+        _powerOnCommand = new Script2(pythonPath, logger);
         _powerOnCommand.add(scriptPath);
         _powerOnCommand.add("power");
         _powerOnCommand.add("interface=" + ipmiIface);
@@ -249,7 +247,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _powerOnCommand.add("password=" + _password, ParamType.PASSWORD);
         _powerOnCommand.add("action=on");
 
-        _powerOffCommand = new Script2(pythonPath, s_logger);
+        _powerOffCommand = new Script2(pythonPath, logger);
         _powerOffCommand.add(scriptPath);
         _powerOffCommand.add("power");
         _powerOffCommand.add("interface=" + ipmiIface);
@@ -258,7 +256,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _powerOffCommand.add("password=" + _password, ParamType.PASSWORD);
         _powerOffCommand.add("action=soft");
 
-        _forcePowerOffCommand = new Script2(pythonPath, s_logger);
+        _forcePowerOffCommand = new Script2(pythonPath, logger);
         _forcePowerOffCommand.add(scriptPath);
         _forcePowerOffCommand.add("power");
         _forcePowerOffCommand.add("interface=" + ipmiIface);
@@ -267,7 +265,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
         _forcePowerOffCommand.add("password=" + _password, ParamType.PASSWORD);
         _forcePowerOffCommand.add("action=off");
 
-        _bootOrRebootCommand = new Script2(pythonPath, s_logger);
+        _bootOrRebootCommand = new Script2(pythonPath, logger);
         _bootOrRebootCommand.add(scriptPath);
         _bootOrRebootCommand.add("boot_or_reboot");
         _bootOrRebootCommand.add("interface=" + ipmiIface);
@@ -299,11 +297,11 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
                 res = cmd.execute(interpreter);
             }
             if (res != null && res.startsWith("Error: Unable to establish LAN")) {
-                s_logger.warn("IPMI script timeout(" + cmd.toString() + "), will retry " + retry + " times");
+                logger.warn("IPMI script timeout(" + cmd.toString() + "), will retry " + retry + " times");
                 try {
                     TimeUnit.SECONDS.sleep(1);
                 } catch (InterruptedException e) {
-                    s_logger.debug("[ignored] interupted while waiting to retry running script.");
+                    logger.debug("[ignored] interupted while waiting to retry running script.");
                 }
                 continue;
             } else if (res == null) {
@@ -313,7 +311,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
             }
         }
 
-        s_logger.warn("IPMI Scirpt failed due to " + res + "(" + cmd.toString() + ")");
+        logger.warn("IPMI Scirpt failed due to " + res + "(" + cmd.toString() + ")");
         return false;
     }
 
@@ -379,12 +377,12 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
             if (!ipmiPing()) {
                 Thread.sleep(1000);
                 if (!ipmiPing()) {
-                    s_logger.warn("Cannot ping ipmi nic " + _ip);
+                    logger.warn("Cannot ping ipmi nic " + _ip);
                     return null;
                 }
             }
         } catch (Exception e) {
-            s_logger.debug("Cannot ping ipmi nic " + _ip, e);
+            logger.debug("Cannot ping ipmi nic " + _ip, e);
             return null;
         }
 
@@ -419,11 +417,11 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
 
         String bootDev = cmd.getBootDev().name();
         if (!doScript(bootCmd)) {
-            s_logger.warn("Set " + _ip + " boot dev to " + bootDev + "failed");
+            logger.warn("Set " + _ip + " boot dev to " + bootDev + "failed");
             return new Answer(cmd, false, "Set " + _ip + " boot dev to " + bootDev + "failed");
         }
 
-        s_logger.warn("Set " + _ip + " boot dev to " + bootDev + "Success");
+        logger.warn("Set " + _ip + " boot dev to " + bootDev + "Success");
         return new Answer(cmd, true, "Set " + _ip + " boot dev to " + bootDev + "Success");
     }
 
@@ -494,7 +492,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
                 return Answer.createUnsupportedCommandAnswer(cmd);
             }
         } catch (Throwable t) {
-            s_logger.debug(t.getMessage(), t);
+            logger.debug(t.getMessage(), t);
             return new Answer(cmd, false, t.getMessage());
         }
     }
@@ -545,7 +543,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
             OutputInterpreter.AllLinesParser interpreter = new OutputInterpreter.AllLinesParser();
             if (!doScript(_getStatusCommand, interpreter)) {
                 success = true;
-                s_logger.warn("Cannot get power status of " + getName() + ", assume VM state changed successfully");
+                logger.warn("Cannot get power status of " + getName() + ", assume VM state changed successfully");
                 break;
             }
 
@@ -600,7 +598,7 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
                     try {
                         TimeUnit.SECONDS.sleep(5);
                     } catch (InterruptedException e) {
-                        s_logger.warn(e.getMessage(), e);
+                        logger.warn(e.getMessage(), e);
                     }
 
                     q = QueryBuilder.create(VMInstanceVO.class);
@@ -614,21 +612,21 @@ public class BareMetalResourceBase extends ManagerBase implements ServerResource
                         return new StartAnswer(cmd);
                     }
 
-                    s_logger.debug(String.format("still wait for baremetal provision done notification for vm[name:%s], current vm state is %s", vmvo.getInstanceName(), vmvo.getState()));
+                    logger.debug(String.format("still wait for baremetal provision done notification for vm[name:%s], current vm state is %s", vmvo.getInstanceName(), vmvo.getState()));
                 }
 
                 return new StartAnswer(cmd, String.format("timeout after %s seconds, no baremetal provision done notification received. vm[name:%s] failed to start", isProvisionDoneNotificationTimeout, vm.getName()));
             }
         }
 
-        s_logger.debug("Start bare metal vm " + vm.getName() + "successfully");
+        logger.debug("Start bare metal vm " + vm.getName() + "successfully");
         _vmName = vm.getName();
         return new StartAnswer(cmd);
     }
 
     protected ReadyAnswer execute(ReadyCommand cmd) {
         // derived resource should check if the PXE server is ready
-        s_logger.debug("Bare metal resource " + getName() + " is ready");
+        logger.debug("Bare metal resource " + getName() + " is ready");
         return new ReadyAnswer(cmd);
     }
 

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetaNetworkGuru.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetaNetworkGuru.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.Pod;
@@ -60,7 +59,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = {NetworkGuru.class})
 public class BaremetaNetworkGuru extends DirectPodBasedNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(BaremetaNetworkGuru.class);
     @Inject
     private HostDao _hostDao;
     @Inject
@@ -149,14 +147,14 @@ public class BaremetaNetworkGuru extends DirectPodBasedNetworkGuru {
          * nic.setBroadcastUri(null); nic.setIsolationUri(null);
          */
 
-        s_logger.debug("Allocated a nic " + nic + " for " + vm);
+        logger.debug("Allocated a nic " + nic + " for " + vm);
     }
 
     private void getBaremetalIp(NicProfile nic, Pod pod, VirtualMachineProfile vm, Network network, String requiredIp) throws
         InsufficientAddressCapacityException, ConcurrentOperationException {
         DataCenter dc = _dcDao.findById(pod.getDataCenterId());
         if (nic.getIPv4Address() == null) {
-            s_logger.debug(String.format("Requiring ip address: %s", nic.getIPv4Address()));
+            logger.debug(String.format("Requiring ip address: %s", nic.getIPv4Address()));
             PublicIp ip = _ipAddrMgr.assignPublicIpAddress(dc.getId(), pod.getId(), vm.getOwner(), VlanType.DirectAttached, network.getId(), requiredIp, false);
             nic.setIPv4Address(ip.getAddress().toString());
             nic.setFormat(AddressFormat.Ip4);

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpElement.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpElement.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.baremetal.database.BaremetalDhcpVO;
 import com.cloud.dc.DataCenter.NetworkType;
@@ -59,7 +58,6 @@ import com.cloud.vm.dao.NicDao;
 
 @Local(value = NetworkElement.class)
 public class BaremetalDhcpElement extends AdapterBase implements DhcpServiceProvider {
-    private static final Logger s_logger = Logger.getLogger(BaremetalDhcpElement.class);
     private static final Map<Service, Map<Capability, String>> capabilities;
 
     @Inject
@@ -101,7 +99,7 @@ public class BaremetalDhcpElement extends AdapterBase implements DhcpServiceProv
     public boolean implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context) throws ConcurrentOperationException,
         ResourceUnavailableException, InsufficientCapacityException {
         if (offering.isSystemOnly() || !canHandle(dest, offering.getTrafficType(), network.getGuestType())) {
-            s_logger.debug("BaremetalDhcpElement can not handle networkoffering: " + offering.getName());
+            logger.debug("BaremetalDhcpElement can not handle networkoffering: " + offering.getName());
             return false;
         }
         return true;

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpManagerImpl.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpManagerImpl.java
@@ -34,7 +34,6 @@ import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.api.AddBaremetalDhcpCmd;
 import org.apache.cloudstack.api.ListBaremetalDhcpCmd;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -77,7 +76,6 @@ import com.cloud.vm.dao.UserVmDao;
 
 @Local(value = {BaremetalDhcpManager.class})
 public class BaremetalDhcpManagerImpl extends ManagerBase implements BaremetalDhcpManager, ResourceStateAdapter {
-    private static final org.apache.log4j.Logger s_logger = Logger.getLogger(BaremetalDhcpManagerImpl.class);
     protected String _name;
     @Inject
     DataCenterDao _dcDao;
@@ -157,15 +155,15 @@ public class BaremetalDhcpManagerImpl extends ManagerBase implements BaremetalDh
         try {
             Answer ans = _agentMgr.send(h.getId(), dhcpCommand);
             if (ans.getResult()) {
-                s_logger.debug(String.format("Set dhcp entry on external DHCP %1$s successfully(ip=%2$s, mac=%3$s, vmname=%4$s)", h.getPrivateIpAddress(),
+                logger.debug(String.format("Set dhcp entry on external DHCP %1$s successfully(ip=%2$s, mac=%3$s, vmname=%4$s)", h.getPrivateIpAddress(),
                     nic.getIPv4Address(), nic.getMacAddress(), profile.getVirtualMachine().getHostName()));
                 return true;
             } else {
-                s_logger.debug(errMsg + " " + ans.getDetails());
+                logger.debug(errMsg + " " + ans.getDetails());
                 throw new ResourceUnavailableException(errMsg, DataCenter.class, zoneId);
             }
         } catch (Exception e) {
-            s_logger.debug(errMsg, e);
+            logger.debug(errMsg, e);
             throw new ResourceUnavailableException(errMsg + e.getMessage(), DataCenter.class, zoneId);
         }
     }
@@ -228,7 +226,7 @@ public class BaremetalDhcpManagerImpl extends ManagerBase implements BaremetalDh
         try {
             uri = new URI(cmd.getUrl());
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             throw new IllegalArgumentException(e.getMessage());
         }
 
@@ -262,7 +260,7 @@ public class BaremetalDhcpManagerImpl extends ManagerBase implements BaremetalDh
                 throw new CloudRuntimeException("Unsupport DHCP server type: " + cmd.getDhcpType());
             }
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             throw new CloudRuntimeException(e.getMessage());
         }
 

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpResourceBase.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpResourceBase.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.IAgentControl;
 import com.cloud.agent.api.Answer;
@@ -44,7 +43,6 @@ import com.cloud.resource.ServerResource;
 import com.cloud.utils.component.ManagerBase;
 
 public class BaremetalDhcpResourceBase extends ManagerBase implements ServerResource {
-    private static final Logger s_logger = Logger.getLogger(BaremetalDhcpResourceBase.class);
     String _name;
     String _guid;
     String _username;
@@ -129,7 +127,7 @@ public class BaremetalDhcpResourceBase extends ManagerBase implements ServerReso
     }
 
     protected ReadyAnswer execute(ReadyCommand cmd) {
-        s_logger.debug("External DHCP resource " + _name + " is ready");
+        logger.debug("External DHCP resource " + _name + " is ready");
         return new ReadyAnswer(cmd);
     }
 

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpdResource.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDhcpdResource.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.trilead.ssh2.SCPClient;
 
@@ -41,14 +40,13 @@ import com.cloud.utils.script.Script;
 import com.cloud.utils.ssh.SSHCmdHelper;
 
 public class BaremetalDhcpdResource extends BaremetalDhcpResourceBase {
-    private static final Logger s_logger = Logger.getLogger(BaremetalDhcpdResource.class);
 
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
         com.trilead.ssh2.Connection sshConnection = null;
         try {
             super.configure(name, params);
-            s_logger.debug(String.format("Trying to connect to DHCP server(IP=%1$s, username=%2$s, password=%3$s)", _ip, _username, "******"));
+            logger.debug(String.format("Trying to connect to DHCP server(IP=%1$s, username=%2$s, password=%3$s)", _ip, _username, "******"));
             sshConnection = SSHCmdHelper.acquireAuthorizedConnection(_ip, _username, _password);
             if (sshConnection == null) {
                 throw new ConfigurationException(String.format("Cannot connect to DHCP server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, "******"));
@@ -89,10 +87,10 @@ public class BaremetalDhcpdResource extends BaremetalDhcpResourceBase {
                 throw new ConfigurationException("prepare Dhcpd at " + _ip + " failed, command:" + cmd);
             }
 
-            s_logger.debug("Dhcpd resource configure successfully");
+            logger.debug("Dhcpd resource configure successfully");
             return true;
         } catch (Exception e) {
-            s_logger.debug("Dhcpd resource configure failed", e);
+            logger.debug("Dhcpd resource configure failed", e);
             throw new ConfigurationException(e.getMessage());
         } finally {
             SSHCmdHelper.releaseSshConnection(sshConnection);

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDnsmasqResource.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalDnsmasqResource.java
@@ -27,7 +27,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.trilead.ssh2.SCPClient;
 
@@ -41,14 +40,13 @@ import com.cloud.utils.script.Script;
 import com.cloud.utils.ssh.SSHCmdHelper;
 
 public class BaremetalDnsmasqResource extends BaremetalDhcpResourceBase {
-    private static final Logger s_logger = Logger.getLogger(BaremetalDnsmasqResource.class);
 
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
         com.trilead.ssh2.Connection sshConnection = null;
         try {
             super.configure(name, params);
-            s_logger.debug(String.format("Trying to connect to DHCP server(IP=%1$s, username=%2$s, password=%3$s)", _ip, _username, _password));
+            logger.debug(String.format("Trying to connect to DHCP server(IP=%1$s, username=%2$s, password=%3$s)", _ip, _username, _password));
             sshConnection = SSHCmdHelper.acquireAuthorizedConnection(_ip, _username, _password);
             if (sshConnection == null) {
                 throw new ConfigurationException(String.format("Cannot connect to DHCP server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, _password));
@@ -81,10 +79,10 @@ public class BaremetalDnsmasqResource extends BaremetalDhcpResourceBase {
             }
             */
 
-            s_logger.debug("Dnsmasq resource configure successfully");
+            logger.debug("Dnsmasq resource configure successfully");
             return true;
         } catch (Exception e) {
-            s_logger.debug("Dnsmasq resorce configure failed", e);
+            logger.debug("Dnsmasq resorce configure failed", e);
             throw new ConfigurationException(e.getMessage());
         } finally {
             SSHCmdHelper.releaseSshConnection(sshConnection);

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalKickStartPxeResource.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalKickStartPxeResource.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.naming.ConfigurationException;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import com.trilead.ssh2.SCPClient;
 
@@ -40,7 +39,6 @@ import com.cloud.utils.script.Script;
 import com.cloud.utils.ssh.SSHCmdHelper;
 
 public class BaremetalKickStartPxeResource extends BaremetalPxeResourceBase {
-    private static final Logger s_logger = Logger.getLogger(BaremetalKickStartPxeResource.class);
     private static final String Name = "BaremetalKickStartPxeResource";
     String _tftpDir;
 
@@ -54,11 +52,11 @@ public class BaremetalKickStartPxeResource extends BaremetalPxeResourceBase {
 
         com.trilead.ssh2.Connection sshConnection = new com.trilead.ssh2.Connection(_ip, 22);
 
-        s_logger.debug(String.format("Trying to connect to kickstart PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, "******"));
+        logger.debug(String.format("Trying to connect to kickstart PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, "******"));
         try {
             sshConnection.connect(null, 60000, 60000);
             if (!sshConnection.authenticateWithPassword(_username, _password)) {
-                s_logger.debug("SSH Failed to authenticate");
+                logger.debug("SSH Failed to authenticate");
                 throw new ConfigurationException(String.format("Cannot connect to kickstart PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, "******"));
             }
 
@@ -132,7 +130,7 @@ public class BaremetalKickStartPxeResource extends BaremetalPxeResourceBase {
 
             sshConnection.connect(null, 60000, 60000);
             if (!sshConnection.authenticateWithPassword(_username, _password)) {
-                s_logger.debug("SSH Failed to authenticate");
+                logger.debug("SSH Failed to authenticate");
                 throw new ConfigurationException(String.format("Cannot connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, _password));
             }
 
@@ -143,7 +141,7 @@ public class BaremetalKickStartPxeResource extends BaremetalPxeResourceBase {
 
             return new Answer(cmd, true, "Success");
         } catch (Exception e) {
-            s_logger.debug("Prepare for creating baremetal template failed", e);
+            logger.debug("Prepare for creating baremetal template failed", e);
             return new Answer(cmd, false, e.getMessage());
         } finally {
             if (sshConnection != null) {
@@ -168,7 +166,7 @@ public class BaremetalKickStartPxeResource extends BaremetalPxeResourceBase {
         try {
             sshConnection.connect(null, 60000, 60000);
             if (!sshConnection.authenticateWithPassword(_username, _password)) {
-                s_logger.debug("SSH Failed to authenticate");
+                logger.debug("SSH Failed to authenticate");
                 throw new ConfigurationException(String.format("Cannot connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, _password));
             }
 
@@ -188,10 +186,10 @@ public class BaremetalKickStartPxeResource extends BaremetalPxeResourceBase {
                 return new Answer(cmd, false, "prepare kickstart at pxe server " + _ip + " failed, command:" + script);
             }
 
-            s_logger.debug("Prepare kickstart PXE server successfully");
+            logger.debug("Prepare kickstart PXE server successfully");
             return new Answer(cmd, true, "Success");
         } catch (Exception e) {
-            s_logger.debug("Prepare for kickstart server failed", e);
+            logger.debug("Prepare for kickstart server failed", e);
             return new Answer(cmd, false, e.getMessage());
         } finally {
             if (sshConnection != null) {

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalKickStartServiceImpl.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalKickStartServiceImpl.java
@@ -34,7 +34,6 @@ import org.apache.cloudstack.api.AddBaremetalKickStartPxeCmd;
 import org.apache.cloudstack.api.AddBaremetalPxeCmd;
 import org.apache.cloudstack.api.ListBaremetalPxeServersCmd;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.baremetal.IpmISetBootDevCommand;
@@ -82,7 +81,6 @@ import com.cloud.vm.dao.NicDao;
 
 @Local(value = BaremetalPxeService.class)
 public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase implements BaremetalPxeService {
-    private static final Logger s_logger = Logger.getLogger(BaremetalKickStartServiceImpl.class);
     @Inject
     ResourceManager _resourceMgr;
     @Inject
@@ -172,7 +170,7 @@ public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase imple
             throw new CloudRuntimeException(String.format("cannot find id_rsa.cloud"));
         }
         if (!keyFile.exists()) {
-            s_logger.error("Unable to locate id_rsa.cloud in your setup at " + keyFile.toString());
+            logger.error("Unable to locate id_rsa.cloud in your setup at " + keyFile.toString());
         }
         return keyFile;
     }
@@ -201,7 +199,7 @@ public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase imple
         cmd.setTemplateUuid(template.getUuid());
         Answer aws = _agentMgr.send(pxeVo.getHostId(), cmd);
         if (!aws.getResult()) {
-            s_logger.warn("Unable to set host: " + dest.getHost().getId() + " to PXE boot because " + aws.getDetails());
+            logger.warn("Unable to set host: " + dest.getHost().getId() + " to PXE boot because " + aws.getDetails());
             return false;
         }
 
@@ -231,7 +229,7 @@ public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase imple
         List<String> tuple =  parseKickstartUrl(profile);
         String cmd =  String.format("/opt/cloud/bin/prepare_pxe.sh %s %s %s %s %s %s", tuple.get(1), tuple.get(2), profile.getTemplate().getUuid(),
                 String.format("01-%s", nic.getMacAddress().replaceAll(":", "-")).toLowerCase(), tuple.get(0), nic.getMacAddress().toLowerCase());
-        s_logger.debug(String.format("prepare pxe on virtual router[ip:%s], cmd: %s", mgmtNic.getIPv4Address(), cmd));
+        logger.debug(String.format("prepare pxe on virtual router[ip:%s], cmd: %s", mgmtNic.getIPv4Address(), cmd));
         Pair<Boolean, String> ret = SshHelper.sshExecute(mgmtNic.getIPv4Address(), 3922, "root", getSystemVMKeyFile(), null, cmd);
         if (!ret.first()) {
             throw new CloudRuntimeException(String.format("failed preparing PXE in virtual router[id:%s], because %s", vr.getId(), ret.second()));
@@ -239,7 +237,7 @@ public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase imple
 
         //String internalServerIp = "10.223.110.231";
         cmd = String.format("/opt/cloud/bin/baremetal_snat.sh %s %s %s", mgmtNic.getIPv4Address(), internalServerIp, mgmtNic.getIPv4Gateway());
-        s_logger.debug(String.format("prepare SNAT on virtual router[ip:%s], cmd: %s", mgmtNic.getIPv4Address(), cmd));
+        logger.debug(String.format("prepare SNAT on virtual router[ip:%s], cmd: %s", mgmtNic.getIPv4Address(), cmd));
         ret = SshHelper.sshExecute(mgmtNic.getIPv4Address(), 3922, "root", getSystemVMKeyFile(), null, cmd);
         if (!ret.first()) {
             throw new CloudRuntimeException(String.format("failed preparing PXE in virtual router[id:%s], because %s", vr.getId(), ret.second()));
@@ -264,12 +262,12 @@ public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase imple
             IpmISetBootDevCommand bootCmd = new IpmISetBootDevCommand(BootDev.pxe);
             Answer aws = _agentMgr.send(dest.getHost().getId(), bootCmd);
             if (!aws.getResult()) {
-                s_logger.warn("Unable to set host: " + dest.getHost().getId() + " to PXE boot because " + aws.getDetails());
+                logger.warn("Unable to set host: " + dest.getHost().getId() + " to PXE boot because " + aws.getDetails());
             }
 
             return aws.getResult();
         } catch (Exception e) {
-            s_logger.warn("Cannot prepare PXE server", e);
+            logger.warn("Cannot prepare PXE server", e);
             return false;
         }
     }
@@ -321,7 +319,7 @@ public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase imple
         try {
             uri = new URI(cmd.getUrl());
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             throw new IllegalArgumentException(e.getMessage());
         }
         String ipAddress = uri.getHost();

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPingPxeResource.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPingPxeResource.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.trilead.ssh2.SCPClient;
 
@@ -45,7 +44,6 @@ import com.cloud.utils.script.Script;
 import com.cloud.utils.ssh.SSHCmdHelper;
 
 public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
-    private static final Logger s_logger = Logger.getLogger(BaremetalPingPxeResource.class);
     private static final String Name = "BaremetalPingPxeResource";
     String _storageServer;
     String _pingDir;
@@ -97,11 +95,11 @@ public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
 
         com.trilead.ssh2.Connection sshConnection = new com.trilead.ssh2.Connection(_ip, 22);
 
-        s_logger.debug(String.format("Trying to connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, "******"));
+        logger.debug(String.format("Trying to connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, "******"));
         try {
             sshConnection.connect(null, 60000, 60000);
             if (!sshConnection.authenticateWithPassword(_username, _password)) {
-                s_logger.debug("SSH Failed to authenticate");
+                logger.debug("SSH Failed to authenticate");
                 throw new ConfigurationException(String.format("Cannot connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, "******"));
             }
 
@@ -151,7 +149,7 @@ public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
         try {
             sshConnection.connect(null, 60000, 60000);
             if (!sshConnection.authenticateWithPassword(_username, _password)) {
-                s_logger.debug("SSH Failed to authenticate");
+                logger.debug("SSH Failed to authenticate");
                 throw new ConfigurationException(String.format("Cannot connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, _password));
             }
 
@@ -161,11 +159,11 @@ public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
             if (!SSHCmdHelper.sshExecuteCmd(sshConnection, script)) {
                 return new PreparePxeServerAnswer(cmd, "prepare PING at " + _ip + " failed, command:" + script);
             }
-            s_logger.debug("Prepare Ping PXE server successfully");
+            logger.debug("Prepare Ping PXE server successfully");
 
             return new PreparePxeServerAnswer(cmd);
         } catch (Exception e) {
-            s_logger.debug("Prepare PING pxe server failed", e);
+            logger.debug("Prepare PING pxe server failed", e);
             return new PreparePxeServerAnswer(cmd, e.getMessage());
         } finally {
             if (sshConnection != null) {
@@ -179,7 +177,7 @@ public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
         try {
             sshConnection.connect(null, 60000, 60000);
             if (!sshConnection.authenticateWithPassword(_username, _password)) {
-                s_logger.debug("SSH Failed to authenticate");
+                logger.debug("SSH Failed to authenticate");
                 throw new ConfigurationException(String.format("Cannot connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, _password));
             }
 
@@ -189,11 +187,11 @@ public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
             if (!SSHCmdHelper.sshExecuteCmd(sshConnection, script)) {
                 return new Answer(cmd, false, "prepare for creating template failed, command:" + script);
             }
-            s_logger.debug("Prepare for creating template successfully");
+            logger.debug("Prepare for creating template successfully");
 
             return new Answer(cmd, true, "Success");
         } catch (Exception e) {
-            s_logger.debug("Prepare for creating baremetal template failed", e);
+            logger.debug("Prepare for creating baremetal template failed", e);
             return new Answer(cmd, false, e.getMessage());
         } finally {
             if (sshConnection != null) {
@@ -237,7 +235,7 @@ public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
 
             sshConnection.connect(null, 60000, 60000);
             if (!sshConnection.authenticateWithPassword(_username, _password)) {
-                s_logger.debug("SSH Failed to authenticate");
+                logger.debug("SSH Failed to authenticate");
                 throw new ConfigurationException(String.format("Cannot connect to PING PXE server(IP=%1$s, username=%2$s, password=%3$s", _ip, _username, _password));
             }
 
@@ -248,7 +246,7 @@ public class BaremetalPingPxeResource extends BaremetalPxeResourceBase {
 
             return new Answer(cmd, true, "Success");
         } catch (Exception e) {
-            s_logger.debug("Prepare for creating baremetal template failed", e);
+            logger.debug("Prepare for creating baremetal template failed", e);
             return new Answer(cmd, false, e.getMessage());
         } finally {
             if (sshConnection != null) {

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeElement.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeElement.java
@@ -51,7 +51,6 @@ import com.cloud.vm.VirtualMachine.Type;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.VMInstanceDao;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.inject.Inject;
@@ -61,7 +60,6 @@ import java.util.Set;
 
 @Local(value = NetworkElement.class)
 public class BaremetalPxeElement extends AdapterBase implements NetworkElement {
-    private static final Logger s_logger = Logger.getLogger(BaremetalPxeElement.class);
     private static final Map<Service, Map<Capability, String>> capabilities;
 
     @Inject
@@ -112,7 +110,7 @@ public class BaremetalPxeElement extends AdapterBase implements NetworkElement {
         }
 
         if (offering.isSystemOnly() || !canHandle(dest, offering.getTrafficType(), network.getGuestType())) {
-            s_logger.debug("BaremetalPxeElement can not handle network offering: " + offering.getName());
+            logger.debug("BaremetalPxeElement can not handle network offering: " + offering.getName());
             return false;
         }
         return true;

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeManagerImpl.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeManagerImpl.java
@@ -35,7 +35,6 @@ import org.apache.cloudstack.api.AddBaremetalPxeCmd;
 import org.apache.cloudstack.api.AddBaremetalPxePingServerCmd;
 import org.apache.cloudstack.api.ListBaremetalPxeServersCmd;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -73,7 +72,6 @@ import com.cloud.vm.dao.UserVmDao;
 
 @Local(value = {BaremetalPxeManager.class})
 public class BaremetalPxeManagerImpl extends ManagerBase implements BaremetalPxeManager, ResourceStateAdapter {
-    private static final org.apache.log4j.Logger s_logger = Logger.getLogger(BaremetalPxeManagerImpl.class);
     @Inject
     DataCenterDao _dcDao;
     @Inject
@@ -235,13 +233,13 @@ public class BaremetalPxeManagerImpl extends ManagerBase implements BaremetalPxe
         try {
             Answer ans = _agentMgr.send(pxeVo.getHostId(), cmd);
             if (!ans.getResult()) {
-                s_logger.debug(String.format("Add userdata to vm:%s failed because %s", vm.getInstanceName(), ans.getDetails()));
+                logger.debug(String.format("Add userdata to vm:%s failed because %s", vm.getInstanceName(), ans.getDetails()));
                 return false;
             } else {
                 return true;
             }
         } catch (Exception e) {
-            s_logger.debug(String.format("Add userdata to vm:%s failed", vm.getInstanceName()), e);
+            logger.debug(String.format("Add userdata to vm:%s failed", vm.getInstanceName()), e);
             return false;
         }
     }

--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeResourceBase.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeResourceBase.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.IAgentControl;
 import com.cloud.agent.api.Answer;
@@ -41,7 +40,6 @@ import com.cloud.resource.ServerResource;
 import com.cloud.utils.component.ManagerBase;
 
 public class BaremetalPxeResourceBase extends ManagerBase implements ServerResource {
-    private static final Logger s_logger = Logger.getLogger(BaremetalPxeResourceBase.class);
     String _name;
     String _guid;
     String _username;
@@ -84,7 +82,7 @@ public class BaremetalPxeResourceBase extends ManagerBase implements ServerResou
     }
 
     protected ReadyAnswer execute(ReadyCommand cmd) {
-        s_logger.debug("Pxe resource " + _name + " is ready");
+        logger.debug("Pxe resource " + _name + " is ready");
         return new ReadyAnswer(cmd);
     }
 

--- a/plugins/hypervisors/hyperv/src/com/cloud/ha/HypervInvestigator.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/ha/HypervInvestigator.java
@@ -23,7 +23,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -38,7 +37,6 @@ import com.cloud.utils.component.AdapterBase;
 
 @Local(value=Investigator.class)
 public class HypervInvestigator extends AdapterBase implements Investigator {
-    private final static Logger s_logger = Logger.getLogger(HypervInvestigator.class);
     @Inject HostDao _hostDao;
     @Inject AgentManager _agentMgr;
     @Inject ResourceManager _resourceMgr;
@@ -70,7 +68,7 @@ public class HypervInvestigator extends AdapterBase implements Investigator {
                     return answer.getResult() ? Status.Down : Status.Up;
                 }
             } catch (Exception e) {
-                s_logger.debug("Failed to send command to host: " + neighbor.getId());
+                logger.debug("Failed to send command to host: " + neighbor.getId());
             }
         }
 

--- a/plugins/hypervisors/kvm/src/com/cloud/ha/KVMInvestigator.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/ha/KVMInvestigator.java
@@ -28,7 +28,6 @@ import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.resource.ResourceManager;
 import com.cloud.utils.component.AdapterBase;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.inject.Inject;
@@ -36,7 +35,6 @@ import java.util.List;
 
 @Local(value = Investigator.class)
 public class KVMInvestigator extends AdapterBase implements Investigator {
-    private final static Logger s_logger = Logger.getLogger(KVMInvestigator.class);
     @Inject
     HostDao _hostDao;
     @Inject
@@ -72,7 +70,7 @@ public class KVMInvestigator extends AdapterBase implements Investigator {
                 hostStatus = answer.getResult() ? Status.Down : Status.Up;
             }
         } catch (Exception e) {
-            s_logger.debug("Failed to send command to host: " + agent.getId());
+            logger.debug("Failed to send command to host: " + agent.getId());
         }
         if (hostStatus == null) {
             hostStatus = Status.Disconnected;
@@ -83,18 +81,18 @@ public class KVMInvestigator extends AdapterBase implements Investigator {
             if (neighbor.getId() == agent.getId() || (neighbor.getHypervisorType() != Hypervisor.HypervisorType.KVM && neighbor.getHypervisorType() != Hypervisor.HypervisorType.LXC)) {
                 continue;
             }
-            s_logger.debug("Investigating host:" + agent.getId() + " via neighbouring host:" + neighbor.getId());
+            logger.debug("Investigating host:" + agent.getId() + " via neighbouring host:" + neighbor.getId());
             try {
                 Answer answer = _agentMgr.easySend(neighbor.getId(), cmd);
                 if (answer != null) {
                     neighbourStatus = answer.getResult() ? Status.Down : Status.Up;
-                    s_logger.debug("Neighbouring host:" + neighbor.getId() + " returned status:" + neighbourStatus + " for the investigated host:" + agent.getId());
+                    logger.debug("Neighbouring host:" + neighbor.getId() + " returned status:" + neighbourStatus + " for the investigated host:" + agent.getId());
                     if (neighbourStatus == Status.Up) {
                         break;
                     }
                 }
             } catch (Exception e) {
-                s_logger.debug("Failed to send command to host: " + neighbor.getId());
+                logger.debug("Failed to send command to host: " + neighbor.getId());
             }
         }
         if (neighbourStatus == Status.Up && (hostStatus == Status.Disconnected || hostStatus == Status.Down)) {

--- a/plugins/hypervisors/ovm/src/com/cloud/ovm/hypervisor/OvmDiscoverer.java
+++ b/plugins/hypervisors/ovm/src/com/cloud/ovm/hypervisor/OvmDiscoverer.java
@@ -28,7 +28,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
 import com.cloud.agent.api.StartupCommand;
@@ -55,7 +54,6 @@ import com.cloud.utils.ssh.SSHCmdHelper;
 
 @Local(value = Discoverer.class)
 public class OvmDiscoverer extends DiscovererBase implements Discoverer, ResourceStateAdapter {
-    private static final Logger s_logger = Logger.getLogger(OvmDiscoverer.class);
     protected String _publicNetworkDevice;
     protected String _privateNetworkDevice;
     protected String _guestNetworkDevice;
@@ -99,25 +97,25 @@ public class OvmDiscoverer extends DiscovererBase implements Discoverer, Resourc
 
         if (!url.getScheme().equals("http")) {
             String msg = "urlString is not http so we're not taking care of the discovery for this: " + url;
-            s_logger.debug(msg);
+            logger.debug(msg);
             return null;
         }
         if (clusterId == null) {
             String msg = "must specify cluster Id when add host";
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new CloudRuntimeException(msg);
         }
 
         if (podId == null) {
             String msg = "must specify pod Id when add host";
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new CloudRuntimeException(msg);
         }
 
         ClusterVO cluster = _clusterDao.findById(clusterId);
         if (cluster == null || (cluster.getHypervisorType() != HypervisorType.Ovm)) {
-            if (s_logger.isInfoEnabled())
-                s_logger.info("invalid cluster id or cluster is not for Ovm hypervisors");
+            if (logger.isInfoEnabled())
+                logger.info("invalid cluster id or cluster is not for Ovm hypervisors");
             return null;
         }
 
@@ -141,7 +139,7 @@ public class OvmDiscoverer extends DiscovererBase implements Discoverer, Resourc
                 throw new CloudRuntimeException("The host " + hostIp + " has been added before");
             }
 
-            s_logger.debug("Ovm discover is going to disover host having guid " + guid);
+            logger.debug("Ovm discover is going to disover host having guid " + guid);
 
             ClusterVO clu = _clusterDao.findById(clusterId);
             if (clu.getGuid() == null) {
@@ -198,16 +196,16 @@ public class OvmDiscoverer extends DiscovererBase implements Discoverer, Resourc
             resources.put(ovmResource, details);
             return resources;
         } catch (XmlRpcException e) {
-            s_logger.debug("XmlRpc exception, Unable to discover OVM: " + url, e);
+            logger.debug("XmlRpc exception, Unable to discover OVM: " + url, e);
             return null;
         } catch (UnknownHostException e) {
-            s_logger.debug("Host name resolve failed exception, Unable to discover OVM: " + url, e);
+            logger.debug("Host name resolve failed exception, Unable to discover OVM: " + url, e);
             return null;
         } catch (ConfigurationException e) {
-            s_logger.debug("Configure resource failed, Unable to discover OVM: " + url, e);
+            logger.debug("Configure resource failed, Unable to discover OVM: " + url, e);
             return null;
         } catch (Exception e) {
-            s_logger.debug("Unable to discover OVM: " + url, e);
+            logger.debug("Unable to discover OVM: " + url, e);
             return null;
         }
     }

--- a/plugins/hypervisors/ovm/src/com/cloud/ovm/hypervisor/OvmFencer.java
+++ b/plugins/hypervisors/ovm/src/com/cloud/ovm/hypervisor/OvmFencer.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.FenceAnswer;
@@ -41,7 +40,6 @@ import com.cloud.vm.VirtualMachine;
 
 @Local(value = FenceBuilder.class)
 public class OvmFencer extends AdapterBase implements FenceBuilder {
-    private static final Logger s_logger = Logger.getLogger(OvmFencer.class);
     @Inject
     AgentManager _agentMgr;
     @Inject
@@ -71,7 +69,7 @@ public class OvmFencer extends AdapterBase implements FenceBuilder {
     @Override
     public Boolean fenceOff(VirtualMachine vm, Host host) {
         if (host.getHypervisorType() != HypervisorType.Ovm) {
-            s_logger.debug("Don't know how to fence non Ovm hosts " + host.getHypervisorType());
+            logger.debug("Don't know how to fence non Ovm hosts " + host.getHypervisorType());
             return null;
         }
 
@@ -95,13 +93,13 @@ public class OvmFencer extends AdapterBase implements FenceBuilder {
             try {
                 answer = (FenceAnswer)_agentMgr.send(h.getId(), fence);
             } catch (AgentUnavailableException e) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
                 }
                 continue;
             } catch (OperationTimedoutException e) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
                 }
                 continue;
             }
@@ -111,8 +109,8 @@ public class OvmFencer extends AdapterBase implements FenceBuilder {
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Unable to fence off " + vm.toString() + " on " + host.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Unable to fence off " + vm.toString() + " on " + host.toString());
         }
 
         return false;

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/ha/Ovm3Investigator.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/ha/Ovm3Investigator.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -37,7 +36,6 @@ import com.cloud.utils.component.AdapterBase;
 
 @Local(value = Investigator.class)
 public class Ovm3Investigator extends AdapterBase implements Investigator {
-    private static final Logger LOGGER = Logger.getLogger(Ovm3Investigator.class);
     @Inject
     HostDao hostDao;
     @Inject
@@ -47,7 +45,7 @@ public class Ovm3Investigator extends AdapterBase implements Investigator {
 
     @Override
     public boolean isVmAlive(com.cloud.vm.VirtualMachine vm, Host host) throws UnknownVM {
-        LOGGER.debug("isVmAlive: " + vm.getHostName() + " on " + host.getName());
+        logger.debug("isVmAlive: " + vm.getHostName() + " on " + host.getName());
         if (host.getHypervisorType() != Hypervisor.HypervisorType.Ovm3) {
             throw new UnknownVM();
         }
@@ -60,7 +58,7 @@ public class Ovm3Investigator extends AdapterBase implements Investigator {
 
     @Override
     public Status isAgentAlive(Host agent) {
-        LOGGER.debug("isAgentAlive: " + agent.getName());
+        logger.debug("isAgentAlive: " + agent.getName());
         if (agent.getHypervisorType() != Hypervisor.HypervisorType.Ovm3) {
             return null;
         }
@@ -76,7 +74,7 @@ public class Ovm3Investigator extends AdapterBase implements Investigator {
                     return answer.getResult() ? Status.Down : Status.Up;
                 }
             } catch (Exception e) {
-                LOGGER.error("Failed to send command to host: " + neighbor.getId(), e);
+                logger.error("Failed to send command to host: " + neighbor.getId(), e);
             }
         }
 

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3Discoverer.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3Discoverer.java
@@ -30,7 +30,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.Listener;
@@ -68,7 +67,6 @@ import com.cloud.utils.ssh.SSHCmdHelper;
 @Local(value = Discoverer.class)
 public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
         Listener, ResourceStateAdapter {
-    private static final Logger LOGGER = Logger.getLogger(Ovm3Discoverer.class);
     protected String publicNetworkDevice;
     protected String privateNetworkDevice;
     protected String guestNetworkDevice;
@@ -125,11 +123,11 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
     private boolean CheckUrl(URI url) throws DiscoveryException {
         if ("http".equals(url.getScheme()) || "https".equals(url.getScheme())) {
             String msg = "Discovering " + url + ": " + _params;
-            LOGGER.debug(msg);
+            logger.debug(msg);
         } else {
             String msg = "urlString is not http(s) so we're not taking care of the discovery for this: "
                     + url;
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new DiscoveryException(msg);
         }
         return true;
@@ -144,13 +142,13 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
         CheckUrl(url);
         if (clusterId == null) {
             String msg = "must specify cluster Id when add host";
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new DiscoveryException(msg);
         }
 
         if (podId == null) {
             String msg = "must specify pod Id when add host";
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new DiscoveryException(msg);
         }
 
@@ -158,30 +156,30 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
         if (cluster == null
                 || (cluster.getHypervisorType() != HypervisorType.Ovm3)) {
             String msg = "invalid cluster id or cluster is not for Ovm3 hypervisors";
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new DiscoveryException(msg);
         } else {
-            LOGGER.debug("cluster: " + cluster);
+            logger.debug("cluster: " + cluster);
         }
 
         String agentUsername = _params.get("agentusername");
         if (agentUsername == null) {
             String msg = "Agent user name must be specified";
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new DiscoveryException(msg);
         }
 
         String agentPassword = _params.get("agentpassword");
         if (agentPassword == null) {
             String msg = "Agent password must be specified";
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new DiscoveryException(msg);
         }
 
         String agentPort = _params.get("agentport");
         if (agentPort == null) {
             String msg = "Agent port must be specified";
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new DiscoveryException(msg);
         }
 
@@ -195,11 +193,11 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
 
             if (checkIfExisted(guid)) {
                 String msg = "The host " + hostIp + " has been added before";
-                LOGGER.info(msg);
+                logger.info(msg);
                 throw new DiscoveryException(msg);
             }
 
-            LOGGER.debug("Ovm3 discover is going to disover host having guid "
+            logger.debug("Ovm3 discover is going to disover host having guid "
                     + guid);
 
             ClusterVO clu = clusterDao.findById(clusterId);
@@ -226,7 +224,7 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
                 String msg = "Cannot Ssh to Ovm3 host(IP=" + hostIp
                         + ", username=" + username
                         + ", password=*******), discovery failed";
-                LOGGER.warn(msg);
+                logger.warn(msg);
                 throw new DiscoveryException(msg);
             }
 
@@ -283,17 +281,17 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
             resources.put(ovmResource, details);
             return resources;
         } catch (UnknownHostException e) {
-            LOGGER.error(
+            logger.error(
                     "Host name resolve failed exception, Unable to discover Ovm3 host: "
                             + url.getHost(), e);
             return null;
         } catch (ConfigurationException e) {
-            LOGGER.error(
+            logger.error(
                     "Configure resource failed, Unable to discover Ovm3 host: "
                             + url.getHost(), e);
             return null;
         } catch (IOException | Ovm3ResourceException e) {
-            LOGGER.error("Unable to discover Ovm3 host: " + url.getHost(), e);
+            logger.error("Unable to discover Ovm3 host: " + url.getHost(), e);
             return null;
         }
     }
@@ -301,7 +299,7 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
     @Override
     public void postDiscovery(List<HostVO> hosts, long msId)
             throws CloudRuntimeException {
-        LOGGER.debug("postDiscovery: " + hosts);
+        logger.debug("postDiscovery: " + hosts);
     }
 
     @Override
@@ -317,26 +315,26 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
     @Override
     public HostVO createHostVOForConnectedAgent(HostVO host,
             StartupCommand[] cmd) {
-        LOGGER.debug("createHostVOForConnectedAgent: " + host);
+        logger.debug("createHostVOForConnectedAgent: " + host);
         return null;
     }
 
     @Override
     public boolean processAnswers(long agentId, long seq, Answer[] answers) {
-        LOGGER.debug("processAnswers: " + agentId);
+        logger.debug("processAnswers: " + agentId);
         return false;
     }
 
     @Override
     public boolean processCommands(long agentId, long seq, Command[] commands) {
-        LOGGER.debug("processCommands: " + agentId);
+        logger.debug("processCommands: " + agentId);
         return false;
     }
 
     @Override
     public AgentControlAnswer processControlCommand(long agentId,
             AgentControlCommand cmd) {
-        LOGGER.debug("processControlCommand: " + agentId);
+        logger.debug("processControlCommand: " + agentId);
         return null;
     }
 
@@ -344,12 +342,12 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
     @Override
     public void processConnect(Host host, StartupCommand cmd,
             boolean forRebalance) {
-        LOGGER.debug("processConnect");
+        logger.debug("processConnect");
     }
 
     @Override
     public boolean processDisconnect(long agentId, Status state) {
-        LOGGER.debug("processDisconnect");
+        logger.debug("processDisconnect");
         return false;
     }
 
@@ -360,13 +358,13 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
 
     @Override
     public int getTimeout() {
-        LOGGER.debug("getTimeout");
+        logger.debug("getTimeout");
         return 0;
     }
 
     @Override
     public boolean processTimeout(long agentId, long seq) {
-        LOGGER.debug("processTimeout: " + agentId);
+        logger.debug("processTimeout: " + agentId);
         return false;
     }
 
@@ -374,7 +372,7 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
     public HostVO createHostVOForDirectConnectAgent(HostVO host,
             StartupCommand[] startup, ServerResource resource,
             Map<String, String> details, List<String> hostTags) {
-        LOGGER.debug("createHostVOForDirectConnectAgent: " + host);
+        logger.debug("createHostVOForDirectConnectAgent: " + host);
         StartupCommand firstCmd = startup[0];
         if (!(firstCmd instanceof StartupRoutingCommand)) {
             return null;
@@ -392,7 +390,7 @@ public class Ovm3Discoverer extends DiscovererBase implements Discoverer,
     @Override
     public DeleteHostAnswer deleteHost(HostVO host, boolean isForced,
             boolean isForceDeleteStorage) throws UnableDeleteHostException {
-        LOGGER.debug("deleteHost: " + host);
+        logger.debug("deleteHost: " + host);
         if (host.getType() != com.cloud.host.Host.Type.Routing
                 || host.getHypervisorType() != HypervisorType.Ovm3) {
             return null;

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3FenceBuilder.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3FenceBuilder.java
@@ -24,7 +24,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.FenceAnswer;
@@ -43,7 +42,6 @@ import com.cloud.vm.VirtualMachine;
 @Local(value = FenceBuilder.class)
 public class Ovm3FenceBuilder extends AdapterBase implements FenceBuilder {
     Map<String, Object> fenceParams;
-    private static final Logger LOGGER = Logger.getLogger(Ovm3FenceBuilder.class);
     @Inject
     AgentManager agentMgr;
     @Inject
@@ -76,11 +74,11 @@ public class Ovm3FenceBuilder extends AdapterBase implements FenceBuilder {
     @Override
     public Boolean fenceOff(VirtualMachine vm, Host host) {
         if (host.getHypervisorType() != HypervisorType.Ovm3) {
-            LOGGER.debug("Don't know how to fence non Ovm3 hosts "
+            logger.debug("Don't know how to fence non Ovm3 hosts "
                     + host.getHypervisorType());
             return null;
         } else {
-            LOGGER.debug("Fencing " + vm + " on host " + host
+            logger.debug("Fencing " + vm + " on host " + host
                     + " with params: "+ fenceParams );
         }
 
@@ -96,8 +94,8 @@ public class Ovm3FenceBuilder extends AdapterBase implements FenceBuilder {
                 try {
                     answer = (FenceAnswer) agentMgr.send(h.getId(), fence);
                 } catch (AgentUnavailableException | OperationTimedoutException e) {
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("Moving on to the next host because "
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Moving on to the next host because "
                                 + h.toString() + " is unavailable", e);
                     }
                     continue;
@@ -108,8 +106,8 @@ public class Ovm3FenceBuilder extends AdapterBase implements FenceBuilder {
             }
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Unable to fence off " + vm.toString() + " on "
+        if (logger.isDebugEnabled()) {
+            logger.debug("Unable to fence off " + vm.toString() + " on "
                     + host.toString());
         }
 

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
@@ -25,7 +25,6 @@ import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.to.DataObjectType;
@@ -45,7 +44,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = HypervisorGuru.class)
 public class Ovm3HypervisorGuru extends HypervisorGuruBase implements HypervisorGuru {
-    private final Logger LOGGER = Logger.getLogger(Ovm3HypervisorGuru.class);
     @Inject
     GuestOSDao guestOsDao;
     @Inject
@@ -86,7 +84,7 @@ public class Ovm3HypervisorGuru extends HypervisorGuruBase implements Hypervisor
      * @see com.cloud.hypervisor.HypervisorGuruBase#getCommandHostDelegation(long, com.cloud.agent.api.Command)
      */
     public Pair<Boolean, Long> getCommandHostDelegation(long hostId, Command cmd) {
-        LOGGER.debug("getCommandHostDelegation: " + cmd.getClass());
+        logger.debug("getCommandHostDelegation: " + cmd.getClass());
         if (cmd instanceof StorageSubSystemCommand) {
             StorageSubSystemCommand c = (StorageSubSystemCommand)cmd;
             c.setExecuteInSequence(true);
@@ -97,7 +95,7 @@ public class Ovm3HypervisorGuru extends HypervisorGuruBase implements Hypervisor
             DataTO destData = cpyCommand.getDestTO();
 
             if (srcData.getObjectType() == DataObjectType.SNAPSHOT && destData.getObjectType() == DataObjectType.TEMPLATE) {
-                LOGGER.debug("Snapshot to Template: " + cmd);
+                logger.debug("Snapshot to Template: " + cmd);
                 DataStoreTO srcStore = srcData.getDataStore();
                 DataStoreTO destStore = destData.getDataStore();
                 if (srcStore instanceof NfsTO && destStore instanceof NfsTO) {

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockAgentManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockAgentManagerImpl.java
@@ -34,7 +34,6 @@ import javax.naming.ConfigurationException;
 
 import com.cloud.user.AccountManager;
 import org.apache.cloudstack.context.CallContext;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.AgentManager;
@@ -74,7 +73,6 @@ import com.cloud.utils.net.NetUtils;
 @Component
 @Local(value = {MockAgentManager.class})
 public class MockAgentManagerImpl extends ManagerBase implements MockAgentManager {
-    private static final Logger s_logger = Logger.getLogger(MockAgentManagerImpl.class);
     @Inject
     HostPodDao _podDao = null;
     @Inject
@@ -110,10 +108,10 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
             Long cidrSize = (Long)cidrPair.get(1);
             return new Pair<String, Long>(cidrAddress, cidrSize);
         } catch (PatternSyntaxException e) {
-            s_logger.error("Exception while splitting pod cidr");
+            logger.error("Exception while splitting pod cidr");
             return null;
         } catch (IndexOutOfBoundsException e) {
-            s_logger.error("Invalid pod cidr. Please check");
+            logger.error("Invalid pod cidr. Please check");
             return null;
         }
     }
@@ -178,7 +176,7 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
                 txn.commit();
             } catch (Exception ex) {
                 txn.rollback();
-                s_logger.error("Error while configuring mock agent " + ex.getMessage());
+                logger.error("Error while configuring mock agent " + ex.getMessage());
                 throw new CloudRuntimeException("Error configuring agent", ex);
             } finally {
                 txn.close();
@@ -197,7 +195,7 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
 
                     newResources.put(agentResource, args);
                 } catch (ConfigurationException e) {
-                    s_logger.error("error while configuring server resource" + e.getMessage());
+                    logger.error("error while configuring server resource" + e.getMessage());
                 }
             }
         }
@@ -210,7 +208,7 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
             random = SecureRandom.getInstance("SHA1PRNG");
             _executor = new ThreadPoolExecutor(1, 5, 1, TimeUnit.DAYS, new LinkedBlockingQueue<Runnable>(), new NamedThreadFactory("Simulator-Agent-Mgr"));
         } catch (NoSuchAlgorithmException e) {
-            s_logger.debug("Failed to initialize random:" + e.toString());
+            logger.debug("Failed to initialize random:" + e.toString());
             return false;
         }
         return true;
@@ -298,7 +296,7 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
                 try {
                     _resourceMgr.deleteHost(host.getId(), true, true);
                 } catch (Exception e) {
-                    s_logger.debug("Failed to delete host: ", e);
+                    logger.debug("Failed to delete host: ", e);
                 }
             }
         }
@@ -363,12 +361,12 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
                     try {
                         _resourceMgr.discoverHosts(cmd);
                     } catch (DiscoveryException e) {
-                        s_logger.debug("Failed to discover host: " + e.toString());
+                        logger.debug("Failed to discover host: " + e.toString());
                         CallContext.unregister();
                         return;
                     }
                 } catch (ConfigurationException e) {
-                    s_logger.debug("Failed to load secondary storage resource: " + e.toString());
+                    logger.debug("Failed to load secondary storage resource: " + e.toString());
                     CallContext.unregister();
                     return;
                 }
@@ -386,7 +384,7 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
             if (_host != null) {
                 return _host;
             } else {
-                s_logger.error("Host with guid " + guid + " was not found");
+                logger.error("Host with guid " + guid + " was not found");
                 return null;
             }
         } catch (Exception ex) {
@@ -494,8 +492,8 @@ public class MockAgentManagerImpl extends ManagerBase implements MockAgentManage
 
     @Override
     public Answer checkNetworkCommand(CheckNetworkCommand cmd) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Checking if network name setup is done on the resource");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Checking if network name setup is done on the resource");
         }
         return new CheckNetworkAnswer(cmd, true, "Network Setup check by names is done");
     }

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockNetworkManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockNetworkManagerImpl.java
@@ -21,7 +21,6 @@ package com.cloud.agent.manager;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.CheckS2SVpnConnectionsCommand;
@@ -60,7 +59,6 @@ import com.cloud.simulator.dao.MockVMDao;
 import com.cloud.utils.component.ManagerBase;
 
 public class MockNetworkManagerImpl extends ManagerBase implements MockNetworkManager {
-    private static final Logger s_logger = Logger.getLogger(MockVmManagerImpl.class);
 
     @Inject
     MockVMDao _mockVmDao;
@@ -123,10 +121,10 @@ public class MockNetworkManagerImpl extends ManagerBase implements MockNetworkMa
     public PlugNicAnswer plugNic(PlugNicCommand cmd) {
         String vmname = cmd.getVmName();
         if (_mockVmDao.findByVmName(vmname) != null) {
-            s_logger.debug("Plugged NIC (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
+            logger.debug("Plugged NIC (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
             return new PlugNicAnswer(cmd, true, "success");
         }
-        s_logger.error("Plug NIC failed for (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
+        logger.error("Plug NIC failed for (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
         return new PlugNicAnswer(cmd, false, "failure");
     }
 
@@ -134,10 +132,10 @@ public class MockNetworkManagerImpl extends ManagerBase implements MockNetworkMa
     public UnPlugNicAnswer unplugNic(UnPlugNicCommand cmd) {
         String vmname = cmd.getVmName();
         if (_mockVmDao.findByVmName(vmname) != null) {
-            s_logger.debug("Plugged NIC (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
+            logger.debug("Plugged NIC (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
             return new UnPlugNicAnswer(cmd, true, "success");
         }
-        s_logger.error("Plug NIC failed for (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
+        logger.error("Plug NIC failed for (dev=" + cmd.getNic().getDeviceId() + ", " + cmd.getNic().getIp() + ") into " + cmd.getVmName());
         return new UnPlugNicAnswer(cmd, false, "failure");
     }
 
@@ -211,7 +209,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements MockNetworkMa
             return new Answer(cmd, true, "success");
         } catch (Exception e) {
             String msg = "Creating guest network failed due to " + e.toString();
-            s_logger.warn(msg, e);
+            logger.warn(msg, e);
             return new Answer(cmd, false, msg);
         }
     }

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockStorageManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockStorageManagerImpl.java
@@ -31,7 +31,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.storage.command.DeleteCommand;
 import org.apache.cloudstack.storage.command.DownloadCommand;
@@ -104,7 +103,6 @@ import com.cloud.vm.DiskProfile;
 @Component
 @Local(value = {MockStorageManager.class})
 public class MockStorageManagerImpl extends ManagerBase implements MockStorageManager {
-    private static final Logger s_logger = Logger.getLogger(MockStorageManagerImpl.class);
     @Inject
     MockStoragePoolDao _mockStoragePoolDao = null;
     @Inject
@@ -1059,7 +1057,7 @@ public class MockStorageManagerImpl extends ManagerBase implements MockStorageMa
                 MessageDigest md = MessageDigest.getInstance("md5");
                 md5 = String.format("%032x", new BigInteger(1, md.digest(cmd.getTemplatePath().getBytes())));
             } catch (NoSuchAlgorithmException e) {
-                s_logger.debug("failed to gernerate md5:" + e.toString());
+                logger.debug("failed to gernerate md5:" + e.toString());
             }
             txn.commit();
             return new Answer(cmd, true, md5);

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManagerImpl.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.Answer;
@@ -93,7 +92,6 @@ import com.cloud.vm.VirtualMachine.PowerState;
 @Component
 @Local(value = {MockVmManager.class})
 public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
-    private static final Logger s_logger = Logger.getLogger(MockVmManagerImpl.class);
 
     @Inject
     MockVMDao _mockVmDao = null;
@@ -262,12 +260,12 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
         final MockVm vm = _mockVmDao.findByVmName(router_name);
         final String args = vm.getBootargs();
         if (args.indexOf("router_pr=100") > 0) {
-            s_logger.debug("Router priority is for MASTER");
+            logger.debug("Router priority is for MASTER");
             final CheckRouterAnswer ans = new CheckRouterAnswer(cmd, "Status: MASTER", true);
             ans.setState(VirtualRouter.RedundantState.MASTER);
             return ans;
         } else {
-            s_logger.debug("Router priority is for BACKUP");
+            logger.debug("Router priority is for BACKUP");
             final CheckRouterAnswer ans = new CheckRouterAnswer(cmd, "Status: BACKUP", true);
             ans.setState(VirtualRouter.RedundantState.BACKUP);
             return ans;
@@ -462,7 +460,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
         final String vmName = cmd.getVmName();
         final String vmSnapshotName = cmd.getTarget().getSnapshotName();
 
-        s_logger.debug("Created snapshot " + vmSnapshotName + " for vm " + vmName);
+        logger.debug("Created snapshot " + vmSnapshotName + " for vm " + vmName);
         return new CreateVMSnapshotAnswer(cmd, cmd.getTarget(), cmd.getVolumeTOs());
     }
 
@@ -473,7 +471,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
         if (_mockVmDao.findByVmName(cmd.getVmName()) == null) {
             return new DeleteVMSnapshotAnswer(cmd, false, "No VM by name " + cmd.getVmName());
         }
-        s_logger.debug("Removed snapshot " + snapshotName + " of VM " + vm);
+        logger.debug("Removed snapshot " + snapshotName + " of VM " + vm);
         return new DeleteVMSnapshotAnswer(cmd, cmd.getVolumeTOs());
     }
 
@@ -485,7 +483,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
         if (vmVo == null) {
             return new RevertToVMSnapshotAnswer(cmd, false, "No VM by name " + cmd.getVmName());
         }
-        s_logger.debug("Reverted to snapshot " + snapshot + " of VM " + vm);
+        logger.debug("Reverted to snapshot " + snapshot + " of VM " + vm);
         return new RevertToVMSnapshotAnswer(cmd, cmd.getVolumeTOs(), vmVo.getPowerState());
     }
 
@@ -571,40 +569,40 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
         boolean updateSeqnoAndSig = false;
         if (currSeqnum != null) {
             if (cmd.getSeqNum() > currSeqnum) {
-                s_logger.info("New seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum);
+                logger.info("New seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum);
                 updateSeqnoAndSig = true;
                 if (!cmd.getSignature().equals(currSig)) {
-                    s_logger.info("New seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + " new signature received:" + cmd.getSignature() + " curr=" +
+                    logger.info("New seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + " new signature received:" + cmd.getSignature() + " curr=" +
                             currSig + ", updated iptables");
                     action = ", updated iptables";
                     reason = reason + "seqno_increased_sig_changed";
                 } else {
-                    s_logger.info("New seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + " no change in signature:" + cmd.getSignature() + ", do nothing");
+                    logger.info("New seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + " no change in signature:" + cmd.getSignature() + ", do nothing");
                     reason = reason + "seqno_increased_sig_same";
                 }
             } else if (cmd.getSeqNum() < currSeqnum) {
-                s_logger.info("Older seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + ", do nothing");
+                logger.info("Older seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + ", do nothing");
                 reason = reason + "seqno_decreased";
             } else {
                 if (!cmd.getSignature().equals(currSig)) {
-                    s_logger.info("Identical seqno received: " + cmd.getSeqNum() + " new signature received:" + cmd.getSignature() + " curr=" + currSig +
+                    logger.info("Identical seqno received: " + cmd.getSeqNum() + " new signature received:" + cmd.getSignature() + " curr=" + currSig +
                             ", updated iptables");
                     action = ", updated iptables";
                     reason = reason + "seqno_same_sig_changed";
                     updateSeqnoAndSig = true;
                 } else {
-                    s_logger.info("Identical seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + " no change in signature:" + cmd.getSignature() +
+                    logger.info("Identical seqno received: " + cmd.getSeqNum() + " curr=" + currSeqnum + " no change in signature:" + cmd.getSignature() +
                             ", do nothing");
                     reason = reason + "seqno_same_sig_same";
                 }
             }
         } else {
-            s_logger.info("New seqno received: " + cmd.getSeqNum() + " old=null");
+            logger.info("New seqno received: " + cmd.getSeqNum() + " old=null");
             updateSeqnoAndSig = true;
             action = ", updated iptables";
             reason = ", seqno_new";
         }
-        s_logger.info("Programmed network rules for vm " + cmd.getVmName() + " seqno=" + cmd.getSeqNum() + " signature=" + cmd.getSignature() + " guestIp=" +
+        logger.info("Programmed network rules for vm " + cmd.getVmName() + " seqno=" + cmd.getSeqNum() + " signature=" + cmd.getSignature() + " guestIp=" +
                 cmd.getGuestIp() + ", numIngressRules=" + cmd.getIngressRuleSet().length + ", numEgressRules=" + cmd.getEgressRuleSet().length + " total cidrs=" +
                 cmd.getTotalNumCidrs() + action + reason);
         return updateSeqnoAndSig;

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/SimulatorManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/SimulatorManagerImpl.java
@@ -32,7 +32,6 @@ import org.apache.cloudstack.storage.command.DownloadCommand;
 import org.apache.cloudstack.storage.command.DownloadProgressCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
 import org.apache.cloudstack.storage.command.UploadStatusCommand;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.Answer;
@@ -134,7 +133,6 @@ import com.google.gson.stream.JsonReader;
 @Component
 @Local(value = {SimulatorManager.class})
 public class SimulatorManagerImpl extends ManagerBase implements SimulatorManager, PluggableService {
-    private static final Logger s_logger = Logger.getLogger(SimulatorManagerImpl.class);
     private static final Gson s_gson = GsonHelper.getGson();
     @Inject
     MockVmManager _mockVmMgr;
@@ -223,7 +221,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                         try {
                             info.setTimeout(Integer.valueOf(entry.getValue()));
                         } catch (final NumberFormatException e) {
-                            s_logger.debug("invalid timeout parameter: " + e.toString());
+                            logger.debug("invalid timeout parameter: " + e.toString());
                         }
                     }
 
@@ -232,9 +230,9 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                             final int wait = Integer.valueOf(entry.getValue());
                             Thread.sleep(wait);
                         } catch (final NumberFormatException e) {
-                            s_logger.debug("invalid wait parameter: " + e.toString());
+                            logger.debug("invalid wait parameter: " + e.toString());
                         } catch (final InterruptedException e) {
-                            s_logger.debug("thread is interrupted: " + e.toString());
+                            logger.debug("thread is interrupted: " + e.toString());
                         }
                     }
 
@@ -422,7 +420,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                         cmd instanceof SecStorageFirewallCfgCommand) {
                     answer = new Answer(cmd);
                 } else {
-                    s_logger.error("Simulator does not implement command of type " + cmd.toString());
+                    logger.error("Simulator does not implement command of type " + cmd.toString());
                     answer = Answer.createUnsupportedCommandAnswer(cmd);
                 }
             }
@@ -436,7 +434,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
 
             return answer;
         } catch (final Exception e) {
-            s_logger.error("Failed execute cmd: ", e);
+            logger.error("Failed execute cmd: ", e);
             txn.rollback();
             return new Answer(cmd, false, e.toString());
         } finally {

--- a/plugins/hypervisors/simulator/src/com/cloud/ha/SimulatorFencer.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/ha/SimulatorFencer.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.FenceAnswer;
@@ -41,7 +40,6 @@ import com.cloud.vm.VirtualMachine;
 
 @Local(value=FenceBuilder.class)
 public class SimulatorFencer extends AdapterBase implements FenceBuilder {
-    private static final Logger s_logger = Logger.getLogger(SimulatorFencer.class);
 
     @Inject HostDao _hostDao;
     @Inject AgentManager _agentMgr;
@@ -72,7 +70,7 @@ public class SimulatorFencer extends AdapterBase implements FenceBuilder {
     @Override
     public Boolean fenceOff(VirtualMachine vm, Host host) {
         if (host.getHypervisorType() != HypervisorType.Simulator) {
-            s_logger.debug("Don't know how to fence non simulator hosts " + host.getHypervisorType());
+            logger.debug("Don't know how to fence non simulator hosts " + host.getHypervisorType());
             return null;
         }
 
@@ -91,13 +89,13 @@ public class SimulatorFencer extends AdapterBase implements FenceBuilder {
                 try {
                     answer = (FenceAnswer)_agentMgr.send(h.getId(), fence);
                 } catch (AgentUnavailableException e) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
                     }
                     continue;
                 } catch (OperationTimedoutException e) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
                     }
                     continue;
                 }
@@ -107,8 +105,8 @@ public class SimulatorFencer extends AdapterBase implements FenceBuilder {
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Unable to fence off " + vm.toString() + " on " + host.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Unable to fence off " + vm.toString() + " on " + host.toString());
         }
 
         return false;

--- a/plugins/hypervisors/simulator/src/com/cloud/ha/SimulatorInvestigator.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/ha/SimulatorInvestigator.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -43,7 +42,6 @@ import com.cloud.vm.VirtualMachine.PowerState;
 
 @Local(value=Investigator.class)
 public class SimulatorInvestigator extends AdapterBase implements Investigator {
-    private final static Logger s_logger = Logger.getLogger(SimulatorInvestigator.class);
     @Inject
     AgentManager _agentMgr;
     @Inject
@@ -72,7 +70,7 @@ public class SimulatorInvestigator extends AdapterBase implements Investigator {
                     return answer.getResult() ? Status.Up : Status.Down;
                 }
             } catch (Exception e) {
-                s_logger.debug("Failed to send command to host: " + neighbor.getId());
+                logger.debug("Failed to send command to host: " + neighbor.getId());
             }
         }
 
@@ -85,17 +83,17 @@ public class SimulatorInvestigator extends AdapterBase implements Investigator {
         try {
             Answer answer = _agentMgr.send(vm.getHostId(), cmd);
             if (!answer.getResult()) {
-                s_logger.debug("Unable to get vm state on " + vm.toString());
+                logger.debug("Unable to get vm state on " + vm.toString());
                 throw new UnknownVM();
             }
             CheckVirtualMachineAnswer cvmAnswer = (CheckVirtualMachineAnswer)answer;
-            s_logger.debug("Agent responded with state " + cvmAnswer.getState().toString());
+            logger.debug("Agent responded with state " + cvmAnswer.getState().toString());
             return cvmAnswer.getState() == PowerState.PowerOn;
         } catch (AgentUnavailableException e) {
-            s_logger.debug("Unable to reach the agent for " + vm.toString() + ": " + e.getMessage());
+            logger.debug("Unable to reach the agent for " + vm.toString() + ": " + e.getMessage());
             throw new UnknownVM();
         } catch (OperationTimedoutException e) {
-            s_logger.debug("Operation timed out for " + vm.toString() + ": " + e.getMessage());
+            logger.debug("Operation timed out for " + vm.toString() + ": " + e.getMessage());
             throw new UnknownVM();
         }
     }

--- a/plugins/hypervisors/simulator/src/com/cloud/resource/SimulatorDiscoverer.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/resource/SimulatorDiscoverer.java
@@ -28,7 +28,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.Listener;
@@ -55,7 +54,6 @@ import com.cloud.storage.dao.VMTemplateZoneDao;
 
 @Local(value = Discoverer.class)
 public class SimulatorDiscoverer extends DiscovererBase implements Discoverer, Listener, ResourceStateAdapter {
-    private static final Logger s_logger = Logger.getLogger(SimulatorDiscoverer.class);
 
     @Inject
     HostDao _hostDao;
@@ -94,8 +92,8 @@ public class SimulatorDiscoverer extends DiscovererBase implements Discoverer, L
             if (scheme.equals("http")) {
                 if (host == null || !host.startsWith("sim")) {
                     String msg = "uri is not of simulator type so we're not taking care of the discovery for this: " + uri;
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug(msg);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(msg);
                     }
                     return null;
                 }
@@ -121,8 +119,8 @@ public class SimulatorDiscoverer extends DiscovererBase implements Discoverer, L
                 }
             } else {
                 String msg = "uriString is not http so we're not taking care of the discovery for this: " + uri;
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug(msg);
+                if (logger.isDebugEnabled()) {
+                    logger.debug(msg);
                 }
                 return null;
             }
@@ -130,15 +128,15 @@ public class SimulatorDiscoverer extends DiscovererBase implements Discoverer, L
             String cluster = null;
             if (clusterId == null) {
                 String msg = "must specify cluster Id when adding host";
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug(msg);
+                if (logger.isDebugEnabled()) {
+                    logger.debug(msg);
                 }
                 throw new RuntimeException(msg);
             } else {
                 ClusterVO clu = _clusterDao.findById(clusterId);
                 if (clu == null || (clu.getHypervisorType() != HypervisorType.Simulator)) {
-                    if (s_logger.isInfoEnabled())
-                        s_logger.info("invalid cluster id or cluster is not for Simulator hypervisors");
+                    if (logger.isInfoEnabled())
+                        logger.info("invalid cluster id or cluster is not for Simulator hypervisors");
                     return null;
                 }
                 cluster = Long.toString(clusterId);
@@ -151,8 +149,8 @@ public class SimulatorDiscoverer extends DiscovererBase implements Discoverer, L
             String pod;
             if (podId == null) {
                 String msg = "must specify pod Id when adding host";
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug(msg);
+                if (logger.isDebugEnabled()) {
+                    logger.debug(msg);
                 }
                 throw new RuntimeException(msg);
             } else {
@@ -176,17 +174,17 @@ public class SimulatorDiscoverer extends DiscovererBase implements Discoverer, L
             resources = createAgentResources(params);
             return resources;
         } catch (Exception ex) {
-            s_logger.error("Exception when discovering simulator hosts: " + ex.getMessage());
+            logger.error("Exception when discovering simulator hosts: " + ex.getMessage());
         }
         return null;
     }
 
     private Map<AgentResourceBase, Map<String, String>> createAgentResources(Map<String, Object> params) {
         try {
-            s_logger.info("Creating Simulator Resources");
+            logger.info("Creating Simulator Resources");
             return _mockAgentMgr.createServerResources(params);
         } catch (Exception ex) {
-            s_logger.warn("Caught exception at agent resource creation: " + ex.getMessage(), ex);
+            logger.warn("Caught exception at agent resource creation: " + ex.getMessage(), ex);
         }
         return null;
     }

--- a/plugins/hypervisors/simulator/src/com/cloud/resource/SimulatorSecondaryDiscoverer.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/resource/SimulatorSecondaryDiscoverer.java
@@ -29,7 +29,6 @@ import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 import org.apache.cloudstack.storage.resource.SecondaryStorageDiscoverer;
 import org.apache.cloudstack.storage.resource.SecondaryStorageResource;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.Listener;
 import com.cloud.agent.api.AgentControlAnswer;
@@ -47,7 +46,6 @@ import com.cloud.storage.dao.SnapshotDao;
 
 @Local(value = Discoverer.class)
 public class SimulatorSecondaryDiscoverer extends SecondaryStorageDiscoverer implements ResourceStateAdapter, Listener {
-    private static final Logger s_logger = Logger.getLogger(SimulatorSecondaryDiscoverer.class);
     @Inject
     MockStorageManager _mockStorageMgr = null;
     @Inject
@@ -71,7 +69,7 @@ public class SimulatorSecondaryDiscoverer extends SecondaryStorageDiscoverer imp
     public Map<? extends ServerResource, Map<String, String>>
         find(long dcId, Long podId, Long clusterId, URI uri, String username, String password, List<String> hostTags) {
         if (!uri.getScheme().equalsIgnoreCase("sim")) {
-            s_logger.debug("It's not NFS or file or ISO, so not a secondary storage server: " + uri.toString());
+            logger.debug("It's not NFS or file or ISO, so not a secondary storage server: " + uri.toString());
             return null;
         }
         List<ImageStoreVO> stores = imageStoreDao.listImageStores();

--- a/plugins/hypervisors/simulator/src/com/cloud/simulator/dao/MockConfigurationDaoImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/simulator/dao/MockConfigurationDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.Formatter;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.simulator.MockConfigurationVO;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {MockConfigurationDao.class})
 public class MockConfigurationDaoImpl extends GenericDaoBase<MockConfigurationVO, Long> implements MockConfigurationDao {
-    final static Logger s_logger = Logger.getLogger(MockConfigurationDaoImpl.class);
     private final SearchBuilder<MockConfigurationVO> _searchByDcIdName;
     private final SearchBuilder<MockConfigurationVO> _searchByDcIDPodIdName;
     private final SearchBuilder<MockConfigurationVO> _searchByDcIDPodIdClusterIdName;
@@ -141,7 +139,7 @@ public class MockConfigurationDaoImpl extends GenericDaoBase<MockConfigurationVO
                 return toEntityBean(rs, false);
             }
         } catch (Exception e) {
-            s_logger.info("[ignored]"
+            logger.info("[ignored]"
                     + "error while executing dynamically build search: " + e.getLocalizedMessage());
         }
         return null;

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -39,7 +39,6 @@ import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.BackupSnapshotCommand;
 import com.cloud.agent.api.Command;
@@ -107,7 +106,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 @Local(value = HypervisorGuru.class)
 public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Configurable {
-    private static final Logger s_logger = Logger.getLogger(VMwareGuru.class);
 
     @Inject
     private NetworkDao _networkDao;
@@ -183,7 +181,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
                 try {
                     VirtualEthernetCardType.valueOf(nicDeviceType);
                 } catch (Exception e) {
-                    s_logger.warn("Invalid NIC device type " + nicDeviceType + " is specified in VM details, switch to default E1000");
+                    logger.warn("Invalid NIC device type " + nicDeviceType + " is specified in VM details, switch to default E1000");
                     details.put(VmDetailConstants.NIC_ADAPTER, VirtualEthernetCardType.E1000.toString());
                 }
             }
@@ -195,7 +193,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
                 try {
                     VirtualEthernetCardType.valueOf(nicDeviceType);
                 } catch (Exception e) {
-                    s_logger.warn("Invalid NIC device type " + nicDeviceType + " is specified in VM details, switch to default E1000");
+                    logger.warn("Invalid NIC device type " + nicDeviceType + " is specified in VM details, switch to default E1000");
                     details.put(VmDetailConstants.NIC_ADAPTER, VirtualEthernetCardType.E1000.toString());
                 }
             }
@@ -303,7 +301,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
         if (userVm) {
             String nestedVirt = _configDao.getValue(Config.VmwareEnableNestedVirtualization.key());
             if (nestedVirt != null) {
-                s_logger.debug("Nested virtualization requested, adding flag to vm configuration");
+                logger.debug("Nested virtualization requested, adding flag to vm configuration");
                 details.put(VmDetailConstants.NESTED_VIRTUALIZATION_FLAG, nestedVirt);
                 to.setDetails(details);
 
@@ -483,7 +481,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
 
         String vCenterIp = NetUtils.resolveToIp(tokens[1]);
         if (vCenterIp == null) {
-            s_logger.error("Fatal : unable to resolve vCenter address " + tokens[1] + ", please check your DNS configuration");
+            logger.error("Fatal : unable to resolve vCenter address " + tokens[1] + ", please check your DNS configuration");
             return guid;
         }
 
@@ -500,7 +498,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
         for (NicVO nic : nicVOs) {
             NetworkVO network = _networkDao.findById(nic.getNetworkId());
             if (network.getBroadcastDomainType() == BroadcastDomainType.Lswitch) {
-                s_logger.debug("Nic " + nic.toString() + " is connected to an lswitch, cleanup required");
+                logger.debug("Nic " + nic.toString() + " is connected to an lswitch, cleanup required");
                 NetworkVO networkVO = _networkDao.findById(nic.getNetworkId());
                 // We need the traffic label to figure out which vSwitch has the
                 // portgroup

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
@@ -28,7 +28,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.vmware.vim25.ClusterDasConfigInfo;
 import com.vmware.vim25.ManagedObjectReference;
@@ -82,7 +81,6 @@ import com.cloud.utils.UriUtils;
 
 @Local(value = Discoverer.class)
 public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer, ResourceStateAdapter {
-    private static final Logger s_logger = Logger.getLogger(VmwareServerDiscoverer.class);
 
     @Inject
     VmwareManager _vmwareMgr;
@@ -110,27 +108,27 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
     List<NetworkElement> networkElements;
 
     public VmwareServerDiscoverer() {
-        s_logger.info("VmwareServerDiscoverer is constructed");
+        logger.info("VmwareServerDiscoverer is constructed");
     }
 
     @Override
     public Map<? extends ServerResource, Map<String, String>>
     find(long dcId, Long podId, Long clusterId, URI url, String username, String password, List<String> hostTags) throws DiscoveryException {
 
-        if (s_logger.isInfoEnabled())
-            s_logger.info("Discover host. dc: " + dcId + ", pod: " + podId + ", cluster: " + clusterId + ", uri host: " + url.getHost());
+        if (logger.isInfoEnabled())
+            logger.info("Discover host. dc: " + dcId + ", pod: " + podId + ", cluster: " + clusterId + ", uri host: " + url.getHost());
 
         if (podId == null) {
-            if (s_logger.isInfoEnabled())
-                s_logger.info("No pod is assigned, assuming that it is not for vmware and skip it to next discoverer");
+            if (logger.isInfoEnabled())
+                logger.info("No pod is assigned, assuming that it is not for vmware and skip it to next discoverer");
             return null;
         }
         boolean failureInClusterDiscovery = true;
         String vsmIp = "";
         ClusterVO cluster = _clusterDao.findById(clusterId);
         if (cluster == null || cluster.getHypervisorType() != HypervisorType.VMware) {
-            if (s_logger.isInfoEnabled())
-                s_logger.info("invalid cluster id or cluster is not for VMware hypervisors");
+            if (logger.isInfoEnabled())
+                logger.info("invalid cluster id or cluster is not for VMware hypervisors");
             return null;
         }
 
@@ -146,7 +144,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
             // If either or both not provided, try to retrieve & use the credentials from database, which are provided earlier while adding VMware DC to zone.
             if (usernameNotProvided || passwordNotProvided) {
                 // Retrieve credentials associated with VMware DC
-                s_logger.info("Username and/or Password not provided while adding cluster to cloudstack zone. "
+                logger.info("Username and/or Password not provided while adding cluster to cloudstack zone. "
                         + "Hence using both username & password provided while adding VMware DC to CloudStack zone.");
                 username = vmwareDc.getUser();
                 password = vmwareDc.getPassword();
@@ -182,7 +180,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
             int maxHostsPerCluster = _hvCapabilitiesDao.getMaxHostsPerCluster(hosts.get(0).getHypervisorType(), hosts.get(0).getHypervisorVersion());
             if (hosts.size() >= maxHostsPerCluster) {
                 String msg = "VMware cluster " + cluster.getName() + " is too big to add new host, current size: " + hosts.size() + ", max. size: " + maxHostsPerCluster;
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new DiscoveredWithErrorException(msg);
             }
         }
@@ -268,7 +266,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
                             "Both public traffic and guest traffic is over same physical network " + pNetworkPublic +
                             ". And virtual switch type chosen for each traffic is different" +
                             ". A physical network cannot be shared by different types of virtual switches.";
-                    s_logger.error(msg);
+                    logger.error(msg);
                     throw new InvalidParameterValueException(msg);
                 }
             }
@@ -276,7 +274,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
 
         privateTrafficLabel = _netmgr.getDefaultManagementTrafficLabel(dcId, HypervisorType.VMware);
         if (privateTrafficLabel != null) {
-            s_logger.info("Detected private network label : " + privateTrafficLabel);
+            logger.info("Detected private network label : " + privateTrafficLabel);
         }
         Pair<Boolean, Long> vsmInfo = new Pair<Boolean, Long>(false, 0L);
         if (nexusDVS && (guestTrafficLabelObj.getVirtualSwitchType() == VirtualSwitchType.NexusDistributedVirtualSwitch) ||
@@ -287,13 +285,13 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
             if (zoneType != NetworkType.Basic) {
                 publicTrafficLabel = _netmgr.getDefaultPublicTrafficLabel(dcId, HypervisorType.VMware);
                 if (publicTrafficLabel != null) {
-                    s_logger.info("Detected public network label : " + publicTrafficLabel);
+                    logger.info("Detected public network label : " + publicTrafficLabel);
                 }
             }
             // Get physical network label
             guestTrafficLabel = _netmgr.getDefaultGuestTrafficLabel(dcId, HypervisorType.VMware);
             if (guestTrafficLabel != null) {
-                s_logger.info("Detected guest network label : " + guestTrafficLabel);
+                logger.info("Detected guest network label : " + guestTrafficLabel);
             }
             // Before proceeding with validation of Nexus 1000v VSM check if an instance of Nexus 1000v VSM is already associated with this cluster.
             boolean clusterHasVsm = _vmwareMgr.hasNexusVSM(clusterId);
@@ -320,18 +318,18 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
 
             if (nexusDVS) {
                 if (vsmCredentials != null) {
-                    s_logger.info("Stocking credentials of Nexus VSM");
+                    logger.info("Stocking credentials of Nexus VSM");
                     context.registerStockObject("vsmcredentials", vsmCredentials);
                 }
             }
             List<ManagedObjectReference> morHosts = _vmwareMgr.addHostToPodCluster(context, dcId, podId, clusterId, URLDecoder.decode(url.getPath(), "UTF-8"));
             if (morHosts == null)
-                s_logger.info("Found 0 hosts.");
+                logger.info("Found 0 hosts.");
             if (privateTrafficLabel != null)
                 context.uregisterStockObject("privateTrafficLabel");
 
             if (morHosts == null) {
-                s_logger.error("Unable to find host or cluster based on url: " + URLDecoder.decode(url.getPath(), "UTF-8"));
+                logger.error("Unable to find host or cluster based on url: " + URLDecoder.decode(url.getPath(), "UTF-8"));
                 return null;
             }
 
@@ -342,7 +340,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
                 morCluster = context.getHostMorByPath(URLDecoder.decode(uriFromCluster.getPath(), "UTF-8"));
 
                 if (morCluster == null || !morCluster.getType().equalsIgnoreCase("ClusterComputeResource")) {
-                    s_logger.warn("Cluster url does not point to a valid vSphere cluster, url: " + clusterDetails.get("url"));
+                    logger.warn("Cluster url does not point to a valid vSphere cluster, url: " + clusterDetails.get("url"));
                     return null;
                 } else {
                     ClusterMO clusterMo = new ClusterMO(context, morCluster);
@@ -356,9 +354,9 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
 
             if (!validateDiscoveredHosts(context, morCluster, morHosts)) {
                 if (morCluster == null)
-                    s_logger.warn("The discovered host is not standalone host, can not be added to a standalone cluster");
+                    logger.warn("The discovered host is not standalone host, can not be added to a standalone cluster");
                 else
-                    s_logger.warn("The discovered host does not belong to the cluster");
+                    logger.warn("The discovered host does not belong to the cluster");
                 return null;
             }
 
@@ -394,7 +392,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
                     resource.configure("VMware", params);
                 } catch (ConfigurationException e) {
                     _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_HOST, dcId, podId, "Unable to add " + url.getHost(), "Error is " + e.getMessage());
-                    s_logger.warn("Unable to instantiate " + url.getHost(), e);
+                    logger.warn("Unable to instantiate " + url.getHost(), e);
                 }
                 resource.start();
 
@@ -414,17 +412,17 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
         } catch (DiscoveredWithErrorException e) {
             throw e;
         } catch (Exception e) {
-            s_logger.warn("Unable to connect to Vmware vSphere server. service address: " + url.getHost() + ". " + e);
+            logger.warn("Unable to connect to Vmware vSphere server. service address: " + url.getHost() + ". " + e);
             return null;
         } finally {
             if (context != null)
                 context.close();
             if (failureInClusterDiscovery && vsmInfo.first()) {
                 try {
-                    s_logger.debug("Deleting Nexus 1000v VSM " + vsmIp + " because cluster discovery and addition to zone has failed.");
+                    logger.debug("Deleting Nexus 1000v VSM " + vsmIp + " because cluster discovery and addition to zone has failed.");
                     _nexusElement.deleteCiscoNexusVSM(vsmInfo.second().longValue());
                 } catch (Exception e) {
-                    s_logger.warn("Deleting Nexus 1000v VSM " + vsmIp + " failed.");
+                    logger.warn("Deleting Nexus 1000v VSM " + vsmIp + " failed.");
                 }
             }
         }
@@ -449,7 +447,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
         vmwareDcZone = _vmwareDcZoneMapDao.findByZoneId(dcId);
         if (vmwareDcZone == null) {
             msg = "Zone " + dcId + " is not associated with any VMware DC yet. " + "Please add VMware DC to this zone first and then try to add clusters.";
-            s_logger.error(msg);
+            logger.error(msg);
             throw new DiscoveryException(msg);
         }
 
@@ -494,13 +492,13 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
             msg =
                     "This cluster " + clusterName + " belongs to vCenter " + url.getHost() + ". But this zone is associated with VMware DC from vCenter " + vCenterHost +
                     ". Make sure the cluster being added belongs to vCenter " + vCenterHost + " and VMware DC " + vmwareDcNameFromDb;
-            s_logger.error(msg);
+            logger.error(msg);
             throw new DiscoveryException(msg);
         } else if (!vmwareDcNameFromDb.equalsIgnoreCase(vmwareDcNameFromApi)) {
             msg =
                     "This cluster " + clusterName + " belongs to VMware DC " + vmwareDcNameFromApi + " .But this zone is associated with VMware DC " + vmwareDcNameFromDb +
                     ". Make sure the cluster being added belongs to VMware DC " + vmwareDcNameFromDb + " in vCenter " + vCenterHost;
-            s_logger.error(msg);
+            logger.error(msg);
             throw new DiscoveryException(msg);
         }
         return updatedInventoryPath;
@@ -547,15 +545,15 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
 
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
-        if (s_logger.isInfoEnabled())
-            s_logger.info("Configure VmwareServerDiscoverer, discover name: " + name);
+        if (logger.isInfoEnabled())
+            logger.info("Configure VmwareServerDiscoverer, discover name: " + name);
 
         super.configure(name, params);
 
         createVmwareToolsIso();
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("VmwareServerDiscoverer has been successfully configured");
+        if (logger.isInfoEnabled()) {
+            logger.info("VmwareServerDiscoverer has been successfully configured");
         }
         _resourceMgr.registerResourceStateAdapter(this.getClass().getSimpleName(), this);
         return true;
@@ -634,7 +632,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
         try {
             trafficLabelObj = new VmwareTrafficLabel(zoneWideTrafficLabel, trafficType, defaultVirtualSwitchType);
         } catch (InvalidParameterValueException e) {
-            s_logger.error("Failed to recognize virtual switch type specified for " + trafficType + " traffic due to " + e.getMessage());
+            logger.error("Failed to recognize virtual switch type specified for " + trafficType + " traffic due to " + e.getMessage());
             throw e;
         }
 
@@ -670,7 +668,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
         try {
             trafficLabelObj = new VmwareTrafficLabel(zoneWideTrafficLabel, trafficType, defVirtualSwitchType);
         } catch (InvalidParameterValueException e) {
-            s_logger.error("Failed to recognize virtual switch type specified for " + trafficType + " traffic due to " + e.getMessage());
+            logger.error("Failed to recognize virtual switch type specified for " + trafficType + " traffic due to " + e.getMessage());
             throw e;
         }
 
@@ -745,11 +743,11 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
             try {
                 resource.configure(host.getName(), params);
             } catch (ConfigurationException e) {
-                s_logger.warn("Unable to configure resource due to " + e.getMessage());
+                logger.warn("Unable to configure resource due to " + e.getMessage());
                 return null;
             }
             if (!resource.start()) {
-                s_logger.warn("Unable to start the resource");
+                logger.warn("Unable to start the resource");
                 return null;
             }
         }
@@ -759,7 +757,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
     private void validateVswitchType(String inputVswitchType) {
         VirtualSwitchType vSwitchType = VirtualSwitchType.getType(inputVswitchType);
         if (vSwitchType == VirtualSwitchType.None) {
-            s_logger.error("Unable to resolve " + inputVswitchType + " to a valid virtual switch type in VMware environment.");
+            logger.error("Unable to resolve " + inputVswitchType + " to a valid virtual switch type in VMware environment.");
             throw new InvalidParameterValueException("Invalid virtual switch type : " + inputVswitchType);
         }
     }

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/dao/LegacyZoneDaoImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/dao/LegacyZoneDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.hypervisor.vmware.LegacyZoneVO;
@@ -35,7 +34,6 @@ import com.cloud.utils.db.SearchCriteria.Op;
 @Local(value = LegacyZoneDao.class)
 @DB
 public class LegacyZoneDaoImpl extends GenericDaoBase<LegacyZoneVO, Long> implements LegacyZoneDao {
-    protected static final Logger s_logger = Logger.getLogger(LegacyZoneDaoImpl.class);
 
     final SearchBuilder<LegacyZoneVO> zoneSearch;
     final SearchBuilder<LegacyZoneVO> fullTableSearch;

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/dao/VmwareDatacenterDaoImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/dao/VmwareDatacenterDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.hypervisor.vmware.VmwareDatacenterVO;
@@ -35,7 +34,6 @@ import com.cloud.utils.db.SearchCriteria.Op;
 @Local(value = VmwareDatacenterDao.class)
 @DB
 public class VmwareDatacenterDaoImpl extends GenericDaoBase<VmwareDatacenterVO, Long> implements VmwareDatacenterDao {
-    protected static final Logger s_logger = Logger.getLogger(VmwareDatacenterDaoImpl.class);
 
     final SearchBuilder<VmwareDatacenterVO> nameSearch;
     final SearchBuilder<VmwareDatacenterVO> guidSearch;

--- a/plugins/hypervisors/vmware/src/com/cloud/network/CiscoNexusVSMDeviceManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/network/CiscoNexusVSMDeviceManagerImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.dc.ClusterDetailsDao;
@@ -65,7 +64,6 @@ public abstract class CiscoNexusVSMDeviceManagerImpl extends AdapterBase {
     @Inject
     PortProfileDao _ppDao;
 
-    private static final org.apache.log4j.Logger s_logger = Logger.getLogger(ExternalLoadBalancerDeviceManagerImpl.class);
 
     @DB
     //public CiscoNexusVSMDeviceVO addCiscoNexusVSM(long clusterId, String ipaddress, String username, String password, ServerResource resource, String vsmName) {
@@ -107,7 +105,7 @@ public abstract class CiscoNexusVSMDeviceManagerImpl extends AdapterBase {
             netconfClient = new NetconfHelper(ipaddress, username, password);
         } catch (CloudRuntimeException e) {
             String msg = "Failed to connect to Nexus VSM " + ipaddress + " with credentials of user " + username;
-            s_logger.error(msg);
+            logger.error(msg);
             throw new CloudRuntimeException(msg);
         }
 
@@ -203,7 +201,7 @@ public abstract class CiscoNexusVSMDeviceManagerImpl extends AdapterBase {
                 if (hosts != null && hosts.size() > 0) {
                     for (Host host : hosts) {
                         if (host.getType() == Host.Type.Routing) {
-                            s_logger.info("Non-empty cluster with id" + clusterId + "still has a host that uses this VSM. Please empty the cluster first");
+                            logger.info("Non-empty cluster with id" + clusterId + "still has a host that uses this VSM. Please empty the cluster first");
                             throw new ResourceInUseException("Non-empty cluster with id" + clusterId +
                                 "still has a host that uses this VSM. Please empty the cluster first");
                         }
@@ -267,7 +265,7 @@ public abstract class CiscoNexusVSMDeviceManagerImpl extends AdapterBase {
     public CiscoNexusVSMDeviceVO getCiscoVSMbyClusId(long clusterId) {
         ClusterVSMMapVO mapVO = _clusterVSMDao.findByClusterId(clusterId);
         if (mapVO == null) {
-            s_logger.info("Couldn't find a VSM associated with the specified cluster Id");
+            logger.info("Couldn't find a VSM associated with the specified cluster Id");
             return null;
         }
         // Else, pull out the VSM associated with the VSM id in mapVO.

--- a/plugins/hypervisors/vmware/src/com/cloud/network/dao/CiscoNexusVSMDeviceDaoImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/network/dao/CiscoNexusVSMDeviceDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.network.CiscoNexusVSMDeviceVO;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.SearchCriteria.Op;
 @Local(value = CiscoNexusVSMDeviceDao.class)
 @DB
 public class CiscoNexusVSMDeviceDaoImpl extends GenericDaoBase<CiscoNexusVSMDeviceVO, Long> implements CiscoNexusVSMDeviceDao {
-    protected static final Logger s_logger = Logger.getLogger(CiscoNexusVSMDeviceDaoImpl.class);
     final SearchBuilder<CiscoNexusVSMDeviceVO> mgmtVlanIdSearch;
     final SearchBuilder<CiscoNexusVSMDeviceVO> domainIdSearch;
     final SearchBuilder<CiscoNexusVSMDeviceVO> nameSearch;

--- a/plugins/hypervisors/vmware/src/com/cloud/network/element/CiscoNexusVSMElement.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/network/element/CiscoNexusVSMElement.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.api.commands.DeleteCiscoNexusVSMCmd;
 import com.cloud.api.commands.DisableCiscoNexusVSMCmd;
@@ -71,7 +70,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Local(value = NetworkElement.class)
 public class CiscoNexusVSMElement extends CiscoNexusVSMDeviceManagerImpl implements CiscoNexusVSMElementService, NetworkElement, Manager {
 
-    private static final Logger s_logger = Logger.getLogger(CiscoNexusVSMElement.class);
 
     @Inject
     CiscoNexusVSMDeviceDao _vsmDao;
@@ -148,7 +146,7 @@ public class CiscoNexusVSMElement extends CiscoNexusVSMDeviceManagerImpl impleme
         try {
             result = deleteCiscoNexusVSM(cmd.getCiscoNexusVSMDeviceId());
         } catch (ResourceInUseException e) {
-            s_logger.info("VSM could not be deleted");
+            logger.info("VSM could not be deleted");
             // TODO: Throw a better exception here.
             throw new CloudRuntimeException("Failed to delete specified VSM");
         }
@@ -267,7 +265,7 @@ public class CiscoNexusVSMElement extends CiscoNexusVSMDeviceManagerImpl impleme
                 netconfClient.disconnect();
             } catch (CloudRuntimeException e) {
                 String msg = "Invalid credentials supplied for user " + vsmUser + " for Cisco Nexus 1000v VSM at " + vsmIp;
-                s_logger.error(msg);
+                logger.error(msg);
                 _clusterDao.remove(clusterId);
                 throw new CloudRuntimeException(msg);
             }
@@ -277,7 +275,7 @@ public class CiscoNexusVSMElement extends CiscoNexusVSMDeviceManagerImpl impleme
             if (vsm != null) {
                 List<ClusterVSMMapVO> clusterList = _clusterVSMDao.listByVSMId(vsm.getId());
                 if (clusterList != null && !clusterList.isEmpty()) {
-                    s_logger.error("Failed to add cluster: specified Nexus VSM is already associated with another cluster");
+                    logger.error("Failed to add cluster: specified Nexus VSM is already associated with another cluster");
                     ResourceInUseException ex =
                         new ResourceInUseException("Failed to add cluster: specified Nexus VSM is already associated with another cluster with specified Id");
                     // get clusterUuid to report error
@@ -322,7 +320,7 @@ public class CiscoNexusVSMElement extends CiscoNexusVSMDeviceManagerImpl impleme
                     msg += "vsmpassword: Password of user account with admin privileges over Cisco Nexus 1000v dvSwitch. ";
                 }
             }
-            s_logger.error(msg);
+            logger.error(msg);
             // Cleaning up the cluster record as addCluster operation failed because of invalid credentials of Nexus dvSwitch.
             _clusterDao.remove(clusterId);
             throw new CloudRuntimeException(msg);

--- a/plugins/hypervisors/xenserver/src/com/cloud/ha/XenServerFencer.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/ha/XenServerFencer.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -42,7 +41,6 @@ import com.cloud.vm.VirtualMachine;
 
 @Local(value = FenceBuilder.class)
 public class XenServerFencer extends AdapterBase implements FenceBuilder {
-    private static final Logger s_logger = Logger.getLogger(XenServerFencer.class);
 
     @Inject
     HostDao _hostDao;
@@ -54,7 +52,7 @@ public class XenServerFencer extends AdapterBase implements FenceBuilder {
     @Override
     public Boolean fenceOff(VirtualMachine vm, Host host) {
         if (host.getHypervisorType() != HypervisorType.XenServer) {
-            s_logger.debug("Don't know how to fence non XenServer hosts " + host.getHypervisorType());
+            logger.debug("Don't know how to fence non XenServer hosts " + host.getHypervisorType());
             return null;
         }
 
@@ -73,18 +71,18 @@ public class XenServerFencer extends AdapterBase implements FenceBuilder {
                 try {
                     Answer ans = _agentMgr.send(h.getId(), fence);
                     if (!(ans instanceof FenceAnswer)) {
-                        s_logger.debug("Answer is not fenceanswer.  Result = " + ans.getResult() + "; Details = " + ans.getDetails());
+                        logger.debug("Answer is not fenceanswer.  Result = " + ans.getResult() + "; Details = " + ans.getDetails());
                         continue;
                     }
                     answer = (FenceAnswer)ans;
                 } catch (AgentUnavailableException e) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
                     }
                     continue;
                 } catch (OperationTimedoutException e) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Moving on to the next host because " + h.toString() + " is unavailable");
                     }
                     continue;
                 }
@@ -94,8 +92,8 @@ public class XenServerFencer extends AdapterBase implements FenceBuilder {
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Unable to fence off " + vm.toString() + " on " + host.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Unable to fence off " + vm.toString() + " on " + host.toString());
         }
 
         return false;

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -83,7 +83,6 @@ import com.xensource.xenapi.Types.UuidInvalid;
 import com.xensource.xenapi.Types.XenAPIException;
 
 import org.apache.cloudstack.hypervisor.xenserver.XenserverConfigs;
-import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
 import javax.ejb.Local;
@@ -104,7 +103,6 @@ import java.util.Set;
 
 @Local(value = Discoverer.class)
 public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, Listener, ResourceStateAdapter {
-    private static final Logger s_logger = Logger.getLogger(XcpServerDiscoverer.class);
     protected String _publicNic;
     protected String _privateNic;
     protected String _storageNic1;
@@ -163,16 +161,16 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                 for(HostPatch patch : patches) {
                     PoolPatch pp = patch.getPoolPatch(conn);
                     if (pp != null && pp.equals(poolPatch) && patch.getApplied(conn)) {
-                        s_logger.debug("host " + hostIp + " does have " + hotFixUuid +" Hotfix.");
+                        logger.debug("host " + hostIp + " does have " + hotFixUuid +" Hotfix.");
                         return true;
                     }
                 }
             }
             return false;
         } catch (UuidInvalid e) {
-            s_logger.debug("host " + hostIp + " doesn't have " + hotFixUuid + " Hotfix");
+            logger.debug("host " + hostIp + " doesn't have " + hotFixUuid + " Hotfix");
         } catch (Exception e) {
-            s_logger.debug("can't get patches information, consider it doesn't have " + hotFixUuid + " Hotfix");
+            logger.debug("can't get patches information, consider it doesn't have " + hotFixUuid + " Hotfix");
         }
         return false;
     }
@@ -186,25 +184,25 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
         Connection conn = null;
         if (!url.getScheme().equals("http")) {
             String msg = "urlString is not http so we're not taking care of the discovery for this: " + url;
-            s_logger.debug(msg);
+            logger.debug(msg);
             return null;
         }
         if (clusterId == null) {
             String msg = "must specify cluster Id when add host";
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new RuntimeException(msg);
         }
 
         if (podId == null) {
             String msg = "must specify pod Id when add host";
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new RuntimeException(msg);
         }
 
         ClusterVO cluster = _clusterDao.findById(clusterId);
         if (cluster == null || cluster.getHypervisorType() != HypervisorType.XenServer) {
-            if (s_logger.isInfoEnabled())
-                s_logger.info("invalid cluster id or cluster is not for XenServer hypervisors");
+            if (logger.isInfoEnabled())
+                logger.info("invalid cluster id or cluster is not for XenServer hypervisors");
             return null;
         }
 
@@ -217,7 +215,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
             conn = _connPool.getConnect(hostIp, username, pass);
             if (conn == null) {
                 String msg = "Unable to get a connection to " + url;
-                s_logger.debug(msg);
+                logger.debug(msg);
                 throw new DiscoveryException(msg);
             }
 
@@ -243,7 +241,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                     if (!clu.getGuid().equals(poolUuid)) {
                         String msg = "Please join the host " +  hostIp + " to XS pool  "
                                        + clu.getGuid() + " through XC/XS before adding it through CS UI";
-                        s_logger.warn(msg);
+                        logger.warn(msg);
                         throw new DiscoveryException(msg);
                     }
                 } else {
@@ -255,7 +253,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                 try {
                     Session.logout(conn);
                 } catch (Exception e) {
-                    s_logger.debug("Caught exception during logout", e);
+                    logger.debug("Caught exception during logout", e);
                 }
                 conn.dispose();
                 conn = null;
@@ -278,7 +276,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                     if (!support_hvm) {
                         String msg = "Unable to add host " + record.address + " because it doesn't support hvm";
                         _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_HOST, dcId, podId, msg, msg);
-                        s_logger.debug(msg);
+                        logger.debug(msg);
                         throw new RuntimeException(msg);
                     }
                 }
@@ -299,12 +297,12 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                 String hostKernelVer = record.softwareVersion.get("linux");
 
                 if (_resourceMgr.findHostByGuid(record.uuid) != null) {
-                    s_logger.debug("Skipping " + record.address + " because " + record.uuid + " is already in the database.");
+                    logger.debug("Skipping " + record.address + " because " + record.uuid + " is already in the database.");
                     continue;
                 }
 
                 CitrixResourceBase resource = createServerResource(dcId, podId, record, latestHotFix);
-                s_logger.info("Found host " + record.hostname + " ip=" + record.address + " product version=" + prodVersion);
+                logger.info("Found host " + record.hostname + " ip=" + record.address + " product version=" + prodVersion);
 
                 Map<String, String> details = new HashMap<String, String>();
                 Map<String, Object> params = new HashMap<String, Object>();
@@ -355,7 +353,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                     resource.configure("XenServer", params);
                 } catch (ConfigurationException e) {
                     _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_HOST, dcId, podId, "Unable to add " + record.address, "Error is " + e.getMessage());
-                    s_logger.warn("Unable to instantiate " + record.address, e);
+                    logger.warn("Unable to instantiate " + record.address, e);
                     continue;
                 }
                 resource.start();
@@ -364,16 +362,16 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
         } catch (SessionAuthenticationFailed e) {
             throw new DiscoveredWithErrorException("Authentication error");
         } catch (XenAPIException e) {
-            s_logger.warn("XenAPI exception", e);
+            logger.warn("XenAPI exception", e);
             return null;
         } catch (XmlRpcException e) {
-            s_logger.warn("Xml Rpc Exception", e);
+            logger.warn("Xml Rpc Exception", e);
             return null;
         } catch (UnknownHostException e) {
-            s_logger.warn("Unable to resolve the host name", e);
+            logger.warn("Unable to resolve the host name", e);
             return null;
         } catch (Exception e) {
-            s_logger.debug("other exceptions: " + e.toString(), e);
+            logger.debug("other exceptions: " + e.toString(), e);
             return null;
         }
         return resources;
@@ -433,7 +431,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
         String msg =
                 "Only support XCP 1.0.0, 1.1.0, 1.4.x, 1.5 beta, 1.6.x; XenServer 5.6,  XenServer 5.6 FP1, XenServer 5.6 SP2, Xenserver 6.0, 6.0.2, 6.1.0, 6.2.0, 6.5.0 but this one is " +
                         prodBrand + " " + prodVersion;
-        s_logger.warn(msg);
+        logger.warn(msg);
         throw new RuntimeException(msg);
     }
 
@@ -553,7 +551,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
 
         StartupRoutingCommand startup = (StartupRoutingCommand)cmd;
         if (startup.getHypervisorType() != HypervisorType.XenServer) {
-            s_logger.debug("Not XenServer so moving on.");
+            logger.debug("Not XenServer so moving on.");
             return;
         }
 
@@ -565,7 +563,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
             _clusterDao.update(cluster.getId(), cluster);
         } else if (!cluster.getGuid().equals(startup.getPool())) {
             String msg = "pool uuid for cluster " + cluster.getId() + " changed from " + cluster.getGuid() + " to " + startup.getPool();
-            s_logger.warn(msg);
+            logger.warn(msg);
             throw new CloudRuntimeException(msg);
         }
 
@@ -579,15 +577,15 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
 
         if (!resource.equals(host.getResource())) {
             String msg = "host " + host.getPrivateIpAddress() + " changed from " + host.getResource() + " to " + resource;
-            s_logger.debug(msg);
+            logger.debug(msg);
             host.setResource(resource);
             host.setSetup(false);
             _hostDao.update(agentId, host);
             throw new HypervisorVersionChangedException(msg);
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Setting up host " + agentId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Setting up host " + agentId);
         }
         HostEnvironment env = new HostEnvironment();
 
@@ -611,12 +609,12 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
                 }
                 return;
             } else {
-                s_logger.warn("Unable to setup agent " + agentId + " due to " + ((answer != null) ? answer.getDetails() : "return null"));
+                logger.warn("Unable to setup agent " + agentId + " due to " + ((answer != null) ? answer.getDetails() : "return null"));
             }
         } catch (AgentUnavailableException e) {
-            s_logger.warn("Unable to setup agent " + agentId + " because it became unavailable.", e);
+            logger.warn("Unable to setup agent " + agentId + " because it became unavailable.", e);
         } catch (OperationTimedoutException e) {
-            s_logger.warn("Unable to setup agent " + agentId + " because it timed out", e);
+            logger.warn("Unable to setup agent " + agentId + " because it timed out", e);
         }
         throw new ConnectionException(true, "Reinitialize agent after setup.");
     }
@@ -656,7 +654,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
 
         HostPodVO pod = _podDao.findById(host.getPodId());
         DataCenterVO dc = _dcDao.findById(host.getDataCenterId());
-        s_logger.info("Host: " + host.getName() + " connected with hypervisor type: " + HypervisorType.XenServer + ". Checking CIDR...");
+        logger.info("Host: " + host.getName() + " connected with hypervisor type: " + HypervisorType.XenServer + ". Checking CIDR...");
         _resourceMgr.checkCIDR(pod, dc, ssCmd.getPrivateIpAddress(), ssCmd.getPrivateNetmask());
         return _resourceMgr.fillRoutingHostVO(host, ssCmd, HypervisorType.XenServer, details, hostTags);
     }

--- a/plugins/network-elements/bigswitch/src/com/cloud/network/element/BigSwitchBcfElement.java
+++ b/plugins/network-elements/bigswitch/src/com/cloud/network/element/BigSwitchBcfElement.java
@@ -30,7 +30,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.network.ExternalNetworkDeviceManager.NetworkDevice;
 import org.apache.commons.net.util.SubnetUtils;
@@ -132,7 +131,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 public class BigSwitchBcfElement extends AdapterBase implements BigSwitchBcfElementService,
 ConnectivityProvider, IpDeployer, SourceNatServiceProvider, StaticNatServiceProvider,
 NetworkACLServiceProvider, FirewallServiceProvider, ResourceStateAdapter {
-    private static final Logger s_logger = Logger.getLogger(BigSwitchBcfElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -198,18 +196,18 @@ NetworkACLServiceProvider, FirewallServiceProvider, ResourceStateAdapter {
     }
 
     private boolean canHandle(Network network, Service service) {
-        s_logger.debug("Checking if BigSwitchBcfElement can handle service " + service.getName() + " on network " + network.getDisplayText());
+        logger.debug("Checking if BigSwitchBcfElement can handle service " + service.getName() + " on network " + network.getDisplayText());
         if (network.getBroadcastDomainType() != BroadcastDomainType.Vlan) {
             return false;
         }
 
         if (!_networkModel.isProviderForNetwork(getProvider(), network.getId())) {
-            s_logger.debug("BigSwitchBcfElement is not a provider for network " + network.getDisplayText());
+            logger.debug("BigSwitchBcfElement is not a provider for network " + network.getDisplayText());
             return false;
         }
 
         if (!_ntwkSrvcDao.canProviderSupportServiceInNetwork(network.getId(), service, BcfConstants.BIG_SWITCH_BCF)) {
-            s_logger.debug("BigSwitchBcfElement can't provide the " + service.getName() + " service on network " + network.getDisplayText());
+            logger.debug("BigSwitchBcfElement can't provide the " + service.getName() + " service on network " + network.getDisplayText());
             return false;
         }
 
@@ -302,7 +300,7 @@ NetworkACLServiceProvider, FirewallServiceProvider, ResourceStateAdapter {
         }
 
         if (network.getBroadcastUri() == null) {
-            s_logger.error("Nic has no broadcast Uri");
+            logger.error("Nic has no broadcast Uri");
             return false;
         }
 
@@ -360,7 +358,7 @@ NetworkACLServiceProvider, FirewallServiceProvider, ResourceStateAdapter {
     @Override
     public boolean verifyServicesCombination(Set<Service> services) {
         if (!services.contains(Service.Connectivity)) {
-            s_logger.warn("Unable to provide services without Connectivity service enabled for this element");
+            logger.warn("Unable to provide services without Connectivity service enabled for this element");
             return false;
         }
         return true;
@@ -646,14 +644,14 @@ NetworkACLServiceProvider, FirewallServiceProvider, ResourceStateAdapter {
             String dstIp = rule.getDestIpAddress();
             String mac = rule.getSourceMacAddress();
             if(!rule.isForRevoke()) {
-                s_logger.debug("BCF enables static NAT for public IP: " + srcIp + " private IP " + dstIp
+                logger.debug("BCF enables static NAT for public IP: " + srcIp + " private IP " + dstIp
                         + " mac " + mac);
                 CreateBcfStaticNatCommand cmd = new CreateBcfStaticNatCommand(
                         tenantId, network.getUuid(), dstIp, srcIp, mac);
 
                 _bcfUtils.sendBcfCommandWithNetworkSyncCheck(cmd, network);
             } else {
-                s_logger.debug("BCF removes static NAT for public IP: " + srcIp + " private IP " + dstIp
+                logger.debug("BCF removes static NAT for public IP: " + srcIp + " private IP " + dstIp
                         + " mac " + mac);
                 DeleteBcfStaticNatCommand cmd = new DeleteBcfStaticNatCommand(tenantId, srcIp);
 

--- a/plugins/network-elements/bigswitch/src/com/cloud/network/guru/BigSwitchBcfGuestNetworkGuru.java
+++ b/plugins/network-elements/bigswitch/src/com/cloud/network/guru/BigSwitchBcfGuestNetworkGuru.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.context.CallContext;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.CreateBcfAttachmentCommand;
@@ -92,7 +91,6 @@ import com.cloud.vm.dao.VMInstanceDao;
  */
 @Local(value = NetworkGuru.class)
 public class BigSwitchBcfGuestNetworkGuru extends GuestNetworkGuru implements NetworkMigrationResponder {
-    private static final Logger s_logger = Logger.getLogger(BigSwitchBcfGuestNetworkGuru.class);
 
     @Inject
     PhysicalNetworkDao _physicalNetworkDao;
@@ -140,7 +138,7 @@ public class BigSwitchBcfGuestNetworkGuru extends GuestNetworkGuru implements Ne
             isMyIsolationMethod(physicalNetwork)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }
@@ -150,21 +148,21 @@ public class BigSwitchBcfGuestNetworkGuru extends GuestNetworkGuru implements Ne
         // Check if the isolation type of the physical network is BCF_SEGMENT, then delegate GuestNetworkGuru to design
         PhysicalNetworkVO physnet = _physicalNetworkDao.findById(plan.getPhysicalNetworkId());
         if (physnet == null || physnet.getIsolationMethods() == null || !physnet.getIsolationMethods().contains("BCF_SEGMENT")) {
-            s_logger.debug("Refusing to design this network, the physical isolation type is not BCF_SEGMENT");
+            logger.debug("Refusing to design this network, the physical isolation type is not BCF_SEGMENT");
             return null;
         }
 
         List<BigSwitchBcfDeviceVO> devices = _bigswitchBcfDao.listByPhysicalNetwork(physnet.getId());
         if (devices.isEmpty()) {
-            s_logger.error("No BigSwitch Controller on physical network " + physnet.getName());
+            logger.error("No BigSwitch Controller on physical network " + physnet.getName());
             return null;
         }
         for (BigSwitchBcfDeviceVO d: devices){
-            s_logger.debug("BigSwitch Controller " + d.getUuid()
+            logger.debug("BigSwitch Controller " + d.getUuid()
                     + " found on physical network " + physnet.getId());
         }
 
-        s_logger.debug("Physical isolation type is BCF_SEGMENT, asking GuestNetworkGuru to design this network");
+        logger.debug("Physical isolation type is BCF_SEGMENT, asking GuestNetworkGuru to design this network");
         NetworkVO networkObject = (NetworkVO)super.design(offering, plan, userSpecified, owner);
         if (networkObject == null) {
             return null;
@@ -312,7 +310,7 @@ public class BigSwitchBcfGuestNetworkGuru extends GuestNetworkGuru implements Ne
     public void shutdown(NetworkProfile profile, NetworkOffering offering) {
         NetworkVO networkObject = _networkDao.findById(profile.getId());
         if (networkObject.getBroadcastDomainType() != BroadcastDomainType.Vlan || networkObject.getBroadcastUri() == null) {
-            s_logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
+            logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
             return;
         }
 
@@ -356,7 +354,7 @@ public class BigSwitchBcfGuestNetworkGuru extends GuestNetworkGuru implements Ne
             tenantId = vpc.getUuid();
             tenantName = vpc.getName();
             boolean released = _vpcDao.releaseFromLockTable(vpc.getId());
-            s_logger.debug("BCF guru release lock vpc id: " + vpc.getId()
+            logger.debug("BCF guru release lock vpc id: " + vpc.getId()
                     + " released? " + released);
         } else {
             // use network id in CS as tenant in BSN
@@ -402,14 +400,14 @@ public class BigSwitchBcfGuestNetworkGuru extends GuestNetworkGuru implements Ne
     public void rollbackMigration(NicProfile nic, Network network,
             VirtualMachineProfile vm, ReservationContext src,
             ReservationContext dst) {
-        s_logger.debug("BCF guru rollback migration");
+        logger.debug("BCF guru rollback migration");
     }
 
     @Override
     public void commitMigration(NicProfile nic, Network network,
             VirtualMachineProfile vm, ReservationContext src,
             ReservationContext dst) {
-        s_logger.debug("BCF guru commit migration");
+        logger.debug("BCF guru commit migration");
     }
 
     private void bcfUtilsInit(){

--- a/plugins/network-elements/bigswitch/src/com/cloud/network/resource/BigSwitchBcfResource.java
+++ b/plugins/network-elements/bigswitch/src/com/cloud/network/resource/BigSwitchBcfResource.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.IAgentControl;
 import com.cloud.agent.api.Answer;
@@ -70,7 +69,6 @@ import com.cloud.resource.ServerResource;
 import com.cloud.utils.component.ManagerBase;
 
 public class BigSwitchBcfResource extends ManagerBase implements ServerResource {
-    private static final Logger s_logger = Logger.getLogger(BigSwitchBcfResource.class);
 
     private String _name;
     private String _guid;
@@ -176,20 +174,20 @@ public class BigSwitchBcfResource extends ManagerBase implements ServerResource 
                 try{
                     executeRequest(new SyncBcfTopologyCommand(true, true), _numRetries);
                 } catch(Exception e){
-                    s_logger.error("BigSwitch BCF sync error", e);
+                    logger.error("BigSwitch BCF sync error", e);
                 }
             } else {
                 try{
                     executeRequest(new SyncBcfTopologyCommand(true, false), _numRetries);
                 } catch (Exception e){
-                    s_logger.error("BigSwitch BCF sync error", e);
+                    logger.error("BigSwitch BCF sync error", e);
                 }
             }
         }
         try {
             ControlClusterStatus ccs = _bigswitchBcfApi.getControlClusterStatus();
             if (!ccs.getStatus()) {
-                s_logger.error("ControlCluster state is not ready: " + ccs.getStatus());
+                logger.error("ControlCluster state is not ready: " + ccs.getStatus());
                 return null;
             }
             if (ccs.isTopologySyncRequested()) {
@@ -200,11 +198,11 @@ public class BigSwitchBcfResource extends ManagerBase implements ServerResource 
                         executeRequest(new SyncBcfTopologyCommand(true, false), _numRetries);
                     }
                 } else {
-                    s_logger.debug("topology sync needed but no topology history");
+                    logger.debug("topology sync needed but no topology history");
                 }
             }
         } catch (BigSwitchBcfApiException e) {
-            s_logger.error("getControlClusterStatus failed", e);
+            logger.error("getControlClusterStatus failed", e);
             return null;
         }
         try {
@@ -222,7 +220,7 @@ public class BigSwitchBcfResource extends ManagerBase implements ServerResource 
             }
 
         } catch (BigSwitchBcfApiException e) {
-            s_logger.error("getCapabilities failed", e);
+            logger.error("getCapabilities failed", e);
         }
         return new PingCommand(Host.Type.L2Networking, id);
     }
@@ -274,7 +272,7 @@ public class BigSwitchBcfResource extends ManagerBase implements ServerResource 
         } else if (cmd instanceof GetControllerDataCommand) {
             return executeRequest((GetControllerDataCommand)cmd, numRetries);
         }
-        s_logger.debug("Received unsupported command " + cmd.toString());
+        logger.debug("Received unsupported command " + cmd.toString());
         return Answer.createUnsupportedCommandAnswer(cmd);
     }
 
@@ -575,7 +573,7 @@ public class BigSwitchBcfResource extends ManagerBase implements ServerResource 
     }
 
     private Answer retry(Command cmd, int numRetries) {
-        s_logger.warn("Retrying " + cmd.getClass().getSimpleName() + ". Number of retries remaining: " + numRetries);
+        logger.warn("Retrying " + cmd.getClass().getSimpleName() + ". Number of retries remaining: " + numRetries);
         return executeRequest(cmd, numRetries);
     }
 

--- a/plugins/network-elements/brocade-vcs/src/com/cloud/network/element/BrocadeVcsElement.java
+++ b/plugins/network-elements/brocade-vcs/src/com/cloud/network/element/BrocadeVcsElement.java
@@ -30,7 +30,6 @@ import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.network.ExternalNetworkDeviceManager.NetworkDevice;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.AgentManager;
@@ -94,7 +93,6 @@ import com.cloud.vm.dao.NicDao;
 @Component
 @Local(value = {NetworkElement.class})
 public class BrocadeVcsElement extends AdapterBase implements NetworkElement, ResourceStateAdapter, BrocadeVcsElementService {
-    private static final Logger s_logger = Logger.getLogger(BrocadeVcsElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -140,18 +138,18 @@ public class BrocadeVcsElement extends AdapterBase implements NetworkElement, Re
     }
 
     protected boolean canHandle(Network network, Service service) {
-        s_logger.debug("Checking if BrocadeVcsElement can handle service " + service.getName() + " on network " + network.getDisplayText());
+        logger.debug("Checking if BrocadeVcsElement can handle service " + service.getName() + " on network " + network.getDisplayText());
         if (network.getBroadcastDomainType() != BroadcastDomainType.Vcs) {
             return false;
         }
 
         if (!_networkModel.isProviderForNetwork(getProvider(), network.getId())) {
-            s_logger.debug("BrocadeVcsElement is not a provider for network " + network.getDisplayText());
+            logger.debug("BrocadeVcsElement is not a provider for network " + network.getDisplayText());
             return false;
         }
 
         if (!_ntwkSrvcDao.canProviderSupportServiceInNetwork(network.getId(), service, Network.Provider.BrocadeVcs)) {
-            s_logger.debug("BrocadeVcsElement can't provide the " + service.getName() + " service on network " + network.getDisplayText());
+            logger.debug("BrocadeVcsElement can't provide the " + service.getName() + " service on network " + network.getDisplayText());
             return false;
         }
 
@@ -168,7 +166,7 @@ public class BrocadeVcsElement extends AdapterBase implements NetworkElement, Re
     @Override
     public boolean implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context) throws ConcurrentOperationException,
             ResourceUnavailableException, InsufficientCapacityException {
-        s_logger.debug("entering BrocadeVcsElement implement function for network " + network.getDisplayText() + " (state " + network.getState() + ")");
+        logger.debug("entering BrocadeVcsElement implement function for network " + network.getDisplayText() + " (state " + network.getState() + ")");
 
         if (!canHandle(network, Service.Connectivity)) {
             return false;
@@ -236,7 +234,7 @@ public class BrocadeVcsElement extends AdapterBase implements NetworkElement, Re
     public boolean verifyServicesCombination(Set<Service> services) {
 
         if (!services.contains(Service.Connectivity)) {
-            s_logger.warn("Unable to provide services without Connectivity service enabled for this element");
+            logger.warn("Unable to provide services without Connectivity service enabled for this element");
             return false;
         }
         return true;

--- a/plugins/network-elements/brocade-vcs/src/com/cloud/network/guru/BrocadeVcsGuestNetworkGuru.java
+++ b/plugins/network-elements/brocade-vcs/src/com/cloud/network/guru/BrocadeVcsGuestNetworkGuru.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.AssociateMacToNetworkAnswer;
@@ -65,7 +64,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = NetworkGuru.class)
 public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(BrocadeVcsGuestNetworkGuru.class);
 
     @Inject
     NetworkOfferingServiceMapDao _ntwkOfferingSrvcDao;
@@ -94,7 +92,7 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
                 && isMyIsolationMethod(physicalNetwork) && _ntwkOfferingSrvcDao.areServicesSupportedByNetworkOffering(offering.getId(), Service.Connectivity)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }
@@ -105,10 +103,10 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
         PhysicalNetworkVO physnet = _physicalNetworkDao.findById(plan.getPhysicalNetworkId());
         DataCenter dc = _dcDao.findById(plan.getDataCenterId());
         if (!canHandle(offering, dc.getNetworkType(), physnet)) {
-            s_logger.debug("Refusing to design this network");
+            logger.debug("Refusing to design this network");
             return null;
         }
-        s_logger.debug("Physical isolation type is VCS, asking GuestNetworkGuru to design this network");
+        logger.debug("Physical isolation type is VCS, asking GuestNetworkGuru to design this network");
         NetworkVO networkObject = (NetworkVO)super.design(offering, plan, userSpecified, owner);
         if (networkObject == null) {
             return null;
@@ -133,7 +131,7 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
 
         List<BrocadeVcsDeviceVO> devices = _brocadeVcsDao.listByPhysicalNetwork(physicalNetworkId);
         if (devices.isEmpty()) {
-            s_logger.error("No Brocade VCS Switch on physical network " + physicalNetworkId);
+            logger.error("No Brocade VCS Switch on physical network " + physicalNetworkId);
             return null;
         }
 
@@ -145,8 +143,8 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
             CreateNetworkAnswer answer = (CreateNetworkAnswer)_agentMgr.easySend(brocadeVcsHost.getId(), cmd);
 
             if (answer == null || !answer.getResult()) {
-                s_logger.error("CreateNetworkCommand failed");
-                s_logger.error("Unable to create network " + network.getId());
+                logger.error("CreateNetworkCommand failed");
+                logger.error("Unable to create network " + network.getId());
                 return null;
             }
 
@@ -170,7 +168,7 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
 
         List<BrocadeVcsDeviceVO> devices = _brocadeVcsDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Brocade VCS Switch on physical network " + network.getPhysicalNetworkId());
+            logger.error("No Brocade VCS Switch on physical network " + network.getPhysicalNetworkId());
             return;
         }
         for (BrocadeVcsDeviceVO brocadeVcsDevice : devices) {
@@ -182,7 +180,7 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
             AssociateMacToNetworkAnswer answer = (AssociateMacToNetworkAnswer)_agentMgr.easySend(brocadeVcsHost.getId(), cmd);
 
             if (answer == null || !answer.getResult()) {
-                s_logger.error("AssociateMacToNetworkCommand failed");
+                logger.error("AssociateMacToNetworkCommand failed");
                 throw new InsufficientVirtualNetworkCapacityException("Unable to associate mac " + interfaceMac + " to network " + network.getId(), DataCenter.class, dc.getId());
             }
         }
@@ -196,7 +194,7 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
 
         List<BrocadeVcsDeviceVO> devices = _brocadeVcsDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Brocade VCS Switch on physical network " + network.getPhysicalNetworkId());
+            logger.error("No Brocade VCS Switch on physical network " + network.getPhysicalNetworkId());
             return;
         }
         for (BrocadeVcsDeviceVO brocadeVcsDevice : devices) {
@@ -207,8 +205,8 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
             DisassociateMacFromNetworkAnswer answer = (DisassociateMacFromNetworkAnswer)_agentMgr.easySend(brocadeVcsHost.getId(), cmd);
 
             if (answer == null || !answer.getResult()) {
-                s_logger.error("DisassociateMacFromNetworkCommand failed");
-                s_logger.error("Unable to disassociate mac " + interfaceMac + " from network " + network.getId());
+                logger.error("DisassociateMacFromNetworkCommand failed");
+                logger.error("Unable to disassociate mac " + interfaceMac + " from network " + network.getId());
                 return;
             }
         }
@@ -236,13 +234,13 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
         if (brocadeVcsNetworkVlanMapping != null) {
             vlanTag = brocadeVcsNetworkVlanMapping.getVlanId();
         } else {
-            s_logger.error("Not able to find vlanId for network " + network.getId());
+            logger.error("Not able to find vlanId for network " + network.getId());
             return false;
         }
 
         List<BrocadeVcsDeviceVO> devices = _brocadeVcsDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Brocade VCS Switch on physical network " + network.getPhysicalNetworkId());
+            logger.error("No Brocade VCS Switch on physical network " + network.getPhysicalNetworkId());
             return false;
         }
         for (BrocadeVcsDeviceVO brocadeVcsDevice : devices) {
@@ -253,8 +251,8 @@ public class BrocadeVcsGuestNetworkGuru extends GuestNetworkGuru {
             DeleteNetworkAnswer answer = (DeleteNetworkAnswer)_agentMgr.easySend(brocadeVcsHost.getId(), cmd);
 
             if (answer == null || !answer.getResult()) {
-                s_logger.error("DeleteNetworkCommand failed");
-                s_logger.error("Unable to delete network " + network.getId());
+                logger.error("DeleteNetworkCommand failed");
+                logger.error("Unable to delete network " + network.getId());
                 return false;
             }
         }

--- a/plugins/network-elements/cisco-vnmc/src/com/cloud/network/element/CiscoVnmcElement.java
+++ b/plugins/network-elements/cisco-vnmc/src/com/cloud/network/element/CiscoVnmcElement.java
@@ -32,7 +32,6 @@ import javax.persistence.EntityExistsException;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.network.ExternalNetworkDeviceManager.NetworkDevice;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -137,7 +136,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Local(value = NetworkElement.class)
 public class CiscoVnmcElement extends AdapterBase implements SourceNatServiceProvider, FirewallServiceProvider, PortForwardingServiceProvider, IpDeployer,
         StaticNatServiceProvider, ResourceStateAdapter, NetworkElement, CiscoVnmcElementService, CiscoAsa1000vService {
-    private static final Logger s_logger = Logger.getLogger(CiscoVnmcElement.class);
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
     @Inject
@@ -274,7 +272,7 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
         final DataCenter zone = _entityMgr.findById(DataCenter.class, network.getDataCenterId());
 
         if (zone.getNetworkType() == NetworkType.Basic) {
-            s_logger.debug("Not handling network implement in zone of type " + NetworkType.Basic);
+            logger.debug("Not handling network implement in zone of type " + NetworkType.Basic);
             return false;
         }
 
@@ -284,24 +282,24 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
 
         final List<CiscoVnmcControllerVO> devices = _ciscoVnmcDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Cisco Vnmc device on network " + network.getName());
+            logger.error("No Cisco Vnmc device on network " + network.getName());
             return false;
         }
 
         List<CiscoAsa1000vDeviceVO> asaList = _ciscoAsa1000vDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (asaList.isEmpty()) {
-            s_logger.debug("No Cisco ASA 1000v device on network " + network.getName());
+            logger.debug("No Cisco ASA 1000v device on network " + network.getName());
             return false;
         }
 
         NetworkAsa1000vMapVO asaForNetwork = _networkAsa1000vMapDao.findByNetworkId(network.getId());
         if (asaForNetwork != null) {
-            s_logger.debug("Cisco ASA 1000v device already associated with network " + network.getName());
+            logger.debug("Cisco ASA 1000v device already associated with network " + network.getName());
             return true;
         }
 
         if (!_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.SourceNat, Provider.CiscoVnmc)) {
-            s_logger.error("SourceNat service is not provided by Cisco Vnmc device on network " + network.getName());
+            logger.error("SourceNat service is not provided by Cisco Vnmc device on network " + network.getName());
             return false;
         }
 
@@ -309,20 +307,20 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
             // ensure that there is an ASA 1000v assigned to this network
             CiscoAsa1000vDevice assignedAsa = assignAsa1000vToNetwork(network);
             if (assignedAsa == null) {
-                s_logger.error("Unable to assign ASA 1000v device to network " + network.getName());
+                logger.error("Unable to assign ASA 1000v device to network " + network.getName());
                 throw new CloudRuntimeException("Unable to assign ASA 1000v device to network " + network.getName());
             }
 
             ClusterVO asaCluster = _clusterDao.findById(assignedAsa.getClusterId());
             ClusterVSMMapVO clusterVsmMap = _clusterVsmMapDao.findByClusterId(assignedAsa.getClusterId());
             if (clusterVsmMap == null) {
-                s_logger.error("Vmware cluster " + asaCluster.getName() + " has no Cisco Nexus VSM device associated with it");
+                logger.error("Vmware cluster " + asaCluster.getName() + " has no Cisco Nexus VSM device associated with it");
                 throw new CloudRuntimeException("Vmware cluster " + asaCluster.getName() + " has no Cisco Nexus VSM device associated with it");
             }
 
             CiscoNexusVSMDeviceVO vsmDevice = _vsmDeviceDao.findById(clusterVsmMap.getVsmId());
             if (vsmDevice == null) {
-                s_logger.error("Unable to load details of Cisco Nexus VSM device associated with cluster " + asaCluster.getName());
+                logger.error("Unable to load details of Cisco Nexus VSM device associated with cluster " + asaCluster.getName());
                 throw new CloudRuntimeException("Unable to load details of Cisco Nexus VSM device associated with cluster " + asaCluster.getName());
             }
 
@@ -357,14 +355,14 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
                     long callerUserId = CallContext.current().getCallingUserId();
                     outsideIp = _ipAddrMgr.allocateIp(owner, false, caller, callerUserId, zone, true);
                 } catch (ResourceAllocationException e) {
-                    s_logger.error("Unable to allocate additional public Ip address. Exception details " + e);
+                    logger.error("Unable to allocate additional public Ip address. Exception details " + e);
                     throw new CloudRuntimeException("Unable to allocate additional public Ip address. Exception details " + e);
                 }
 
                 try {
                     outsideIp = _ipAddrMgr.associateIPToGuestNetwork(outsideIp.getId(), network.getId(), true);
                 } catch (ResourceAllocationException e) {
-                    s_logger.error("Unable to assign allocated additional public Ip " + outsideIp.getAddress().addr() + " to network with vlan " + vlanId +
+                    logger.error("Unable to assign allocated additional public Ip " + outsideIp.getAddress().addr() + " to network with vlan " + vlanId +
                         ". Exception details " + e);
                     throw new CloudRuntimeException("Unable to assign allocated additional public Ip " + outsideIp.getAddress().addr() + " to network with vlan " +
                         vlanId + ". Exception details " + e);
@@ -377,33 +375,33 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
             // all public ip addresses must be from same subnet, this essentially means single public subnet in zone
             if (!createLogicalEdgeFirewall(vlanId, network.getGateway(), gatewayNetmask, outsideIp.getAddress().addr(), sourceNatIp.getNetmask(), publicGateways,
                 ciscoVnmcHost.getId())) {
-                s_logger.error("Failed to create logical edge firewall in Cisco VNMC device for network " + network.getName());
+                logger.error("Failed to create logical edge firewall in Cisco VNMC device for network " + network.getName());
                 throw new CloudRuntimeException("Failed to create logical edge firewall in Cisco VNMC device for network " + network.getName());
             }
 
             // create stuff in VSM for ASA device
             if (!configureNexusVsmForAsa(vlanId, network.getGateway(), vsmDevice.getUserName(), vsmDevice.getPassword(), vsmDevice.getipaddr(),
                 assignedAsa.getInPortProfile(), ciscoVnmcHost.getId())) {
-                s_logger.error("Failed to configure Cisco Nexus VSM " + vsmDevice.getipaddr() + " for ASA device for network " + network.getName());
+                logger.error("Failed to configure Cisco Nexus VSM " + vsmDevice.getipaddr() + " for ASA device for network " + network.getName());
                 throw new CloudRuntimeException("Failed to configure Cisco Nexus VSM " + vsmDevice.getipaddr() + " for ASA device for network " + network.getName());
             }
 
             // configure source NAT
             if (!configureSourceNat(vlanId, network.getCidr(), sourceNatIp, ciscoVnmcHost.getId())) {
-                s_logger.error("Failed to configure source NAT in Cisco VNMC device for network " + network.getName());
+                logger.error("Failed to configure source NAT in Cisco VNMC device for network " + network.getName());
                 throw new CloudRuntimeException("Failed to configure source NAT in Cisco VNMC device for network " + network.getName());
             }
 
             // associate Asa 1000v instance with logical edge firewall
             if (!associateAsaWithLogicalEdgeFirewall(vlanId, assignedAsa.getManagementIp(), ciscoVnmcHost.getId())) {
-                s_logger.error("Failed to associate Cisco ASA 1000v (" + assignedAsa.getManagementIp() + ") with logical edge firewall in VNMC for network " +
+                logger.error("Failed to associate Cisco ASA 1000v (" + assignedAsa.getManagementIp() + ") with logical edge firewall in VNMC for network " +
                     network.getName());
                 throw new CloudRuntimeException("Failed to associate Cisco ASA 1000v (" + assignedAsa.getManagementIp() +
                     ") with logical edge firewall in VNMC for network " + network.getName());
             }
         } catch (CloudRuntimeException e) {
             unassignAsa1000vFromNetwork(network);
-            s_logger.error("CiscoVnmcElement failed", e);
+            logger.error("CiscoVnmcElement failed", e);
             return false;
         } catch (Exception e) {
             unassignAsa1000vFromNetwork(network);
@@ -479,7 +477,7 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
     @Override
     public boolean verifyServicesCombination(Set<Service> services) {
         if (!services.contains(Service.Firewall)) {
-            s_logger.warn("CiscoVnmc must be used as Firewall Service Provider in the network");
+            logger.warn("CiscoVnmc must be used as Firewall Service Provider in the network");
             return false;
         }
         return true;
@@ -644,26 +642,26 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
     public boolean applyFWRules(Network network, List<? extends FirewallRule> rules) throws ResourceUnavailableException {
 
         if (!_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Firewall, Provider.CiscoVnmc)) {
-            s_logger.error("Firewall service is not provided by Cisco Vnmc device on network " + network.getName());
+            logger.error("Firewall service is not provided by Cisco Vnmc device on network " + network.getName());
             return false;
         }
 
         // Find VNMC host for physical network
         List<CiscoVnmcControllerVO> devices = _ciscoVnmcDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Cisco Vnmc device on network " + network.getName());
+            logger.error("No Cisco Vnmc device on network " + network.getName());
             return true;
         }
 
         // Find if ASA 1000v is associated with network
         NetworkAsa1000vMapVO asaForNetwork = _networkAsa1000vMapDao.findByNetworkId(network.getId());
         if (asaForNetwork == null) {
-            s_logger.debug("Cisco ASA 1000v device is not associated with network " + network.getName());
+            logger.debug("Cisco ASA 1000v device is not associated with network " + network.getName());
             return true;
         }
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
+            logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return true;
         }
@@ -690,7 +688,7 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
             if (answer == null || !answer.getResult()) {
                 String details = (answer != null) ? answer.getDetails() : "details unavailable";
                 String msg = "Unable to apply firewall rules to Cisco ASA 1000v appliance due to: " + details + ".";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ResourceUnavailableException(msg, DataCenter.class, network.getDataCenterId());
             }
         }
@@ -702,26 +700,26 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
     public boolean applyPFRules(Network network, List<PortForwardingRule> rules) throws ResourceUnavailableException {
 
         if (!_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.PortForwarding, Provider.CiscoVnmc)) {
-            s_logger.error("Port forwarding service is not provided by Cisco Vnmc device on network " + network.getName());
+            logger.error("Port forwarding service is not provided by Cisco Vnmc device on network " + network.getName());
             return false;
         }
 
         // Find VNMC host for physical network
         List<CiscoVnmcControllerVO> devices = _ciscoVnmcDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Cisco Vnmc device on network " + network.getName());
+            logger.error("No Cisco Vnmc device on network " + network.getName());
             return true;
         }
 
         // Find if ASA 1000v is associated with network
         NetworkAsa1000vMapVO asaForNetwork = _networkAsa1000vMapDao.findByNetworkId(network.getId());
         if (asaForNetwork == null) {
-            s_logger.debug("Cisco ASA 1000v device is not associated with network " + network.getName());
+            logger.debug("Cisco ASA 1000v device is not associated with network " + network.getName());
             return true;
         }
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External firewall was asked to apply port forwarding rules for network with ID " + network.getId() +
+            logger.debug("External firewall was asked to apply port forwarding rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return true;
         }
@@ -745,7 +743,7 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
             if (answer == null || !answer.getResult()) {
                 String details = (answer != null) ? answer.getDetails() : "details unavailable";
                 String msg = "Unable to apply port forwarding rules to Cisco ASA 1000v appliance due to: " + details + ".";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ResourceUnavailableException(msg, DataCenter.class, network.getDataCenterId());
             }
         }
@@ -756,26 +754,26 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
     @Override
     public boolean applyStaticNats(Network network, List<? extends StaticNat> rules) throws ResourceUnavailableException {
         if (!_networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.StaticNat, Provider.CiscoVnmc)) {
-            s_logger.error("Static NAT service is not provided by Cisco Vnmc device on network " + network.getName());
+            logger.error("Static NAT service is not provided by Cisco Vnmc device on network " + network.getName());
             return false;
         }
 
         // Find VNMC host for physical network
         List<CiscoVnmcControllerVO> devices = _ciscoVnmcDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Cisco Vnmc device on network " + network.getName());
+            logger.error("No Cisco Vnmc device on network " + network.getName());
             return true;
         }
 
         // Find if ASA 1000v is associated with network
         NetworkAsa1000vMapVO asaForNetwork = _networkAsa1000vMapDao.findByNetworkId(network.getId());
         if (asaForNetwork == null) {
-            s_logger.debug("Cisco ASA 1000v device is not associated with network " + network.getName());
+            logger.debug("Cisco ASA 1000v device is not associated with network " + network.getName());
             return true;
         }
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External firewall was asked to apply static NAT rules for network with ID " + network.getId() +
+            logger.debug("External firewall was asked to apply static NAT rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return true;
         }
@@ -800,7 +798,7 @@ public class CiscoVnmcElement extends AdapterBase implements SourceNatServicePro
             if (answer == null || !answer.getResult()) {
                 String details = (answer != null) ? answer.getDetails() : "details unavailable";
                 String msg = "Unable to apply static NAT rules to Cisco ASA 1000v appliance due to: " + details + ".";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ResourceUnavailableException(msg, DataCenter.class, network.getDataCenterId());
             }
         }

--- a/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/element/ElasticLoadBalancerElement.java
+++ b/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/element/ElasticLoadBalancerElement.java
@@ -25,7 +25,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -58,7 +57,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Component
 @Local(value = NetworkElement.class)
 public class ElasticLoadBalancerElement extends AdapterBase implements LoadBalancingServiceProvider, IpDeployer {
-    private static final Logger s_logger = Logger.getLogger(ElasticLoadBalancerElement.class);
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
     @Inject
     NetworkModel _networkManager;
@@ -76,7 +74,7 @@ public class ElasticLoadBalancerElement extends AdapterBase implements LoadBalan
 
     private boolean canHandle(Network network, List<LoadBalancingRule> rules) {
         if (network.getGuestType() != Network.GuestType.Shared || network.getTrafficType() != TrafficType.Guest) {
-            s_logger.debug("Not handling network with type  " + network.getGuestType() + " and traffic type " + network.getTrafficType());
+            logger.debug("Not handling network with type  " + network.getGuestType() + " and traffic type " + network.getTrafficType());
             return false;
         }
 
@@ -86,7 +84,7 @@ public class ElasticLoadBalancerElement extends AdapterBase implements LoadBalan
             if (schemeCaps != null) {
                 for (LoadBalancingRule rule : rules) {
                     if (!schemeCaps.contains(rule.getScheme().toString())) {
-                        s_logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + this.getName());
+                        logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + this.getName());
                         return false;
                     }
                 }

--- a/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/ElasticLoadBalancerManagerImpl.java
+++ b/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/ElasticLoadBalancerManagerImpl.java
@@ -35,7 +35,6 @@ import org.apache.cloudstack.api.command.user.loadbalancer.CreateLoadBalancerRul
 import org.apache.cloudstack.config.ApiServiceConfiguration;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.AgentManager;
@@ -105,7 +104,6 @@ import com.cloud.vm.dao.NicDao;
 @Component
 @Local(value = {ElasticLoadBalancerManager.class})
 public class ElasticLoadBalancerManagerImpl extends ManagerBase implements ElasticLoadBalancerManager, VirtualMachineGuru {
-    private static final Logger s_logger = Logger.getLogger(ElasticLoadBalancerManagerImpl.class);
 
     @Inject
     private AgentManager _agentMgr;
@@ -164,7 +162,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
         try {
             answers = _agentMgr.send(elbVm.getHostId(), cmds);
         } catch (OperationTimedoutException e) {
-            s_logger.warn("ELB: Timed Out", e);
+            logger.warn("ELB: Timed Out", e);
             throw new AgentUnavailableException("Unable to send commands to virtual elbVm ", elbVm.getHostId(), e);
         }
 
@@ -251,7 +249,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
         DomainRouterVO elbVm = findElbVmForLb(rules.get(0));
 
         if (elbVm == null) {
-            s_logger.warn("Unable to apply lb rules, ELB vm  doesn't exist in the network " + network.getId());
+            logger.warn("Unable to apply lb rules, ELB vm  doesn't exist in the network " + network.getId());
             throw new ResourceUnavailableException("Unable to apply lb rules", DataCenter.class, network.getDataCenterId());
         }
 
@@ -271,10 +269,10 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
             }
             return applyLBRules(elbVm, lbRules, network.getId());
         } else if (elbVm.getState() == State.Stopped || elbVm.getState() == State.Stopping) {
-            s_logger.debug("ELB VM is in " + elbVm.getState() + ", so not sending apply LoadBalancing rules commands to the backend");
+            logger.debug("ELB VM is in " + elbVm.getState() + ", so not sending apply LoadBalancing rules commands to the backend");
             return true;
         } else {
-            s_logger.warn("Unable to apply loadbalancing rules, ELB VM is not in the right state " + elbVm.getState());
+            logger.warn("Unable to apply loadbalancing rules, ELB VM is not in the right state " + elbVm.getState());
             throw new ResourceUnavailableException("Unable to apply loadbalancing rules, ELB VM is not in the right state", VirtualRouter.class, elbVm.getId());
         }
     }
@@ -298,13 +296,13 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
         // this can sometimes happen, if DB is manually or programmatically manipulated
         if (offerings == null || offerings.size() < 2) {
             String msg = "Data integrity problem : System Offering For Elastic LB VM has been removed?";
-            s_logger.error(msg);
+            logger.error(msg);
             throw new ConfigurationException(msg);
         }
 
         String enabled = _configDao.getValue(Config.ElasticLoadBalancerEnabled.key());
         _enabled = (enabled == null) ? false : Boolean.parseBoolean(enabled);
-        s_logger.info("Elastic Load balancer enabled: " + _enabled);
+        logger.info("Elastic Load balancer enabled: " + _enabled);
         if (_enabled) {
             String traffType = _configDao.getValue(Config.ElasticLoadBalancerNetwork.key());
             if ("guest".equalsIgnoreCase(traffType)) {
@@ -313,11 +311,11 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
                 _frontendTrafficType = TrafficType.Public;
             } else
                 throw new ConfigurationException("ELB: Traffic type for front end of load balancer has to be guest or public; found : " + traffType);
-            s_logger.info("ELB: Elastic Load Balancer: will balance on " + traffType);
+            logger.info("ELB: Elastic Load Balancer: will balance on " + traffType);
             int gcIntervalMinutes = NumbersUtil.parseInt(configs.get(Config.ElasticLoadBalancerVmGcInterval.key()), 5);
             if (gcIntervalMinutes < 5)
                 gcIntervalMinutes = 5;
-            s_logger.info("ELB: Elastic Load Balancer: scheduling GC to run every " + gcIntervalMinutes + " minutes");
+            logger.info("ELB: Elastic Load Balancer: scheduling GC to run every " + gcIntervalMinutes + " minutes");
             _gcThreadPool = Executors.newScheduledThreadPool(1, new NamedThreadFactory("ELBVM-GC"));
             _gcThreadPool.scheduleAtFixedRate(new CleanupThread(), gcIntervalMinutes, gcIntervalMinutes, TimeUnit.MINUTES);
             _itMgr.registerGuru(VirtualMachine.Type.ElasticLoadBalancerVm, this);
@@ -329,7 +327,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
     }
 
     private DomainRouterVO stop(DomainRouterVO elbVm, boolean forced) throws ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("Stopping ELB vm " + elbVm);
+        logger.debug("Stopping ELB vm " + elbVm);
         try {
             _itMgr.advanceStop(elbVm.getUuid(), forced);
             return _routerDao.findById(elbVm.getId());
@@ -348,7 +346,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
         List<DomainRouterVO> unusedElbVms = _elbVmMapDao.listUnusedElbVms();
         if (unusedElbVms != null) {
             if (unusedElbVms.size() > 0) {
-                s_logger.info("Found " + unusedElbVms.size() + " unused ELB vms");
+                logger.info("Found " + unusedElbVms.size() + " unused ELB vms");
             }
             Set<Long> currentGcCandidates = new HashSet<Long>();
             for (DomainRouterVO elbVm : unusedElbVms) {
@@ -361,22 +359,22 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
                 boolean gceed = false;
 
                 try {
-                    s_logger.info("Attempting to stop ELB VM: " + elbVm);
+                    logger.info("Attempting to stop ELB VM: " + elbVm);
                     stop(elbVm, true);
                     gceed = true;
                 } catch (ConcurrentOperationException e) {
-                    s_logger.warn("Unable to stop unused ELB vm " + elbVm + " due to ", e);
+                    logger.warn("Unable to stop unused ELB vm " + elbVm + " due to ", e);
                 } catch (ResourceUnavailableException e) {
-                    s_logger.warn("Unable to stop unused ELB vm " + elbVm + " due to ", e);
+                    logger.warn("Unable to stop unused ELB vm " + elbVm + " due to ", e);
                     continue;
                 }
                 if (gceed) {
                     try {
-                        s_logger.info("Attempting to destroy ELB VM: " + elbVm);
+                        logger.info("Attempting to destroy ELB VM: " + elbVm);
                         _itMgr.expunge(elbVm.getUuid());
                         _routerDao.remove(elbVm.getId());
                     } catch (ResourceUnavailableException e) {
-                        s_logger.warn("Unable to destroy unused ELB vm " + elbVm + " due to ", e);
+                        logger.warn("Unable to destroy unused ELB vm " + elbVm + " due to ", e);
                         gceed = false;
                     }
                 }
@@ -446,14 +444,14 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
             } else if (nic.getTrafficType() == TrafficType.Control) {
                 //  control command is sent over management network in VMware
                 if (dest.getHost().getHypervisorType() == HypervisorType.VMware) {
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("Check if we need to add management server explicit route to ELB vm. pod cidr: " + dest.getPod().getCidrAddress() + "/"
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Check if we need to add management server explicit route to ELB vm. pod cidr: " + dest.getPod().getCidrAddress() + "/"
                                 + dest.getPod().getCidrSize() + ", pod gateway: " + dest.getPod().getGateway() + ", management host: "
                                 + ApiServiceConfiguration.ManagementHostIPAdr.value());
                     }
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Added management server explicit route to ELB vm.");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Added management server explicit route to ELB vm.");
                     }
                     // always add management explicit route, for basic networking setup
                     buf.append(" mgmtcidr=").append(_mgmtCidr);
@@ -479,8 +477,8 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
             buf.append(" dns2=").append(defaultDns2);
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Boot Args for " + profile + ": " + buf.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Boot Args for " + profile + ": " + buf.toString());
         }
 
         if (controlNic == null) {
@@ -515,7 +513,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
     public boolean finalizeStart(VirtualMachineProfile profile, long hostId, Commands cmds, ReservationContext context) {
         CheckSshAnswer answer = (CheckSshAnswer)cmds.getAnswer("checkSsh");
         if (answer == null || !answer.getResult()) {
-            s_logger.warn("Unable to ssh to the ELB VM: " + (answer != null ? answer.getDetails() : "No answer (answer for \"checkSsh\" was null)"));
+            logger.warn("Unable to ssh to the ELB VM: " + (answer != null ? answer.getDetails() : "No answer (answer for \"checkSsh\" was null)"));
             return false;
         }
 
@@ -550,7 +548,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
         }
 
         if (controlNic == null) {
-            s_logger.error("Control network doesn't exist for the ELB vm " + elbVm);
+            logger.error("Control network doesn't exist for the ELB vm " + elbVm);
             return false;
         }
 
@@ -568,7 +566,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
             lbRules.add(loadBalancing);
         }
 
-        s_logger.debug("Found " + lbRules.size() + " load balancing rule(s) to apply as a part of ELB vm " + elbVm + " start.");
+        logger.debug("Found " + lbRules.size() + " load balancing rule(s) to apply as a part of ELB vm " + elbVm + " start.");
         if (!lbRules.isEmpty()) {
             createApplyLoadBalancingRulesCommands(lbRules, elbVm, cmds, guestNetworkId);
         }

--- a/plugins/network-elements/f5/src/com/cloud/network/element/F5ExternalLoadBalancerElement.java
+++ b/plugins/network-elements/f5/src/com/cloud/network/element/F5ExternalLoadBalancerElement.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.google.gson.Gson;
 
@@ -97,7 +96,6 @@ import com.cloud.vm.VirtualMachineProfile;
 public class F5ExternalLoadBalancerElement extends ExternalLoadBalancerDeviceManagerImpl implements LoadBalancingServiceProvider, IpDeployer,
         F5ExternalLoadBalancerElementService, ExternalLoadBalancerDeviceManager {
 
-    private static final Logger s_logger = Logger.getLogger(F5ExternalLoadBalancerElement.class);
 
     @Inject
     NetworkModel _networkManager;
@@ -125,7 +123,7 @@ public class F5ExternalLoadBalancerElement extends ExternalLoadBalancerDeviceMan
     private boolean canHandle(Network config, List<LoadBalancingRule> rules) {
         if ((config.getGuestType() != Network.GuestType.Isolated && config.getGuestType() != Network.GuestType.Shared) || config.getTrafficType() != TrafficType.Guest) {
 
-            s_logger.trace("Not handling network with Type  " + config.getGuestType() + " and traffic type " + config.getTrafficType());
+            logger.trace("Not handling network with Type  " + config.getGuestType() + " and traffic type " + config.getTrafficType());
             return false;
         }
 
@@ -135,7 +133,7 @@ public class F5ExternalLoadBalancerElement extends ExternalLoadBalancerDeviceMan
             if (schemeCaps != null && rules != null && !rules.isEmpty()) {
                 for (LoadBalancingRule rule : rules) {
                     if (!schemeCaps.contains(rule.getScheme().toString())) {
-                        s_logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + this.getName());
+                        logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + this.getName());
                         return false;
                     }
                 }
@@ -517,8 +515,8 @@ public class F5ExternalLoadBalancerElement extends ExternalLoadBalancerDeviceMan
     public IpDeployer getIpDeployer(Network network) {
         ExternalLoadBalancerDeviceVO lbDevice = getExternalLoadBalancerForNetwork(network);
         if (lbDevice == null) {
-            s_logger.error("Cannot find external load balanacer for network " + network.getName());
-            s_logger.error("Make F5 as dummy ip deployer, since we likely met this when clean up resource after shutdown network");
+            logger.error("Cannot find external load balanacer for network " + network.getName());
+            logger.error("Make F5 as dummy ip deployer, since we likely met this when clean up resource after shutdown network");
             return this;
         }
         if (_networkManager.isNetworkInlineMode(network)) {

--- a/plugins/network-elements/globodns/src/com/globo/globodns/cloudstack/element/GloboDnsElement.java
+++ b/plugins/network-elements/globodns/src/com/globo/globodns/cloudstack/element/GloboDnsElement.java
@@ -29,7 +29,6 @@ import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.AgentManager;
@@ -82,7 +81,6 @@ import com.globo.globodns.cloudstack.resource.GloboDnsResource;
 @Local(NetworkElement.class)
 public class GloboDnsElement extends AdapterBase implements ResourceStateAdapter, NetworkElement, GloboDnsElementService, Configurable {
 
-    private static final Logger s_logger = Logger.getLogger(GloboDnsElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -134,7 +132,7 @@ public class GloboDnsElement extends AdapterBase implements ResourceStateAdapter
             throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
 
         if (!isTypeSupported(vm.getType())) {
-            s_logger.info("GloboDNS only manages records for VMs of type User, ConsoleProxy and DomainRouter. VM " + vm + " is " + vm.getType());
+            logger.info("GloboDNS only manages records for VMs of type User, ConsoleProxy and DomainRouter. VM " + vm + " is " + vm.getType());
             return false;
         }
 
@@ -164,7 +162,7 @@ public class GloboDnsElement extends AdapterBase implements ResourceStateAdapter
             ResourceUnavailableException {
 
         if (!isTypeSupported(vm.getType())) {
-            s_logger.info("GloboDNS only manages records for VMs of type User, ConsoleProxy and DomainRouter. VM " + vm + " is " + vm.getType());
+            logger.info("GloboDNS only manages records for VMs of type User, ConsoleProxy and DomainRouter. VM " + vm + " is " + vm.getType());
             return false;
         }
 

--- a/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/element/InternalLoadBalancerElement.java
+++ b/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/element/InternalLoadBalancerElement.java
@@ -27,8 +27,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.api.command.admin.internallb.ConfigureInternalLoadBalancerElementCmd;
 import org.apache.cloudstack.api.command.admin.internallb.CreateInternalLoadBalancerElementCmd;
 import org.apache.cloudstack.api.command.admin.internallb.ListInternalLoadBalancerElementsCmd;
@@ -57,6 +55,7 @@ import com.cloud.network.VirtualRouterProvider.Type;
 import com.cloud.network.dao.NetworkServiceMapDao;
 import com.cloud.network.dao.PhysicalNetworkServiceProviderDao;
 import com.cloud.network.dao.VirtualRouterProviderDao;
+import com.cloud.network.element.HAProxyLBRule;
 import com.cloud.network.element.IpDeployer;
 import com.cloud.network.element.LoadBalancingServiceProvider;
 import com.cloud.network.element.NetworkElement;
@@ -86,7 +85,6 @@ import com.cloud.vm.dao.DomainRouterDao;
 
 @Local(value = {NetworkElement.class})
 public class InternalLoadBalancerElement extends AdapterBase implements LoadBalancingServiceProvider, InternalLoadBalancerElementService, IpDeployer {
-    private static final Logger s_logger = Logger.getLogger(InternalLoadBalancerElement.class);
     protected static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
     private static InternalLoadBalancerElement internalLbElement = null;
 
@@ -110,6 +108,8 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
     ApplicationLoadBalancerRuleDao _appLbDao;
     @Inject
     EntityManager _entityMgr;
+    @Inject
+    private HAProxyLBRule haProxyLBRule;
 
     protected InternalLoadBalancerElement() {
     }
@@ -125,11 +125,11 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
         //works in Advance zone only
         DataCenter dc = _entityMgr.findById(DataCenter.class, config.getDataCenterId());
         if (dc.getNetworkType() != NetworkType.Advanced) {
-            s_logger.trace("Not hanling zone of network type " + dc.getNetworkType());
+            logger.trace("Not hanling zone of network type " + dc.getNetworkType());
             return false;
         }
         if (config.getGuestType() != Network.GuestType.Isolated || config.getTrafficType() != TrafficType.Guest) {
-            s_logger.trace("Not handling network with Type  " + config.getGuestType() + " and traffic type " + config.getTrafficType());
+            logger.trace("Not handling network with Type  " + config.getGuestType() + " and traffic type " + config.getTrafficType());
             return false;
         }
 
@@ -138,14 +138,14 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
             String schemeCaps = lbCaps.get(Capability.LbSchemes);
             if (schemeCaps != null && lbScheme != null) {
                 if (!schemeCaps.contains(lbScheme.toString())) {
-                    s_logger.debug("Scheme " + lbScheme.toString() + " is not supported by the provider " + getName());
+                    logger.debug("Scheme " + lbScheme.toString() + " is not supported by the provider " + getName());
                     return false;
                 }
             }
         }
 
         if (!_ntwkModel.isProviderSupportServiceInNetwork(config.getId(), Service.Lb, getProvider())) {
-            s_logger.trace("Element " + getProvider().getName() + " doesn't support service " + Service.Lb + " in the network " + config);
+            logger.trace("Element " + getProvider().getName() + " doesn't support service " + Service.Lb + " in the network " + config);
             return false;
         }
         return true;
@@ -163,10 +163,10 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
 
     @Override
     public boolean implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context) throws ConcurrentOperationException,
-        ResourceUnavailableException, InsufficientCapacityException {
+    ResourceUnavailableException, InsufficientCapacityException {
 
         if (!canHandle(network, null)) {
-            s_logger.trace("No need to implement " + getName());
+            logger.trace("No need to implement " + getName());
             return true;
         }
 
@@ -175,10 +175,10 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
 
     @Override
     public boolean prepare(Network network, NicProfile nic, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
-        throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
+            throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
 
         if (!canHandle(network, null)) {
-            s_logger.trace("No need to prepare " + getName());
+            logger.trace("No need to prepare " + getName());
             return true;
         }
 
@@ -197,16 +197,16 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
             Ip sourceIp = new Ip(ip);
             long active = _appLbDao.countActiveBySourceIp(sourceIp, network.getId());
             if (active > 0) {
-                s_logger.debug("Have to implement internal lb vm for source ip " + sourceIp + " as a part of network " + network + " implement as there are " + active +
-                    " internal lb rules exist for this ip");
+                logger.debug("Have to implement internal lb vm for source ip " + sourceIp + " as a part of network " + network + " implement as there are " + active +
+                        " internal lb rules exist for this ip");
                 List<? extends VirtualRouter> internalLbVms;
                 try {
                     internalLbVms = _internalLbMgr.deployInternalLbVm(network, sourceIp, dest, _accountMgr.getAccount(network.getAccountId()), null);
                 } catch (InsufficientCapacityException e) {
-                    s_logger.warn("Failed to deploy element " + getName() + " for ip " + sourceIp + " due to:", e);
+                    logger.warn("Failed to deploy element " + getName() + " for ip " + sourceIp + " due to:", e);
                     return false;
                 } catch (ConcurrentOperationException e) {
-                    s_logger.warn("Failed to deploy element " + getName() + " for ip " + sourceIp + " due to:", e);
+                    logger.warn("Failed to deploy element " + getName() + " for ip " + sourceIp + " due to:", e);
                     return false;
                 }
 
@@ -221,7 +221,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
 
     @Override
     public boolean release(Network network, NicProfile nic, VirtualMachineProfile vm, ReservationContext context) throws ConcurrentOperationException,
-        ResourceUnavailableException {
+    ResourceUnavailableException {
         return true;
     }
 
@@ -236,11 +236,11 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
             result = result && _internalLbMgr.destroyInternalLbVm(internalLbVm.getId(), context.getAccount(), context.getCaller().getId());
             if (cleanup) {
                 if (!result) {
-                    s_logger.warn("Failed to stop internal lb element " + internalLbVm + ", but would try to process clean up anyway.");
+                    logger.warn("Failed to stop internal lb element " + internalLbVm + ", but would try to process clean up anyway.");
                 }
                 result = (_internalLbMgr.destroyInternalLbVm(internalLbVm.getId(), context.getAccount(), context.getCaller().getId()));
                 if (!result) {
-                    s_logger.warn("Failed to clean up internal lb element " + internalLbVm);
+                    logger.warn("Failed to clean up internal lb element " + internalLbVm);
                 }
             }
         }
@@ -271,7 +271,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
 
     @Override
     public boolean shutdownProviderInstances(PhysicalNetworkServiceProvider provider, ReservationContext context) throws ConcurrentOperationException,
-        ResourceUnavailableException {
+    ResourceUnavailableException {
         VirtualRouterProviderVO element = _vrProviderDao.findByNspIdAndType(provider.getId(), Type.InternalLbVm);
         if (element == null) {
             return true;
@@ -309,7 +309,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
 
         //2) Get rules to apply
         Map<Ip, List<LoadBalancingRule>> rulesToApply = getLbRulesToApply(rules);
-        s_logger.debug("Applying " + rulesToApply.size() + " on element " + getName());
+        logger.debug("Applying " + rulesToApply.size() + " on element " + getName());
 
         for (Ip sourceIp : rulesToApply.keySet()) {
             if (vmsToDestroy.contains(sourceIp)) {
@@ -318,11 +318,11 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
                 if (vms.size() > 0) {
                     //only one internal lb per IP exists
                     try {
-                        s_logger.debug("Destroying internal lb vm for ip " + sourceIp.addr() + " as all the rules for this vm are in Revoke state");
+                        logger.debug("Destroying internal lb vm for ip " + sourceIp.addr() + " as all the rules for this vm are in Revoke state");
                         return _internalLbMgr.destroyInternalLbVm(vms.get(0).getId(), _accountMgr.getAccount(Account.ACCOUNT_ID_SYSTEM),
-                            _accountMgr.getUserIncludingRemoved(User.UID_SYSTEM).getId());
+                                _accountMgr.getUserIncludingRemoved(User.UID_SYSTEM).getId());
                     } catch (ConcurrentOperationException e) {
-                        s_logger.warn("Failed to apply lb rule(s) for ip " + sourceIp.addr() + " on the element " + getName() + " due to:", e);
+                        logger.warn("Failed to apply lb rule(s) for ip " + sourceIp.addr() + " on the element " + getName() + " due to:", e);
                         return false;
                     }
                 }
@@ -333,10 +333,10 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
                     DeployDestination dest = new DeployDestination(_entityMgr.findById(DataCenter.class, network.getDataCenterId()), null, null, null);
                     internalLbVms = _internalLbMgr.deployInternalLbVm(network, sourceIp, dest, _accountMgr.getAccount(network.getAccountId()), null);
                 } catch (InsufficientCapacityException e) {
-                    s_logger.warn("Failed to apply lb rule(s) for ip " + sourceIp.addr() + "on the element " + getName() + " due to:", e);
+                    logger.warn("Failed to apply lb rule(s) for ip " + sourceIp.addr() + "on the element " + getName() + " due to:", e);
                     return false;
                 } catch (ConcurrentOperationException e) {
-                    s_logger.warn("Failed to apply lb rule(s) for ip " + sourceIp.addr() + "on the element " + getName() + " due to:", e);
+                    logger.warn("Failed to apply lb rule(s) for ip " + sourceIp.addr() + "on the element " + getName() + " due to:", e);
                     return false;
                 }
 
@@ -347,7 +347,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
                 //2.3 Apply Internal LB rules on the VM
                 if (!_internalLbMgr.applyLoadBalancingRules(network, rulesToApply.get(sourceIp), internalLbVms)) {
                     throw new CloudRuntimeException("Failed to apply load balancing rules for ip " + sourceIp.addr() + " in network " + network.getId() + " on element " +
-                        getName());
+                            getName());
                 }
             }
         }
@@ -372,7 +372,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
             //2) Check if there are non revoked rules for the source ip address
             List<LoadBalancingRule> rulesToCheck = groupedRules.get(sourceIp);
             if (_appLbDao.countBySourceIpAndNotRevoked(sourceIp, rulesToCheck.get(0).getNetworkId()) == 0) {
-                s_logger.debug("Have to destroy internal lb vm for source ip " + sourceIp + " as it has 0 rules in non-Revoke state");
+                logger.debug("Have to destroy internal lb vm for source ip " + sourceIp + " as it has 0 rules in non-Revoke state");
                 vmsToDestroy.add(sourceIp);
             }
         }
@@ -395,7 +395,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
                 rulesToApply.add(rule);
                 groupedRules.put(sourceIp, rulesToApply);
             } else {
-                s_logger.debug("Internal lb rule " + rule + " doesn't have any vms assigned, skipping");
+                logger.debug("Internal lb rule " + rule + " doesn't have any vms assigned, skipping");
             }
         }
         return groupedRules;
@@ -410,7 +410,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
             if (routers == null || routers.isEmpty()) {
                 return true;
             }
-            return VirtualRouterElement.validateHAProxyLBRule(rule);
+            return haProxyLBRule.validateHAProxyLBRule(rule);
         }
         return true;
     }
@@ -449,7 +449,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
         VirtualRouterProviderVO element = _vrProviderDao.findById(id);
         if (element == null || element.getType() != Type.InternalLbVm) {
             throw new InvalidParameterValueException("Can't find " + getName() + " element with network service provider id " + id + " to be used as a provider for " +
-                getName());
+                    getName());
         }
 
         element.setEnabled(enable);
@@ -462,7 +462,7 @@ public class InternalLoadBalancerElement extends AdapterBase implements LoadBala
     public VirtualRouterProvider addInternalLoadBalancerElement(long ntwkSvcProviderId) {
         VirtualRouterProviderVO element = _vrProviderDao.findByNspIdAndType(ntwkSvcProviderId, Type.InternalLbVm);
         if (element != null) {
-            s_logger.debug("There is already an " + getName() + " with service provider id " + ntwkSvcProviderId);
+            logger.debug("There is already an " + getName() + " with service provider id " + ntwkSvcProviderId);
             return null;
         }
 

--- a/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/lb/InternalLoadBalancerVMManagerImpl.java
+++ b/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/lb/InternalLoadBalancerVMManagerImpl.java
@@ -32,7 +32,6 @@ import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationSe
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.lb.ApplicationLoadBalancerRuleVO;
 import org.apache.cloudstack.lb.dao.ApplicationLoadBalancerRuleDao;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -121,7 +120,6 @@ import com.cloud.vm.dao.NicDao;
 
 @Local(value = {InternalLoadBalancerVMManager.class, InternalLoadBalancerVMService.class})
 public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements InternalLoadBalancerVMManager, InternalLoadBalancerVMService, VirtualMachineGuru {
-    private static final Logger s_logger = Logger.getLogger(InternalLoadBalancerVMManagerImpl.class);
     static final private String InternalLbVmNamePrefix = "b";
 
     private String _instance;
@@ -206,13 +204,13 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
                 controlNic = nic;
                 // Internal LB control command is sent over management server in VMware
                 if (dest.getHost().getHypervisorType() == HypervisorType.VMware) {
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("Check if we need to add management server explicit route to Internal LB. pod cidr: " + dest.getPod().getCidrAddress() + "/" +
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Check if we need to add management server explicit route to Internal LB. pod cidr: " + dest.getPod().getCidrAddress() + "/" +
                                 dest.getPod().getCidrSize() + ", pod gateway: " + dest.getPod().getGateway() + ", management host: " + _mgmtHost);
                     }
 
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("Add management server explicit route to Internal LB.");
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Add management server explicit route to Internal LB.");
                     }
 
                     buf.append(" mgmtcidr=").append(_mgmtCidr);
@@ -235,8 +233,8 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         final String type = "ilbvm";
         buf.append(" type=" + type);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Boot Args for " + profile + ": " + buf.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Boot Args for " + profile + ": " + buf.toString());
         }
 
         return true;
@@ -271,7 +269,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         if (answer != null && answer instanceof CheckSshAnswer) {
             final CheckSshAnswer sshAnswer = (CheckSshAnswer)answer;
             if (sshAnswer == null || !sshAnswer.getResult()) {
-                s_logger.warn("Unable to ssh to the internal LB VM: " + sshAnswer.getDetails());
+                logger.warn("Unable to ssh to the internal LB VM: " + sshAnswer.getDetails());
                 result = false;
             }
         } else {
@@ -295,7 +293,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         if (answer != null && answer instanceof GetDomRVersionAnswer) {
             final GetDomRVersionAnswer versionAnswer = (GetDomRVersionAnswer)answer;
             if (answer == null || !answer.getResult()) {
-                s_logger.warn("Unable to get the template/scripts version of internal LB VM " + internalLbVm.getInstanceName() + " due to: " + versionAnswer.getDetails());
+                logger.warn("Unable to get the template/scripts version of internal LB VM " + internalLbVm.getInstanceName() + " due to: " + versionAnswer.getDetails());
                 result = false;
             } else {
                 internalLbVm.setTemplateVersion(versionAnswer.getTemplateVersion());
@@ -315,7 +313,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         final NicProfile controlNic = getNicProfileByTrafficType(profile, TrafficType.Control);
 
         if (controlNic == null) {
-            s_logger.error("Control network doesn't exist for the internal LB vm " + internalLbVm);
+            logger.error("Control network doesn't exist for the internal LB vm " + internalLbVm);
             return false;
         }
 
@@ -375,7 +373,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
             if (off != null) {
                 _internalLbVmOfferingId = off.getId();
             } else {
-                s_logger.warn("Invalid offering UUID is passed in " + Config.InternalLbVmServiceOfferingId.key() + "; the default offering will be used instead");
+                logger.warn("Invalid offering UUID is passed in " + Config.InternalLbVmServiceOfferingId.key() + "; the default offering will be used instead");
             }
         }
 
@@ -387,15 +385,15 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
                     Storage.ProvisioningType.THIN, true, null, true, VirtualMachine.Type.InternalLoadBalancerVm, true);
             if (offerings == null || offerings.size() < 2) {
                 String msg = "Data integrity problem : System Offering For Internal LB VM has been removed?";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ConfigurationException(msg);
             }
         }
 
         _itMgr.registerGuru(VirtualMachine.Type.InternalLoadBalancerVm, this);
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info(getName() + " has been configured");
+        if (logger.isInfoEnabled()) {
+            logger.info(getName() + " has been configured");
         }
 
         return true;
@@ -426,7 +424,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
     }
 
     protected void finalizeLbRulesForIp(final Commands cmds, final DomainRouterVO internalLbVm, final Provider provider, final Ip sourceIp, final long guestNtwkId) {
-        s_logger.debug("Resending load balancing rules as a part of start for " + internalLbVm);
+        logger.debug("Resending load balancing rules as a part of start for " + internalLbVm);
         final List<ApplicationLoadBalancerRuleVO> lbs = _lbDao.listBySrcIpSrcNtwkId(sourceIp, guestNtwkId);
         final List<LoadBalancingRule> lbRules = new ArrayList<LoadBalancingRule>();
         if (_ntwkModel.isProviderSupportServiceInNetwork(guestNtwkId, Service.Lb, provider)) {
@@ -440,7 +438,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
             }
         }
 
-        s_logger.debug("Found " + lbRules.size() + " load balancing rule(s) to apply as a part of Intenrnal LB vm" + internalLbVm + " start.");
+        logger.debug("Found " + lbRules.size() + " load balancing rule(s) to apply as a part of Intenrnal LB vm" + internalLbVm + " start.");
         if (!lbRules.isEmpty()) {
             createApplyLoadBalancingRulesCommands(lbRules, internalLbVm, cmds, guestNtwkId);
         }
@@ -507,7 +505,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         }
 
         if (controlIpAddress == null) {
-            s_logger.warn("Unable to find Internal LB control ip in its attached NICs!. Internal LB vm: " + internalLbVmId);
+            logger.warn("Unable to find Internal LB control ip in its attached NICs!. Internal LB vm: " + internalLbVmId);
             final DomainRouterVO internalLbVm = _internalLbVmDao.findById(internalLbVmId);
             return internalLbVm.getPrivateIpAddress();
         }
@@ -517,8 +515,8 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
 
     @Override
     public boolean destroyInternalLbVm(final long vmId, final Account caller, final Long callerUserId) throws ResourceUnavailableException, ConcurrentOperationException {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Attempting to destroy Internal LB vm " + vmId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Attempting to destroy Internal LB vm " + vmId);
         }
 
         final DomainRouterVO internalLbVm = _internalLbVmDao.findById(vmId);
@@ -548,7 +546,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
 
     protected VirtualRouter stopInternalLbVm(final DomainRouterVO internalLbVm, final boolean forced, final Account caller, final long callerUserId) throws ResourceUnavailableException,
     ConcurrentOperationException {
-        s_logger.debug("Stopping internal lb vm " + internalLbVm);
+        logger.debug("Stopping internal lb vm " + internalLbVm);
         try {
             _itMgr.advanceStop(internalLbVm.getUuid(), forced);
             return _internalLbVmDao.findById(internalLbVm.getId());
@@ -573,7 +571,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         if (internalLbVms != null) {
             runningInternalLbVms = new ArrayList<DomainRouterVO>();
         } else {
-            s_logger.debug("Have no internal lb vms to start");
+            logger.debug("Have no internal lb vms to start");
             return null;
         }
 
@@ -599,8 +597,8 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
             throw new ConcurrentOperationException("Unable to lock network " + guestNetwork.getId());
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Lock is acquired for network id " + lock.getId() + " as a part of internal lb startup in " + dest);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Lock is acquired for network id " + lock.getId() + " as a part of internal lb startup in " + dest);
         }
 
         final long internalLbProviderId = getInternalLbProviderId(guestNetwork);
@@ -616,7 +614,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
             final DeploymentPlan plan = planAndInternalLbVms.first();
 
             if (internalLbVms.size() > 0) {
-                s_logger.debug("Found " + internalLbVms.size() + " internal lb vms for the requested IP " + requestedGuestIp.addr());
+                logger.debug("Found " + internalLbVms.size() + " internal lb vms for the requested IP " + requestedGuestIp.addr());
                 return internalLbVms;
             }
 
@@ -636,8 +634,8 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         } finally {
             if (lock != null) {
                 _networkDao.releaseFromLockTable(lock.getId());
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Lock is released for network id " + lock.getId() + " as a part of internal lb vm startup in " + dest);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Lock is released for network id " + lock.getId() + " as a part of internal lb vm startup in " + dest);
                 }
             }
         }
@@ -669,7 +667,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
 
         //1) Guest network - default
         if (guestNetwork != null) {
-            s_logger.debug("Adding nic for Internal LB in Guest network " + guestNetwork);
+            logger.debug("Adding nic for Internal LB in Guest network " + guestNetwork);
             final NicProfile guestNic = new NicProfile();
             if (guestIp != null) {
                 guestNic.setIPv4Address(guestIp.addr());
@@ -688,7 +686,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         }
 
         //2) Control network
-        s_logger.debug("Adding nic for Internal LB vm in Control network ");
+        logger.debug("Adding nic for Internal LB vm in Control network ");
         final List<? extends NetworkOffering> offerings = _ntwkModel.getSystemAccountNetworkOfferings(NetworkOffering.SystemControlNetwork);
         final NetworkOffering controlOffering = offerings.get(0);
         final Network controlConfig = _ntwkMgr.setupNetwork(_accountMgr.getSystemAccount(), controlOffering, plan, null, null, false).get(0);
@@ -740,8 +738,8 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
             final HypervisorType hType = iter.next();
             try {
                 final long id = _internalLbVmDao.getNextInSequence(Long.class, "id");
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Creating the internal lb vm " + id + " in datacenter " + dest.getDataCenter() + " with hypervisor type " + hType);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Creating the internal lb vm " + id + " in datacenter " + dest.getDataCenter() + " with hypervisor type " + hType);
                 }
                 String templateName = null;
                 switch (hType) {
@@ -766,7 +764,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
                 final VMTemplateVO template = _templateDao.findRoutingTemplate(hType, templateName);
 
                 if (template == null) {
-                    s_logger.debug(hType + " won't support system vm, skip it");
+                    logger.debug(hType + " won't support system vm, skip it");
                     continue;
                 }
 
@@ -784,7 +782,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
                 internalLbVm = _internalLbVmDao.findById(internalLbVm.getId());
             } catch (final InsufficientCapacityException ex) {
                 if (allocateRetry < 2 && iter.hasNext()) {
-                    s_logger.debug("Failed to allocate the Internal lb vm with hypervisor type " + hType + ", retrying one more time");
+                    logger.debug("Failed to allocate the Internal lb vm with hypervisor type " + hType + ", retrying one more time");
                     continue;
                 } else {
                     throw ex;
@@ -799,7 +797,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
                     break;
                 } catch (final InsufficientCapacityException ex) {
                     if (startRetry < 2 && iter.hasNext()) {
-                        s_logger.debug("Failed to start the Internal lb vm  " + internalLbVm + " with hypervisor type " + hType + ", " +
+                        logger.debug("Failed to start the Internal lb vm  " + internalLbVm + " with hypervisor type " + hType + ", " +
                                 "destroying it and recreating one more time");
                         // destroy the internal lb vm
                         destroyInternalLbVm(internalLbVm.getId(), _accountMgr.getSystemAccount(), User.UID_SYSTEM);
@@ -820,10 +818,10 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
 
     protected DomainRouterVO startInternalLbVm(DomainRouterVO internalLbVm, final Account caller, final long callerUserId, final Map<Param, Object> params)
             throws StorageUnavailableException, InsufficientCapacityException, ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("Starting Internal LB VM " + internalLbVm);
+        logger.debug("Starting Internal LB VM " + internalLbVm);
         _itMgr.start(internalLbVm.getUuid(), params, null, null);
         if (internalLbVm.isStopPending()) {
-            s_logger.info("Clear the stop pending flag of Internal LB VM " + internalLbVm.getHostName() + " after start router successfully!");
+            logger.info("Clear the stop pending flag of Internal LB VM " + internalLbVm.getHostName() + " after start router successfully!");
             internalLbVm.setStopPending(false);
             internalLbVm = _internalLbVmDao.persist(internalLbVm);
         }
@@ -862,10 +860,10 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
     public boolean applyLoadBalancingRules(final Network network, final List<LoadBalancingRule> rules, final List<? extends VirtualRouter> internalLbVms)
             throws ResourceUnavailableException {
         if (rules == null || rules.isEmpty()) {
-            s_logger.debug("No lb rules to be applied for network " + network);
+            logger.debug("No lb rules to be applied for network " + network);
             return true;
         }
-        s_logger.info("lb rules to be applied for network ");
+        logger.info("lb rules to be applied for network ");
         //only one internal lb vm is supported per ip address at this time
         if (internalLbVms == null || internalLbVms.isEmpty()) {
             throw new CloudRuntimeException("Can't apply the lb rules on network " + network + " as the list of internal lb vms is empty");
@@ -875,10 +873,10 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         if (lbVm.getState() == State.Running) {
             return sendLBRules(lbVm, rules, network.getId());
         } else if (lbVm.getState() == State.Stopped || lbVm.getState() == State.Stopping) {
-            s_logger.debug("Internal LB VM " + lbVm.getInstanceName() + " is in " + lbVm.getState() + ", so not sending apply lb rules commands to the backend");
+            logger.debug("Internal LB VM " + lbVm.getInstanceName() + " is in " + lbVm.getState() + ", so not sending apply lb rules commands to the backend");
             return true;
         } else {
-            s_logger.warn("Unable to apply lb rules, Internal LB VM is not in the right state " + lbVm.getState());
+            logger.warn("Unable to apply lb rules, Internal LB VM is not in the right state " + lbVm.getState());
             throw new ResourceUnavailableException("Unable to apply lb rules; Internal LB VM is not in the right state", DataCenter.class, lbVm.getDataCenterId());
         }
     }
@@ -894,7 +892,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
         try {
             answers = _agentMgr.send(internalLbVm.getHostId(), cmds);
         } catch (final OperationTimedoutException e) {
-            s_logger.warn("Timed Out", e);
+            logger.warn("Timed Out", e);
             throw new AgentUnavailableException("Unable to send commands to virtual router ", internalLbVm.getHostId(), e);
         }
 

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_element.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_element.xml
@@ -42,5 +42,5 @@
     </bean>
   
     <bean class="org.apache.cloudstack.internallbelement.ElementChildTestConfiguration" />
-    
+    <bean class="com.cloud.network.element.HAProxyLBRule" />
 </beans>

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailElementImpl.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailElementImpl.java
@@ -32,7 +32,6 @@ import org.apache.cloudstack.network.contrail.model.InstanceIpModel;
 import org.apache.cloudstack.network.contrail.model.VMInterfaceModel;
 import org.apache.cloudstack.network.contrail.model.VirtualMachineModel;
 import org.apache.cloudstack.network.contrail.model.VirtualNetworkModel;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.deploy.DeployDestination;
@@ -85,7 +84,6 @@ public class ContrailElementImpl extends AdapterBase
     NicDao _nicDao;
     @Inject
     ServerDBSync _dbSync;
-    private static final Logger s_logger = Logger.getLogger(ContrailElement.class);
 
     // PluggableService
     @Override
@@ -122,9 +120,9 @@ public class ContrailElementImpl extends AdapterBase
     @Override
     public boolean implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context) throws ConcurrentOperationException,
         ResourceUnavailableException, InsufficientCapacityException {
-        s_logger.debug("NetworkElement implement: " + network.getName() + ", traffic type: " + network.getTrafficType());
+        logger.debug("NetworkElement implement: " + network.getName() + ", traffic type: " + network.getTrafficType());
         if (network.getTrafficType() == TrafficType.Guest) {
-            s_logger.debug("ignore network " + network.getName());
+            logger.debug("ignore network " + network.getName());
             return true;
         }
         VirtualNetworkModel vnModel = _manager.getDatabase().lookupVirtualNetwork(network.getUuid(), _manager.getCanonicalName(network), network.getTrafficType());
@@ -139,7 +137,7 @@ public class ContrailElementImpl extends AdapterBase
             }
             _manager.getDatabase().getVirtualNetworks().add(vnModel);
         } catch (Exception ex) {
-            s_logger.warn("virtual-network update: ", ex);
+            logger.warn("virtual-network update: ", ex);
         }
         return true;
     }
@@ -148,14 +146,14 @@ public class ContrailElementImpl extends AdapterBase
     public boolean prepare(Network network, NicProfile nicProfile, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
         throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
 
-        s_logger.debug("NetworkElement prepare: " + network.getName() + ", traffic type: " + network.getTrafficType());
+        logger.debug("NetworkElement prepare: " + network.getName() + ", traffic type: " + network.getTrafficType());
 
         if (network.getTrafficType() == TrafficType.Guest) {
-            s_logger.debug("ignore network " + network.getName());
+            logger.debug("ignore network " + network.getName());
             return true;
         }
 
-        s_logger.debug("network: " + network.getId());
+        logger.debug("network: " + network.getId());
 
         VirtualNetworkModel vnModel = _manager.getDatabase().lookupVirtualNetwork(network.getUuid(), _manager.getCanonicalName(network), network.getTrafficType());
 
@@ -185,7 +183,7 @@ public class ContrailElementImpl extends AdapterBase
         try {
             vmiModel.build(_manager.getModelController(), (VMInstanceVO)vm.getVirtualMachine(), nic);
         } catch (IOException ex) {
-            s_logger.warn("vm interface set", ex);
+            logger.warn("vm interface set", ex);
             return false;
         }
 
@@ -199,7 +197,7 @@ public class ContrailElementImpl extends AdapterBase
         try {
             vmModel.update(_manager.getModelController());
         } catch (Exception ex) {
-            s_logger.warn("virtual-machine-update", ex);
+            logger.warn("virtual-machine-update", ex);
             return false;
         }
         _manager.getDatabase().getVirtualMachines().add(vmModel);
@@ -213,7 +211,7 @@ public class ContrailElementImpl extends AdapterBase
         if (network.getTrafficType() == TrafficType.Guest) {
             return true;
         } else if (!_manager.isManagedPhysicalNetwork(network)) {
-            s_logger.debug("release ignore network " + network.getId());
+            logger.debug("release ignore network " + network.getId());
             return true;
         }
 
@@ -222,7 +220,7 @@ public class ContrailElementImpl extends AdapterBase
 
         VirtualMachineModel vmModel = _manager.getDatabase().lookupVirtualMachine(vm.getUuid());
         if (vmModel == null) {
-            s_logger.debug("vm " + vm.getInstanceName() + " not in local database");
+            logger.debug("vm " + vm.getInstanceName() + " not in local database");
             return true;
         }
         VMInterfaceModel vmiModel = vmModel.getVMInterface(nic.getUuid());
@@ -230,7 +228,7 @@ public class ContrailElementImpl extends AdapterBase
             try {
                 vmiModel.destroy(_manager.getModelController());
             } catch (IOException ex) {
-                s_logger.warn("virtual-machine-interface delete", ex);
+                logger.warn("virtual-machine-interface delete", ex);
             }
             vmModel.removeSuccessor(vmiModel);
         }
@@ -252,7 +250,7 @@ public class ContrailElementImpl extends AdapterBase
      */
     @Override
     public boolean shutdown(Network network, ReservationContext context, boolean cleanup) throws ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("NetworkElement shutdown");
+        logger.debug("NetworkElement shutdown");
         return true;
     }
 
@@ -261,7 +259,7 @@ public class ContrailElementImpl extends AdapterBase
      */
     @Override
     public boolean destroy(Network network, ReservationContext context) throws ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("NetworkElement destroy");
+        logger.debug("NetworkElement destroy");
         return true;
     }
 
@@ -275,11 +273,11 @@ public class ContrailElementImpl extends AdapterBase
                 List<NetworkVO> systemNets = _manager.findSystemNetworks(types);
                 if (systemNets != null && !systemNets.isEmpty()) {
                     for (NetworkVO net: systemNets) {
-                        s_logger.debug("update system network service: " + net.getName() + "; service provider: " + serviceMap);
+                        logger.debug("update system network service: " + net.getName() + "; service provider: " + serviceMap);
                         _networksDao.update(net.getId(), net, serviceMap);
                     }
                 } else {
-                    s_logger.debug("no system networks created yet");
+                    logger.debug("no system networks created yet");
                 }
                 serviceMap = ((ConfigurationServerImpl)_configServer).getServicesAndProvidersForNetwork( _manager.getPublicRouterOffering().getId());
                 types = new ArrayList<TrafficType>();
@@ -287,11 +285,11 @@ public class ContrailElementImpl extends AdapterBase
                 systemNets = _manager.findSystemNetworks(types);
                 if (systemNets != null && !systemNets.isEmpty()) {
                     for (NetworkVO net: systemNets) {
-                        s_logger.debug("update system network service: " + net.getName() + "; service provider: " + serviceMap);
+                        logger.debug("update system network service: " + net.getName() + "; service provider: " + serviceMap);
                         _networksDao.update(net.getId(), net, serviceMap);
                     }
                 } else {
-                    s_logger.debug("no system networks created yet");
+                    logger.debug("no system networks created yet");
                 }
                 return true;
        }
@@ -299,7 +297,7 @@ public class ContrailElementImpl extends AdapterBase
     @Override
     public boolean shutdownProviderInstances(PhysicalNetworkServiceProvider provider, ReservationContext context) throws ConcurrentOperationException,
         ResourceUnavailableException {
-        s_logger.debug("NetworkElement shutdown ProviderInstances");
+        logger.debug("NetworkElement shutdown ProviderInstances");
         return true;
     }
 
@@ -311,8 +309,8 @@ public class ContrailElementImpl extends AdapterBase
     @Override
     public boolean verifyServicesCombination(Set<Service> services) {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkElement verifyServices");
-        s_logger.debug("Services: " + services);
+        logger.debug("NetworkElement verifyServices");
+        logger.debug("Services: " + services);
         return true;
     }
 
@@ -330,11 +328,11 @@ public class ContrailElementImpl extends AdapterBase
             }
             if (isFloatingIpCreate(ip)) {
                 if (_manager.createFloatingIp(ip)) {
-                    s_logger.debug("Successfully created floating ip: " + ip.getAddress().addr());
+                    logger.debug("Successfully created floating ip: " + ip.getAddress().addr());
                 }
             } else {
                 if (_manager.deleteFloatingIp(ip)) {
-                    s_logger.debug("Successfully deleted floating ip: " + ip.getAddress().addr());
+                    logger.debug("Successfully deleted floating ip: " + ip.getAddress().addr());
                 }
             }
         }

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailGuru.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailGuru.java
@@ -28,7 +28,6 @@ import org.apache.cloudstack.network.contrail.model.InstanceIpModel;
 import org.apache.cloudstack.network.contrail.model.VMInterfaceModel;
 import org.apache.cloudstack.network.contrail.model.VirtualMachineModel;
 import org.apache.cloudstack.network.contrail.model.VirtualNetworkModel;
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenter.NetworkType;
@@ -91,7 +90,6 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
     @Inject
     DataCenterDao _dcDao;
 
-    private static final Logger s_logger = Logger.getLogger(ContrailGuru.class);
     private static final TrafficType[] TrafficTypes = {TrafficType.Guest};
 
     private boolean canHandle(NetworkOffering offering, NetworkType networkType, PhysicalNetwork physicalNetwork) {
@@ -126,7 +124,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
         PhysicalNetworkVO physnet = _physicalNetworkDao.findById(plan.getPhysicalNetworkId());
         DataCenter dc = _dcDao.findById(plan.getDataCenterId());
         if (!canHandle(offering, dc.getNetworkType(),physnet)) {
-            s_logger.debug("Refusing to design this network");
+            logger.debug("Refusing to design this network");
             return null;
         }
         NetworkVO network =
@@ -136,14 +134,14 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
             network.setCidr(userSpecified.getCidr());
             network.setGateway(userSpecified.getGateway());
         }
-        s_logger.debug("Allocated network " + userSpecified.getName() + (network.getCidr() == null ? "" : " subnet: " + network.getCidr()));
+        logger.debug("Allocated network " + userSpecified.getName() + (network.getCidr() == null ? "" : " subnet: " + network.getCidr()));
         return network;
     }
 
     @Override
     public Network implement(Network network, NetworkOffering offering, DeployDestination destination, ReservationContext context)
             throws InsufficientVirtualNetworkCapacityException {
-        s_logger.debug("Implement network: " + network.getName() + ", traffic type: " + network.getTrafficType());
+        logger.debug("Implement network: " + network.getName() + ", traffic type: " + network.getTrafficType());
 
         VirtualNetworkModel vnModel = _manager.getDatabase().lookupVirtualNetwork(network.getUuid(), _manager.getCanonicalName(network), network.getTrafficType());
         if (vnModel == null) {
@@ -156,7 +154,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
                 vnModel.update(_manager.getModelController());
             }
         } catch (Exception ex) {
-            s_logger.warn("virtual-network update: ", ex);
+            logger.warn("virtual-network update: ", ex);
             return network;
         }
         _manager.getDatabase().getVirtualNetworks().add(vnModel);
@@ -164,7 +162,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
         if (network.getVpcId() != null) {
             List<IPAddressVO> ips = _ipAddressDao.listByAssociatedVpc(network.getVpcId(), true);
             if (ips.isEmpty()) {
-                s_logger.debug("Creating a source nat ip for network " + network);
+                logger.debug("Creating a source nat ip for network " + network);
                 Account owner = _accountMgr.getAccount(network.getAccountId());
                 try {
                     PublicIp publicIp = _ipAddrMgr.assignSourceNatIpAddressToGuestNetwork(owner, network);
@@ -174,7 +172,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
                     _ipAddressDao.update(ip.getId(), ip);
                     _ipAddressDao.releaseFromLockTable(ip.getId());
                 } catch (Exception e) {
-                    s_logger.error("Unable to allocate source nat ip: " + e);
+                    logger.error("Unable to allocate source nat ip: " + e);
                 }
             }
         }
@@ -190,7 +188,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
     @Override
     public NicProfile allocate(Network network, NicProfile profile, VirtualMachineProfile vm) throws InsufficientVirtualNetworkCapacityException,
     InsufficientAddressCapacityException, ConcurrentOperationException {
-        s_logger.debug("allocate NicProfile on " + network.getName());
+        logger.debug("allocate NicProfile on " + network.getName());
 
         if (profile != null && profile.getRequestedIPv4() != null) {
             throw new CloudRuntimeException("Does not support custom ip allocation at this time: " + profile);
@@ -204,7 +202,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
         try {
             broadcastUri = new URI("vlan://untagged");
         } catch (Exception e) {
-            s_logger.warn("unable to instantiate broadcast URI: " + e);
+            logger.warn("unable to instantiate broadcast URI: " + e);
         }
         profile.setBroadcastUri(broadcastUri);
 
@@ -217,8 +215,8 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
     @Override
     public void reserve(NicProfile nic, Network network, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
             throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException, ConcurrentOperationException {
-        s_logger.debug("reserve NicProfile on network id: " + network.getId() + " " + network.getName());
-        s_logger.debug("deviceId: " + nic.getDeviceId());
+        logger.debug("reserve NicProfile on network id: " + network.getId() + " " + network.getName());
+        logger.debug("deviceId: " + nic.getDeviceId());
 
         NicVO nicVO = _nicDao.findById(nic.getId());
         assert nicVO != null;
@@ -244,7 +242,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
             vmiModel.build(_manager.getModelController(), (VMInstanceVO)vm.getVirtualMachine(), nicVO);
             vmiModel.setActive();
         } catch (IOException ex) {
-            s_logger.error("virtual-machine-interface set", ex);
+            logger.error("virtual-machine-interface set", ex);
             return;
         }
 
@@ -253,17 +251,17 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
             ipModel = new InstanceIpModel(vm.getInstanceName(), nic.getDeviceId());
             ipModel.addToVMInterface(vmiModel);
         } else {
-            s_logger.debug("Reuse existing instance-ip object on " + ipModel.getName());
+            logger.debug("Reuse existing instance-ip object on " + ipModel.getName());
         }
         if (nic.getIPv4Address() != null) {
-            s_logger.debug("Nic using existing IP address " + nic.getIPv4Address());
+            logger.debug("Nic using existing IP address " + nic.getIPv4Address());
             ipModel.setAddress(nic.getIPv4Address());
         }
 
         try {
             vmModel.update(_manager.getModelController());
         } catch (Exception ex) {
-            s_logger.warn("virtual-machine update", ex);
+            logger.warn("virtual-machine update", ex);
             return;
         }
 
@@ -274,15 +272,15 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
         if (nic.getMacAddress() == null) {
             MacAddressesType macs = vmi.getMacAddresses();
             if (macs == null) {
-                s_logger.debug("no mac address is allocated for Nic " + nicVO.getUuid());
+                logger.debug("no mac address is allocated for Nic " + nicVO.getUuid());
             } else {
-                s_logger.info("VMI " + _manager.getVifNameByVmUuid(vm.getUuid(), nicVO.getDeviceId()) + " got mac address: " + macs.getMacAddress().get(0));
+                logger.info("VMI " + _manager.getVifNameByVmUuid(vm.getUuid(), nicVO.getDeviceId()) + " got mac address: " + macs.getMacAddress().get(0));
                 nic.setMacAddress(macs.getMacAddress().get(0));
             }
         }
 
         if (nic.getIPv4Address() == null) {
-            s_logger.debug("Allocated IP address " + ipModel.getAddress());
+            logger.debug("Allocated IP address " + ipModel.getAddress());
             nic.setIPv4Address(ipModel.getAddress());
             if (network.getCidr() != null) {
                 nic.setIPv4Netmask(NetUtils.cidr2Netmask(network.getCidr()));
@@ -298,7 +296,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
     @Override
     public boolean release(NicProfile nic, VirtualMachineProfile vm, String reservationId) {
 
-        s_logger.debug("release NicProfile " + nic.getId());
+        logger.debug("release NicProfile " + nic.getId());
 
         return true;
     }
@@ -308,7 +306,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
      */
     @Override
     public void deallocate(Network network, NicProfile nic, VirtualMachineProfile vm) {
-        s_logger.debug("deallocate NicProfile " + nic.getId() + " on " + network.getName());
+        logger.debug("deallocate NicProfile " + nic.getId() + " on " + network.getName());
         NicVO nicVO = _nicDao.findById(nic.getId());
         assert nicVO != null;
 
@@ -332,7 +330,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
             try {
                 vmModel.delete(_manager.getModelController());
             } catch (IOException ex) {
-                s_logger.warn("virtual-machine delete", ex);
+                logger.warn("virtual-machine delete", ex);
                 return;
             }
         }
@@ -342,12 +340,12 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
     @Override
     public void updateNicProfile(NicProfile profile, Network network) {
         // TODO Auto-generated method stub
-        s_logger.debug("update NicProfile " + profile.getId() + " on " + network.getName());
+        logger.debug("update NicProfile " + profile.getId() + " on " + network.getName());
     }
 
     @Override
     public void shutdown(NetworkProfile network, NetworkOffering offering) {
-        s_logger.debug("NetworkGuru shutdown");
+        logger.debug("NetworkGuru shutdown");
         VirtualNetworkModel vnModel = _manager.getDatabase().lookupVirtualNetwork(network.getUuid(), _manager.getCanonicalName(network), network.getTrafficType());
         if (vnModel == null) {
             return;
@@ -356,21 +354,21 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
             _manager.getDatabase().getVirtualNetworks().remove(vnModel);
             vnModel.delete(_manager.getModelController());
         } catch (IOException e) {
-            s_logger.warn("virtual-network delete", e);
+            logger.warn("virtual-network delete", e);
         }
     }
 
     @Override
     public boolean trash(Network network, NetworkOffering offering) {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkGuru trash");
+        logger.debug("NetworkGuru trash");
         return true;
     }
 
     @Override
     public void updateNetworkProfile(NetworkProfile networkProfile) {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkGuru updateNetworkProfile");
+        logger.debug("NetworkGuru updateNetworkProfile");
     }
 
     @Override

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailManagerImpl.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailManagerImpl.java
@@ -50,7 +50,6 @@ import org.apache.cloudstack.network.contrail.model.ModelController;
 import org.apache.cloudstack.network.contrail.model.VirtualNetworkModel;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.ConfigurationManager;
 import com.cloud.configuration.ConfigurationService;
@@ -145,7 +144,6 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
     @Inject
     NetworkACLDao _networkAclDao;
 
-    private static final Logger s_logger = Logger.getLogger(ContrailManager.class);
 
     private ApiConnector _api;
 
@@ -175,8 +173,8 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
         try {
             _dbSyncTimer.schedule(new DBSyncTask(), 0, _dbSyncInterval);
         } catch (Exception ex) {
-            s_logger.debug("Unable to start DB Sync timer " + ex.getMessage());
-            s_logger.debug("timer start", ex);
+            logger.debug("Unable to start DB Sync timer " + ex.getMessage());
+            logger.debug("timer start", ex);
         }
         return true;
     }
@@ -340,10 +338,10 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
             }
             _api = ApiConnectorFactory.build(hostname, port);
         } catch (IOException ex) {
-            s_logger.warn("Unable to read " + configuration, ex);
+            logger.warn("Unable to read " + configuration, ex);
             throw new ConfigurationException();
         } catch (Exception ex) {
-            s_logger.debug("Exception in configure: " + ex);
+            logger.debug("Exception in configure: " + ex);
             ex.printStackTrace();
             throw new ConfigurationException();
         } finally {
@@ -360,7 +358,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
                     Provider.JuniperContrailVpcRouter);
             _vpcOffering = locateVpcOffering();
         }catch (Exception ex) {
-            s_logger.debug("Exception in locating network offerings: " + ex);
+            logger.debug("Exception in locating network offerings: " + ex);
             ex.printStackTrace();
             throw new ConfigurationException();
         }
@@ -524,12 +522,12 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
     public void syncNetworkDB(short syncMode) throws IOException {
         if (_dbSync.syncAll(syncMode) == ServerDBSync.SYNC_STATE_OUT_OF_SYNC) {
             if (syncMode == DBSyncGeneric.SYNC_MODE_CHECK) {
-                s_logger.info("# Cloudstack DB & VNC are out of sync #");
+                logger.info("# Cloudstack DB & VNC are out of sync #");
             } else {
-                s_logger.info("# Cloudstack DB & VNC were out of sync, performed re-sync operation #");
+                logger.info("# Cloudstack DB & VNC were out of sync, performed re-sync operation #");
             }
         } else {
-            s_logger.info("# Cloudstack DB & VNC are in sync #");
+            logger.info("# Cloudstack DB & VNC are in sync #");
         }
     }
 
@@ -539,13 +537,13 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
         @Override
         public void run() {
             try {
-                s_logger.debug("DB Sync task is running");
+                logger.debug("DB Sync task is running");
                 syncNetworkDB(_syncMode);
                 // Change to check mode
                 _syncMode = DBSyncGeneric.SYNC_MODE_CHECK;
             } catch (Exception ex) {
-                s_logger.debug(ex);
-                s_logger.info("Unable to sync network db");
+                logger.debug(ex);
+                logger.info("Unable to sync network db");
             }
         }
     }
@@ -596,7 +594,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
         sc.setParameters("trafficType", types.toArray());
         List<NetworkVO> dbNets = _networksDao.search(sc, null);
         if (dbNets == null) {
-            s_logger.debug("no system networks for the given traffic types: " + types.toString());
+            logger.debug("no system networks for the given traffic types: " + types.toString());
             dbNets = new ArrayList<NetworkVO>();
         }
 
@@ -671,7 +669,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
 
         List<NetworkVO> dbNets = _networksDao.search(sc, null);
         if (dbNets == null) {
-            s_logger.debug("no juniper managed networks for the given traffic types: " + types.toString());
+            logger.debug("no juniper managed networks for the given traffic types: " + types.toString());
             dbNets = new ArrayList<NetworkVO>();
         }
 
@@ -713,7 +711,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
         sc.setParameters("vpcOffering", getVpcOffering().getId());
         List<VpcVO> vpcs = _vpcDao.search(sc, null);
         if (vpcs == null || vpcs.size() == 0) {
-            s_logger.debug("no vpcs found");
+            logger.debug("no vpcs found");
             return null;
         }
         return vpcs;
@@ -737,7 +735,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
         sc.setParameters("vpcId", vpcIds.toArray());
         List<NetworkACLVO> acls = _networkAclDao.search(sc, null);
         if (acls == null || acls.size() == 0) {
-            s_logger.debug("no acls found");
+            logger.debug("no acls found");
             return null;
         }
         /* only return if acl is associated to any network */
@@ -761,7 +759,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
         List<NetworkVO> dbNets = findManagedNetworks(null);
 
         if (dbNets == null || dbNets.isEmpty()) {
-            s_logger.debug("Juniper managed networks is empty");
+            logger.debug("Juniper managed networks is empty");
             return null;
         }
 
@@ -783,7 +781,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
 
         List<IPAddressVO> publicIps = _ipAddressDao.search(sc, null);
         if (publicIps == null) {
-            s_logger.debug("no public ips");
+            logger.debug("no public ips");
             return null;
         }
 
@@ -808,7 +806,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
                         vnModel.update(getModelController());
                     }
                 } catch (Exception ex) {
-                    s_logger.warn("virtual-network update: ", ex);
+                    logger.warn("virtual-network update: ", ex);
                 }
                 getDatabase().getVirtualNetworks().add(vnModel);
             }
@@ -923,7 +921,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
             }
             getDatabase().getVirtualNetworks().add(vnModel);
         } catch (Exception ex) {
-            s_logger.warn("virtual-network update: ", ex);
+            logger.warn("virtual-network update: ", ex);
         }
         return vnModel;
     }
@@ -943,7 +941,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
                 fipPoolModel.update(getModelController());
                 vnModel.setFipPoolModel(fipPoolModel);
             } catch (Exception ex) {
-                s_logger.warn("floating-ip-pool create: ", ex);
+                logger.warn("floating-ip-pool create: ", ex);
                 return false;
             }
         }
@@ -957,7 +955,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
             try {
                 fipModel.update(getModelController());
             } catch (Exception ex) {
-                s_logger.warn("floating-ip create: ", ex);
+                logger.warn("floating-ip create: ", ex);
                 return false;
             }
         }
@@ -974,7 +972,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
             try {
                 fipModel.destroy(getModelController());
             } catch (IOException ex) {
-                s_logger.warn("floating ip delete", ex);
+                logger.warn("floating ip delete", ex);
                 return false;
             }
             fipPoolModel.removeSuccessor(fipModel);
@@ -998,7 +996,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
         try {
             fipPool = (FloatingIpPool)_api.findByFQN(FloatingIpPool.class, fipPoolName);
         } catch (Exception ex) {
-            s_logger.debug(ex);
+            logger.debug(ex);
         }
         if (fipPool == null) {
             return null;
@@ -1008,7 +1006,7 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
             try {
                 return (List<FloatingIp>)_api.getObjects(FloatingIp.class, ips);
             } catch (IOException ex) {
-                s_logger.debug(ex);
+                logger.debug(ex);
                 return null;
             }
         }

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailVpcElementImpl.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailVpcElementImpl.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import org.apache.cloudstack.network.contrail.model.VirtualNetworkModel;
 import org.apache.cloudstack.network.contrail.model.NetworkPolicyModel;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.deploy.DeployDestination;
@@ -48,8 +47,6 @@ import com.cloud.vm.ReservationContext;
 @Component
 @Local(value = {NetworkACLServiceProvider.class, VpcProvider.class, ContrailElementImpl.class})
 public class ContrailVpcElementImpl extends ContrailElementImpl implements NetworkACLServiceProvider, VpcProvider {
-    private static final Logger s_logger =
-            Logger.getLogger(ContrailElement.class);
 
     @Inject
     NetworkACLDao _networkACLDao;
@@ -65,7 +62,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
             ReservationContext context) throws ConcurrentOperationException,
             ResourceUnavailableException, InsufficientCapacityException {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkElement implementVpc");
+        logger.debug("NetworkElement implementVpc");
         return true;
     }
 
@@ -73,7 +70,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
     public boolean shutdownVpc(Vpc vpc, ReservationContext context)
             throws ConcurrentOperationException, ResourceUnavailableException {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkElement shutdownVpc");
+        logger.debug("NetworkElement shutdownVpc");
         return true;
     }
 
@@ -81,7 +78,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
     public boolean createPrivateGateway(PrivateGateway gateway)
             throws ConcurrentOperationException, ResourceUnavailableException {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkElement createPrivateGateway");
+        logger.debug("NetworkElement createPrivateGateway");
         return false;
     }
 
@@ -89,7 +86,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
     public boolean deletePrivateGateway(PrivateGateway privateGateway)
             throws ConcurrentOperationException, ResourceUnavailableException {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkElement deletePrivateGateway");
+        logger.debug("NetworkElement deletePrivateGateway");
         return false;
     }
 
@@ -97,7 +94,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
     public boolean applyStaticRoutes(Vpc vpc, List<StaticRouteProfile> routes)
             throws ResourceUnavailableException {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkElement applyStaticRoutes");
+        logger.debug("NetworkElement applyStaticRoutes");
         return true;
     }
 
@@ -105,9 +102,9 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
     public boolean applyNetworkACLs(Network net,
             List<? extends NetworkACLItem> rules)
                     throws ResourceUnavailableException {
-        s_logger.debug("NetworkElement applyNetworkACLs");
+        logger.debug("NetworkElement applyNetworkACLs");
         if (rules == null || rules.isEmpty()) {
-            s_logger.debug("no rules to apply");
+            logger.debug("no rules to apply");
             return true;
         }
 
@@ -127,7 +124,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
                     project = _manager.getDefaultVncProject();
                 }
             } catch (IOException ex) {
-                s_logger.warn("read project", ex);
+                logger.warn("read project", ex);
                 return false;
             }
             policyModel.setProject(project);
@@ -145,7 +142,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
         try {
             policyModel.build(_manager.getModelController(), rules);
         } catch (Exception e) {
-            s_logger.error(e);
+            logger.error(e);
             e.printStackTrace();
             return false;
         }
@@ -156,7 +153,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
             }
             _manager.getDatabase().getNetworkPolicys().add(policyModel);
         } catch (Exception ex) {
-            s_logger.error("network-policy update: ", ex);
+            logger.error("network-policy update: ", ex);
             ex.printStackTrace();
             return false;
         }
@@ -192,7 +189,7 @@ public class ContrailVpcElementImpl extends ContrailElementImpl implements Netwo
             List<? extends NetworkACLItem> rules)
                     throws ResourceUnavailableException {
         // TODO Auto-generated method stub
-        s_logger.debug("NetworkElement applyACLItemsToPrivateGw");
+        logger.debug("NetworkElement applyACLItemsToPrivateGw");
         return true;
     }
 

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ManagementNetworkGuru.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ManagementNetworkGuru.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.deploy.DeploymentPlan;
@@ -48,7 +47,6 @@ import com.cloud.utils.PropertiesUtil;
  */
 @Component
 public class ManagementNetworkGuru extends ContrailGuru {
-    private static final Logger s_logger = Logger.getLogger(ManagementNetworkGuru.class);
     private static final TrafficType[] TrafficTypes = {TrafficType.Management};
 
     private final String configuration = "contrail.properties";
@@ -71,7 +69,7 @@ public class ManagementNetworkGuru extends ContrailGuru {
             }
             inputFile = new FileInputStream(configFile);
         } catch (FileNotFoundException e) {
-            s_logger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new ConfigurationException(e.getMessage());
         }
 
@@ -79,14 +77,14 @@ public class ManagementNetworkGuru extends ContrailGuru {
         try {
             configProps.load(inputFile);
         } catch (IOException e) {
-            s_logger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new ConfigurationException(e.getMessage());
         } finally {
             closeAutoCloseable(inputFile, "error closing config file");
         }
         _mgmtCidr = configProps.getProperty("management.cidr");
         _mgmtGateway = configProps.getProperty("management.gateway");
-        s_logger.info("Management network " + _mgmtCidr + " gateway: " + _mgmtGateway);
+        logger.info("Management network " + _mgmtCidr + " gateway: " + _mgmtGateway);
         return true;
     }
 
@@ -123,7 +121,7 @@ public class ManagementNetworkGuru extends ContrailGuru {
             network.setCidr(_mgmtCidr);
             network.setGateway(_mgmtGateway);
         }
-        s_logger.debug("Allocated network " + userSpecified.getName() + (network.getCidr() == null ? "" : " subnet: " + network.getCidr()));
+        logger.debug("Allocated network " + userSpecified.getName() + (network.getCidr() == null ? "" : " subnet: " + network.getCidr()));
         return network;
     }
 

--- a/plugins/network-elements/juniper-contrail/test/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
+++ b/plugins/network-elements/juniper-contrail/test/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
@@ -24,7 +24,6 @@ import java.net.InetAddress;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.RoleType;
@@ -63,7 +62,6 @@ import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionStatus;
 
 public class MockAccountManager extends ManagerBase implements AccountManager {
-    private static final Logger s_logger = Logger.getLogger(MockAccountManager.class);
 
     @Inject
     AccountDao _accountDao;
@@ -88,7 +86,7 @@ public class MockAccountManager extends ManagerBase implements AccountManager {
             throw new ConfigurationException("Unable to find the system user using " + User.UID_SYSTEM);
         }
         CallContext.register(_systemUser, _systemAccount);
-        s_logger.info("MockAccountManager initialization successful");
+        logger.info("MockAccountManager initialization successful");
         return true;
     }
 

--- a/plugins/network-elements/juniper-srx/src/com/cloud/network/element/JuniperSRXExternalFirewallElement.java
+++ b/plugins/network-elements/juniper-srx/src/com/cloud/network/element/JuniperSRXExternalFirewallElement.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.response.ExternalFirewallResponse;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -94,7 +93,6 @@ import com.cloud.vm.VirtualMachineProfile;
 public class JuniperSRXExternalFirewallElement extends ExternalFirewallDeviceManagerImpl implements SourceNatServiceProvider, FirewallServiceProvider,
         PortForwardingServiceProvider, IpDeployer, JuniperSRXFirewallElementService, StaticNatServiceProvider {
 
-    private static final Logger s_logger = Logger.getLogger(JuniperSRXExternalFirewallElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -131,18 +129,18 @@ public class JuniperSRXExternalFirewallElement extends ExternalFirewallDeviceMan
         DataCenter zone = _entityMgr.findById(DataCenter.class, network.getDataCenterId());
         if ((zone.getNetworkType() == NetworkType.Advanced && !(network.getGuestType() == Network.GuestType.Isolated || network.getGuestType() == Network.GuestType.Shared)) ||
             (zone.getNetworkType() == NetworkType.Basic && network.getGuestType() != Network.GuestType.Shared)) {
-            s_logger.trace("Element " + getProvider().getName() + "is not handling network type = " + network.getGuestType());
+            logger.trace("Element " + getProvider().getName() + "is not handling network type = " + network.getGuestType());
             return false;
         }
 
         if (service == null) {
             if (!_networkManager.isProviderForNetwork(getProvider(), network.getId())) {
-                s_logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
+                logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
                 return false;
             }
         } else {
             if (!_networkManager.isProviderSupportServiceInNetwork(network.getId(), service, getProvider())) {
-                s_logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
+                logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
                 return false;
             }
         }
@@ -157,7 +155,7 @@ public class JuniperSRXExternalFirewallElement extends ExternalFirewallDeviceMan
 
         // don't have to implement network is Basic zone
         if (zone.getNetworkType() == NetworkType.Basic) {
-            s_logger.debug("Not handling network implement in zone of type " + NetworkType.Basic);
+            logger.debug("Not handling network implement in zone of type " + NetworkType.Basic);
             return false;
         }
 
@@ -170,7 +168,7 @@ public class JuniperSRXExternalFirewallElement extends ExternalFirewallDeviceMan
         } catch (InsufficientCapacityException capacityException) {
             // TODO: handle out of capacity exception in more gracefule manner when multiple providers are present for
             // the network
-            s_logger.error("Fail to implement the JuniperSRX for network " + network, capacityException);
+            logger.error("Fail to implement the JuniperSRX for network " + network, capacityException);
             return false;
         }
     }
@@ -192,7 +190,7 @@ public class JuniperSRXExternalFirewallElement extends ExternalFirewallDeviceMan
 
         // don't have to implement network is Basic zone
         if (zone.getNetworkType() == NetworkType.Basic) {
-            s_logger.debug("Not handling network shutdown in zone of type " + NetworkType.Basic);
+            logger.debug("Not handling network shutdown in zone of type " + NetworkType.Basic);
             return false;
         }
 
@@ -527,7 +525,7 @@ public class JuniperSRXExternalFirewallElement extends ExternalFirewallDeviceMan
     @Override
     public boolean verifyServicesCombination(Set<Service> services) {
         if (!services.contains(Service.Firewall)) {
-            s_logger.warn("SRX must be used as Firewall Service Provider in the network");
+            logger.warn("SRX must be used as Firewall Service Provider in the network");
             return false;
         }
         return true;

--- a/plugins/network-elements/midonet/src/com/cloud/network/element/MidoNetElement.java
+++ b/plugins/network-elements/midonet/src/com/cloud/network/element/MidoNetElement.java
@@ -32,7 +32,6 @@ import javax.naming.ConfigurationException;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 import org.midonet.client.MidonetApi;
 import org.midonet.client.dto.DtoRule;
 import org.midonet.client.dto.DtoRule.DtoRange;
@@ -92,7 +91,6 @@ import com.sun.jersey.core.util.MultivaluedMapImpl;
 public class MidoNetElement extends AdapterBase implements ConnectivityProvider, DhcpServiceProvider, SourceNatServiceProvider, StaticNatServiceProvider, IpDeployer,
         PortForwardingServiceProvider, FirewallServiceProvider, PluggableService {
 
-    private static final Logger s_logger = Logger.getLogger(MidoNetElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -147,7 +145,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
         }
 
         if (this.api == null) {
-            s_logger.info("midonet API server address is  " + value);
+            logger.info("midonet API server address is  " + value);
             setMidonetApi(new MidonetApi(value));
             this.api.enableLogging();
         }
@@ -177,12 +175,12 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
 
         if (service == null) {
             if (!_networkModel.isProviderForNetwork(getProvider(), network.getId())) {
-                s_logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
+                logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
                 return false;
             }
         } else {
             if (!_networkModel.isProviderSupportServiceInNetwork(network.getId(), service, getProvider())) {
-                s_logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
+                logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
                 return false;
             }
         }
@@ -287,7 +285,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
 
     public boolean associatePublicIP(Network network, final List<? extends PublicIpAddress> ipAddress) throws ResourceUnavailableException {
 
-        s_logger.debug("associatePublicIP called with network: " + network.toString());
+        logger.debug("associatePublicIP called with network: " + network.toString());
         /*
          * Get Mido Router for this network and set source rules
          * These should only be allocated inside the for loop, because
@@ -352,7 +350,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
     @Override
     public boolean applyIps(Network network, List<? extends PublicIpAddress> ipAddress, Set<Service> services) throws ResourceUnavailableException {
 
-        s_logger.debug("applyIps called with network: " + network.toString());
+        logger.debug("applyIps called with network: " + network.toString());
         if (!this.midoInNetwork(network)) {
             return false;
         }
@@ -376,7 +374,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
      */
     @Override
     public IpDeployer getIpDeployer(Network network) {
-        s_logger.debug("getIpDeployer called with network " + network.toString());
+        logger.debug("getIpDeployer called with network " + network.toString());
         return this;
     }
 
@@ -387,7 +385,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
     public boolean addDhcpEntry(Network network, NicProfile nic, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
         throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException {
 
-        s_logger.debug("addDhcpEntry called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
+        logger.debug("addDhcpEntry called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
         if (!this.midoInNetwork(network)) {
             return false;
         }
@@ -421,7 +419,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
 
         // On DHCP subnet, add host using host details
         if (sub == null) {
-            s_logger.error("Failed to create DHCP subnet on Midonet bridge");
+            logger.error("Failed to create DHCP subnet on Midonet bridge");
             return false;
         } else {
             // Check if the host already exists - we may just be restarting an existing VM
@@ -580,7 +578,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
      */
     @Override
     public boolean applyStaticNats(Network network, List<? extends StaticNat> rules) throws ResourceUnavailableException {
-        s_logger.debug("applyStaticNats called with network: " + network.toString());
+        logger.debug("applyStaticNats called with network: " + network.toString());
         if (!midoInNetwork(network)) {
             return false;
         }
@@ -728,7 +726,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
     @Override
     public boolean implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context) throws ConcurrentOperationException,
         ResourceUnavailableException, InsufficientCapacityException {
-        s_logger.debug("implement called with network: " + network.toString());
+        logger.debug("implement called with network: " + network.toString());
         if (!midoInNetwork(network)) {
             return false;
         }
@@ -748,7 +746,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
     @Override
     public boolean prepare(Network network, NicProfile nic, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
         throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
-        s_logger.debug("prepare called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
+        logger.debug("prepare called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
         if (!midoInNetwork(network)) {
             return false;
         }
@@ -808,7 +806,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
     @Override
     public boolean release(Network network, NicProfile nic, VirtualMachineProfile vm, ReservationContext context) throws ConcurrentOperationException,
         ResourceUnavailableException {
-        s_logger.debug("release called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
+        logger.debug("release called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
         if (!midoInNetwork(network)) {
             return false;
         }
@@ -848,7 +846,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
 
     @Override
     public boolean shutdown(Network network, ReservationContext context, boolean cleanup) throws ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("shutdown called with network: " + network.toString());
+        logger.debug("shutdown called with network: " + network.toString());
         if (!midoInNetwork(network)) {
             return false;
         }
@@ -864,7 +862,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
 
     @Override
     public boolean destroy(Network network, ReservationContext context) throws ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("destroy called with network: " + network.toString());
+        logger.debug("destroy called with network: " + network.toString());
         if (!midoInNetwork(network)) {
             return false;
         }
@@ -913,7 +911,7 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
 
     @Override
     public boolean applyPFRules(Network network, List<PortForwardingRule> rules) throws ResourceUnavailableException {
-        s_logger.debug("applyPFRules called with network " + network.toString());
+        logger.debug("applyPFRules called with network " + network.toString());
         if (!midoInNetwork(network)) {
             return false;
         }
@@ -1410,11 +1408,11 @@ public class MidoNetElement extends AdapterBase implements ConnectivityProvider,
 
             String networkUUIDStr = String.valueOf(networkID);
 
-            s_logger.debug("Attempting to create guest network bridge");
+            logger.debug("Attempting to create guest network bridge");
             try {
                 netBridge = api.addBridge().tenantId(accountUuid).name(networkUUIDStr).create();
             } catch (HttpInternalServerError ex) {
-                s_logger.warn("Bridge creation failed, retrying bridge get in case it now exists.", ex);
+                logger.warn("Bridge creation failed, retrying bridge get in case it now exists.", ex);
                 netBridge = getNetworkBridge(networkID, accountUuid);
             }
         }

--- a/plugins/network-elements/midonet/src/com/cloud/network/guru/MidoNetGuestNetworkGuru.java
+++ b/plugins/network-elements/midonet/src/com/cloud/network/guru/MidoNetGuestNetworkGuru.java
@@ -22,7 +22,6 @@ package com.cloud.network.guru;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.DataCenter.NetworkType;
@@ -47,7 +46,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Component
 @Local(value = NetworkGuru.class)
 public class MidoNetGuestNetworkGuru extends GuestNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(MidoNetGuestNetworkGuru.class);
 
     @Inject
     AccountDao _accountDao;
@@ -64,7 +62,7 @@ public class MidoNetGuestNetworkGuru extends GuestNetworkGuru {
             isMyIsolationMethod(physicalNetwork)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + Network.GuestType.Isolated + " in zone of type " + NetworkType.Advanced +
+            logger.trace("We only take care of Guest networks of type   " + Network.GuestType.Isolated + " in zone of type " + NetworkType.Advanced +
                 " using isolation method MIDO.");
             return false;
         }
@@ -72,15 +70,15 @@ public class MidoNetGuestNetworkGuru extends GuestNetworkGuru {
 
     @Override
     public Network design(NetworkOffering offering, DeploymentPlan plan, Network userSpecified, Account owner) {
-        s_logger.debug("design called");
+        logger.debug("design called");
         // Check if the isolation type of the related physical network is MIDO
         PhysicalNetworkVO physnet = _physicalNetworkDao.findById(plan.getPhysicalNetworkId());
         if (physnet == null || physnet.getIsolationMethods() == null || !physnet.getIsolationMethods().contains("MIDO")) {
-            s_logger.debug("Refusing to design this network, the physical isolation type is not MIDO");
+            logger.debug("Refusing to design this network, the physical isolation type is not MIDO");
             return null;
         }
 
-        s_logger.debug("Physical isolation type is MIDO, asking GuestNetworkGuru to design this network");
+        logger.debug("Physical isolation type is MIDO, asking GuestNetworkGuru to design this network");
         NetworkVO networkObject = (NetworkVO)super.design(offering, plan, userSpecified, owner);
         if (networkObject == null) {
             return null;
@@ -95,7 +93,7 @@ public class MidoNetGuestNetworkGuru extends GuestNetworkGuru {
     public Network implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context)
         throws InsufficientVirtualNetworkCapacityException {
         assert (network.getState() == Network.State.Implementing) : "Why are we implementing " + network;
-        s_logger.debug("implement called network: " + network.toString());
+        logger.debug("implement called network: " + network.toString());
 
         long dcId = dest.getDataCenter().getId();
 
@@ -126,7 +124,7 @@ public class MidoNetGuestNetworkGuru extends GuestNetworkGuru {
         String broadcastUriStr = accountUUIDStr + "." + String.valueOf(network.getId()) + ":" + routerName;
 
         implemented.setBroadcastUri(Networks.BroadcastDomainType.Mido.toUri(broadcastUriStr));
-        s_logger.debug("Broadcast URI set to " + broadcastUriStr);
+        logger.debug("Broadcast URI set to " + broadcastUriStr);
 
         return implemented;
     }
@@ -134,27 +132,27 @@ public class MidoNetGuestNetworkGuru extends GuestNetworkGuru {
     @Override
     public void reserve(NicProfile nic, Network network, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
         throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException {
-        s_logger.debug("reserve called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
+        logger.debug("reserve called with network: " + network.toString() + " nic: " + nic.toString() + " vm: " + vm.toString());
 
         super.reserve(nic, network, vm, dest, context);
     }
 
     @Override
     public boolean release(NicProfile nic, VirtualMachineProfile vm, String reservationId) {
-        s_logger.debug("release called with nic: " + nic.toString() + " vm: " + vm.toString());
+        logger.debug("release called with nic: " + nic.toString() + " vm: " + vm.toString());
         return super.release(nic, vm, reservationId);
     }
 
     @Override
     public void shutdown(NetworkProfile profile, NetworkOffering offering) {
-        s_logger.debug("shutdown called");
+        logger.debug("shutdown called");
 
         super.shutdown(profile, offering);
     }
 
     @Override
     public boolean trash(Network network, NetworkOffering offering) {
-        s_logger.debug("trash called with network: " + network.toString());
+        logger.debug("trash called with network: " + network.toString());
 
         return super.trash(network, offering);
     }

--- a/plugins/network-elements/midonet/src/com/cloud/network/guru/MidoNetPublicNetworkGuru.java
+++ b/plugins/network-elements/midonet/src/com/cloud/network/guru/MidoNetPublicNetworkGuru.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.Vlan;
@@ -57,7 +56,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = NetworkGuru.class)
 public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(MidoNetPublicNetworkGuru.class);
 
     // Inject any stuff we need to use (DAOs etc)
     @Inject
@@ -72,7 +70,7 @@ public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
     // Only change is to make broadcast domain type Mido
     @Override
     public Network design(NetworkOffering offering, DeploymentPlan plan, Network network, Account owner) {
-        s_logger.debug("design called with network: " + network);
+        logger.debug("design called with network: " + network);
         if (!canHandle(offering)) {
             return null;
         }
@@ -121,7 +119,7 @@ public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
 
     @Override
     public void updateNicProfile(NicProfile profile, Network network) {
-        s_logger.debug("updateNicProfile called with network: " + network + " profile: " + profile);
+        logger.debug("updateNicProfile called with network: " + network + " profile: " + profile);
 
         DataCenter dc = _dcDao.findById(network.getDataCenterId());
         if (profile != null) {
@@ -137,7 +135,7 @@ public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
         if (nic == null) {
             nic = new NicProfile(Nic.ReservationStrategy.Create, null, null, null, null);
         }
-        s_logger.debug("allocate called with network: " + network + " nic: " + nic + " vm: " + vm);
+        logger.debug("allocate called with network: " + network + " nic: " + nic + " vm: " + vm);
         DataCenter dc = _dcDao.findById(network.getDataCenterId());
 
         if (nic.getRequestedIPv4() != null) {
@@ -162,7 +160,7 @@ public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
     @Override
     public void reserve(NicProfile nic, Network network, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
         throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException, ConcurrentOperationException {
-        s_logger.debug("reserve called with network: " + network + " nic: " + nic + " vm: " + vm);
+        logger.debug("reserve called with network: " + network + " nic: " + nic + " vm: " + vm);
         if (nic.getIPv4Address() == null) {
             getIp(nic, dest.getDataCenter(), vm, network);
         }
@@ -170,14 +168,14 @@ public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
 
     @Override
     public boolean release(NicProfile nic, VirtualMachineProfile vm, String reservationId) {
-        s_logger.debug("release called with nic: " + nic + " vm: " + vm);
+        logger.debug("release called with nic: " + nic + " vm: " + vm);
         return true;
     }
 
     @Override
     public Network implement(Network network, NetworkOffering offering, DeployDestination destination, ReservationContext context)
         throws InsufficientVirtualNetworkCapacityException {
-        s_logger.debug("implement called with network: " + network);
+        logger.debug("implement called with network: " + network);
         long dcId = destination.getDataCenter().getId();
 
         //get physical network id
@@ -204,9 +202,9 @@ public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
     @Override
     @DB
     public void deallocate(Network network, NicProfile nic, VirtualMachineProfile vm) {
-        s_logger.debug("deallocate called with network: " + network + " nic: " + nic + " vm: " + vm);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("public network deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
+        logger.debug("deallocate called with network: " + network + " nic: " + nic + " vm: " + vm);
+        if (logger.isDebugEnabled()) {
+            logger.debug("public network deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
         }
 
         final IPAddressVO ip = _ipAddressDao.findByIpAndSourceNetworkId(nic.getNetworkId(), nic.getIPv4Address());
@@ -221,19 +219,19 @@ public class MidoNetPublicNetworkGuru extends PublicNetworkGuru {
         }
         nic.deallocate();
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deallocated nic: " + nic);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deallocated nic: " + nic);
         }
     }
 
     @Override
     public void shutdown(NetworkProfile network, NetworkOffering offering) {
-        s_logger.debug("shutdown called with network: " + network);
+        logger.debug("shutdown called with network: " + network);
     }
 
     @Override
     public boolean trash(Network network, NetworkOffering offering) {
-        s_logger.debug("trash called with network: " + network);
+        logger.debug("trash called with network: " + network);
         return true;
     }
 

--- a/plugins/network-elements/netscaler/src/com/cloud/network/element/NetscalerElement.java
+++ b/plugins/network-elements/netscaler/src/com/cloud/network/element/NetscalerElement.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.google.gson.Gson;
 
@@ -121,7 +120,6 @@ import com.cloud.vm.VirtualMachineProfile;
 public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl implements LoadBalancingServiceProvider, NetscalerLoadBalancerElementService,
         ExternalLoadBalancerDeviceManager, IpDeployer, StaticNatServiceProvider, GslbServiceProvider {
 
-    private static final Logger s_logger = Logger.getLogger(NetscalerElement.class);
     public static final AutoScaleCounterType AutoScaleCounterSnmp = new AutoScaleCounterType("snmp");
     public static final AutoScaleCounterType AutoScaleCounterNetscaler = new AutoScaleCounterType("netscaler");
 
@@ -166,7 +164,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
             (zone.getNetworkType() == NetworkType.Basic && config.getGuestType() == Network.GuestType.Shared && config.getTrafficType() == TrafficType.Guest);
 
         if (!(handleInAdvanceZone || handleInBasicZone)) {
-            s_logger.trace("Not handling network with Type  " + config.getGuestType() + " and traffic type " + config.getTrafficType() + " in zone of type " +
+            logger.trace("Not handling network with Type  " + config.getGuestType() + " and traffic type " + config.getTrafficType() + " in zone of type " +
                 zone.getNetworkType());
             return false;
         }
@@ -189,7 +187,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
         }
 
         if (_ntwkSrvcDao.canProviderSupportServiceInNetwork(guestConfig.getId(), Service.StaticNat, Network.Provider.Netscaler) && !isBasicZoneNetwok(guestConfig)) {
-            s_logger.error("NetScaler provider can not be Static Nat service provider for the network " + guestConfig.getGuestType() + " and traffic type " +
+            logger.error("NetScaler provider can not be Static Nat service provider for the network " + guestConfig.getGuestType() + " and traffic type " +
                 guestConfig.getTrafficType());
             return false;
         }
@@ -346,7 +344,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
             uri = new URI(cmd.getUrl());
         } catch (Exception e) {
             String msg = "Error parsing the url parameter specified in addNetscalerLoadBalancer command due to " + e.getMessage();
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new InvalidParameterValueException(msg);
         }
         Map<String, String> configParams = new HashMap<String, String>();
@@ -357,7 +355,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
 
         if (dedicatedUse && !deviceName.equals(NetworkDevice.NetscalerVPXLoadBalancer.getName())) {
             String msg = "Only Netscaler VPX load balancers can be specified for dedicated use";
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new InvalidParameterValueException(msg);
         }
 
@@ -365,13 +363,13 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
 
             if (!deviceName.equals(NetworkDevice.NetscalerVPXLoadBalancer.getName()) && !deviceName.equals(NetworkDevice.NetscalerMPXLoadBalancer.getName())) {
                 String msg = "Only Netscaler VPX or MPX load balancers can be specified as GSLB service provider";
-                s_logger.debug(msg);
+                logger.debug(msg);
                 throw new InvalidParameterValueException(msg);
             }
 
             if (cmd.getSitePublicIp() == null || cmd.getSitePrivateIp() == null) {
                 String msg = "Public and Privae IP needs to provided for NetScaler that will be GSLB provider";
-                s_logger.debug(msg);
+                logger.debug(msg);
                 throw new InvalidParameterValueException(msg);
             }
 
@@ -676,15 +674,15 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
 
         // NetScaler can only act as Lb and Static Nat service provider
         if (services != null && !services.isEmpty() && !netscalerServices.containsAll(services)) {
-            s_logger.warn("NetScaler network element can only support LB and Static NAT services and service combination " + services + " is not supported.");
+            logger.warn("NetScaler network element can only support LB and Static NAT services and service combination " + services + " is not supported.");
 
             StringBuffer buff = new StringBuffer();
             for (Service service : services) {
                 buff.append(service.getName());
                 buff.append(" ");
             }
-            s_logger.warn("NetScaler network element can only support LB and Static NAT services and service combination " + buff.toString() + " is not supported.");
-            s_logger.warn("NetScaler network element can only support LB and Static NAT services and service combination " + services + " is not supported.");
+            logger.warn("NetScaler network element can only support LB and Static NAT services and service combination " + buff.toString() + " is not supported.");
+            logger.warn("NetScaler network element can only support LB and Static NAT services and service combination " + services + " is not supported.");
             return false;
         }
 
@@ -720,14 +718,14 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
                 lbDeviceVO = allocateLoadBalancerForNetwork(network);
             } catch (Exception e) {
                 errMsg = "Could not allocate a NetSclaer load balancer for configuring elastic load balancer rules due to " + e.getMessage();
-                s_logger.error(errMsg);
+                logger.error(errMsg);
                 throw new ResourceUnavailableException(errMsg, this.getClass(), 0);
             }
         }
 
         if (!isNetscalerDevice(lbDeviceVO.getDeviceName())) {
             errMsg = "There are no NetScaler load balancer assigned for this network. So NetScaler element can not be handle elastic load balancer rules.";
-            s_logger.error(errMsg);
+            logger.error(errMsg);
             throw new ResourceUnavailableException(errMsg, this.getClass(), 0);
         }
 
@@ -765,7 +763,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
                 String msg =
                     "Unable to apply elastic load balancer rules to the external load balancer appliance in zone " + network.getDataCenterId() + " due to: " + details +
                         ".";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ResourceUnavailableException(msg, DataCenter.class, network.getDataCenterId());
             }
         }
@@ -791,14 +789,14 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
                         lbDevice = allocateLoadBalancerForNetwork(config);
                     } catch (Exception e) {
                         errMsg = "Could not allocate a NetSclaer load balancer for configuring static NAT rules due to" + e.getMessage();
-                        s_logger.error(errMsg);
+                        logger.error(errMsg);
                         throw new ResourceUnavailableException(errMsg, this.getClass(), 0);
                     }
                 }
 
                 if (!isNetscalerDevice(lbDevice.getDeviceName())) {
                     errMsg = "There are no NetScaler load balancer assigned for this network. So NetScaler element will not be handling the static nat rules.";
-                    s_logger.error(errMsg);
+                    logger.error(errMsg);
                     throw new ResourceUnavailableException(errMsg, this.getClass(), 0);
                 }
                 SetStaticNatRulesAnswer answer = null;
@@ -827,7 +825,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
                         ExternalLoadBalancerDeviceVO lbDevice = getNetScalerForEIP(rule);
                         if (lbDevice == null) {
                             String errMsg = "There is no NetScaler device configured to perform EIP to guest IP address: " + rule.getDestIpAddress();
-                            s_logger.error(errMsg);
+                            logger.error(errMsg);
                             throw new ResourceUnavailableException(errMsg, this.getClass(), 0);
                         }
 
@@ -842,7 +840,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
                         SetStaticNatRulesAnswer answer = (SetStaticNatRulesAnswer)_agentMgr.send(lbDevice.getHostId(), cmd);
                         if (answer == null) {
                             String errMsg = "Failed to configure INAT rule on NetScaler device " + lbDevice.getHostId();
-                            s_logger.error(errMsg);
+                            logger.error(errMsg);
                             throw new ResourceUnavailableException(errMsg, this.getClass(), 0);
                         }
                     }
@@ -851,7 +849,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
             }
             return true;
         } catch (Exception e) {
-            s_logger.error("Failed to configure StaticNat rule due to " + e.getMessage());
+            logger.error("Failed to configure StaticNat rule due to " + e.getMessage());
             return false;
         }
     }
@@ -887,13 +885,13 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
         ExternalLoadBalancerDeviceVO lbDeviceVO = getExternalLoadBalancerForNetwork(network);
 
         if (lbDeviceVO == null) {
-            s_logger.warn("There is no external load balancer device assigned to this network either network is not implement are already shutdown so just returning");
+            logger.warn("There is no external load balancer device assigned to this network either network is not implement are already shutdown so just returning");
             return null;
         }
 
         if (!isNetscalerDevice(lbDeviceVO.getDeviceName())) {
             errMsg = "There are no NetScaler load balancer assigned for this network. So NetScaler element can not be handle elastic load balancer rules.";
-            s_logger.error(errMsg);
+            logger.error(errMsg);
             throw new ResourceUnavailableException(errMsg, this.getClass(), 0);
         }
 
@@ -939,10 +937,10 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
                     return getLBHealthChecks(network, lbrules);
                 }
             } catch (ResourceUnavailableException e) {
-                s_logger.error("Error in getting the LB Rules from NetScaler " + e);
+                logger.error("Error in getting the LB Rules from NetScaler " + e);
             }
         } else {
-            s_logger.error("Network cannot handle to LB service ");
+            logger.error("Network cannot handle to LB service ");
         }
         return null;
     }
@@ -961,7 +959,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
         ExternalLoadBalancerDeviceVO nsGslbProvider = findGslbProvider(zoneId, physicalNetworkId);
         if (nsGslbProvider == null) {
             String msg = "Unable to find a NetScaler configured as gslb service provider in zone " + zoneId;
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new ResourceUnavailableException(msg, DataCenter.class, zoneId);
         }
 
@@ -972,7 +970,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
         Answer answer = _agentMgr.easySend(zoneGslbProviderHosId, gslbConfigCmd);
         if (answer == null || !answer.getResult()) {
             String msg = "Unable to apply global load balancer rule to the gslb service provider in zone " + zoneId;
-            s_logger.debug(msg);
+            logger.debug(msg);
             throw new ResourceUnavailableException(msg, DataCenter.class, zoneId);
         }
 
@@ -1031,7 +1029,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
             if (schemeCaps != null) {
                 for (LoadBalancingRule rule : rules) {
                     if (!schemeCaps.contains(rule.getScheme().toString())) {
-                        s_logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + this.getName());
+                        logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + this.getName());
                         return false;
                     }
                 }

--- a/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/element/NiciraNvpElement.java
+++ b/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/element/NiciraNvpElement.java
@@ -32,7 +32,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
@@ -137,7 +136,6 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
     private static final int MAX_PORT = 65535;
     private static final int MIN_PORT = 0;
 
-    private static final Logger s_logger = Logger.getLogger(NiciraNvpElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -187,18 +185,18 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
     }
 
     protected boolean canHandle(Network network, Service service) {
-        s_logger.debug("Checking if NiciraNvpElement can handle service " + service.getName() + " on network " + network.getDisplayText());
+        logger.debug("Checking if NiciraNvpElement can handle service " + service.getName() + " on network " + network.getDisplayText());
         if (network.getBroadcastDomainType() != BroadcastDomainType.Lswitch) {
             return false;
         }
 
         if (!networkModel.isProviderForNetwork(getProvider(), network.getId())) {
-            s_logger.debug("NiciraNvpElement is not a provider for network " + network.getDisplayText());
+            logger.debug("NiciraNvpElement is not a provider for network " + network.getDisplayText());
             return false;
         }
 
         if (!ntwkSrvcDao.canProviderSupportServiceInNetwork(network.getId(), service, Network.Provider.NiciraNvp)) {
-            s_logger.debug("NiciraNvpElement can't provide the " + service.getName() + " service on network " + network.getDisplayText());
+            logger.debug("NiciraNvpElement can't provide the " + service.getName() + " service on network " + network.getDisplayText());
             return false;
         }
 
@@ -215,20 +213,20 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
     @Override
     public boolean implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context) throws ConcurrentOperationException,
     ResourceUnavailableException, InsufficientCapacityException {
-        s_logger.debug("entering NiciraNvpElement implement function for network " + network.getDisplayText() + " (state " + network.getState() + ")");
+        logger.debug("entering NiciraNvpElement implement function for network " + network.getDisplayText() + " (state " + network.getState() + ")");
 
         if (!canHandle(network, Service.Connectivity)) {
             return false;
         }
 
         if (network.getBroadcastUri() == null) {
-            s_logger.error("Nic has no broadcast Uri with the LSwitch Uuid");
+            logger.error("Nic has no broadcast Uri with the LSwitch Uuid");
             return false;
         }
 
         List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
+            logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
             return false;
         }
         NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -244,7 +242,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         // Implement SourceNat immediately as we have al the info already
         if (networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.SourceNat, Provider.NiciraNvp)) {
-            s_logger.debug("Apparently we are supposed to provide SourceNat on this network");
+            logger.debug("Apparently we are supposed to provide SourceNat on this network");
 
             PublicIp sourceNatIp = ipAddrMgr.assignSourceNatIpAddressToGuestNetwork(owner, network);
             String publicCidr = sourceNatIp.getAddress().addr() + "/" + NetUtils.getCidrSize(sourceNatIp.getVlanNetmask());
@@ -270,7 +268,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
                                     context.getAccount().getAccountName());
             CreateLogicalRouterAnswer answer = (CreateLogicalRouterAnswer)agentMgr.easySend(niciraNvpHost.getId(), cmd);
             if (answer.getResult() == false) {
-                s_logger.error("Failed to create Logical Router for network " + network.getDisplayText());
+                logger.error("Failed to create Logical Router for network " + network.getDisplayText());
                 return false;
             }
 
@@ -291,7 +289,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
         }
 
         if (network.getBroadcastUri() == null) {
-            s_logger.error("Nic has no broadcast Uri with the LSwitch Uuid");
+            logger.error("Nic has no broadcast Uri with the LSwitch Uuid");
             return false;
         }
 
@@ -299,7 +297,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
+            logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
             return false;
         }
         NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -311,14 +309,14 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
             FindLogicalSwitchPortAnswer answer = (FindLogicalSwitchPortAnswer)agentMgr.easySend(niciraNvpHost.getId(), findCmd);
 
             if (answer.getResult()) {
-                s_logger.warn("Existing Logical Switchport found for nic " + nic.getName() + " with uuid " + existingNicMap.getLogicalSwitchPortUuid());
+                logger.warn("Existing Logical Switchport found for nic " + nic.getName() + " with uuid " + existingNicMap.getLogicalSwitchPortUuid());
                 UpdateLogicalSwitchPortCommand cmd =
                         new UpdateLogicalSwitchPortCommand(existingNicMap.getLogicalSwitchPortUuid(), BroadcastDomainType.getValue(network.getBroadcastUri()),
                                 nicVO.getUuid(), context.getDomain().getName() + "-" + context.getAccount().getAccountName(), nic.getName());
                 agentMgr.easySend(niciraNvpHost.getId(), cmd);
                 return true;
             } else {
-                s_logger.error("Stale entry found for nic " + nic.getName() + " with logical switchport uuid " + existingNicMap.getLogicalSwitchPortUuid());
+                logger.error("Stale entry found for nic " + nic.getName() + " with logical switchport uuid " + existingNicMap.getLogicalSwitchPortUuid());
                 niciraNvpNicMappingDao.remove(existingNicMap.getId());
             }
         }
@@ -329,7 +327,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
         CreateLogicalSwitchPortAnswer answer = (CreateLogicalSwitchPortAnswer)agentMgr.easySend(niciraNvpHost.getId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("CreateLogicalSwitchPortCommand failed");
+            logger.error("CreateLogicalSwitchPortCommand failed");
             return false;
         }
 
@@ -349,7 +347,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
         }
 
         if (network.getBroadcastUri() == null) {
-            s_logger.error("Nic has no broadcast Uri with the LSwitch Uuid");
+            logger.error("Nic has no broadcast Uri with the LSwitch Uuid");
             return false;
         }
 
@@ -357,7 +355,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
+            logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
             return false;
         }
         NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -365,7 +363,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         NiciraNvpNicMappingVO nicMap = niciraNvpNicMappingDao.findByNicUuid(nicVO.getUuid());
         if (nicMap == null) {
-            s_logger.error("No mapping for nic " + nic.getName());
+            logger.error("No mapping for nic " + nic.getName());
             return false;
         }
 
@@ -373,7 +371,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
         DeleteLogicalSwitchPortAnswer answer = (DeleteLogicalSwitchPortAnswer)agentMgr.easySend(niciraNvpHost.getId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("DeleteLogicalSwitchPortCommand failed");
+            logger.error("DeleteLogicalSwitchPortCommand failed");
             return false;
         }
 
@@ -390,20 +388,20 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
+            logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
             return false;
         }
         NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
         HostVO niciraNvpHost = hostDao.findById(niciraNvpDevice.getHostId());
 
         if (networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.SourceNat, Provider.NiciraNvp)) {
-            s_logger.debug("Apparently we were providing SourceNat on this network");
+            logger.debug("Apparently we were providing SourceNat on this network");
 
             // Deleting the LogicalRouter will also take care of all provisioned
             // nat rules.
             NiciraNvpRouterMappingVO routermapping = niciraNvpRouterMappingDao.findByNetworkId(network.getId());
             if (routermapping == null) {
-                s_logger.warn("No logical router uuid found for network " + network.getDisplayText());
+                logger.warn("No logical router uuid found for network " + network.getDisplayText());
                 // This might be cause by a failed deployment, so don't make shutdown fail as well.
                 return true;
             }
@@ -411,7 +409,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
             DeleteLogicalRouterCommand cmd = new DeleteLogicalRouterCommand(routermapping.getLogicalRouterUuid());
             DeleteLogicalRouterAnswer answer = (DeleteLogicalRouterAnswer)agentMgr.easySend(niciraNvpHost.getId(), cmd);
             if (answer.getResult() == false) {
-                s_logger.error("Failed to delete LogicalRouter for network " + network.getDisplayText());
+                logger.error("Failed to delete LogicalRouter for network " + network.getDisplayText());
                 return false;
             }
 
@@ -452,11 +450,11 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
         // This element can only function in a Nicra Nvp based
         // SDN network, so Connectivity needs to be present here
         if (!services.contains(Service.Connectivity)) {
-            s_logger.warn("Unable to provide services without Connectivity service enabled for this element");
+            logger.warn("Unable to provide services without Connectivity service enabled for this element");
             return false;
         }
         if ((services.contains(Service.PortForwarding) || services.contains(Service.StaticNat)) && !services.contains(Service.SourceNat)) {
-            s_logger.warn("Unable to provide StaticNat and/or PortForwarding without the SourceNat service");
+            logger.warn("Unable to provide StaticNat and/or PortForwarding without the SourceNat service");
             return false;
         }
         return true;
@@ -734,7 +732,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
             // SourceNat is required for StaticNat and PortForwarding
             List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
             if (devices.isEmpty()) {
-                s_logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
+                logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
                 return false;
             }
             NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -743,7 +741,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
             NiciraNvpRouterMappingVO routermapping = niciraNvpRouterMappingDao.findByNetworkId(network.getId());
             if (routermapping == null) {
-                s_logger.error("No logical router uuid found for network " + network.getDisplayText());
+                logger.error("No logical router uuid found for network " + network.getDisplayText());
                 return false;
             }
 
@@ -762,7 +760,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
             //FIXME answer can be null if the host is down
             return answer.getResult();
         } else {
-            s_logger.debug("No need to provision ip addresses as we are not providing L3 services.");
+            logger.debug("No need to provision ip addresses as we are not providing L3 services.");
         }
 
         return true;
@@ -779,7 +777,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
+            logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
             return false;
         }
         NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -787,7 +785,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         NiciraNvpRouterMappingVO routermapping = niciraNvpRouterMappingDao.findByNetworkId(network.getId());
         if (routermapping == null) {
-            s_logger.error("No logical router uuid found for network " + network.getDisplayText());
+            logger.error("No logical router uuid found for network " + network.getDisplayText());
             return false;
         }
 
@@ -819,7 +817,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(network.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
+            logger.error("No NiciraNvp Controller on physical network " + network.getPhysicalNetworkId());
             return false;
         }
         NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -827,7 +825,7 @@ NiciraNvpElementService, ResourceStateAdapter, IpDeployer {
 
         NiciraNvpRouterMappingVO routermapping = niciraNvpRouterMappingDao.findByNetworkId(network.getId());
         if (routermapping == null) {
-            s_logger.error("No logical router uuid found for network " + network.getDisplayText());
+            logger.error("No logical router uuid found for network " + network.getDisplayText());
             return false;
         }
 

--- a/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuru.java
+++ b/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuru.java
@@ -26,7 +26,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.CreateLogicalSwitchAnswer;
@@ -71,7 +70,6 @@ import com.cloud.vm.VirtualMachineProfile;
 public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
     private static final int MAX_NAME_LENGTH = 40;
 
-    private static final Logger s_logger = Logger.getLogger(NiciraNvpGuestNetworkGuru.class);
 
     @Inject
     protected NetworkModel networkModel;
@@ -108,7 +106,7 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
                 && isMyIsolationMethod(physicalNetwork) && ntwkOfferingSrvcDao.areServicesSupportedByNetworkOffering(offering.getId(), Service.Connectivity)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }
@@ -119,18 +117,18 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
         final PhysicalNetworkVO physnet = physicalNetworkDao.findById(plan.getPhysicalNetworkId());
         final DataCenter dc = _dcDao.findById(plan.getDataCenterId());
         if (!canHandle(offering, dc.getNetworkType(), physnet)) {
-            s_logger.debug("Refusing to design this network");
+            logger.debug("Refusing to design this network");
             return null;
         }
 
         final List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(physnet.getId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + physnet.getName());
+            logger.error("No NiciraNvp Controller on physical network " + physnet.getName());
             return null;
         }
-        s_logger.debug("Nicira Nvp " + devices.get(0).getUuid() + " found on physical network " + physnet.getId());
+        logger.debug("Nicira Nvp " + devices.get(0).getUuid() + " found on physical network " + physnet.getId());
 
-        s_logger.debug("Physical isolation type is supported, asking GuestNetworkGuru to design this network");
+        logger.debug("Physical isolation type is supported, asking GuestNetworkGuru to design this network");
         final NetworkVO networkObject = (NetworkVO) super.design(offering, plan, userSpecified, owner);
         if (networkObject == null) {
             return null;
@@ -176,7 +174,7 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
 
         final List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(physicalNetworkId);
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + physicalNetworkId);
+            logger.error("No NiciraNvp Controller on physical network " + physicalNetworkId);
             return null;
         }
         final NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -190,16 +188,16 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
         final CreateLogicalSwitchAnswer answer = (CreateLogicalSwitchAnswer) agentMgr.easySend(niciraNvpHost.getId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("CreateLogicalSwitchCommand failed");
+            logger.error("CreateLogicalSwitchCommand failed");
             return null;
         }
 
         try {
             implemented.setBroadcastUri(new URI("lswitch", answer.getLogicalSwitchUuid(), null));
             implemented.setBroadcastDomainType(BroadcastDomainType.Lswitch);
-            s_logger.info("Implemented OK, network linked to  = " + implemented.getBroadcastUri().toString());
+            logger.info("Implemented OK, network linked to  = " + implemented.getBroadcastUri().toString());
         } catch (final URISyntaxException e) {
-            s_logger.error("Unable to store logical switch id in broadcast uri, uuid = " + implemented.getUuid(), e);
+            logger.error("Unable to store logical switch id in broadcast uri, uuid = " + implemented.getUuid(), e);
             return null;
         }
 
@@ -221,13 +219,13 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
     public void shutdown(final NetworkProfile profile, final NetworkOffering offering) {
         final NetworkVO networkObject = networkDao.findById(profile.getId());
         if (networkObject.getBroadcastDomainType() != BroadcastDomainType.Lswitch || networkObject.getBroadcastUri() == null) {
-            s_logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
+            logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
             return;
         }
 
         final List<NiciraNvpDeviceVO> devices = niciraNvpDao.listByPhysicalNetwork(networkObject.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No NiciraNvp Controller on physical network " + networkObject.getPhysicalNetworkId());
+            logger.error("No NiciraNvp Controller on physical network " + networkObject.getPhysicalNetworkId());
             return;
         }
         final NiciraNvpDeviceVO niciraNvpDevice = devices.get(0);
@@ -237,7 +235,7 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru {
         final DeleteLogicalSwitchAnswer answer = (DeleteLogicalSwitchAnswer) agentMgr.easySend(niciraNvpHost.getId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("DeleteLogicalSwitchCommand failed");
+            logger.error("DeleteLogicalSwitchCommand failed");
         }
 
         super.shutdown(profile, offering);

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
@@ -31,7 +31,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.guru.DeallocateVmVspAnswer;
@@ -85,7 +84,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = NetworkGuru.class)
 public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
-    public static final Logger s_logger = Logger.getLogger(NuageVspGuestNetworkGuru.class);
 
     @Inject
     NetworkOfferingServiceMapDao _ntwkOfferingSrvcDao;
@@ -114,7 +112,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
         PhysicalNetworkVO physnet = _physicalNetworkDao.findById(plan.getPhysicalNetworkId());
         DataCenter dc = _dcDao.findById(plan.getDataCenterId());
         if (!canHandle(offering, dc.getNetworkType(), physnet)) {
-            s_logger.debug("Refusing to design this network");
+            logger.debug("Refusing to design this network");
             return null;
         }
 
@@ -163,7 +161,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
         AccountVO networksAccount = _accountDao.findById(network.getAccountId());
         if (networksAccount.getType() == Account.ACCOUNT_TYPE_PROJECT) {
             String errorMessage = "CS project support is not yet implemented in NuageVsp";
-            s_logger.debug(errorMessage);
+            logger.debug(errorMessage);
             throw new InsufficientVirtualNetworkCapacityException(errorMessage, Account.class, network.getAccountId());
         }
         boolean isL3Network = isL3Network(offering.getId());
@@ -182,13 +180,13 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
         ImplementNetworkVspAnswer answer = (ImplementNetworkVspAnswer)_agentMgr.easySend(nuageVspHost.getId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("ImplementNetworkNuageVspCommand failed");
+            logger.error("ImplementNetworkNuageVspCommand failed");
             if ((null != answer) && (null != answer.getDetails())) {
-                s_logger.error(answer.getDetails());
+                logger.error(answer.getDetails());
             }
             return null;
         }
-        s_logger.info("Implemented OK, network " + networkUuid + " in tenant " + tenantId + " linked to " + implemented.getBroadcastUri().toString());
+        logger.info("Implemented OK, network " + networkUuid + " in tenant " + tenantId + " linked to " + implemented.getBroadcastUri().toString());
         return implemented;
     }
 
@@ -204,7 +202,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
         nic.setBroadcastUri(network.getBroadcastUri());
         nic.setIsolationUri(network.getBroadcastUri());
 
-        s_logger.debug("Handling reserve() call back to with Create a new VM or add an interface to existing VM in network " + network.getName());
+        logger.debug("Handling reserve() call back to with Create a new VM or add an interface to existing VM in network " + network.getName());
         DataCenter dc = _dcDao.findById(network.getDataCenterId());
         Account networksAccount = _accountDao.findById(network.getAccountId());
         DomainVO networksDomain = _domainDao.findById(network.getDomainId());
@@ -233,9 +231,9 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
         ReserveVmInterfaceVspAnswer answer = (ReserveVmInterfaceVspAnswer)_agentMgr.easySend(nuageVspHost.getId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("ReserveVmInterfaceNuageVspCommand failed");
+            logger.error("ReserveVmInterfaceNuageVspCommand failed");
             if ((null != answer) && (null != answer.getDetails())) {
-                s_logger.error(answer.getDetails());
+                logger.error(answer.getDetails());
             }
             throw new InsufficientVirtualNetworkCapacityException("Failed to reserve VM in Nuage VSP.", Network.class, network.getId());
         }
@@ -249,7 +247,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
                 && isMyIsolationMethod(physicalNetwork)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }
@@ -258,7 +256,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
     public boolean release(NicProfile nic, VirtualMachineProfile vm, String reservationId) {
         long networkId = nic.getNetworkId();
         Network network = _networkDao.findById(networkId);
-        s_logger.debug("Handling release() call back, which is called when a VM is stopped or destroyed, to delete the VM with state " + vm.getVirtualMachine().getState()
+        logger.debug("Handling release() call back, which is called when a VM is stopped or destroyed, to delete the VM with state " + vm.getVirtualMachine().getState()
                 + " from netork " + network.getName());
         if (vm.getVirtualMachine().getState().equals(VirtualMachine.State.Stopping)) {
             try {
@@ -266,16 +264,16 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
                 ReleaseVmVspCommand cmd = new ReleaseVmVspCommand(network.getUuid(), vm.getUuid(), vm.getInstanceName());
                 ReleaseVmVspAnswer answer = (ReleaseVmVspAnswer)_agentMgr.easySend(nuageVspHost.getId(), cmd);
                 if (answer == null || !answer.getResult()) {
-                    s_logger.error("ReleaseVmNuageVspCommand for VM " + vm.getUuid() + " failed");
+                    logger.error("ReleaseVmNuageVspCommand for VM " + vm.getUuid() + " failed");
                     if ((null != answer) && (null != answer.getDetails())) {
-                        s_logger.error(answer.getDetails());
+                        logger.error(answer.getDetails());
                     }
                 }
             } catch (InsufficientVirtualNetworkCapacityException e) {
-                s_logger.debug("Handling release() call back. Failed to delete CS VM " + vm.getInstanceName() + " in VSP. " + e.getMessage());
+                logger.debug("Handling release() call back. Failed to delete CS VM " + vm.getInstanceName() + " in VSP. " + e.getMessage());
             }
         } else {
-            s_logger.debug("Handling release() call back. VM " + vm.getInstanceName() + " is in " + vm.getVirtualMachine().getState() + " state. So, the CS VM is not deleted."
+            logger.debug("Handling release() call back. VM " + vm.getInstanceName() + " is in " + vm.getVirtualMachine().getState() + " state. So, the CS VM is not deleted."
                     + " This could be a case where VM interface is deleted. deallocate() call back should be called later");
         }
 
@@ -287,7 +285,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
     public void deallocate(Network network, NicProfile nic, VirtualMachineProfile vm) {
 
         try {
-            s_logger.debug("Handling deallocate() call back, which is called when a VM is destroyed or interface is removed, " + "to delete VM Interface with IP "
+            logger.debug("Handling deallocate() call back, which is called when a VM is destroyed or interface is removed, " + "to delete VM Interface with IP "
                     + nic.getIPv4Address() + " from a VM " + vm.getInstanceName() + " with state " + vm.getVirtualMachine().getState());
             DomainVO networksDomain = _domainDao.findById(network.getDomainId());
             NicVO nicFrmDd = _nicDao.findById(nic.getId());
@@ -303,13 +301,13 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
                     isL3Network(networkOfferingId), vpcUuid, networksDomain.getUuid(), vm.getInstanceName(), vm.getUuid());
             DeallocateVmVspAnswer answer = (DeallocateVmVspAnswer)_agentMgr.easySend(nuageVspHost.getId(), cmd);
             if (answer == null || !answer.getResult()) {
-                s_logger.error("DeallocateVmNuageVspCommand for VM " + vm.getUuid() + " failed");
+                logger.error("DeallocateVmNuageVspCommand for VM " + vm.getUuid() + " failed");
                 if ((null != answer) && (null != answer.getDetails())) {
-                    s_logger.error(answer.getDetails());
+                    logger.error(answer.getDetails());
                 }
             }
         } catch (InsufficientVirtualNetworkCapacityException e) {
-            s_logger.error("Handling deallocate(). VM " + vm.getInstanceName() + " with NIC IP " + nic.getIPv4Address()
+            logger.error("Handling deallocate(). VM " + vm.getInstanceName() + " with NIC IP " + nic.getIPv4Address()
                     + " is getting destroyed. REST API failed to update the VM state in NuageVsp", e);
         }
         super.deallocate(network, nic, vm);
@@ -323,7 +321,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
     @Override
     public boolean trash(Network network, NetworkOffering offering) {
 
-        s_logger.debug("Handling trash() call back to delete the network " + network.getName() + " with uuid " + network.getUuid() + " from VSP");
+        logger.debug("Handling trash() call back to delete the network " + network.getName() + " with uuid " + network.getUuid() + " from VSP");
         long domainId = network.getDomainId();
         Domain domain = _domainDao.findById(domainId);
         Long vpcId = network.getVpcId();
@@ -337,13 +335,13 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
             TrashNetworkVspCommand cmd = new TrashNetworkVspCommand(domain.getUuid(), network.getUuid(), isL3Network(offering.getId()), vpcUuid);
             TrashNetworkVspAnswer answer = (TrashNetworkVspAnswer)_agentMgr.easySend(nuageVspHost.getId(), cmd);
             if (answer == null || !answer.getResult()) {
-                s_logger.error("TrashNetworkNuageVspCommand for network " + network.getUuid() + " failed");
+                logger.error("TrashNetworkNuageVspCommand for network " + network.getUuid() + " failed");
                 if ((null != answer) && (null != answer.getDetails())) {
-                    s_logger.error(answer.getDetails());
+                    logger.error(answer.getDetails());
                 }
             }
         } catch (Exception e) {
-            s_logger.warn("Failed to clean up network information in Vsp " + e.getMessage());
+            logger.warn("Failed to clean up network information in Vsp " + e.getMessage());
         }
 
         return super.trash(network, offering);
@@ -361,13 +359,13 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
             Iterator<Long> ipIterator = allIPsInCidr.iterator();
             long vip = ipIterator.next();
             if (NetUtils.ip2Long(network.getGateway()) == vip) {
-                s_logger.debug("Gateway of the Network(" + network.getUuid() + ") has the first IP " + NetUtils.long2Ip(vip));
+                logger.debug("Gateway of the Network(" + network.getUuid() + ") has the first IP " + NetUtils.long2Ip(vip));
                 vip = ipIterator.next();
                 virtualRouterIp = NetUtils.long2Ip(vip);
-                s_logger.debug("So, reserving the 2nd IP " + virtualRouterIp + " for the Virtual Router IP in Network(" + network.getUuid() + ")");
+                logger.debug("So, reserving the 2nd IP " + virtualRouterIp + " for the Virtual Router IP in Network(" + network.getUuid() + ")");
             } else {
                 virtualRouterIp = NetUtils.long2Ip(vip);
-                s_logger.debug("1nd IP is not used as the gateway IP. So, reserving" + virtualRouterIp + " for the Virtual Router IP for " + "Network(" + network.getUuid() + ")");
+                logger.debug("1nd IP is not used as the gateway IP. So, reserving" + virtualRouterIp + " for the Virtual Router IP for " + "Network(" + network.getUuid() + ")");
             }
             addressRange.add(NetUtils.long2Ip(ipIterator.next()));
             addressRange.add(NetUtils.long2Ip((Long)allIPsInCidr.toArray()[allIPsInCidr.size() - 1]));
@@ -390,7 +388,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru {
                 }
             }
         } catch (Exception e) {
-            s_logger.error("Failed to parse the VM interface Json response from VSP REST API. VM interface json string is  " + vmInterfacesDetails, e);
+            logger.error("Failed to parse the VM interface Json response from VSP REST API. VM interface json string is  " + vmInterfacesDetails, e);
             throw new InsufficientVirtualNetworkCapacityException("Failed to parse the VM interface Json response from VSP REST API. VM interface Json " + "string is  "
                     + vmInterfacesDetails + ". So. failed to get IP for the VM from VSP address for network " + network, Network.class, network.getId());
         }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/manager/NuageVspManagerImpl.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/manager/NuageVspManagerImpl.java
@@ -39,7 +39,6 @@ import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.network.ExternalNetworkDeviceManager;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.log4j.Logger;
 
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.commands.AddNuageVspDeviceCmd;
@@ -82,7 +81,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Local(value = {NuageVspManager.class})
 public class NuageVspManagerImpl extends ManagerBase implements NuageVspManager, Configurable {
 
-    private static final Logger s_logger = Logger.getLogger(NuageVspManagerImpl.class);
 
     private static final int ONE_MINUTE_MULTIPLIER = 60 * 1000;
 
@@ -290,7 +288,7 @@ public class NuageVspManagerImpl extends ManagerBase implements NuageVspManager,
         try {
             initNuageScheduledTasks();
         } catch (Exception ce) {
-            s_logger.warn("Failed to load NuageVsp configuration properties. Check if the NuageVsp properties are configured correctly");
+            logger.warn("Failed to load NuageVsp configuration properties. Check if the NuageVsp properties are configured correctly");
         }
         return true;
     }
@@ -318,7 +316,7 @@ public class NuageVspManagerImpl extends ManagerBase implements NuageVspManager,
             scheduler
                     .scheduleWithFixedDelay(new NuageVspSyncTask("ENTERPRISE"), ONE_MINUTE_MULTIPLIER * 15, ONE_MINUTE_MULTIPLIER * syncUpIntervalInMinutes, TimeUnit.MILLISECONDS);
         } else {
-            s_logger.warn("NuageVsp configuration for syncWorkers=" + numOfSyncThreads + " syncInterval=" + syncUpIntervalInMinutes
+            logger.warn("NuageVsp configuration for syncWorkers=" + numOfSyncThreads + " syncInterval=" + syncUpIntervalInMinutes
                     + " could not be read properly. So, check if the properties are configured properly in global properties");
         }
     }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/resource/NuageVspResource.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/resource/NuageVspResource.java
@@ -32,7 +32,6 @@ import net.nuage.vsp.acs.client.NuageVspGuruClient;
 import net.nuage.vsp.acs.client.NuageVspSyncClient;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.IAgentControl;
 import com.cloud.agent.api.Answer;
@@ -70,7 +69,6 @@ import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 public class NuageVspResource extends ManagerBase implements ServerResource {
-    private static final Logger s_logger = Logger.getLogger(NuageVspResource.class);
 
     private String _name;
     private String _guid;
@@ -184,7 +182,7 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
         try {
             login();
         } catch (Exception e) {
-            s_logger.error("Failed to login to Nuage VSD on " + name + " as user " + cmsUser + " Exception " + e.getMessage());
+            logger.error("Failed to login to Nuage VSD on " + name + " as user " + cmsUser + " Exception " + e.getMessage());
             throw new CloudRuntimeException("Failed to login to Nuage VSD on " + name + " as user " + cmsUser, e);
         }
 
@@ -219,7 +217,7 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
         } catch (Exception e) {
             _isNuageVspClientLoaded = false;
             String errorMessage = "Nuage Vsp Plugin client is not yet installed. Please install NuageVsp plugin client to use NuageVsp plugin in Cloudstack. ";
-            s_logger.warn(errorMessage + e.getMessage());
+            logger.warn(errorMessage + e.getMessage());
             throw new Exception(errorMessage);
         }
 
@@ -261,13 +259,13 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
     @Override
     public PingCommand getCurrentStatus(long id) {
         if ((_relativePath == null) || (_relativePath.isEmpty()) || (_cmsUserInfo == null) || (_cmsUserInfo.length == 0)) {
-            s_logger.error("Failed to ping to Nuage VSD");
+            logger.error("Failed to ping to Nuage VSD");
             return null;
         }
         try {
             login();
         } catch (Exception e) {
-            s_logger.error("Failed to ping to Nuage VSD on " + _name + " as user " + _cmsUserInfo[1] + " Exception " + e.getMessage());
+            logger.error("Failed to ping to Nuage VSD on " + _name + " as user " + _cmsUserInfo[1] + " Exception " + e.getMessage());
             return null;
         }
         return new PingCommand(Host.Type.L2Networking, id);
@@ -306,7 +304,7 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
         else if (cmd instanceof SyncVspCommand) {
             return executeRequest((SyncVspCommand)cmd);
         }
-        s_logger.debug("Received unsupported command " + cmd.toString());
+        logger.debug("Received unsupported command " + cmd.toString());
         return Answer.createUnsupportedCommandAnswer(cmd);
     }
 

--- a/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightElement.java
+++ b/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightElement.java
@@ -28,7 +28,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.network.opendaylight.agent.commands.StartupOpenDaylightControllerCommand;
@@ -62,7 +61,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Local(value = {NetworkElement.class, ConnectivityProvider.class})
 public class OpendaylightElement extends AdapterBase implements ConnectivityProvider, ResourceStateAdapter {
 
-    private static final Logger s_logger = Logger.getLogger(OpendaylightElement.class);
     private static final Map<Service, Map<Capability, String>> s_capabilities = setCapabilities();
 
     @Inject

--- a/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightGuestNetworkGuru.java
+++ b/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightGuestNetworkGuru.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.network.opendaylight.agent.commands.AddHypervisorCommand;
 import org.apache.cloudstack.network.opendaylight.agent.commands.ConfigureNetworkCommand;
@@ -70,7 +69,6 @@ import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VirtualMachineProfile;
 
 public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(OpendaylightGuestNetworkGuru.class);
 
     @Inject
     protected NetworkOfferingServiceMapDao ntwkOfferingSrvcDao;
@@ -96,7 +94,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
                 && ntwkOfferingSrvcDao.isProviderForNetworkOffering(offering.getId(), Provider.Opendaylight)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }
@@ -106,17 +104,17 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
         PhysicalNetworkVO physnet = physicalNetworkDao.findById(plan.getPhysicalNetworkId());
         DataCenter dc = _dcDao.findById(plan.getDataCenterId());
         if (!canHandle(offering, dc.getNetworkType(), physnet)) {
-            s_logger.debug("Refusing to design this network");
+            logger.debug("Refusing to design this network");
             return null;
         }
 
         List<OpenDaylightControllerVO> devices = openDaylightControllerMappingDao.listByPhysicalNetwork(physnet.getId());
         if (devices.isEmpty()) {
-            s_logger.error("No Controller on physical network " + physnet.getName());
+            logger.error("No Controller on physical network " + physnet.getName());
             return null;
         }
-        s_logger.debug("Controller " + devices.get(0).getUuid() + " found on physical network " + physnet.getId());
-        s_logger.debug("Physical isolation type is ODL, asking GuestNetworkGuru to design this network");
+        logger.debug("Controller " + devices.get(0).getUuid() + " found on physical network " + physnet.getId());
+        logger.debug("Physical isolation type is ODL, asking GuestNetworkGuru to design this network");
 
         NetworkVO networkObject = (NetworkVO)super.design(offering, plan, userSpecified, owner);
         if (networkObject == null) {
@@ -161,7 +159,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
 
         List<OpenDaylightControllerVO> devices = openDaylightControllerMappingDao.listByPhysicalNetwork(physicalNetworkId);
         if (devices.isEmpty()) {
-            s_logger.error("No Controller on physical network " + physicalNetworkId);
+            logger.error("No Controller on physical network " + physicalNetworkId);
             return null;
         }
         OpenDaylightControllerVO controller = devices.get(0);
@@ -170,13 +168,13 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
         ConfigureNetworkAnswer answer = (ConfigureNetworkAnswer)agentManager.easySend(controller.getHostId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("ConfigureNetworkCommand failed");
+            logger.error("ConfigureNetworkCommand failed");
             return null;
         }
 
         implemented.setBroadcastUri(BroadcastDomainType.OpenDaylight.toUri(answer.getNetworkUuid()));
         implemented.setBroadcastDomainType(BroadcastDomainType.OpenDaylight);
-        s_logger.info("Implemented OK, network linked to  = " + implemented.getBroadcastUri().toString());
+        logger.info("Implemented OK, network linked to  = " + implemented.getBroadcastUri().toString());
 
         return implemented;
     }
@@ -191,7 +189,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
 
         List<OpenDaylightControllerVO> devices = openDaylightControllerMappingDao.listByPhysicalNetwork(physicalNetworkId);
         if (devices.isEmpty()) {
-            s_logger.error("No Controller on physical network " + physicalNetworkId);
+            logger.error("No Controller on physical network " + physicalNetworkId);
             throw new InsufficientVirtualNetworkCapacityException("No OpenDaylight Controller configured for this network", dest.getPod().getId());
         }
         OpenDaylightControllerVO controller = devices.get(0);
@@ -199,7 +197,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
         AddHypervisorCommand addCmd = new AddHypervisorCommand(dest.getHost().getUuid(), dest.getHost().getPrivateIpAddress());
         AddHypervisorAnswer addAnswer = (AddHypervisorAnswer)agentManager.easySend(controller.getHostId(), addCmd);
         if (addAnswer == null || !addAnswer.getResult()) {
-            s_logger.error("Failed to add " + dest.getHost().getName() + " as a node to the controller");
+            logger.error("Failed to add " + dest.getHost().getName() + " as a node to the controller");
             throw new InsufficientVirtualNetworkCapacityException("Failed to add destination hypervisor to the OpenDaylight Controller", dest.getPod().getId());
         }
 
@@ -208,7 +206,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
         ConfigurePortAnswer answer = (ConfigurePortAnswer)agentManager.easySend(controller.getHostId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("ConfigureNetworkCommand failed");
+            logger.error("ConfigureNetworkCommand failed");
             throw new InsufficientVirtualNetworkCapacityException("Failed to configure the port on the OpenDaylight Controller", dest.getPod().getId());
         }
 
@@ -225,7 +223,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
 
             List<OpenDaylightControllerVO> devices = openDaylightControllerMappingDao.listByPhysicalNetwork(physicalNetworkId);
             if (devices.isEmpty()) {
-                s_logger.error("No Controller on physical network " + physicalNetworkId);
+                logger.error("No Controller on physical network " + physicalNetworkId);
                 throw new CloudRuntimeException("No OpenDaylight controller on this physical network");
             }
             OpenDaylightControllerVO controller = devices.get(0);
@@ -234,7 +232,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
             DestroyPortAnswer answer = (DestroyPortAnswer)agentManager.easySend(controller.getHostId(), cmd);
 
             if (answer == null || !answer.getResult()) {
-                s_logger.error("DestroyPortCommand failed");
+                logger.error("DestroyPortCommand failed");
                 success = false;
             }
         }
@@ -246,13 +244,13 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
     public void shutdown(NetworkProfile profile, NetworkOffering offering) {
         NetworkVO networkObject = networkDao.findById(profile.getId());
         if (networkObject.getBroadcastDomainType() != BroadcastDomainType.OpenDaylight || networkObject.getBroadcastUri() == null) {
-            s_logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
+            logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
             return;
         }
 
         List<OpenDaylightControllerVO> devices = openDaylightControllerMappingDao.listByPhysicalNetwork(networkObject.getPhysicalNetworkId());
         if (devices.isEmpty()) {
-            s_logger.error("No Controller on physical network " + networkObject.getPhysicalNetworkId());
+            logger.error("No Controller on physical network " + networkObject.getPhysicalNetworkId());
             return;
         }
         OpenDaylightControllerVO controller = devices.get(0);
@@ -261,7 +259,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
         DestroyNetworkAnswer answer = (DestroyNetworkAnswer)agentManager.easySend(controller.getHostId(), cmd);
 
         if (answer == null || !answer.getResult()) {
-            s_logger.error("DestroyNetworkCommand failed");
+            logger.error("DestroyNetworkCommand failed");
         }
 
         super.shutdown(profile, offering);

--- a/plugins/network-elements/ovs/src/com/cloud/network/element/OvsElement.java
+++ b/plugins/network-elements/ovs/src/com/cloud/network/element/OvsElement.java
@@ -28,7 +28,6 @@ import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.network.topology.NetworkTopology;
 import org.apache.cloudstack.network.topology.NetworkTopologyContext;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.agent.api.StartupOvsCommand;
@@ -107,7 +106,6 @@ StaticNatServiceProvider, IpDeployer {
     @Inject
     NetworkTopologyContext _networkTopologyContext;
 
-    private static final Logger s_logger = Logger.getLogger(OvsElement.class);
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
     @Override
@@ -121,21 +119,21 @@ StaticNatServiceProvider, IpDeployer {
     }
 
     protected boolean canHandle(final Network network, final Service service) {
-        s_logger.debug("Checking if OvsElement can handle service "
+        logger.debug("Checking if OvsElement can handle service "
                 + service.getName() + " on network " + network.getDisplayText());
         if (network.getBroadcastDomainType() != BroadcastDomainType.Vswitch) {
             return false;
         }
 
         if (!_networkModel.isProviderForNetwork(getProvider(), network.getId())) {
-            s_logger.debug("OvsElement is not a provider for network "
+            logger.debug("OvsElement is not a provider for network "
                     + network.getDisplayText());
             return false;
         }
 
         if (!_ntwkSrvcDao.canProviderSupportServiceInNetwork(network.getId(),
                 service, Network.Provider.Ovs)) {
-            s_logger.debug("OvsElement can't provide the " + service.getName()
+            logger.debug("OvsElement can't provide the " + service.getName()
                     + " service on network " + network.getDisplayText());
             return false;
         }
@@ -156,7 +154,7 @@ StaticNatServiceProvider, IpDeployer {
             final DeployDestination dest, final ReservationContext context)
                     throws ConcurrentOperationException, ResourceUnavailableException,
                     InsufficientCapacityException {
-        s_logger.debug("entering OvsElement implement function for network "
+        logger.debug("entering OvsElement implement function for network "
                 + network.getDisplayText() + " (state " + network.getState()
                 + ")");
 
@@ -254,7 +252,7 @@ StaticNatServiceProvider, IpDeployer {
     @Override
     public boolean verifyServicesCombination(final Set<Service> services) {
         if (!services.contains(Service.Connectivity)) {
-            s_logger.warn("Unable to provide services without Connectivity service enabled for this element");
+            logger.warn("Unable to provide services without Connectivity service enabled for this element");
             return false;
         }
 
@@ -443,7 +441,7 @@ StaticNatServiceProvider, IpDeployer {
             List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                     network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router element doesn't need to associate ip addresses on the backend; virtual "
+                logger.debug("Virtual router element doesn't need to associate ip addresses on the backend; virtual "
                         + "router doesn't exist in the network "
                         + network.getId());
                 return true;
@@ -467,7 +465,7 @@ StaticNatServiceProvider, IpDeployer {
         List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                 network.getId(), Role.VIRTUAL_ROUTER);
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug("Ovs element doesn't need to apply static nat on the backend; virtual "
+            logger.debug("Ovs element doesn't need to apply static nat on the backend; virtual "
                     + "router doesn't exist in the network " + network.getId());
             return true;
         }
@@ -487,7 +485,7 @@ StaticNatServiceProvider, IpDeployer {
         List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                 network.getId(), Role.VIRTUAL_ROUTER);
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug("Ovs element doesn't need to apply firewall rules on the backend; virtual "
+            logger.debug("Ovs element doesn't need to apply firewall rules on the backend; virtual "
                     + "router doesn't exist in the network " + network.getId());
             return true;
         }
@@ -509,7 +507,7 @@ StaticNatServiceProvider, IpDeployer {
             List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                     network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual "
+                logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual "
                         + "router doesn't exist in the network "
                         + network.getId());
                 return true;
@@ -559,7 +557,7 @@ StaticNatServiceProvider, IpDeployer {
             if (schemeCaps != null) {
                 for (LoadBalancingRule rule : rules) {
                     if (!schemeCaps.contains(rule.getScheme().toString())) {
-                        s_logger.debug("Scheme " + rules.get(0).getScheme()
+                        logger.debug("Scheme " + rules.get(0).getScheme()
                                 + " is not supported by the provider "
                                 + getName());
                         return false;

--- a/plugins/network-elements/ovs/src/com/cloud/network/guru/OvsGuestNetworkGuru.java
+++ b/plugins/network-elements/ovs/src/com/cloud/network/guru/OvsGuestNetworkGuru.java
@@ -21,7 +21,6 @@ import com.cloud.network.vpc.dao.VpcDao;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.context.CallContext;
@@ -56,8 +55,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Component
 @Local(value = NetworkGuru.class)
 public class OvsGuestNetworkGuru extends GuestNetworkGuru {
-    private static final Logger s_logger = Logger
-        .getLogger(OvsGuestNetworkGuru.class);
 
     @Inject
     OvsTunnelManager _ovsTunnelMgr;
@@ -85,7 +82,7 @@ public class OvsGuestNetworkGuru extends GuestNetworkGuru {
                 offering.getId(), Service.Connectivity)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   "
+            logger.trace("We only take care of Guest networks of type   "
                 + GuestType.Isolated + " in zone of type "
                 + NetworkType.Advanced);
             return false;
@@ -100,7 +97,7 @@ public class OvsGuestNetworkGuru extends GuestNetworkGuru {
             .getPhysicalNetworkId());
         DataCenter dc = _dcDao.findById(plan.getDataCenterId());
         if (!canHandle(offering, dc.getNetworkType(), physnet)) {
-            s_logger.debug("Refusing to design this network");
+            logger.debug("Refusing to design this network");
             return null;
         }
         NetworkVO config = (NetworkVO)super.design(offering, plan,
@@ -135,7 +132,7 @@ public class OvsGuestNetworkGuru extends GuestNetworkGuru {
             .findById(physicalNetworkId);
 
         if (!canHandle(offering, nwType, physnet)) {
-            s_logger.debug("Refusing to design this network");
+            logger.debug("Refusing to design this network");
             return null;
         }
         NetworkVO implemented = (NetworkVO)super.implement(network, offering,
@@ -184,13 +181,13 @@ public class OvsGuestNetworkGuru extends GuestNetworkGuru {
         NetworkVO networkObject = _networkDao.findById(profile.getId());
         if (networkObject.getBroadcastDomainType() != BroadcastDomainType.Vswitch
             || networkObject.getBroadcastUri() == null) {
-            s_logger.warn("BroadcastUri is empty or incorrect for guestnetwork "
+            logger.warn("BroadcastUri is empty or incorrect for guestnetwork "
                 + networkObject.getDisplayText());
             return;
         }
 
         if (profile.getBroadcastDomainType() == BroadcastDomainType.Vswitch ) {
-            s_logger.debug("Releasing vnet for the network id=" + profile.getId());
+            logger.debug("Releasing vnet for the network id=" + profile.getId());
             _dcDao.releaseVnet(BroadcastDomainType.getValue(profile.getBroadcastUri()), profile.getDataCenterId(), profile.getPhysicalNetworkId(),
                     profile.getAccountId(), profile.getReservationId());
         }

--- a/plugins/network-elements/ovs/src/com/cloud/network/ovs/dao/VpcDistributedRouterSeqNoDaoImpl.java
+++ b/plugins/network-elements/ovs/src/com/cloud/network/ovs/dao/VpcDistributedRouterSeqNoDaoImpl.java
@@ -18,7 +18,6 @@ package com.cloud.network.ovs.dao;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.GenericDaoBase;
@@ -28,7 +27,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {VpcDistributedRouterSeqNoDao.class})
 public class VpcDistributedRouterSeqNoDaoImpl extends GenericDaoBase<VpcDistributedRouterSeqNoVO, Long> implements VpcDistributedRouterSeqNoDao {
-    protected static final Logger s_logger = Logger.getLogger(VpcDistributedRouterSeqNoDaoImpl.class);
     private SearchBuilder<VpcDistributedRouterSeqNoVO> VpcIdSearch;
 
     protected VpcDistributedRouterSeqNoDaoImpl() {

--- a/plugins/network-elements/palo-alto/src/com/cloud/network/element/PaloAltoExternalFirewallElement.java
+++ b/plugins/network-elements/palo-alto/src/com/cloud/network/element/PaloAltoExternalFirewallElement.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.network.ExternalNetworkDeviceManager.NetworkDevice;
@@ -87,7 +86,6 @@ import com.cloud.vm.VirtualMachineProfile;
 public class PaloAltoExternalFirewallElement extends ExternalFirewallDeviceManagerImpl implements SourceNatServiceProvider, FirewallServiceProvider,
         PortForwardingServiceProvider, IpDeployer, PaloAltoFirewallElementService, StaticNatServiceProvider {
 
-    private static final Logger s_logger = Logger.getLogger(PaloAltoExternalFirewallElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -123,18 +121,18 @@ public class PaloAltoExternalFirewallElement extends ExternalFirewallDeviceManag
     private boolean canHandle(Network network, Service service) {
         DataCenter zone = _entityMgr.findById(DataCenter.class, network.getDataCenterId());
         if (zone.getNetworkType() == NetworkType.Advanced && network.getGuestType() != Network.GuestType.Isolated) {
-            s_logger.trace("Element " + getProvider().getName() + "is not handling network type = " + network.getGuestType());
+            logger.trace("Element " + getProvider().getName() + "is not handling network type = " + network.getGuestType());
             return false;
         }
 
         if (service == null) {
             if (!_networkManager.isProviderForNetwork(getProvider(), network.getId())) {
-                s_logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
+                logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
                 return false;
             }
         } else {
             if (!_networkManager.isProviderSupportServiceInNetwork(network.getId(), service, getProvider())) {
-                s_logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
+                logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
                 return false;
             }
         }
@@ -149,7 +147,7 @@ public class PaloAltoExternalFirewallElement extends ExternalFirewallDeviceManag
 
         // don't have to implement network is Basic zone
         if (zone.getNetworkType() == NetworkType.Basic) {
-            s_logger.debug("Not handling network implement in zone of type " + NetworkType.Basic);
+            logger.debug("Not handling network implement in zone of type " + NetworkType.Basic);
             return false;
         }
 
@@ -162,7 +160,7 @@ public class PaloAltoExternalFirewallElement extends ExternalFirewallDeviceManag
         } catch (InsufficientCapacityException capacityException) {
             // TODO: handle out of capacity exception in more gracefule manner when multiple providers are present for
             // the network
-            s_logger.error("Fail to implement the Palo Alto for network " + network, capacityException);
+            logger.error("Fail to implement the Palo Alto for network " + network, capacityException);
             return false;
         }
     }
@@ -184,7 +182,7 @@ public class PaloAltoExternalFirewallElement extends ExternalFirewallDeviceManag
 
         // don't have to implement network is Basic zone
         if (zone.getNetworkType() == NetworkType.Basic) {
-            s_logger.debug("Not handling network shutdown in zone of type " + NetworkType.Basic);
+            logger.debug("Not handling network shutdown in zone of type " + NetworkType.Basic);
             return false;
         }
 
@@ -432,7 +430,7 @@ public class PaloAltoExternalFirewallElement extends ExternalFirewallDeviceManag
     @Override
     public boolean verifyServicesCombination(Set<Service> services) {
         if (!services.contains(Service.Firewall)) {
-            s_logger.warn("Palo Alto must be used as Firewall Service Provider in the network");
+            logger.warn("Palo Alto must be used as Firewall Service Provider in the network");
             return false;
         }
         return true;

--- a/plugins/network-elements/stratosphere-ssp/src/org/apache/cloudstack/network/dao/SspUuidDaoImpl.java
+++ b/plugins/network-elements/stratosphere-ssp/src/org/apache/cloudstack/network/dao/SspUuidDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.network.Network;
 import com.cloud.utils.db.GenericDaoBase;
@@ -32,7 +31,6 @@ import com.cloud.vm.NicProfile;
 @Local(SspUuidDao.class)
 public class SspUuidDaoImpl extends GenericDaoBase<SspUuidVO, Long> implements SspUuidDao {
 
-    private static final Logger s_logger = Logger.getLogger(SspUuidDaoImpl.class);
 
     protected final SearchBuilder<SspUuidVO> native2uuid;
     protected final SearchBuilder<SspUuidVO> uuid2native;

--- a/plugins/network-elements/stratosphere-ssp/src/org/apache/cloudstack/network/guru/SspGuestNetworkGuru.java
+++ b/plugins/network-elements/stratosphere-ssp/src/org/apache/cloudstack/network/guru/SspGuestNetworkGuru.java
@@ -19,7 +19,6 @@ package org.apache.cloudstack.network.guru;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.network.element.SspElement;
 import org.apache.cloudstack.network.element.SspManager;
@@ -48,7 +47,6 @@ import com.cloud.vm.VirtualMachineProfile;
  */
 @Local(value = NetworkGuru.class)
 public class SspGuestNetworkGuru extends GuestNetworkGuru implements NetworkMigrationResponder {
-    private static final Logger s_logger = Logger.getLogger(SspGuestNetworkGuru.class);
 
     @Inject
     SspManager _sspMgr;
@@ -64,7 +62,7 @@ public class SspGuestNetworkGuru extends GuestNetworkGuru implements NetworkMigr
 
     @Override
     protected boolean canHandle(NetworkOffering offering, NetworkType networkType, PhysicalNetwork physicalNetwork) {
-        s_logger.trace("canHandle");
+        logger.trace("canHandle");
 
         String setting = null;
         if (physicalNetwork != null && physicalNetwork.getIsolationMethods().contains("SSP")) {
@@ -75,18 +73,18 @@ public class SspGuestNetworkGuru extends GuestNetworkGuru implements NetworkMigr
         }
         if (setting != null) {
             if (networkType != NetworkType.Advanced) {
-                s_logger.info("SSP enebled by " + setting + " but not active because networkType was " + networkType);
+                logger.info("SSP enebled by " + setting + " but not active because networkType was " + networkType);
             } else if (!isMyTrafficType(offering.getTrafficType())) {
-                s_logger.info("SSP enabled by " + setting + " but not active because traffic type not Guest");
+                logger.info("SSP enabled by " + setting + " but not active because traffic type not Guest");
             } else if (offering.getGuestType() != Network.GuestType.Isolated) {
-                s_logger.info("SSP works for network isolatation.");
+                logger.info("SSP works for network isolatation.");
             } else if (!_sspMgr.canHandle(physicalNetwork)) {
-                s_logger.info("SSP manager not ready");
+                logger.info("SSP manager not ready");
             } else {
                 return true;
             }
         } else {
-            s_logger.debug("SSP not configured to be active");
+            logger.debug("SSP not configured to be active");
         }
         return false;
     }
@@ -101,7 +99,7 @@ public class SspGuestNetworkGuru extends GuestNetworkGuru implements NetworkMigr
     @Override
     public Network implement(Network network, NetworkOffering offering, DeployDestination dest, ReservationContext context)
         throws InsufficientVirtualNetworkCapacityException {
-        s_logger.trace("implement " + network.toString());
+        logger.trace("implement " + network.toString());
         super.implement(network, offering, dest, context);
         _sspMgr.createNetwork(network, offering, dest, context);
         return network;
@@ -109,7 +107,7 @@ public class SspGuestNetworkGuru extends GuestNetworkGuru implements NetworkMigr
 
     @Override
     public void shutdown(NetworkProfile profile, NetworkOffering offering) {
-        s_logger.trace("shutdown " + profile.toString());
+        logger.trace("shutdown " + profile.toString());
         _sspMgr.deleteNetwork(profile);
         super.shutdown(profile, offering);
     }
@@ -138,10 +136,10 @@ public class SspGuestNetworkGuru extends GuestNetworkGuru implements NetworkMigr
         try {
             reserve(nic, network, vm, dest, context);
         } catch (InsufficientVirtualNetworkCapacityException e) {
-            s_logger.error("prepareForMigration failed", e);
+            logger.error("prepareForMigration failed", e);
             return false;
         } catch (InsufficientAddressCapacityException e) {
-            s_logger.error("prepareForMigration failed", e);
+            logger.error("prepareForMigration failed", e);
             return false;
         }
         return true;

--- a/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
+++ b/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
@@ -18,7 +18,6 @@ package com.cloud.network.guru;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.context.CallContext;
@@ -49,7 +48,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Component
 @Local(value = NetworkGuru.class)
 public class VxlanGuestNetworkGuru extends GuestNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(VxlanGuestNetworkGuru.class);
 
     public VxlanGuestNetworkGuru() {
         super();
@@ -63,7 +61,7 @@ public class VxlanGuestNetworkGuru extends GuestNetworkGuru {
             isMyIsolationMethod(physicalNetwork)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }
@@ -151,7 +149,7 @@ public class VxlanGuestNetworkGuru extends GuestNetworkGuru {
     public void shutdown(NetworkProfile profile, NetworkOffering offering) {
         NetworkVO networkObject = _networkDao.findById(profile.getId());
         if (networkObject.getBroadcastDomainType() != BroadcastDomainType.Vxlan || networkObject.getBroadcastUri() == null) {
-            s_logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
+            logger.warn("BroadcastUri is empty or incorrect for guestnetwork " + networkObject.getDisplayText());
             return;
         }
 

--- a/plugins/storage-allocators/random/src/org/apache/cloudstack/storage/allocator/RandomStoragePoolAllocator.java
+++ b/plugins/storage-allocators/random/src/org/apache/cloudstack/storage/allocator/RandomStoragePoolAllocator.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
@@ -35,7 +34,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = StoragePoolAllocator.class)
 public class RandomStoragePoolAllocator extends AbstractStoragePoolAllocator {
-    private static final Logger s_logger = Logger.getLogger(RandomStoragePoolAllocator.class);
 
     @Override
     public List<StoragePool> select(DiskProfile dskCh, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, int returnUpTo) {
@@ -50,18 +48,18 @@ public class RandomStoragePoolAllocator extends AbstractStoragePoolAllocator {
             return null;
         }
 
-        s_logger.debug("Looking for pools in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
+        logger.debug("Looking for pools in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
         List<StoragePoolVO> pools = _storagePoolDao.listBy(dcId, podId, clusterId, ScopeType.CLUSTER);
         if (pools.size() == 0) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("No storage pools available for allocation, returning");
+            if (logger.isDebugEnabled()) {
+                logger.debug("No storage pools available for allocation, returning");
             }
             return suitablePools;
         }
 
         Collections.shuffle(pools);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("RandomStoragePoolAllocator has " + pools.size() + " pools to check for allocation");
+        if (logger.isDebugEnabled()) {
+            logger.debug("RandomStoragePoolAllocator has " + pools.size() + " pools to check for allocation");
         }
         for (StoragePoolVO pool : pools) {
             if (suitablePools.size() == returnUpTo) {
@@ -74,8 +72,8 @@ public class RandomStoragePoolAllocator extends AbstractStoragePoolAllocator {
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("RandomStoragePoolAllocator returning " + suitablePools.size() + " suitable storage pools");
+        if (logger.isDebugEnabled()) {
+            logger.debug("RandomStoragePoolAllocator returning " + suitablePools.size() + " suitable storage pools");
         }
 
         return suitablePools;

--- a/plugins/storage/volume/cloudbyte/src/org/apache/cloudstack/storage/datastore/util/ElastistorVolumeApiServiceImpl.java
+++ b/plugins/storage/volume/cloudbyte/src/org/apache/cloudstack/storage/datastore/util/ElastistorVolumeApiServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.ListResponse;
@@ -47,7 +46,6 @@ import com.cloud.vm.dao.UserVmDao;
 
 @Component
 public class ElastistorVolumeApiServiceImpl extends ManagerBase implements ElastistorVolumeApiService {
-    private static final Logger s_logger = Logger.getLogger(ElastistorVolumeApiServiceImpl.class);
 
     @Inject
     protected VolumeDao _volsDao;
@@ -74,7 +72,7 @@ public class ElastistorVolumeApiServiceImpl extends ManagerBase implements Elast
         cmdList.add(ListElastistorPoolCmd.class);
         cmdList.add(ListElastistorInterfaceCmd.class);
 
-        s_logger.info("Commands were registered successfully with elastistor volume api service. [cmdcount:" + cmdList.size() + "]");
+        logger.info("Commands were registered successfully with elastistor volume api service. [cmdcount:" + cmdList.size() + "]");
         return cmdList;
 
     }
@@ -125,7 +123,7 @@ public class ElastistorVolumeApiServiceImpl extends ManagerBase implements Elast
 
             return response;
         } catch (Throwable e) {
-            s_logger.error("Unable to list elastistor volume.", e);
+            logger.error("Unable to list elastistor volume.", e);
             throw new CloudRuntimeException("Unable to list elastistor volume. " + e.getMessage());
         }
     }
@@ -165,7 +163,7 @@ public class ElastistorVolumeApiServiceImpl extends ManagerBase implements Elast
             return response;
 
         } catch (Throwable e) {
-            s_logger.error("Unable to list elastistor pools.", e);
+            logger.error("Unable to list elastistor pools.", e);
             throw new CloudRuntimeException("Unable to list elastistor pools. " + e.getMessage());
         }
 
@@ -199,7 +197,7 @@ public class ElastistorVolumeApiServiceImpl extends ManagerBase implements Elast
 
             return response;
         } catch (Throwable e) {
-            s_logger.error("Unable to list elastistor interfaces.", e);
+            logger.error("Unable to list elastistor interfaces.", e);
             throw new CloudRuntimeException("Unable to list elastistor interfaces. " + e.getMessage());
         }
 

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
@@ -21,13 +21,11 @@ import com.cloud.user.UserAccount;
 import com.cloud.user.dao.UserAccountDao;
 import com.cloud.utils.Pair;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import javax.inject.Inject;
 import java.util.Map;
 
 public class LdapAuthenticator extends DefaultUserAuthenticator {
-    private static final Logger s_logger = Logger.getLogger(LdapAuthenticator.class.getName());
 
     @Inject
     private LdapManager _ldapManager;
@@ -48,14 +46,14 @@ public class LdapAuthenticator extends DefaultUserAuthenticator {
     public Pair<Boolean, ActionOnFailedAuthentication> authenticate(final String username, final String password, final Long domainId, final Map<String, Object[]> requestParameters) {
 
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
-            s_logger.debug("Username or Password cannot be empty");
+            logger.debug("Username or Password cannot be empty");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
         final UserAccount user = _userAccountDao.getUserAccount(username, domainId);
 
         if (user == null) {
-            s_logger.debug("Unable to find user with " + username + " in domain " + domainId);
+            logger.debug("Unable to find user with " + username + " in domain " + domainId);
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         } else if (_ldapManager.isLdapEnabled()) {
             boolean result = _ldapManager.canAuthenticate(username, password);

--- a/plugins/user-authenticators/md5/src/com/cloud/server/auth/MD5UserAuthenticator.java
+++ b/plugins/user-authenticators/md5/src/com/cloud/server/auth/MD5UserAuthenticator.java
@@ -20,7 +20,6 @@ import com.cloud.user.dao.UserAccountDao;
 import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.inject.Inject;
@@ -36,30 +35,29 @@ import java.util.Map;
  */
 @Local(value = {UserAuthenticator.class})
 public class MD5UserAuthenticator extends DefaultUserAuthenticator {
-    public static final Logger s_logger = Logger.getLogger(MD5UserAuthenticator.class);
 
     @Inject
     private UserAccountDao _userAccountDao;
 
     @Override
     public Pair<Boolean, ActionOnFailedAuthentication> authenticate(String username, String password, Long domainId, Map<String, Object[]> requestParameters) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Retrieving user: " + username);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Retrieving user: " + username);
         }
 
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
-            s_logger.debug("Username or Password cannot be empty");
+            logger.debug("Username or Password cannot be empty");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
         UserAccount user = _userAccountDao.getUserAccount(username, domainId);
         if (user == null) {
-            s_logger.debug("Unable to find user with " + username + " in domain " + domainId);
+            logger.debug("Unable to find user with " + username + " in domain " + domainId);
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
         if (!user.getPassword().equals(encode(password))) {
-            s_logger.debug("Password does not match");
+            logger.debug("Password does not match");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, ActionOnFailedAuthentication.INCREMENT_INCORRECT_LOGIN_ATTEMPT_COUNT);
         }
         return new Pair<Boolean, ActionOnFailedAuthentication>(true, null);

--- a/plugins/user-authenticators/pbkdf2/src/org/apache/cloudstack/server/auth/PBKDF2UserAuthenticator.java
+++ b/plugins/user-authenticators/pbkdf2/src/org/apache/cloudstack/server/auth/PBKDF2UserAuthenticator.java
@@ -23,7 +23,6 @@ import com.cloud.utils.ConstantTimeComparator;
 import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 import org.bouncycastle.crypto.PBEParametersGenerator;
 import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -41,7 +40,6 @@ import static java.lang.String.format;
 
 @Local({UserAuthenticator.class})
 public class PBKDF2UserAuthenticator extends DefaultUserAuthenticator {
-    public static final Logger s_logger = Logger.getLogger(PBKDF2UserAuthenticator.class);
     private static final int s_saltlen = 64;
     private static final int s_rounds = 100000;
     private static final int s_keylen = 512;
@@ -50,12 +48,12 @@ public class PBKDF2UserAuthenticator extends DefaultUserAuthenticator {
     private UserAccountDao _userAccountDao;
 
     public Pair<Boolean, UserAuthenticator.ActionOnFailedAuthentication> authenticate(String username, String password, Long domainId, Map<String, Object[]> requestParameters) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Retrieving user: " + username);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Retrieving user: " + username);
         }
 
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
-            s_logger.debug("Username or Password cannot be empty");
+            logger.debug("Username or Password cannot be empty");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
@@ -64,7 +62,7 @@ public class PBKDF2UserAuthenticator extends DefaultUserAuthenticator {
         if (user != null) {
             isValidUser = true;
         } else {
-            s_logger.debug("Unable to find user with " + username + " in domain " + domainId);
+            logger.debug("Unable to find user with " + username + " in domain " + domainId);
         }
 
         byte[] salt = new byte[0];
@@ -73,7 +71,7 @@ public class PBKDF2UserAuthenticator extends DefaultUserAuthenticator {
             if (isValidUser) {
                 String[] storedPassword = user.getPassword().split(":");
                 if ((storedPassword.length != 3) || (!StringUtils.isNumeric(storedPassword[2]))) {
-                    s_logger.warn("The stored password for " + username + " isn't in the right format for this authenticator");
+                    logger.warn("The stored password for " + username + " isn't in the right format for this authenticator");
                     isValidUser = false;
                 } else {
                     // Encoding format = <salt>:<password hash>:<rounds>
@@ -112,7 +110,7 @@ public class PBKDF2UserAuthenticator extends DefaultUserAuthenticator {
         } catch (UnsupportedEncodingException e) {
             throw new CloudRuntimeException("Unable to hash password", e);
         } catch (InvalidKeySpecException e) {
-            s_logger.error("Exception in EncryptUtil.createKey ", e);
+            logger.error("Exception in EncryptUtil.createKey ", e);
             throw new CloudRuntimeException("Unable to hash password", e);
         }
     }

--- a/plugins/user-authenticators/plain-text/src/com/cloud/server/auth/PlainTextUserAuthenticator.java
+++ b/plugins/user-authenticators/plain-text/src/com/cloud/server/auth/PlainTextUserAuthenticator.java
@@ -19,7 +19,6 @@ import com.cloud.user.UserAccount;
 import com.cloud.user.dao.UserAccountDao;
 import com.cloud.utils.Pair;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.inject.Inject;
@@ -27,30 +26,29 @@ import java.util.Map;
 
 @Local(value = {UserAuthenticator.class})
 public class PlainTextUserAuthenticator extends DefaultUserAuthenticator {
-    public static final Logger s_logger = Logger.getLogger(PlainTextUserAuthenticator.class);
 
     @Inject
     private UserAccountDao _userAccountDao;
 
     @Override
     public Pair<Boolean, ActionOnFailedAuthentication> authenticate(String username, String password, Long domainId, Map<String, Object[]> requestParameters) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Retrieving user: " + username);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Retrieving user: " + username);
         }
 
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
-            s_logger.debug("Username or Password cannot be empty");
+            logger.debug("Username or Password cannot be empty");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
         UserAccount user = _userAccountDao.getUserAccount(username, domainId);
         if (user == null) {
-            s_logger.debug("Unable to find user with " + username + " in domain " + domainId);
+            logger.debug("Unable to find user with " + username + " in domain " + domainId);
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
         if (!user.getPassword().equals(password)) {
-            s_logger.debug("Password does not match");
+            logger.debug("Password does not match");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, ActionOnFailedAuthentication.INCREMENT_INCORRECT_LOGIN_ATTEMPT_COUNT);
         }
         return new Pair<Boolean, ActionOnFailedAuthentication>(true, null);

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAML2AuthManagerImpl.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAML2AuthManagerImpl.java
@@ -37,7 +37,6 @@ import org.apache.cloudstack.framework.security.keystore.KeystoreDao;
 import org.apache.cloudstack.framework.security.keystore.KeystoreVO;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.log4j.Logger;
 import org.opensaml.DefaultBootstrap;
 import org.opensaml.common.xml.SAMLConstants;
 import org.opensaml.saml2.metadata.ContactPerson;
@@ -93,7 +92,6 @@ import java.util.TimerTask;
 @Component
 @Local(value = {SAML2AuthManager.class, PluggableAPIAuthenticator.class})
 public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManager, Configurable {
-    private static final Logger s_logger = Logger.getLogger(SAML2AuthManagerImpl.class);
 
     private SAMLProviderMetadata _spMetadata = new SAMLProviderMetadata();
     private Map<String, SAMLProviderMetadata> _idpMetadataMap = new HashMap<String, SAMLProviderMetadata>();
@@ -124,10 +122,10 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
     @Override
     public boolean start() {
         if (isSAMLPluginEnabled()) {
-            s_logger.info("SAML auth plugin loaded");
+            logger.info("SAML auth plugin loaded");
             return setup();
         } else {
-            s_logger.info("SAML auth plugin not enabled so not loading");
+            logger.info("SAML auth plugin not enabled so not loading");
             return super.start();
         }
     }
@@ -147,9 +145,9 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
                 KeyPair keyPair = SAMLUtils.generateRandomKeyPair();
                 _ksDao.save(SAMLPluginConstants.SAMLSP_KEYPAIR, SAMLUtils.savePrivateKey(keyPair.getPrivate()), SAMLUtils.savePublicKey(keyPair.getPublic()), "samlsp-keypair");
                 keyStoreVO = _ksDao.findByName(SAMLPluginConstants.SAMLSP_KEYPAIR);
-                s_logger.info("No SAML keystore found, created and saved a new Service Provider keypair");
+                logger.info("No SAML keystore found, created and saved a new Service Provider keypair");
             } catch (NoSuchProviderException | NoSuchAlgorithmException e) {
-                s_logger.error("Unable to create and save SAML keypair: " + e.toString());
+                logger.error("Unable to create and save SAML keypair: " + e.toString());
             }
         }
 
@@ -178,7 +176,7 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
                         _ksDao.save(SAMLPluginConstants.SAMLSP_X509CERT, Base64.encodeBase64String(bos.toByteArray()), "", "samlsp-x509cert");
                         bos.close();
                     } catch (NoSuchAlgorithmException | NoSuchProviderException | CertificateEncodingException | SignatureException | InvalidKeyException | IOException e) {
-                        s_logger.error("SAML Plugin won't be able to use X509 signed authentication");
+                        logger.error("SAML Plugin won't be able to use X509 signed authentication");
                     }
                 } else {
                     try {
@@ -187,7 +185,7 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
                         spX509Key = (X509Certificate) si.readObject();
                         bi.close();
                     } catch (IOException | ClassNotFoundException ignored) {
-                        s_logger.error("SAML Plugin won't be able to use X509 signed authentication. Failed to load X509 Certificate from Database.");
+                        logger.error("SAML Plugin won't be able to use X509 signed authentication. Failed to load X509 Certificate from Database.");
                     }
                 }
             }
@@ -214,7 +212,7 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
     private void addIdpToMap(EntityDescriptor descriptor, Map<String, SAMLProviderMetadata> idpMap) {
         SAMLProviderMetadata idpMetadata = new SAMLProviderMetadata();
         idpMetadata.setEntityId(descriptor.getEntityID());
-        s_logger.debug("Adding IdP to the list of discovered IdPs: " + descriptor.getEntityID());
+        logger.debug("Adding IdP to the list of discovered IdPs: " + descriptor.getEntityID());
         if (descriptor.getOrganization() != null) {
             if (descriptor.getOrganization().getDisplayNames() != null) {
                 for (OrganizationDisplayName orgName : descriptor.getOrganization().getDisplayNames()) {
@@ -288,21 +286,21 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
                         try {
                             idpMetadata.setSigningCertificate(KeyInfoHelper.getCertificates(kd.getKeyInfo()).get(0));
                         } catch (CertificateException ignored) {
-                            s_logger.info("[ignored] encountered invalid certificate signing.", ignored);
+                            logger.info("[ignored] encountered invalid certificate signing.", ignored);
                         }
                     }
                     if (kd.getUse() == UsageType.ENCRYPTION) {
                         try {
                             idpMetadata.setEncryptionCertificate(KeyInfoHelper.getCertificates(kd.getKeyInfo()).get(0));
                         } catch (CertificateException ignored) {
-                            s_logger.info("[ignored] encountered invalid certificate encryption.", ignored);
+                            logger.info("[ignored] encountered invalid certificate encryption.", ignored);
                         }
                     }
                     if (kd.getUse() == UsageType.UNSPECIFIED) {
                         try {
                             unspecifiedKey = KeyInfoHelper.getCertificates(kd.getKeyInfo()).get(0);
                         } catch (CertificateException ignored) {
-                            s_logger.info("[ignored] encountered invalid certificate.", ignored);
+                            logger.info("[ignored] encountered invalid certificate.", ignored);
                         }
                     }
                 }
@@ -314,7 +312,7 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
                 idpMetadata.setEncryptionCertificate(unspecifiedKey);
             }
             if (idpMap.containsKey(idpMetadata.getEntityId())) {
-                s_logger.warn("Duplicate IdP metadata found with entity Id: " + idpMetadata.getEntityId());
+                logger.warn("Duplicate IdP metadata found with entity Id: " + idpMetadata.getEntityId());
             }
             idpMap.put(idpMetadata.getEntityId(), idpMetadata);
         }
@@ -345,16 +343,16 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
             if (_idpMetaDataProvider == null) {
                 return;
             }
-            s_logger.debug("Starting SAML IDP Metadata Refresh Task");
+            logger.debug("Starting SAML IDP Metadata Refresh Task");
 
             Map <String, SAMLProviderMetadata> metadataMap = new HashMap<String, SAMLProviderMetadata>();
             try {
                 discoverAndAddIdp(_idpMetaDataProvider.getMetadata(), metadataMap);
                 _idpMetadataMap = metadataMap;
                 expireTokens();
-                s_logger.debug("Finished refreshing SAML Metadata and expiring old auth tokens");
+                logger.debug("Finished refreshing SAML Metadata and expiring old auth tokens");
             } catch (MetadataProviderException e) {
-                s_logger.warn("SAML Metadata Refresh task failed with exception: " + e.getMessage());
+                logger.warn("SAML Metadata Refresh task failed with exception: " + e.getMessage());
             }
 
         }
@@ -362,7 +360,7 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
 
     private boolean setup() {
         if (!initSP()) {
-            s_logger.error("SAML Plugin failed to initialize, please fix the configuration and restart management server");
+            logger.error("SAML Plugin failed to initialize, please fix the configuration and restart management server");
             return false;
         }
         _timer = new Timer();
@@ -378,11 +376,11 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
             } else {
                 File metadataFile = PropertiesUtil.findConfigFile(idpMetaDataUrl);
                 if (metadataFile == null) {
-                    s_logger.error("Provided Metadata is not a URL, Unable to locate metadata file from local path: " + idpMetaDataUrl);
+                    logger.error("Provided Metadata is not a URL, Unable to locate metadata file from local path: " + idpMetaDataUrl);
                     return false;
                 }
                 else{
-                    s_logger.debug("Provided Metadata is not a URL, trying to read metadata file from local path: " + metadataFile.getAbsolutePath());
+                    logger.debug("Provided Metadata is not a URL, trying to read metadata file from local path: " + metadataFile.getAbsolutePath());
                     _idpMetaDataProvider = new FilesystemMetadataProvider(_timer, metadataFile);
                 }
             }
@@ -392,14 +390,14 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
             _timer.scheduleAtFixedRate(new MetadataRefreshTask(), 0, _refreshInterval * 1000);
 
         } catch (MetadataProviderException e) {
-            s_logger.error("Unable to read SAML2 IDP MetaData URL, error:" + e.getMessage());
-            s_logger.error("SAML2 Authentication may be unavailable");
+            logger.error("Unable to read SAML2 IDP MetaData URL, error:" + e.getMessage());
+            logger.error("SAML2 Authentication may be unavailable");
             return false;
         } catch (ConfigurationException | FactoryConfigurationError e) {
-            s_logger.error("OpenSAML bootstrapping failed: error: " + e.getMessage());
+            logger.error("OpenSAML bootstrapping failed: error: " + e.getMessage());
             return false;
         } catch (NullPointerException e) {
-            s_logger.error("Unable to setup SAML Auth Plugin due to NullPointerException" +
+            logger.error("Unable to setup SAML Auth Plugin due to NullPointerException" +
                     " please check the SAML global settings: " + e.getMessage());
             return false;
         }
@@ -477,7 +475,7 @@ public class SAML2AuthManagerImpl extends AdapterBase implements SAML2AuthManage
         if (_samlTokenDao.findByUuid(authnId) == null) {
             _samlTokenDao.persist(token);
         } else {
-            s_logger.warn("Duplicate SAML token for entity=" + entity + " token id=" + authnId + " domain=" + domainPath);
+            logger.warn("Duplicate SAML token for entity=" + entity + " token id=" + authnId + " domain=" + domainPath);
         }
     }
 

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAML2UserAuthenticator.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/saml/SAML2UserAuthenticator.java
@@ -22,7 +22,6 @@ import com.cloud.user.dao.UserAccountDao;
 import com.cloud.user.dao.UserDao;
 import com.cloud.utils.Pair;
 import org.apache.cxf.common.util.StringUtils;
-import org.apache.log4j.Logger;
 
 import javax.ejb.Local;
 import javax.inject.Inject;
@@ -30,7 +29,6 @@ import java.util.Map;
 
 @Local(value = {UserAuthenticator.class})
 public class SAML2UserAuthenticator extends DefaultUserAuthenticator {
-    public static final Logger s_logger = Logger.getLogger(SAML2UserAuthenticator.class);
 
     @Inject
     private UserAccountDao _userAccountDao;
@@ -39,18 +37,18 @@ public class SAML2UserAuthenticator extends DefaultUserAuthenticator {
 
     @Override
     public Pair<Boolean, ActionOnFailedAuthentication> authenticate(String username, String password, Long domainId, Map<String, Object[]> requestParameters) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Trying SAML2 auth for user: " + username);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Trying SAML2 auth for user: " + username);
         }
 
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
-            s_logger.debug("Username or Password cannot be empty");
+            logger.debug("Username or Password cannot be empty");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
         final UserAccount userAccount = _userAccountDao.getUserAccount(username, domainId);
         if (userAccount == null || userAccount.getSource() != User.Source.SAML2) {
-            s_logger.debug("Unable to find user with " + username + " in domain " + domainId + ", or user source is not SAML2");
+            logger.debug("Unable to find user with " + username + " in domain " + domainId + ", or user source is not SAML2");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         } else {
             User user = _userDao.getUser(userAccount.getId());

--- a/plugins/user-authenticators/sha256salted/src/com/cloud/server/auth/SHA256SaltedUserAuthenticator.java
+++ b/plugins/user-authenticators/sha256salted/src/com/cloud/server/auth/SHA256SaltedUserAuthenticator.java
@@ -21,7 +21,6 @@ import com.cloud.user.dao.UserAccountDao;
 import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 import org.bouncycastle.util.encoders.Base64;
 
 import javax.ejb.Local;
@@ -34,7 +33,6 @@ import java.util.Map;
 
 @Local(value = {UserAuthenticator.class})
 public class SHA256SaltedUserAuthenticator extends DefaultUserAuthenticator {
-    public static final Logger s_logger = Logger.getLogger(SHA256SaltedUserAuthenticator.class);
     private static final String s_defaultPassword = "000000000000000000000000000=";
     private static final String s_defaultSalt = "0000000000000000000000000000000=";
     @Inject
@@ -46,19 +44,19 @@ public class SHA256SaltedUserAuthenticator extends DefaultUserAuthenticator {
      */
     @Override
     public Pair<Boolean, ActionOnFailedAuthentication> authenticate(String username, String password, Long domainId, Map<String, Object[]> requestParameters) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Retrieving user: " + username);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Retrieving user: " + username);
         }
 
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
-            s_logger.debug("Username or Password cannot be empty");
+            logger.debug("Username or Password cannot be empty");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
         }
 
         boolean realUser = true;
         UserAccount user = _userAccountDao.getUserAccount(username, domainId);
         if (user == null) {
-            s_logger.debug("Unable to find user with " + username + " in domain " + domainId);
+            logger.debug("Unable to find user with " + username + " in domain " + domainId);
             realUser = false;
         }
         /* Fake Data */
@@ -67,7 +65,7 @@ public class SHA256SaltedUserAuthenticator extends DefaultUserAuthenticator {
         if (realUser) {
             String storedPassword[] = user.getPassword().split(":");
             if (storedPassword.length != 2) {
-                s_logger.warn("The stored password for " + username + " isn't in the right format for this authenticator");
+                logger.warn("The stored password for " + username + " isn't in the right format for this authenticator");
                 realUser = false;
             } else {
                 realPassword = storedPassword[1];

--- a/server/src/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
+++ b/server/src/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.manager.allocator.HostAllocator;
@@ -69,7 +68,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Component
 @Local(value = {HostAllocator.class})
 public class FirstFitAllocator extends AdapterBase implements HostAllocator {
-    private static final Logger s_logger = Logger.getLogger(FirstFitAllocator.class);
     @Inject
     protected HostDao _hostDao = null;
     @Inject
@@ -119,8 +117,8 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             return new ArrayList<Host>();
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Looking for hosts in dc: " + dcId + "  pod:" + podId + "  cluster:" + clusterId);
         }
 
         String hostTagOnOffering = offering.getHostTag();
@@ -141,29 +139,29 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
                 List<HostVO> hostsMatchingOfferingTag = new ArrayList<HostVO>();
                 List<HostVO> hostsMatchingTemplateTag = new ArrayList<HostVO>();
                 if (hasSvcOfferingTag) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Looking for hosts having tag specified on SvcOffering:" + hostTagOnOffering);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Looking for hosts having tag specified on SvcOffering:" + hostTagOnOffering);
                     }
                     hostsMatchingOfferingTag = _hostDao.listByHostTag(type, clusterId, podId, dcId, hostTagOnOffering);
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Hosts with tag '" + hostTagOnOffering + "' are:" + hostsMatchingOfferingTag);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Hosts with tag '" + hostTagOnOffering + "' are:" + hostsMatchingOfferingTag);
                     }
                 }
                 if (hasTemplateTag) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Looking for hosts having tag specified on Template:" + hostTagOnTemplate);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Looking for hosts having tag specified on Template:" + hostTagOnTemplate);
                     }
                     hostsMatchingTemplateTag = _hostDao.listByHostTag(type, clusterId, podId, dcId, hostTagOnTemplate);
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Hosts with tag '" + hostTagOnTemplate + "' are:" + hostsMatchingTemplateTag);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Hosts with tag '" + hostTagOnTemplate + "' are:" + hostsMatchingTemplateTag);
                     }
                 }
 
                 if (hasSvcOfferingTag && hasTemplateTag) {
                     hostsMatchingOfferingTag.retainAll(hostsMatchingTemplateTag);
                     clusterHosts = _hostDao.listByHostTag(type, clusterId, podId, dcId, hostTagOnTemplate);
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Found " + hostsMatchingOfferingTag.size() + " Hosts satisfying both tags, host ids are:" + hostsMatchingOfferingTag);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Found " + hostsMatchingOfferingTag.size() + " Hosts satisfying both tags, host ids are:" + hostsMatchingOfferingTag);
                     }
 
                     clusterHosts = hostsMatchingOfferingTag;
@@ -218,25 +216,25 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
                 hostsCopy.retainAll(_resourceMgr.listAllUpAndEnabledNonHAHosts(type, clusterId, podId, dcId));
             } else {
                 if (hasSvcOfferingTag) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Looking for hosts having tag specified on SvcOffering:" + hostTagOnOffering);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Looking for hosts having tag specified on SvcOffering:" + hostTagOnOffering);
                     }
                     hostsCopy.retainAll(_hostDao.listByHostTag(type, clusterId, podId, dcId, hostTagOnOffering));
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Hosts with tag '" + hostTagOnOffering + "' are:" + hostsCopy);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Hosts with tag '" + hostTagOnOffering + "' are:" + hostsCopy);
                     }
                 }
 
                 if (hasTemplateTag) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Looking for hosts having tag specified on Template:" + hostTagOnTemplate);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Looking for hosts having tag specified on Template:" + hostTagOnTemplate);
                     }
 
                     hostsCopy.retainAll(_hostDao.listByHostTag(type, clusterId, podId, dcId, hostTagOnTemplate));
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Hosts with tag '" + hostTagOnTemplate + "' are:" + hostsCopy);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Hosts with tag '" + hostTagOnTemplate + "' are:" + hostsCopy);
                     }
                 }
             }
@@ -260,20 +258,20 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             hosts = reorderHostsByCapacity(plan, hosts);
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("FirstFitAllocator has " + hosts.size() + " hosts to check for allocation: " + hosts);
+        if (logger.isDebugEnabled()) {
+            logger.debug("FirstFitAllocator has " + hosts.size() + " hosts to check for allocation: " + hosts);
         }
 
         // We will try to reorder the host lists such that we give priority to hosts that have
         // the minimums to support a VM's requirements
         hosts = prioritizeHosts(template, offering, hosts);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Found " + hosts.size() + " hosts for allocation after prioritization: " + hosts);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Found " + hosts.size() + " hosts for allocation after prioritization: " + hosts);
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Looking for speed=" + (offering.getCpu() * offering.getSpeed()) + "Mhz, Ram=" + offering.getRamSize());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Looking for speed=" + (offering.getCpu() * offering.getSpeed()) + "Mhz, Ram=" + offering.getRamSize());
         }
 
         long serviceOfferingId = offering.getId();
@@ -285,16 +283,16 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
                 break;
             }
             if (avoid.shouldAvoid(host)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, skipping this and trying other available hosts");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " is in avoid set, skipping this and trying other available hosts");
                 }
                 continue;
             }
 
             //find number of guest VMs occupying capacity on this host.
             if (_capacityMgr.checkIfHostReachMaxGuestLimit(host)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() +
                         " already has max Running VMs(count includes system VMs), skipping this and trying other available hosts");
                 }
                 continue;
@@ -304,7 +302,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             if ((offeringDetails   = _serviceOfferingDetailsDao.findDetail(serviceOfferingId, GPU.Keys.vgpuType.toString())) != null) {
                 ServiceOfferingDetailsVO groupName = _serviceOfferingDetailsDao.findDetail(serviceOfferingId, GPU.Keys.pciDevice.toString());
                 if(!_resourceMgr.isGPUDeviceAvailable(host.getId(), groupName.getValue(), offeringDetails.getValue())){
-                    s_logger.info("Host name: " + host.getName() + ", hostId: "+ host.getId() +" does not have required GPU devices available");
+                    logger.info("Host name: " + host.getName() + ", hostId: "+ host.getId() +" does not have required GPU devices available");
                     continue;
                 }
             }
@@ -322,20 +320,20 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
                 considerReservedCapacity);
 
             if (hostHasCpuCapability && hostHasCapacity) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Found a suitable host, adding to list: " + host.getId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Found a suitable host, adding to list: " + host.getId());
                 }
                 suitableHosts.add(host);
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Not using host " + host.getId() + "; host has cpu capability? " + hostHasCpuCapability + ", host has capacity?" + hostHasCapacity);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Not using host " + host.getId() + "; host has cpu capability? " + hostHasCpuCapability + ", host has capacity?" + hostHasCapacity);
                 }
                 avoid.addHost(host.getId());
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Host Allocator returning " + suitableHosts.size() + " suitable hosts");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Host Allocator returning " + suitableHosts.size() + " suitable hosts");
         }
 
         return suitableHosts;
@@ -351,8 +349,8 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             capacityType = CapacityVO.CAPACITY_TYPE_MEMORY;
         }
         List<Long> hostIdsByFreeCapacity = _capacityDao.orderHostsByFreeCapacity(clusterId, capacityType);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("List of hosts in descending order of free capacity in the cluster: "+ hostIdsByFreeCapacity);
+        if (logger.isDebugEnabled()) {
+            logger.debug("List of hosts in descending order of free capacity in the cluster: "+ hostIdsByFreeCapacity);
         }
 
         //now filter the given list of Hosts by this ordered list
@@ -381,8 +379,8 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
         Long clusterId = plan.getClusterId();
 
         List<Long> hostIdsByVmCount = _vmInstanceDao.listHostIdsByVmCount(dcId, podId, clusterId, account.getAccountId());
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("List of hosts in ascending order of number of VMs: " + hostIdsByVmCount);
+        if (logger.isDebugEnabled()) {
+            logger.debug("List of hosts in ascending order of number of VMs: " + hostIdsByVmCount);
         }
 
         //now filter the given list of Hosts by this ordered list
@@ -434,9 +432,9 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
             hostsToCheck.addAll(hosts);
         }
 
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (noHvmHosts.size() > 0) {
-                s_logger.debug("Not considering hosts: " + noHvmHosts + "  to deploy template: " + template + " as they are not HVM enabled");
+                logger.debug("Not considering hosts: " + noHvmHosts + "  to deploy template: " + template + " as they are not HVM enabled");
             }
         }
         // If a host is tagged with the same guest OS category as the template, move it to a high priority list

--- a/server/src/com/cloud/agent/manager/allocator/impl/RecreateHostAllocator.java
+++ b/server/src/com/cloud/agent/manager/allocator/impl/RecreateHostAllocator.java
@@ -27,7 +27,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
@@ -58,7 +57,6 @@ import com.cloud.vm.VirtualMachineProfile;
 @Component
 @Local(value = HostAllocator.class)
 public class RecreateHostAllocator extends FirstFitRoutingAllocator {
-    private final static Logger s_logger = Logger.getLogger(RecreateHostAllocator.class);
 
     @Inject
     HostPodDao _podDao;
@@ -83,10 +81,10 @@ public class RecreateHostAllocator extends FirstFitRoutingAllocator {
             return hosts;
         }
 
-        s_logger.debug("First fit was unable to find a host");
+        logger.debug("First fit was unable to find a host");
         VirtualMachine.Type vmType = vm.getType();
         if (vmType == VirtualMachine.Type.User) {
-            s_logger.debug("vm is not a system vm so let's just return empty list");
+            logger.debug("vm is not a system vm so let's just return empty list");
             return new ArrayList<Host>();
         }
 
@@ -95,11 +93,11 @@ public class RecreateHostAllocator extends FirstFitRoutingAllocator {
         //getting rid of direct.attached.untagged.vlan.enabled config param: Bug 7204
         //basic network type for zone maps to direct untagged case
         if (dc.getNetworkType().equals(NetworkType.Basic)) {
-            s_logger.debug("Direct Networking mode so we can only allow the host to be allocated in the same pod due to public ip address cannot change");
+            logger.debug("Direct Networking mode so we can only allow the host to be allocated in the same pod due to public ip address cannot change");
             List<VolumeVO> vols = _volsDao.findByInstance(vm.getId());
             VolumeVO vol = vols.get(0);
             long podId = vol.getPodId();
-            s_logger.debug("Pod id determined from volume " + vol.getId() + " is " + podId);
+            logger.debug("Pod id determined from volume " + vol.getId() + " is " + podId);
             Iterator<PodCluster> it = pcs.iterator();
             while (it.hasNext()) {
                 PodCluster pc = it.next();
@@ -120,22 +118,22 @@ public class RecreateHostAllocator extends FirstFitRoutingAllocator {
         }
 
         for (Pair<Long, Long> pcId : avoidPcs) {
-            s_logger.debug("Removing " + pcId + " from the list of available pods");
+            logger.debug("Removing " + pcId + " from the list of available pods");
             pcs.remove(new PodCluster(new HostPodVO(pcId.first()), pcId.second() != null ? new ClusterVO(pcId.second()) : null));
         }
 
         for (PodCluster p : pcs) {
             if (p.getPod().getAllocationState() != Grouping.AllocationState.Enabled) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Pod name: " + p.getPod().getName() + ", podId: " + p.getPod().getId() + " is in " + p.getPod().getAllocationState().name() +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Pod name: " + p.getPod().getName() + ", podId: " + p.getPod().getId() + " is in " + p.getPod().getAllocationState().name() +
                         " state, skipping this and trying other pods");
                 }
                 continue;
             }
             Long clusterId = p.getCluster() == null ? null : p.getCluster().getId();
             if (p.getCluster() != null && p.getCluster().getAllocationState() != Grouping.AllocationState.Enabled) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Cluster name: " + p.getCluster().getName() + ", clusterId: " + clusterId + " is in " + p.getCluster().getAllocationState().name() +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Cluster name: " + p.getCluster().getName() + ", clusterId: " + clusterId + " is in " + p.getCluster().getAllocationState().name() +
                         " state, skipping this and trying other pod-clusters");
                 }
                 continue;
@@ -148,7 +146,7 @@ public class RecreateHostAllocator extends FirstFitRoutingAllocator {
 
         }
 
-        s_logger.debug("Unable to find any available pods at all!");
+        logger.debug("Unable to find any available pods at all!");
         return new ArrayList<Host>();
     }
 

--- a/server/src/com/cloud/agent/manager/allocator/impl/UserConcentratedAllocator.java
+++ b/server/src/com/cloud/agent/manager/allocator/impl/UserConcentratedAllocator.java
@@ -27,7 +27,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 
@@ -60,7 +59,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 @Local(value = PodAllocator.class)
 public class UserConcentratedAllocator extends AdapterBase implements PodAllocator {
-    private final static Logger s_logger = Logger.getLogger(UserConcentratedAllocator.class);
 
     @Inject
     UserVmDao _vmDao;
@@ -89,7 +87,7 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
         List<HostPodVO> podsInZone = _podDao.listByDataCenterId(zoneId);
 
         if (podsInZone.size() == 0) {
-            s_logger.debug("No pods found in zone " + zone.getName());
+            logger.debug("No pods found in zone " + zone.getName());
             return null;
         }
 
@@ -112,8 +110,8 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
                         dataCenterAndPodHasEnoughCapacity(zoneId, podId, (offering.getRamSize()) * 1024L * 1024L, Capacity.CAPACITY_TYPE_MEMORY, hostCandiates);
 
                     if (!enoughCapacity) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Not enough RAM available in zone/pod to allocate storage for user VM (zone: " + zoneId + ", pod: " + podId + ")");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Not enough RAM available in zone/pod to allocate storage for user VM (zone: " + zoneId + ", pod: " + podId + ")");
                         }
                         continue;
                     }
@@ -122,8 +120,8 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
                     enoughCapacity =
                         dataCenterAndPodHasEnoughCapacity(zoneId, podId, ((long)offering.getCpu() * offering.getSpeed()), Capacity.CAPACITY_TYPE_CPU, hostCandiates);
                     if (!enoughCapacity) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Not enough cpu available in zone/pod to allocate storage for user VM (zone: " + zoneId + ", pod: " + podId + ")");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Not enough cpu available in zone/pod to allocate storage for user VM (zone: " + zoneId + ", pod: " + podId + ")");
                         }
                         continue;
                     }
@@ -147,13 +145,13 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
         }
 
         if (availablePods.size() == 0) {
-            s_logger.debug("There are no pods with enough memory/CPU capacity in zone " + zone.getName());
+            logger.debug("There are no pods with enough memory/CPU capacity in zone " + zone.getName());
             return null;
         } else {
             // Return a random pod
             int next = _rand.nextInt(availablePods.size());
             HostPodVO selectedPod = availablePods.get(next);
-            s_logger.debug("Found pod " + selectedPod.getName() + " in zone " + zone.getName());
+            logger.debug("Found pod " + selectedPod.getName() + " in zone " + zone.getName());
             return new Pair<Pod, Long>(selectedPod, podHostCandidates.get(selectedPod.getId()));
         }
     }
@@ -165,9 +163,9 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
         sc.addAnd("capacityType", SearchCriteria.Op.EQ, capacityType);
         sc.addAnd("dataCenterId", SearchCriteria.Op.EQ, dataCenterId);
         sc.addAnd("podId", SearchCriteria.Op.EQ, podId);
-        s_logger.trace("Executing search");
+        logger.trace("Executing search");
         capacities = _capacityDao.search(sc, null);
-        s_logger.trace("Done with a search");
+        logger.trace("Done with a search");
 
         boolean enoughCapacity = false;
         if (capacities != null) {
@@ -196,8 +194,8 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
 
     private boolean skipCalculation(VMInstanceVO vm) {
         if (vm.getState() == State.Expunging) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Skip counting capacity for Expunging VM : " + vm.getInstanceName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Skip counting capacity for Expunging VM : " + vm.getInstanceName());
             }
             return true;
         }
@@ -217,8 +215,8 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
 
             long millisecondsSinceLastUpdate = DateUtil.currentGMTTime().getTime() - vm.getUpdateTime().getTime();
             if (millisecondsSinceLastUpdate > secondsToSkipVMs * 1000L) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Skip counting " + vm.getState().toString() + " vm " + vm.getInstanceName() + " in capacity allocation as it has been " +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Skip counting " + vm.getState().toString() + " vm " + vm.getInstanceName() + " in capacity allocation as it has been " +
                         vm.getState().toString().toLowerCase() + " for " + millisecondsSinceLastUpdate / 60000 + " minutes");
                 }
                 return true;
@@ -262,15 +260,15 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
                 if (capacityType == Capacity.CAPACITY_TYPE_MEMORY) {
                     usedCapacity += so.getRamSize() * 1024L * 1024L;
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Counting memory capacity used by vm: " + vm.getId() + ", size: " + so.getRamSize() + "MB, host: " + hostId + ", currently counted: " +
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Counting memory capacity used by vm: " + vm.getId() + ", size: " + so.getRamSize() + "MB, host: " + hostId + ", currently counted: " +
                                 usedCapacity + " Bytes");
                     }
                 } else if (capacityType == Capacity.CAPACITY_TYPE_CPU) {
                     usedCapacity += so.getCpu() * so.getSpeed();
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Counting cpu capacity used by vm: " + vm.getId() + ", cpu: " + so.getCpu() + ", speed: " + so.getSpeed() + ", currently counted: " +
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Counting cpu capacity used by vm: " + vm.getId() + ", cpu: " + so.getCpu() + ", speed: " + so.getSpeed() + ", currently counted: " +
                                 usedCapacity + " Bytes");
                     }
                 }
@@ -287,9 +285,9 @@ public class UserConcentratedAllocator extends AdapterBase implements PodAllocat
          * List<VMTemplateStoragePoolVO> tpvoList = _templatePoolDao.listByTemplateStatus(templateId, dcId, podId,
          * Status.DOWNLOADED);
          *
-         * if (thvoList != null && thvoList.size() > 0) { if (s_logger.isDebugEnabled()) { s_logger.debug("Found " +
+         * if (thvoList != null && thvoList.size() > 0) { if (logger.isDebugEnabled()) { logger.debug("Found " +
          * thvoList.size() + " storage hosts in pod " + podId + " with template " + templateId); } return true; } else if
-         * (tpvoList != null && tpvoList.size() > 0) { if (s_logger.isDebugEnabled()) { s_logger.debug("Found " +
+         * (tpvoList != null && tpvoList.size() > 0) { if (logger.isDebugEnabled()) { logger.debug("Found " +
          * tpvoList.size() + " storage pools in pod " + podId + " with template " + templateId); } return true; }else { return
          * false; }
          */

--- a/server/src/com/cloud/agent/manager/authn/impl/BasicAgentAuthManager.java
+++ b/server/src/com/cloud/agent/manager/authn/impl/BasicAgentAuthManager.java
@@ -22,7 +22,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -39,7 +38,6 @@ import com.cloud.utils.component.AdapterBase;
 @Component
 @Local(value = {AgentAuthorizer.class, StartupCommandProcessor.class})
 public class BasicAgentAuthManager extends AdapterBase implements AgentAuthorizer, StartupCommandProcessor {
-    private static final Logger s_logger = Logger.getLogger(BasicAgentAuthManager.class);
     @Inject
     HostDao _hostDao = null;
     @Inject
@@ -54,7 +52,7 @@ public class BasicAgentAuthManager extends AdapterBase implements AgentAuthorize
         } catch (AgentAuthnException e) {
             throw new ConnectionException(true, "Failed to authenticate/authorize", e);
         }
-        s_logger.debug("Authorized agent with guid " + cmd[0].getGuid());
+        logger.debug("Authorized agent with guid " + cmd[0].getGuid());
         return false;//so that the next host creator can process it
     }
 

--- a/server/src/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/com/cloud/alert/AlertManagerImpl.java
@@ -40,7 +40,6 @@ import javax.mail.URLName;
 import javax.mail.internet.InternetAddress;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.sun.mail.smtp.SMTPMessage;
 import com.sun.mail.smtp.SMTPSSLTransport;
@@ -89,8 +88,6 @@ import com.cloud.utils.db.SearchCriteria;
 
 @Local(value = {AlertManager.class})
 public class AlertManagerImpl extends ManagerBase implements AlertManager, Configurable {
-    private static final Logger s_logger = Logger.getLogger(AlertManagerImpl.class.getName());
-    private static final Logger s_alertsLogger = Logger.getLogger("org.apache.cloudstack.alerts");
 
     private static final long INITIAL_CAPACITY_CHECK_DELAY = 30L * 1000L; // thirty seconds expressed in milliseconds
 
@@ -235,7 +232,7 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                 _emailAlert.clearAlert(alertType.getType(), dataCenterId, podId);
             }
         } catch (Exception ex) {
-            s_logger.error("Problem clearing email alert", ex);
+            logger.error("Problem clearing email alert", ex);
         }
     }
 
@@ -251,11 +248,11 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
             if (_emailAlert != null) {
                 _emailAlert.sendAlert(alertType, dataCenterId, podId, null, subject, body);
             } else {
-                s_alertsLogger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " + podId +
+                logger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " + podId +
                     " // message:: " + subject + " // body:: " + body);
             }
         } catch (Exception ex) {
-            s_logger.error("Problem sending email alert", ex);
+            logger.error("Problem sending email alert", ex);
         }
     }
 
@@ -270,9 +267,9 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
 
         try {
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("recalculating system capacity");
-                s_logger.debug("Executing cpu/ram capacity update");
+            if (logger.isDebugEnabled()) {
+                logger.debug("recalculating system capacity");
+                logger.debug("Executing cpu/ram capacity update");
             }
 
             // Calculate CPU and RAM capacities
@@ -283,9 +280,9 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                     _capacityMgr.updateCapacityForHost(host);
                 }
             }
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Done executing cpu/ram capacity update");
-                s_logger.debug("Executing storage capacity update");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Done executing cpu/ram capacity update");
+                logger.debug("Executing storage capacity update");
             }
             // Calculate storage pool capacity
             List<StoragePoolVO> storagePools = _storagePoolDao.listAll();
@@ -298,9 +295,9 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                 }
             }
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Done executing storage capacity update");
-                s_logger.debug("Executing capacity updates for public ip and Vlans");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Done executing storage capacity update");
+                logger.debug("Executing capacity updates for public ip and Vlans");
             }
 
             List<DataCenterVO> datacenters = _dcDao.listAll();
@@ -327,9 +324,9 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                 }
             }
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Done capacity updates for public ip and Vlans");
-                s_logger.debug("Executing capacity updates for private ip");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Done capacity updates for public ip and Vlans");
+                logger.debug("Executing capacity updates for private ip");
             }
 
             // Calculate new Private IP capacity
@@ -341,13 +338,13 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                 createOrUpdateIpCapacity(dcId, podId, Capacity.CAPACITY_TYPE_PRIVATE_IP, _configMgr.findPodAllocationState(pod));
             }
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Done executing capacity updates for private ip");
-                s_logger.debug("Done recalculating system capacity");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Done executing capacity updates for private ip");
+                logger.debug("Done recalculating system capacity");
             }
 
         } catch (Throwable t) {
-            s_logger.error("Caught exception in recalculating capacity", t);
+            logger.error("Caught exception in recalculating capacity", t);
         }
     }
 
@@ -420,11 +417,11 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
         @Override
         protected void runInContext() {
             try {
-                s_logger.debug("Running Capacity Checker ... ");
+                logger.debug("Running Capacity Checker ... ");
                 checkForAlerts();
-                s_logger.debug("Done running Capacity Checker ... ");
+                logger.debug("Done running Capacity Checker ... ");
             } catch (Throwable t) {
-                s_logger.error("Exception in CapacityChecker", t);
+                logger.error("Exception in CapacityChecker", t);
             }
         }
     }
@@ -632,13 +629,13 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
         }
 
         try {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug(msgSubject);
-                s_logger.debug(msgContent);
+            if (logger.isDebugEnabled()) {
+                logger.debug(msgSubject);
+                logger.debug(msgContent);
             }
             _emailAlert.sendAlert(alertType, dc.getId(), podId, clusterId, msgSubject, msgContent);
         } catch (Exception ex) {
-            s_logger.error("Exception in CapacityChecker", ex);
+            logger.error("Exception in CapacityChecker", ex);
         }
     }
 
@@ -694,7 +691,7 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                     try {
                         _recipientList[i] = new InternetAddress(recipientList[i], recipientList[i]);
                     } catch (Exception ex) {
-                        s_logger.error("Exception creating address for: " + recipientList[i], ex);
+                        logger.error("Exception creating address for: " + recipientList[i], ex);
                     }
                 }
             }
@@ -749,7 +746,7 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
         // TODO:  make sure this handles SSL transport (useAuth is true) and regular
         public void sendAlert(AlertType alertType, long dataCenterId, Long podId, Long clusterId, String subject, String content) throws MessagingException,
             UnsupportedEncodingException {
-            s_alertsLogger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " +
+            logger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " +
                 podId + " // clusterId:: " + clusterId + " // message:: " + subject);
             AlertVO alert = null;
             if ((alertType != AlertManager.AlertType.ALERT_TYPE_HOST) &&
@@ -776,8 +773,8 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                 newAlert.setName(alertType.getName());
                 _alertDao.persist(newAlert);
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Have already sent: " + alert.getSentCount() + " emails for alert type '" + alertType + "' -- skipping send email");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Have already sent: " + alert.getSentCount() + " emails for alert type '" + alertType + "' -- skipping send email");
                 }
                 return;
             }
@@ -813,9 +810,9 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                         smtpTrans.sendMessage(msg, msg.getAllRecipients());
                         smtpTrans.close();
                     } catch (SendFailedException e) {
-                        s_logger.error(" Failed to send email alert " + e);
+                        logger.error(" Failed to send email alert " + e);
                     } catch (MessagingException e) {
-                        s_logger.error(" Failed to send email alert " + e);
+                        logger.error(" Failed to send email alert " + e);
                     }
                 }
             });
@@ -859,7 +856,7 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
             sendAlert(alertType, dataCenterId, podId, msg, msg);
             return true;
         } catch (Exception ex) {
-            s_logger.warn("Failed to generate an alert of type=" + alertType + "; msg=" + msg);
+            logger.warn("Failed to generate an alert of type=" + alertType + "; msg=" + msg);
             return false;
         }
     }

--- a/server/src/com/cloud/alert/ClusterAlertAdapter.java
+++ b/server/src/com/cloud/alert/ClusterAlertAdapter.java
@@ -22,7 +22,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.cluster.ClusterManager;
@@ -38,7 +37,6 @@ import com.cloud.utils.events.SubscriptionMgr;
 @Local(value = AlertAdapter.class)
 public class ClusterAlertAdapter extends AdapterBase implements AlertAdapter {
 
-    private static final Logger s_logger = Logger.getLogger(ClusterAlertAdapter.class);
 
     @Inject
     private AlertManager _alertMgr;
@@ -46,8 +44,8 @@ public class ClusterAlertAdapter extends AdapterBase implements AlertAdapter {
     private ManagementServerHostDao _mshostDao;
 
     public void onClusterAlert(Object sender, EventArgs args) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Receive cluster alert, EventArgs: " + args.getClass().getName());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Receive cluster alert, EventArgs: " + args.getClass().getName());
         }
 
         if (args instanceof ClusterNodeJoinEventArgs) {
@@ -55,21 +53,21 @@ public class ClusterAlertAdapter extends AdapterBase implements AlertAdapter {
         } else if (args instanceof ClusterNodeLeftEventArgs) {
             onClusterNodeLeft(sender, (ClusterNodeLeftEventArgs)args);
         } else {
-            s_logger.error("Unrecognized cluster alert event");
+            logger.error("Unrecognized cluster alert event");
         }
     }
 
     private void onClusterNodeJoined(Object sender, ClusterNodeJoinEventArgs args) {
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             for (ManagementServerHostVO mshost : args.getJoinedNodes()) {
-                s_logger.debug("Handle cluster node join alert, joined node: " + mshost.getServiceIP() + ", msidL: " + mshost.getMsid());
+                logger.debug("Handle cluster node join alert, joined node: " + mshost.getServiceIP() + ", msidL: " + mshost.getMsid());
             }
         }
 
         for (ManagementServerHostVO mshost : args.getJoinedNodes()) {
             if (mshost.getId() == args.getSelf().longValue()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Management server node " + mshost.getServiceIP() + " is up, send alert");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Management server node " + mshost.getServiceIP() + " is up, send alert");
                 }
 
                 _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_MANAGMENT_NODE, 0, new Long(0), "Management server node " + mshost.getServiceIP() + " is up", "");
@@ -80,23 +78,23 @@ public class ClusterAlertAdapter extends AdapterBase implements AlertAdapter {
 
     private void onClusterNodeLeft(Object sender, ClusterNodeLeftEventArgs args) {
 
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             for (ManagementServerHostVO mshost : args.getLeftNodes()) {
-                s_logger.debug("Handle cluster node left alert, leaving node: " + mshost.getServiceIP() + ", msid: " + mshost.getMsid());
+                logger.debug("Handle cluster node left alert, leaving node: " + mshost.getServiceIP() + ", msid: " + mshost.getMsid());
             }
         }
 
         for (ManagementServerHostVO mshost : args.getLeftNodes()) {
             if (mshost.getId() != args.getSelf().longValue()) {
                 if (_mshostDao.increaseAlertCount(mshost.getId()) > 0) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Detected management server node " + mshost.getServiceIP() + " is down, send alert");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Detected management server node " + mshost.getServiceIP() + " is down, send alert");
                     }
                     _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_MANAGMENT_NODE, 0, new Long(0), "Management server node " + mshost.getServiceIP() + " is down",
                         "");
                 } else {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Detected management server node " + mshost.getServiceIP() + " is down, but alert has already been set");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Detected management server node " + mshost.getServiceIP() + " is down, but alert has already been set");
                     }
                 }
             }
@@ -106,8 +104,8 @@ public class ClusterAlertAdapter extends AdapterBase implements AlertAdapter {
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Start configuring cluster alert manager : " + name);
+        if (logger.isInfoEnabled()) {
+            logger.info("Start configuring cluster alert manager : " + name);
         }
 
         try {

--- a/server/src/com/cloud/alert/ConsoleProxyAlertAdapter.java
+++ b/server/src/com/cloud/alert/ConsoleProxyAlertAdapter.java
@@ -22,7 +22,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.consoleproxy.ConsoleProxyAlertEventArgs;
@@ -39,7 +38,6 @@ import com.cloud.vm.dao.ConsoleProxyDao;
 @Local(value = AlertAdapter.class)
 public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapter {
 
-    private static final Logger s_logger = Logger.getLogger(ConsoleProxyAlertAdapter.class);
 
     @Inject
     private AlertManager _alertMgr;
@@ -49,8 +47,8 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
     private ConsoleProxyDao _consoleProxyDao;
 
     public void onProxyAlert(Object sender, ConsoleProxyAlertEventArgs args) {
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("received console proxy alert");
+        if (logger.isDebugEnabled())
+            logger.debug("received console proxy alert");
 
         DataCenterVO dc = _dcDao.findById(args.getZoneId());
         ConsoleProxyVO proxy = args.getProxy();
@@ -64,14 +62,14 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
 
         switch (args.getType()) {
         case ConsoleProxyAlertEventArgs.PROXY_CREATED:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("New console proxy created, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
+            if (logger.isDebugEnabled())
+                logger.debug("New console proxy created, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
                         ", private IP: " + proxy.getPrivateIpAddress());
             break;
 
         case ConsoleProxyAlertEventArgs.PROXY_UP:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Console proxy is up, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
+            if (logger.isDebugEnabled())
+                logger.debug("Console proxy is up, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
                         ", private IP: " + proxy.getPrivateIpAddress());
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_CONSOLE_PROXY, args.getZoneId(), proxy.getPodIdToDeployIn(),
@@ -81,8 +79,8 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
             break;
 
         case ConsoleProxyAlertEventArgs.PROXY_DOWN:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Console proxy is down, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
+            if (logger.isDebugEnabled())
+                logger.debug("Console proxy is down, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
                         ", private IP: " + (proxy.getPrivateIpAddress() == null ? "N/A" : proxy.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_CONSOLE_PROXY, args.getZoneId(), proxy.getPodIdToDeployIn(),
@@ -92,8 +90,8 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
             break;
 
         case ConsoleProxyAlertEventArgs.PROXY_REBOOTED:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Console proxy is rebooted, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
+            if (logger.isDebugEnabled())
+                logger.debug("Console proxy is rebooted, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " + proxy.getPublicIpAddress() +
                         ", private IP: " + (proxy.getPrivateIpAddress() == null ? "N/A" : proxy.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_CONSOLE_PROXY, args.getZoneId(), proxy.getPodIdToDeployIn(),
@@ -103,16 +101,16 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
             break;
 
         case ConsoleProxyAlertEventArgs.PROXY_CREATE_FAILURE:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Console proxy creation failure, zone: " + dc.getName());
+            if (logger.isDebugEnabled())
+                logger.debug("Console proxy creation failure, zone: " + dc.getName());
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_CONSOLE_PROXY, args.getZoneId(), null,
                     "Console proxy creation failure. zone: " + dc.getName() + ", error details: " + args.getMessage(),
                     "Console proxy creation failure (zone " + dc.getName() + ")");
             break;
 
         case ConsoleProxyAlertEventArgs.PROXY_START_FAILURE:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Console proxy startup failure, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Console proxy startup failure, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " +
                         proxy.getPublicIpAddress() + ", private IP: " + (proxy.getPrivateIpAddress() == null ? "N/A" : proxy.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_CONSOLE_PROXY, args.getZoneId(), proxy.getPodIdToDeployIn(),
@@ -122,8 +120,8 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
             break;
 
         case ConsoleProxyAlertEventArgs.PROXY_FIREWALL_ALERT:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Console proxy firewall alert, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Console proxy firewall alert, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " +
                         proxy.getPublicIpAddress() + ", private IP: " + (proxy.getPrivateIpAddress() == null ? "N/A" : proxy.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(
@@ -136,8 +134,8 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
             break;
 
         case ConsoleProxyAlertEventArgs.PROXY_STORAGE_ALERT:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Console proxy storage alert, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Console proxy storage alert, zone: " + dc.getName() + ", proxy: " + proxy.getHostName() + ", public IP: " +
                         proxy.getPublicIpAddress() + ", private IP: " + proxy.getPrivateIpAddress() + ", message: " + args.getMessage());
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_STORAGE_MISC, args.getZoneId(), proxy.getPodIdToDeployIn(),
@@ -149,8 +147,8 @@ public class ConsoleProxyAlertAdapter extends AdapterBase implements AlertAdapte
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
 
-        if (s_logger.isInfoEnabled())
-            s_logger.info("Start configuring console proxy alert manager : " + name);
+        if (logger.isInfoEnabled())
+            logger.info("Start configuring console proxy alert manager : " + name);
 
         try {
             SubscriptionMgr.getInstance().subscribe(ConsoleProxyManager.ALERT_SUBJECT, this, "onProxyAlert");

--- a/server/src/com/cloud/alert/SecondaryStorageVmAlertAdapter.java
+++ b/server/src/com/cloud/alert/SecondaryStorageVmAlertAdapter.java
@@ -22,7 +22,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.DataCenterVO;
@@ -39,7 +38,6 @@ import com.cloud.vm.dao.SecondaryStorageVmDao;
 @Local(value = AlertAdapter.class)
 public class SecondaryStorageVmAlertAdapter extends AdapterBase implements AlertAdapter {
 
-    private static final Logger s_logger = Logger.getLogger(SecondaryStorageVmAlertAdapter.class);
 
     @Inject
     private AlertManager _alertMgr;
@@ -49,8 +47,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
     private SecondaryStorageVmDao _ssvmDao;
 
     public void onSSVMAlert(Object sender, SecStorageVmAlertEventArgs args) {
-        if (s_logger.isDebugEnabled())
-            s_logger.debug("received secondary storage vm alert");
+        if (logger.isDebugEnabled())
+            logger.debug("received secondary storage vm alert");
 
         DataCenterVO dc = _dcDao.findById(args.getZoneId());
         SecondaryStorageVmVO secStorageVm = args.getSecStorageVm();
@@ -63,14 +61,14 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
 
         switch (args.getType()) {
         case SecStorageVmAlertEventArgs.SSVM_CREATED:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("New secondary storage vm created, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("New secondary storage vm created, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
                         secStorageVm.getPublicIpAddress() + ", private IP: " + secStorageVm.getPrivateIpAddress());
             break;
 
         case SecStorageVmAlertEventArgs.SSVM_UP:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Secondary Storage Vm is up, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Secondary Storage Vm is up, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
                         secStorageVm.getPublicIpAddress() + ", private IP: " + secStorageVm.getPrivateIpAddress());
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_SSVM, args.getZoneId(), secStorageVm.getPodIdToDeployIn(), "Secondary Storage Vm up in zone: " +
@@ -79,8 +77,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
             break;
 
         case SecStorageVmAlertEventArgs.SSVM_DOWN:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Secondary Storage Vm is down, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Secondary Storage Vm is down, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
                         secStorageVm.getPublicIpAddress() + ", private IP: " + (secStorageVm.getPrivateIpAddress() == null ? "N/A" : secStorageVm.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(
@@ -93,8 +91,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
             break;
 
         case SecStorageVmAlertEventArgs.SSVM_REBOOTED:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Secondary Storage Vm is rebooted, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Secondary Storage Vm is rebooted, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
                         secStorageVm.getPublicIpAddress() + ", private IP: " + (secStorageVm.getPrivateIpAddress() == null ? "N/A" : secStorageVm.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(
@@ -107,8 +105,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
             break;
 
         case SecStorageVmAlertEventArgs.SSVM_CREATE_FAILURE:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Secondary Storage Vm creation failure, zone: " + dc.getName());
+            if (logger.isDebugEnabled())
+                logger.debug("Secondary Storage Vm creation failure, zone: " + dc.getName());
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_SSVM, args.getZoneId(), null,
                     "Secondary Storage Vm creation failure. zone: " + dc.getName() + ", error details: " + args.getMessage(),
@@ -116,8 +114,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
             break;
 
         case SecStorageVmAlertEventArgs.SSVM_START_FAILURE:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Secondary Storage Vm startup failure, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Secondary Storage Vm startup failure, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
                         secStorageVm.getPublicIpAddress() + ", private IP: " + (secStorageVm.getPrivateIpAddress() == null ? "N/A" : secStorageVm.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_SSVM, args.getZoneId(), secStorageVm.getPodIdToDeployIn(),
@@ -128,8 +126,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
             break;
 
         case SecStorageVmAlertEventArgs.SSVM_FIREWALL_ALERT:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Secondary Storage Vm firewall alert, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Secondary Storage Vm firewall alert, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
                         secStorageVm.getPublicIpAddress() + ", private IP: " + (secStorageVm.getPrivateIpAddress() == null ? "N/A" : secStorageVm.getPrivateIpAddress()));
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_SSVM, args.getZoneId(), secStorageVm.getPodIdToDeployIn(),
@@ -139,8 +137,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
             break;
 
         case SecStorageVmAlertEventArgs.SSVM_STORAGE_ALERT:
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Secondary Storage Vm storage alert, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
+            if (logger.isDebugEnabled())
+                logger.debug("Secondary Storage Vm storage alert, zone: " + dc.getName() + ", secStorageVm: " + secStorageVm.getHostName() + ", public IP: " +
                         secStorageVm.getPublicIpAddress() + ", private IP: " + secStorageVm.getPrivateIpAddress() + ", message: " + args.getMessage());
 
             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_STORAGE_MISC, args.getZoneId(), secStorageVm.getPodIdToDeployIn(),
@@ -153,8 +151,8 @@ public class SecondaryStorageVmAlertAdapter extends AdapterBase implements Alert
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
 
-        if (s_logger.isInfoEnabled())
-            s_logger.info("Start configuring secondary storage vm alert manager : " + name);
+        if (logger.isInfoEnabled())
+            logger.info("Start configuring secondary storage vm alert manager : " + name);
 
         try {
             SubscriptionMgr.getInstance().subscribe(SecondaryStorageVmManager.ALERT_SUBJECT, this, "onSSVMAlert");

--- a/server/src/com/cloud/api/ApiAsyncJobDispatcher.java
+++ b/server/src/com/cloud/api/ApiAsyncJobDispatcher.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -45,7 +44,6 @@ import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.EntityManager;
 
 public class ApiAsyncJobDispatcher extends AdapterBase implements AsyncJobDispatcher {
-    private static final Logger s_logger = Logger.getLogger(ApiAsyncJobDispatcher.class);
 
     @Inject
     private ApiDispatcher _dispatcher;
@@ -118,7 +116,7 @@ public class ApiAsyncJobDispatcher extends AdapterBase implements AsyncJobDispat
             String errorMsg = null;
             int errorCode = ApiErrorCode.INTERNAL_ERROR.getHttpCode();
             if (!(e instanceof ServerApiException)) {
-                s_logger.error("Unexpected exception while executing " + job.getCmd(), e);
+                logger.error("Unexpected exception while executing " + job.getCmd(), e);
                 errorMsg = e.getMessage();
             } else {
                 ServerApiException sApiEx = (ServerApiException)e;

--- a/server/src/com/cloud/api/ApiServer.java
+++ b/server/src/com/cloud/api/ApiServer.java
@@ -16,45 +16,44 @@
 // under the License.
 package com.cloud.api;
 
-import com.cloud.api.dispatch.DispatchChainFactory;
-import com.cloud.api.dispatch.DispatchTask;
-import com.cloud.api.response.ApiResponseSerializer;
-import com.cloud.configuration.Config;
-import com.cloud.domain.Domain;
-import com.cloud.domain.DomainVO;
-import com.cloud.domain.dao.DomainDao;
-import com.cloud.event.ActionEventUtils;
-import com.cloud.event.EventCategory;
-import com.cloud.event.EventTypes;
-import com.cloud.exception.AccountLimitException;
-import com.cloud.exception.CloudAuthenticationException;
-import com.cloud.exception.InsufficientCapacityException;
-import com.cloud.exception.InvalidParameterValueException;
-import com.cloud.exception.PermissionDeniedException;
-import com.cloud.exception.RequestLimitException;
-import com.cloud.exception.ResourceAllocationException;
-import com.cloud.exception.ResourceUnavailableException;
-import com.cloud.user.Account;
-import com.cloud.user.AccountManager;
-import com.cloud.user.DomainManager;
-import com.cloud.user.User;
-import com.cloud.user.UserAccount;
-import com.cloud.user.UserVO;
-import com.cloud.utils.ConstantTimeComparator;
-import com.cloud.utils.HttpUtils;
-import com.cloud.utils.NumbersUtil;
-import com.cloud.utils.Pair;
-import com.cloud.utils.StringUtils;
-import com.cloud.utils.component.ComponentContext;
-import com.cloud.utils.component.ManagerBase;
-import com.cloud.utils.component.PluggableService;
-import com.cloud.utils.concurrency.NamedThreadFactory;
-import com.cloud.utils.db.EntityManager;
-import com.cloud.utils.db.SearchCriteria;
-import com.cloud.utils.db.TransactionLegacy;
-import com.cloud.utils.db.UUIDManager;
-import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.exception.ExceptionProxyObject;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.security.SecureRandom;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
 import org.apache.cloudstack.acl.APIChecker;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
@@ -134,51 +133,51 @@ import org.apache.http.protocol.ResponseConnControl;
 import org.apache.http.protocol.ResponseContent;
 import org.apache.http.protocol.ResponseDate;
 import org.apache.http.protocol.ResponseServer;
-import org.apache.log4j.Logger;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.net.InetAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLEncoder;
-import java.security.SecureRandom;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.cloud.api.dispatch.DispatchChainFactory;
+import com.cloud.api.dispatch.DispatchTask;
+import com.cloud.api.response.ApiResponseSerializer;
+import com.cloud.configuration.Config;
+import com.cloud.domain.Domain;
+import com.cloud.domain.DomainVO;
+import com.cloud.domain.dao.DomainDao;
+import com.cloud.event.ActionEventUtils;
+import com.cloud.event.EventCategory;
+import com.cloud.event.EventTypes;
+import com.cloud.exception.AccountLimitException;
+import com.cloud.exception.CloudAuthenticationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.exception.RequestLimitException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.user.Account;
+import com.cloud.user.AccountManager;
+import com.cloud.user.DomainManager;
+import com.cloud.user.User;
+import com.cloud.user.UserAccount;
+import com.cloud.user.UserVO;
+import com.cloud.utils.ConstantTimeComparator;
+import com.cloud.utils.HttpUtils;
+import com.cloud.utils.NumbersUtil;
+import com.cloud.utils.Pair;
+import com.cloud.utils.StringUtils;
+import com.cloud.utils.component.ComponentContext;
+import com.cloud.utils.component.ManagerBase;
+import com.cloud.utils.component.PluggableService;
+import com.cloud.utils.concurrency.NamedThreadFactory;
+import com.cloud.utils.db.EntityManager;
+import com.cloud.utils.db.SearchCriteria;
+import com.cloud.utils.db.TransactionLegacy;
+import com.cloud.utils.db.UUIDManager;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.exception.ExceptionProxyObject;
 
 @Component
 public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiServerService {
-    private static final Logger s_logger = Logger.getLogger(ApiServer.class.getName());
-    private static final Logger s_accessLogger = Logger.getLogger("apiserver." + ApiServer.class.getName());
 
     public static boolean encodeApiResponse = false;
     public static boolean s_enableSecureCookie = false;
@@ -243,8 +242,8 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         AsyncJob job = eventInfo.first();
         String jobEvent = eventInfo.second();
 
-        if (s_logger.isTraceEnabled())
-            s_logger.trace("Handle asyjob publish event " + jobEvent);
+        if (logger.isTraceEnabled())
+            logger.trace("Handle asyjob publish event " + jobEvent);
 
         EventBus eventBus = null;
         try {
@@ -269,11 +268,11 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             if (begin >= 0) {
                 cmdEventType = info.substring(begin + marker.length() + 2, info.indexOf(",", begin) - 1);
 
-                if (s_logger.isDebugEnabled())
-                    s_logger.debug("Retrieved cmdEventType from job info: " + cmdEventType);
+                if (logger.isDebugEnabled())
+                    logger.debug("Retrieved cmdEventType from job info: " + cmdEventType);
             } else {
-                if (s_logger.isDebugEnabled())
-                    s_logger.debug("Unable to locate cmdEventType marker in job info. publish as unknown event");
+                if (logger.isDebugEnabled())
+                    logger.debug("Unable to locate cmdEventType marker in job info. publish as unknown event");
             }
         }
         // For some reason, the instanceType / instanceId are not abstract, which means we may get null values.
@@ -310,7 +309,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             eventBus.publish(event);
         } catch (EventBusException evx) {
             String errMsg = "Failed to publish async job event on the the event bus.";
-            s_logger.warn(errMsg, evx);
+            logger.warn(errMsg, evx);
         }
     }
 
@@ -332,7 +331,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         if (strSnapshotLimit != null) {
             final Long snapshotLimit = NumbersUtil.parseLong(strSnapshotLimit, 1L);
             if (snapshotLimit.longValue() <= 0) {
-                s_logger.debug("Global config parameter " + Config.ConcurrentSnapshotsThresholdPerHost.toString() + " is less or equal 0; defaulting to unlimited");
+                logger.debug("Global config parameter " + Config.ConcurrentSnapshotsThresholdPerHost.toString() + " is less or equal 0; defaulting to unlimited");
             } else {
                 _dispatcher.setCreateSnapshotQueueSizeLimit(snapshotLimit);
             }
@@ -341,8 +340,8 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         final Set<Class<?>> cmdClasses = new HashSet<Class<?>>();
         for (final PluggableService pluggableService : _pluggableServices) {
             cmdClasses.addAll(pluggableService.getCommands());
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Discovered plugin " + pluggableService.getClass().getSimpleName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Discovered plugin " + pluggableService.getClass().getSimpleName());
             }
         }
 
@@ -400,7 +399,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             try {
                 paramList = URLEncodedUtils.parse(new URI(request.getRequestLine().getUri()), HttpUtils.UTF_8);
             } catch (final URISyntaxException e) {
-                s_logger.error("Error parsing url request", e);
+                logger.error("Error parsing url request", e);
             }
 
             // Use Multimap as the parameter map should be in the form (name=String, value=String[])
@@ -442,11 +441,10 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 sb.append(" " + se.getErrorCode() + " " + se.getDescription());
             } catch (final RuntimeException e) {
                 // log runtime exception like NullPointerException to help identify the source easier
-                s_logger.error("Unhandled exception, ", e);
+                logger.error("Unhandled exception, ", e);
                 throw e;
             }
         } finally {
-            s_accessLogger.info(sb.toString());
             CallContext.unregister();
         }
     }
@@ -483,13 +481,13 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         try {
             command = (String[])params.get("command");
             if (command == null) {
-                s_logger.error("invalid request, no command sent");
-                if (s_logger.isTraceEnabled()) {
-                    s_logger.trace("dumping request parameters");
+                logger.error("invalid request, no command sent");
+                if (logger.isTraceEnabled()) {
+                    logger.trace("dumping request parameters");
                     for (final  Object key : params.keySet()) {
                         final String keyStr = (String)key;
                         final String[] value = (String[])params.get(key);
-                        s_logger.trace("   key: " + keyStr + ", value: " + ((value == null) ? "'null'" : value[0]));
+                        logger.trace("   key: " + keyStr + ", value: " + ((value == null) ? "'null'" : value[0]));
                     }
                 }
                 throw new ServerApiException(ApiErrorCode.UNSUPPORTED_ACTION_ERROR, "Invalid request, no command sent");
@@ -514,7 +512,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 if (cmdClass != null) {
                     APICommand annotation = cmdClass.getAnnotation(APICommand.class);
                     if (annotation == null) {
-                        s_logger.error("No APICommand annotation found for class " + cmdClass.getCanonicalName());
+                        logger.error("No APICommand annotation found for class " + cmdClass.getCanonicalName());
                         throw new CloudRuntimeException("No APICommand annotation found for class " + cmdClass.getCanonicalName());
                     }
 
@@ -536,16 +534,16 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                         buildAuditTrail(auditTrailSb, command[0], response);
                 } else {
                     final String errorString = "Unknown API command: " + command[0];
-                    s_logger.warn(errorString);
+                    logger.warn(errorString);
                     auditTrailSb.append(" " + errorString);
                     throw new ServerApiException(ApiErrorCode.UNSUPPORTED_ACTION_ERROR, errorString);
                 }
             }
         } catch (final InvalidParameterValueException ex) {
-            s_logger.info(ex.getMessage());
+            logger.info(ex.getMessage());
             throw new ServerApiException(ApiErrorCode.PARAM_ERROR, ex.getMessage(), ex);
         } catch (final IllegalArgumentException ex) {
-            s_logger.info(ex.getMessage());
+            logger.info(ex.getMessage());
             throw new ServerApiException(ApiErrorCode.PARAM_ERROR, ex.getMessage(), ex);
         } catch (final PermissionDeniedException ex) {
             final ArrayList<ExceptionProxyObject> idList = ex.getIdProxyList();
@@ -557,16 +555,16 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                     buf.append(obj.getUuid());
                     buf.append(" ");
                 }
-                s_logger.info("PermissionDenied: " + ex.getMessage() + " on objs: [" + buf.toString() + "]");
+                logger.info("PermissionDenied: " + ex.getMessage() + " on objs: [" + buf.toString() + "]");
             } else {
-                s_logger.info("PermissionDenied: " + ex.getMessage());
+                logger.info("PermissionDenied: " + ex.getMessage());
             }
             throw new ServerApiException(ApiErrorCode.ACCOUNT_ERROR, ex.getMessage(), ex);
         } catch (final AccountLimitException ex) {
-            s_logger.info(ex.getMessage());
+            logger.info(ex.getMessage());
             throw new ServerApiException(ApiErrorCode.ACCOUNT_RESOURCE_LIMIT_ERROR, ex.getMessage(), ex);
         } catch (final InsufficientCapacityException ex) {
-            s_logger.info(ex.getMessage());
+            logger.info(ex.getMessage());
             String errorMsg = ex.getMessage();
             if (!_accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())) {
                 // hide internal details to non-admin user for security reason
@@ -574,10 +572,10 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             }
             throw new ServerApiException(ApiErrorCode.INSUFFICIENT_CAPACITY_ERROR, errorMsg, ex);
         } catch (final ResourceAllocationException ex) {
-            s_logger.info(ex.getMessage());
+            logger.info(ex.getMessage());
             throw new ServerApiException(ApiErrorCode.RESOURCE_ALLOCATION_ERROR, ex.getMessage(), ex);
         } catch (final ResourceUnavailableException ex) {
-            s_logger.info(ex.getMessage());
+            logger.info(ex.getMessage());
             String errorMsg = ex.getMessage();
             if (!_accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())) {
                 // hide internal details to non-admin user for security reason
@@ -585,10 +583,10 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             }
             throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, errorMsg, ex);
         } catch (final ServerApiException ex) {
-            s_logger.info(ex.getDescription());
+            logger.info(ex.getDescription());
             throw ex;
         } catch (final Exception ex) {
-            s_logger.error("unhandled exception executing api command: " + ((command == null) ? "null" : command), ex);
+            logger.error("unhandled exception executing api command: " + ((command == null) ? "null" : command), ex);
             String errorMsg = ex.getMessage();
             if (!_accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())) {
                 // hide internal details to non-admin user for security reason
@@ -682,14 +680,14 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             AsyncJobVO job = new AsyncJobVO("", callerUserId, caller.getId(), cmdObj.getClass().getName(),
                     ApiGsonHelper.getBuilder().create().toJson(params), instanceId,
                     asyncCmd.getInstanceType() != null ? asyncCmd.getInstanceType().toString() : null,
-                    injectedJobId);
+                            injectedJobId);
             job.setDispatcher(_asyncDispatcher.getName());
 
             final long jobId = _asyncMgr.submitAsyncJob(job);
 
             if (jobId == 0L) {
                 final String errorMsg = "Unable to schedule async job for command " + job.getCmd();
-                s_logger.warn(errorMsg);
+                logger.warn(errorMsg);
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, errorMsg);
             }
 
@@ -780,7 +778,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
 
             final String[] command = (String[])requestParameters.get(ApiConstants.COMMAND);
             if (command == null) {
-                s_logger.info("missing command, ignoring request...");
+                logger.info("missing command, ignoring request...");
                 return false;
             }
 
@@ -793,17 +791,17 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 try {
                     checkCommandAvailable(user, commandName);
                 } catch (final RequestLimitException ex) {
-                    s_logger.debug(ex.getMessage());
+                    logger.debug(ex.getMessage());
                     throw new ServerApiException(ApiErrorCode.API_LIMIT_EXCEED, ex.getMessage());
                 } catch (final PermissionDeniedException ex) {
-                    s_logger.debug("The given command:" + commandName + " does not exist or it is not available for user with id:" + userId);
+                    logger.debug("The given command:" + commandName + " does not exist or it is not available for user with id:" + userId);
                     throw new ServerApiException(ApiErrorCode.UNSUPPORTED_ACTION_ERROR, "The given command does not exist or it is not available for user");
                 }
                 return true;
             } else {
                 // check against every available command to see if the command exists or not
                 if (!s_apiNameCmdClassMap.containsKey(commandName) && !commandName.equals("login") && !commandName.equals("logout")) {
-                    s_logger.debug("The given command:" + commandName + " does not exist or it is not available for user with id:" + userId);
+                    logger.debug("The given command:" + commandName + " does not exist or it is not available for user with id:" + userId);
                     throw new ServerApiException(ApiErrorCode.UNSUPPORTED_ACTION_ERROR, "The given command does not exist or it is not available for user");
                 }
             }
@@ -846,7 +844,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
 
             // if api/secret key are passed to the parameters
             if ((signature == null) || (apiKey == null)) {
-                s_logger.debug("Expired session, missing signature, or missing apiKey -- ignoring request. Signature: " + signature + ", apiKey: " + apiKey);
+                logger.debug("Expired session, missing signature, or missing apiKey -- ignoring request. Signature: " + signature + ", apiKey: " + apiKey);
                 return false; // no signature, bad request
             }
 
@@ -855,20 +853,20 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             if ("3".equals(signatureVersion)) {
                 // New signature authentication. Check for expire parameter and its validity
                 if (expires == null) {
-                    s_logger.debug("Missing Expires parameter -- ignoring request. Signature: " + signature + ", apiKey: " + apiKey);
+                    logger.debug("Missing Expires parameter -- ignoring request. Signature: " + signature + ", apiKey: " + apiKey);
                     return false;
                 }
                 synchronized (DateFormatToUse) {
                     try {
                         expiresTS = DateFormatToUse.parse(expires);
                     } catch (final ParseException pe) {
-                        s_logger.debug("Incorrect date format for Expires parameter", pe);
+                        logger.debug("Incorrect date format for Expires parameter", pe);
                         return false;
                     }
                 }
                 final Date now = new Date(System.currentTimeMillis());
                 if (expiresTS.before(now)) {
-                    s_logger.debug("Request expired -- ignoring ...sig: " + signature + ", apiKey: " + apiKey);
+                    logger.debug("Request expired -- ignoring ...sig: " + signature + ", apiKey: " + apiKey);
                     return false;
                 }
             }
@@ -879,7 +877,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             // verify there is a user with this api key
             final Pair<User, Account> userAcctPair = _accountMgr.findUserByApiKey(apiKey);
             if (userAcctPair == null) {
-                s_logger.debug("apiKey does not map to a valid user -- ignoring request, apiKey: " + apiKey);
+                logger.debug("apiKey does not map to a valid user -- ignoring request, apiKey: " + apiKey);
                 return false;
             }
 
@@ -887,7 +885,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             final Account account = userAcctPair.second();
 
             if (user.getState() != Account.State.enabled || !account.getState().equals(Account.State.enabled)) {
-                s_logger.info("disabled or locked user accessing the api, userid = " + user.getId() + "; name = " + user.getUsername() + "; state: " + user.getState() +
+                logger.info("disabled or locked user accessing the api, userid = " + user.getId() + "; name = " + user.getUsername() + "; state: " + user.getState() +
                         "; accountState: " + account.getState());
                 return false;
             }
@@ -895,10 +893,10 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             try {
                 checkCommandAvailable(user, commandName);
             } catch (final RequestLimitException ex) {
-                s_logger.debug(ex.getMessage());
+                logger.debug(ex.getMessage());
                 throw new ServerApiException(ApiErrorCode.API_LIMIT_EXCEED, ex.getMessage());
             } catch (final PermissionDeniedException ex) {
-                s_logger.debug("The given command:" + commandName + " does not exist or it is not available for user");
+                logger.debug("The given command:" + commandName + " does not exist or it is not available for user");
                 throw new ServerApiException(ApiErrorCode.UNSUPPORTED_ACTION_ERROR, "The given command:" + commandName + " does not exist or it is not available for user with id:"
                         + userId);
             }
@@ -906,7 +904,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             // verify secret key exists
             secretKey = user.getSecretKey();
             if (secretKey == null) {
-                s_logger.info("User does not have a secret key associated with the account -- ignoring request, username: " + user.getUsername());
+                logger.info("User does not have a secret key associated with the account -- ignoring request, username: " + user.getUsername());
                 return false;
             }
 
@@ -922,7 +920,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             final boolean equalSig = ConstantTimeComparator.compareStrings(signature, computedSignature);
 
             if (!equalSig) {
-                s_logger.info("User signature: " + signature + " is not equaled to computed signature: " + computedSignature);
+                logger.info("User signature: " + signature + " is not equaled to computed signature: " + computedSignature);
             } else {
                 CallContext.register(user, account);
             }
@@ -930,7 +928,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         } catch (final ServerApiException ex) {
             throw ex;
         } catch (final Exception ex) {
-            s_logger.error("unable to verify request signature");
+            logger.error("unable to verify request signature");
         }
         return false;
     }
@@ -1018,13 +1016,13 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             float offsetInHrs = 0f;
             if (timezone != null) {
                 final TimeZone t = TimeZone.getTimeZone(timezone);
-                s_logger.info("Current user logged in under " + timezone + " timezone");
+                logger.info("Current user logged in under " + timezone + " timezone");
 
                 final java.util.Date date = new java.util.Date();
                 final long longDate = date.getTime();
                 final float offsetInMs = (t.getOffset(longDate));
                 offsetInHrs = offsetInMs / (1000 * 60 * 60);
-                s_logger.info("Timezone offset from UTC is: " + offsetInHrs);
+                logger.info("Timezone offset from UTC is: " + offsetInHrs);
             }
 
             final Account account = _accountMgr.getAccount(userAcct.getAccountId());
@@ -1086,7 +1084,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
 
         if ((user == null) || (user.getRemoved() != null) || !user.getState().equals(Account.State.enabled) || (account == null) ||
                 !account.getState().equals(Account.State.enabled)) {
-            s_logger.warn("Deleted/Disabled/Locked user with id=" + userId + " attempting to access public API");
+            logger.warn("Deleted/Disabled/Locked user with id=" + userId + " attempting to access public API");
             return false;
         }
         return true;
@@ -1157,7 +1155,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             }
             resp.setEntity(body);
         } catch (final Exception ex) {
-            s_logger.error("error!", ex);
+            logger.error("error!", ex);
         }
     }
 
@@ -1166,7 +1164,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
     // we have to cite a license if we are using this code directly, so we need to add the appropriate citation or
     // modify the
     // code to be very specific to our needs
-    static class ListenerThread extends Thread {
+    class ListenerThread extends Thread {
         private HttpService _httpService = null;
         private ServerSocket _serverSocket = null;
         private HttpParams _params = null;
@@ -1175,16 +1173,16 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             try {
                 _serverSocket = new ServerSocket(port);
             } catch (final IOException ioex) {
-                s_logger.error("error initializing api server", ioex);
+                logger.error("error initializing api server", ioex);
                 return;
             }
 
             _params = new BasicHttpParams();
             _params.setIntParameter(CoreConnectionPNames.SO_TIMEOUT, 30000)
-                    .setIntParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, 8 * 1024)
-                    .setBooleanParameter(CoreConnectionPNames.STALE_CONNECTION_CHECK, false)
-                    .setBooleanParameter(CoreConnectionPNames.TCP_NODELAY, true)
-                    .setParameter(CoreProtocolPNames.ORIGIN_SERVER, "HttpComponents/1.1");
+            .setIntParameter(CoreConnectionPNames.SOCKET_BUFFER_SIZE, 8 * 1024)
+            .setBooleanParameter(CoreConnectionPNames.STALE_CONNECTION_CHECK, false)
+            .setBooleanParameter(CoreConnectionPNames.TCP_NODELAY, true)
+            .setParameter(CoreProtocolPNames.ORIGIN_SERVER, "HttpComponents/1.1");
 
             // Set up the HTTP protocol processor
             final BasicHttpProcessor httpproc = new BasicHttpProcessor();
@@ -1205,7 +1203,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
 
         @Override
         public void run() {
-            s_logger.info("ApiServer listening on port " + _serverSocket.getLocalPort());
+            logger.info("ApiServer listening on port " + _serverSocket.getLocalPort());
             while (!Thread.interrupted()) {
                 try {
                     // Set up HTTP connection
@@ -1218,14 +1216,14 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 } catch (final InterruptedIOException ex) {
                     break;
                 } catch (final IOException e) {
-                    s_logger.error("I/O error initializing connection thread", e);
+                    logger.error("I/O error initializing connection thread", e);
                     break;
                 }
             }
         }
     }
 
-    static class WorkerTask extends ManagedContextRunnable {
+    class WorkerTask extends ManagedContextRunnable {
         private final HttpService _httpService;
         private final HttpServerConnection _conn;
 
@@ -1243,15 +1241,15 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                     _conn.close();
                 }
             } catch (final ConnectionClosedException ex) {
-                if (s_logger.isTraceEnabled()) {
-                    s_logger.trace("ApiServer:  Client closed connection");
+                if (logger.isTraceEnabled()) {
+                    logger.trace("ApiServer:  Client closed connection");
                 }
             } catch (final IOException ex) {
-                if (s_logger.isTraceEnabled()) {
-                    s_logger.trace("ApiServer:  IOException - " + ex);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("ApiServer:  IOException - " + ex);
                 }
             } catch (final HttpException ex) {
-                s_logger.warn("ApiServer:  Unrecoverable HTTP protocol violation" + ex);
+                logger.warn("ApiServer:  Unrecoverable HTTP protocol violation" + ex);
             } finally {
                 try {
                     _conn.shutdown();
@@ -1291,7 +1289,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             responseText = ApiResponseSerializer.toSerializedString(apiResponse, responseType);
 
         } catch (final Exception e) {
-            s_logger.error("Exception responding to http request", e);
+            logger.error("Exception responding to http request", e);
         }
         return responseText;
     }
@@ -1341,7 +1339,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             responseText = ApiResponseSerializer.toSerializedString(apiResponse, responseType);
 
         } catch (final Exception e) {
-            s_logger.error("Exception responding to http request", e);
+            logger.error("Exception responding to http request", e);
         }
         return responseText;
     }

--- a/server/src/com/cloud/api/auth/APIAuthenticationManagerImpl.java
+++ b/server/src/com/cloud/api/auth/APIAuthenticationManagerImpl.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.auth.APIAuthenticationManager;
@@ -36,7 +35,6 @@ import com.cloud.utils.component.ManagerBase;
 @Local(value = APIAuthenticationManager.class)
 @SuppressWarnings("unchecked")
 public class APIAuthenticationManagerImpl extends ManagerBase implements APIAuthenticationManager {
-    public static final Logger s_logger = Logger.getLogger(APIAuthenticationManagerImpl.class.getName());
 
     private List<PluggableAPIAuthenticator> _apiAuthenticators;
 
@@ -84,7 +82,7 @@ public class APIAuthenticationManagerImpl extends ManagerBase implements APIAuth
             if (commands != null) {
                 cmdList.addAll(commands);
             } else {
-                s_logger.warn("API Authenticator returned null api commands:" + apiAuthenticator.getName());
+                logger.warn("API Authenticator returned null api commands:" + apiAuthenticator.getName());
             }
         }
         return cmdList;
@@ -100,8 +98,8 @@ public class APIAuthenticationManagerImpl extends ManagerBase implements APIAuth
                 apiAuthenticator = ComponentContext.inject(apiAuthenticator);
                 apiAuthenticator.setAuthenticators(_apiAuthenticators);
             } catch (InstantiationException | IllegalAccessException e) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("APIAuthenticationManagerImpl::getAPIAuthenticator failed: " + e.getMessage());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("APIAuthenticationManagerImpl::getAPIAuthenticator failed: " + e.getMessage());
                 }
             }
         }

--- a/server/src/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/com/cloud/api/query/QueryManagerImpl.java
@@ -107,7 +107,6 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.query.QueryService;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.query.dao.AccountJoinDao;
@@ -227,7 +226,6 @@ import com.cloud.vm.dao.UserVmDetailsDao;
 @Local(value = {QueryService.class})
 public class QueryManagerImpl extends ManagerBase implements QueryService, Configurable {
 
-    public static final Logger s_logger = Logger.getLogger(QueryManagerImpl.class);
 
     @Inject
     private AccountManager _accountMgr;
@@ -1565,10 +1563,10 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
         // FIXME: do we need to support list hosts with VmId, maybe we should
         // create another command just for this
         // Right now it is handled separately outside this QueryService
-        s_logger.debug(">>>Searching for hosts>>>");
+        logger.debug(">>>Searching for hosts>>>");
         Pair<List<HostJoinVO>, Integer> hosts = searchForServersInternal(cmd);
         ListResponse<HostResponse> response = new ListResponse<HostResponse>();
-        s_logger.debug(">>>Generating Response>>>");
+        logger.debug(">>>Generating Response>>>");
         List<HostResponse> hostResponses = ViewResponseHelper.createHostResponse(cmd.getDetails(), hosts.first().toArray(new HostJoinVO[hosts.first().size()]));
         response.setResponses(hostResponses, hosts.second());
         return response;
@@ -2562,7 +2560,7 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
                 domainIds = new ArrayList<Long>();
                 DomainVO domainRecord = _domainDao.findById(account.getDomainId());
                 if ( domainRecord == null ){
-                    s_logger.error("Could not find the domainId for account:" + account.getAccountName());
+                    logger.error("Could not find the domainId for account:" + account.getAccountName());
                     throw new CloudAuthenticationException("Could not find the domainId for account:" + account.getAccountName());
                 }
                 domainIds.add(domainRecord.getId());
@@ -2733,13 +2731,13 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
                     UserVmVO vmInstance = _userVmDao.findById(vmId);
                     domainRecord = _domainDao.findById(vmInstance.getDomainId());
                     if ( domainRecord == null ){
-                        s_logger.error("Could not find the domainId for vmId:" + vmId);
+                        logger.error("Could not find the domainId for vmId:" + vmId);
                         throw new CloudAuthenticationException("Could not find the domainId for vmId:" + vmId);
                     }
                 } else {
                     domainRecord = _domainDao.findById(caller.getDomainId());
                     if ( domainRecord == null ){
-                        s_logger.error("Could not find the domainId for account:" + caller.getAccountName());
+                        logger.error("Could not find the domainId for account:" + caller.getAccountName());
                         throw new CloudAuthenticationException("Could not find the domainId for account:" + caller.getAccountName());
                     }
                 }
@@ -2885,7 +2883,7 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
                 List<Long> domainIds = new ArrayList<Long>();
                 DomainVO domainRecord = _domainDao.findById(account.getDomainId());
                 if (domainRecord == null) {
-                    s_logger.error("Could not find the domainId for account:" + account.getAccountName());
+                    logger.error("Could not find the domainId for account:" + account.getAccountName());
                     throw new CloudAuthenticationException("Could not find the domainId for account:" + account.getAccountName());
                 }
                 domainIds.add(domainRecord.getId());
@@ -2926,7 +2924,7 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
                 List<Long> domainIds = new ArrayList<Long>();
                 DomainVO domainRecord = _domainDao.findById(account.getDomainId());
                 if (domainRecord == null) {
-                    s_logger.error("Could not find the domainId for account:" + account.getAccountName());
+                    logger.error("Could not find the domainId for account:" + account.getAccountName());
                     throw new CloudAuthenticationException("Could not find the domainId for account:" + account.getAccountName());
                 }
                 domainIds.add(domainRecord.getId());
@@ -3118,14 +3116,14 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
                 throw new InvalidParameterValueException("Please specify a valid template ID.");
             }// If ISO requested then it should be ISO.
             if (isIso && template.getFormat() != ImageFormat.ISO) {
-                s_logger.error("Template Id " + templateId + " is not an ISO");
+                logger.error("Template Id " + templateId + " is not an ISO");
                 InvalidParameterValueException ex = new InvalidParameterValueException(
                         "Specified Template Id is not an ISO");
                 ex.addProxyObject(template.getUuid(), "templateId");
                 throw ex;
             }// If ISO not requested then it shouldn't be an ISO.
             if (!isIso && template.getFormat() == ImageFormat.ISO) {
-                s_logger.error("Incorrect format of the template id " + templateId);
+                logger.error("Incorrect format of the template id " + templateId);
                 InvalidParameterValueException ex = new InvalidParameterValueException("Incorrect format "
                         + template.getFormat() + " of the specified template id");
                 ex.addProxyObject(template.getUuid(), "templateId");

--- a/server/src/com/cloud/api/query/dao/AccountJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/AccountJoinDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
@@ -43,7 +42,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {AccountJoinDao.class})
 public class AccountJoinDaoImpl extends GenericDaoBase<AccountJoinVO, Long> implements AccountJoinDao {
-    public static final Logger s_logger = Logger.getLogger(AccountJoinDaoImpl.class);
 
     private final SearchBuilder<AccountJoinVO> acctIdSearch;
     @Inject

--- a/server/src/com/cloud/api/query/dao/AffinityGroupJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/AffinityGroupJoinDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.affinity.AffinityGroup;
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.SearchCriteria;
 
 @Local(value = {AffinityGroupJoinDao.class})
 public class AffinityGroupJoinDaoImpl extends GenericDaoBase<AffinityGroupJoinVO, Long> implements AffinityGroupJoinDao {
-    public static final Logger s_logger = Logger.getLogger(AffinityGroupJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;

--- a/server/src/com/cloud/api/query/dao/DataCenterJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/DataCenterJoinDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
@@ -42,7 +41,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {DataCenterJoinDao.class})
 public class DataCenterJoinDaoImpl extends GenericDaoBase<DataCenterJoinVO, Long> implements DataCenterJoinDao {
-    public static final Logger s_logger = Logger.getLogger(DataCenterJoinDaoImpl.class);
 
     private SearchBuilder<DataCenterJoinVO> dofIdSearch;
     @Inject

--- a/server/src/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/DiskOfferingJoinDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.DiskOfferingResponse;
@@ -36,7 +35,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {DiskOfferingJoinDao.class})
 public class DiskOfferingJoinDaoImpl extends GenericDaoBase<DiskOfferingJoinVO, Long> implements DiskOfferingJoinDao {
-    public static final Logger s_logger = Logger.getLogger(DiskOfferingJoinDaoImpl.class);
 
     private final SearchBuilder<DiskOfferingJoinVO> dofIdSearch;
     private final Attribute _typeAttr;

--- a/server/src/com/cloud/api/query/dao/DomainJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/DomainJoinDaoImpl.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.ResourceLimitAndCountResponse;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.ApiDBUtils;
@@ -37,7 +36,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value={DomainJoinDao.class})
 public class DomainJoinDaoImpl extends GenericDaoBase<DomainJoinVO, Long> implements DomainJoinDao {
-    public static final Logger s_logger = Logger.getLogger(DomainJoinDaoImpl.class);
 
     private SearchBuilder<DomainJoinVO> domainIdSearch;
 

--- a/server/src/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/DomainRouterJoinDaoImpl.java
@@ -26,7 +26,6 @@ import org.apache.cloudstack.api.response.DomainRouterResponse;
 import org.apache.cloudstack.api.response.NicResponse;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.ApiResponseHelper;
@@ -44,7 +43,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {DomainRouterJoinDao.class})
 public class DomainRouterJoinDaoImpl extends GenericDaoBase<DomainRouterJoinVO, Long> implements DomainRouterJoinDao {
-    public static final Logger s_logger = Logger.getLogger(DomainRouterJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao  _configDao;

--- a/server/src/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ApiConstants.HostDetails;
@@ -55,7 +54,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {HostJoinDao.class})
 public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements HostJoinDao {
-    public static final Logger s_logger = Logger.getLogger(HostJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;
@@ -197,7 +195,7 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                     hostVoDetails = h.getDetails();
                     hostResponse.setDetails(hostVoDetails);
                 } catch (Exception e) {
-                    s_logger.debug("failed to get host details", e);
+                    logger.debug("failed to get host details", e);
                 }
             }
 

--- a/server/src/com/cloud/api/query/dao/HostTagDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/HostTagDaoImpl.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.api.response.HostTagResponse;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.query.vo.HostTagVO;
@@ -35,7 +34,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {HostTagDao.class})
 public class HostTagDaoImpl extends GenericDaoBase<HostTagVO, Long> implements HostTagDao {
-    public static final Logger s_logger = Logger.getLogger(HostTagDaoImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;

--- a/server/src/com/cloud/api/query/dao/ImageStoreJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/ImageStoreJoinDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ApiConstants;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {ImageStoreJoinDao.class})
 public class ImageStoreJoinDaoImpl extends GenericDaoBase<ImageStoreJoinVO, Long> implements ImageStoreJoinDao {
-    public static final Logger s_logger = Logger.getLogger(ImageStoreJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;

--- a/server/src/com/cloud/api/query/dao/InstanceGroupJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/InstanceGroupJoinDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.InstanceGroupResponse;
@@ -35,7 +34,6 @@ import com.cloud.vm.InstanceGroup;
 @Component
 @Local(value = {InstanceGroupJoinDao.class})
 public class InstanceGroupJoinDaoImpl extends GenericDaoBase<InstanceGroupJoinVO, Long> implements InstanceGroupJoinDao {
-    public static final Logger s_logger = Logger.getLogger(InstanceGroupJoinDaoImpl.class);
 
     private SearchBuilder<InstanceGroupJoinVO> vrIdSearch;
 

--- a/server/src/com/cloud/api/query/dao/ProjectAccountJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/ProjectAccountJoinDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.ProjectAccountResponse;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {ProjectAccountJoinDao.class})
 public class ProjectAccountJoinDaoImpl extends GenericDaoBase<ProjectAccountJoinVO, Long> implements ProjectAccountJoinDao {
-    public static final Logger s_logger = Logger.getLogger(ProjectAccountJoinDaoImpl.class);
 
     private SearchBuilder<ProjectAccountJoinVO> paIdSearch;
 

--- a/server/src/com/cloud/api/query/dao/ProjectInvitationJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/ProjectInvitationJoinDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.ProjectInvitationResponse;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {ProjectInvitationJoinDao.class})
 public class ProjectInvitationJoinDaoImpl extends GenericDaoBase<ProjectInvitationJoinVO, Long> implements ProjectInvitationJoinDao {
-    public static final Logger s_logger = Logger.getLogger(ProjectInvitationJoinDaoImpl.class);
 
     private SearchBuilder<ProjectInvitationJoinVO> piIdSearch;
 

--- a/server/src/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.ProjectResponse;
@@ -42,7 +41,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {ProjectJoinDao.class})
 public class ProjectJoinDaoImpl extends GenericDaoBase<ProjectJoinVO, Long> implements ProjectJoinDao {
-    public static final Logger s_logger = Logger.getLogger(ProjectJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;

--- a/server/src/com/cloud/api/query/dao/StoragePoolJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/StoragePoolJoinDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.api.response.StoragePoolResponse;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {StoragePoolJoinDao.class})
 public class StoragePoolJoinDaoImpl extends GenericDaoBase<StoragePoolJoinVO, Long> implements StoragePoolJoinDao {
-    public static final Logger s_logger = Logger.getLogger(StoragePoolJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;

--- a/server/src/com/cloud/api/query/dao/StorageTagDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/StorageTagDaoImpl.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.api.response.StorageTagResponse;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.query.vo.StorageTagVO;
@@ -35,7 +34,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {StorageTagDao.class})
 public class StorageTagDaoImpl extends GenericDaoBase<StorageTagVO, Long> implements StorageTagDao {
-    public static final Logger s_logger = Logger.getLogger(StorageTagDaoImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;

--- a/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
@@ -56,7 +55,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Local(value = {TemplateJoinDao.class})
 public class TemplateJoinDaoImpl extends GenericDaoBase<TemplateJoinVO, Long> implements TemplateJoinDao {
 
-    public static final Logger s_logger = Logger.getLogger(TemplateJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao  _configDao;

--- a/server/src/com/cloud/api/query/dao/UserAccountJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/UserAccountJoinDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.UserResponse;
@@ -35,7 +34,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {UserAccountJoinDao.class})
 public class UserAccountJoinDaoImpl extends GenericDaoBase<UserAccountJoinVO, Long> implements UserAccountJoinDao {
-    public static final Logger s_logger = Logger.getLogger(UserAccountJoinDaoImpl.class);
 
     private SearchBuilder<UserAccountJoinVO> vrIdSearch;
 

--- a/server/src/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
@@ -64,7 +63,6 @@ import com.cloud.vm.dao.UserVmDetailsDao;
 @Component
 @Local(value = {UserVmJoinDao.class})
 public class UserVmJoinDaoImpl extends GenericDaoBase<UserVmJoinVO, Long> implements UserVmJoinDao {
-    public static final Logger s_logger = Logger.getLogger(UserVmJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao  _configDao;

--- a/server/src/com/cloud/api/query/dao/VolumeJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/VolumeJoinDaoImpl.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.response.VolumeResponse;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.api.ApiDBUtils;
@@ -45,7 +44,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {VolumeJoinDao.class})
 public class VolumeJoinDaoImpl extends GenericDaoBase<VolumeJoinVO, Long> implements VolumeJoinDao {
-    public static final Logger s_logger = Logger.getLogger(VolumeJoinDaoImpl.class);
 
     @Inject
     private ConfigurationDao  _configDao;

--- a/server/src/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/com/cloud/capacity/CapacityManagerImpl.java
@@ -29,7 +29,6 @@ import javax.naming.ConfigurationException;
 
 import com.cloud.resource.ResourceState;
 import com.cloud.utils.fsm.StateMachine2;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreDriver;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreProvider;
@@ -104,7 +103,6 @@ import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 @Local(value = CapacityManager.class)
 public class CapacityManagerImpl extends ManagerBase implements CapacityManager, StateListener<State, VirtualMachine.Event, VirtualMachine>, Listener, ResourceListener,
         Configurable {
-    private static final Logger s_logger = Logger.getLogger(CapacityManagerImpl.class);
     @Inject
     CapacityDao _capacityDao;
     @Inject
@@ -192,7 +190,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         if (hostId != null) {
             HostVO host = _hostDao.findById(hostId);
             if (host == null) {
-                s_logger.warn("Host " + hostId + " no long exist anymore!");
+                logger.warn("Host " + hostId + " no long exist anymore!");
                 return true;
             }
 
@@ -224,9 +222,9 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                     long actualTotalMem = capacityMemory.getTotalCapacity();
                     long totalMem = (long)(actualTotalMem * memoryOvercommitRatio);
                     long totalCpu = (long)(actualTotalCpu * cpuOvercommitRatio);
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
-                        s_logger.debug("Hosts's actual total RAM: " + actualTotalMem + " and RAM after applying overprovisioning: " + totalMem);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
+                        logger.debug("Hosts's actual total RAM: " + actualTotalMem + " and RAM after applying overprovisioning: " + totalMem);
                     }
 
                     if (!moveFromReserved) {
@@ -255,11 +253,11 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                         }
                     }
 
-                    s_logger.debug("release cpu from host: " + hostId + ", old used: " + usedCpu + ",reserved: " + reservedCpu + ", actual total: " + actualTotalCpu +
+                    logger.debug("release cpu from host: " + hostId + ", old used: " + usedCpu + ",reserved: " + reservedCpu + ", actual total: " + actualTotalCpu +
                         ", total with overprovisioning: " + totalCpu + "; new used: " + capacityCpu.getUsedCapacity() + ",reserved:" + capacityCpu.getReservedCapacity() +
                         "; movedfromreserved: " + moveFromReserved + ",moveToReservered" + moveToReservered);
 
-                    s_logger.debug("release mem from host: " + hostId + ", old used: " + usedMem + ",reserved: " + reservedMem + ", total: " + totalMem + "; new used: " +
+                    logger.debug("release mem from host: " + hostId + ", old used: " + usedMem + ",reserved: " + reservedMem + ", total: " + totalMem + "; new used: " +
                         capacityMemory.getUsedCapacity() + ",reserved:" + capacityMemory.getReservedCapacity() + "; movedfromreserved: " + moveFromReserved +
                         ",moveToReservered" + moveToReservered);
 
@@ -270,7 +268,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
             return true;
         } catch (Exception e) {
-            s_logger.debug("Failed to transit vm's state, due to " + e.getMessage());
+            logger.debug("Failed to transit vm's state, due to " + e.getMessage());
             return false;
         }
     }
@@ -315,27 +313,27 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                     long actualTotalMem = capacityMem.getTotalCapacity();
                     long totalCpu = (long)(actualTotalCpu * cpuOvercommitRatio);
                     long totalMem = (long)(actualTotalMem * memoryOvercommitRatio);
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
                     }
 
                     long freeCpu = totalCpu - (reservedCpu + usedCpu);
                     long freeMem = totalMem - (reservedMem + usedMem);
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("We are allocating VM, increasing the used capacity of this host:" + hostId);
-                        s_logger.debug("Current Used CPU: " + usedCpu + " , Free CPU:" + freeCpu + " ,Requested CPU: " + cpu);
-                        s_logger.debug("Current Used RAM: " + usedMem + " , Free RAM:" + freeMem + " ,Requested RAM: " + ram);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("We are allocating VM, increasing the used capacity of this host:" + hostId);
+                        logger.debug("Current Used CPU: " + usedCpu + " , Free CPU:" + freeCpu + " ,Requested CPU: " + cpu);
+                        logger.debug("Current Used RAM: " + usedMem + " , Free RAM:" + freeMem + " ,Requested RAM: " + ram);
                     }
                     capacityCpu.setUsedCapacity(usedCpu + cpu);
                     capacityMem.setUsedCapacity(usedMem + ram);
 
                     if (fromLastHost) {
                         /* alloc from reserved */
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("We are allocating VM to the last host again, so adjusting the reserved capacity if it is not less than required");
-                            s_logger.debug("Reserved CPU: " + reservedCpu + " , Requested CPU: " + cpu);
-                            s_logger.debug("Reserved RAM: " + reservedMem + " , Requested RAM: " + ram);
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("We are allocating VM to the last host again, so adjusting the reserved capacity if it is not less than required");
+                            logger.debug("Reserved CPU: " + reservedCpu + " , Requested CPU: " + cpu);
+                            logger.debug("Reserved RAM: " + reservedMem + " , Requested RAM: " + ram);
                         }
                         if (reservedCpu >= cpu && reservedMem >= ram) {
                             capacityCpu.setReservedCapacity(reservedCpu - cpu);
@@ -344,18 +342,18 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                     } else {
                         /* alloc from free resource */
                         if (!((reservedCpu + usedCpu + cpu <= totalCpu) && (reservedMem + usedMem + ram <= totalMem))) {
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Host doesnt seem to have enough free capacity, but increasing the used capacity anyways, " +
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Host doesnt seem to have enough free capacity, but increasing the used capacity anyways, " +
                                     "since the VM is already starting on this host ");
                             }
                         }
                     }
 
-                    s_logger.debug("CPU STATS after allocation: for host: " + hostId + ", old used: " + usedCpu + ", old reserved: " + reservedCpu + ", actual total: " +
+                    logger.debug("CPU STATS after allocation: for host: " + hostId + ", old used: " + usedCpu + ", old reserved: " + reservedCpu + ", actual total: " +
                         actualTotalCpu + ", total with overprovisioning: " + totalCpu + "; new used:" + capacityCpu.getUsedCapacity() + ", reserved:" +
                         capacityCpu.getReservedCapacity() + "; requested cpu:" + cpu + ",alloc_from_last:" + fromLastHost);
 
-                    s_logger.debug("RAM STATS after allocation: for host: " + hostId + ", old used: " + usedMem + ", old reserved: " + reservedMem + ", total: " +
+                    logger.debug("RAM STATS after allocation: for host: " + hostId + ", old used: " + usedMem + ", old reserved: " + reservedMem + ", total: " +
                         totalMem + "; new used: " + capacityMem.getUsedCapacity() + ", reserved: " + capacityMem.getReservedCapacity() + "; requested mem: " + ram +
                         ",alloc_from_last:" + fromLastHost);
 
@@ -364,7 +362,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                 }
             });
         } catch (Exception e) {
-            s_logger.error("Exception allocating VM capacity", e);
+            logger.error("Exception allocating VM capacity", e);
             return;
         }
     }
@@ -377,14 +375,14 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         boolean isCpuNumGood = host.getCpus().intValue() >= cpuNum;
         boolean isCpuSpeedGood = host.getSpeed().intValue() >= cpuSpeed;
         if (isCpuNumGood && isCpuSpeedGood) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Host: " + hostId + " has cpu capability (cpu:" + host.getCpus() + ", speed:" + host.getSpeed() +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Host: " + hostId + " has cpu capability (cpu:" + host.getCpus() + ", speed:" + host.getSpeed() +
                     ") to support requested CPU: " + cpuNum + " and requested speed: " + cpuSpeed);
             }
             return true;
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Host: " + hostId + " doesn't have cpu capability (cpu:" + host.getCpus() + ", speed:" + host.getSpeed() +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Host: " + hostId + " doesn't have cpu capability (cpu:" + host.getCpus() + ", speed:" + host.getSpeed() +
                     ") to support requested CPU: " + cpuNum + " and requested speed: " + cpuSpeed);
             }
             return false;
@@ -396,8 +394,8 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         boolean considerReservedCapacity) {
         boolean hasCapacity = false;
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Checking if host: " + hostId + " has enough capacity for requested CPU: " + cpu + " and requested RAM: " + ram +
+        if (logger.isDebugEnabled()) {
+            logger.debug("Checking if host: " + hostId + " has enough capacity for requested CPU: " + cpu + " and requested RAM: " + ram +
                 " , cpuOverprovisioningFactor: " + cpuOvercommitRatio);
         }
 
@@ -406,13 +404,13 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
         if (capacityCpu == null || capacityMem == null) {
             if (capacityCpu == null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Cannot checkIfHostHasCapacity, Capacity entry for CPU not found in Db, for hostId: " + hostId);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Cannot checkIfHostHasCapacity, Capacity entry for CPU not found in Db, for hostId: " + hostId);
                 }
             }
             if (capacityMem == null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Cannot checkIfHostHasCapacity, Capacity entry for RAM not found in Db, for hostId: " + hostId);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Cannot checkIfHostHasCapacity, Capacity entry for RAM not found in Db, for hostId: " + hostId);
                 }
             }
 
@@ -427,8 +425,8 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         long actualTotalMem = capacityMem.getTotalCapacity();
         long totalCpu = (long)(actualTotalCpu * cpuOvercommitRatio);
         long totalMem = (long)(actualTotalMem * memoryOvercommitRatio);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
         }
 
         String failureReason = "";
@@ -436,10 +434,10 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
             long freeCpu = reservedCpu;
             long freeMem = reservedMem;
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("We need to allocate to the last host again, so checking if there is enough reserved capacity");
-                s_logger.debug("Reserved CPU: " + freeCpu + " , Requested CPU: " + cpu);
-                s_logger.debug("Reserved RAM: " + freeMem + " , Requested RAM: " + ram);
+            if (logger.isDebugEnabled()) {
+                logger.debug("We need to allocate to the last host again, so checking if there is enough reserved capacity");
+                logger.debug("Reserved CPU: " + freeCpu + " , Requested CPU: " + cpu);
+                logger.debug("Reserved RAM: " + freeMem + " , Requested RAM: " + ram);
             }
             /* alloc from reserved */
             if (reservedCpu >= cpu) {
@@ -457,8 +455,8 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
             long reservedMemValueToUse = reservedMem;
 
             if (!considerReservedCapacity) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("considerReservedCapacity is" + considerReservedCapacity + " , not considering reserved capacity for calculating free capacity");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("considerReservedCapacity is" + considerReservedCapacity + " , not considering reserved capacity for calculating free capacity");
                 }
                 reservedCpuValueToUse = 0;
                 reservedMemValueToUse = 0;
@@ -466,9 +464,9 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
             long freeCpu = totalCpu - (reservedCpuValueToUse + usedCpu);
             long freeMem = totalMem - (reservedMemValueToUse + usedMem);
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Free CPU: " + freeCpu + " , Requested CPU: " + cpu);
-                s_logger.debug("Free RAM: " + freeMem + " , Requested RAM: " + ram);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Free CPU: " + freeCpu + " , Requested CPU: " + cpu);
+                logger.debug("Free RAM: " + freeMem + " , Requested RAM: " + ram);
             }
             /* alloc from free resource */
             if ((reservedCpuValueToUse + usedCpu + cpu <= totalCpu)) {
@@ -483,29 +481,29 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         }
 
         if (hasCapacity) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Host has enough CPU and RAM available");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Host has enough CPU and RAM available");
             }
 
-            s_logger.debug("STATS: Can alloc CPU from host: " + hostId + ", used: " + usedCpu + ", reserved: " + reservedCpu + ", actual total: " + actualTotalCpu +
+            logger.debug("STATS: Can alloc CPU from host: " + hostId + ", used: " + usedCpu + ", reserved: " + reservedCpu + ", actual total: " + actualTotalCpu +
                 ", total with overprovisioning: " + totalCpu + "; requested cpu:" + cpu + ",alloc_from_last_host?:" + checkFromReservedCapacity +
                 " ,considerReservedCapacity?: " + considerReservedCapacity);
 
-            s_logger.debug("STATS: Can alloc MEM from host: " + hostId + ", used: " + usedMem + ", reserved: " + reservedMem + ", total: " + totalMem +
+            logger.debug("STATS: Can alloc MEM from host: " + hostId + ", used: " + usedMem + ", reserved: " + reservedMem + ", total: " + totalMem +
                 "; requested mem: " + ram + ",alloc_from_last_host?:" + checkFromReservedCapacity + " ,considerReservedCapacity?: " + considerReservedCapacity);
         } else {
 
             if (checkFromReservedCapacity) {
-                s_logger.debug("STATS: Failed to alloc resource from host: " + hostId + " reservedCpu: " + reservedCpu + ", requested cpu: " + cpu + ", reservedMem: " +
+                logger.debug("STATS: Failed to alloc resource from host: " + hostId + " reservedCpu: " + reservedCpu + ", requested cpu: " + cpu + ", reservedMem: " +
                     reservedMem + ", requested mem: " + ram);
             } else {
-                s_logger.debug("STATS: Failed to alloc resource from host: " + hostId + " reservedCpu: " + reservedCpu + ", used cpu: " + usedCpu + ", requested cpu: " +
+                logger.debug("STATS: Failed to alloc resource from host: " + hostId + " reservedCpu: " + reservedCpu + ", used cpu: " + usedCpu + ", requested cpu: " +
                     cpu + ", actual total cpu: " + actualTotalCpu + ", total cpu with overprovisioning: " + totalCpu + ", reservedMem: " + reservedMem + ", used Mem: " +
                     usedMem + ", requested mem: " + ram + ", total Mem:" + totalMem + " ,considerReservedCapacity?: " + considerReservedCapacity);
             }
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug(failureReason + ", cannot allocate to this host.");
+            if (logger.isDebugEnabled()) {
+                logger.debug(failureReason + ", cannot allocate to this host.");
             }
         }
 
@@ -593,8 +591,8 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         final CapacityState capacityState = (host.getResourceState() == ResourceState.Enabled) ? CapacityState.Enabled : CapacityState.Disabled;
 
         List<VMInstanceVO> vms = _vmDao.listUpByHostId(host.getId());
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Found " + vms.size() + " VMs on host " + host.getId());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Found " + vms.size() + " VMs on host " + host.getId());
         }
 
         ClusterVO cluster = _clusterDao.findById(host.getClusterId());
@@ -628,8 +626,8 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         }
 
         List<VMInstanceVO> vmsByLastHostId = _vmDao.listByLastHostId(host.getId());
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Found " + vmsByLastHostId.size() + " VM, not running on host " + host.getId());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Found " + vmsByLastHostId.size() + " VM, not running on host " + host.getId());
         }
         for (VMInstanceVO vm : vmsByLastHostId) {
             long secondsSinceLastUpdate = (DateUtil.currentGMTTime().getTime() - vm.getUpdateTime().getTime()) / 1000;
@@ -680,50 +678,50 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
             long hostTotalCpu = host.getCpus().longValue() * host.getSpeed().longValue();
 
             if (cpuCap.getTotalCapacity() != hostTotalCpu) {
-                s_logger.debug("Calibrate total cpu for host: " + host.getId() + " old total CPU:" + cpuCap.getTotalCapacity() + " new total CPU:" + hostTotalCpu);
+                logger.debug("Calibrate total cpu for host: " + host.getId() + " old total CPU:" + cpuCap.getTotalCapacity() + " new total CPU:" + hostTotalCpu);
                 cpuCap.setTotalCapacity(hostTotalCpu);
 
             }
             // Set the capacity state as per the host allocation state.
             if(capacityState != cpuCap.getCapacityState()){
-                s_logger.debug("Calibrate cpu capacity state for host: " + host.getId() + " old capacity state:" + cpuCap.getTotalCapacity() + " new capacity state:" + hostTotalCpu);
+                logger.debug("Calibrate cpu capacity state for host: " + host.getId() + " old capacity state:" + cpuCap.getTotalCapacity() + " new capacity state:" + hostTotalCpu);
                 cpuCap.setCapacityState(capacityState);
             }
             memCap.setCapacityState(capacityState);
 
             if (cpuCap.getUsedCapacity() == usedCpu && cpuCap.getReservedCapacity() == reservedCpu) {
-                s_logger.debug("No need to calibrate cpu capacity, host:" + host.getId() + " usedCpu: " + cpuCap.getUsedCapacity() + " reservedCpu: " +
+                logger.debug("No need to calibrate cpu capacity, host:" + host.getId() + " usedCpu: " + cpuCap.getUsedCapacity() + " reservedCpu: " +
                     cpuCap.getReservedCapacity());
             } else {
                 if (cpuCap.getReservedCapacity() != reservedCpu) {
-                    s_logger.debug("Calibrate reserved cpu for host: " + host.getId() + " old reservedCpu:" + cpuCap.getReservedCapacity() + " new reservedCpu:" +
+                    logger.debug("Calibrate reserved cpu for host: " + host.getId() + " old reservedCpu:" + cpuCap.getReservedCapacity() + " new reservedCpu:" +
                         reservedCpu);
                     cpuCap.setReservedCapacity(reservedCpu);
                 }
                 if (cpuCap.getUsedCapacity() != usedCpu) {
-                    s_logger.debug("Calibrate used cpu for host: " + host.getId() + " old usedCpu:" + cpuCap.getUsedCapacity() + " new usedCpu:" + usedCpu);
+                    logger.debug("Calibrate used cpu for host: " + host.getId() + " old usedCpu:" + cpuCap.getUsedCapacity() + " new usedCpu:" + usedCpu);
                     cpuCap.setUsedCapacity(usedCpu);
                 }
             }
 
             if (memCap.getTotalCapacity() != host.getTotalMemory()) {
-                s_logger.debug("Calibrate total memory for host: " + host.getId() + " old total memory:" + memCap.getTotalCapacity() + " new total memory:" +
+                logger.debug("Calibrate total memory for host: " + host.getId() + " old total memory:" + memCap.getTotalCapacity() + " new total memory:" +
                     host.getTotalMemory());
                 memCap.setTotalCapacity(host.getTotalMemory());
 
             }
             // Set the capacity state as per the host allocation state.
             if(capacityState != memCap.getCapacityState()){
-                s_logger.debug("Calibrate memory capacity state for host: " + host.getId() + " old capacity state:" + memCap.getTotalCapacity() + " new capacity state:" + hostTotalCpu);
+                logger.debug("Calibrate memory capacity state for host: " + host.getId() + " old capacity state:" + memCap.getTotalCapacity() + " new capacity state:" + hostTotalCpu);
                 memCap.setCapacityState(capacityState);
             }
 
             if (memCap.getUsedCapacity() == usedMemory && memCap.getReservedCapacity() == reservedMemory) {
-                s_logger.debug("No need to calibrate memory capacity, host:" + host.getId() + " usedMem: " + memCap.getUsedCapacity() + " reservedMem: " +
+                logger.debug("No need to calibrate memory capacity, host:" + host.getId() + " usedMem: " + memCap.getUsedCapacity() + " reservedMem: " +
                     memCap.getReservedCapacity());
             } else {
                 if (memCap.getReservedCapacity() != reservedMemory) {
-                    s_logger.debug("Calibrate reserved memory for host: " + host.getId() + " old reservedMem:" + memCap.getReservedCapacity() + " new reservedMem:" +
+                    logger.debug("Calibrate reserved memory for host: " + host.getId() + " old reservedMem:" + memCap.getReservedCapacity() + " new reservedMem:" +
                         reservedMemory);
                     memCap.setReservedCapacity(reservedMemory);
                 }
@@ -733,7 +731,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                      * state(starting/migrating) that I don't know on which host
                      * they are allocated
                      */
-                    s_logger.debug("Calibrate used memory for host: " + host.getId() + " old usedMem: " + memCap.getUsedCapacity() + " new usedMem: " + usedMemory);
+                    logger.debug("Calibrate used memory for host: " + host.getId() + " old usedMem: " + memCap.getUsedCapacity() + " new usedMem: " + usedMemory);
                     memCap.setUsedCapacity(usedMemory);
                 }
             }
@@ -742,7 +740,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                 _capacityDao.update(cpuCap.getId(), cpuCap);
                 _capacityDao.update(memCap.getId(), memCap);
             } catch (Exception e) {
-                s_logger.error("Caught exception while updating cpu/memory capacity for the host " + host.getId(), e);
+                logger.error("Caught exception while updating cpu/memory capacity for the host " + host.getId(), e);
             }
         } else {
             final long usedMemoryFinal = usedMemory;
@@ -789,7 +787,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
       State oldState = transition.getCurrentState();
       State newState = transition.getToState();
       Event event = transition.getEvent();
-      s_logger.debug("VM state transitted from :" + oldState + " to " + newState + " with event: " + event + "vm's original host id: " + vm.getLastHostId() +
+      logger.debug("VM state transitted from :" + oldState + " to " + newState + " with event: " + event + "vm's original host id: " + vm.getLastHostId() +
               " new host id: " + vm.getHostId() + " host id before state transition: " + oldHostId);
 
       if (oldState == State.Starting) {
@@ -832,7 +830,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
       if ((newState == State.Starting || newState == State.Migrating || event == Event.AgentReportMigrated) && vm.getHostId() != null) {
         boolean fromLastHost = false;
         if (vm.getHostId().equals(vm.getLastHostId())) {
-          s_logger.debug("VM starting again on the last host it was stopped on");
+          logger.debug("VM starting again on the last host it was stopped on");
           fromLastHost = true;
         }
         allocateVmCapacity(vm, fromLastHost);
@@ -880,7 +878,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                     CapacityVOCpu.setReservedCapacity(0);
                     CapacityVOCpu.setTotalCapacity(newTotalCpu);
                 } else {
-                    s_logger.debug("What? new cpu is :" + newTotalCpu + ", old one is " + CapacityVOCpu.getUsedCapacity() + "," + CapacityVOCpu.getReservedCapacity() +
+                    logger.debug("What? new cpu is :" + newTotalCpu + ", old one is " + CapacityVOCpu.getUsedCapacity() + "," + CapacityVOCpu.getReservedCapacity() +
                         "," + CapacityVOCpu.getTotalCapacity());
                 }
                 _capacityDao.update(CapacityVOCpu.getId(), CapacityVOCpu);
@@ -907,7 +905,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                     CapacityVOMem.setReservedCapacity(0);
                     CapacityVOMem.setTotalCapacity(newTotalMem);
                 } else {
-                    s_logger.debug("What? new cpu is :" + newTotalMem + ", old one is " + CapacityVOMem.getUsedCapacity() + "," + CapacityVOMem.getReservedCapacity() +
+                    logger.debug("What? new cpu is :" + newTotalMem + ", old one is " + CapacityVOMem.getUsedCapacity() + "," + CapacityVOMem.getReservedCapacity() +
                         "," + CapacityVOMem.getTotalCapacity());
                 }
                 _capacityDao.update(CapacityVOMem.getId(), CapacityVOMem);
@@ -949,14 +947,14 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
         float cpuConsumption = _capacityDao.findClusterConsumption(clusterId, Capacity.CAPACITY_TYPE_CPU, cpuRequested);
         if (cpuConsumption / clusterCpuOverProvisioning > clusterCpuCapacityDisableThreshold) {
-            s_logger.debug("Cluster: " + clusterId + " cpu consumption " + cpuConsumption / clusterCpuOverProvisioning
+            logger.debug("Cluster: " + clusterId + " cpu consumption " + cpuConsumption / clusterCpuOverProvisioning
                 + " crosses disable threshold " + clusterCpuCapacityDisableThreshold);
             return true;
         }
 
         float memoryConsumption = _capacityDao.findClusterConsumption(clusterId, Capacity.CAPACITY_TYPE_MEMORY, ramRequested);
         if (memoryConsumption / clusterMemoryOverProvisioning > clusterMemoryCapacityDisableThreshold) {
-            s_logger.debug("Cluster: " + clusterId + " memory consumption " + memoryConsumption / clusterMemoryOverProvisioning
+            logger.debug("Cluster: " + clusterId + " memory consumption " + memoryConsumption / clusterMemoryOverProvisioning
                 + " crosses disable threshold " + clusterMemoryCapacityDisableThreshold);
             return true;
         }
@@ -1067,8 +1065,8 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         String hypervisorVersion = host.getHypervisorVersion();
         Long maxGuestLimit = _hypervisorCapabilitiesDao.getMaxGuestsLimit(hypervisorType, hypervisorVersion);
         if (vmCount.longValue() >= maxGuestLimit.longValue()) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " already reached max Running VMs(count includes system VMs), limit is: " +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Host name: " + host.getName() + ", hostId: " + host.getId() + " already reached max Running VMs(count includes system VMs), limit is: " +
                     maxGuestLimit + ",Running VM counts is: " + vmCount.longValue());
             }
             return true;

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -37,7 +37,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.affinity.AffinityGroup;
@@ -217,7 +216,6 @@ import com.cloud.vm.dao.NicSecondaryIpDao;
 
 @Local(value = {ConfigurationManager.class, ConfigurationService.class})
 public class ConfigurationManagerImpl extends ManagerBase implements ConfigurationManager, ConfigurationService, Configurable {
-    public static final Logger s_logger = Logger.getLogger(ConfigurationManagerImpl.class);
 
     @Inject
     EntityManager _entityMgr;
@@ -421,13 +419,13 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         if (mgtCidr == null || mgtCidr.trim().isEmpty()) {
             final String[] localCidrs = NetUtils.getLocalCidrs();
             if (localCidrs != null && localCidrs.length > 0) {
-                s_logger.warn("Management network CIDR is not configured originally. Set it default to " + localCidrs[0]);
+                logger.warn("Management network CIDR is not configured originally. Set it default to " + localCidrs[0]);
 
                 _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_MANAGMENT_NODE, 0, new Long(0), "Management network CIDR is not configured originally. Set it default to "
                         + localCidrs[0], "");
                 _configDao.update(Config.ManagementNetwork.key(), Config.ManagementNetwork.getCategory(), localCidrs[0]);
             } else {
-                s_logger.warn("Management network CIDR is not properly configured and we are not able to find a default setting");
+                logger.warn("Management network CIDR is not properly configured and we are not able to find a default setting");
                 _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_MANAGMENT_NODE, 0, new Long(0),
                         "Management network CIDR is not properly configured and we are not able to find a default setting", "");
             }
@@ -447,7 +445,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final String validationMsg = validateConfigurationValue(name, value, scope);
 
         if (validationMsg != null) {
-            s_logger.error("Invalid configuration option, name: " + name + ", value:" + value);
+            logger.error("Invalid configuration option, name: " + name + ", value:" + value);
             throw new InvalidParameterValueException(validationMsg);
         }
 
@@ -519,7 +517,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         txn.start();
 
         if (!_configDao.update(name, category, value)) {
-            s_logger.error("Failed to update configuration option, name: " + name + ", value:" + value);
+            logger.error("Failed to update configuration option, name: " + name + ", value:" + value);
             throw new CloudRuntimeException("Failed to update configuration value. Please contact Cloud Support.");
         }
 
@@ -622,7 +620,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         // FIX ME - All configuration parameters are not moved from config.java to configKey
         if (config == null) {
             if (_configDepot.get(name) == null) {
-                s_logger.warn("Probably the component manager where configuration variable " + name + " is defined needs to implement Configurable interface");
+                logger.warn("Probably the component manager where configuration variable " + name + " is defined needs to implement Configurable interface");
                 throw new InvalidParameterValueException("Config parameter with name " + name + " doesn't exist");
             }
             catergory = _configDepot.get(name).category();
@@ -681,24 +679,24 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         final ConfigurationVO cfg = _configDao.findByName(name);
         if (cfg == null) {
-            s_logger.error("Missing configuration variable " + name + " in configuration table");
+            logger.error("Missing configuration variable " + name + " in configuration table");
             return "Invalid configuration variable.";
         }
 
         final String configScope = cfg.getScope();
         if (scope != null) {
             if (!configScope.contains(scope)) {
-                s_logger.error("Invalid scope id provided for the parameter " + name);
+                logger.error("Invalid scope id provided for the parameter " + name);
                 return "Invalid scope id provided for the parameter " + name;
             }
         }
         Class<?> type = null;
         final Config c = Config.getConfig(name);
         if (c == null) {
-            s_logger.warn("Did not find configuration " + name + " in Config.java. Perhaps moved to ConfigDepot");
+            logger.warn("Did not find configuration " + name + " in Config.java. Perhaps moved to ConfigDepot");
             final ConfigKey<?> configKey = _configDepot.get(name);
             if(configKey == null) {
-                s_logger.warn("Did not find configuration " + name + " in ConfigDepot too.");
+                logger.warn("Did not find configuration " + name + " in ConfigDepot too.");
                 return null;
             }
             type = configKey.type();
@@ -717,7 +715,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
         } catch (final Exception e) {
             // catching generic exception as some throws NullPointerException and some throws NumberFormatExcpeion
-            s_logger.error(errMsg);
+            logger.error(errMsg);
             return errMsg;
         }
 
@@ -727,7 +725,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
             if (overprovisioningFactorsForValidation.contains(name)) {
                 final String msg = "value cannot be null for the parameter " + name;
-                s_logger.error(msg);
+                logger.error(msg);
                 return msg;
             }
             return null;
@@ -737,18 +735,18 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         try {
             if (overprovisioningFactorsForValidation.contains(name) && Float.parseFloat(value) < 1f) {
                 final String msg = name + " should be greater than or equal to 1";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new InvalidParameterValueException(msg);
             }
         } catch (final NumberFormatException e) {
             final String msg = "There was an error trying to parse the float value for: " + name;
-            s_logger.error(msg);
+            logger.error(msg);
             throw new InvalidParameterValueException(msg);
         }
 
         if (type.equals(Boolean.class)) {
             if (!(value.equals("true") || value.equals("false"))) {
-                s_logger.error("Configuration variable " + name + " is expecting true or false instead of " + value);
+                logger.error("Configuration variable " + name + " is expecting true or false instead of " + value);
                 return "Please enter either 'true' or 'false'.";
             }
             return null;
@@ -765,7 +763,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     throw new InvalidParameterValueException("Please enter a value greater than 6 for the configuration parameter:" + name);
                 }
             } catch (final NumberFormatException e) {
-                s_logger.error("There was an error trying to parse the integer value for:" + name);
+                logger.error("There was an error trying to parse the integer value for:" + name);
                 throw new InvalidParameterValueException("There was an error trying to parse the integer value for:" + name);
             }
         }
@@ -777,7 +775,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     throw new InvalidParameterValueException("Please enter a value between 0 and 1 for the configuration parameter: " + name);
                 }
             } catch (final NumberFormatException e) {
-                s_logger.error("There was an error trying to parse the float value for:" + name);
+                logger.error("There was an error trying to parse the float value for:" + name);
                 throw new InvalidParameterValueException("There was an error trying to parse the float value for:" + name);
             }
         }
@@ -797,16 +795,16 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             if (range.equals("privateip")) {
                 try {
                     if (!NetUtils.isSiteLocalAddress(value)) {
-                        s_logger.error("privateip range " + value + " is not a site local address for configuration variable " + name);
+                        logger.error("privateip range " + value + " is not a site local address for configuration variable " + name);
                         return "Please enter a site local IP address.";
                     }
                 } catch (final NullPointerException e) {
-                    s_logger.error("Error parsing ip address for " + name);
+                    logger.error("Error parsing ip address for " + name);
                     throw new InvalidParameterValueException("Error parsing ip address");
                 }
             } else if (range.equals("netmask")) {
                 if (!NetUtils.isValidNetmask(value)) {
-                    s_logger.error("netmask " + value + " is not a valid net mask for configuration variable " + name);
+                    logger.error("netmask " + value + " is not a valid net mask for configuration variable " + name);
                     return "Please enter a valid netmask.";
                 }
             } else if (range.equals("hypervisorList")) {
@@ -850,7 +848,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                         return null;
                     }
                 }
-                s_logger.error("configuration value for " + name + " is invalid");
+                logger.error("configuration value for " + name + " is invalid");
                 return "Please enter : " + range;
 
             }
@@ -858,14 +856,14 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             final String[] options = range.split("-");
             if (options.length != 2) {
                 final String msg = "configuration range " + range + " for " + name + " is invalid";
-                s_logger.error(msg);
+                logger.error(msg);
                 return msg;
             }
             final int min = Integer.parseInt(options[0]);
             final int max = Integer.parseInt(options[1]);
             final int val = Integer.parseInt(value);
             if (val < min || val > max) {
-                s_logger.error("configuration value for " + name + " is invalid");
+                logger.error("configuration value for " + name + " is invalid");
                 return "Please enter : " + range;
             }
         }
@@ -1235,7 +1233,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 }
             });
         } catch (final Exception e) {
-            s_logger.error("Unable to edit pod due to " + e.getMessage(), e);
+            logger.error("Unable to edit pod due to " + e.getMessage(), e);
             throw new CloudRuntimeException("Failed to edit pod. Please contact Cloud Support.");
         }
 
@@ -1763,7 +1761,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                                 _networkSvc.addTrafficTypeToPhysicalNetwork(mgmtPhyNetwork.getId(), TrafficType.Storage.toString(), "vlan", mgmtTraffic.getXenNetworkLabel(),
                                         mgmtTraffic.getKvmNetworkLabel(), mgmtTraffic.getVmwareNetworkLabel(), mgmtTraffic.getSimulatorNetworkLabel(), mgmtTraffic.getVlan(),
                                         mgmtTraffic.getHypervNetworkLabel(), mgmtTraffic.getOvm3NetworkLabel());
-                                s_logger.info("No storage traffic type was specified by admin, create default storage traffic on physical network " + mgmtPhyNetwork.getId()
+                                logger.info("No storage traffic type was specified by admin, create default storage traffic on physical network " + mgmtPhyNetwork.getId()
                                         + " with same configure of management traffic type");
                             }
                         } catch (final InvalidParameterValueException ex) {
@@ -2895,7 +2893,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     if (supportsMultipleSubnets == null || !Boolean.valueOf(supportsMultipleSubnets)) {
                         throw new  InvalidParameterValueException("The Dhcp serivice provider for this network dose not support the dhcp  across multiple subnets");
                     }
-                    s_logger.info("adding a new subnet to the network " + network.getId());
+                    logger.info("adding a new subnet to the network " + network.getId());
                 } else if (sameSubnet != null)  {
                     // if it is same subnet the user might not send the vlan and the
                     // netmask details. so we are
@@ -3256,7 +3254,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             @Override
             public VlanVO doInTransaction(final TransactionStatus status) {
                 VlanVO vlan = new VlanVO(vlanType, vlanId, vlanGateway, vlanNetmask, zone.getId(), ipRange, networkId, physicalNetworkId, vlanIp6Gateway, vlanIp6Cidr, ipv6Range);
-                s_logger.debug("Saving vlan range " + vlan);
+                logger.debug("Saving vlan range " + vlan);
                 vlan = _vlanDao.persist(vlan);
 
                 // IPv6 use a used ip map, is different from ipv4, no need to save
@@ -3319,8 +3317,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     throw new CloudRuntimeException("Unable to acquire vlan configuration: " + vlanDbId);
                 }
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("lock vlan " + vlanDbId + " is acquired");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("lock vlan " + vlanDbId + " is acquired");
                 }
                 for (final IPAddressVO ip : ips) {
                     boolean success = true;
@@ -3344,7 +3342,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                         success = _ipAddrMgr.disassociatePublicIpAddress(ip.getId(), userId, caller);
                     }
                     if (!success) {
-                        s_logger.warn("Some ip addresses failed to be released as a part of vlan " + vlanDbId + " removal");
+                        logger.warn("Some ip addresses failed to be released as a part of vlan " + vlanDbId + " removal");
                     } else {
                         resourceCountToBeDecrement++;
                         UsageEventUtils.publishUsageEvent(EventTypes.EVENT_NET_IP_RELEASE, acctVln.get(0).getAccountId(), ip.getDataCenterId(), ip.getId(),
@@ -3501,14 +3499,14 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 if (vlan == null) {
                     throw new CloudRuntimeException("Unable to acquire vlan configuration: " + vlanDbId);
                 }
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("lock vlan " + vlanDbId + " is acquired");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("lock vlan " + vlanDbId + " is acquired");
                 }
                 for (final IPAddressVO ip : ips) {
                     // Disassociate allocated IP's that are not in use
                     if (!ip.isOneToOneNat() && !ip.isSourceNat() && !(_firewallDao.countRulesByIpId(ip.getId()) > 0)) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Releasing Public IP addresses" + ip + " of vlan " + vlanDbId + " as part of Public IP" + " range release to the system pool");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Releasing Public IP addresses" + ip + " of vlan " + vlanDbId + " as part of Public IP" + " range release to the system pool");
                         }
                         success = success && _ipAddrMgr.disassociatePublicIpAddress(ip.getId(), userId, caller);
                     } else {
@@ -3516,7 +3514,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     }
                 }
                 if (!success) {
-                    s_logger.warn("Some Public IP addresses that were not in use failed to be released as a part of" + " vlan " + vlanDbId + "release to the system pool");
+                    logger.warn("Some Public IP addresses that were not in use failed to be released as a part of" + " vlan " + vlanDbId + "release to the system pool");
                 }
             } finally {
                 _vlanDao.releaseFromLockTable(vlanDbId);
@@ -3799,8 +3797,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     public void checkDiskOfferingAccess(final Account caller, final DiskOffering dof) {
         for (final SecurityChecker checker : _secChecker) {
             if (checker.checkAccess(caller, dof)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Access granted to " + caller + " to disk offering:" + dof.getId() + " by " + checker.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Access granted to " + caller + " to disk offering:" + dof.getId() + " by " + checker.getName());
                 }
                 return;
             } else {
@@ -3816,8 +3814,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     public void checkZoneAccess(final Account caller, final DataCenter zone) {
         for (final SecurityChecker checker : _secChecker) {
             if (checker.checkAccess(caller, zone)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Access granted to " + caller + " to zone:" + zone.getId() + " by " + checker.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Access granted to " + caller + " to zone:" + zone.getId() + " by " + checker.getName());
                 }
                 return;
             } else {
@@ -4000,7 +3998,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         // dhcp provider and userdata provider should be same because vm will be contacting dhcp server for user data.
         if (dhcpProvider == null && IsVrUserdataProvider) {
-            s_logger.debug("User data provider VR can't be selected without VR as dhcp provider. In this case VM fails to contact the DHCP server for userdata");
+            logger.debug("User data provider VR can't be selected without VR as dhcp provider. In this case VM fails to contact the DHCP server for userdata");
             throw new InvalidParameterValueException("Without VR as dhcp provider, User data can't selected for VR. Please select VR as DHCP provider ");
         }
 
@@ -4060,7 +4058,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         // if Firewall service is missing, add Firewall service/provider
         // combination
         if (firewallProvider != null) {
-            s_logger.debug("Adding Firewall service with provider " + firewallProvider.getName());
+            logger.debug("Adding Firewall service with provider " + firewallProvider.getName());
             final Set<Provider> firewallProviderSet = new HashSet<Provider>();
             firewallProviderSet.add(firewallProvider);
             serviceProviderMap.put(Service.Firewall, firewallProviderSet);
@@ -4386,7 +4384,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 NetworkOfferingVO offering = offeringFinal;
 
                 // 1) create network offering object
-                s_logger.debug("Adding network offering " + offering);
+                logger.debug("Adding network offering " + offering);
                 offering.setConcurrentConnections(maxconn);
                 offering.setKeepAliveEnabled(enableKeepAlive);
                 offering = _networkOfferingDao.persist(offering, details);
@@ -4402,7 +4400,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                                 }
                                 final NetworkOfferingServiceMapVO offService = new NetworkOfferingServiceMapVO(offering.getId(), service, provider);
                                 _ntwkOffServiceMapDao.persist(offService);
-                                s_logger.trace("Added service for the network offering: " + offService + " with provider " + provider.getName());
+                                logger.trace("Added service for the network offering: " + offService + " with provider " + provider.getName());
                             }
 
                             if (vpcOff) {
@@ -4413,7 +4411,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                         } else {
                             final NetworkOfferingServiceMapVO offService = new NetworkOfferingServiceMapVO(offering.getId(), service, null);
                             _ntwkOffServiceMapDao.persist(offService);
-                            s_logger.trace("Added service for the network offering: " + offService + " with null provider");
+                            logger.trace("Added service for the network offering: " + offService + " with null provider");
                         }
                     }
                 }
@@ -4835,7 +4833,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         // Check if the account exists
         final Account account = _accountDao.findEnabledAccount(accountName, domainId);
         if (account == null) {
-            s_logger.error("Unable to find account by name: " + accountName + " in domain " + domainId);
+            logger.error("Unable to find account by name: " + accountName + " in domain " + domainId);
             throw new InvalidParameterValueException("Account by name: " + accountName + " doesn't exist in domain " + domainId);
         }
 
@@ -4955,11 +4953,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     }
                 });
             } catch (final CloudRuntimeException e) {
-                s_logger.error(e);
+                logger.error(e);
                 return false;
             }
         } else {
-            s_logger.trace("Account id=" + accountId + " has no account specific virtual ip ranges, nothing to release");
+            logger.trace("Account id=" + accountId + " has no account specific virtual ip ranges, nothing to release");
         }
         return true;
     }

--- a/server/src/com/cloud/consoleproxy/AgentBasedConsoleProxyManager.java
+++ b/server/src/com/cloud/consoleproxy/AgentBasedConsoleProxyManager.java
@@ -22,7 +22,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.security.keys.KeysManager;
@@ -48,7 +47,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 @Local(value = {ConsoleProxyManager.class})
 public class AgentBasedConsoleProxyManager extends ManagerBase implements ConsoleProxyManager {
-    private static final Logger s_logger = Logger.getLogger(AgentBasedConsoleProxyManager.class);
 
     @Inject
     protected HostDao _hostDao;
@@ -101,8 +99,8 @@ public class AgentBasedConsoleProxyManager extends ManagerBase implements Consol
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Start configuring AgentBasedConsoleProxyManager");
+        if (logger.isInfoEnabled()) {
+            logger.info("Start configuring AgentBasedConsoleProxyManager");
         }
 
         Map<String, String> configs = _configDao.getConfiguration("management-server", params);
@@ -126,8 +124,8 @@ public class AgentBasedConsoleProxyManager extends ManagerBase implements Consol
         _listener = new ConsoleProxyListener(new AgentBasedAgentHook(_instanceDao, _hostDao, _configDao, _ksMgr, _agentMgr, _keysMgr));
         _agentMgr.registerForHostEvents(_listener, true, true, false);
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("AgentBasedConsoleProxyManager has been configured. SSL enabled: " + _sslEnabled);
+        if (logger.isInfoEnabled()) {
+            logger.info("AgentBasedConsoleProxyManager has been configured. SSL enabled: " + _sslEnabled);
         }
         return true;
     }
@@ -140,22 +138,22 @@ public class AgentBasedConsoleProxyManager extends ManagerBase implements Consol
     public ConsoleProxyInfo assignProxy(long dataCenterId, long userVmId) {
         UserVmVO userVm = _userVmDao.findById(userVmId);
         if (userVm == null) {
-            s_logger.warn("User VM " + userVmId + " no longer exists, return a null proxy for user vm:" + userVmId);
+            logger.warn("User VM " + userVmId + " no longer exists, return a null proxy for user vm:" + userVmId);
             return null;
         }
 
         HostVO host = findHost(userVm);
         if (host != null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Assign embedded console proxy running at " + host.getName() + " to user vm " + userVmId + " with public IP " + host.getPublicIpAddress());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Assign embedded console proxy running at " + host.getName() + " to user vm " + userVmId + " with public IP " + host.getPublicIpAddress());
             }
 
             // only private IP, public IP, host id have meaningful values, rest
             // of all are place-holder values
             String publicIp = host.getPublicIpAddress();
             if (publicIp == null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host " + host.getName() + "/" + host.getPrivateIpAddress() +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Host " + host.getName() + "/" + host.getPrivateIpAddress() +
                         " does not have public interface, we will return its private IP for cosole proxy.");
                 }
                 publicIp = host.getPrivateIpAddress();
@@ -169,7 +167,7 @@ public class AgentBasedConsoleProxyManager extends ManagerBase implements Consol
 
             return new ConsoleProxyInfo(_sslEnabled, publicIp, _consoleProxyPort, urlPort, _consoleProxyUrlDomain);
         } else {
-            s_logger.warn("Host that VM is running is no longer available, console access to VM " + userVmId + " will be temporarily unavailable.");
+            logger.warn("Host that VM is running is no longer available, console access to VM " + userVmId + " will be temporarily unavailable.");
         }
         return null;
     }

--- a/server/src/com/cloud/consoleproxy/AgentBasedStandaloneConsoleProxyManager.java
+++ b/server/src/com/cloud/consoleproxy/AgentBasedStandaloneConsoleProxyManager.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
@@ -29,13 +28,12 @@ import com.cloud.vm.UserVmVO;
 
 @Local(value = {ConsoleProxyManager.class})
 public class AgentBasedStandaloneConsoleProxyManager extends AgentBasedConsoleProxyManager {
-    private static final Logger s_logger = Logger.getLogger(AgentBasedStandaloneConsoleProxyManager.class);
 
     @Override
     public ConsoleProxyInfo assignProxy(long dataCenterId, long userVmId) {
         UserVmVO userVm = _userVmDao.findById(userVmId);
         if (userVm == null) {
-            s_logger.warn("User VM " + userVmId + " no longer exists, return a null proxy for user vm:" + userVmId);
+            logger.warn("User VM " + userVmId + " no longer exists, return a null proxy for user vm:" + userVmId);
             return null;
         }
 
@@ -60,19 +58,19 @@ public class AgentBasedStandaloneConsoleProxyManager extends AgentBasedConsolePr
                 }
             }
             if (allocatedHost == null) {
-                if (s_logger.isDebugEnabled())
-                    s_logger.debug("Failed to find a console proxy at host: " + host.getName() + " and in the pod: " + host.getPodId() + " to user vm " + userVmId);
+                if (logger.isDebugEnabled())
+                    logger.debug("Failed to find a console proxy at host: " + host.getName() + " and in the pod: " + host.getPodId() + " to user vm " + userVmId);
                 return null;
             }
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("Assign standalone console proxy running at " + allocatedHost.getName() + " to user vm " + userVmId + " with public IP " +
+            if (logger.isDebugEnabled())
+                logger.debug("Assign standalone console proxy running at " + allocatedHost.getName() + " to user vm " + userVmId + " with public IP " +
                     allocatedHost.getPublicIpAddress());
 
             // only private IP, public IP, host id have meaningful values, rest of all are place-holder values
             String publicIp = allocatedHost.getPublicIpAddress();
             if (publicIp == null) {
-                if (s_logger.isDebugEnabled())
-                    s_logger.debug("Host " + allocatedHost.getName() + "/" + allocatedHost.getPrivateIpAddress() +
+                if (logger.isDebugEnabled())
+                    logger.debug("Host " + allocatedHost.getName() + "/" + allocatedHost.getPrivateIpAddress() +
                         " does not have public interface, we will return its private IP for cosole proxy.");
                 publicIp = allocatedHost.getPrivateIpAddress();
             }
@@ -83,7 +81,7 @@ public class AgentBasedStandaloneConsoleProxyManager extends AgentBasedConsolePr
 
             return new ConsoleProxyInfo(_sslEnabled, publicIp, _consoleProxyPort, urlPort, _consoleProxyUrlDomain);
         } else {
-            s_logger.warn("Host that VM is running is no longer available, console access to VM " + userVmId + " will be temporarily unavailable.");
+            logger.warn("Host that VM is running is no longer available, console access to VM " + userVmId + " will be temporarily unavailable.");
         }
         return null;
     }

--- a/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -33,7 +33,6 @@ import javax.naming.ConfigurationException;
 
 import com.cloud.utils.fsm.StateMachine2;
 
-import org.apache.log4j.Logger;
 import org.apache.cloudstack.affinity.AffinityGroupProcessor;
 import org.apache.cloudstack.affinity.AffinityGroupService;
 import org.apache.cloudstack.affinity.AffinityGroupVMMapVO;
@@ -135,7 +134,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 public class DeploymentPlanningManagerImpl extends ManagerBase implements DeploymentPlanningManager, Manager, Listener,
 StateListener<State, VirtualMachine.Event, VirtualMachine> {
 
-    private static final Logger s_logger = Logger.getLogger(DeploymentPlanningManagerImpl.class);
     @Inject
     AgentManager _agentMgr;
     @Inject
@@ -261,16 +259,16 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         if (vm.getType() == VirtualMachine.Type.User) {
             checkForNonDedicatedResources(vmProfile, dc, avoids);
         }
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deploy avoids pods: " + avoids.getPodsToAvoid() + ", clusters: " + avoids.getClustersToAvoid() + ", hosts: " + avoids.getHostsToAvoid());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deploy avoids pods: " + avoids.getPodsToAvoid() + ", clusters: " + avoids.getClustersToAvoid() + ", hosts: " + avoids.getHostsToAvoid());
         }
 
         // call planners
         //DataCenter dc = _dcDao.findById(vm.getDataCenterId());
         // check if datacenter is in avoid set
         if (avoids.shouldAvoid(dc)) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("DataCenter id = '" + dc.getId() + "' provided is in avoid set, DeploymentPlanner cannot allocate the VM, returning.");
+            if (logger.isDebugEnabled()) {
+                logger.debug("DataCenter id = '" + dc.getId() + "' provided is in avoid set, DeploymentPlanner cannot allocate the VM, returning.");
             }
             return null;
         }
@@ -291,30 +289,30 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         int cpu_requested = offering.getCpu() * offering.getSpeed();
         long ram_requested = offering.getRamSize() * 1024L * 1024L;
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("DeploymentPlanner allocation algorithm: " + planner);
+        if (logger.isDebugEnabled()) {
+            logger.debug("DeploymentPlanner allocation algorithm: " + planner);
 
-            s_logger.debug("Trying to allocate a host and storage pools from dc:" + plan.getDataCenterId() + ", pod:" + plan.getPodId() + ",cluster:" +
+            logger.debug("Trying to allocate a host and storage pools from dc:" + plan.getDataCenterId() + ", pod:" + plan.getPodId() + ",cluster:" +
                     plan.getClusterId() + ", requested cpu: " + cpu_requested + ", requested ram: " + ram_requested);
 
-            s_logger.debug("Is ROOT volume READY (pool already allocated)?: " + (plan.getPoolId() != null ? "Yes" : "No"));
+            logger.debug("Is ROOT volume READY (pool already allocated)?: " + (plan.getPoolId() != null ? "Yes" : "No"));
         }
 
         String haVmTag = (String)vmProfile.getParameter(VirtualMachineProfile.Param.HaTag);
 
         if (plan.getHostId() != null && haVmTag == null) {
             Long hostIdSpecified = plan.getHostId();
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("DeploymentPlan has host_id specified, choosing this host and making no checks on this host: " + hostIdSpecified);
+            if (logger.isDebugEnabled()) {
+                logger.debug("DeploymentPlan has host_id specified, choosing this host and making no checks on this host: " + hostIdSpecified);
             }
             HostVO host = _hostDao.findById(hostIdSpecified);
             if (host == null) {
-                s_logger.debug("The specified host cannot be found");
+                logger.debug("The specified host cannot be found");
             } else if (avoids.shouldAvoid(host)) {
-                s_logger.debug("The specified host is in avoid set");
+                logger.debug("The specified host is in avoid set");
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Looking for suitable pools for this host under zone: " + host.getDataCenterId() + ", pod: " + host.getPodId() + ", cluster: " +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Looking for suitable pools for this host under zone: " + host.getDataCenterId() + ", pod: " + host.getPodId() + ", cluster: " +
                             host.getClusterId());
                 }
 
@@ -323,7 +321,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
 
                 if (vm.getHypervisorType() == HypervisorType.BareMetal) {
                     DeployDestination dest = new DeployDestination(dc, pod, cluster, host, new HashMap<Volume, StoragePool>());
-                    s_logger.debug("Returning Deployment Destination: " + dest);
+                    logger.debug("Returning Deployment Destination: " + dest);
                     return dest;
                 }
 
@@ -353,35 +351,35 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                             storageVolMap.remove(vol);
                         }
                         DeployDestination dest = new DeployDestination(dc, pod, cluster, host, storageVolMap);
-                        s_logger.debug("Returning Deployment Destination: " + dest);
+                        logger.debug("Returning Deployment Destination: " + dest);
                         return dest;
                     }
                 }
             }
-            s_logger.debug("Cannot deploy to specified host, returning.");
+            logger.debug("Cannot deploy to specified host, returning.");
             return null;
         }
 
         if (vm.getLastHostId() != null && haVmTag == null) {
-            s_logger.debug("This VM has last host_id specified, trying to choose the same host: " + vm.getLastHostId());
+            logger.debug("This VM has last host_id specified, trying to choose the same host: " + vm.getLastHostId());
 
             HostVO host = _hostDao.findById(vm.getLastHostId());
             ServiceOfferingDetailsVO offeringDetails = null;
             if (host == null) {
-                s_logger.debug("The last host of this VM cannot be found");
+                logger.debug("The last host of this VM cannot be found");
             } else if (avoids.shouldAvoid(host)) {
-                s_logger.debug("The last host of this VM is in avoid set");
+                logger.debug("The last host of this VM is in avoid set");
             } else if (plan.getClusterId() != null && host.getClusterId() != null
                     && !plan.getClusterId().equals(host.getClusterId())) {
-                s_logger.debug("The last host of this VM cannot be picked as the plan specifies different clusterId: "
+                logger.debug("The last host of this VM cannot be picked as the plan specifies different clusterId: "
                         + plan.getClusterId());
             } else if (_capacityMgr.checkIfHostReachMaxGuestLimit(host)) {
-                s_logger.debug("The last Host, hostId: " + host.getId() +
+                logger.debug("The last Host, hostId: " + host.getId() +
                         " already has max Running VMs(count includes system VMs), skipping this and trying other available hosts");
             } else if ((offeringDetails  = _serviceOfferingDetailsDao.findDetail(offering.getId(), GPU.Keys.vgpuType.toString())) != null) {
                 ServiceOfferingDetailsVO groupName = _serviceOfferingDetailsDao.findDetail(offering.getId(), GPU.Keys.pciDevice.toString());
                 if(!_resourceMgr.isGPUDeviceAvailable(host.getId(), groupName.getValue(), offeringDetails.getValue())){
-                    s_logger.debug("The last host of this VM does not have required GPU devices available");
+                    logger.debug("The last host of this VM does not have required GPU devices available");
                 }
             } else {
                 if (host.getStatus() == Status.Up && host.getResourceState() == ResourceState.Enabled) {
@@ -415,15 +413,15 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
 
                         if (hostHasCapacity
                                 && hostHasCpuCapability) {
-                            s_logger.debug("The last host of this VM is UP and has enough capacity");
-                            s_logger.debug("Now checking for suitable pools under zone: " + host.getDataCenterId()
+                            logger.debug("The last host of this VM is UP and has enough capacity");
+                            logger.debug("Now checking for suitable pools under zone: " + host.getDataCenterId()
                                     + ", pod: " + host.getPodId() + ", cluster: " + host.getClusterId());
 
                             Pod pod = _podDao.findById(host.getPodId());
                             Cluster cluster = _clusterDao.findById(host.getClusterId());
                             if (vm.getHypervisorType() == HypervisorType.BareMetal) {
                                 DeployDestination dest = new DeployDestination(dc, pod, cluster, host, new HashMap<Volume, StoragePool>());
-                                s_logger.debug("Returning Deployment Destination: " + dest);
+                                logger.debug("Returning Deployment Destination: " + dest);
                                 return dest;
                             }
 
@@ -456,22 +454,22 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                                     }
                                     DeployDestination dest = new DeployDestination(dc, pod, cluster, host,
                                             storageVolMap);
-                                    s_logger.debug("Returning Deployment Destination: " + dest);
+                                    logger.debug("Returning Deployment Destination: " + dest);
                                     return dest;
                                 }
                             }
                         } else {
-                            s_logger.debug("The last host of this VM does not have enough capacity");
+                            logger.debug("The last host of this VM does not have enough capacity");
                         }
                     } else {
-                        s_logger.debug("Service Offering host tag does not match the last host of this VM");
+                        logger.debug("Service Offering host tag does not match the last host of this VM");
                     }
                 } else {
-                    s_logger.debug("The last host of this VM is not UP or is not enabled, host status is: " + host.getStatus().name() + ", host resource state is: " +
+                    logger.debug("The last host of this VM is not UP or is not enabled, host status is: " + host.getStatus().name() + ", host resource state is: " +
                             host.getResourceState());
                 }
             }
-            s_logger.debug("Cannot choose the last host to deploy this VM ");
+            logger.debug("Cannot choose the last host to deploy this VM ");
         }
 
         DeployDestination dest = null;
@@ -648,7 +646,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 if (hostResourceType == resourceUsageRequired) {
                     return true;
                 } else {
-                    s_logger.debug("Cannot use this host for usage: " + resourceUsageRequired + ", since this host has been reserved for planner usage : " +
+                    logger.debug("Cannot use this host for usage: " + resourceUsageRequired + ", since this host has been reserved for planner usage : " +
                             hostResourceType);
                     return false;
                 }
@@ -661,7 +659,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     public Boolean doInTransaction(TransactionStatus status) {
                         final PlannerHostReservationVO lockedEntry = _plannerHostReserveDao.lockRow(id, true);
                         if (lockedEntry == null) {
-                            s_logger.error("Unable to lock the host entry for reservation, host: " + hostId);
+                            logger.error("Unable to lock the host entry for reservation, host: " + hostId);
                             return false;
                         }
                         // check before updating
@@ -674,7 +672,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                             if (lockedEntry.getResourceUsage() == resourceUsageRequired) {
                                 return true;
                             } else {
-                                s_logger.debug("Cannot use this host for usage: " + resourceUsageRequired + ", since this host has been reserved for planner usage : " +
+                                logger.debug("Cannot use this host for usage: " + resourceUsageRequired + ", since this host has been reserved for planner usage : " +
                                         hostResourceTypeFinal);
                                 return false;
                             }
@@ -699,8 +697,8 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 // check if any VMs are starting or running on this host
                 List<VMInstanceVO> vms = _vmInstanceDao.listUpByHostId(hostId);
                 if (vms.size() > 0) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Cannot release reservation, Found " + vms.size() + " VMs Running on host " + hostId);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Cannot release reservation, Found " + vms.size() + " VMs Running on host " + hostId);
                     }
                     return false;
                 }
@@ -713,8 +711,8 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     for (VMInstanceVO stoppedVM : vmsByLastHostId) {
                         long secondsSinceLastUpdate = (DateUtil.currentGMTTime().getTime() - stoppedVM.getUpdateTime().getTime()) / 1000;
                         if (secondsSinceLastUpdate < _vmCapacityReleaseInterval) {
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Cannot release reservation, Found VM: " + stoppedVM + " Stopped but reserved on host " + hostId);
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Cannot release reservation, Found VM: " + stoppedVM + " Stopped but reserved on host " + hostId);
                             }
                             return false;
                         }
@@ -724,8 +722,8 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 // check if any VMs are stopping on or migrating to this host
                 List<VMInstanceVO> vmsStoppingMigratingByHostId = _vmInstanceDao.findByHostInStates(hostId, State.Stopping, State.Migrating, State.Starting);
                 if (vmsStoppingMigratingByHostId.size() > 0) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Cannot release reservation, Found " + vmsStoppingMigratingByHostId.size() + " VMs stopping/migrating/starting on host " + hostId);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Cannot release reservation, Found " + vmsStoppingMigratingByHostId.size() + " VMs stopping/migrating/starting on host " + hostId);
                     }
                     return false;
                 }
@@ -736,14 +734,14 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 List<VMInstanceVO> vmsStartingNoHost = _vmInstanceDao.listStartingWithNoHostId();
 
                 if (vmsStartingNoHost.size() > 0) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Cannot release reservation, Found " + vms.size() + " VMs starting as of now and no hostId yet stored");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Cannot release reservation, Found " + vms.size() + " VMs starting as of now and no hostId yet stored");
                     }
                     return false;
                 }
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Host has no VMs associated, releasing the planner reservation for host " + hostId);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Host has no VMs associated, releasing the planner reservation for host " + hostId);
                 }
 
                 final long id = reservationEntry.getId();
@@ -753,7 +751,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     public Boolean doInTransaction(TransactionStatus status) {
                         final PlannerHostReservationVO lockedEntry = _plannerHostReserveDao.lockRow(id, true);
                         if (lockedEntry == null) {
-                            s_logger.error("Unable to lock the host entry for reservation, host: " + hostId);
+                            logger.error("Unable to lock the host entry for reservation, host: " + hostId);
                             return false;
                         }
                         // check before updating
@@ -776,11 +774,11 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         @Override
         protected void runInContext() {
             try {
-                s_logger.debug("Checking if any host reservation can be released ... ");
+                logger.debug("Checking if any host reservation can be released ... ");
                 checkHostReservations();
-                s_logger.debug("Done running HostReservationReleaseChecker ... ");
+                logger.debug("Done running HostReservationReleaseChecker ... ");
             } catch (Throwable t) {
-                s_logger.error("Exception in HostReservationReleaseChecker", t);
+                logger.error("Exception in HostReservationReleaseChecker", t);
             }
         }
     }
@@ -862,7 +860,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
             @Override
             public void onPublishMessage(String senderAddress, String subject, Object obj) {
                 VMInstanceVO vm = ((VMInstanceVO)obj);
-                s_logger.debug("MessageBus message: host reserved capacity released for VM: " + vm.getLastHostId() +
+                logger.debug("MessageBus message: host reserved capacity released for VM: " + vm.getLastHostId() +
                         ", checking if host reservation can be released for host:" + vm.getLastHostId());
                 Long hostId = vm.getLastHostId();
                 checkHostReservationRelease(hostId);
@@ -922,20 +920,20 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
     private DeployDestination checkClustersforDestination(List<Long> clusterList, VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, DataCenter dc,
             DeploymentPlanner.PlannerResourceUsage resourceUsageRequired, ExcludeList plannerAvoidOutput) {
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("ClusterId List to consider: " + clusterList);
+        if (logger.isTraceEnabled()) {
+            logger.trace("ClusterId List to consider: " + clusterList);
         }
 
         for (Long clusterId : clusterList) {
             ClusterVO clusterVO = _clusterDao.findById(clusterId);
 
             if (clusterVO.getHypervisorType() != vmProfile.getHypervisorType()) {
-                s_logger.debug("Cluster: " + clusterId + " has HyperVisorType that does not match the VM, skipping this cluster");
+                logger.debug("Cluster: " + clusterId + " has HyperVisorType that does not match the VM, skipping this cluster");
                 avoid.addCluster(clusterVO.getId());
                 continue;
             }
 
-            s_logger.debug("Checking resources in Cluster: " + clusterId + " under Pod: " + clusterVO.getPodId());
+            logger.debug("Checking resources in Cluster: " + clusterId + " under Pod: " + clusterVO.getPodId());
             // search for resources(hosts and storage) under this zone, pod,
             // cluster.
             DataCenterDeployment potentialPlan =
@@ -974,21 +972,21 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                             storageVolMap.remove(vol);
                         }
                         DeployDestination dest = new DeployDestination(dc, pod, clusterVO, host, storageVolMap);
-                        s_logger.debug("Returning Deployment Destination: " + dest);
+                        logger.debug("Returning Deployment Destination: " + dest);
                         return dest;
                     }
                 } else {
-                    s_logger.debug("No suitable storagePools found under this Cluster: " + clusterId);
+                    logger.debug("No suitable storagePools found under this Cluster: " + clusterId);
                 }
             } else {
-                s_logger.debug("No suitable hosts found under this Cluster: " + clusterId);
+                logger.debug("No suitable hosts found under this Cluster: " + clusterId);
             }
 
             if (canAvoidCluster(clusterVO, avoid, plannerAvoidOutput, vmProfile)) {
                 avoid.addCluster(clusterVO.getId());
             }
         }
-        s_logger.debug("Could not find suitable Deployment Destination for this VM under any clusters, returning. ");
+        logger.debug("Could not find suitable Deployment Destination for this VM under any clusters, returning. ");
         return null;
     }
 
@@ -1100,7 +1098,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
 
     protected Pair<Host, Map<Volume, StoragePool>> findPotentialDeploymentResources(List<Host> suitableHosts, Map<Volume, List<StoragePool>> suitableVolumeStoragePools,
             ExcludeList avoid, DeploymentPlanner.PlannerResourceUsage resourceUsageRequired, List<Volume> readyAndReusedVolumes) {
-        s_logger.debug("Trying to find a potenial host and associated storage pools from the suitable host/pool lists for this VM");
+        logger.debug("Trying to find a potenial host and associated storage pools from the suitable host/pool lists for this VM");
 
         boolean hostCanAccessPool = false;
         boolean haveEnoughSpace = false;
@@ -1124,7 +1122,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
             Map<StoragePool, List<Volume>> volumeAllocationMap = new HashMap<StoragePool, List<Volume>>();
             for (Volume vol : volumesOrderBySizeDesc) {
                 haveEnoughSpace = false;
-                s_logger.debug("Checking if host: " + potentialHost.getId() + " can access any suitable storage pool for volume: " + vol.getVolumeType());
+                logger.debug("Checking if host: " + potentialHost.getId() + " can access any suitable storage pool for volume: " + vol.getVolumeType());
                 List<StoragePool> volumePoolList = suitableVolumeStoragePools.get(vol);
                 hostCanAccessPool = false;
                 for (StoragePool potentialSPool : volumePoolList) {
@@ -1151,19 +1149,19 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     break;
                 }
                 if (!haveEnoughSpace) {
-                    s_logger.warn("insufficient capacity to allocate all volumes");
+                    logger.warn("insufficient capacity to allocate all volumes");
                     break;
                 }
             }
             if (hostCanAccessPool && haveEnoughSpace && checkIfHostFitsPlannerUsage(potentialHost.getId(), resourceUsageRequired)) {
-                s_logger.debug("Found a potential host " + "id: " + potentialHost.getId() + " name: " + potentialHost.getName() +
+                logger.debug("Found a potential host " + "id: " + potentialHost.getId() + " name: " + potentialHost.getName() +
                         " and associated storage pools for this VM");
                 return new Pair<Host, Map<Volume, StoragePool>>(potentialHost, storage);
             } else {
                 avoid.addHost(potentialHost.getId());
             }
         }
-        s_logger.debug("Could not find a potential host that has associated storage pools from the suitable host/pool lists for this VM");
+        logger.debug("Could not find a potential host that has associated storage pools from the suitable host/pool lists for this VM");
         return null;
     }
 
@@ -1175,7 +1173,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
             hostCanAccessSPool = true;
         }
 
-        s_logger.debug("Host: " + host.getId() + (hostCanAccessSPool ? " can" : " cannot") + " access pool: " + pool.getId());
+        logger.debug("Host: " + host.getId() + (hostCanAccessSPool ? " can" : " cannot") + " access pool: " + pool.getId());
         return hostCanAccessSPool;
     }
 
@@ -1189,7 +1187,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         }
 
         if (suitableHosts.isEmpty()) {
-            s_logger.debug("No suitable hosts found");
+            logger.debug("No suitable hosts found");
         }
         return suitableHosts;
     }
@@ -1219,14 +1217,14 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         Set<Long> poolsToAvoidOutput = new HashSet<Long>(originalAvoidPoolSet);
 
         for (VolumeVO toBeCreated : volumesTobeCreated) {
-            s_logger.debug("Checking suitable pools for volume (Id, Type): (" + toBeCreated.getId() + "," + toBeCreated.getVolumeType().name() + ")");
+            logger.debug("Checking suitable pools for volume (Id, Type): (" + toBeCreated.getId() + "," + toBeCreated.getVolumeType().name() + ")");
 
             // If the plan specifies a poolId, it means that this VM's ROOT
             // volume is ready and the pool should be reused.
             // In this case, also check if rest of the volumes are ready and can
             // be reused.
             if (plan.getPoolId() != null || (toBeCreated.getVolumeType() == Volume.Type.DATADISK && toBeCreated.getPoolId() != null && toBeCreated.getState() == Volume.State.Ready)) {
-                s_logger.debug("Volume has pool already allocated, checking if pool can be reused, poolId: " + toBeCreated.getPoolId());
+                logger.debug("Volume has pool already allocated, checking if pool can be reused, poolId: " + toBeCreated.getPoolId());
                 List<StoragePool> suitablePools = new ArrayList<StoragePool>();
                 StoragePool pool = null;
                 if (toBeCreated.getPoolId() != null) {
@@ -1249,12 +1247,12 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                                 canReusePool = true;
                             }
                         } else {
-                            s_logger.debug("Pool of the volume does not fit the specified plan, need to reallocate a pool for this volume");
+                            logger.debug("Pool of the volume does not fit the specified plan, need to reallocate a pool for this volume");
                             canReusePool = false;
                         }
 
                         if (canReusePool) {
-                            s_logger.debug("Planner need not allocate a pool for this volume since its READY");
+                            logger.debug("Planner need not allocate a pool for this volume since its READY");
                             suitablePools.add(pool);
                             suitableVolumeStoragePools.put(toBeCreated, suitablePools);
                             if (!(toBeCreated.getState() == Volume.State.Allocated || toBeCreated.getState() == Volume.State.Creating)) {
@@ -1263,21 +1261,21 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                             continue;
                         }
                     } else {
-                        s_logger.debug("Pool of the volume is in avoid set, need to reallocate a pool for this volume");
+                        logger.debug("Pool of the volume is in avoid set, need to reallocate a pool for this volume");
                     }
                 } else {
-                    s_logger.debug("Pool of the volume is in maintenance, need to reallocate a pool for this volume");
+                    logger.debug("Pool of the volume is in maintenance, need to reallocate a pool for this volume");
                 }
             }
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("We need to allocate new storagepool for this volume");
+            if (logger.isDebugEnabled()) {
+                logger.debug("We need to allocate new storagepool for this volume");
             }
             if (!isRootAdmin(vmProfile)) {
                 if (!isEnabledForAllocation(plan.getDataCenterId(), plan.getPodId(), plan.getClusterId())) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Cannot allocate new storagepool for this volume in this cluster, allocation state is disabled");
-                        s_logger.debug("Cannot deploy to this specified plan, allocation state is disabled, returning.");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Cannot allocate new storagepool for this volume in this cluster, allocation state is disabled");
+                        logger.debug("Cannot deploy to this specified plan, allocation state is disabled, returning.");
                     }
                     // Cannot find suitable storage pools under this cluster for
                     // this volume since allocation_state is disabled.
@@ -1289,7 +1287,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 }
             }
 
-            s_logger.debug("Calling StoragePoolAllocators to find suitable pools");
+            logger.debug("Calling StoragePoolAllocators to find suitable pools");
 
             DiskOfferingVO diskOffering = _diskOfferingDao.findById(toBeCreated.getDiskOfferingId());
 
@@ -1305,7 +1303,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 Boolean useLocalStorageForSystemVM = ConfigurationManagerImpl.SystemVMUseLocalStorage.valueIn(zone.getId());
                 if (useLocalStorageForSystemVM != null) {
                     useLocalStorage = useLocalStorageForSystemVM.booleanValue();
-                    s_logger.debug("System VMs will use " + (useLocalStorage ? "local" : "shared") + " storage for zone id=" + plan.getDataCenterId());
+                    logger.debug("System VMs will use " + (useLocalStorage ? "local" : "shared") + " storage for zone id=" + plan.getDataCenterId());
                 }
             } else {
                 useLocalStorage = diskOffering.getUseLocalStorage();
@@ -1341,7 +1339,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
             }
 
             if (!foundPotentialPools) {
-                s_logger.debug("No suitable pools found for volume: " + toBeCreated + " under cluster: " + plan.getClusterId());
+                logger.debug("No suitable pools found for volume: " + toBeCreated + " under cluster: " + plan.getClusterId());
                 // No suitable storage pools found under this cluster for this
                 // volume. - remove any suitable pools found for other volumes.
                 // All volumes should get suitable pools under this cluster;
@@ -1364,7 +1362,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         }
 
         if (suitableVolumeStoragePools.isEmpty()) {
-            s_logger.debug("No suitable pools found");
+            logger.debug("No suitable pools found");
         }
 
         return new Pair<Map<Volume, List<StoragePool>>, List<Volume>>(suitableVolumeStoragePools, readyAndReusedVolumes);
@@ -1374,19 +1372,19 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         // Check if the zone exists in the system
         DataCenterVO zone = _dcDao.findById(zoneId);
         if (zone != null && Grouping.AllocationState.Disabled == zone.getAllocationState()) {
-            s_logger.info("Zone is currently disabled, cannot allocate to this zone: " + zoneId);
+            logger.info("Zone is currently disabled, cannot allocate to this zone: " + zoneId);
             return false;
         }
 
         Pod pod = _podDao.findById(podId);
         if (pod != null && Grouping.AllocationState.Disabled == pod.getAllocationState()) {
-            s_logger.info("Pod is currently disabled, cannot allocate to this pod: " + podId);
+            logger.info("Pod is currently disabled, cannot allocate to this pod: " + podId);
             return false;
         }
 
         Cluster cluster = _clusterDao.findById(clusterId);
         if (cluster != null && Grouping.AllocationState.Disabled == cluster.getAllocationState()) {
-            s_logger.info("Cluster is currently disabled, cannot allocate to this cluster: " + clusterId);
+            logger.info("Cluster is currently disabled, cannot allocate to this cluster: " + clusterId);
             return false;
         }
 

--- a/server/src/com/cloud/event/dao/EventJoinDaoImpl.java
+++ b/server/src/com/cloud/event/dao/EventJoinDaoImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.response.EventResponse;
@@ -37,7 +36,6 @@ import com.cloud.utils.db.SearchCriteria;
 @Component
 @Local(value = {EventJoinDao.class})
 public class EventJoinDaoImpl extends GenericDaoBase<EventJoinVO, Long> implements EventJoinDao {
-    public static final Logger s_logger = Logger.getLogger(EventJoinDaoImpl.class);
 
     private SearchBuilder<EventJoinVO> vrSearch;
 

--- a/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
+++ b/server/src/com/cloud/ha/AbstractInvestigatorImpl.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -40,7 +39,6 @@ import com.cloud.utils.db.QueryBuilder;
 import com.cloud.utils.db.SearchCriteria.Op;
 
 public abstract class AbstractInvestigatorImpl extends AdapterBase implements Investigator {
-    private static final Logger s_logger = Logger.getLogger(AbstractInvestigatorImpl.class);
 
     @Inject
     private final HostDao _hostDao = null;
@@ -90,32 +88,32 @@ public abstract class AbstractInvestigatorImpl extends AdapterBase implements In
         try {
             Answer pingTestAnswer = _agentMgr.send(hostId, new PingTestCommand(testHostIp));
             if (pingTestAnswer == null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("host (" + testHostIp + ") returns Unknown (null) answer");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("host (" + testHostIp + ") returns Unknown (null) answer");
                 }
                 return Status.Unknown;
             }
 
             if (pingTestAnswer.getResult()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("host (" + testHostIp + ") has been successfully pinged, returning that host is up");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("host (" + testHostIp + ") has been successfully pinged, returning that host is up");
                 }
                 // computing host is available, but could not reach agent, return false
                 return Status.Up;
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("host (" + testHostIp + ") cannot be pinged, returning Unknown (I don't know) state");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("host (" + testHostIp + ") cannot be pinged, returning Unknown (I don't know) state");
                 }
                 return Status.Unknown;
             }
         } catch (AgentUnavailableException e) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", trapped AgentUnavailableException returning Unknown state");
+            if (logger.isDebugEnabled()) {
+                logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", trapped AgentUnavailableException returning Unknown state");
             }
             return Status.Unknown;
         } catch (OperationTimedoutException e) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", trapped OperationTimedoutException returning Unknown state");
+            if (logger.isDebugEnabled()) {
+                logger.debug("host (" + testHostIp + "): " + e.getLocalizedMessage() + ", trapped OperationTimedoutException returning Unknown state");
             }
             return Status.Unknown;
         }

--- a/server/src/com/cloud/ha/CheckOnAgentInvestigator.java
+++ b/server/src/com/cloud/ha/CheckOnAgentInvestigator.java
@@ -19,7 +19,6 @@ package com.cloud.ha;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.CheckVirtualMachineAnswer;
@@ -34,7 +33,6 @@ import com.cloud.vm.VirtualMachine.PowerState;
 
 @Local(value = Investigator.class)
 public class CheckOnAgentInvestigator extends AdapterBase implements Investigator {
-    private final static Logger s_logger = Logger.getLogger(CheckOnAgentInvestigator.class);
     @Inject
     AgentManager _agentMgr;
 
@@ -52,17 +50,17 @@ public class CheckOnAgentInvestigator extends AdapterBase implements Investigato
         try {
             CheckVirtualMachineAnswer answer = (CheckVirtualMachineAnswer)_agentMgr.send(vm.getHostId(), cmd);
             if (!answer.getResult()) {
-                s_logger.debug("Unable to get vm state on " + vm.toString());
+                logger.debug("Unable to get vm state on " + vm.toString());
                 throw new UnknownVM();
             }
 
-            s_logger.debug("Agent responded with state " + answer.getState().toString());
+            logger.debug("Agent responded with state " + answer.getState().toString());
             return answer.getState() == PowerState.PowerOn;
         } catch (AgentUnavailableException e) {
-            s_logger.debug("Unable to reach the agent for " + vm.toString() + ": " + e.getMessage());
+            logger.debug("Unable to reach the agent for " + vm.toString() + ": " + e.getMessage());
             throw new UnknownVM();
         } catch (OperationTimedoutException e) {
-            s_logger.debug("Operation timed out for " + vm.toString() + ": " + e.getMessage());
+            logger.debug("Operation timed out for " + vm.toString() + ": " + e.getMessage());
             throw new UnknownVM();
         }
     }

--- a/server/src/com/cloud/ha/HighAvailabilityManagerExtImpl.java
+++ b/server/src/com/cloud/ha/HighAvailabilityManagerExtImpl.java
@@ -64,8 +64,8 @@ public class HighAvailabilityManagerExtImpl extends HighAvailabilityManagerImpl 
     protected class UsageServerMonitorTask extends ManagedContextRunnable {
         @Override
         protected void runInContext() {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("checking health of usage server");
+            if (logger.isInfoEnabled()) {
+                logger.info("checking health of usage server");
             }
 
             try {
@@ -80,8 +80,8 @@ public class HighAvailabilityManagerExtImpl extends HighAvailabilityManagerImpl 
                             isRunning = true;
                         }
                     }
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("usage server running? " + isRunning + ", heartbeat: " + lastHeartbeat);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("usage server running? " + isRunning + ", heartbeat: " + lastHeartbeat);
                     }
                 } finally {
                     txn.close();
@@ -98,7 +98,7 @@ public class HighAvailabilityManagerExtImpl extends HighAvailabilityManagerImpl 
                     _alertMgr.clearAlert(AlertManager.AlertType.ALERT_TYPE_USAGE_SERVER, 0, 0);
                 }
             } catch (Exception ex) {
-                s_logger.warn("Error while monitoring usage job", ex);
+                logger.warn("Error while monitoring usage job", ex);
             }
         }
     }

--- a/server/src/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -29,7 +29,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.apache.log4j.NDC;
 import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -104,7 +103,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Local(value = { HighAvailabilityManager.class })
 public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvailabilityManager, ClusterManagerListener {
 
-    protected static final Logger s_logger = Logger.getLogger(HighAvailabilityManagerImpl.class);
     WorkerThread[] _workers;
     boolean _stopped;
     long _timeToSleep;
@@ -209,13 +207,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         for (Investigator investigator : investigators) {
             hostState = investigator.isAgentAlive(host);
             if (hostState != null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug(investigator.getName() + " was able to determine host " + hostId + " is in " + hostState.toString());
+                if (logger.isDebugEnabled()) {
+                    logger.debug(investigator.getName() + " was able to determine host " + hostId + " is in " + hostState.toString());
                 }
                 return hostState;
             }
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug(investigator.getName() + " unable to determine the state of the host.  Moving on.");
+            if (logger.isDebugEnabled()) {
+                logger.debug(investigator.getName() + " unable to determine the state of the host.  Moving on.");
             }
         }
 
@@ -230,11 +228,11 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         }
 
         if (host.getHypervisorType() == HypervisorType.VMware || host.getHypervisorType() == HypervisorType.Hyperv) {
-            s_logger.info("Don't restart VMs on host " + host.getId() + " as it is a " + host.getHypervisorType().toString() + " host");
+            logger.info("Don't restart VMs on host " + host.getId() + " as it is a " + host.getHypervisorType().toString() + " host");
             return;
         }
 
-        s_logger.warn("Scheduling restart for VMs on host " + host.getId() + "-" + host.getName());
+        logger.warn("Scheduling restart for VMs on host " + host.getId() + "-" + host.getName());
 
         final List<VMInstanceVO> vms = _instanceDao.listByHostId(host.getId());
         final DataCenterVO dcVO = _dcDao.findById(host.getDataCenterId());
@@ -266,13 +264,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                 "Host [" + hostDesc + "] is down." + ((sb != null) ? sb.toString() : ""));
 
         for (VMInstanceVO vm : reorderedVMList) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Notifying HA Mgr of to restart vm " + vm.getId() + "-" + vm.getInstanceName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Notifying HA Mgr of to restart vm " + vm.getId() + "-" + vm.getInstanceName());
             }
             vm = _instanceDao.findByUuid(vm.getUuid());
             Long hostId = vm.getHostId();
             if (hostId != null && !hostId.equals(host.getId())) {
-                s_logger.debug("VM " + vm.getInstanceName() + " is not on down host " + host.getId() + " it is on other host "
+                logger.debug("VM " + vm.getInstanceName() + " is not on down host " + host.getId() + " it is on other host "
                         + hostId + " VM HA is done");
                 continue;
             }
@@ -285,14 +283,14 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         assert (type == WorkType.CheckStop || type == WorkType.ForceStop || type == WorkType.Stop);
 
         if (_haDao.hasBeenScheduled(vm.getId(), type)) {
-            s_logger.info("There's already a job scheduled to stop " + vm);
+            logger.info("There's already a job scheduled to stop " + vm);
             return;
         }
 
         HaWorkVO work = new HaWorkVO(vm.getId(), vm.getType(), type, Step.Scheduled, hostId, vm.getState(), 0, vm.getUpdated());
         _haDao.persist(work);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Scheduled " + work);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Scheduled " + work);
         }
         wakeupWorkers();
     }
@@ -318,7 +316,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         Long hostId = vm.getHostId();
         if (hostId == null) {
             try {
-                s_logger.debug("Found a vm that is scheduled to be restarted but has no host id: " + vm);
+                logger.debug("Found a vm that is scheduled to be restarted but has no host id: " + vm);
                 _itMgr.advanceStop(vm.getUuid(), true);
             } catch (ResourceUnavailableException e) {
                 assert false : "How do we hit this when force is true?";
@@ -333,13 +331,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         }
 
         if (vm.getHypervisorType() == HypervisorType.VMware || vm.getHypervisorType() == HypervisorType.Hyperv) {
-            s_logger.info("Skip HA for VMware VM or Hyperv VM" + vm.getInstanceName());
+            logger.info("Skip HA for VMware VM or Hyperv VM" + vm.getInstanceName());
             return;
         }
 
         if (!investigate) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("VM does not require investigation so I'm marking it as Stopped: " + vm.toString());
+            if (logger.isDebugEnabled()) {
+                logger.debug("VM does not require investigation so I'm marking it as Stopped: " + vm.toString());
             }
 
             AlertManager.AlertType alertType = AlertManager.AlertType.ALERT_TYPE_USERVM;
@@ -357,8 +355,8 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                     ") stopped unexpectedly on host " + hostDesc, "Virtual Machine " + vm.getHostName() + " (id: " + vm.getId() + ") running on host [" + vm.getHostId() +
                     "] stopped unexpectedly.");
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("VM is not HA enabled so we're done.");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("VM is not HA enabled so we're done.");
                 }
             }
 
@@ -378,7 +376,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         }
 
         if (vm.getHypervisorType() == HypervisorType.VMware) {
-            s_logger.info("Skip HA for VMware VM " + vm.getInstanceName());
+            logger.info("Skip HA for VMware VM " + vm.getInstanceName());
             return;
         }
 
@@ -399,8 +397,8 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                 hostId != null ? hostId : 0L, vm.getState(), maxRetries + 1, vm.getUpdated());
         _haDao.persist(work);
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Schedule vm for HA:  " + vm);
+        if (logger.isInfoEnabled()) {
+            logger.info("Schedule vm for HA:  " + vm);
         }
 
         wakeupWorkers();
@@ -415,7 +413,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                 str.append(item.getId()).append(", ");
             }
             str.delete(str.length() - 2, str.length()).append("]");
-            s_logger.info(str.toString());
+            logger.info(str.toString());
             return null;
         }
 
@@ -426,7 +424,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                 str.append(item.getId()).append(", ");
             }
             str.delete(str.length() - 2, str.length()).append("]");
-            s_logger.info(str.toString());
+            logger.info(str.toString());
             return (System.currentTimeMillis() >> 10) + _investigateRetryInterval;
         }
 
@@ -434,13 +432,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
 
         VirtualMachine vm = _itMgr.findById(work.getInstanceId());
         if (vm == null) {
-            s_logger.info("Unable to find vm: " + vmId);
+            logger.info("Unable to find vm: " + vmId);
             return null;
         }
 
-        s_logger.info("HA on " + vm);
+        logger.info("HA on " + vm);
         if (vm.getState() != work.getPreviousState() || vm.getUpdated() != work.getUpdateTime()) {
-            s_logger.info("VM " + vm + " has been changed.  Current State = " + vm.getState() + " Previous State = " + work.getPreviousState() + " last updated = " +
+            logger.info("VM " + vm + " has been changed.  Current State = " + vm.getState() + " Previous State = " + work.getPreviousState() + " last updated = " +
                 vm.getUpdated() + " previous updated = " + work.getUpdateTime());
             return null;
         }
@@ -459,7 +457,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         if (host == null) {
             host = _hostDao.findByIdIncludingRemoved(work.getHostId());
             if (host != null) {
-                s_logger.debug("VM " + vm.toString() + " is now no longer on host " + work.getHostId() + " as the host is removed");
+                logger.debug("VM " + vm.toString() + " is now no longer on host " + work.getHostId() + " as the host is removed");
                 isHostRemoved = true;
             }
         }
@@ -472,7 +470,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         if (work.getStep() == Step.Investigating) {
             if (!isHostRemoved) {
                 if (vm.getHostId() == null || vm.getHostId() != work.getHostId()) {
-                    s_logger.info("VM " + vm.toString() + " is now no longer on host " + work.getHostId());
+                    logger.info("VM " + vm.toString() + " is now no longer on host " + work.getHostId());
                     return null;
                 }
 
@@ -482,19 +480,19 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                     try
                     {
                         alive = investigator.isVmAlive(vm, host);
-                        s_logger.info(investigator.getName() + " found " + vm + " to be alive? " + alive);
+                        logger.info(investigator.getName() + " found " + vm + " to be alive? " + alive);
                         break;
                     } catch (UnknownVM e) {
-                        s_logger.info(investigator.getName() + " could not find " + vm);
+                        logger.info(investigator.getName() + " could not find " + vm);
                     }
                 }
 
                 boolean fenced = false;
                 if (alive == null) {
-                    s_logger.debug("Fencing off VM that we don't know the state of");
+                    logger.debug("Fencing off VM that we don't know the state of");
                     for (FenceBuilder fb : fenceBuilders) {
                         Boolean result = fb.fenceOff(vm, host);
-                        s_logger.info("Fencer " + fb.getName() + " returned " + result);
+                        logger.info("Fencer " + fb.getName() + " returned " + result);
                         if (result != null && result) {
                             fenced = true;
                             break;
@@ -504,18 +502,18 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                 } else if (!alive) {
                     fenced = true;
                 } else {
-                    s_logger.debug("VM " + vm.getInstanceName() + " is found to be alive by " + investigator.getName());
+                    logger.debug("VM " + vm.getInstanceName() + " is found to be alive by " + investigator.getName());
                     if (host.getStatus() == Status.Up) {
-                        s_logger.info(vm + " is alive and host is up. No need to restart it.");
+                        logger.info(vm + " is alive and host is up. No need to restart it.");
                         return null;
                     } else {
-                        s_logger.debug("Rescheduling because the host is not up but the vm is alive");
+                        logger.debug("Rescheduling because the host is not up but the vm is alive");
                         return (System.currentTimeMillis() >> 10) + _investigateRetryInterval;
                     }
                 }
 
                 if (!fenced) {
-                    s_logger.debug("We were unable to fence off the VM " + vm);
+                    logger.debug("We were unable to fence off the VM " + vm);
                     _alertMgr.sendAlert(alertType, vm.getDataCenterId(), vm.getPodIdToDeployIn(), "Unable to restart " + vm.getHostName() +
                         " which was running on host " + hostDesc, "Insufficient capacity to restart VM, name: " + vm.getHostName() + ", id: " + vmId +
                         " which was running on host " + hostDesc);
@@ -538,7 +536,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                 work.setStep(Step.Scheduled);
                 _haDao.update(work.getId(), work);
             } else {
-                s_logger.debug("How come that HA step is Investigating and the host is removed? Calling forced Stop on Vm anyways");
+                logger.debug("How come that HA step is Investigating and the host is removed? Calling forced Stop on Vm anyways");
                 try {
                     _itMgr.advanceStop(vm.getUuid(), true);
                 } catch (ResourceUnavailableException e) {
@@ -557,22 +555,22 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
         vm = _itMgr.findById(vm.getId());
 
         if (!_forceHA && !vm.isHaEnabled()) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("VM is not HA enabled so we're done.");
+            if (logger.isDebugEnabled()) {
+                logger.debug("VM is not HA enabled so we're done.");
             }
             return null; // VM doesn't require HA
         }
 
         if ((host == null || host.getRemoved() != null || host.getState() != Status.Up)
                  && !volumeMgr.canVmRestartOnAnotherServer(vm.getId())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("VM can not restart on another server.");
+            if (logger.isDebugEnabled()) {
+                logger.debug("VM can not restart on another server.");
             }
             return null;
         }
 
         if (work.getTimesTried() > _maxRetries) {
-            s_logger.warn("Retried to max times so deleting: " + vmId);
+            logger.warn("Retried to max times so deleting: " + vmId);
             return null;
         }
 
@@ -590,33 +588,33 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                 // First try starting the vm with its original planner, if it doesn't succeed send HAPlanner as its an emergency.
                 _itMgr.advanceStart(vm.getUuid(), params, null);
             }catch (InsufficientCapacityException e){
-                s_logger.warn("Failed to deploy vm " + vmId + " with original planner, sending HAPlanner");
+                logger.warn("Failed to deploy vm " + vmId + " with original planner, sending HAPlanner");
                 _itMgr.advanceStart(vm.getUuid(), params, _haPlanners.get(0));
             }
 
             VMInstanceVO started = _instanceDao.findById(vm.getId());
             if (started != null && started.getState() == VirtualMachine.State.Running) {
-                s_logger.info("VM is now restarted: " + vmId + " on " + started.getHostId());
+                logger.info("VM is now restarted: " + vmId + " on " + started.getHostId());
                 return null;
             }
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Rescheduling VM " + vm.toString() + " to try again in " + _restartRetryInterval);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Rescheduling VM " + vm.toString() + " to try again in " + _restartRetryInterval);
             }
         } catch (final InsufficientCapacityException e) {
-            s_logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
+            logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
             _alertMgr.sendAlert(alertType, vm.getDataCenterId(), vm.getPodIdToDeployIn(), "Unable to restart " + vm.getHostName() + " which was running on host " +
                 hostDesc, "Insufficient capacity to restart VM, name: " + vm.getHostName() + ", id: " + vmId + " which was running on host " + hostDesc);
         } catch (final ResourceUnavailableException e) {
-            s_logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
+            logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
             _alertMgr.sendAlert(alertType, vm.getDataCenterId(), vm.getPodIdToDeployIn(), "Unable to restart " + vm.getHostName() + " which was running on host " +
                 hostDesc, "The Storage is unavailable for trying to restart VM, name: " + vm.getHostName() + ", id: " + vmId + " which was running on host " + hostDesc);
         } catch (ConcurrentOperationException e) {
-            s_logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
+            logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
             _alertMgr.sendAlert(alertType, vm.getDataCenterId(), vm.getPodIdToDeployIn(), "Unable to restart " + vm.getHostName() + " which was running on host " +
                 hostDesc, "The Storage is unavailable for trying to restart VM, name: " + vm.getHostName() + ", id: " + vmId + " which was running on host " + hostDesc);
         } catch (OperationTimedoutException e) {
-            s_logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
+            logger.warn("Unable to restart " + vm.toString() + " due to " + e.getMessage());
             _alertMgr.sendAlert(alertType, vm.getDataCenterId(), vm.getPodIdToDeployIn(), "Unable to restart " + vm.getHostName() + " which was running on host " +
                 hostDesc, "The Storage is unavailable for trying to restart VM, name: " + vm.getHostName() + ", id: " + vmId + " which was running on host " + hostDesc);
         }
@@ -642,7 +640,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
             _itMgr.migrateAway(vm.getUuid(), srcHostId);
             return null;
         } catch (InsufficientServerCapacityException e) {
-            s_logger.warn("Insufficient capacity for migrating a VM.");
+            logger.warn("Insufficient capacity for migrating a VM.");
             _resourceMgr.maintenanceFailed(srcHostId);
             return (System.currentTimeMillis() >> 10) + _migrateRetryInterval;
         }
@@ -652,8 +650,8 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
     public void scheduleDestroy(VMInstanceVO vm, long hostId) {
         final HaWorkVO work = new HaWorkVO(vm.getId(), vm.getType(), WorkType.Destroy, Step.Scheduled, hostId, vm.getState(), 0, vm.getUpdated());
         _haDao.persist(work);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Scheduled " + work.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Scheduled " + work.toString());
         }
         wakeupWorkers();
     }
@@ -665,29 +663,29 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
 
     protected Long destroyVM(HaWorkVO work) {
         final VirtualMachine vm = _itMgr.findById(work.getInstanceId());
-        s_logger.info("Destroying " + vm.toString());
+        logger.info("Destroying " + vm.toString());
         try {
             if (vm.getState() != State.Destroyed) {
-                s_logger.info("VM is no longer in Destroyed state " + vm.toString());
+                logger.info("VM is no longer in Destroyed state " + vm.toString());
                 return null;
             }
 
             if (vm.getHostId() != null) {
                 _itMgr.destroy(vm.getUuid());
-                s_logger.info("Successfully destroy " + vm);
+                logger.info("Successfully destroy " + vm);
                 return null;
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug(vm + " has already been stopped");
+                if (logger.isDebugEnabled()) {
+                    logger.debug(vm + " has already been stopped");
                 }
                 return null;
             }
         } catch (final AgentUnavailableException e) {
-            s_logger.debug("Agnet is not available" + e.getMessage());
+            logger.debug("Agnet is not available" + e.getMessage());
         } catch (OperationTimedoutException e) {
-            s_logger.debug("operation timed out: " + e.getMessage());
+            logger.debug("operation timed out: " + e.getMessage());
         } catch (ConcurrentOperationException e) {
-            s_logger.debug("concurrent operation: " + e.getMessage());
+            logger.debug("concurrent operation: " + e.getMessage());
         }
 
         work.setTimesTried(work.getTimesTried() + 1);
@@ -697,50 +695,50 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
     protected Long stopVM(final HaWorkVO work) throws ConcurrentOperationException {
         VirtualMachine vm = _itMgr.findById(work.getInstanceId());
         if (vm == null) {
-            s_logger.info("No longer can find VM " + work.getInstanceId() + ". Throwing away " + work);
+            logger.info("No longer can find VM " + work.getInstanceId() + ". Throwing away " + work);
             work.setStep(Step.Done);
             return null;
         }
-        s_logger.info("Stopping " + vm);
+        logger.info("Stopping " + vm);
         try {
             if (work.getWorkType() == WorkType.Stop) {
                 _itMgr.advanceStop(vm.getUuid(), false);
-                s_logger.info("Successfully stopped " + vm);
+                logger.info("Successfully stopped " + vm);
                 return null;
             } else if (work.getWorkType() == WorkType.CheckStop) {
                 if ((vm.getState() != work.getPreviousState()) || vm.getUpdated() != work.getUpdateTime() || vm.getHostId() == null ||
                     vm.getHostId().longValue() != work.getHostId()) {
-                    s_logger.info(vm + " is different now.  Scheduled Host: " + work.getHostId() + " Current Host: " +
+                    logger.info(vm + " is different now.  Scheduled Host: " + work.getHostId() + " Current Host: " +
                         (vm.getHostId() != null ? vm.getHostId() : "none") + " State: " + vm.getState());
                     return null;
                 }
 
                 _itMgr.advanceStop(vm.getUuid(), false);
-                s_logger.info("Stop for " + vm + " was successful");
+                logger.info("Stop for " + vm + " was successful");
                 return null;
             } else if (work.getWorkType() == WorkType.ForceStop) {
                 if ((vm.getState() != work.getPreviousState()) || vm.getUpdated() != work.getUpdateTime() || vm.getHostId() == null ||
                     vm.getHostId().longValue() != work.getHostId()) {
-                    s_logger.info(vm + " is different now.  Scheduled Host: " + work.getHostId() + " Current Host: " +
+                    logger.info(vm + " is different now.  Scheduled Host: " + work.getHostId() + " Current Host: " +
                         (vm.getHostId() != null ? vm.getHostId() : "none") + " State: " + vm.getState());
                     return null;
                 }
 
                 _itMgr.advanceStop(vm.getUuid(), true);
-                s_logger.info("Stop for " + vm + " was successful");
+                logger.info("Stop for " + vm + " was successful");
                 return null;
             } else {
                 assert false : "Who decided there's other steps but didn't modify the guy who does the work?";
             }
         } catch (final ResourceUnavailableException e) {
-            s_logger.debug("Agnet is not available" + e.getMessage());
+            logger.debug("Agnet is not available" + e.getMessage());
         } catch (OperationTimedoutException e) {
-            s_logger.debug("operation timed out: " + e.getMessage());
+            logger.debug("operation timed out: " + e.getMessage());
         }
 
         work.setTimesTried(work.getTimesTried() + 1);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Stop was unsuccessful.  Rescheduling");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Stop was unsuccessful.  Rescheduling");
         }
         return (System.currentTimeMillis() >> 10) + _stopRetryInterval;
     }
@@ -849,12 +847,12 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
     protected class CleanupTask extends ManagedContextRunnable {
         @Override
         protected void runInContext() {
-            s_logger.info("HA Cleanup Thread Running");
+            logger.info("HA Cleanup Thread Running");
 
             try {
                 _haDao.cleanup(System.currentTimeMillis() - _timeBetweenFailures);
             } catch (Exception e) {
-                s_logger.warn("Error while cleaning up", e);
+                logger.warn("Error while cleaning up", e);
             }
         }
     }
@@ -866,7 +864,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
 
         @Override
         public void run() {
-            s_logger.info("Starting work");
+            logger.info("Starting work");
             while (!_stopped) {
                 _managedContext.runWithContext(new Runnable() {
                     @Override
@@ -875,13 +873,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                     }
                 });
             }
-            s_logger.info("Time to go home!");
+            logger.info("Time to go home!");
         }
 
         private void runWithContext() {
             HaWorkVO work = null;
             try {
-                s_logger.trace("Checking the database");
+                logger.trace("Checking the database");
                 work = _haDao.take(_serverId);
                 if (work == null) {
                     try {
@@ -890,13 +888,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                         }
                         return;
                     } catch (final InterruptedException e) {
-                        s_logger.info("Interrupted");
+                        logger.info("Interrupted");
                         return;
                     }
                 }
 
                 NDC.push("work-" + work.getId());
-                s_logger.info("Processing " + work);
+                logger.info("Processing " + work);
 
                 try {
                     final WorkType wt = work.getWorkType();
@@ -915,21 +913,21 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                     }
 
                     if (nextTime == null) {
-                        s_logger.info("Completed " + work);
+                        logger.info("Completed " + work);
                         work.setStep(Step.Done);
                     } else {
-                        s_logger.info("Rescheduling " + work + " to try again at " + new Date(nextTime << 10));
+                        logger.info("Rescheduling " + work + " to try again at " + new Date(nextTime << 10));
                         work.setTimeToTry(nextTime);
                         work.setTimesTried(work.getTimesTried() + 1);
                         work.setServerId(null);
                         work.setDateTaken(null);
                     }
                 } catch (Exception e) {
-                    s_logger.warn("Encountered unhandled exception during HA process, reschedule retry", e);
+                    logger.warn("Encountered unhandled exception during HA process, reschedule retry", e);
 
                     long nextTime = (System.currentTimeMillis() >> 10) + _restartRetryInterval;
 
-                    s_logger.info("Rescheduling " + work + " to try again at " + new Date(nextTime << 10));
+                    logger.info("Rescheduling " + work + " to try again at " + new Date(nextTime << 10));
                     work.setTimeToTry(nextTime);
                     work.setTimesTried(work.getTimesTried() + 1);
                     work.setServerId(null);
@@ -941,13 +939,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
                     work.setUpdateTime(vm.getUpdated());
                     work.setPreviousState(vm.getState());
                     if (!Step.Done.equals(work.getStep()) && work.getTimesTried() >= _maxRetries) {
-                        s_logger.warn("Giving up, retries max times for work: " + work);
+                        logger.warn("Giving up, retries max times for work: " + work);
                         work.setStep(Step.Done);
                     }
                 }
                 _haDao.update(work.getId(), work);
             } catch (final Throwable th) {
-                s_logger.error("Caught this throwable, ", th);
+                logger.error("Caught this throwable, ", th);
             } finally {
                 if (work != null) {
                     NDC.pop();

--- a/server/src/com/cloud/ha/KVMFencer.java
+++ b/server/src/com/cloud/ha/KVMFencer.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.alert.AlertManager;
@@ -42,7 +41,6 @@ import com.cloud.vm.VirtualMachine;
 
 @Local(value = FenceBuilder.class)
 public class KVMFencer extends AdapterBase implements FenceBuilder {
-    private static final Logger s_logger = Logger.getLogger(KVMFencer.class);
 
     @Inject
     HostDao _hostDao;
@@ -78,7 +76,7 @@ public class KVMFencer extends AdapterBase implements FenceBuilder {
     @Override
     public Boolean fenceOff(VirtualMachine vm, Host host) {
         if (host.getHypervisorType() != HypervisorType.KVM && host.getHypervisorType() != HypervisorType.LXC) {
-            s_logger.warn("Don't know how to fence non kvm hosts " + host.getHypervisorType());
+            logger.warn("Don't know how to fence non kvm hosts " + host.getHypervisorType());
             return null;
         }
 
@@ -101,10 +99,10 @@ public class KVMFencer extends AdapterBase implements FenceBuilder {
                 try {
                     answer = (FenceAnswer)_agentMgr.send(h.getId(), fence);
                 } catch (AgentUnavailableException e) {
-                    s_logger.info("Moving on to the next host because " + h.toString() + " is unavailable");
+                    logger.info("Moving on to the next host because " + h.toString() + " is unavailable");
                     continue;
                 } catch (OperationTimedoutException e) {
-                    s_logger.info("Moving on to the next host because " + h.toString() + " is unavailable");
+                    logger.info("Moving on to the next host because " + h.toString() + " is unavailable");
                     continue;
                 }
                 if (answer != null && answer.getResult()) {
@@ -118,7 +116,7 @@ public class KVMFencer extends AdapterBase implements FenceBuilder {
                             "Fencing off host " + host.getId() + " did not succeed after asking " + i + " hosts. " +
                             "Check Agent logs for more information.");
 
-        s_logger.error("Unable to fence off " + vm.toString() + " on " + host.toString());
+        logger.error("Unable to fence off " + vm.toString() + " on " + host.toString());
 
         return false;
     }

--- a/server/src/com/cloud/ha/ManagementIPSystemVMInvestigator.java
+++ b/server/src/com/cloud/ha/ManagementIPSystemVMInvestigator.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
@@ -34,7 +33,6 @@ import com.cloud.vm.VirtualMachine;
 
 @Local(value = {Investigator.class})
 public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
-    private static final Logger s_logger = Logger.getLogger(ManagementIPSystemVMInvestigator.class);
 
     @Inject
     private final HostDao _hostDao = null;
@@ -44,28 +42,28 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
     @Override
     public boolean isVmAlive(VirtualMachine vm, Host host) throws UnknownVM {
         if (!vm.getType().isUsedBySystem()) {
-            s_logger.debug("Not a System Vm, unable to determine state of " + vm + " returning null");
+            logger.debug("Not a System Vm, unable to determine state of " + vm + " returning null");
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Testing if " + vm + " is alive");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Testing if " + vm + " is alive");
         }
 
         if (vm.getHostId() == null) {
-            s_logger.debug("There's no host id for " + vm);
+            logger.debug("There's no host id for " + vm);
             throw new UnknownVM();
         }
 
         HostVO vmHost = _hostDao.findById(vm.getHostId());
         if (vmHost == null) {
-            s_logger.debug("Unable to retrieve the host by using id " + vm.getHostId());
+            logger.debug("Unable to retrieve the host by using id " + vm.getHostId());
             throw new UnknownVM();
         }
 
         List<? extends Nic> nics = _networkMgr.getNicsForTraffic(vm.getId(), TrafficType.Management);
         if (nics.size() == 0) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Unable to find a management nic, cannot ping this system VM, unable to determine state of " + vm + " returning null");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Unable to find a management nic, cannot ping this system VM, unable to determine state of " + vm + " returning null");
             }
             throw new UnknownVM();
         }
@@ -81,8 +79,8 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
                 assert vmState != null;
                 // In case of Status.Unknown, next host will be tried
                 if (vmState == Status.Up) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("successfully pinged vm's private IP (" + vm.getPrivateIpAddress() + "), returning that the VM is up");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("successfully pinged vm's private IP (" + vm.getPrivateIpAddress() + "), returning that the VM is up");
                     }
                     return Boolean.TRUE;
                 } else if (vmState == Status.Down) {
@@ -91,8 +89,8 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
                     Status vmHostState = testIpAddress(otherHost, vmHost.getPrivateIpAddress());
                     assert vmHostState != null;
                     if (vmHostState == Status.Up) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("successfully pinged vm's host IP (" + vmHost.getPrivateIpAddress() +
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("successfully pinged vm's host IP (" + vmHost.getPrivateIpAddress() +
                                 "), but could not ping VM, returning that the VM is down");
                         }
                         return Boolean.FALSE;
@@ -101,8 +99,8 @@ public class ManagementIPSystemVMInvestigator extends AbstractInvestigatorImpl {
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("unable to determine state of " + vm + " returning null");
+        if (logger.isDebugEnabled()) {
+            logger.debug("unable to determine state of " + vm + " returning null");
         }
         throw new UnknownVM();
     }

--- a/server/src/com/cloud/ha/RecreatableFencer.java
+++ b/server/src/com/cloud/ha/RecreatableFencer.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
@@ -35,7 +34,6 @@ import com.cloud.vm.VirtualMachine;
 @Component
 @Local(value = FenceBuilder.class)
 public class RecreatableFencer extends AdapterBase implements FenceBuilder {
-    private static final Logger s_logger = Logger.getLogger(RecreatableFencer.class);
     @Inject
     VolumeDao _volsDao;
     @Inject
@@ -49,22 +47,22 @@ public class RecreatableFencer extends AdapterBase implements FenceBuilder {
     public Boolean fenceOff(VirtualMachine vm, Host host) {
         VirtualMachine.Type type = vm.getType();
         if (type != VirtualMachine.Type.ConsoleProxy && type != VirtualMachine.Type.DomainRouter && type != VirtualMachine.Type.SecondaryStorageVm) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Don't know how to fence off " + type);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Don't know how to fence off " + type);
             }
             return null;
         }
         List<VolumeVO> vols = _volsDao.findByInstance(vm.getId());
         for (VolumeVO vol : vols) {
             if (!vol.isRecreatable()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Unable to fence off volumes that are not recreatable: " + vol);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Unable to fence off volumes that are not recreatable: " + vol);
                 }
                 return null;
             }
             if (vol.getPoolType().isShared()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Unable to fence off volumes that are shared: " + vol);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Unable to fence off volumes that are shared: " + vol);
                 }
                 return null;
             }

--- a/server/src/com/cloud/ha/UserVmDomRInvestigator.java
+++ b/server/src/com/cloud/ha/UserVmDomRInvestigator.java
@@ -22,7 +22,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -41,7 +40,6 @@ import com.cloud.vm.dao.UserVmDao;
 
 @Local(value = {Investigator.class})
 public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
-    private static final Logger s_logger = Logger.getLogger(UserVmDomRInvestigator.class);
 
     @Inject
     private final UserVmDao _userVmDao = null;
@@ -55,14 +53,14 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
     @Override
     public boolean isVmAlive(VirtualMachine vm, Host host) throws UnknownVM {
         if (vm.getType() != VirtualMachine.Type.User) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Not a User Vm, unable to determine state of " + vm + " returning null");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Not a User Vm, unable to determine state of " + vm + " returning null");
             }
             throw new UnknownVM();
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("testing if " + vm + " is alive");
+        if (logger.isDebugEnabled()) {
+            logger.debug("testing if " + vm + " is alive");
         }
         // to verify that the VM is alive, we ask the domR (router) to ping the VM (private IP)
         UserVmVO userVm = _userVmDao.findById(vm.getId());
@@ -76,8 +74,8 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
 
             List<VirtualRouter> routers = _vnaMgr.getRoutersForNetwork(nic.getNetworkId());
             if (routers == null || routers.isEmpty()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Unable to find a router in network " + nic.getNetworkId() + " to ping " + vm);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Unable to find a router in network " + nic.getNetworkId() + " to ping " + vm);
                 }
                 continue;
             }
@@ -97,16 +95,16 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
             return result;
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Returning null since we're unable to determine state of " + vm);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Returning null since we're unable to determine state of " + vm);
         }
         throw new UnknownVM();
     }
 
     @Override
     public Status isAgentAlive(Host agent) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("checking if agent (" + agent.getId() + ") is alive");
+        if (logger.isDebugEnabled()) {
+            logger.debug("checking if agent (" + agent.getId() + ") is alive");
         }
 
         if (agent.getPodId() == null) {
@@ -116,29 +114,29 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
         List<Long> otherHosts = findHostByPod(agent.getPodId(), agent.getId());
 
         for (Long hostId : otherHosts) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("sending ping from (" + hostId + ") to agent's host ip address (" + agent.getPrivateIpAddress() + ")");
+            if (logger.isDebugEnabled()) {
+                logger.debug("sending ping from (" + hostId + ") to agent's host ip address (" + agent.getPrivateIpAddress() + ")");
             }
             Status hostState = testIpAddress(hostId, agent.getPrivateIpAddress());
             assert hostState != null;
             // In case of Status.Unknown, next host will be tried
             if (hostState == Status.Up) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("ping from (" + hostId + ") to agent's host ip address (" + agent.getPrivateIpAddress() +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("ping from (" + hostId + ") to agent's host ip address (" + agent.getPrivateIpAddress() +
                         ") successful, returning that agent is disconnected");
                 }
                 return Status.Disconnected; // the computing host ip is ping-able, but the computing agent is down, report that the agent is disconnected
             } else if (hostState == Status.Down) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("returning host state: " + hostState);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("returning host state: " + hostState);
                 }
                 return Status.Down;
             }
         }
 
         // could not reach agent, could not reach agent's host, unclear what the problem is but it'll require more investigation...
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("could not reach agent, could not reach agent's host, returning that we don't have enough information");
+        if (logger.isDebugEnabled()) {
+            logger.debug("could not reach agent, could not reach agent's host, returning that we don't have enough information");
         }
         return null;
     }
@@ -167,21 +165,21 @@ public class UserVmDomRInvestigator extends AbstractInvestigatorImpl {
             try {
                 Answer pingTestAnswer = _agentMgr.easySend(hostId, new PingTestCommand(routerPrivateIp, privateIp));
                 if (pingTestAnswer != null && pingTestAnswer.getResult()) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("user vm's " + vm.getHostName() + " ip address " + privateIp + "  has been successfully pinged from the Virtual Router " +
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("user vm's " + vm.getHostName() + " ip address " + privateIp + "  has been successfully pinged from the Virtual Router " +
                             router.getHostName() + ", returning that vm is alive");
                     }
                     return Boolean.TRUE;
                 }
             } catch (Exception e) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Couldn't reach due to", e);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Couldn't reach due to", e);
                 }
                 continue;
             }
         }
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug(vm + " could not be pinged, returning that it is unknown");
+        if (logger.isDebugEnabled()) {
+            logger.debug(vm + " could not be pinged, returning that it is unknown");
         }
         return null;
 

--- a/server/src/com/cloud/ha/XenServerInvestigator.java
+++ b/server/src/com/cloud/ha/XenServerInvestigator.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -38,7 +37,6 @@ import com.cloud.vm.VirtualMachine;
 
 @Local(value = Investigator.class)
 public class XenServerInvestigator extends AdapterBase implements Investigator {
-    private final static Logger s_logger = Logger.getLogger(XenServerInvestigator.class);
     @Inject
     HostDao _hostDao;
     @Inject
@@ -65,7 +63,7 @@ public class XenServerInvestigator extends AdapterBase implements Investigator {
             if (answer != null && answer.getResult()) {
                 CheckOnHostAnswer ans = (CheckOnHostAnswer)answer;
                 if (!ans.isDetermined()) {
-                    s_logger.debug("Host " + neighbor + " couldn't determine the status of " + agent);
+                    logger.debug("Host " + neighbor + " couldn't determine the status of " + agent);
                     continue;
                 }
                 // even it returns true, that means host is up, but XAPI may not work

--- a/server/src/com/cloud/ha/dao/HighAvailabilityDaoImpl.java
+++ b/server/src/com/cloud/ha/dao/HighAvailabilityDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.ha.HaWorkVO;
@@ -38,7 +37,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {HighAvailabilityDao.class})
 public class HighAvailabilityDaoImpl extends GenericDaoBase<HaWorkVO, Long> implements HighAvailabilityDao {
-    private static final Logger s_logger = Logger.getLogger(HighAvailabilityDaoImpl.class);
 
     private final SearchBuilder<HaWorkVO> TBASearch;
     private final SearchBuilder<HaWorkVO> PreviousInstanceSearch;

--- a/server/src/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.to.DiskTO;
@@ -52,7 +51,6 @@ import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 public abstract class HypervisorGuruBase extends AdapterBase implements HypervisorGuru {
-    public static final Logger s_logger = Logger.getLogger(HypervisorGuruBase.class);
 
     @Inject
     VMTemplateDetailsDao _templateDetailsDao;
@@ -115,7 +113,7 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
             }
             to.setNicSecIps(secIps);
         } else {
-            s_logger.warn("Unabled to load NicVO for NicProfile " + profile.getId());
+            logger.warn("Unabled to load NicVO for NicProfile " + profile.getId());
             //Workaround for dynamically created nics
             //FixMe: uuid and secondary IPs can be made part of nic profile
             to.setUuid(UUID.randomUUID().toString());

--- a/server/src/com/cloud/hypervisor/HypervisorGuruManagerImpl.java
+++ b/server/src/com/cloud/hypervisor/HypervisorGuruManagerImpl.java
@@ -24,7 +24,6 @@ import javax.annotation.PostConstruct;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.Command;
@@ -36,7 +35,6 @@ import com.cloud.utils.component.ManagerBase;
 @Component
 @Local(value = {HypervisorGuruManager.class})
 public class HypervisorGuruManagerImpl extends ManagerBase implements HypervisorGuruManager {
-    public static final Logger s_logger = Logger.getLogger(HypervisorGuruManagerImpl.class.getName());
 
     @Inject
     HostDao _hostDao;

--- a/server/src/com/cloud/hypervisor/kvm/discoverer/KvmServerDiscoverer.java
+++ b/server/src/com/cloud/hypervisor/kvm/discoverer/KvmServerDiscoverer.java
@@ -18,14 +18,12 @@ package com.cloud.hypervisor.kvm.discoverer;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.resource.Discoverer;
 
 @Local(value = Discoverer.class)
 public class KvmServerDiscoverer extends LibvirtServerDiscoverer {
-    private static final Logger s_logger = Logger.getLogger(KvmServerDiscoverer.class);
 
     @Override
     public Hypervisor.HypervisorType getHypervisorType() {

--- a/server/src/com/cloud/hypervisor/kvm/discoverer/LxcServerDiscoverer.java
+++ b/server/src/com/cloud/hypervisor/kvm/discoverer/LxcServerDiscoverer.java
@@ -18,14 +18,12 @@ package com.cloud.hypervisor.kvm.discoverer;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.hypervisor.Hypervisor;
 import com.cloud.resource.Discoverer;
 
 @Local(value = Discoverer.class)
 public class LxcServerDiscoverer extends LibvirtServerDiscoverer {
-    private static final Logger s_logger = Logger.getLogger(LxcServerDiscoverer.class);
 
     @Override
     public Hypervisor.HypervisorType getHypervisorType() {

--- a/server/src/com/cloud/metadata/ResourceMetaDataManagerImpl.java
+++ b/server/src/com/cloud/metadata/ResourceMetaDataManagerImpl.java
@@ -45,7 +45,6 @@ import org.apache.cloudstack.resourcedetail.dao.LBStickinessPolicyDetailsDao;
 import org.apache.cloudstack.resourcedetail.dao.LBHealthCheckPolicyDetailsDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.dao.DataCenterDetailsDao;
@@ -70,7 +69,6 @@ import com.cloud.vm.dao.UserVmDetailsDao;
 @Component
 @Local(value = {ResourceMetaDataService.class, ResourceMetaDataManager.class})
 public class ResourceMetaDataManagerImpl extends ManagerBase implements ResourceMetaDataService, ResourceMetaDataManager {
-    public static final Logger s_logger = Logger.getLogger(ResourceMetaDataManagerImpl.class);
     @Inject
     VolumeDetailsDao _volumeDetailDao;
     @Inject

--- a/server/src/com/cloud/network/ExternalFirewallDeviceManagerImpl.java
+++ b/server/src/com/cloud/network/ExternalFirewallDeviceManagerImpl.java
@@ -30,7 +30,6 @@ import org.apache.cloudstack.api.response.ExternalFirewallResponse;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.network.ExternalNetworkDeviceManager.NetworkDevice;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -174,7 +173,6 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
     @Inject
     FirewallRulesDao _fwRulesDao;
 
-    private static final org.apache.log4j.Logger s_logger = Logger.getLogger(ExternalFirewallDeviceManagerImpl.class);
     private long _defaultFwCapacity;
 
     @Override
@@ -219,7 +217,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         try {
             uri = new URI(url);
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             throw new InvalidParameterValueException(e.getMessage());
         }
 
@@ -302,7 +300,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             _externalFirewallDeviceDao.remove(fwDeviceId);
             return true;
         } catch (Exception e) {
-            s_logger.debug("Failed to delete external firewall device due to " + e.getMessage());
+            logger.debug("Failed to delete external firewall device due to " + e.getMessage());
             return false;
         }
     }
@@ -388,7 +386,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
                         _networkExternalFirewallDao.remove(fwDeviceForNetwork.getId());
                     }
                 } catch (Exception exception) {
-                    s_logger.error("Failed to release firewall device for the network" + network.getId() + " due to " + exception.getMessage());
+                    logger.error("Failed to release firewall device for the network" + network.getId() + " due to " + exception.getMessage());
                     return false;
                 } finally {
                     deviceMapLock.unlock();
@@ -423,7 +421,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
     @Override
     public boolean manageGuestNetworkWithExternalFirewall(boolean add, Network network) throws ResourceUnavailableException, InsufficientCapacityException {
         if (network.getTrafficType() != TrafficType.Guest) {
-            s_logger.trace("External firewall can only be used for add/remove guest networks.");
+            logger.trace("External firewall can only be used for add/remove guest networks.");
             return false;
         }
 
@@ -453,7 +451,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         } else {
             ExternalFirewallDeviceVO fwDeviceVO = getExternalFirewallForNetwork(network);
             if (fwDeviceVO == null) {
-                s_logger.warn("Network shutdown requested on external firewall element, which did not implement the network."
+                logger.warn("Network shutdown requested on external firewall element, which did not implement the network."
                     + " Either network implement failed half way through or already network shutdown is completed.");
                 return true;
             }
@@ -478,7 +476,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             }
             if (sourceNatIp == null) {
                 String errorMsg = "External firewall was unable to find the source NAT IP address for network " + network.getName();
-                s_logger.error(errorMsg);
+                logger.error(errorMsg);
                 return true;
             }
         }
@@ -515,10 +513,10 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             String answerDetails = (answer != null) ? answer.getDetails() : "answer was null";
             String msg =
                 "External firewall was unable to " + action + " the guest network on the external firewall in zone " + zone.getName() + " due to " + answerDetails;
-            s_logger.error(msg);
+            logger.error(msg);
             if (!add && (!reservedIpAddressesForGuestNetwork.contains(network.getGateway()))) {
                 // If we failed the implementation as well, then just return, no complain
-                s_logger.error("Skip the shutdown of guest network on SRX because it seems we didn't implement it as well");
+                logger.error("Skip the shutdown of guest network on SRX because it seems we didn't implement it as well");
                 return true;
             }
             throw new ResourceUnavailableException(msg, DataCenter.class, zoneId);
@@ -545,7 +543,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             List<NicVO> nics = _nicDao.listByNetworkId(network.getId());
             for (NicVO nic : nics) {
                 if (nic.getVmType() == null && nic.getReservationStrategy().equals(ReservationStrategy.PlaceHolder) && nic.getIPv4Address().equals(network.getGateway())) {
-                    s_logger.debug("Removing placeholder nic " + nic + " for the network " + network);
+                    logger.debug("Removing placeholder nic " + nic + " for the network " + network);
                     _nicDao.remove(nic.getId());
                 }
             }
@@ -553,7 +551,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         }
 
         String action = add ? "implemented" : "shut down";
-        s_logger.debug("External firewall has " + action + " the guest network for account " + account.getAccountName() + "(id = " + account.getAccountId() +
+        logger.debug("External firewall has " + action + " the guest network for account " + account.getAccountName() + "(id = " + account.getAccountId() +
             ") with VLAN tag " + guestVlanTag);
 
         return true;
@@ -574,7 +572,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         assert (externalFirewall != null);
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
+            logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return true;
         }
@@ -617,7 +615,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         assert (externalFirewall != null);
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
+            logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return true;
         }
@@ -645,7 +643,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             if (answer == null || !answer.getResult()) {
                 String details = (answer != null) ? answer.getDetails() : "details unavailable";
                 String msg = "External firewall was unable to apply static nat rules to the SRX appliance in zone " + zone.getName() + " due to: " + details + ".";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ResourceUnavailableException(msg, DataCenter.class, zone.getId());
             }
         }
@@ -658,7 +656,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             if (answer == null || !answer.getResult()) {
                 String details = (answer != null) ? answer.getDetails() : "details unavailable";
                 String msg = "External firewall was unable to apply static nat rules to the SRX appliance in zone " + zone.getName() + " due to: " + details + ".";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ResourceUnavailableException(msg, DataCenter.class, zone.getId());
             }
         }
@@ -671,7 +669,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             if (answer == null || !answer.getResult()) {
                 String details = (answer != null) ? answer.getDetails() : "details unavailable";
                 String msg = "External firewall was unable to apply port forwarding rules to the SRX appliance in zone " + zone.getName() + " due to: " + details + ".";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ResourceUnavailableException(msg, DataCenter.class, zone.getId());
             }
         }
@@ -713,7 +711,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         if (answer == null || !answer.getResult()) {
             String details = (answer != null) ? answer.getDetails() : "details unavailable";
             String msg = "External firewall was unable to create a remote access VPN in zone " + zone.getName() + " due to: " + details + ".";
-            s_logger.error(msg);
+            logger.error(msg);
             throw new ResourceUnavailableException(msg, DataCenter.class, zone.getId());
         }
 
@@ -749,7 +747,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
             String details = (answer != null) ? answer.getDetails() : "details unavailable";
             DataCenterVO zone = _dcDao.findById(network.getDataCenterId());
             String msg = "External firewall was unable to add remote access users in zone " + zone.getName() + " due to: " + details + ".";
-            s_logger.error(msg);
+            logger.error(msg);
             throw new ResourceUnavailableException(msg, DataCenter.class, zone.getId());
         }
 
@@ -822,7 +820,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         assert (externalFirewall != null);
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
+            logger.debug("External firewall was asked to apply firewall rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return true;
         }

--- a/server/src/com/cloud/network/ExternalIpAddressAllocator.java
+++ b/server/src/com/cloud/network/ExternalIpAddressAllocator.java
@@ -30,7 +30,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 
@@ -41,7 +40,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 
 @Local(value = IpAddrAllocator.class)
 public class ExternalIpAddressAllocator extends AdapterBase implements IpAddrAllocator {
-    private static final Logger s_logger = Logger.getLogger(ExternalIpAddressAllocator.class);
     @Inject
     ConfigurationDao _configDao = null;
     @Inject
@@ -57,7 +55,7 @@ public class ExternalIpAddressAllocator extends AdapterBase implements IpAddrAll
             return new IpAddr();
         }
         String urlString = _externalIpAllocatorUrl + "?command=getIpAddr&mac=" + macAddr + "&dc=" + dcId + "&pod=" + podId;
-        s_logger.debug("getIP:" + urlString);
+        logger.debug("getIP:" + urlString);
 
         BufferedReader in = null;
         try {
@@ -68,10 +66,10 @@ public class ExternalIpAddressAllocator extends AdapterBase implements IpAddrAll
             in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String inputLine;
             while ((inputLine = in.readLine()) != null) {
-                s_logger.debug(inputLine);
+                logger.debug(inputLine);
                 String[] tokens = inputLine.split(",");
                 if (tokens.length != 3) {
-                    s_logger.debug("the return value should be: mac,netmask,gateway");
+                    logger.debug("the return value should be: mac,netmask,gateway");
                     return new IpAddr();
                 }
                 return new IpAddr(tokens[0], tokens[1], tokens[2]);
@@ -103,7 +101,7 @@ public class ExternalIpAddressAllocator extends AdapterBase implements IpAddrAll
 
         String urlString = _externalIpAllocatorUrl + "?command=releaseIpAddr&ip=" + ip + "&dc=" + dcId + "&pod=" + podId;
 
-        s_logger.debug("releaseIP:" + urlString);
+        logger.debug("releaseIP:" + urlString);
         BufferedReader in = null;
         try {
             URL url = new URL(urlString);

--- a/server/src/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
+++ b/server/src/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
@@ -32,7 +32,6 @@ import org.apache.cloudstack.api.response.ExternalLoadBalancerResponse;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.network.ExternalNetworkDeviceManager.NetworkDevice;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -193,7 +192,6 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
     IpAddressManager _ipAddrMgr;
 
     private long _defaultLbCapacity;
-    private static final org.apache.log4j.Logger s_logger = Logger.getLogger(ExternalLoadBalancerDeviceManagerImpl.class);
 
     @Override
     @DB
@@ -240,7 +238,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
         try {
             uri = new URI(url);
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             throw new InvalidParameterValueException(e.getMessage());
         }
 
@@ -344,7 +342,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
 
             return true;
         } catch (Exception e) {
-            s_logger.debug(e);
+            logger.debug(e);
             return false;
         }
     }
@@ -456,7 +454,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                             if (tryLbProvisioning) {
                                 retry = false;
                                 // TODO: throwing warning instead of error for now as its possible another provider can service this network
-                                s_logger.warn("There are no load balancer device with the capacity for implementing this network");
+                                logger.warn("There are no load balancer device with the capacity for implementing this network");
                                 throw exception;
                             } else {
                                 tryLbProvisioning = true; // if possible provision a LB appliance in to the physical network
@@ -495,11 +493,11 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                             try {
                                 createLbAnswer = (CreateLoadBalancerApplianceAnswer)_agentMgr.easySend(lbProviderDevice.getHostId(), lbProvisionCmd);
                                 if (createLbAnswer == null || !createLbAnswer.getResult()) {
-                                    s_logger.error("Could not provision load balancer instance on the load balancer device " + lbProviderDevice.getId());
+                                    logger.error("Could not provision load balancer instance on the load balancer device " + lbProviderDevice.getId());
                                     continue;
                                 }
                             } catch (Exception agentException) {
-                                s_logger.error("Could not provision load balancer instance on the load balancer device " + lbProviderDevice.getId() + " due to " +
+                                logger.error("Could not provision load balancer instance on the load balancer device " + lbProviderDevice.getId() + " due to " +
                                     agentException.getMessage());
                                 continue;
                             }
@@ -524,7 +522,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                             try {
                                 publicIPVlanTag = BroadcastDomainType.getValue(publicIp.getVlanTag());
                             } catch (URISyntaxException e) {
-                                s_logger.error("Failed to parse public ip vlan tag" + e.getMessage());
+                                logger.error("Failed to parse public ip vlan tag" + e.getMessage());
                             }
 
                             String url =
@@ -537,7 +535,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                                     addExternalLoadBalancer(physicalNetworkId, url, username, password, createLbAnswer.getDeviceName(),
                                         createLbAnswer.getServerResource(), false, false, null, null);
                             } catch (Exception e) {
-                                s_logger.error("Failed to add load balancer appliance in to cloudstack due to " + e.getMessage() +
+                                logger.error("Failed to add load balancer appliance in to cloudstack due to " + e.getMessage() +
                                     ". So provisioned load balancer appliance will be destroyed.");
                             }
 
@@ -554,14 +552,14 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                                 try {
                                     answer = (DestroyLoadBalancerApplianceAnswer)_agentMgr.easySend(lbProviderDevice.getHostId(), lbDeleteCmd);
                                     if (answer == null || !answer.getResult()) {
-                                        s_logger.warn("Failed to destroy load balancer appliance created");
+                                        logger.warn("Failed to destroy load balancer appliance created");
                                     } else {
                                         // release the public & private IP back to dc pool, as the load balancer appliance is now destroyed
                                         _dcDao.releasePrivateIpAddress(lbIP, guestConfig.getDataCenterId(), null);
                                         _ipAddrMgr.disassociatePublicIpAddress(publicIp.getId(), _accountMgr.getSystemUser().getId(), _accountMgr.getSystemAccount());
                                     }
                                 } catch (Exception e) {
-                                    s_logger.warn("Failed to destroy load balancer appliance created for the network" + guestConfig.getId() + " due to " + e.getMessage());
+                                    logger.warn("Failed to destroy load balancer appliance created for the network" + guestConfig.getId() + " due to " + e.getMessage());
                                 }
                             }
                         }
@@ -696,16 +694,16 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                     try {
                         answer = (DestroyLoadBalancerApplianceAnswer)_agentMgr.easySend(lbDevice.getParentHostId(), lbDeleteCmd);
                         if (answer == null || !answer.getResult()) {
-                            s_logger.warn("Failed to destoy load balancer appliance used by the network"
+                            logger.warn("Failed to destoy load balancer appliance used by the network"
                                     + guestConfig.getId() + " due to " + answer == null ? "communication error with agent"
                                     : answer.getDetails());
                         }
                     } catch (Exception e) {
-                        s_logger.warn("Failed to destroy load balancer appliance used by the network" + guestConfig.getId() + " due to " + e.getMessage());
+                        logger.warn("Failed to destroy load balancer appliance used by the network" + guestConfig.getId() + " due to " + e.getMessage());
                     }
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Successfully destroyed load balancer appliance used for the network" + guestConfig.getId());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Successfully destroyed load balancer appliance used for the network" + guestConfig.getId());
                     }
                     deviceMapLock.unlock();
 
@@ -725,11 +723,11 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
 
                 return true;
             } else {
-                s_logger.error("Failed to release load balancer device for the network" + guestConfig.getId() + "as failed to acquire lock ");
+                logger.error("Failed to release load balancer device for the network" + guestConfig.getId() + "as failed to acquire lock ");
                 return false;
             }
         } catch (Exception exception) {
-            s_logger.error("Failed to release load balancer device for the network" + guestConfig.getId() + " due to " + exception.getMessage());
+            logger.error("Failed to release load balancer device for the network" + guestConfig.getId() + " due to " + exception.getMessage());
         } finally {
             deviceMapLock.releaseRef();
         }
@@ -795,7 +793,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                             loadBalancingIpAddress = directIp.getAddress().addr();
                         } catch (InsufficientCapacityException capException) {
                             String msg = "Ran out of guest IP addresses from the shared network.";
-                            s_logger.error(msg);
+                            logger.error(msg);
                             throw new ResourceUnavailableException(msg, DataCenter.class, network.getDataCenterId());
                         }
                     }
@@ -803,7 +801,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
 
                 if (loadBalancingIpAddress == null) {
                     String msg = "Ran out of guest IP addresses.";
-                    s_logger.error(msg);
+                    logger.error(msg);
                     throw new ResourceUnavailableException(msg, DataCenter.class, network.getDataCenterId());
                 }
 
@@ -828,7 +826,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                     throw ex;
                 }
 
-                s_logger.debug("Created static nat rule for inline load balancer");
+                logger.debug("Created static nat rule for inline load balancer");
                 nic.setState(MappingState.Create);
             } else {
                 loadBalancingIpNic = _nicDao.findById(mapping.getNicId());
@@ -850,11 +848,11 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                     // Delete the NIC
                     _nicDao.expunge(loadBalancingIpNic.getId());
 
-                    s_logger.debug("Revoked static nat rule for inline load balancer");
+                    logger.debug("Revoked static nat rule for inline load balancer");
                     nic.setState(MappingState.Remove);
                 }
             } else {
-                s_logger.debug("Revoking a rule for an inline load balancer that has not been programmed yet.");
+                logger.debug("Revoking a rule for an inline load balancer that has not been programmed yet.");
                 nic.setNic(null);
                 return nic;
             }
@@ -876,7 +874,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
 
         ExternalLoadBalancerDeviceVO lbDeviceVO = getExternalLoadBalancerForNetwork(network);
         if (lbDeviceVO == null) {
-            s_logger.warn("There is no external load balancer device assigned to this network either network is not implement are already shutdown so just returning");
+            logger.warn("There is no external load balancer device assigned to this network either network is not implement are already shutdown so just returning");
             return true;
         }
 
@@ -885,7 +883,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
         boolean externalLoadBalancerIsInline = _networkMgr.isNetworkInlineMode(network);
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External load balancer was asked to apply LB rules for network with ID " + network.getId() +
+            logger.debug("External load balancer was asked to apply LB rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return true;
         }
@@ -939,13 +937,13 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                 if (answer == null || !answer.getResult()) {
                     String details = (answer != null) ? answer.getDetails() : "details unavailable";
                     String msg = "Unable to apply load balancer rules to the external load balancer appliance in zone " + zone.getName() + " due to: " + details + ".";
-                    s_logger.error(msg);
+                    logger.error(msg);
                     throw new ResourceUnavailableException(msg, DataCenter.class, network.getDataCenterId());
                 }
             }
         } catch (Exception ex) {
             if (externalLoadBalancerIsInline) {
-                s_logger.error("Rollbacking static nat operation of inline mode load balancing due to error on applying LB rules!");
+                logger.error("Rollbacking static nat operation of inline mode load balancing due to error on applying LB rules!");
                 String existedGuestIp = loadBalancersToApply.get(0).getSrcIp();
                 // Rollback static NAT operation in current session
                 for (int i = 0; i < loadBalancingRules.size(); i++) {
@@ -972,7 +970,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
     @Override
     public boolean manageGuestNetworkWithExternalLoadBalancer(boolean add, Network guestConfig) throws ResourceUnavailableException, InsufficientCapacityException {
         if (guestConfig.getTrafficType() != TrafficType.Guest) {
-            s_logger.trace("External load balancer can only be used for guest networks.");
+            logger.trace("External load balancer can only be used for guest networks.");
             return false;
         }
 
@@ -989,17 +987,17 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                 lbDeviceVO = allocateLoadBalancerForNetwork(guestConfig);
                 if (lbDeviceVO == null) {
                     String msg = "failed to alloacate a external load balancer for the network " + guestConfig.getId();
-                    s_logger.error(msg);
+                    logger.error(msg);
                     throw new InsufficientNetworkCapacityException(msg, DataCenter.class, guestConfig.getDataCenterId());
                 }
             }
             externalLoadBalancer = _hostDao.findById(lbDeviceVO.getHostId());
-            s_logger.debug("Allocated external load balancer device:" + lbDeviceVO.getId() + " for the network: " + guestConfig.getId());
+            logger.debug("Allocated external load balancer device:" + lbDeviceVO.getId() + " for the network: " + guestConfig.getId());
         } else {
             // find the load balancer device allocated for the network
             ExternalLoadBalancerDeviceVO lbDeviceVO = getExternalLoadBalancerForNetwork(guestConfig);
             if (lbDeviceVO == null) {
-                s_logger.warn("Network shutdwon requested on external load balancer element, which did not implement the network."
+                logger.warn("Network shutdwon requested on external load balancer element, which did not implement the network."
                     + " Either network implement failed half way through or already network shutdown is completed. So just returning.");
                 return true;
             }
@@ -1025,14 +1023,14 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
             selfIp = _ipAddrMgr.acquireGuestIpAddress(guestConfig, null);
             if (selfIp == null) {
                 String msg = "failed to acquire guest IP address so not implementing the network on the external load balancer ";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new InsufficientNetworkCapacityException(msg, Network.class, guestConfig.getId());
             }
         } else {
             // get the self-ip used by the load balancer
             Nic selfipNic = getPlaceholderNic(guestConfig);
             if (selfipNic == null) {
-                s_logger.warn("Network shutdwon requested on external load balancer element, which did not implement the network."
+                logger.warn("Network shutdwon requested on external load balancer element, which did not implement the network."
                     + " Either network implement failed half way through or already network shutdown is completed. So just returning.");
                 return true;
             }
@@ -1053,7 +1051,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
             String answerDetails = (answer != null) ? answer.getDetails() : null;
             answerDetails = (answerDetails != null) ? " due to " + answerDetails : "";
             String msg = "External load balancer was unable to " + action + " the guest network on the external load balancer in zone " + zone.getName() + answerDetails;
-            s_logger.error(msg);
+            logger.error(msg);
             throw new ResourceUnavailableException(msg, Network.class, guestConfig.getId());
         }
 
@@ -1069,14 +1067,14 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
             boolean releasedLB = freeLoadBalancerForNetwork(guestConfig);
             if (!releasedLB) {
                 String msg = "Failed to release the external load balancer used for the network: " + guestConfig.getId();
-                s_logger.error(msg);
+                logger.error(msg);
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             Account account = _accountDao.findByIdIncludingRemoved(guestConfig.getAccountId());
             String action = add ? "implemented" : "shut down";
-            s_logger.debug("External load balancer has " + action + " the guest network for account " + account.getAccountName() + "(id = " + account.getAccountId() +
+            logger.debug("External load balancer has " + action + " the guest network for account " + account.getAccountName() + "(id = " + account.getAccountId() +
                 ") with VLAN tag " + guestVlanTag);
         }
 
@@ -1129,20 +1127,20 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
         List<Provider> providers = _networkMgr.getProvidersForServiceInNetwork(network, Service.Firewall);
         //Only support one provider now
         if (providers == null) {
-            s_logger.error("Cannot find firewall provider for network " + network.getId());
+            logger.error("Cannot find firewall provider for network " + network.getId());
             return null;
         }
         if (providers.size() != 1) {
-            s_logger.error("Found " + providers.size() + " firewall provider for network " + network.getId());
+            logger.error("Found " + providers.size() + " firewall provider for network " + network.getId());
             return null;
         }
 
         NetworkElement element = _networkModel.getElementImplementingProvider(providers.get(0).getName());
         if (!(element instanceof IpDeployer)) {
-            s_logger.error("The firewall provider for network " + network.getName() + " don't have ability to deploy IP address!");
+            logger.error("The firewall provider for network " + network.getName() + " don't have ability to deploy IP address!");
             return null;
         }
-        s_logger.info("Let " + element.getName() + " handle ip association for " + getName() + " in network " + network.getId());
+        logger.info("Let " + element.getName() + " handle ip association for " + getName() + " in network " + network.getId());
         return (IpDeployer)element;
     }
 
@@ -1159,7 +1157,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
 
         ExternalLoadBalancerDeviceVO lbDeviceVO = getExternalLoadBalancerForNetwork(network);
         if (lbDeviceVO == null) {
-            s_logger.warn("There is no external load balancer device assigned to this network either network is not implement are already shutdown so just returning");
+            logger.warn("There is no external load balancer device assigned to this network either network is not implement are already shutdown so just returning");
             return null;
         }
 
@@ -1168,7 +1166,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
         boolean externalLoadBalancerIsInline = _networkMgr.isNetworkInlineMode(network);
 
         if (network.getState() == Network.State.Allocated) {
-            s_logger.debug("External load balancer was asked to apply LB rules for network with ID " + network.getId() +
+            logger.debug("External load balancer was asked to apply LB rules for network with ID " + network.getId() +
                 "; this network is not implemented. Skipping backend commands.");
             return null;
         }
@@ -1223,7 +1221,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                 return answer == null ? null : answer.getLoadBalancers();
             }
         } catch (Exception ex) {
-            s_logger.error("Exception Occured ", ex);
+            logger.error("Exception Occured ", ex);
         }
         //null return is handled by clients
         return null;

--- a/server/src/com/cloud/network/ExternalNetworkDeviceManagerImpl.java
+++ b/server/src/com/cloud/network/ExternalNetworkDeviceManagerImpl.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ApiConstants;
@@ -123,7 +122,6 @@ public class ExternalNetworkDeviceManagerImpl extends ManagerBase implements Ext
     // obsolete
     // private final static IdentityService _identityService = (IdentityService)ComponentLocator.getLocator(ManagementServer.Name).getManager(IdentityService.class);
 
-    private static final org.apache.log4j.Logger s_logger = Logger.getLogger(ExternalNetworkDeviceManagerImpl.class);
 
     @Override
     public Host addNetworkDevice(AddNetworkDeviceCmd cmd) {
@@ -149,7 +147,7 @@ public class ExternalNetworkDeviceManagerImpl extends ManagerBase implements Ext
 //            if (devs.size() == 1) {
 //                res.add(devs.get(0));
 //            } else {
-//                s_logger.debug("List " + type + ": " + devs.size() + " found");
+//                logger.debug("List " + type + ": " + devs.size() + " found");
 //            }
 //        } else {
 //            List<HostVO> devs = _hostDao.listBy(type, zoneId);

--- a/server/src/com/cloud/network/Ipv6AddressManagerImpl.java
+++ b/server/src/com/cloud/network/Ipv6AddressManagerImpl.java
@@ -24,7 +24,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 
@@ -46,7 +45,6 @@ import com.cloud.utils.net.NetUtils;
 
 @Local(value = {Ipv6AddressManager.class})
 public class Ipv6AddressManagerImpl extends ManagerBase implements Ipv6AddressManager {
-    public static final Logger s_logger = Logger.getLogger(Ipv6AddressManagerImpl.class.getName());
 
     String _name = null;
     int _ipv6RetryMax = 0;
@@ -80,7 +78,7 @@ public class Ipv6AddressManagerImpl extends ManagerBase implements Ipv6AddressMa
         }
         List<VlanVO> vlans = _vlanDao.listVlansByNetworkId(networkId);
         if (vlans == null) {
-            s_logger.debug("Cannot find related vlan attached to network " + networkId);
+            logger.debug("Cannot find related vlan attached to network " + networkId);
             return null;
         }
         String ip = null;

--- a/server/src/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/com/cloud/network/NetworkModelImpl.java
@@ -38,7 +38,6 @@ import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.lb.dao.ApplicationLoadBalancerRuleDao;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.log4j.Logger;
 
 import com.cloud.api.ApiDBUtils;
 import com.cloud.configuration.Config;
@@ -127,7 +126,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 @Local(value = {NetworkModel.class})
 public class NetworkModelImpl extends ManagerBase implements NetworkModel {
-    static final Logger s_logger = Logger.getLogger(NetworkModelImpl.class);
     @Inject
     EntityManager _entityMgr;
     @Inject
@@ -339,7 +337,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                             // no active rules/revoked rules are associated with this public IP, so remove the
                             // association with the provider
                             if (ip.isSourceNat()) {
-                                s_logger.debug("Not releasing ip " + ip.getAddress().addr() + " as it is in use for SourceNat");
+                                logger.debug("Not releasing ip " + ip.getAddress().addr() + " as it is in use for SourceNat");
                             } else {
                                 ip.setState(State.Releasing);
                             }
@@ -594,7 +592,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
             }
         } else {
             if (network.getCidr() == null) {
-                s_logger.debug("Network - " + network.getId() +  " has NULL CIDR.");
+                logger.debug("Network - " + network.getId() +  " has NULL CIDR.");
                 return false;
             }
             hasFreeIps = (getAvailableIps(network, null)).size() > 0;
@@ -766,7 +764,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
             }
         }
         if (ret_network == null) {
-            s_logger.debug("Can not find network with security group enabled with free IPs");
+            logger.debug("Can not find network with security group enabled with free IPs");
         }
         return ret_network;
     }
@@ -779,7 +777,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         }
 
         if (networks.size() > 1) {
-            s_logger.debug("There are multiple network with security group enabled? select one of them...");
+            logger.debug("There are multiple network with security group enabled? select one of them...");
         }
         return networks.get(0);
     }
@@ -873,12 +871,12 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                 }
             }
         } else {
-            s_logger.debug("Unable to find default network for the vm; vm doesn't have any nics");
+            logger.debug("Unable to find default network for the vm; vm doesn't have any nics");
             return null;
         }
 
         if (defaultNic == null) {
-            s_logger.debug("Unable to find default network for the vm; vm doesn't have default nic");
+            logger.debug("Unable to find default network for the vm; vm doesn't have default nic");
         }
 
         return defaultNic;
@@ -890,7 +888,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         String userDataProvider = _ntwkSrvcDao.getProviderForServiceInNetwork(network.getId(), Service.UserData);
 
         if (userDataProvider == null) {
-            s_logger.debug("Network " + network + " doesn't support service " + Service.UserData.getName());
+            logger.debug("Network " + network + " doesn't support service " + Service.UserData.getName());
             return null;
         }
 
@@ -932,7 +930,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         List<NetworkVO> virtualNetworks = _networksDao.listByZoneAndGuestType(accountId, dataCenterId, Network.GuestType.Isolated, false);
 
         if (virtualNetworks.isEmpty()) {
-            s_logger.trace("Unable to find default Virtual network account id=" + accountId);
+            logger.trace("Unable to find default Virtual network account id=" + accountId);
             return null;
         }
 
@@ -943,7 +941,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         if (networkElementNic != null) {
             return networkElementNic.getIPv4Address();
         } else {
-            s_logger.warn("Unable to set find network element for the network id=" + virtualNetwork.getId());
+            logger.warn("Unable to set find network element for the network id=" + virtualNetwork.getId());
             return null;
         }
     }
@@ -1150,7 +1148,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
             Long pNtwkId = null;
             for (PhysicalNetwork pNtwk : pNtwks) {
                 if (pNtwk.getTags().contains(tag)) {
-                    s_logger.debug("Found physical network id=" + pNtwk.getId() + " based on requested tags " + tag);
+                    logger.debug("Found physical network id=" + pNtwk.getId() + " based on requested tags " + tag);
                     pNtwkId = pNtwk.getId();
                     break;
                 }
@@ -1187,7 +1185,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
     @Override
     public boolean isSecurityGroupSupportedInNetwork(Network network) {
         if (network.getTrafficType() != TrafficType.Guest) {
-            s_logger.trace("Security group can be enabled for Guest networks only; and network " + network + " has a diff traffic type");
+            logger.trace("Security group can be enabled for Guest networks only; and network " + network + " has a diff traffic type");
             return false;
         }
 
@@ -1255,8 +1253,8 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                 return label;
             }
         } catch (Exception ex) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Failed to retrive the default label for management traffic:" + "zone: " + zoneId + " hypervisor: " + hypervisorType + " due to:" +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to retrive the default label for management traffic:" + "zone: " + zoneId + " hypervisor: " + hypervisorType + " due to:" +
                     ex.getMessage());
             }
         }
@@ -1290,8 +1288,8 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                 return label;
             }
         } catch (Exception ex) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Failed to retrive the default label for storage traffic:" + "zone: " + zoneId + " hypervisor: " + hypervisorType + " due to:" +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to retrive the default label for storage traffic:" + "zone: " + zoneId + " hypervisor: " + hypervisorType + " due to:" +
                     ex.getMessage());
             }
         }
@@ -1328,7 +1326,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
     public boolean isProviderEnabledInPhysicalNetwork(long physicalNetowrkId, String providerName) {
         PhysicalNetworkServiceProviderVO ntwkSvcProvider = _pNSPDao.findByServiceProvider(physicalNetowrkId, providerName);
         if (ntwkSvcProvider == null) {
-            s_logger.warn("Unable to find provider " + providerName + " in physical network id=" + physicalNetowrkId);
+            logger.warn("Unable to find provider " + providerName + " in physical network id=" + physicalNetowrkId);
             return false;
         }
         return isProviderEnabled(ntwkSvcProvider);
@@ -1370,7 +1368,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
 
         if (physicalNetworkId == null) {
             assert (false) : "Can't get the physical network";
-            s_logger.warn("Can't get the physical network");
+            logger.warn("Can't get the physical network");
             return null;
         }
 
@@ -1657,8 +1655,8 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                 return label;
             }
         } catch (Exception ex) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Failed to retrieve the default label for public traffic." + "zone: " + dcId + " hypervisor: " + hypervisorType + " due to: " +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to retrieve the default label for public traffic." + "zone: " + dcId + " hypervisor: " + hypervisorType + " due to: " +
                     ex.getMessage());
             }
         }
@@ -1692,8 +1690,8 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                 return label;
             }
         } catch (Exception ex) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Failed to retrive the default label for management traffic:" + "zone: " + dcId + " hypervisor: " + hypervisorType + " due to:" +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to retrive the default label for management traffic:" + "zone: " + dcId + " hypervisor: " + hypervisorType + " due to:" +
                     ex.getMessage());
             }
         }
@@ -1766,13 +1764,13 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         Long networkDomainId = null;
         Network network = getNetwork(networkId);
         if (network.getGuestType() != Network.GuestType.Shared) {
-            s_logger.trace("Network id=" + networkId + " is not shared");
+            logger.trace("Network id=" + networkId + " is not shared");
             return false;
         }
 
         NetworkDomainVO networkDomainMap = _networkDomainDao.getDomainNetworkMapByNetworkId(networkId);
         if (networkDomainMap == null) {
-            s_logger.trace("Network id=" + networkId + " is shared, but not domain specific");
+            logger.trace("Network id=" + networkId + " is shared, but not domain specific");
             return true;
         } else {
             networkDomainId = networkDomainMap.getDomainId();
@@ -1801,7 +1799,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
 
         for (String ip : ips) {
             if (requestedIp != null && requestedIp.equals(ip)) {
-                s_logger.warn("Requested ip address " + requestedIp + " is already in use in network" + network);
+                logger.warn("Requested ip address " + requestedIp + " is already in use in network" + network);
                 return null;
             }
 
@@ -1859,14 +1857,14 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
     boolean isServiceEnabledInNetwork(long physicalNetworkId, long networkId, Service service) {
         // check if the service is supported in the network
         if (!areServicesSupportedInNetwork(networkId, service)) {
-            s_logger.debug("Service " + service.getName() + " is not supported in the network id=" + networkId);
+            logger.debug("Service " + service.getName() + " is not supported in the network id=" + networkId);
             return false;
         }
 
         // get provider for the service and check if all of them are supported
         String provider = _ntwkSrvcDao.getProviderForServiceInNetwork(networkId, service);
         if (!isProviderEnabledInPhysicalNetwork(physicalNetworkId, provider)) {
-            s_logger.debug("Provider " + provider + " is not enabled in physical network id=" + physicalNetworkId);
+            logger.debug("Provider " + provider + " is not enabled in physical network id=" + physicalNetworkId);
             return false;
         }
 
@@ -1890,7 +1888,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         }
 
         if (networkList.size() > 1) {
-            s_logger.info("More than one physical networks exist in zone id=" + zoneId + " with traffic type=" + trafficType + ". ");
+            logger.info("More than one physical networks exist in zone id=" + zoneId + " with traffic type=" + trafficType + ". ");
         }
 
         return networkList.get(0);
@@ -2037,7 +2035,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         networkSearch.and("traffictype", networkSearch.entity().getTrafficType(), Op.EQ);
         NicForTrafficTypeSearch.done();
 
-        s_logger.info("Network Model is configured.");
+        logger.info("Network Model is configured.");
 
         return true;
     }
@@ -2051,11 +2049,11 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
             Provider implementedProvider = element.getProvider();
             if (implementedProvider != null) {
                 if (s_providerToNetworkElementMap.containsKey(implementedProvider.getName())) {
-                    s_logger.error("Cannot start NetworkModel: Provider <-> NetworkElement must be a one-to-one map, " + "multiple NetworkElements found for Provider: " +
+                    logger.error("Cannot start NetworkModel: Provider <-> NetworkElement must be a one-to-one map, " + "multiple NetworkElements found for Provider: " +
                         implementedProvider.getName());
                     continue;
                 }
-                s_logger.info("Add provider <-> element map entry. " + implementedProvider.getName() + "-" + element.getName() + "-" + element.getClass().getSimpleName());
+                logger.info("Add provider <-> element map entry. " + implementedProvider.getName() + "-" + element.getName() + "-" + element.getClass().getSimpleName());
                 s_providerToNetworkElementMap.put(implementedProvider.getName(), element.getName());
             }
             if (capabilities != null && implementedProvider != null) {
@@ -2071,7 +2069,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                 }
             }
         }
-        s_logger.info("Started Network Model");
+        logger.info("Started Network Model");
         return true;
     }
 
@@ -2265,7 +2263,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
         //if the network has vms in Starting state (nics for those might not be allocated yet as Starting state also used when vm is being Created)
         //don't GC
         if (_nicDao.countNicsForStartingVms(networkId) > 0) {
-            s_logger.debug("Network id=" + networkId + " is not ready for GC as it has vms that are Starting at the moment");
+            logger.debug("Network id=" + networkId + " is not ready for GC as it has vms that are Starting at the moment");
             return false;
         }
 
@@ -2318,7 +2316,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel {
                 try {
                     md5 = MessageDigest.getInstance("MD5");
                 } catch (NoSuchAlgorithmException e) {
-                    s_logger.error("Unexpected exception " + e.getMessage(), e);
+                    logger.error("Unexpected exception " + e.getMessage(), e);
                     throw new CloudRuntimeException("Unable to get MD5 MessageDigest", e);
                 }
                 md5.reset();

--- a/server/src/com/cloud/network/StorageNetworkManagerImpl.java
+++ b/server/src/com/cloud/network/StorageNetworkManagerImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.command.admin.network.CreateStorageNetworkIpRangeCmd;
@@ -61,7 +60,6 @@ import com.cloud.vm.dao.SecondaryStorageVmDao;
 @Component
 @Local(value = {StorageNetworkManager.class, StorageNetworkService.class})
 public class StorageNetworkManagerImpl extends ManagerBase implements StorageNetworkManager, StorageNetworkService {
-    private static final Logger s_logger = Logger.getLogger(StorageNetworkManagerImpl.class);
 
     @Inject
     StorageNetworkIpAddressDao _sNwIpDao;
@@ -240,7 +238,7 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
                     err.append("endIp=" + endIpFinal);
                     err.append("netmask=" + netmask);
                     err.append("zoneId=" + zoneId);
-                    s_logger.debug(err.toString(), e);
+                    logger.debug(err.toString(), e);
                     throw e;
                 }
 
@@ -280,7 +278,7 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
                     range = _sNwIpRangeDao.acquireInLockTable(rangeId);
                     if (range == null) {
                         String msg = "Unable to acquire lock on storage network ip range id=" + rangeId + ", delete failed";
-                        s_logger.warn(msg);
+                        logger.warn(msg);
                         throw new CloudRuntimeException(msg);
                     }
                     /*
@@ -332,7 +330,7 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
                 r = _sNwIpRangeDao.acquireInLockTable(rangeId);
                 if (r == null) {
                     String msg = "Unable to acquire lock on storage network ip range id=" + rangeId + ", delete failed";
-                    s_logger.warn(msg);
+                    logger.warn(msg);
                     throw new CloudRuntimeException(msg);
                 }
 

--- a/server/src/com/cloud/network/as/AutoScaleManagerImpl.java
+++ b/server/src/com/cloud/network/as/AutoScaleManagerImpl.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -127,7 +126,6 @@ import com.cloud.vm.UserVmService;
 
 @Local(value = {AutoScaleService.class, AutoScaleManager.class})
 public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScaleManager, AutoScaleService {
-    private static final Logger s_logger = Logger.getLogger(AutoScaleManagerImpl.class);
     private ScheduledExecutorService _executor = Executors.newScheduledThreadPool(1);
 
     @Inject
@@ -382,7 +380,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         }
 
         profileVO = checkValidityAndPersist(profileVO);
-        s_logger.info("Successfully create AutoScale Vm Profile with Id: " + profileVO.getId());
+        logger.info("Successfully create AutoScale Vm Profile with Id: " + profileVO.getId());
 
         return profileVO;
     }
@@ -433,7 +431,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         }
 
         vmProfile = checkValidityAndPersist(vmProfile);
-        s_logger.info("Updated Auto Scale Vm Profile id:" + vmProfile.getId());
+        logger.info("Updated Auto Scale Vm Profile id:" + vmProfile.getId());
 
         return vmProfile;
     }
@@ -448,7 +446,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         }
         boolean success = _autoScaleVmProfileDao.remove(id);
         if (success) {
-            s_logger.info("Successfully deleted AutoScale Vm Profile with Id: " + id);
+            logger.info("Successfully deleted AutoScale Vm Profile with Id: " + id);
         }
         return success;
     }
@@ -577,7 +575,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         AutoScalePolicyVO policyVO = new AutoScalePolicyVO(cmd.getDomainId(), cmd.getAccountId(), duration, quietTime, null, action);
 
         policyVO = checkValidityAndPersist(policyVO, cmd.getConditionIds());
-        s_logger.info("Successfully created AutoScale Policy with Id: " + policyVO.getId());
+        logger.info("Successfully created AutoScale Policy with Id: " + policyVO.getId());
         return policyVO;
     }
 
@@ -598,15 +596,15 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
                 boolean success = true;
                 success = _autoScalePolicyDao.remove(id);
                 if (!success) {
-                    s_logger.warn("Failed to remove AutoScale Policy db object");
+                    logger.warn("Failed to remove AutoScale Policy db object");
                     return false;
                 }
                 success = _autoScalePolicyConditionMapDao.removeByAutoScalePolicyId(id);
                 if (!success) {
-                    s_logger.warn("Failed to remove AutoScale Policy Condition mappings");
+                    logger.warn("Failed to remove AutoScale Policy Condition mappings");
                     return false;
                 }
-                s_logger.info("Successfully deleted autoscale policy id : " + id);
+                logger.info("Successfully deleted autoscale policy id : " + id);
 
                 return success;
             }
@@ -738,7 +736,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         for (AutoScaleVmGroupPolicyMapVO vmGroupPolicy : vmGroupPolicyList) {
             AutoScaleVmGroupVO vmGroupVO = _autoScaleVmGroupDao.findById(vmGroupPolicy.getVmGroupId());
             if (vmGroupVO == null) {
-                s_logger.warn("Stale database entry! There is an entry in VmGroupPolicyMap but the vmGroup is missing:" + vmGroupPolicy.getVmGroupId());
+                logger.warn("Stale database entry! There is an entry in VmGroupPolicyMap but the vmGroup is missing:" + vmGroupPolicy.getVmGroupId());
 
                 continue;
 
@@ -752,7 +750,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         }
 
         policy = checkValidityAndPersist(policy, conditionIds);
-        s_logger.info("Successfully updated Auto Scale Policy id:" + policyId);
+        logger.info("Successfully updated Auto Scale Policy id:" + policyId);
         return policy;
     }
 
@@ -789,7 +787,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         }
 
         vmGroupVO = checkValidityAndPersist(vmGroupVO, cmd.getScaleUpPolicyIds(), cmd.getScaleDownPolicyIds());
-        s_logger.info("Successfully created Autoscale Vm Group with Id: " + vmGroupVO.getId());
+        logger.info("Successfully created Autoscale Vm Group with Id: " + vmGroupVO.getId());
 
         return vmGroupVO;
     }
@@ -813,7 +811,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
             } catch (ResourceUnavailableException re) {
                 throw re;
             } catch (Exception e) {
-                s_logger.warn("Exception during configureLbAutoScaleVmGroup in lb rules manager", e);
+                logger.warn("Exception during configureLbAutoScaleVmGroup in lb rules manager", e);
                 return false;
             }
         }
@@ -844,7 +842,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
             _autoScaleVmGroupDao.persist(autoScaleVmGroupVO);
         } finally {
             if (!success) {
-                s_logger.warn("Could not delete AutoScale Vm Group id : " + id);
+                logger.warn("Could not delete AutoScale Vm Group id : " + id);
                 return false;
             }
         }
@@ -855,17 +853,17 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
                 boolean success = _autoScaleVmGroupDao.remove(id);
 
                 if (!success) {
-                    s_logger.warn("Failed to remove AutoScale Group db object");
+                    logger.warn("Failed to remove AutoScale Group db object");
                     return false;
                 }
 
                 success = _autoScaleVmGroupPolicyMapDao.removeByGroupId(id);
                 if (!success) {
-                    s_logger.warn("Failed to remove AutoScale Group Policy mappings");
+                    logger.warn("Failed to remove AutoScale Group Policy mappings");
                     return false;
                 }
 
-                s_logger.info("Successfully deleted autoscale vm group id : " + id);
+                logger.info("Successfully deleted autoscale vm group id : " + id);
                 return success; // Successfull
             }
         });
@@ -1039,7 +1037,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
 
         vmGroupVO = checkValidityAndPersist(vmGroupVO, scaleUpPolicyIds, scaleDownPolicyIds);
         if (vmGroupVO != null) {
-            s_logger.debug("Updated Auto Scale VmGroup id:" + vmGroupId);
+            logger.debug("Updated Auto Scale VmGroup id:" + vmGroupId);
             return vmGroupVO;
         } else
             return null;
@@ -1064,10 +1062,10 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
             _autoScaleVmGroupDao.persist(vmGroup);
         } finally {
             if (!success) {
-                s_logger.warn("Failed to enable AutoScale Vm Group id : " + id);
+                logger.warn("Failed to enable AutoScale Vm Group id : " + id);
                 return null;
             }
-            s_logger.info("Successfully enabled AutoScale Vm Group with Id:" + id);
+            logger.info("Successfully enabled AutoScale Vm Group with Id:" + id);
         }
         return vmGroup;
     }
@@ -1091,10 +1089,10 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
             _autoScaleVmGroupDao.persist(vmGroup);
         } finally {
             if (!success) {
-                s_logger.warn("Failed to disable AutoScale Vm Group id : " + id);
+                logger.warn("Failed to disable AutoScale Vm Group id : " + id);
                 return null;
             }
-            s_logger.info("Successfully disabled AutoScale Vm Group with Id:" + id);
+            logger.info("Successfully disabled AutoScale Vm Group with Id:" + id);
         }
         return vmGroup;
     }
@@ -1115,7 +1113,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
 
         CounterVO counter = null;
 
-        s_logger.debug("Adding Counter " + name);
+        logger.debug("Adding Counter " + name);
         counter = _counterDao.persist(new CounterVO(src, name, cmd.getValue()));
 
         CallContext.current().setEventDetails(" Id: " + counter.getId() + " Name: " + name);
@@ -1146,7 +1144,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         ConditionVO condition = null;
 
         condition = _conditionDao.persist(new ConditionVO(cid, threshold, cmd.getEntityOwnerId(), cmd.getDomainId(), op));
-        s_logger.info("Successfully created condition with Id: " + condition.getId());
+        logger.info("Successfully created condition with Id: " + condition.getId());
 
         CallContext.current().setEventDetails(" Id: " + condition.getId());
         return condition;
@@ -1215,13 +1213,13 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
 
         ConditionVO condition = _conditionDao.findByCounterId(counterId);
         if (condition != null) {
-            s_logger.info("Cannot delete counter " + counter.getName() + " as it is being used in a condition.");
+            logger.info("Cannot delete counter " + counter.getName() + " as it is being used in a condition.");
             throw new ResourceInUseException("Counter is in use.");
         }
 
         boolean success = _counterDao.remove(counterId);
         if (success) {
-            s_logger.info("Successfully deleted counter with Id: " + counterId);
+            logger.info("Successfully deleted counter with Id: " + counterId);
         }
 
         return success;
@@ -1238,12 +1236,12 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
 
         // Verify if condition is used in any autoscale policy
         if (_autoScalePolicyConditionMapDao.isConditionInUse(conditionId)) {
-            s_logger.info("Cannot delete condition " + conditionId + " as it is being used in a condition.");
+            logger.info("Cannot delete condition " + conditionId + " as it is being used in a condition.");
             throw new ResourceInUseException("Cannot delete Condition when it is in use by one or more AutoScale Policies.");
         }
         boolean success = _conditionDao.remove(conditionId);
         if (success) {
-            s_logger.info("Successfully deleted condition " + condition.getId());
+            logger.info("Successfully deleted condition " + condition.getId());
         }
         return success;
     }
@@ -1254,15 +1252,15 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         int count = 0;
         count = _autoScaleVmProfileDao.removeByAccountId(accountId);
         if (count > 0) {
-            s_logger.debug("Deleted " + count + " AutoScale Vm Profile for account Id: " + accountId);
+            logger.debug("Deleted " + count + " AutoScale Vm Profile for account Id: " + accountId);
         }
         count = _autoScalePolicyDao.removeByAccountId(accountId);
         if (count > 0) {
-            s_logger.debug("Deleted " + count + " AutoScale Policies for account Id: " + accountId);
+            logger.debug("Deleted " + count + " AutoScale Policies for account Id: " + accountId);
         }
         count = _conditionDao.removeByAccountId(accountId);
         if (count > 0) {
-            s_logger.debug("Deleted " + count + " Conditions for account Id: " + accountId);
+            logger.debug("Deleted " + count + " Conditions for account Id: " + accountId);
         }
     }
 
@@ -1271,7 +1269,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         Integer currentVM = _autoScaleVmGroupVmMapDao.countByGroup(asGroup.getId());
         Integer maxVm = asGroup.getMaxMembers();
         if (currentVM + numVm > maxVm) {
-            s_logger.warn("number of VM will greater than the maximum in this group if scaling up, so do nothing more");
+            logger.warn("number of VM will greater than the maximum in this group if scaling up, so do nothing more");
             return false;
         }
         return true;
@@ -1281,7 +1279,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         Integer currentVM = _autoScaleVmGroupVmMapDao.countByGroup(asGroup.getId());
         Integer minVm = asGroup.getMinMembers();
         if (currentVM - 1 < minVm) {
-            s_logger.warn("number of VM will less than the minimum in this group if scaling down, so do nothing more");
+            logger.warn("number of VM will less than the minimum in this group if scaling down, so do nothing more");
             return false;
         }
         return true;
@@ -1349,17 +1347,17 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
                 return -1;
             }
         } catch (InsufficientCapacityException ex) {
-            s_logger.info(ex);
-            s_logger.trace(ex.getMessage(), ex);
+            logger.info(ex);
+            logger.trace(ex.getMessage(), ex);
             throw new ServerApiException(ApiErrorCode.INSUFFICIENT_CAPACITY_ERROR, ex.getMessage());
         } catch (ResourceUnavailableException ex) {
-            s_logger.warn("Exception: ", ex);
+            logger.warn("Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, ex.getMessage());
         } catch (ConcurrentOperationException ex) {
-            s_logger.warn("Exception: ", ex);
+            logger.warn("Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, ex.getMessage());
         } catch (ResourceAllocationException ex) {
-            s_logger.warn("Exception: ", ex);
+            logger.warn("Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.RESOURCE_ALLOCATION_ERROR, ex.getMessage());
         }
     }
@@ -1376,10 +1374,10 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
             CallContext.current().setEventDetails("Vm Id: " + vmId);
             _userVmManager.startVirtualMachine(vmId, null, null, null);
         } catch (final ResourceUnavailableException ex) {
-            s_logger.warn("Exception: ", ex);
+            logger.warn("Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, ex.getMessage());
         } catch (ConcurrentOperationException ex) {
-            s_logger.warn("Exception: ", ex);
+            logger.warn("Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, ex.getMessage());
         } catch (InsufficientCapacityException ex) {
             StringBuilder message = new StringBuilder(ex.getMessage());
@@ -1388,8 +1386,8 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
                     message.append(", Please check the affinity groups provided, there may not be sufficient capacity to follow them");
                 }
             }
-            s_logger.info(ex);
-            s_logger.info(message.toString(), ex);
+            logger.info(ex);
+            logger.info(message.toString(), ex);
             throw new ServerApiException(ApiErrorCode.INSUFFICIENT_CAPACITY_ERROR, message.toString());
         }
         return true;
@@ -1404,7 +1402,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
             for (LoadBalancerVMMapVO LbVmMapVo : LbVmMapVos) {
                 long instanceId = LbVmMapVo.getInstanceId();
                 if (instanceId == vmId) {
-                    s_logger.warn("the new VM is already mapped to LB rule. What's wrong?");
+                    logger.warn("the new VM is already mapped to LB rule. What's wrong?");
                     return true;
                 }
             }
@@ -1437,7 +1435,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
     public void doScaleUp(long groupId, Integer numVm) {
         AutoScaleVmGroupVO asGroup = _autoScaleVmGroupDao.findById(groupId);
         if (asGroup == null) {
-            s_logger.error("Can not find the groupid " + groupId + " for scaling up");
+            logger.error("Can not find the groupid " + groupId + " for scaling up");
             return;
         }
         if (!checkConditionUp(asGroup, numVm)) {
@@ -1446,7 +1444,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
         for (int i = 0; i < numVm; i++) {
             long vmId = createNewVM(asGroup);
             if (vmId == -1) {
-                s_logger.error("Can not deploy new VM for scaling up in the group "
+                logger.error("Can not deploy new VM for scaling up in the group "
                     + asGroup.getId() + ". Waiting for next round");
                 break;
             }
@@ -1469,11 +1467,11 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
                         }
                     }
                 } else {
-                    s_logger.error("Can not assign LB rule for this new VM");
+                    logger.error("Can not assign LB rule for this new VM");
                     break;
                 }
             } else {
-                s_logger.error("Can not deploy new VM for scaling up in the group "
+                logger.error("Can not deploy new VM for scaling up in the group "
                     + asGroup.getId() + ". Waiting for next round");
                 break;
             }
@@ -1484,7 +1482,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
     public void doScaleDown(final long groupId) {
         AutoScaleVmGroupVO asGroup = _autoScaleVmGroupDao.findById(groupId);
         if (asGroup == null) {
-            s_logger.error("Can not find the groupid " + groupId + " for scaling up");
+            logger.error("Can not find the groupid " + groupId + " for scaling up");
             return;
         }
         if (!checkConditionDown(asGroup)) {
@@ -1527,7 +1525,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
                 }, destroyVmGracePeriod, TimeUnit.SECONDS);
             }
         } else {
-            s_logger.error("Can not remove LB rule for the VM being destroyed. Do nothing more.");
+            logger.error("Can not remove LB rule for the VM being destroyed. Do nothing more.");
         }
     }
 

--- a/server/src/com/cloud/network/element/CloudZonesNetworkElement.java
+++ b/server/src/com/cloud/network/element/CloudZonesNetworkElement.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -62,7 +61,6 @@ import com.cloud.vm.dao.UserVmDao;
 
 @Local(value = NetworkElement.class)
 public class CloudZonesNetworkElement extends AdapterBase implements NetworkElement, UserDataServiceProvider {
-    private static final Logger s_logger = Logger.getLogger(CloudZonesNetworkElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -227,15 +225,15 @@ public class CloudZonesNetworkElement extends AdapterBase implements NetworkElem
             try {
                 _agentManager.send(dest.getHost().getId(), cmds);
             } catch (OperationTimedoutException e) {
-                s_logger.debug("Unable to send vm data command to host " + dest.getHost());
+                logger.debug("Unable to send vm data command to host " + dest.getHost());
                 return false;
             }
             Answer dataAnswer = cmds.getAnswer("vmdata");
             if (dataAnswer != null && dataAnswer.getResult()) {
-                s_logger.info("Sent vm data successfully to vm " + uservm.getInstanceName());
+                logger.info("Sent vm data successfully to vm " + uservm.getInstanceName());
                 return true;
             }
-            s_logger.info("Failed to send vm data to vm " + uservm.getInstanceName());
+            logger.info("Failed to send vm data to vm " + uservm.getInstanceName());
             return false;
         }
         return false;

--- a/server/src/com/cloud/network/element/HAProxyLBRule.java
+++ b/server/src/com/cloud/network/element/HAProxyLBRule.java
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.network.element;
+
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.network.lb.LoadBalancingRule;
+import com.cloud.network.lb.LoadBalancingRule.LbStickinessPolicy;
+import com.cloud.network.rules.LbStickinessMethod.StickinessMethodType;
+import com.cloud.utils.Pair;
+import com.cloud.utils.net.NetUtils;
+
+@Component
+public class HAProxyLBRule {
+
+    private Logger logger = Logger.getLogger(getClass());
+
+    public boolean validateHAProxyLBRule(final LoadBalancingRule rule) {
+        final String timeEndChar = "dhms";
+
+        if (rule.getSourcePortStart() == NetUtils.HAPROXY_STATS_PORT) {
+            logger.debug("Can't create LB on port 8081, haproxy is listening for  LB stats on this port");
+            return false;
+        }
+
+        for (final LbStickinessPolicy stickinessPolicy : rule.getStickinessPolicies()) {
+            final List<Pair<String, String>> paramsList = stickinessPolicy.getParams();
+
+            if (StickinessMethodType.LBCookieBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
+
+            } else if (StickinessMethodType.SourceBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
+                String tablesize = "200k"; // optional
+                String expire = "30m"; // optional
+
+                /* overwrite default values with the stick parameters */
+                for (final Pair<String, String> paramKV : paramsList) {
+                    final String key = paramKV.first();
+                    final String value = paramKV.second();
+                    if ("tablesize".equalsIgnoreCase(key)) {
+                        tablesize = value;
+                    }
+                    if ("expire".equalsIgnoreCase(key)) {
+                        expire = value;
+                    }
+                }
+                if (expire != null && !containsOnlyNumbers(expire, timeEndChar)) {
+                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: expire is not in timeformat: " + expire);
+                }
+                if (tablesize != null && !containsOnlyNumbers(tablesize, "kmg")) {
+                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: tablesize is not in size format: " + tablesize);
+
+                }
+            } else if (StickinessMethodType.AppCookieBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
+                String length = null; // optional
+                String holdTime = null; // optional
+
+                for (final Pair<String, String> paramKV : paramsList) {
+                    final String key = paramKV.first();
+                    final String value = paramKV.second();
+                    if ("length".equalsIgnoreCase(key)) {
+                        length = value;
+                    }
+                    if ("holdtime".equalsIgnoreCase(key)) {
+                        holdTime = value;
+                    }
+                }
+
+                if (length != null && !containsOnlyNumbers(length, null)) {
+                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: length is not a number: " + length);
+                }
+                if (holdTime != null && !containsOnlyNumbers(holdTime, timeEndChar) && !containsOnlyNumbers(holdTime, null)) {
+                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: holdtime is not in timeformat: " + holdTime);
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * This function detects numbers like 12 ,32h ,42m .. etc,. 1) plain number
+     * like 12 2) time or tablesize like 12h, 34m, 45k, 54m , here last
+     * character is non-digit but from known characters .
+     */
+    private static boolean containsOnlyNumbers(final String str, final String endChar) {
+        if (str == null) {
+            return false;
+        }
+
+        String number = str;
+        if (endChar != null) {
+            boolean matchedEndChar = false;
+            if (str.length() < 2) {
+                return false; // at least one numeric and one char. example:
+            }
+            // 3h
+            final char strEnd = str.toCharArray()[str.length() - 1];
+            for (final char c : endChar.toCharArray()) {
+                if (strEnd == c) {
+                    number = str.substring(0, str.length() - 1);
+                    matchedEndChar = true;
+                    break;
+                }
+            }
+            if (!matchedEndChar) {
+                return false;
+            }
+        }
+        try {
+            Integer.parseInt(number);
+        } catch (final NumberFormatException e) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/server/src/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VirtualRouterElement.java
@@ -33,7 +33,6 @@ import org.apache.cloudstack.api.command.admin.router.ListVirtualRouterElementsC
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.network.topology.NetworkTopology;
 import org.apache.cloudstack.network.topology.NetworkTopologyContext;
-import org.apache.log4j.Logger;
 import org.cloud.network.router.deployment.RouterDeploymentDefinition;
 import org.cloud.network.router.deployment.RouterDeploymentDefinitionBuilder;
 
@@ -73,7 +72,6 @@ import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.OvsProviderDao;
 import com.cloud.network.dao.VirtualRouterProviderDao;
 import com.cloud.network.lb.LoadBalancingRule;
-import com.cloud.network.lb.LoadBalancingRule.LbStickinessPolicy;
 import com.cloud.network.lb.LoadBalancingRulesManager;
 import com.cloud.network.router.VirtualRouter;
 import com.cloud.network.router.VirtualRouter.Role;
@@ -90,13 +88,11 @@ import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
-import com.cloud.utils.Pair;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.crypt.DBEncryptionUtil;
 import com.cloud.utils.db.QueryBuilder;
 import com.cloud.utils.db.SearchCriteria.Op;
 import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.ReservationContext;
@@ -114,7 +110,6 @@ import com.google.gson.Gson;
 public class VirtualRouterElement extends AdapterBase implements VirtualRouterElementService, DhcpServiceProvider, UserDataServiceProvider, SourceNatServiceProvider,
 StaticNatServiceProvider, FirewallServiceProvider, LoadBalancingServiceProvider, PortForwardingServiceProvider, RemoteAccessVPNServiceProvider, IpDeployer,
 NetworkMigrationResponder, AggregatedCommandExecutor {
-    private static final Logger s_logger = Logger.getLogger(VirtualRouterElement.class);
     public static final AutoScaleCounterType AutoScaleCounterCpu = new AutoScaleCounterType("cpu");
     public static final AutoScaleCounterType AutoScaleCounterMemory = new AutoScaleCounterType("memory");
     protected static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
@@ -164,6 +159,9 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
     @Inject
     protected RouterDeploymentDefinitionBuilder routerDeploymentDefinitionBuilder;
 
+    @Inject
+    private HAProxyLBRule haProxyLBRule;
+
     protected boolean canHandle(final Network network, final Service service) {
         final Long physicalNetworkId = _networkMdl.getPhysicalNetworkId(network);
         if (physicalNetworkId == null) {
@@ -180,12 +178,12 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
 
         if (service == null) {
             if (!_networkMdl.isProviderForNetwork(getProvider(), network.getId())) {
-                s_logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
+                logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
                 return false;
             }
         } else {
             if (!_networkMdl.isProviderSupportServiceInNetwork(network.getId(), service, getProvider())) {
-                s_logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
+                logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
                 return false;
             }
         }
@@ -265,7 +263,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         if (canHandle(network, Service.Firewall)) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
                 return true;
             }
 
@@ -291,104 +289,6 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         }
     }
 
-    /*
-     * This function detects numbers like 12 ,32h ,42m .. etc,. 1) plain number
-     * like 12 2) time or tablesize like 12h, 34m, 45k, 54m , here last
-     * character is non-digit but from known characters .
-     */
-    private static boolean containsOnlyNumbers(final String str, final String endChar) {
-        if (str == null) {
-            return false;
-        }
-
-        String number = str;
-        if (endChar != null) {
-            boolean matchedEndChar = false;
-            if (str.length() < 2) {
-                return false; // at least one numeric and one char. example:
-            }
-            // 3h
-            final char strEnd = str.toCharArray()[str.length() - 1];
-            for (final char c : endChar.toCharArray()) {
-                if (strEnd == c) {
-                    number = str.substring(0, str.length() - 1);
-                    matchedEndChar = true;
-                    break;
-                }
-            }
-            if (!matchedEndChar) {
-                return false;
-            }
-        }
-        try {
-            Integer.parseInt(number);
-        } catch (final NumberFormatException e) {
-            return false;
-        }
-        return true;
-    }
-
-    public static boolean validateHAProxyLBRule(final LoadBalancingRule rule) {
-        final String timeEndChar = "dhms";
-
-        if (rule.getSourcePortStart() == NetUtils.HAPROXY_STATS_PORT) {
-            s_logger.debug("Can't create LB on port 8081, haproxy is listening for  LB stats on this port");
-            return false;
-        }
-
-        for (final LbStickinessPolicy stickinessPolicy : rule.getStickinessPolicies()) {
-            final List<Pair<String, String>> paramsList = stickinessPolicy.getParams();
-
-            if (StickinessMethodType.LBCookieBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
-
-            } else if (StickinessMethodType.SourceBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
-                String tablesize = "200k"; // optional
-                String expire = "30m"; // optional
-
-                /* overwrite default values with the stick parameters */
-                for (final Pair<String, String> paramKV : paramsList) {
-                    final String key = paramKV.first();
-                    final String value = paramKV.second();
-                    if ("tablesize".equalsIgnoreCase(key)) {
-                        tablesize = value;
-                    }
-                    if ("expire".equalsIgnoreCase(key)) {
-                        expire = value;
-                    }
-                }
-                if (expire != null && !containsOnlyNumbers(expire, timeEndChar)) {
-                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: expire is not in timeformat: " + expire);
-                }
-                if (tablesize != null && !containsOnlyNumbers(tablesize, "kmg")) {
-                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: tablesize is not in size format: " + tablesize);
-
-                }
-            } else if (StickinessMethodType.AppCookieBased.getName().equalsIgnoreCase(stickinessPolicy.getMethodName())) {
-                String length = null; // optional
-                String holdTime = null; // optional
-
-                for (final Pair<String, String> paramKV : paramsList) {
-                    final String key = paramKV.first();
-                    final String value = paramKV.second();
-                    if ("length".equalsIgnoreCase(key)) {
-                        length = value;
-                    }
-                    if ("holdtime".equalsIgnoreCase(key)) {
-                        holdTime = value;
-                    }
-                }
-
-                if (length != null && !containsOnlyNumbers(length, null)) {
-                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: length is not a number: " + length);
-                }
-                if (holdTime != null && !containsOnlyNumbers(holdTime, timeEndChar) && !containsOnlyNumbers(holdTime, null)) {
-                    throw new InvalidParameterValueException("Failed LB in validation rule id: " + rule.getId() + " Cause: holdtime is not in timeformat: " + holdTime);
-                }
-            }
-        }
-        return true;
-    }
-
     @Override
     public boolean validateLBRule(final Network network, final LoadBalancingRule rule) {
         final List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
@@ -398,7 +298,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             if (routers == null || routers.isEmpty()) {
                 return true;
             }
-            return validateHAProxyLBRule(rule);
+            return haProxyLBRule.validateHAProxyLBRule(rule);
         }
         return true;
     }
@@ -412,7 +312,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
 
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to apply lb rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need to apply lb rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
                 return true;
             }
 
@@ -439,7 +339,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         if (canHandle(network, Service.Vpn)) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to apply vpn users on the backend; virtual router" + " doesn't exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need to apply vpn users on the backend; virtual router" + " doesn't exist in the network " + network.getId());
                 return null;
             }
 
@@ -448,7 +348,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
 
             return networkTopology.applyVpnUsers(network, users, routers);
         } else {
-            s_logger.debug("Element " + getName() + " doesn't handle applyVpnUsers command");
+            logger.debug("Element " + getName() + " doesn't handle applyVpnUsers command");
             return null;
         }
     }
@@ -463,12 +363,12 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         if (canHandle(network, Service.Vpn)) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need stop vpn on the backend; virtual router doesn't" + " exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need stop vpn on the backend; virtual router doesn't" + " exist in the network " + network.getId());
                 return true;
             }
             return _routerMgr.startRemoteAccessVpn(network, vpn, routers);
         } else {
-            s_logger.debug("Element " + getName() + " doesn't handle createVpn command");
+            logger.debug("Element " + getName() + " doesn't handle createVpn command");
             return false;
         }
     }
@@ -483,12 +383,12 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         if (canHandle(network, Service.Vpn)) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need stop vpn on the backend; virtual router doesn't " + "exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need stop vpn on the backend; virtual router doesn't " + "exist in the network " + network.getId());
                 return true;
             }
             return _routerMgr.deleteRemoteAccessVpn(network, vpn, routers);
         } else {
-            s_logger.debug("Element " + getName() + " doesn't handle removeVpn command");
+            logger.debug("Element " + getName() + " doesn't handle removeVpn command");
             return false;
         }
     }
@@ -505,7 +405,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         if (canHandle) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to associate ip addresses on the backend; virtual " + "router doesn't exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need to associate ip addresses on the backend; virtual " + "router doesn't exist in the network " + network.getId());
                 return true;
             }
 
@@ -662,7 +562,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         if (canHandle(network, Service.StaticNat)) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to apply static nat on the backend; virtual " + "router doesn't exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need to apply static nat on the backend; virtual " + "router doesn't exist in the network " + network.getId());
                 return true;
             }
 
@@ -686,11 +586,11 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             result = result && _routerMgr.stop(router, false, context.getCaller(), context.getAccount()) != null;
             if (cleanup) {
                 if (!result) {
-                    s_logger.warn("Failed to stop virtual router element " + router + ", but would try to process clean up anyway.");
+                    logger.warn("Failed to stop virtual router element " + router + ", but would try to process clean up anyway.");
                 }
                 result = _routerMgr.destroyRouter(router.getId(), context.getAccount(), context.getCaller().getId()) != null;
                 if (!result) {
-                    s_logger.warn("Failed to clean up virtual router element " + router);
+                    logger.warn("Failed to clean up virtual router element " + router);
                 }
             }
         }
@@ -722,7 +622,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         }
         final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug("Can't find virtual router element in network " + network.getId());
+            logger.debug("Can't find virtual router element in network " + network.getId());
             return true;
         }
 
@@ -759,7 +659,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         }
         final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug("Can't find virtual router element in network " + network.getId());
+            logger.debug("Can't find virtual router element in network " + network.getId());
             return true;
         }
 
@@ -778,7 +678,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         }
         final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug("Can't find virtual router element in network " + network.getId());
+            logger.debug("Can't find virtual router element in network " + network.getId());
             return true;
         }
 
@@ -803,7 +703,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
     public VirtualRouterProvider configure(final ConfigureVirtualRouterElementCmd cmd) {
         final VirtualRouterProviderVO element = _vrProviderDao.findById(cmd.getId());
         if (element == null || !(element.getType() == Type.VirtualRouter || element.getType() == Type.VPCVirtualRouter)) {
-            s_logger.debug("Can't find Virtual Router element with network service provider id " + cmd.getId());
+            logger.debug("Can't find Virtual Router element with network service provider id " + cmd.getId());
             return null;
         }
 
@@ -817,7 +717,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
     public OvsProvider configure(final ConfigureOvsElementCmd cmd) {
         final OvsProviderVO element = _ovsProviderDao.findById(cmd.getId());
         if (element == null) {
-            s_logger.debug("Can't find Ovs element with network service provider id " + cmd.getId());
+            logger.debug("Can't find Ovs element with network service provider id " + cmd.getId());
             return null;
         }
 
@@ -834,7 +734,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         }
         VirtualRouterProviderVO element = _vrProviderDao.findByNspIdAndType(nspId, providerType);
         if (element != null) {
-            s_logger.debug("There is already a virtual router element with service provider id " + nspId);
+            logger.debug("There is already a virtual router element with service provider id " + nspId);
             return null;
         }
         element = new VirtualRouterProviderVO(nspId, providerType);
@@ -847,7 +747,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         if (canHandle(network, Service.PortForwarding)) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
                 return true;
             }
 
@@ -951,7 +851,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             try {
                 return _routerMgr.removeDhcpSupportForSubnet(network, routers);
             } catch (final ResourceUnavailableException e) {
-                s_logger.debug("Router resource unavailable ");
+                logger.debug("Router resource unavailable ");
             }
         }
         return false;
@@ -990,7 +890,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             }
 
             if (network.getIp6Gateway() != null) {
-                s_logger.info("Skip password and userdata service setup for IPv6 VM");
+                logger.info("Skip password and userdata service setup for IPv6 VM");
                 return true;
             }
 
@@ -1117,7 +1017,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             if (schemeCaps != null) {
                 for (final LoadBalancingRule rule : rules) {
                     if (!schemeCaps.contains(rule.getScheme().toString())) {
-                        s_logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + getName());
+                        logger.debug("Scheme " + rules.get(0).getScheme() + " is not supported by the provider " + getName());
                         return false;
                     }
                 }
@@ -1141,7 +1041,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             try {
                 networkTopology.setupDhcpForPvlan(false, router, router.getHostId(), nic);
             } catch (final ResourceUnavailableException e) {
-                s_logger.warn("Timed Out", e);
+                logger.warn("Timed Out", e);
             }
         } else if (vm.getType() == VirtualMachine.Type.User) {
             assert vm instanceof UserVmVO;
@@ -1166,7 +1066,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             try {
                 networkTopology.setupDhcpForPvlan(true, router, router.getHostId(), nic);
             } catch (final ResourceUnavailableException e) {
-                s_logger.warn("Timed Out", e);
+                logger.warn("Timed Out", e);
             }
         } else if (vm.getType() == VirtualMachine.Type.User) {
             assert vm instanceof UserVmVO;
@@ -1190,7 +1090,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
             try {
                 networkTopology.setupDhcpForPvlan(true, router, router.getHostId(), nic);
             } catch (final ResourceUnavailableException e) {
-                s_logger.warn("Timed Out", e);
+                logger.warn("Timed Out", e);
             }
         } else if (vm.getType() == VirtualMachine.Type.User) {
             assert vm instanceof UserVmVO;

--- a/server/src/com/cloud/network/element/VpcVirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VpcVirtualRouterElement.java
@@ -25,7 +25,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.network.topology.NetworkTopology;
-import org.apache.log4j.Logger;
 import org.cloud.network.router.deployment.RouterDeploymentDefinition;
 import org.cloud.network.router.deployment.RouterDeploymentDefinitionBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,7 +82,6 @@ import com.cloud.vm.VirtualMachineProfile;
         NetworkACLServiceProvider.class })
 public class VpcVirtualRouterElement extends VirtualRouterElement implements VpcProvider, Site2SiteVpnServiceProvider, NetworkACLServiceProvider {
 
-    private static final Logger s_logger = Logger.getLogger(VpcVirtualRouterElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
@@ -136,12 +134,12 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         if (service == null) {
             if (!_networkMdl.isProviderForNetwork(getProvider(), network.getId())) {
-                s_logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
+                logger.trace("Element " + getProvider().getName() + " is not a provider for the network " + network);
                 return false;
             }
         } else {
             if (!_networkMdl.isProviderSupportServiceInNetwork(network.getId(), service, getProvider())) {
-                s_logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
+                logger.trace("Element " + getProvider().getName() + " doesn't support service " + service.getName() + " in the network " + network);
                 return false;
             }
         }
@@ -184,13 +182,13 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final Long vpcId = network.getVpcId();
         if (vpcId == null) {
-            s_logger.trace("Network " + network + " is not associated with any VPC");
+            logger.trace("Network " + network + " is not associated with any VPC");
             return false;
         }
 
         final Vpc vpc = _vpcMgr.getActiveVpc(vpcId);
         if (vpc == null) {
-            s_logger.warn("Unable to find Enabled VPC by id " + vpcId);
+            logger.warn("Unable to find Enabled VPC by id " + vpcId);
             return false;
         }
 
@@ -219,7 +217,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
     protected void configureGuestNetwork(final Network network, final List<DomainRouterVO> routers )
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException {
 
-        s_logger.info("Adding VPC routers to Guest Network: " + routers.size() + " to be added!");
+        logger.info("Adding VPC routers to Guest Network: " + routers.size() + " to be added!");
 
         for (final DomainRouterVO router : routers) {
             if (!_networkMdl.isVmPartOfNetwork(router.getId(), network.getId())) {
@@ -228,9 +226,9 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
                     paramsForRouter.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, true);
                 }
                 if (!_vpcRouterMgr.addVpcRouterToGuestNetwork(router, network, paramsForRouter)) {
-                    s_logger.error("Failed to add VPC router " + router + " to guest network " + network);
+                    logger.error("Failed to add VPC router " + router + " to guest network " + network);
                 } else {
-                    s_logger.debug("Successfully added VPC router " + router + " to guest network " + network);
+                    logger.debug("Successfully added VPC router " + router + " to guest network " + network);
                 }
             }
         }
@@ -242,13 +240,13 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final Long vpcId = network.getVpcId();
         if (vpcId == null) {
-            s_logger.trace("Network " + network + " is not associated with any VPC");
+            logger.trace("Network " + network + " is not associated with any VPC");
             return false;
         }
 
         final Vpc vpc = _vpcMgr.getActiveVpc(vpcId);
         if (vpc == null) {
-            s_logger.warn("Unable to find Enabled VPC by id " + vpcId);
+            logger.warn("Unable to find Enabled VPC by id " + vpcId);
             return false;
         }
 
@@ -281,7 +279,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         boolean success = true;
         final Long vpcId = network.getVpcId();
         if (vpcId == null) {
-            s_logger.debug("Network " + network + " doesn't belong to any vpc, so skipping unplug nic part");
+            logger.debug("Network " + network + " doesn't belong to any vpc, so skipping unplug nic part");
             return success;
         }
 
@@ -289,15 +287,15 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         for (final VirtualRouter router : routers) {
             // 1) Check if router is already a part of the network
             if (!_networkMdl.isVmPartOfNetwork(router.getId(), network.getId())) {
-                s_logger.debug("Router " + router + " is not a part the network " + network);
+                logger.debug("Router " + router + " is not a part the network " + network);
                 continue;
             }
             // 2) Call unplugNics in the network service
             success = success && _vpcRouterMgr.removeVpcRouterFromGuestNetwork(router, network);
             if (!success) {
-                s_logger.warn("Failed to unplug nic in network " + network + " for virtual router " + router);
+                logger.warn("Failed to unplug nic in network " + network + " for virtual router " + router);
             } else {
-                s_logger.debug("Successfully unplugged nic in network " + network + " for virtual router " + router);
+                logger.debug("Successfully unplugged nic in network " + network + " for virtual router " + router);
             }
         }
 
@@ -309,7 +307,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         boolean success = true;
         final Long vpcId = config.getVpcId();
         if (vpcId == null) {
-            s_logger.debug("Network " + config + " doesn't belong to any vpc, so skipping unplug nic part");
+            logger.debug("Network " + config + " doesn't belong to any vpc, so skipping unplug nic part");
             return success;
         }
 
@@ -317,15 +315,15 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         for (final VirtualRouter router : routers) {
             // 1) Check if router is already a part of the network
             if (!_networkMdl.isVmPartOfNetwork(router.getId(), config.getId())) {
-                s_logger.debug("Router " + router + " is not a part the network " + config);
+                logger.debug("Router " + router + " is not a part the network " + config);
                 continue;
             }
             // 2) Call unplugNics in the network service
             success = success && _vpcRouterMgr.removeVpcRouterFromGuestNetwork(router, config);
             if (!success) {
-                s_logger.warn("Failed to unplug nic in network " + config + " for virtual router " + router);
+                logger.warn("Failed to unplug nic in network " + config + " for virtual router " + router);
             } else {
-                s_logger.debug("Successfully unplugged nic in network " + config + " for virtual router " + router);
+                logger.debug("Successfully unplugged nic in network " + config + " for virtual router " + router);
             }
         }
 
@@ -349,13 +347,13 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         //For the 2nd time it returns the VPC routers.
         final Long vpcId = network.getVpcId();
         if (vpcId == null) {
-            s_logger.error("Network " + network + " is not associated with any VPC");
+            logger.error("Network " + network + " is not associated with any VPC");
             return routers;
         }
 
         final Vpc vpc = _vpcMgr.getActiveVpc(vpcId);
         if (vpc == null) {
-            s_logger.warn("Unable to find Enabled VPC by id " + vpcId);
+            logger.warn("Unable to find Enabled VPC by id " + vpcId);
             return routers;
         }
 
@@ -369,11 +367,11 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         try {
             routers = routerDeploymentDefinition.deployVirtualRouter();
         } catch (final ConcurrentOperationException e) {
-            s_logger.error("Error occurred when loading routers from routerDeploymentDefinition.deployVirtualRouter()!", e);
+            logger.error("Error occurred when loading routers from routerDeploymentDefinition.deployVirtualRouter()!", e);
         } catch (final InsufficientCapacityException e) {
-            s_logger.error("Error occurred when loading routers from routerDeploymentDefinition.deployVirtualRouter()!", e);
+            logger.error("Error occurred when loading routers from routerDeploymentDefinition.deployVirtualRouter()!", e);
         } catch (final ResourceUnavailableException e) {
-            s_logger.error("Error occurred when loading routers from routerDeploymentDefinition.deployVirtualRouter()!", e);
+            logger.error("Error occurred when loading routers from routerDeploymentDefinition.deployVirtualRouter()!", e);
         }
 
         return routers;
@@ -413,17 +411,17 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
     @Override
     public boolean createPrivateGateway(final PrivateGateway gateway) throws ConcurrentOperationException, ResourceUnavailableException {
         if (gateway.getType() != VpcGateway.Type.Private) {
-            s_logger.warn("Type of vpc gateway is not " + VpcGateway.Type.Private);
+            logger.warn("Type of vpc gateway is not " + VpcGateway.Type.Private);
             return false;
         }
 
         final List<DomainRouterVO> routers = _vpcRouterMgr.getVpcRouters(gateway.getVpcId());
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug(getName() + " element doesn't need to create Private gateway on the backend; VPC virtual " + "router doesn't exist in the vpc id=" + gateway.getVpcId());
+            logger.debug(getName() + " element doesn't need to create Private gateway on the backend; VPC virtual " + "router doesn't exist in the vpc id=" + gateway.getVpcId());
             return true;
         }
 
-        s_logger.info("Adding VPC routers to Guest Network: " + routers.size() + " to be added!");
+        logger.info("Adding VPC routers to Guest Network: " + routers.size() + " to be added!");
 
         final DataCenterVO dcVO = _dcDao.findById(gateway.getZoneId());
         final NetworkTopology networkTopology = networkTopologyContext.retrieveNetworkTopology(dcVO);
@@ -433,15 +431,15 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
                 try {
                     final List<NetworkACLItemVO> rules = _networkACLItemDao.listByACL(gateway.getNetworkACLId());
                     if (!applyACLItemsToPrivateGw(gateway, rules)) {
-                        s_logger.debug("Failed to apply network acl id  " + gateway.getNetworkACLId() + "  on gateway ");
+                        logger.debug("Failed to apply network acl id  " + gateway.getNetworkACLId() + "  on gateway ");
                         return false;
                     }
                 } catch (final Exception ex) {
-                    s_logger.debug("Failed to apply network acl id  " + gateway.getNetworkACLId() + "  on gateway ");
+                    logger.debug("Failed to apply network acl id  " + gateway.getNetworkACLId() + "  on gateway ");
                     return false;
                 }
             } else {
-                s_logger.debug("Failed to setup private gateway  " + gateway);
+                logger.debug("Failed to setup private gateway  " + gateway);
                 return false;
             }
         }
@@ -452,17 +450,17 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
     @Override
     public boolean deletePrivateGateway(final PrivateGateway gateway) throws ConcurrentOperationException, ResourceUnavailableException {
         if (gateway.getType() != VpcGateway.Type.Private) {
-            s_logger.warn("Type of vpc gateway is not " + VpcGateway.Type.Private);
+            logger.warn("Type of vpc gateway is not " + VpcGateway.Type.Private);
             return false;
         }
 
         final List<DomainRouterVO> routers = _vpcRouterMgr.getVpcRouters(gateway.getVpcId());
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug(getName() + " element doesn't need to delete Private gateway on the backend; VPC virtual " + "router doesn't exist in the vpc id=" + gateway.getVpcId());
+            logger.debug(getName() + " element doesn't need to delete Private gateway on the backend; VPC virtual " + "router doesn't exist in the vpc id=" + gateway.getVpcId());
             return true;
         }
 
-        s_logger.info("Adding VPC routers to Guest Network: " + routers.size() + " to be added!");
+        logger.info("Adding VPC routers to Guest Network: " + routers.size() + " to be added!");
 
         int result = 0;
         for (final DomainRouterVO domainRouterVO : routers) {
@@ -486,7 +484,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         if (canHandle) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug(getName() + " element doesn't need to associate ip addresses on the backend; VPC virtual " + "router doesn't exist in the network "
+                logger.debug(getName() + " element doesn't need to associate ip addresses on the backend; VPC virtual " + "router doesn't exist in the network "
                         + network.getId());
                 return true;
             }
@@ -505,7 +503,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         if (canHandle(network, Service.NetworkACL)) {
             final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
-                s_logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
+                logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
                 return true;
             }
 
@@ -519,7 +517,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
                     return true;
                 }
             } catch (final Exception ex) {
-                s_logger.debug("Failed to apply network acl in network " + network.getId());
+                logger.debug("Failed to apply network acl in network " + network.getId());
                 return false;
             }
         } else {
@@ -536,7 +534,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
     public boolean applyStaticRoutes(final Vpc vpc, final List<StaticRouteProfile> routes) throws ResourceUnavailableException {
         final List<DomainRouterVO> routers = _routerDao.listByVpcId(vpc.getId());
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug("Virtual router elemnt doesn't need to static routes on the backend; virtual " + "router doesn't exist in the vpc " + vpc);
+            logger.debug("Virtual router elemnt doesn't need to static routes on the backend; virtual " + "router doesn't exist in the vpc " + vpc);
             return true;
         }
 
@@ -546,7 +544,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         if (!networkTopology.applyStaticRoutes(routes, routers)) {
             throw new CloudRuntimeException("Failed to apply static routes in vpc " + vpc);
         } else {
-            s_logger.debug("Applied static routes on vpc " + vpc);
+            logger.debug("Applied static routes on vpc " + vpc);
             return true;
         }
     }
@@ -558,7 +556,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final List<DomainRouterVO> routers = _vpcRouterMgr.getVpcRouters(gateway.getVpcId());
         if (routers == null || routers.isEmpty()) {
-            s_logger.debug("Virtual router element doesn't need to apply network acl rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
+            logger.debug("Virtual router element doesn't need to apply network acl rules on the backend; virtual " + "router doesn't exist in the network " + network.getId());
             return true;
         }
 
@@ -579,7 +577,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final Map<Capability, String> vpnCapabilities = capabilities.get(Service.Vpn);
         if (!vpnCapabilities.get(Capability.VpnTypes).contains("s2svpn")) {
-            s_logger.error("try to start site 2 site vpn on unsupported network element?");
+            logger.error("try to start site 2 site vpn on unsupported network element?");
             return false;
         }
 
@@ -610,7 +608,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final Map<Capability, String> vpnCapabilities = capabilities.get(Service.Vpn);
         if (!vpnCapabilities.get(Capability.VpnTypes).contains("s2svpn")) {
-            s_logger.error("try to stop site 2 site vpn on unsupported network element?");
+            logger.error("try to stop site 2 site vpn on unsupported network element?");
             return false;
         }
 
@@ -643,7 +641,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final List<DomainRouterVO> routers = _vpcRouterMgr.getVpcRouters(vpn.getVpcId());
         if (routers == null) {
-            s_logger.debug("Cannot apply vpn users on the backend; virtual router doesn't exist in the network " + vpn.getVpcId());
+            logger.debug("Cannot apply vpn users on the backend; virtual router doesn't exist in the network " + vpn.getVpcId());
             return null;
         }
 
@@ -666,7 +664,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final List<DomainRouterVO> routers = _vpcRouterMgr.getVpcRouters(vpn.getVpcId());
         if (routers == null) {
-            s_logger.debug("Cannot apply vpn users on the backend; virtual router doesn't exist in the network " + vpn.getVpcId());
+            logger.debug("Cannot apply vpn users on the backend; virtual router doesn't exist in the network " + vpn.getVpcId());
             return false;
         }
 
@@ -685,7 +683,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final List<DomainRouterVO> routers = _vpcRouterMgr.getVpcRouters(vpn.getVpcId());
         if (routers == null) {
-            s_logger.debug("Cannot apply vpn users on the backend; virtual router doesn't exist in the network " + vpn.getVpcId());
+            logger.debug("Cannot apply vpn users on the backend; virtual router doesn't exist in the network " + vpn.getVpcId());
             return false;
         }
 

--- a/server/src/com/cloud/network/guru/ControlNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/ControlNetworkGuru.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.dc.DataCenter;
@@ -55,7 +54,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = {NetworkGuru.class})
 public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(ControlNetworkGuru.class);
     @Inject
     DataCenterDao _dcDao;
     @Inject
@@ -86,7 +84,7 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
         if (offering.isSystemOnly() && isMyTrafficType(offering.getTrafficType())) {
             return true;
         } else {
-            s_logger.trace("We only care about System only Control network");
+            logger.trace("We only care about System only Control network");
             return false;
         }
     }
@@ -178,14 +176,14 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
             DataCenterVO dcVo = _dcDao.findById(dcId);
             if (dcVo.getNetworkType() != NetworkType.Basic) {
                 super.release(nic, vm, reservationId);
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Released nic: " + nic);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Released nic: " + nic);
                 }
                 return true;
             } else {
                 nic.deallocate();
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Released nic: " + nic);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Released nic: " + nic);
                 }
                 return true;
             }
@@ -194,8 +192,8 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
         _dcDao.releaseLinkLocalIpAddress(nic.getId(), reservationId);
 
         nic.deallocate();
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Released nic: " + nic);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Released nic: " + nic);
         }
 
         return true;
@@ -233,7 +231,7 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
             _gateway = NetUtils.getLinkLocalGateway();
         }
 
-        s_logger.info("Control network setup: cidr=" + _cidr + "; gateway = " + _gateway);
+        logger.info("Control network setup: cidr=" + _cidr + "; gateway = " + _gateway);
 
         return true;
     }

--- a/server/src/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/DirectNetworkGuru.java
@@ -22,7 +22,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenter.NetworkType;
@@ -74,7 +73,6 @@ import com.cloud.vm.dao.NicSecondaryIpDao;
 
 @Local(value = {NetworkGuru.class})
 public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(DirectNetworkGuru.class);
 
     @Inject
     DataCenterDao _dcDao;
@@ -121,7 +119,7 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
         if (dc.getNetworkType() == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && offering.getGuestType() == GuestType.Shared) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type " + GuestType.Shared);
+            logger.trace("We only take care of Guest networks of type " + GuestType.Shared);
             return false;
         }
     }
@@ -253,7 +251,7 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
                         if (vm.getType() == VirtualMachine.Type.DomainRouter) {
                             Nic placeholderNic = _networkModel.getPlaceholderNicForRouter(network, null);
                             if (placeholderNic == null) {
-                                s_logger.debug("Saving placeholder nic with ip4 address " + nic.getIPv4Address() + " and ipv6 address " + nic.getIPv6Address() +
+                                logger.debug("Saving placeholder nic with ip4 address " + nic.getIPv4Address() + " and ipv6 address " + nic.getIPv6Address() +
                                         " for the network " + network);
                                 _networkMgr.savePlaceholderNic(network, nic.getIPv4Address(), nic.getIPv6Address(), VirtualMachine.Type.DomainRouter);
                             }
@@ -282,8 +280,8 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
     @Override
     @DB
     public void deallocate(final Network network, final NicProfile nic, VirtualMachineProfile vm) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
         }
 
         if (nic.getIPv4Address() != null) {
@@ -295,14 +293,14 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
                         // if the ip address a part of placeholder, don't release it
                         Nic placeholderNic = _networkModel.getPlaceholderNicForRouter(network, null);
                         if (placeholderNic != null && placeholderNic.getIPv4Address().equalsIgnoreCase(ip.getAddress().addr())) {
-                            s_logger.debug("Not releasing direct ip " + ip.getId() + " yet as its ip is saved in the placeholder");
+                            logger.debug("Not releasing direct ip " + ip.getId() + " yet as its ip is saved in the placeholder");
                         } else {
                             _ipAddrMgr.markIpAsUnavailable(ip.getId());
                             _ipAddressDao.unassignIpAddress(ip.getId());
                         }
 
                         //unassign nic secondary ip address
-                        s_logger.debug("remove nic " + nic.getId() + " secondary ip ");
+                        logger.debug("remove nic " + nic.getId() + " secondary ip ");
                         List<String> nicSecIps = null;
                         nicSecIps = _nicSecondaryIpDao.getSecondaryIpAddressesForNic(nic.getId());
                         for (String secIp : nicSecIps) {
@@ -338,12 +336,12 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
                     public void doInTransactionWithoutResult(TransactionStatus status) {
                         for (Nic nic : nics) {
                             if (nic.getIPv4Address() != null) {
-                                s_logger.debug("Releasing ip " + nic.getIPv4Address() + " of placeholder nic " + nic);
+                                logger.debug("Releasing ip " + nic.getIPv4Address() + " of placeholder nic " + nic);
                                 IPAddressVO ip = _ipAddressDao.findByIpAndSourceNetworkId(nic.getNetworkId(), nic.getIPv4Address());
                                 if (ip != null) {
                                     _ipAddrMgr.markIpAsUnavailable(ip.getId());
                                     _ipAddressDao.unassignIpAddress(ip.getId());
-                                    s_logger.debug("Removing placeholder nic " + nic);
+                                    logger.debug("Removing placeholder nic " + nic);
                                     _nicDao.remove(nic.getId());
                                 }
                             }
@@ -353,7 +351,7 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
             }
             return true;
         }catch (Exception e) {
-            s_logger.error("trash. Exception:" + e.getMessage());
+            logger.error("trash. Exception:" + e.getMessage());
             throw new CloudRuntimeException("trash. Exception:" + e.getMessage(),e);
         }
     }

--- a/server/src/com/cloud/network/guru/DirectPodBasedNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/DirectPodBasedNetworkGuru.java
@@ -22,7 +22,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.ZoneConfig;
 import com.cloud.dc.DataCenter;
@@ -64,7 +63,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = NetworkGuru.class)
 public class DirectPodBasedNetworkGuru extends DirectNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(DirectPodBasedNetworkGuru.class);
 
     @Inject
     DataCenterDao _dcDao;
@@ -87,7 +85,7 @@ public class DirectPodBasedNetworkGuru extends DirectNetworkGuru {
         if (dc.getNetworkType() == NetworkType.Basic && isMyTrafficType(offering.getTrafficType())) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest Direct Pod based networks");
+            logger.trace("We only take care of Guest Direct Pod based networks");
             return false;
         }
     }
@@ -184,7 +182,7 @@ public class DirectPodBasedNetworkGuru extends DirectNetworkGuru {
                         if (placeholderNic != null) {
                             IPAddressVO userIp = _ipAddressDao.findByIpAndSourceNetworkId(network.getId(), placeholderNic.getIPv4Address());
                             ip = PublicIp.createFromAddrAndVlan(userIp, _vlanDao.findById(userIp.getVlanId()));
-                            s_logger.debug("Nic got an ip address " + placeholderNic.getIPv4Address() + " stored in placeholder nic for the network " + network +
+                            logger.debug("Nic got an ip address " + placeholderNic.getIPv4Address() + " stored in placeholder nic for the network " + network +
                                 " and gateway " + podRangeGateway);
                         }
                     }
@@ -209,7 +207,7 @@ public class DirectPodBasedNetworkGuru extends DirectNetworkGuru {
                     if (vm.getType() == VirtualMachine.Type.DomainRouter) {
                         Nic placeholderNic = _networkModel.getPlaceholderNicForRouter(network, pod.getId());
                         if (placeholderNic == null) {
-                            s_logger.debug("Saving placeholder nic with ip4 address " + nic.getIPv4Address() + " for the network " + network);
+                            logger.debug("Saving placeholder nic with ip4 address " + nic.getIPv4Address() + " for the network " + network);
                             _networkMgr.savePlaceholderNic(network, nic.getIPv4Address(), null, VirtualMachine.Type.DomainRouter);
                         }
                     }

--- a/server/src/com/cloud/network/guru/ExternalGuestNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/ExternalGuestNetworkGuru.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenter.NetworkType;
@@ -67,7 +66,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = NetworkGuru.class)
 public class ExternalGuestNetworkGuru extends GuestNetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(ExternalGuestNetworkGuru.class);
     @Inject
     NetworkOrchestrationService _networkMgr;
     @Inject
@@ -98,7 +96,7 @@ public class ExternalGuestNetworkGuru extends GuestNetworkGuru {
             isMyIsolationMethod(physicalNetwork) && !offering.isSystemOnly()) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }

--- a/server/src/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/GuestNetworkGuru.java
@@ -28,7 +28,6 @@ import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationSe
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.dc.DataCenter;
@@ -84,7 +83,6 @@ import com.cloud.vm.dao.NicDao;
 
 @Local(value = NetworkGuru.class)
 public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGuru, Configurable {
-    private static final Logger s_logger = Logger.getLogger(GuestNetworkGuru.class);
 
     @Inject
     protected VpcDao _vpcDao;
@@ -161,7 +159,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
         }
         if (methods.isEmpty()) {
             // The empty isolation method is assumed to be VLAN
-            s_logger.debug("Empty physical isolation type for physical network " + physicalNetwork.getUuid());
+            logger.debug("Empty physical isolation type for physical network " + physicalNetwork.getUuid());
             methods = new ArrayList<String>(1);
             methods.add("VLAN".toLowerCase());
         }
@@ -233,8 +231,8 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
     @DB
     public void deallocate(final Network network, final NicProfile nic, final VirtualMachineProfile vm) {
         if (network.getSpecifyIpRanges()) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
             }
 
             final IPAddressVO ip = _ipAddressDao.findByIpAndSourceNetworkId(nic.getNetworkId(), nic.getIPv4Address());
@@ -430,7 +428,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
         }
 
         if ((profile.getBroadcastDomainType() == BroadcastDomainType.Vlan || profile.getBroadcastDomainType() == BroadcastDomainType.Vxlan) && !offering.getSpecifyVlan()) {
-            s_logger.debug("Releasing vnet for the network id=" + profile.getId());
+            logger.debug("Releasing vnet for the network id=" + profile.getId());
             _dcDao.releaseVnet(BroadcastDomainType.getValue(profile.getBroadcastUri()), profile.getDataCenterId(), profile.getPhysicalNetworkId(), profile.getAccountId(),
                     profile.getReservationId());
             ActionEventUtils.onCompletedActionEvent(CallContext.current().getCallingUserId(), profile.getAccountId(), EventVO.LEVEL_INFO, EventTypes.EVENT_ZONE_VLAN_RELEASE,

--- a/server/src/com/cloud/network/guru/PodBasedNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/PodBasedNetworkGuru.java
@@ -21,7 +21,6 @@ import java.util.Random;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.Pod;
 import com.cloud.dc.dao.DataCenterDao;
@@ -50,7 +49,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = {NetworkGuru.class})
 public class PodBasedNetworkGuru extends AdapterBase implements NetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(PodBasedNetworkGuru.class);
     @Inject
     DataCenterDao _dcDao;
     @Inject
@@ -134,7 +132,7 @@ public class PodBasedNetworkGuru extends AdapterBase implements NetworkGuru {
         nic.setBroadcastUri(null);
         nic.setIsolationUri(null);
 
-        s_logger.debug("Allocated a nic " + nic + " for " + vm);
+        logger.debug("Allocated a nic " + nic + " for " + vm);
     }
 
     @Override
@@ -151,8 +149,8 @@ public class PodBasedNetworkGuru extends AdapterBase implements NetworkGuru {
 
         nic.deallocate();
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Released nic: " + nic);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Released nic: " + nic);
         }
 
         return true;

--- a/server/src/com/cloud/network/guru/PrivateNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/PrivateNetworkGuru.java
@@ -19,7 +19,6 @@ package com.cloud.network.guru;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.ConfigurationManager;
 import com.cloud.dc.DataCenter;
@@ -56,7 +55,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = NetworkGuru.class)
 public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(PrivateNetworkGuru.class);
     @Inject
     protected ConfigurationManager _configMgr;
     @Inject
@@ -93,7 +91,7 @@ public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
             offering.isSystemOnly()) {
             return true;
         } else {
-            s_logger.trace("We only take care of system Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            logger.trace("We only take care of system Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }
@@ -140,8 +138,8 @@ public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
 
     @Override
     public void deallocate(Network network, NicProfile nic, VirtualMachineProfile vm) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
         }
 
         PrivateIpVO ip = _privateIpDao.findByIpAndSourceNetworkId(nic.getNetworkId(), nic.getIPv4Address());

--- a/server/src/com/cloud/network/guru/PublicNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/PublicNetworkGuru.java
@@ -20,7 +20,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.Vlan.VlanType;
@@ -60,7 +59,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = {NetworkGuru.class})
 public class PublicNetworkGuru extends AdapterBase implements NetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(PublicNetworkGuru.class);
 
     @Inject
     DataCenterDao _dcDao;
@@ -197,8 +195,8 @@ public class PublicNetworkGuru extends AdapterBase implements NetworkGuru {
     @Override
     @DB
     public void deallocate(Network network, NicProfile nic, VirtualMachineProfile vm) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("public network deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
+        if (logger.isDebugEnabled()) {
+            logger.debug("public network deallocate network: networkId: " + nic.getNetworkId() + ", ip: " + nic.getIPv4Address());
         }
 
         final IPAddressVO ip = _ipAddressDao.findByIpAndSourceNetworkId(nic.getNetworkId(), nic.getIPv4Address());
@@ -213,8 +211,8 @@ public class PublicNetworkGuru extends AdapterBase implements NetworkGuru {
         }
         nic.deallocate();
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deallocated nic: " + nic);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deallocated nic: " + nic);
         }
     }
 

--- a/server/src/com/cloud/network/guru/StorageNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/StorageNetworkGuru.java
@@ -19,7 +19,6 @@ package com.cloud.network.guru;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.dc.Pod;
 import com.cloud.dc.StorageNetworkIpAddressVO;
@@ -46,7 +45,6 @@ import com.cloud.vm.VirtualMachineProfile;
 
 @Local(value = NetworkGuru.class)
 public class StorageNetworkGuru extends PodBasedNetworkGuru implements NetworkGuru {
-    private static final Logger s_logger = Logger.getLogger(StorageNetworkGuru.class);
     @Inject
     StorageNetworkManager _sNwMgr;
     @Inject
@@ -77,7 +75,7 @@ public class StorageNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
         if (isMyTrafficType(offering.getTrafficType()) && offering.isSystemOnly()) {
             return true;
         } else {
-            s_logger.trace("It's not storage network offering, skip it.");
+            logger.trace("It's not storage network offering, skip it.");
             return false;
         }
     }
@@ -144,7 +142,7 @@ public class StorageNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
             nic.setBroadcastUri(null);
         }
         nic.setIsolationUri(null);
-        s_logger.debug("Allocated a storage nic " + nic + " for " + vm);
+        logger.debug("Allocated a storage nic " + nic + " for " + vm);
     }
 
     @Override
@@ -155,7 +153,7 @@ public class StorageNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
         }
 
         _sNwMgr.releaseIpAddress(nic.getIPv4Address());
-        s_logger.debug("Release an storage ip " + nic.getIPv4Address());
+        logger.debug("Release an storage ip " + nic.getIPv4Address());
         nic.deallocate();
         return true;
     }

--- a/server/src/com/cloud/network/lb/LBHealthCheckManagerImpl.java
+++ b/server/src/com/cloud/network/lb/LBHealthCheckManagerImpl.java
@@ -27,7 +27,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -44,7 +43,6 @@ import com.cloud.utils.concurrency.NamedThreadFactory;
 @Component
 @Local(value = {LBHealthCheckManager.class})
 public class LBHealthCheckManagerImpl extends ManagerBase implements LBHealthCheckManager, Manager {
-    private static final Logger s_logger = Logger.getLogger(LBHealthCheckManagerImpl.class);
 
     @Inject
     ConfigurationDao _configDao;
@@ -60,8 +58,8 @@ public class LBHealthCheckManagerImpl extends ManagerBase implements LBHealthChe
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
         _configs = _configDao.getConfiguration("management-server", params);
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info(format("Configuring LBHealthCheck Manager %1$s", name));
+        if (logger.isInfoEnabled()) {
+            logger.info(format("Configuring LBHealthCheck Manager %1$s", name));
         }
         this.name = name;
         _interval = NumbersUtil.parseLong(_configs.get(Config.LBHealthCheck.key()), 600);
@@ -71,14 +69,14 @@ public class LBHealthCheckManagerImpl extends ManagerBase implements LBHealthChe
 
     @Override
     public boolean start() {
-        s_logger.debug("LB HealthCheckmanager is getting Started");
+        logger.debug("LB HealthCheckmanager is getting Started");
         _executor.scheduleAtFixedRate(new UpdateLBHealthCheck(), 10, _interval, TimeUnit.SECONDS);
         return true;
     }
 
     @Override
     public boolean stop() {
-        s_logger.debug("HealthCheckmanager is getting Stopped");
+        logger.debug("HealthCheckmanager is getting Stopped");
         _executor.shutdown();
         return true;
     }
@@ -95,7 +93,7 @@ public class LBHealthCheckManagerImpl extends ManagerBase implements LBHealthChe
                 updateLBHealthCheck(Scheme.Public);
                 updateLBHealthCheck(Scheme.Internal);
             } catch (Exception e) {
-                s_logger.error("Exception in LB HealthCheck Update Checker", e);
+                logger.error("Exception in LB HealthCheck Update Checker", e);
             }
         }
     }
@@ -105,9 +103,9 @@ public class LBHealthCheckManagerImpl extends ManagerBase implements LBHealthChe
         try {
             _lbService.updateLBHealthChecks(scheme);
         } catch (ResourceUnavailableException e) {
-            s_logger.debug("Error while updating the LB HealtCheck ", e);
+            logger.debug("Error while updating the LB HealtCheck ", e);
         }
-        s_logger.debug("LB HealthCheck Manager is running and getting the updates from LB providers and updating service status");
+        logger.debug("LB HealthCheck Manager is running and getting the updates from LB providers and updating service status");
     }
 
 }

--- a/server/src/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -45,7 +45,6 @@ import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationSe
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.lb.ApplicationLoadBalancerRuleVO;
 import org.apache.cloudstack.lb.dao.ApplicationLoadBalancerRuleDao;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.to.LoadBalancerTO;
 import com.cloud.configuration.ConfigurationManager;
@@ -170,7 +169,6 @@ import com.google.gson.reflect.TypeToken;
 
 @Local(value = {LoadBalancingRulesManager.class, LoadBalancingRulesService.class})
 public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements LoadBalancingRulesManager, LoadBalancingRulesService {
-    private static final Logger s_logger = Logger.getLogger(LoadBalancingRulesManagerImpl.class);
 
     @Inject
     NetworkOrchestrationService _networkMgr;
@@ -318,7 +316,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         DataCenter zone = _entityMgr.findById(DataCenter.class, vmGroup.getZoneId());
         if (zone == null) {
             // This should never happen, but still a cautious check
-            s_logger.warn("Unable to find zone while packaging AutoScale Vm Group, zoneid: " + vmGroup.getZoneId());
+            logger.warn("Unable to find zone while packaging AutoScale Vm Group, zoneid: " + vmGroup.getZoneId());
             throw new InvalidParameterValueException("Unable to find zone");
         } else {
             if (zone.getNetworkType() == NetworkType.Advanced) {
@@ -364,7 +362,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         List<LoadBalancingRule> rules = Arrays.asList(rule);
 
         if (!applyLbRules(rules, false)) {
-            s_logger.debug("LB rules' autoscale config are not completely applied");
+            logger.debug("LB rules' autoscale config are not completely applied");
             return false;
         }
 
@@ -403,16 +401,16 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         try {
             success = applyAutoScaleConfig(loadBalancer, vmGroup, currentState);
         } catch (ResourceUnavailableException e) {
-            s_logger.warn("Unable to configure AutoScaleVmGroup to the lb rule: " + loadBalancer.getId() + " because resource is unavaliable:", e);
+            logger.warn("Unable to configure AutoScaleVmGroup to the lb rule: " + loadBalancer.getId() + " because resource is unavaliable:", e);
             if (isRollBackAllowedForProvider(loadBalancer)) {
                 loadBalancer.setState(backupState);
                 _lbDao.persist(loadBalancer);
-                s_logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " lb state rolback while creating AutoscaleVmGroup");
+                logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " lb state rolback while creating AutoscaleVmGroup");
             }
             throw e;
         } finally {
             if (!success) {
-                s_logger.warn("Failed to configure LB Auto Scale Vm Group with Id:" + vmGroupid);
+                logger.warn("Failed to configure LB Auto Scale Vm Group with Id:" + vmGroupid);
             }
         }
 
@@ -422,15 +420,15 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     @Override
                     public void doInTransactionWithoutResult(TransactionStatus status) {
                         loadBalancer.setState(FirewallRule.State.Active);
-                        s_logger.debug("LB rule " + loadBalancer.getId() + " state is set to Active");
+                        logger.debug("LB rule " + loadBalancer.getId() + " state is set to Active");
                         _lbDao.persist(loadBalancer);
                         vmGroup.setState(AutoScaleVmGroup.State_Enabled);
                         _autoScaleVmGroupDao.persist(vmGroup);
-                        s_logger.debug("LB Auto Scale Vm Group with Id: " + vmGroupid + " is set to Enabled state.");
+                        logger.debug("LB Auto Scale Vm Group with Id: " + vmGroupid + " is set to Enabled state.");
                     }
                 });
             }
-            s_logger.info("Successfully configured LB Autoscale Vm Group with Id: " + vmGroupid);
+            logger.info("Successfully configured LB Autoscale Vm Group with Id: " + vmGroupid);
         }
         return success;
     }
@@ -637,7 +635,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         Network network = _networkDao.findById(lbRule.getNetworkId());
         Purpose purpose = lbRule.getPurpose();
         if (purpose != Purpose.LoadBalancing) {
-            s_logger.debug("Unable to validate network rules for purpose: " + purpose.toString());
+            logger.debug("Unable to validate network rules for purpose: " + purpose.toString());
             return false;
         }
         for (LoadBalancingServiceProvider ne : _lbProviders) {
@@ -675,12 +673,12 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         try {
             applyLoadBalancerConfig(cmd.getLbRuleId());
         } catch (ResourceUnavailableException e) {
-            s_logger.warn("Unable to apply Stickiness policy to the lb rule: " + cmd.getLbRuleId() + " because resource is unavaliable:", e);
+            logger.warn("Unable to apply Stickiness policy to the lb rule: " + cmd.getLbRuleId() + " because resource is unavaliable:", e);
             if (isRollBackAllowedForProvider(loadBalancer)) {
                 loadBalancer.setState(backupState);
                 _lbDao.persist(loadBalancer);
                 deleteLBStickinessPolicy(cmd.getEntityId(), false);
-                s_logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " lb state rolback while creating sticky policy");
+                logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " lb state rolback while creating sticky policy");
             } else {
                 deleteLBStickinessPolicy(cmd.getEntityId(), false);
                 if (oldStickinessPolicyId != 0) {
@@ -691,7 +689,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         if (backupState.equals(FirewallRule.State.Active))
                             applyLoadBalancerConfig(cmd.getLbRuleId());
                     } catch (ResourceUnavailableException e1) {
-                        s_logger.info("[ignored] applying load balancer config.", e1);
+                        logger.info("[ignored] applying load balancer config.", e1);
                     } finally {
                         loadBalancer.setState(backupState);
                         _lbDao.persist(loadBalancer);
@@ -720,11 +718,11 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         try {
             applyLoadBalancerConfig(cmd.getLbRuleId());
         } catch (ResourceUnavailableException e) {
-            s_logger.warn("Unable to apply healthcheck policy to the lb rule: " + cmd.getLbRuleId() + " because resource is unavaliable:", e);
+            logger.warn("Unable to apply healthcheck policy to the lb rule: " + cmd.getLbRuleId() + " because resource is unavaliable:", e);
             if (isRollBackAllowedForProvider(loadBalancer)) {
                 loadBalancer.setState(backupState);
                 _lbDao.persist(loadBalancer);
-                s_logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " lb state rolback while creating healthcheck policy");
+                logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " lb state rolback while creating healthcheck policy");
             }
             deleteLBHealthCheckPolicy(cmd.getEntityId(), false);
             success = false;
@@ -760,11 +758,11 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
             boolean backupStickyState = stickinessPolicy.isRevoke();
             stickinessPolicy.setRevoke(true);
             _lb2stickinesspoliciesDao.persist(stickinessPolicy);
-            s_logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", stickinesspolicyID " + stickinessPolicyId);
+            logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", stickinesspolicyID " + stickinessPolicyId);
 
             try {
                 if (!applyLoadBalancerConfig(loadBalancerId)) {
-                    s_logger.warn("Failed to remove load balancer rule id " + loadBalancerId + " for stickinesspolicyID " + stickinessPolicyId);
+                    logger.warn("Failed to remove load balancer rule id " + loadBalancerId + " for stickinesspolicyID " + stickinessPolicyId);
                     throw new CloudRuntimeException("Failed to remove load balancer rule id " + loadBalancerId + " for stickinesspolicyID " + stickinessPolicyId);
                 }
             } catch (ResourceUnavailableException e) {
@@ -773,9 +771,9 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     _lb2stickinesspoliciesDao.persist(stickinessPolicy);
                     loadBalancer.setState(backupState);
                     _lbDao.persist(loadBalancer);
-                    s_logger.debug("LB Rollback rule id: " + loadBalancer.getId() + "  while deleting sticky policy: " + stickinessPolicyId);
+                    logger.debug("LB Rollback rule id: " + loadBalancer.getId() + "  while deleting sticky policy: " + stickinessPolicyId);
                 }
-                s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+                logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
                 success = false;
             }
         } else {
@@ -813,7 +811,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
             boolean backupStickyState = healthCheckPolicy.isRevoke();
             healthCheckPolicy.setRevoke(true);
             _lb2healthcheckDao.persist(healthCheckPolicy);
-            s_logger.debug("Set health check policy to revoke for loadbalancing rule id : " + loadBalancerId + ", healthCheckpolicyID " + healthCheckPolicyId);
+            logger.debug("Set health check policy to revoke for loadbalancing rule id : " + loadBalancerId + ", healthCheckpolicyID " + healthCheckPolicyId);
 
             // removing the state of services set by the monitor.
             final List<LoadBalancerVMMapVO> maps = _lb2VmMapDao.listByLoadBalancerId(loadBalancerId);
@@ -821,7 +819,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 Transaction.execute(new TransactionCallbackNoReturn() {
                     @Override
                     public void doInTransactionWithoutResult(TransactionStatus status) {
-                        s_logger.debug("Resetting health state policy for services in loadbalancing rule id : " + loadBalancerId);
+                        logger.debug("Resetting health state policy for services in loadbalancing rule id : " + loadBalancerId);
                         for (LoadBalancerVMMapVO map : maps) {
                             map.setState(null);
                             _lb2VmMapDao.persist(map);
@@ -832,7 +830,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
             try {
                 if (!applyLoadBalancerConfig(loadBalancerId)) {
-                    s_logger.warn("Failed to remove load balancer rule id " + loadBalancerId + " for healthCheckpolicyID " + healthCheckPolicyId);
+                    logger.warn("Failed to remove load balancer rule id " + loadBalancerId + " for healthCheckpolicyID " + healthCheckPolicyId);
                     throw new CloudRuntimeException("Failed to remove load balancer rule id " + loadBalancerId + " for healthCheckpolicyID " + healthCheckPolicyId);
                 }
             } catch (ResourceUnavailableException e) {
@@ -841,9 +839,9 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     _lb2healthcheckDao.persist(healthCheckPolicy);
                     loadBalancer.setState(backupState);
                     _lbDao.persist(loadBalancer);
-                    s_logger.debug("LB Rollback rule id: " + loadBalancer.getId() + "  while deleting healthcheck policy: " + healthCheckPolicyId);
+                    logger.debug("LB Rollback rule id: " + loadBalancer.getId() + "  while deleting healthcheck policy: " + healthCheckPolicyId);
                 }
-                s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+                logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
                 success = false;
             }
         } else {
@@ -867,7 +865,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
             if (capability != null && capability.equalsIgnoreCase("true")) {
                 /*
-                 * s_logger.debug(
+                 * logger.debug(
                  * "HealthCheck Manager :: LB Provider in the Network has the Healthcheck policy capability :: "
                  * + provider.get(0).getName());
                  */
@@ -903,7 +901,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                                             if (dstIp.equalsIgnoreCase(lbto.getDestinations()[i].getDestIp())) {
                                                 lbVmMap.setState(des.getMonitorState());
                                                 _lb2VmMapDao.persist(lbVmMap);
-                                                s_logger.debug("Updating the LB VM Map table with the service state");
+                                                logger.debug("Updating the LB VM Map table with the service state");
                                             }
                                         }
                                     }
@@ -917,7 +915,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     }
                 }
             } else {
-                // s_logger.debug("HealthCheck Manager :: LB Provider in the Network DNOT the Healthcheck policy capability ");
+                // logger.debug("HealthCheck Manager :: LB Provider in the Network DNOT the Healthcheck policy capability ");
             }
         }
     }
@@ -1079,8 +1077,8 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
             vmIdIpMap.put(instanceId, vmIpsList);
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Adding " + vm + " to the load balancer pool");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Adding " + vm + " to the load balancer pool");
             }
             vmsToAdd.add(vm);
         }
@@ -1116,7 +1114,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
             applyLoadBalancerConfig(loadBalancerId);
             success = true;
         } catch (ResourceUnavailableException e) {
-            s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+            logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
             success = false;
         } finally {
             if (!success) {
@@ -1131,7 +1129,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 });
                 if (!vmInstanceIds.isEmpty()) {
                     _lb2VmMapDao.remove(loadBalancer.getId(), vmInstanceIds, null);
-                    s_logger.debug("LB Rollback rule id: " + loadBalancer.getId() + "  while attaching VM: " + vmInstanceIds);
+                    logger.debug("LB Rollback rule id: " + loadBalancer.getId() + "  while attaching VM: " + vmInstanceIds);
                 }
                 loadBalancer.setState(backupState);
                 _lbDao.persist(loadBalancer);
@@ -1150,7 +1148,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
     @Override
     public boolean assignSSLCertToLoadBalancerRule(Long lbId, String certName, String publicCert, String privateKey) {
-        s_logger.error("Calling the manager for LB");
+        logger.error("Calling the manager for LB");
         LoadBalancerVO loadBalancer = _lbDao.findById(lbId);
 
         return false;  //TODO
@@ -1171,7 +1169,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
         SslCertVO certVO = _entityMgr.findById(SslCertVO.class, lbCertMap.getCertId());
         if (certVO == null) {
-            s_logger.warn("Cert rule with cert ID " + lbCertMap.getCertId() + " but Cert is not found");
+            logger.warn("Cert rule with cert ID " + lbCertMap.getCertId() + " but Cert is not found");
             return null;
         }
 
@@ -1233,9 +1231,9 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 _lbDao.persist(loadBalancer);
                 LoadBalancerCertMapVO certMap = _lbCertMapDao.findByLbRuleId(lbRuleId);
                 _lbCertMapDao.remove(certMap.getId());
-                s_logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " while adding cert");
+                logger.debug("LB Rollback rule id: " + loadBalancer.getId() + " while adding cert");
             }
-            s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+            logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
         }
         return success;
     }
@@ -1269,7 +1267,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
             _lbCertMapDao.persist(lbCertMap);
 
             if (!applyLoadBalancerConfig(lbRuleId)) {
-                s_logger.warn("Failed to remove cert from load balancer rule id " + lbRuleId);
+                logger.warn("Failed to remove cert from load balancer rule id " + lbRuleId);
                 CloudRuntimeException ex = new CloudRuntimeException("Failed to remove certificate load balancer rule id " + lbRuleId);
                 ex.addProxyObject(loadBalancer.getUuid(), "loadBalancerId");
                 throw ex;
@@ -1281,9 +1279,9 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 _lbCertMapDao.persist(lbCertMap);
                 loadBalancer.setState(backupState);
                 _lbDao.persist(loadBalancer);
-                s_logger.debug("Rolled back certificate removal lb id " + lbRuleId);
+                logger.debug("Rolled back certificate removal lb id " + lbRuleId);
             }
-            s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+            logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
             if (!success) {
                 CloudRuntimeException ex = new CloudRuntimeException("Failed to remove certificate from load balancer rule id " + lbRuleId);
                 ex.addProxyObject(loadBalancer.getUuid(), "loadBalancerId");
@@ -1347,7 +1345,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         lbvm.setRevoke(true);
                         _lb2VmMapDao.persist(lbvm);
                     }
-                    s_logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", vmId " + instanceId);
+                    logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", vmId " + instanceId);
 
                 } else {
                     for (String vmIp: lbVmIps) {
@@ -1358,7 +1356,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         }
                         map.setRevoke(true);
                         _lb2VmMapDao.persist(map);
-                        s_logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", vmId " +
+                        logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", vmId " +
                                 instanceId + ", vmip " + vmIp);
                     }
                 }
@@ -1374,7 +1372,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
             }
 
             if (!applyLoadBalancerConfig(loadBalancerId)) {
-                s_logger.warn("Failed to remove load balancer rule id " + loadBalancerId + " for vms " + instanceIds);
+                logger.warn("Failed to remove load balancer rule id " + loadBalancerId + " for vms " + instanceIds);
                 CloudRuntimeException ex = new CloudRuntimeException("Failed to remove specified load balancer rule id for vms " + instanceIds);
                 ex.addProxyObject(loadBalancer.getUuid(), "loadBalancerId");
                 throw ex;
@@ -1390,13 +1388,13 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         LoadBalancerVMMapVO map = _lb2VmMapDao.findByLoadBalancerIdAndVmId(loadBalancerId, instanceId);
                         map.setRevoke(false);
                         _lb2VmMapDao.persist(map);
-                        s_logger.debug("LB Rollback rule id: " + loadBalancerId + ",while removing vmId " + instanceId);
+                        logger.debug("LB Rollback rule id: " + loadBalancerId + ",while removing vmId " + instanceId);
                     }else {
                         for (String vmIp: lbVmIps) {
                             LoadBalancerVMMapVO map = _lb2VmMapDao.findByLoadBalancerIdAndVmIdVmIp (loadBalancerId, instanceId, vmIp);
                             map.setRevoke(true);
                             _lb2VmMapDao.persist(map);
-                            s_logger.debug("LB Rollback rule id: " + loadBalancerId + ",while removing vmId " +
+                            logger.debug("LB Rollback rule id: " + loadBalancerId + ",while removing vmId " +
                                     instanceId + ", vmip " + vmIp);
                         }
                     }
@@ -1404,9 +1402,9 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
                 loadBalancer.setState(backupState);
                 _lbDao.persist(loadBalancer);
-                s_logger.debug("LB Rollback rule id: " + loadBalancerId + " while removing vm instances");
+                logger.debug("LB Rollback rule id: " + loadBalancerId + " while removing vm instances");
             }
-            s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+            logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
         }
         if (!success) {
             CloudRuntimeException ex = new CloudRuntimeException("Failed to remove specified load balancer rule id for vms " + vmIds);
@@ -1438,7 +1436,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
             map.setRevoke(true);
             _lb2VmMapDao.persist(map);
-            s_logger.debug("Set load balancer rule for revoke: rule id " + map.getLoadBalancerId() + ", vmId " + instanceId);
+            logger.debug("Set load balancer rule for revoke: rule id " + map.getLoadBalancerId() + ", vmId " + instanceId);
         }
 
         // Reapply all lbs that had the vm assigned
@@ -1492,8 +1490,8 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 boolean generateUsageEvent = false;
 
                 if (lb.getState() == FirewallRule.State.Staged) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Found a rule that is still in stage state so just removing it: " + lb);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Found a rule that is still in stage state so just removing it: " + lb);
                     }
                     generateUsageEvent = true;
                 } else if (lb.getState() == FirewallRule.State.Add || lb.getState() == FirewallRule.State.Active) {
@@ -1507,7 +1505,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     for (LoadBalancerVMMapVO map : maps) {
                         map.setRevoke(true);
                         _lb2VmMapDao.persist(map);
-                        s_logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", vmId " + map.getInstanceId());
+                        logger.debug("Set load balancer rule for revoke: rule id " + loadBalancerId + ", vmId " + map.getInstanceId());
                     }
                 }
 
@@ -1539,7 +1537,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         if (apply) {
             try {
                 if (!applyLoadBalancerConfig(loadBalancerId)) {
-                    s_logger.warn("Unable to apply the load balancer config");
+                    logger.warn("Unable to apply the load balancer config");
                     return false;
                 }
             } catch (ResourceUnavailableException e) {
@@ -1547,14 +1545,14 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     if (backupMaps != null) {
                         for (LoadBalancerVMMapVO map : backupMaps) {
                             _lb2VmMapDao.persist(map);
-                            s_logger.debug("LB Rollback rule id: " + loadBalancerId + ", vmId " + map.getInstanceId());
+                            logger.debug("LB Rollback rule id: " + loadBalancerId + ", vmId " + map.getInstanceId());
                         }
                     }
                     lb.setState(backupState);
                     _lbDao.persist(lb);
-                    s_logger.debug("LB Rollback rule id: " + loadBalancerId + " while deleting LB rule.");
+                    logger.debug("LB Rollback rule id: " + loadBalancerId + " while deleting LB rule.");
                 } else {
-                    s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+                    logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
                 }
                 return false;
             }
@@ -1562,7 +1560,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
         FirewallRuleVO relatedRule = _firewallDao.findByRelatedId(lb.getId());
         if (relatedRule != null) {
-            s_logger.warn("Unable to remove firewall rule id=" + lb.getId() + " as it has related firewall rule id=" + relatedRule.getId() +
+            logger.warn("Unable to remove firewall rule id=" + lb.getId() + " as it has related firewall rule id=" + relatedRule.getId() +
                 "; leaving it in Revoke state");
             return false;
         } else {
@@ -1574,7 +1572,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         // Bug CS-15411 opened to document this
         // _elbMgr.handleDeleteLoadBalancerRule(lb, callerUserId, caller);
 
-        s_logger.debug("Load balancer with id " + lb.getId() + " is removed successfully");
+        logger.debug("Load balancer with id " + lb.getId() + " is removed successfully");
 
         return true;
     }
@@ -1628,7 +1626,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         // set networkId just for verification purposes
                         _networkModel.checkIpForService(ipVO, Service.Lb, networkId);
 
-                        s_logger.debug("The ip is not associated with the VPC network id=" + networkId + " so assigning");
+                        logger.debug("The ip is not associated with the VPC network id=" + networkId + " so assigning");
                         ipVO = _ipAddrMgr.associateIPToGuestNetwork(ipAddrId, networkId, false);
                         performedIpAssoc = true;
                     }
@@ -1643,7 +1641,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                 result = createPublicLoadBalancer(xId, name, description, srcPortStart, defPortStart, ipVO.getId(), protocol, algorithm, openFirewall, CallContext.current(),
                         lbProtocol, forDisplay);
             } catch (Exception ex) {
-                s_logger.warn("Failed to create load balancer due to ", ex);
+                logger.warn("Failed to create load balancer due to ", ex);
                 if (ex instanceof NetworkRuleConflictException) {
                     throw (NetworkRuleConflictException)ex;
                 }
@@ -1654,7 +1652,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
             } finally {
                 if (result == null && systemIp != null) {
-                    s_logger.debug("Releasing system IP address " + systemIp + " as corresponding lb rule failed to create");
+                    logger.debug("Releasing system IP address " + systemIp + " as corresponding lb rule failed to create");
                     _ipAddrMgr.handleSystemIpRelease(systemIp);
                 }
                 // release ip address if ipassoc was perfored
@@ -1765,7 +1763,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     if (!_firewallDao.setStateToAdd(newRule)) {
                         throw new CloudRuntimeException("Unable to update the state to add for " + newRule);
                     }
-                    s_logger.debug("Load balancer " + newRule.getId() + " for Ip address id=" + sourceIpId + ", public port " + srcPort + ", private port " + destPort +
+                    logger.debug("Load balancer " + newRule.getId() + " for Ip address id=" + sourceIpId + ", public port " + srcPort + ", private port " + destPort +
                         " is added successfully.");
                     CallContext.current().setEventDetails("Load balancer Id: " + newRule.getId());
                     UsageEventUtils.publishUsageEvent(EventTypes.EVENT_LOAD_BALANCER_CREATE, ipAddr.getAllocatedToAccountId(), ipAddr.getDataCenterId(), newRule.getId(),
@@ -1807,8 +1805,8 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
     @Override
     public boolean revokeLoadBalancersForNetwork(long networkId, Scheme scheme) throws ResourceUnavailableException {
         List<LoadBalancerVO> lbs = _lbDao.listByNetworkIdAndScheme(networkId, scheme);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Revoking " + lbs.size() + " " + scheme + " load balancing rules for network id=" + networkId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Revoking " + lbs.size() + " " + scheme + " load balancing rules for network id=" + networkId);
         }
         if (lbs != null) {
             for (LoadBalancerVO lb : lbs) { // called during restart, not persisting state in db
@@ -1816,7 +1814,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
             }
             return applyLoadBalancerRules(lbs, false); // called during restart, not persisting state in db
         } else {
-            s_logger.info("Network id=" + networkId + " doesn't have load balancer rules, nothing to revoke");
+            logger.info("Network id=" + networkId + " doesn't have load balancer rules, nothing to revoke");
             return true;
         }
     }
@@ -1825,10 +1823,10 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
     public boolean applyLoadBalancersForNetwork(long networkId, Scheme scheme) throws ResourceUnavailableException {
         List<LoadBalancerVO> lbs = _lbDao.listByNetworkIdAndScheme(networkId, scheme);
         if (lbs != null) {
-            s_logger.debug("Applying load balancer rules of scheme " + scheme + " in network id=" + networkId);
+            logger.debug("Applying load balancer rules of scheme " + scheme + " in network id=" + networkId);
             return applyLoadBalancerRules(lbs, true);
         } else {
-            s_logger.info("Network id=" + networkId + " doesn't have load balancer rules of scheme " + scheme + ", nothing to apply");
+            logger.info("Network id=" + networkId + " doesn't have load balancer rules of scheme " + scheme + ", nothing to apply");
             return true;
         }
     }
@@ -1878,7 +1876,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         }
 
         if (!applyLbRules(rules, false)) {
-            s_logger.debug("LB rules are not completely applied");
+            logger.debug("LB rules are not completely applied");
             return false;
         }
 
@@ -1891,11 +1889,11 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
                         if (lb.getState() == FirewallRule.State.Revoke) {
                             removeLBRule(lb);
-                            s_logger.debug("LB " + lb.getId() + " is successfully removed");
+                            logger.debug("LB " + lb.getId() + " is successfully removed");
                             checkForReleaseElasticIp = true;
                         } else if (lb.getState() == FirewallRule.State.Add) {
                             lb.setState(FirewallRule.State.Active);
-                            s_logger.debug("LB rule " + lb.getId() + " state is set to Active");
+                            logger.debug("LB rule " + lb.getId() + " state is set to Active");
                             _lbDao.persist(lb);
                         }
 
@@ -1906,7 +1904,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         for (LoadBalancerVMMapVO lbVmMap : lbVmMaps) {
                             instanceIds.add(lbVmMap.getInstanceId());
                             _lb2VmMapDao.remove(lb.getId(), lbVmMap.getInstanceId(), lbVmMap.getInstanceIp(), null);
-                            s_logger.debug("Load balancer rule id " + lb.getId() + " is removed for vm " +
+                            logger.debug("Load balancer rule id " + lb.getId() + " is removed for vm " +
                                     lbVmMap.getInstanceId() + " instance ip " + lbVmMap.getInstanceIp());
                         }
 
@@ -1914,14 +1912,14 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         if (_lb2VmMapDao.listByLoadBalancerId(lb.getId()).isEmpty()) {
                             lb.setState(FirewallRule.State.Add);
                             _lbDao.persist(lb);
-                            s_logger.debug("LB rule " + lb.getId() + " state is set to Add as there are no more active LB-VM mappings");
+                            logger.debug("LB rule " + lb.getId() + " state is set to Add as there are no more active LB-VM mappings");
                         }
 
                         // remove LB-Stickiness policy mapping that were state to revoke
                         List<LBStickinessPolicyVO> stickinesspolicies = _lb2stickinesspoliciesDao.listByLoadBalancerId(lb.getId(), true);
                         if (!stickinesspolicies.isEmpty()) {
                             _lb2stickinesspoliciesDao.remove(lb.getId(), true);
-                            s_logger.debug("Load balancer rule id " + lb.getId() + " is removed stickiness policies");
+                            logger.debug("Load balancer rule id " + lb.getId() + " is removed stickiness policies");
                         }
 
                         // remove LB-HealthCheck policy mapping that were state to
@@ -1929,13 +1927,13 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         List<LBHealthCheckPolicyVO> healthCheckpolicies = _lb2healthcheckDao.listByLoadBalancerId(lb.getId(), true);
                         if (!healthCheckpolicies.isEmpty()) {
                             _lb2healthcheckDao.remove(lb.getId(), true);
-                            s_logger.debug("Load balancer rule id " + lb.getId() + " is removed health check monitors policies");
+                            logger.debug("Load balancer rule id " + lb.getId() + " is removed health check monitors policies");
                         }
 
                         LoadBalancerCertMapVO lbCertMap = _lbCertMapDao.findByLbRuleId(lb.getId());
                         if (lbCertMap != null && lbCertMap.isRevoke()) {
                             _lbCertMapDao.remove(lbCertMap.getId());
-                            s_logger.debug("Load balancer rule id " + lb.getId() + " removed certificate mapping");
+                            logger.debug("Load balancer rule id " + lb.getId() + " removed certificate mapping");
                         }
 
                         return checkForReleaseElasticIp;
@@ -1949,11 +1947,11 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                         try {
                             success = handleSystemLBIpRelease(lb);
                         } catch (Exception ex) {
-                            s_logger.warn("Failed to release system ip as a part of lb rule " + lb + " deletion due to exception ", ex);
+                            logger.warn("Failed to release system ip as a part of lb rule " + lb + " deletion due to exception ", ex);
                             success = false;
                         } finally {
                             if (!success) {
-                                s_logger.warn("Failed to release system ip as a part of lb rule " + lb + " deletion");
+                                logger.warn("Failed to release system ip as a part of lb rule " + lb + " deletion");
                             }
                         }
                     }
@@ -1974,12 +1972,12 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         IpAddress ip = _ipAddressDao.findById(lb.getSourceIpAddressId());
         boolean success = true;
         if (ip.getSystem()) {
-            s_logger.debug("Releasing system ip address " + lb.getSourceIpAddressId() + " as a part of delete lb rule");
+            logger.debug("Releasing system ip address " + lb.getSourceIpAddressId() + " as a part of delete lb rule");
             if (!_ipAddrMgr.disassociatePublicIpAddress(lb.getSourceIpAddressId(), CallContext.current().getCallingUserId(), CallContext.current().getCallingAccount())) {
-                s_logger.warn("Unable to release system ip address id=" + lb.getSourceIpAddressId() + " as a part of delete lb rule");
+                logger.warn("Unable to release system ip address id=" + lb.getSourceIpAddressId() + " as a part of delete lb rule");
                 success = false;
             } else {
-                s_logger.warn("Successfully released system ip address id=" + lb.getSourceIpAddressId() + " as a part of delete lb rule");
+                logger.warn("Successfully released system ip address id=" + lb.getSourceIpAddressId() + " as a part of delete lb rule");
             }
         }
         return success;
@@ -1989,11 +1987,11 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
     public boolean removeAllLoadBalanacersForIp(long ipId, Account caller, long callerUserId) {
         List<FirewallRuleVO> rules = _firewallDao.listByIpAndPurposeAndNotRevoked(ipId, Purpose.LoadBalancing);
         if (rules != null) {
-            s_logger.debug("Found " + rules.size() + " lb rules to cleanup");
+            logger.debug("Found " + rules.size() + " lb rules to cleanup");
             for (FirewallRule rule : rules) {
                 boolean result = deleteLoadBalancerRule(rule.getId(), true, caller, callerUserId, false);
                 if (result == false) {
-                    s_logger.warn("Unable to remove load balancer rule " + rule.getId());
+                    logger.warn("Unable to remove load balancer rule " + rule.getId());
                     return false;
                 }
             }
@@ -2005,11 +2003,11 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
     public boolean removeAllLoadBalanacersForNetwork(long networkId, Account caller, long callerUserId) {
         List<FirewallRuleVO> rules = _firewallDao.listByNetworkAndPurposeAndNotRevoked(networkId, Purpose.LoadBalancing);
         if (rules != null) {
-            s_logger.debug("Found " + rules.size() + " lb rules to cleanup");
+            logger.debug("Found " + rules.size() + " lb rules to cleanup");
             for (FirewallRule rule : rules) {
                 boolean result = deleteLoadBalancerRule(rule.getId(), true, caller, callerUserId, false);
                 if (result == false) {
-                    s_logger.warn("Unable to remove load balancer rule " + rule.getId());
+                    logger.warn("Unable to remove load balancer rule " + rule.getId());
                     return false;
                 }
             }
@@ -2135,9 +2133,9 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
                     _lbDao.update(lb.getId(), lb);
                     _lbDao.persist(lb);
 
-                    s_logger.debug("LB Rollback rule id: " + lbRuleId + " while updating LB rule.");
+                    logger.debug("LB Rollback rule id: " + lbRuleId + " while updating LB rule.");
                 }
-                s_logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
+                logger.warn("Unable to apply the load balancer config because resource is unavaliable.", e);
                 success = false;
             }
         }
@@ -2172,7 +2170,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         vmLoadBalancerMappings = _lb2VmMapDao.listByLoadBalancerId(loadBalancerId);
         if(vmLoadBalancerMappings == null) {
             String msg = "no VM Loadbalancer Mapping found";
-            s_logger.error(msg);
+            logger.error(msg);
             throw new CloudRuntimeException(msg);
         }
         Map<Long, String> vmServiceState = new HashMap<Long, String>(vmLoadBalancerMappings.size());
@@ -2414,7 +2412,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
     public boolean applyLbRules(List<LoadBalancingRule> rules, boolean continueOnError) throws ResourceUnavailableException {
         if (rules == null || rules.size() == 0) {
-            s_logger.debug("There are no Load Balancing Rules to forward to the network elements");
+            logger.debug("There are no Load Balancing Rules to forward to the network elements");
             return true;
         }
 
@@ -2443,7 +2441,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
             if (!continueOnError) {
                 throw e;
             }
-            s_logger.warn("Problems with applying load balancing rules but pushing on", e);
+            logger.warn("Problems with applying load balancing rules but pushing on", e);
             success = false;
         }
 

--- a/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -27,7 +27,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.Answer;
@@ -96,7 +95,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Component
 @Local(value = { VpcVirtualNetworkApplianceManager.class, VpcVirtualNetworkApplianceService.class })
 public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplianceManagerImpl implements VpcVirtualNetworkApplianceManager {
-    private static final Logger s_logger = Logger.getLogger(VpcVirtualNetworkApplianceManagerImpl.class);
 
     @Inject
     private NetworkACLManager _networkACLMgr;
@@ -127,7 +125,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     public boolean addVpcRouterToGuestNetwork(final VirtualRouter router, final Network network, final Map<VirtualMachineProfile.Param, Object> params)
             throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
         if (network.getTrafficType() != TrafficType.Guest) {
-            s_logger.warn("Network " + network + " is not of type " + TrafficType.Guest);
+            logger.warn("Network " + network + " is not of type " + TrafficType.Guest);
             return false;
         }
 
@@ -143,7 +141,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
             if (guestNic != null) {
                 result = setupVpcGuestNetwork(network, router, true, guestNic);
             } else {
-                s_logger.warn("Failed to add router " + router + " to guest network " + network);
+                logger.warn("Failed to add router " + router + " to guest network " + network);
                 result = false;
             }
             // 3) apply networking rules
@@ -151,18 +149,18 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 sendNetworkRulesToRouter(router.getId(), network.getId());
             }
         } catch (final Exception ex) {
-            s_logger.warn("Failed to add router " + router + " to network " + network + " due to ", ex);
+            logger.warn("Failed to add router " + router + " to network " + network + " due to ", ex);
             result = false;
         } finally {
             if (!result) {
-                s_logger.debug("Removing the router " + router + " from network " + network + " as a part of cleanup");
+                logger.debug("Removing the router " + router + " from network " + network + " as a part of cleanup");
                 if (removeVpcRouterFromGuestNetwork(router, network)) {
-                    s_logger.debug("Removed the router " + router + " from network " + network + " as a part of cleanup");
+                    logger.debug("Removed the router " + router + " from network " + network + " as a part of cleanup");
                 } else {
-                    s_logger.warn("Failed to remove the router " + router + " from network " + network + " as a part of cleanup");
+                    logger.warn("Failed to remove the router " + router + " from network " + network + " as a part of cleanup");
                 }
             } else {
-                s_logger.debug("Succesfully added router " + router + " to guest network " + network);
+                logger.debug("Succesfully added router " + router + " to guest network " + network);
             }
         }
 
@@ -173,7 +171,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     public boolean removeVpcRouterFromGuestNetwork(final VirtualRouter router, final Network network) throws ConcurrentOperationException,
     ResourceUnavailableException {
         if (network.getTrafficType() != TrafficType.Guest) {
-            s_logger.warn("Network " + network + " is not of type " + TrafficType.Guest);
+            logger.warn("Network " + network + " is not of type " + TrafficType.Guest);
             return false;
         }
 
@@ -181,13 +179,13 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
         try {
             // Check if router is a part of the Guest network
             if (!_networkModel.isVmPartOfNetwork(router.getId(), network.getId())) {
-                s_logger.debug("Router " + router + " is not a part of the Guest network " + network);
+                logger.debug("Router " + router + " is not a part of the Guest network " + network);
                 return result;
             }
 
             result = setupVpcGuestNetwork(network, router, false, _networkModel.getNicProfile(router, network.getId(), null));
             if (!result) {
-                s_logger.warn("Failed to destroy guest network config " + network + " on router " + router);
+                logger.warn("Failed to destroy guest network config " + network + " on router " + router);
                 return false;
             }
 
@@ -215,15 +213,15 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
             final Answer setupAnswer = cmds.getAnswer("setupguestnetwork");
             final String setup = add ? "set" : "destroy";
             if (!(setupAnswer != null && setupAnswer.getResult())) {
-                s_logger.warn("Unable to " + setup + " guest network on router " + router);
+                logger.warn("Unable to " + setup + " guest network on router " + router);
                 result = false;
             }
             return result;
         } else if (router.getState() == State.Stopped || router.getState() == State.Stopping) {
-            s_logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending setup guest network command to the backend");
+            logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending setup guest network command to the backend");
             return true;
         } else {
-            s_logger.warn("Unable to setup guest network on virtual router " + router + " is not in the right state " + router.getState());
+            logger.warn("Unable to setup guest network on virtual router " + router + " is not in the right state " + router.getState());
             throw new ResourceUnavailableException("Unable to setup guest network on the backend," + " virtual router " + router + " is not in the right state", DataCenter.class,
                     router.getDataCenterId());
         }
@@ -249,7 +247,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                             defaultDns1 = nic.getIPv4Dns1();
                             defaultDns2 = nic.getIPv4Dns2();
                         }
-                        s_logger.debug("Removing nic " + nic + " of type " + nic.getTrafficType() + " from the nics passed on vm start. " + "The nic will be plugged later");
+                        logger.debug("Removing nic " + nic + " of type " + nic.getTrafficType() + " from the nics passed on vm start. " + "The nic will be plugged later");
                         it.remove();
                     }
                 }
@@ -282,7 +280,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
             // 1) FORM SSH CHECK COMMAND
             final NicProfile controlNic = getControlNic(profile);
             if (controlNic == null) {
-                s_logger.error("Control network doesn't exist for the router " + domainRouterVO);
+                logger.error("Control network doesn't exist for the router " + domainRouterVO);
                 return false;
             }
 
@@ -380,7 +378,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                         if (privateGwAclId != null) {
                             // set network acl on private gateway
                             final List<NetworkACLItemVO> networkACLs = _networkACLItemDao.listByACL(privateGwAclId);
-                            s_logger.debug("Found " + networkACLs.size() + " network ACLs to apply as a part of VPC VR " + domainRouterVO + " start for private gateway ip = "
+                            logger.debug("Found " + networkACLs.size() + " network ACLs to apply as a part of VPC VR " + domainRouterVO + " start for private gateway ip = "
                                     + ipVO.getIpAddress());
 
                             _commandSetupHelper.createNetworkACLsCommands(networkACLs, domainRouterVO, cmds, ipVO.getNetworkId(), true);
@@ -388,7 +386,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                     }
                 }
             } catch (final Exception ex) {
-                s_logger.warn("Failed to add router " + domainRouterVO + " to network due to exception ", ex);
+                logger.warn("Failed to add router " + domainRouterVO + " to network due to exception ", ex);
                 return false;
             }
 
@@ -405,7 +403,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 staticRouteProfiles.add(new StaticRouteProfile(route, gateway));
             }
 
-            s_logger.debug("Found " + staticRouteProfiles.size() + " static routes to apply as a part of vpc route " + domainRouterVO + " start");
+            logger.debug("Found " + staticRouteProfiles.size() + " static routes to apply as a part of vpc route " + domainRouterVO + " start");
             if (!staticRouteProfiles.isEmpty()) {
                 _commandSetupHelper.createStaticRouteCommands(staticRouteProfiles, domainRouterVO, cmds);
             }
@@ -464,7 +462,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 if (_networkModel.isProviderSupportServiceInNetwork(guestNetworkId, Service.NetworkACL, Provider.VPCVirtualRouter)) {
                     final List<NetworkACLItemVO> networkACLs = _networkACLMgr.listNetworkACLItems(guestNetworkId);
                     if (networkACLs != null && !networkACLs.isEmpty()) {
-                        s_logger.debug("Found " + networkACLs.size() + " network ACLs to apply as a part of VPC VR " + domainRouterVO + " start for guest network id=" + guestNetworkId);
+                        logger.debug("Found " + networkACLs.size() + " network ACLs to apply as a part of VPC VR " + domainRouterVO + " start for guest network id=" + guestNetworkId);
                         _commandSetupHelper.createNetworkACLsCommands(networkACLs, domainRouterVO, cmds, guestNetworkId, false);
                     }
                 }
@@ -511,20 +509,20 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
 
             try {
                 if (_nwHelper.sendCommandsToRouter(router, cmds)) {
-                    s_logger.debug("Successfully applied ip association for ip " + ip + " in vpc network " + network);
+                    logger.debug("Successfully applied ip association for ip " + ip + " in vpc network " + network);
                     return true;
                 } else {
-                    s_logger.warn("Failed to associate ip address " + ip + " in vpc network " + network);
+                    logger.warn("Failed to associate ip address " + ip + " in vpc network " + network);
                     return false;
                 }
             } catch (final Exception ex) {
-                s_logger.warn("Failed to send  " + (add ? "add " : "delete ") + " private network " + network + " commands to rotuer ");
+                logger.warn("Failed to send  " + (add ? "add " : "delete ") + " private network " + network + " commands to rotuer ");
                 return false;
             }
         } else if (router.getState() == State.Stopped || router.getState() == State.Stopping) {
-            s_logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending setup private network command to the backend");
+            logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending setup private network command to the backend");
         } else {
-            s_logger.warn("Unable to setup private gateway, virtual router " + router + " is not in the right state " + router.getState());
+            logger.warn("Unable to setup private gateway, virtual router " + router + " is not in the right state " + router.getState());
 
             throw new ResourceUnavailableException("Unable to setup Private gateway on the backend," + " virtual router " + router + " is not in the right state",
                     DataCenter.class, router.getDataCenterId());
@@ -536,28 +534,28 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     public boolean destroyPrivateGateway(final PrivateGateway gateway, final VirtualRouter router) throws ConcurrentOperationException, ResourceUnavailableException {
 
         if (!_networkModel.isVmPartOfNetwork(router.getId(), gateway.getNetworkId())) {
-            s_logger.debug("Router doesn't have nic for gateway " + gateway + " so no need to removed it");
+            logger.debug("Router doesn't have nic for gateway " + gateway + " so no need to removed it");
             return true;
         }
 
         final Network privateNetwork = _networkModel.getNetwork(gateway.getNetworkId());
 
-        s_logger.debug("Releasing private ip for gateway " + gateway + " from " + router);
+        logger.debug("Releasing private ip for gateway " + gateway + " from " + router);
         boolean result = setupVpcPrivateNetwork(router, false, _networkModel.getNicProfile(router, privateNetwork.getId(), null));
         if (!result) {
-            s_logger.warn("Failed to release private ip for gateway " + gateway + " on router " + router);
+            logger.warn("Failed to release private ip for gateway " + gateway + " on router " + router);
             return false;
         }
 
         // revoke network acl on the private gateway.
         if (!_networkACLMgr.revokeACLItemsForPrivateGw(gateway)) {
-            s_logger.debug("Failed to delete network acl items on " + gateway + " from router " + router);
+            logger.debug("Failed to delete network acl items on " + gateway + " from router " + router);
             return false;
         }
 
-        s_logger.debug("Removing router " + router + " from private network " + privateNetwork + " as a part of delete private gateway");
+        logger.debug("Removing router " + router + " from private network " + privateNetwork + " as a part of delete private gateway");
         result = result && _itMgr.removeVmFromNetwork(router, privateNetwork, null);
-        s_logger.debug("Private gateawy " + gateway + " is removed from router " + router);
+        logger.debug("Private gateawy " + gateway + " is removed from router " + router);
         return result;
     }
 
@@ -574,7 +572,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
             final ArrayList<? extends PublicIpAddress> publicIps = getPublicIpsToApply(domainRouterVO, provider, guestNetworkId, IpAddress.State.Releasing);
 
             if (publicIps != null && !publicIps.isEmpty()) {
-                s_logger.debug("Found " + publicIps.size() + " ip(s) to apply as a part of domR " + domainRouterVO + " start.");
+                logger.debug("Found " + publicIps.size() + " ip(s) to apply as a part of domR " + domainRouterVO + " start.");
                 // Re-apply public ip addresses - should come before PF/LB/VPN
                 _commandSetupHelper.createVpcAssociatePublicIPCommands(domainRouterVO, publicIps, cmds, vlanMacAddress);
             }
@@ -584,7 +582,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     @Override
     public boolean startSite2SiteVpn(final Site2SiteVpnConnection conn, final VirtualRouter router) throws ResourceUnavailableException {
         if (router.getState() != State.Running) {
-            s_logger.warn("Unable to apply site-to-site VPN configuration, virtual router is not in the right state " + router.getState());
+            logger.warn("Unable to apply site-to-site VPN configuration, virtual router is not in the right state " + router.getState());
             throw new ResourceUnavailableException("Unable to apply site 2 site VPN configuration," + " virtual router is not in the right state", DataCenter.class,
                     router.getDataCenterId());
         }
@@ -595,7 +593,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     @Override
     public boolean stopSite2SiteVpn(final Site2SiteVpnConnection conn, final VirtualRouter router) throws ResourceUnavailableException {
         if (router.getState() != State.Running) {
-            s_logger.warn("Unable to apply site-to-site VPN configuration, virtual router is not in the right state " + router.getState());
+            logger.warn("Unable to apply site-to-site VPN configuration, virtual router is not in the right state " + router.getState());
             throw new ResourceUnavailableException("Unable to apply site 2 site VPN configuration," + " virtual router is not in the right state", DataCenter.class,
                     router.getDataCenterId());
         }
@@ -629,7 +627,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 final Nic nic = _nicDao.findByIp4AddressAndNetworkIdAndInstanceId(publicNtwkId, router.getId(), ip.getAddress().addr());
                 if (nic != null) {
                     nicsToUnplug.put(ip.getVlanTag(), ip);
-                    s_logger.debug("Need to unplug the nic for ip=" + ip + "; vlan=" + ip.getVlanTag() + " in public network id =" + publicNtwkId);
+                    logger.debug("Need to unplug the nic for ip=" + ip + "; vlan=" + ip.getVlanTag() + " in public network id =" + publicNtwkId);
                 }
             }
         }
@@ -652,14 +650,14 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
 
                 if (nic == null && nicsToPlug.get(ip.getVlanTag()) == null) {
                     nicsToPlug.put(ip.getVlanTag(), ip);
-                    s_logger.debug("Need to plug the nic for ip=" + ip + "; vlan=" + ip.getVlanTag() + " in public network id =" + publicNtwkId);
+                    logger.debug("Need to plug the nic for ip=" + ip + "; vlan=" + ip.getVlanTag() + " in public network id =" + publicNtwkId);
                 } else {
                     final PublicIpAddress nicToUnplug = nicsToUnplug.get(ip.getVlanTag());
                     if (nicToUnplug != null) {
                         final NicVO nicVO = _nicDao.findByIp4AddressAndNetworkIdAndInstanceId(publicNtwkId, router.getId(), nicToUnplug.getAddress().addr());
                         nicVO.setIPv4Address(ip.getAddress().addr());
                         _nicDao.update(nicVO.getId(), nicVO);
-                        s_logger.debug("Updated the nic " + nicVO + " with the new ip address " + ip.getAddress().addr());
+                        logger.debug("Updated the nic " + nicVO + " with the new ip address " + ip.getAddress().addr());
                         nicsToUnplug.remove(ip.getVlanTag());
                     }
                 }
@@ -690,7 +688,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     @Override
     public boolean startRemoteAccessVpn(final RemoteAccessVpn vpn, final VirtualRouter router) throws ResourceUnavailableException {
         if (router.getState() != State.Running) {
-            s_logger.warn("Unable to apply remote access VPN configuration, virtual router is not in the right state " + router.getState());
+            logger.warn("Unable to apply remote access VPN configuration, virtual router is not in the right state " + router.getState());
             throw new ResourceUnavailableException("Unable to apply remote access VPN configuration," + " virtual router is not in the right state", DataCenter.class,
                     router.getDataCenterId());
         }
@@ -701,19 +699,19 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
         try {
             _agentMgr.send(router.getHostId(), cmds);
         } catch (final OperationTimedoutException e) {
-            s_logger.debug("Failed to start remote access VPN: ", e);
+            logger.debug("Failed to start remote access VPN: ", e);
             throw new AgentUnavailableException("Unable to send commands to virtual router ", router.getHostId(), e);
         }
         Answer answer = cmds.getAnswer("users");
         if (!answer.getResult()) {
-            s_logger.error("Unable to start vpn: unable add users to vpn in zone " + router.getDataCenterId() + " for account " + vpn.getAccountId() + " on domR: "
+            logger.error("Unable to start vpn: unable add users to vpn in zone " + router.getDataCenterId() + " for account " + vpn.getAccountId() + " on domR: "
                     + router.getInstanceName() + " due to " + answer.getDetails());
             throw new ResourceUnavailableException("Unable to start vpn: Unable to add users to vpn in zone " + router.getDataCenterId() + " for account " + vpn.getAccountId()
                     + " on domR: " + router.getInstanceName() + " due to " + answer.getDetails(), DataCenter.class, router.getDataCenterId());
         }
         answer = cmds.getAnswer("startVpn");
         if (!answer.getResult()) {
-            s_logger.error("Unable to start vpn in zone " + router.getDataCenterId() + " for account " + vpn.getAccountId() + " on domR: " + router.getInstanceName() + " due to "
+            logger.error("Unable to start vpn in zone " + router.getDataCenterId() + " for account " + vpn.getAccountId() + " on domR: " + router.getInstanceName() + " due to "
                     + answer.getDetails());
             throw new ResourceUnavailableException("Unable to start vpn in zone " + router.getDataCenterId() + " for account " + vpn.getAccountId() + " on domR: "
                     + router.getInstanceName() + " due to " + answer.getDetails(), DataCenter.class, router.getDataCenterId());
@@ -731,9 +729,9 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
             _commandSetupHelper.createApplyVpnCommands(false, vpn, router, cmds);
             result = result && _nwHelper.sendCommandsToRouter(router, cmds);
         } else if (router.getState() == State.Stopped) {
-            s_logger.debug("Router " + router + " is in Stopped state, not sending deleteRemoteAccessVpn command to it");
+            logger.debug("Router " + router + " is in Stopped state, not sending deleteRemoteAccessVpn command to it");
         } else {
-            s_logger.warn("Failed to delete remote access VPN: domR " + router + " is not in right state " + router.getState());
+            logger.warn("Failed to delete remote access VPN: domR " + router + " is not in right state " + router.getState());
             throw new ResourceUnavailableException("Failed to delete remote access VPN: domR is not in right state " + router.getState(), DataCenter.class,
                     router.getDataCenterId());
         }

--- a/server/src/com/cloud/network/rules/RulesManagerImpl.java
+++ b/server/src/com/cloud/network/rules/RulesManagerImpl.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import org.apache.cloudstack.api.command.user.firewall.ListPortForwardingRulesCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.ConfigurationManager;
 import com.cloud.domain.dao.DomainDao;
@@ -99,7 +98,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 @Local(value = {RulesManager.class, RulesService.class})
 public class RulesManagerImpl extends ManagerBase implements RulesManager, RulesService {
-    private static final Logger s_logger = Logger.getLogger(RulesManagerImpl.class);
 
     @Inject
     IpAddressManager _ipAddrMgr;
@@ -229,7 +227,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
             if (assignToVpcNtwk) {
                 _networkModel.checkIpForService(ipAddress, Service.PortForwarding, networkId);
 
-                s_logger.debug("The ip is not associated with the VPC network id=" + networkId + ", so assigning");
+                logger.debug("The ip is not associated with the VPC network id=" + networkId + ", so assigning");
                 try {
                     ipAddress = _ipAddrMgr.associateIPToGuestNetwork(ipAddrId, networkId, false);
                     performedIpAssoc = true;
@@ -499,15 +497,15 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                     if (assignToVpcNtwk) {
                         _networkModel.checkIpForService(ipAddress, Service.StaticNat, networkId);
 
-                        s_logger.debug("The ip is not associated with the VPC network id=" + networkId + ", so assigning");
+                        logger.debug("The ip is not associated with the VPC network id=" + networkId + ", so assigning");
                         try {
                             ipAddress = _ipAddrMgr.associateIPToGuestNetwork(ipId, networkId, false);
                         } catch (Exception ex) {
-                            s_logger.warn("Failed to associate ip id=" + ipId + " to VPC network id=" + networkId + " as " + "a part of enable static nat");
+                            logger.warn("Failed to associate ip id=" + ipId + " to VPC network id=" + networkId + " as " + "a part of enable static nat");
                             return false;
                         }
                     }  else if (ipAddress.isPortable()) {
-                        s_logger.info("Portable IP " + ipAddress.getUuid() + " is not associated with the network yet " + " so associate IP with the network " +
+                        logger.info("Portable IP " + ipAddress.getUuid() + " is not associated with the network yet " + " so associate IP with the network " +
                             networkId);
                         try {
                             // check if StaticNat service is enabled in the network
@@ -521,7 +519,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                             // associate portable IP with guest network
                             ipAddress = _ipAddrMgr.associatePortableIPToGuestNetwork(ipId, networkId, false);
                         } catch (Exception e) {
-                            s_logger.warn("Failed to associate portable id=" + ipId + " to network id=" + networkId + " as " + "a part of enable static nat");
+                            logger.warn("Failed to associate portable id=" + ipId + " to network id=" + networkId + " as " + "a part of enable static nat");
                             return false;
                         }
                     }
@@ -537,7 +535,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                                 _ipAddrMgr.transferPortableIP(ipId, ipAddress.getAssociatedWithNetworkId(), networkId);
                                 ipAddress = _ipAddressDao.findById(ipId);
                             } catch (Exception e) {
-                                s_logger.warn("Failed to associate portable id=" + ipId + " to network id=" + networkId + " as " + "a part of enable static nat");
+                                logger.warn("Failed to associate portable id=" + ipId + " to network id=" + networkId + " as " + "a part of enable static nat");
                                 return false;
                             }
                         } else {
@@ -596,19 +594,19 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
             ipAddress.setVmIp(dstIp);
             if (_ipAddressDao.update(ipAddress.getId(), ipAddress)) {
                 // enable static nat on the backend
-                s_logger.trace("Enabling static nat for ip address " + ipAddress + " and vm id=" + vmId + " on the backend");
+                logger.trace("Enabling static nat for ip address " + ipAddress + " and vm id=" + vmId + " on the backend");
                 if (applyStaticNatForIp(ipId, false, caller, false)) {
                     performedIpAssoc = false; // ignor unassignIPFromVpcNetwork in finally block
                     return true;
                 } else {
-                    s_logger.warn("Failed to enable static nat rule for ip address " + ipId + " on the backend");
+                    logger.warn("Failed to enable static nat rule for ip address " + ipId + " on the backend");
                     ipAddress.setOneToOneNat(isOneToOneNat);
                     ipAddress.setAssociatedWithVmId(associatedWithVmId);
                     ipAddress.setVmIp(null);
                     _ipAddressDao.update(ipAddress.getId(), ipAddress);
                 }
             } else {
-                s_logger.warn("Failed to update ip address " + ipAddress + " in the DB as a part of enableStaticNat");
+                logger.warn("Failed to update ip address " + ipAddress + " in the DB as a part of enableStaticNat");
 
             }
         } finally {
@@ -668,7 +666,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                         oldIP.getUuid());
             }
         // unassign old static nat rule
-        s_logger.debug("Disassociating static nat for ip " + oldIP);
+        logger.debug("Disassociating static nat for ip " + oldIP);
         if (!disableStaticNat(oldIP.getId(), caller, callerUserId, true)) {
                 throw new CloudRuntimeException("Failed to disable old static nat rule for vm "+ vm.getInstanceName() +
                         " with id "+vm.getUuid() +"  and public ip " + oldIP);
@@ -758,7 +756,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         Set<Long> ipsToReprogram = new HashSet<Long>();
 
         if (rules == null || rules.isEmpty()) {
-            s_logger.debug("No port forwarding rules are found for vm id=" + vmId);
+            logger.debug("No port forwarding rules are found for vm id=" + vmId);
             return true;
         }
 
@@ -770,9 +768,9 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
 
         // apply rules for all ip addresses
         for (Long ipId : ipsToReprogram) {
-            s_logger.debug("Applying port forwarding rules for ip address id=" + ipId + " as a part of vm expunge");
+            logger.debug("Applying port forwarding rules for ip address id=" + ipId + " as a part of vm expunge");
             if (!applyPortForwardingRules(ipId, true, _accountMgr.getSystemAccount())) {
-                s_logger.warn("Failed to apply port forwarding rules for ip id=" + ipId);
+                logger.warn("Failed to apply port forwarding rules for ip id=" + ipId);
                 success = false;
             }
         }
@@ -866,7 +864,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         List<PortForwardingRuleVO> rules = _portForwardingDao.listForApplication(ipId);
 
         if (rules.size() == 0) {
-            s_logger.debug("There are no port forwarding rules to apply for ip id=" + ipId);
+            logger.debug("There are no port forwarding rules to apply for ip id=" + ipId);
             return true;
         }
 
@@ -879,7 +877,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                 return false;
             }
         } catch (ResourceUnavailableException ex) {
-            s_logger.warn("Failed to apply port forwarding rules for ip due to ", ex);
+            logger.warn("Failed to apply port forwarding rules for ip due to ", ex);
             return false;
         }
 
@@ -891,7 +889,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         List<StaticNatRule> staticNatRules = new ArrayList<StaticNatRule>();
 
         if (rules.size() == 0) {
-            s_logger.debug("There are no static nat rules to apply for ip id=" + sourceIpId);
+            logger.debug("There are no static nat rules to apply for ip id=" + sourceIpId);
             return true;
         }
 
@@ -908,7 +906,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                 return false;
             }
         } catch (ResourceUnavailableException ex) {
-            s_logger.warn("Failed to apply static nat rules for ip due to ", ex);
+            logger.warn("Failed to apply static nat rules for ip due to ", ex);
             return false;
         }
 
@@ -919,7 +917,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
     public boolean applyPortForwardingRulesForNetwork(long networkId, boolean continueOnError, Account caller) {
         List<PortForwardingRuleVO> rules = listByNetworkId(networkId);
         if (rules.size() == 0) {
-            s_logger.debug("There are no port forwarding rules to apply for network id=" + networkId);
+            logger.debug("There are no port forwarding rules to apply for network id=" + networkId);
             return true;
         }
 
@@ -932,7 +930,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                 return false;
             }
         } catch (ResourceUnavailableException ex) {
-            s_logger.warn("Failed to apply port forwarding rules for network due to ", ex);
+            logger.warn("Failed to apply port forwarding rules for network due to ", ex);
             return false;
         }
 
@@ -945,7 +943,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         List<StaticNatRule> staticNatRules = new ArrayList<StaticNatRule>();
 
         if (rules.size() == 0) {
-            s_logger.debug("There are no static nat rules to apply for network id=" + networkId);
+            logger.debug("There are no static nat rules to apply for network id=" + networkId);
             return true;
         }
 
@@ -962,7 +960,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                 return false;
             }
         } catch (ResourceUnavailableException ex) {
-            s_logger.warn("Failed to apply static nat rules for network due to ", ex);
+            logger.warn("Failed to apply static nat rules for network due to ", ex);
             return false;
         }
 
@@ -973,7 +971,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
     public boolean applyStaticNatsForNetwork(long networkId, boolean continueOnError, Account caller) {
         List<IPAddressVO> ips = _ipAddressDao.listStaticNatPublicIps(networkId);
         if (ips.isEmpty()) {
-            s_logger.debug("There are no static nat to apply for network id=" + networkId);
+            logger.debug("There are no static nat to apply for network id=" + networkId);
             return true;
         }
 
@@ -994,7 +992,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                 return false;
             }
         } catch (ResourceUnavailableException ex) {
-            s_logger.warn("Failed to create static nat for network due to ", ex);
+            logger.warn("Failed to create static nat for network due to ", ex);
             return false;
         }
 
@@ -1078,8 +1076,8 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         List<FirewallRule> rules = new ArrayList<FirewallRule>();
 
         List<PortForwardingRuleVO> pfRules = _portForwardingDao.listByIpAndNotRevoked(ipId);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing " + pfRules.size() + " port forwarding rules for ip id=" + ipId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing " + pfRules.size() + " port forwarding rules for ip id=" + ipId);
         }
 
         for (PortForwardingRuleVO rule : pfRules) {
@@ -1088,8 +1086,8 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         }
 
         List<FirewallRuleVO> staticNatRules = _firewallDao.listByIpAndPurposeAndNotRevoked(ipId, Purpose.StaticNat);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing " + staticNatRules.size() + " static nat rules for ip id=" + ipId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing " + staticNatRules.size() + " static nat rules for ip id=" + ipId);
         }
 
         for (FirewallRuleVO rule : staticNatRules) {
@@ -1112,8 +1110,8 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         rules.addAll(_portForwardingDao.listByIpAndNotRevoked(ipId));
         rules.addAll(_firewallDao.listByIpAndPurposeAndNotRevoked(ipId, Purpose.StaticNat));
 
-        if (s_logger.isDebugEnabled() && success) {
-            s_logger.debug("Successfully released rules for ip id=" + ipId + " and # of rules now = " + rules.size());
+        if (logger.isDebugEnabled() && success) {
+            logger.debug("Successfully released rules for ip id=" + ipId + " and # of rules now = " + rules.size());
         }
 
         return (rules.size() == 0 && success);
@@ -1124,13 +1122,13 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         List<FirewallRule> rules = new ArrayList<FirewallRule>();
 
         List<PortForwardingRuleVO> pfRules = _portForwardingDao.listByNetwork(networkId);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing " + pfRules.size() + " port forwarding rules for network id=" + networkId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing " + pfRules.size() + " port forwarding rules for network id=" + networkId);
         }
 
         List<FirewallRuleVO> staticNatRules = _firewallDao.listByNetworkAndPurpose(networkId, Purpose.StaticNat);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing " + staticNatRules.size() + " static nat rules for network id=" + networkId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing " + staticNatRules.size() + " static nat rules for network id=" + networkId);
         }
 
         // Mark all pf rules (Active and non-Active) to be revoked, but don't revoke it yet - pass apply=false
@@ -1154,8 +1152,8 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         rules.addAll(_portForwardingDao.listByNetworkAndNotRevoked(networkId));
         rules.addAll(_firewallDao.listByNetworkAndPurposeAndNotRevoked(networkId, Purpose.StaticNat));
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Successfully released rules for network id=" + networkId + " and # of rules now = " + rules.size());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Successfully released rules for network id=" + networkId + " and # of rules now = " + rules.size());
         }
 
         return success && rules.size() == 0;
@@ -1261,18 +1259,18 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
 
         // Revoke all firewall rules for the ip
         try {
-            s_logger.debug("Revoking all " + Purpose.Firewall + "rules as a part of disabling static nat for public IP id=" + ipId);
+            logger.debug("Revoking all " + Purpose.Firewall + "rules as a part of disabling static nat for public IP id=" + ipId);
             if (!_firewallMgr.revokeFirewallRulesForIp(ipId, callerUserId, caller)) {
-                s_logger.warn("Unable to revoke all the firewall rules for ip id=" + ipId + " as a part of disable statis nat");
+                logger.warn("Unable to revoke all the firewall rules for ip id=" + ipId + " as a part of disable statis nat");
                 success = false;
             }
         } catch (ResourceUnavailableException e) {
-            s_logger.warn("Unable to revoke all firewall rules for ip id=" + ipId + " as a part of ip release", e);
+            logger.warn("Unable to revoke all firewall rules for ip id=" + ipId + " as a part of ip release", e);
             success = false;
         }
 
         if (!revokeAllPFAndStaticNatRulesForIp(ipId, callerUserId, caller)) {
-            s_logger.warn("Unable to revoke all static nat rules for ip " + ipAddress);
+            logger.warn("Unable to revoke all static nat rules for ip " + ipAddress);
             success = false;
         }
 
@@ -1288,13 +1286,13 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
             _vpcMgr.unassignIPFromVpcNetwork(ipAddress.getId(), networkId);
 
             if (isIpSystem && releaseIpIfElastic && !_ipAddrMgr.handleSystemIpRelease(ipAddress)) {
-                s_logger.warn("Failed to release system ip address " + ipAddress);
+                logger.warn("Failed to release system ip address " + ipAddress);
                 success = false;
             }
 
             return true;
         } else {
-            s_logger.warn("Failed to disable one to one nat for the ip address id" + ipId);
+            logger.warn("Failed to disable one to one nat for the ip address id" + ipId);
             return false;
         }
     }
@@ -1331,7 +1329,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                     return false;
                 }
             } catch (ResourceUnavailableException ex) {
-                s_logger.warn("Failed to create static nat rule due to ", ex);
+                logger.warn("Failed to create static nat rule due to ", ex);
                 return false;
             }
         }
@@ -1350,18 +1348,18 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
 
         if (staticNats != null && !staticNats.isEmpty()) {
             if (forRevoke) {
-                s_logger.debug("Found " + staticNats.size() + " static nats to disable for network id " + networkId);
+                logger.debug("Found " + staticNats.size() + " static nats to disable for network id " + networkId);
             }
             try {
                 if (!_ipAddrMgr.applyStaticNats(staticNats, continueOnError, forRevoke)) {
                     return false;
                 }
             } catch (ResourceUnavailableException ex) {
-                s_logger.warn("Failed to create static nat rule due to ", ex);
+                logger.warn("Failed to create static nat rule due to ", ex);
                 return false;
             }
         } else {
-            s_logger.debug("Found 0 static nat rules to apply for network id " + networkId);
+            logger.debug("Found 0 static nat rules to apply for network id " + networkId);
         }
 
         return true;
@@ -1370,7 +1368,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
     protected List<StaticNat> createStaticNatForIp(IpAddress sourceIp, Account caller, boolean forRevoke) {
         List<StaticNat> staticNats = new ArrayList<StaticNat>();
         if (!sourceIp.isOneToOneNat()) {
-            s_logger.debug("Source ip id=" + sourceIp + " is not one to one nat");
+            logger.debug("Source ip id=" + sourceIp + " is not one to one nat");
             return staticNats;
         }
 
@@ -1434,36 +1432,36 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                 }
                 // check if there is already static nat enabled
                 if (_ipAddressDao.findByAssociatedVmId(vm.getId()) != null && !getNewIp) {
-                    s_logger.debug("Vm " + vm + " already has ip associated with it in guest network " + guestNetwork);
+                    logger.debug("Vm " + vm + " already has ip associated with it in guest network " + guestNetwork);
                     continue;
                 }
 
-                s_logger.debug("Allocating system ip and enabling static nat for it for the vm " + vm + " in guest network " + guestNetwork);
+                logger.debug("Allocating system ip and enabling static nat for it for the vm " + vm + " in guest network " + guestNetwork);
                 IpAddress ip = _ipAddrMgr.assignSystemIp(guestNetwork.getId(), _accountMgr.getAccount(vm.getAccountId()), false, true);
                 if (ip == null) {
                     throw new CloudRuntimeException("Failed to allocate system ip for vm " + vm + " in guest network " + guestNetwork);
                 }
 
-                s_logger.debug("Allocated system ip " + ip + ", now enabling static nat on it for vm " + vm);
+                logger.debug("Allocated system ip " + ip + ", now enabling static nat on it for vm " + vm);
 
                 try {
                     success = enableStaticNat(ip.getId(), vm.getId(), guestNetwork.getId(), isSystemVM, null);
                 } catch (NetworkRuleConflictException ex) {
-                    s_logger.warn("Failed to enable static nat as a part of enabling elasticIp and staticNat for vm " + vm + " in guest network " + guestNetwork +
+                    logger.warn("Failed to enable static nat as a part of enabling elasticIp and staticNat for vm " + vm + " in guest network " + guestNetwork +
                         " due to exception ", ex);
                     success = false;
                 } catch (ResourceUnavailableException ex) {
-                    s_logger.warn("Failed to enable static nat as a part of enabling elasticIp and staticNat for vm " + vm + " in guest network " + guestNetwork +
+                    logger.warn("Failed to enable static nat as a part of enabling elasticIp and staticNat for vm " + vm + " in guest network " + guestNetwork +
                         " due to exception ", ex);
                     success = false;
                 }
 
                 if (!success) {
-                    s_logger.warn("Failed to enable static nat on system ip " + ip + " for the vm " + vm + ", releasing the ip...");
+                    logger.warn("Failed to enable static nat on system ip " + ip + " for the vm " + vm + ", releasing the ip...");
                     _ipAddrMgr.handleSystemIpRelease(ip);
                     throw new CloudRuntimeException("Failed to enable static nat on system ip for the vm " + vm);
                 } else {
-                    s_logger.warn("Succesfully enabled static nat on system ip " + ip + " for the vm " + vm);
+                    logger.warn("Succesfully enabled static nat on system ip " + ip + " for the vm " + vm);
                 }
             }
         }
@@ -1475,19 +1473,19 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
 
     @Override
     public List<FirewallRuleVO> listAssociatedRulesForGuestNic(Nic nic) {
-        s_logger.debug("Checking if PF/StaticNat/LoadBalancer rules are configured for nic " + nic.getId());
+        logger.debug("Checking if PF/StaticNat/LoadBalancer rules are configured for nic " + nic.getId());
         List<FirewallRuleVO> result = new ArrayList<FirewallRuleVO>();
         // add PF rules
         result.addAll(_portForwardingDao.listByNetworkAndDestIpAddr(nic.getIPv4Address(), nic.getNetworkId()));
         if(result.size() > 0) {
-            s_logger.debug("Found " + result.size() + " portforwarding rule configured for the nic in the network " + nic.getNetworkId());
+            logger.debug("Found " + result.size() + " portforwarding rule configured for the nic in the network " + nic.getNetworkId());
         }
         // add static NAT rules
         List<FirewallRuleVO> staticNatRules = _firewallDao.listStaticNatByVmId(nic.getInstanceId());
         for (FirewallRuleVO rule : staticNatRules) {
             if (rule.getNetworkId() == nic.getNetworkId()) {
                 result.add(rule);
-                s_logger.debug("Found rule " + rule.getId() + " " + rule.getPurpose() + " configured");
+                logger.debug("Found rule " + rule.getId() + " " + rule.getPurpose() + " configured");
             }
         }
         List<? extends IpAddress> staticNatIps = _ipAddressDao.listStaticNatPublicIps(nic.getNetworkId());
@@ -1500,7 +1498,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                         new FirewallRuleVO(null, ip.getId(), 0, 65535, NetUtils.ALL_PROTO.toString(), nic.getNetworkId(), vm.getAccountId(), vm.getDomainId(),
                                 Purpose.StaticNat, null, null, null, null, null);
                 result.add(staticNatRule);
-                s_logger.debug("Found rule " + staticNatRule.getId() + " " + staticNatRule.getPurpose() + " configured");
+                logger.debug("Found rule " + staticNatRule.getId() + " " + staticNatRule.getPurpose() + " configured");
             }
         }
         // add LB rules
@@ -1509,7 +1507,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
             FirewallRuleVO lbRule = _firewallDao.findById(lb.getLoadBalancerId());
             if (lbRule.getNetworkId() == nic.getNetworkId()) {
                 result.add(lbRule);
-                s_logger.debug("Found rule " + lbRule.getId() + " " + lbRule.getPurpose() + " configured");
+                logger.debug("Found rule " + lbRule.getId() + " " + lbRule.getPurpose() + " configured");
             }
         }
         return result;

--- a/server/src/com/cloud/network/security/SecurityGroupManagerImpl2.java
+++ b/server/src/com/cloud/network/security/SecurityGroupManagerImpl2.java
@@ -77,7 +77,7 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
                         }
                     });
                 } catch (final Throwable th) {
-                    s_logger.error("SG Work: Caught this throwable, ", th);
+                    logger.error("SG Work: Caught this throwable, ", th);
                 }
             }
         }
@@ -99,15 +99,15 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
             return;
         }
         if (_schedulerDisabled) {
-            s_logger.debug("Security Group Mgr v2: scheduler disabled, doing nothing for " + affectedVms.size() + " vms");
+            logger.debug("Security Group Mgr v2: scheduler disabled, doing nothing for " + affectedVms.size() + " vms");
             return;
         }
         Set<Long> workItems = new TreeSet<Long>();
         workItems.addAll(affectedVms);
         workItems.removeAll(_disabledVms);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Security Group Mgr v2: scheduling ruleset updates for " + affectedVms.size() + " vms " + " (unique=" + workItems.size() +
+        if (logger.isDebugEnabled()) {
+            logger.debug("Security Group Mgr v2: scheduling ruleset updates for " + affectedVms.size() + " vms " + " (unique=" + workItems.size() +
                 "), current queue size=" + _workQueue.size());
         }
 
@@ -123,8 +123,8 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
         int newJobs = _workQueue.submitWorkForVms(workItems);
         _mBean.logScheduledDetails(workItems);
         p.stop();
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Security Group Mgr v2: done scheduling ruleset updates for " + workItems.size() + " vms: num new jobs=" + newJobs +
+        if (logger.isDebugEnabled()) {
+            logger.debug("Security Group Mgr v2: done scheduling ruleset updates for " + workItems.size() + " vms: num new jobs=" + newJobs +
                 " num rows insert or updated=" + updated + " time taken=" + p.getDurationInMillis());
         }
     }
@@ -139,31 +139,31 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
 
     @Override
     public void work() {
-        s_logger.trace("Checking the work queue");
+        logger.trace("Checking the work queue");
         List<SecurityGroupWork> workItems;
         try {
             workItems = _workQueue.getWork(1);
             for (SecurityGroupWork work : workItems) {
-                if (s_logger.isTraceEnabled()) {
-                    s_logger.trace("Processing " + work.getInstanceId());
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Processing " + work.getInstanceId());
                 }
 
                 try {
                     VmRulesetLogVO rulesetLog = _rulesetLogDao.findByVmId(work.getInstanceId());
                     if (rulesetLog == null) {
-                        s_logger.warn("Could not find ruleset log for vm " + work.getInstanceId());
+                        logger.warn("Could not find ruleset log for vm " + work.getInstanceId());
                         continue;
                     }
                     work.setLogsequenceNumber(rulesetLog.getLogsequence());
                     sendRulesetUpdates(work);
                     _mBean.logUpdateDetails(work.getInstanceId(), work.getLogsequenceNumber());
                 } catch (Exception e) {
-                    s_logger.error("Problem during SG work " + work, e);
+                    logger.error("Problem during SG work " + work, e);
                     work.setStep(Step.Error);
                 }
             }
         } catch (InterruptedException e1) {
-            s_logger.warn("SG work: caught InterruptException", e1);
+            logger.warn("SG work: caught InterruptException", e1);
         }
     }
 
@@ -172,8 +172,8 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
         UserVm vm = _userVMDao.findById(userVmId);
 
         if (vm != null && vm.getState() == State.Running) {
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("SecurityGroupManager v2: found vm, " + userVmId + " state=" + vm.getState());
+            if (logger.isTraceEnabled()) {
+                logger.trace("SecurityGroupManager v2: found vm, " + userVmId + " state=" + vm.getState());
             }
             Map<PortAndProto, Set<String>> ingressRules = generateRulesForVM(userVmId, SecurityRuleType.IngressRule);
             Map<PortAndProto, Set<String>> egressRules = generateRulesForVM(userVmId, SecurityRuleType.EgressRule);
@@ -193,28 +193,28 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
                     generateRulesetCmd(vm.getInstanceName(), vm.getPrivateIpAddress(), vm.getPrivateMacAddress(), vm.getId(), null, work.getLogsequenceNumber(),
                         ingressRules, egressRules, nicSecIps);
                 cmd.setMsId(_serverId);
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("SecurityGroupManager v2: sending ruleset update for vm " + vm.getInstanceName() + ":ingress num rules=" +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("SecurityGroupManager v2: sending ruleset update for vm " + vm.getInstanceName() + ":ingress num rules=" +
                         cmd.getIngressRuleSet().length + ":egress num rules=" + cmd.getEgressRuleSet().length + " num cidrs=" + cmd.getTotalNumCidrs() + " sig=" +
                         cmd.getSignature());
                 }
                 Commands cmds = new Commands(cmd);
                 try {
                     _agentMgr.send(agentId, cmds, _answerListener);
-                    if (s_logger.isTraceEnabled()) {
-                        s_logger.trace("SecurityGroupManager v2: sent ruleset updates for " + vm.getInstanceName() + " curr queue size=" + _workQueue.size());
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("SecurityGroupManager v2: sent ruleset updates for " + vm.getInstanceName() + " curr queue size=" + _workQueue.size());
                     }
                 } catch (AgentUnavailableException e) {
-                    s_logger.debug("Unable to send updates for vm: " + userVmId + "(agentid=" + agentId + ")");
+                    logger.debug("Unable to send updates for vm: " + userVmId + "(agentid=" + agentId + ")");
                     _workTracker.handleException(agentId);
                 }
             }
         } else {
-            if (s_logger.isDebugEnabled()) {
+            if (logger.isDebugEnabled()) {
                 if (vm != null)
-                    s_logger.debug("No rules sent to vm " + vm + "state=" + vm.getState());
+                    logger.debug("No rules sent to vm " + vm + "state=" + vm.getState());
                 else
-                    s_logger.debug("Could not find vm: No rules sent to vm " + userVmId);
+                    logger.debug("Could not find vm: No rules sent to vm " + userVmId);
             }
         }
     }
@@ -279,7 +279,7 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
         try {
             JmxUtil.registerMBean("SecurityGroupManager", "SecurityGroupManagerImpl2", _mBean);
         } catch (Exception e) {
-            s_logger.error("Failed to register MBean", e);
+            logger.error("Failed to register MBean", e);
         }
         boolean result = super.configure(name, params);
         Map<String, String> configs = _configDao.getConfiguration("Network", params);
@@ -295,7 +295,7 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
         } else {
             _disabledVms.remove(vmId);
         }
-        s_logger.warn("JMX operation: Scheduler state for vm " + vmId + ": new state disabled=" + disable);
+        logger.warn("JMX operation: Scheduler state for vm " + vmId + ": new state disabled=" + disable);
 
     }
 
@@ -305,13 +305,13 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
     }
 
     public void enableAllVmsForScheduler() {
-        s_logger.warn("Cleared list of disabled VMs (JMX operation?)");
+        logger.warn("Cleared list of disabled VMs (JMX operation?)");
         _disabledVms.clear();
     }
 
     public void disableScheduler(boolean disable) {
         _schedulerDisabled = disable;
-        s_logger.warn("JMX operation: Scheduler state changed: new state disabled=" + disable);
+        logger.warn("JMX operation: Scheduler state changed: new state disabled=" + disable);
     }
 
     public boolean isSchedulerDisabled() {
@@ -320,7 +320,7 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
 
     public void clearWorkQueue() {
         _workQueue.clear();
-        s_logger.warn("Cleared the work queue (possible JMX operation)");
+        logger.warn("Cleared the work queue (possible JMX operation)");
     }
 
 }

--- a/server/src/com/cloud/network/vpc/NetworkACLManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/NetworkACLManagerImpl.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
 import org.apache.cloudstack.framework.messagebus.PublishScope;
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.ConfigurationManager;
 import com.cloud.event.ActionEvent;
@@ -55,7 +54,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 
 @Local(value = {NetworkACLManager.class})
 public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLManager {
-    private static final Logger s_logger = Logger.getLogger(NetworkACLManagerImpl.class);
 
     @Inject
     AccountManager _accountMgr;
@@ -117,7 +115,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
 
             if (!applyACLToPrivateGw(privateGateway)) {
                 aclApplyStatus = false;
-                s_logger.debug("failed to apply network acl item on private gateway " + privateGateway.getId() + "acl id " + aclId);
+                logger.debug("failed to apply network acl item on private gateway " + privateGateway.getId() + "acl id " + aclId);
                 break;
             }
         }
@@ -169,7 +167,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         if (aclItems == null || aclItems.isEmpty()) {
             //Revoke ACL Items of the existing ACL if the new network acl is empty
             //Other wise existing rules will not be removed on the router elelment
-            s_logger.debug("New network ACL is empty. Revoke existing rules before applying ACL");
+            logger.debug("New network ACL is empty. Revoke existing rules before applying ACL");
             if (!revokeACLItemsForPrivateGw(gateway)) {
                 throw new CloudRuntimeException("Failed to replace network ACL. Error while removing existing ACL " + "items for privatewa gateway: " + gateway.getId());
             }
@@ -202,7 +200,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
             //Existing rules won't be removed otherwise
             List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(acl.getId());
             if (aclItems == null || aclItems.isEmpty()) {
-                s_logger.debug("New network ACL is empty. Revoke existing rules before applying ACL");
+                logger.debug("New network ACL is empty. Revoke existing rules before applying ACL");
                 if (!revokeACLItemsForNetwork(network.getId())) {
                     throw new CloudRuntimeException("Failed to replace network ACL. Error while removing existing ACL items for network: " + network.getId());
                 }
@@ -212,7 +210,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         network.setNetworkACLId(acl.getId());
         //Update Network ACL
         if (_networkDao.update(network.getId(), network)) {
-            s_logger.debug("Updated network: " + network.getId() + " with Network ACL Id: " + acl.getId() + ", Applying ACL items");
+            logger.debug("Updated network: " + network.getId() + " with Network ACL Id: " + acl.getId() + ", Applying ACL items");
             //Apply ACL to network
             Boolean result = applyACLToNetwork(network.getId());
             if (result) {
@@ -292,8 +290,8 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     @DB
     private void revokeRule(NetworkACLItemVO rule) {
         if (rule.getState() == State.Staged) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Found a rule that is still in stage state so just removing it: " + rule);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Found a rule that is still in stage state so just removing it: " + rule);
             }
             _networkACLItemDao.remove(rule.getId());
         } else if (rule.getState() == State.Add || rule.getState() == State.Active) {
@@ -310,12 +308,12 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         }
         List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(network.getNetworkACLId());
         if (aclItems.isEmpty()) {
-            s_logger.debug("Found no network ACL Items for network id=" + networkId);
+            logger.debug("Found no network ACL Items for network id=" + networkId);
             return true;
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing " + aclItems.size() + " Network ACL Items for network id=" + networkId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing " + aclItems.size() + " Network ACL Items for network id=" + networkId);
         }
 
         for (NetworkACLItemVO aclItem : aclItems) {
@@ -327,8 +325,8 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
 
         boolean success = applyACLItemsToNetwork(network.getId(), aclItems);
 
-        if (s_logger.isDebugEnabled() && success) {
-            s_logger.debug("Successfully released Network ACLs for network id=" + networkId + " and # of rules now = " + aclItems.size());
+        if (logger.isDebugEnabled() && success) {
+            logger.debug("Successfully released Network ACLs for network id=" + networkId + " and # of rules now = " + aclItems.size());
         }
 
         return success;
@@ -339,12 +337,12 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
 
         List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(gateway.getNetworkACLId());
         if (aclItems.isEmpty()) {
-            s_logger.debug("Found no network ACL Items for private gateway  id=" + gateway.getId());
+            logger.debug("Found no network ACL Items for private gateway  id=" + gateway.getId());
             return true;
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Releasing " + aclItems.size() + " Network ACL Items for private gateway  id=" + gateway.getId());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Releasing " + aclItems.size() + " Network ACL Items for private gateway  id=" + gateway.getId());
         }
 
         for (NetworkACLItemVO aclItem : aclItems) {
@@ -356,8 +354,8 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
 
         boolean success = applyACLToPrivateGw(gateway, aclItems);
 
-        if (s_logger.isDebugEnabled() && success) {
-            s_logger.debug("Successfully released Network ACLs for private gateway id=" + gateway.getId() + " and # of rules now = " + aclItems.size());
+        if (logger.isDebugEnabled() && success) {
+            logger.debug("Successfully released Network ACLs for private gateway id=" + gateway.getId() + " and # of rules now = " + aclItems.size());
         }
 
         return success;
@@ -398,7 +396,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
                 return provider.applyACLItemsToPrivateGw(gateway, rules);
             }
         } catch(Exception ex) {
-            s_logger.debug("Failed to apply acl to private gateway " + gateway);
+            logger.debug("Failed to apply acl to private gateway " + gateway);
         }
         return false;
     }
@@ -488,7 +486,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
                 continue;
             }
             foundProvider = true;
-            s_logger.debug("Applying NetworkACL for network: " + network.getId() + " with Network ACL service provider");
+            logger.debug("Applying NetworkACL for network: " + network.getId() + " with Network ACL service provider");
             handled = element.applyNetworkACLs(network, rules);
             if (handled) {
                 // publish message on message bus, so that network elements implementing distributed routing
@@ -498,7 +496,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
             }
         }
         if (!foundProvider) {
-            s_logger.debug("Unable to find NetworkACL service provider for network: " + network.getId());
+            logger.debug("Unable to find NetworkACL service provider for network: " + network.getId());
         }
         return handled;
     }

--- a/server/src/com/cloud/network/vpc/NetworkACLServiceImpl.java
+++ b/server/src/com/cloud/network/vpc/NetworkACLServiceImpl.java
@@ -24,7 +24,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -67,7 +66,6 @@ import com.cloud.utils.net.NetUtils;
 @Component
 @Local(value = {NetworkACLService.class})
 public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLService {
-    private static final Logger s_logger = Logger.getLogger(NetworkACLServiceImpl.class);
 
     @Inject
     AccountManager _accountMgr;
@@ -324,7 +322,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
             if (aclId == null) {
                 //Network is not associated with any ACL. Create a new ACL and add aclItem in it for backward compatibility
-                s_logger.debug("Network " + network.getId() + " is not associated with any ACL. Creating an ACL before adding acl item");
+                logger.debug("Network " + network.getId() + " is not associated with any ACL. Creating an ACL before adding acl item");
 
                 //verify that ACLProvider is supported by network offering
                 if (!_networkModel.areServicesSupportedByNetworkOffering(network.getNetworkOfferingId(), Network.Service.NetworkACL)) {
@@ -343,14 +341,14 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
                 if (acl == null) {
                     throw new CloudRuntimeException("Error while create ACL before adding ACL Item for network " + network.getId());
                 }
-                s_logger.debug("Created ACL: " + aclName + " for network " + network.getId());
+                logger.debug("Created ACL: " + aclName + " for network " + network.getId());
                 aclId = acl.getId();
                 //Apply acl to network
                 try {
                     if (!_networkAclMgr.replaceNetworkACL(acl, (NetworkVO)network)) {
                         throw new CloudRuntimeException("Unable to apply auto created ACL to network " + network.getId());
                     }
-                    s_logger.debug("Created ACL is applied to network " + network.getId());
+                    logger.debug("Created ACL is applied to network " + network.getId());
                 } catch (ResourceUnavailableException e) {
                     throw new CloudRuntimeException("Unable to apply auto created ACL to network " + network.getId(), e);
                 }

--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -48,7 +48,6 @@ import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationSe
 import org.apache.cloudstack.framework.config.ConfigDepot;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
-import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.configuration.ConfigurationManager;
@@ -145,7 +144,6 @@ import com.cloud.vm.dao.DomainRouterDao;
 
 @Local(value = {VpcManager.class, VpcService.class, VpcProvisioningService.class})
 public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvisioningService, VpcService {
-    private static final Logger s_logger = Logger.getLogger(VpcManagerImpl.class);
 
     public static final String SERVICE = "service";
     public static final String CAPABILITYTYPE = "capabilitytype";
@@ -252,7 +250,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             public void doInTransactionWithoutResult(final TransactionStatus status) {
 
                 if (_vpcOffDao.findByUniqueName(VpcOffering.defaultVPCOfferingName) == null) {
-                    s_logger.debug("Creating default VPC offering " + VpcOffering.defaultVPCOfferingName);
+                    logger.debug("Creating default VPC offering " + VpcOffering.defaultVPCOfferingName);
 
                     final Map<Service, Set<Provider>> svcProviderMap = new HashMap<Service, Set<Provider>>();
                     final Set<Provider> defaultProviders = new HashSet<Provider>();
@@ -273,7 +271,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                 //configure default vpc offering with Netscaler as LB Provider
                 if (_vpcOffDao.findByUniqueName(VpcOffering.defaultVPCNSOfferingName) == null) {
-                    s_logger.debug("Creating default VPC offering with Netscaler as LB Provider" + VpcOffering.defaultVPCNSOfferingName);
+                    logger.debug("Creating default VPC offering with Netscaler as LB Provider" + VpcOffering.defaultVPCNSOfferingName);
                     final Map<Service, Set<Provider>> svcProviderMap = new HashMap<Service, Set<Provider>>();
                     final Set<Provider> defaultProviders = new HashSet<Provider>();
                     defaultProviders.add(Provider.VPCVirtualRouter);
@@ -293,7 +291,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 }
 
                 if (_vpcOffDao.findByUniqueName(VpcOffering.redundantVPCOfferingName) == null) {
-                    s_logger.debug("Creating Redundant VPC offering " + VpcOffering.redundantVPCOfferingName);
+                    logger.debug("Creating Redundant VPC offering " + VpcOffering.redundantVPCOfferingName);
 
                     final Map<Service, Set<Provider>> svcProviderMap = new HashMap<Service, Set<Provider>>();
                     final Set<Provider> defaultProviders = new HashSet<Provider>();
@@ -383,7 +381,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             }
 
             if (service == Service.Connectivity) {
-                s_logger.debug("Applying Connectivity workaround, setting provider to NiciraNvp");
+                logger.debug("Applying Connectivity workaround, setting provider to NiciraNvp");
                 svcProviderMap.put(service, sdnProviders);
             } else {
                 svcProviderMap.put(service, defaultProviders);
@@ -398,12 +396,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         }
 
         if (!sourceNatSvc) {
-            s_logger.debug("Automatically adding source nat service to the list of VPC services");
+            logger.debug("Automatically adding source nat service to the list of VPC services");
             svcProviderMap.put(Service.SourceNat, defaultProviders);
         }
 
         if (!firewallSvs) {
-            s_logger.debug("Automatically adding network ACL service to the list of VPC services");
+            logger.debug("Automatically adding network ACL service to the list of VPC services");
             svcProviderMap.put(Service.NetworkACL, defaultProviders);
         }
 
@@ -464,7 +462,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 if (state != null) {
                     offering.setState(state);
                 }
-                s_logger.debug("Adding vpc offering " + offering);
+                logger.debug("Adding vpc offering " + offering);
                 offering = _vpcOffDao.persist(offering);
                 // populate services and providers
                 if (svcProviderMap != null) {
@@ -474,7 +472,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                             for (final Network.Provider provider : providers) {
                                 final VpcOfferingServiceMapVO offService = new VpcOfferingServiceMapVO(offering.getId(), service, provider);
                                 _vpcOffSvcMapDao.persist(offService);
-                                s_logger.trace("Added service for the vpc offering: " + offService + " with provider " + provider.getName());
+                                logger.trace("Added service for the vpc offering: " + offService + " with provider " + provider.getName());
                             }
                         } else {
                             throw new InvalidParameterValueException("Provider is missing for the VPC offering service " + service.getName());
@@ -754,7 +752,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         }
 
         if (_vpcOffDao.update(vpcOffId, offering)) {
-            s_logger.debug("Updated VPC offeirng id=" + vpcOffId);
+            logger.debug("Updated VPC offeirng id=" + vpcOffId);
             return _vpcOffDao.findById(vpcOffId);
         } else {
             return null;
@@ -850,7 +848,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                 final VpcVO persistedVpc = _vpcDao.persist(vpc, finalizeServicesAndProvidersForVpc(vpc.getZoneId(), vpc.getVpcOfferingId()));
                 _resourceLimitMgr.incrementResourceCount(vpc.getAccountId(), ResourceType.vpc);
-                s_logger.debug("Created VPC " + persistedVpc);
+                logger.debug("Created VPC " + persistedVpc);
 
                 return persistedVpc;
             }
@@ -908,7 +906,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @Override
     @DB
     public boolean destroyVpc(final Vpc vpc, final Account caller, final Long callerUserId) throws ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("Destroying vpc " + vpc);
+        logger.debug("Destroying vpc " + vpc);
 
         //don't allow to delete vpc if it's in use by existing non system networks (system networks are networks of a private gateway of the VPC,
         //and they will get removed as a part of VPC cleanup
@@ -919,7 +917,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         //mark VPC as inactive
         if (vpc.getState() != Vpc.State.Inactive) {
-            s_logger.debug("Updating VPC " + vpc + " with state " + Vpc.State.Inactive + " as a part of vpc delete");
+            logger.debug("Updating VPC " + vpc + " with state " + Vpc.State.Inactive + " as a part of vpc delete");
             final VpcVO vpcVO = _vpcDao.findById(vpc.getId());
             vpcVO.setState(Vpc.State.Inactive);
 
@@ -936,22 +934,22 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         //shutdown VPC
         if (!shutdownVpc(vpc.getId())) {
-            s_logger.warn("Failed to shutdown vpc " + vpc + " as a part of vpc destroy process");
+            logger.warn("Failed to shutdown vpc " + vpc + " as a part of vpc destroy process");
             return false;
         }
 
         //cleanup vpc resources
         if (!cleanupVpcResources(vpc.getId(), caller, callerUserId)) {
-            s_logger.warn("Failed to cleanup resources for vpc " + vpc);
+            logger.warn("Failed to cleanup resources for vpc " + vpc);
             return false;
         }
 
         //update the instance with removed flag only when the cleanup is executed successfully
         if (_vpcDao.remove(vpc.getId())) {
-            s_logger.debug("Vpc " + vpc + " is destroyed succesfully");
+            logger.debug("Vpc " + vpc + " is destroyed succesfully");
             return true;
         } else {
-            s_logger.warn("Vpc " + vpc + " failed to destroy");
+            logger.warn("Vpc " + vpc + " failed to destroy");
             return false;
         }
     }
@@ -989,7 +987,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         }
 
         if (_vpcDao.update(vpcId, vpc)) {
-            s_logger.debug("Updated VPC id=" + vpcId);
+            logger.debug("Updated VPC id=" + vpcId);
             return _vpcDao.findById(vpcId);
         } else {
             return null;
@@ -1178,20 +1176,20 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         boolean result = true;
         try {
             if (!startVpc(vpc, dest, context)) {
-                s_logger.warn("Failed to start vpc " + vpc);
+                logger.warn("Failed to start vpc " + vpc);
                 result = false;
             }
         } catch (final Exception ex) {
-            s_logger.warn("Failed to start vpc " + vpc + " due to ", ex);
+            logger.warn("Failed to start vpc " + vpc + " due to ", ex);
             result = false;
         } finally {
             //do cleanup
             if (!result && destroyOnFailure) {
-                s_logger.debug("Destroying vpc " + vpc + " that failed to start");
+                logger.debug("Destroying vpc " + vpc + " that failed to start");
                 if (destroyVpc(vpc, caller, callerUser.getId())) {
-                    s_logger.warn("Successfully destroyed vpc " + vpc + " that failed to start");
+                    logger.warn("Successfully destroyed vpc " + vpc + " that failed to start");
                 } else {
-                    s_logger.warn("Failed to destroy vpc " + vpc + " that failed to start");
+                    logger.warn("Failed to destroy vpc " + vpc + " that failed to start");
                 }
             }
         }
@@ -1206,9 +1204,9 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         for (final VpcProvider element : getVpcElements()) {
             if (providersToImplement.contains(element.getProvider())) {
                 if (element.implementVpc(vpc, dest, context)) {
-                    s_logger.debug("Vpc " + vpc + " has started succesfully");
+                    logger.debug("Vpc " + vpc + " has started succesfully");
                 } else {
-                    s_logger.warn("Vpc " + vpc + " failed to start");
+                    logger.warn("Vpc " + vpc + " failed to start");
                     success = false;
                 }
             }
@@ -1231,7 +1229,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         _accountMgr.checkAccess(caller, null, false, vpc);
 
         //shutdown provider
-        s_logger.debug("Shutting down vpc " + vpc);
+        logger.debug("Shutting down vpc " + vpc);
         //TODO - shutdown all vpc resources here (ACLs, gateways, etc)
 
         boolean success = true;
@@ -1240,9 +1238,9 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         for (final VpcProvider element : getVpcElements()) {
             if (providersToImplement.contains(element.getProvider())) {
                 if (element.shutdownVpc(vpc, context)) {
-                    s_logger.debug("Vpc " + vpc + " has been shutdown succesfully");
+                    logger.debug("Vpc " + vpc + " has been shutdown succesfully");
                 } else {
-                    s_logger.warn("Vpc " + vpc + " failed to shutdown");
+                    logger.warn("Vpc " + vpc + " failed to shutdown");
                     success = false;
                 }
             }
@@ -1396,7 +1394,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                         throw new InvalidParameterValueException("Invalid gateway specified. It should never be equal to the cidr subnet value");
                     }
                 } finally {
-                    s_logger.debug("Releasing lock for " + locked);
+                    logger.debug("Releasing lock for " + locked);
                     _vpcDao.releaseFromLockTable(locked.getId());
                 }
             }
@@ -1425,18 +1423,18 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     }
 
     public boolean cleanupVpcResources(final long vpcId, final Account caller, final long callerUserId) throws ResourceUnavailableException, ConcurrentOperationException {
-        s_logger.debug("Cleaning up resources for vpc id=" + vpcId);
+        logger.debug("Cleaning up resources for vpc id=" + vpcId);
         boolean success = true;
 
         //1) Remove VPN connections and VPN gateway
-        s_logger.debug("Cleaning up existed site to site VPN connections");
+        logger.debug("Cleaning up existed site to site VPN connections");
         _s2sVpnMgr.cleanupVpnConnectionByVpc(vpcId);
-        s_logger.debug("Cleaning up existed site to site VPN gateways");
+        logger.debug("Cleaning up existed site to site VPN gateways");
         _s2sVpnMgr.cleanupVpnGatewayByVpc(vpcId);
 
         //2) release all ip addresses
         final List<IPAddressVO> ipsToRelease = _ipAddressDao.listByAssociatedVpc(vpcId, null);
-        s_logger.debug("Releasing ips for vpc id=" + vpcId + " as a part of vpc cleanup");
+        logger.debug("Releasing ips for vpc id=" + vpcId + " as a part of vpc cleanup");
         for (final IPAddressVO ipToRelease : ipsToRelease) {
             if (ipToRelease.isPortable()) {
                 // portable IP address are associated with owner, until explicitly requested to be disassociated.
@@ -1444,25 +1442,25 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 ipToRelease.setVpcId(null);
                 ipToRelease.setAssociatedWithNetworkId(null);
                 _ipAddressDao.update(ipToRelease.getId(), ipToRelease);
-                s_logger.debug("Portable IP address " + ipToRelease + " is no longer associated with any VPC");
+                logger.debug("Portable IP address " + ipToRelease + " is no longer associated with any VPC");
             } else {
                 success = success && _ipAddrMgr.disassociatePublicIpAddress(ipToRelease.getId(), callerUserId, caller);
                 if (!success) {
-                    s_logger.warn("Failed to cleanup ip " + ipToRelease + " as a part of vpc id=" + vpcId + " cleanup");
+                    logger.warn("Failed to cleanup ip " + ipToRelease + " as a part of vpc id=" + vpcId + " cleanup");
                 }
             }
         }
 
         if (success) {
-            s_logger.debug("Released ip addresses for vpc id=" + vpcId + " as a part of cleanup vpc process");
+            logger.debug("Released ip addresses for vpc id=" + vpcId + " as a part of cleanup vpc process");
         } else {
-            s_logger.warn("Failed to release ip addresses for vpc id=" + vpcId + " as a part of cleanup vpc process");
+            logger.warn("Failed to release ip addresses for vpc id=" + vpcId + " as a part of cleanup vpc process");
             //although it failed, proceed to the next cleanup step as it doesn't depend on the public ip release
         }
 
         //3) Delete all static route rules
         if (!revokeStaticRoutesForVpc(vpcId, caller)) {
-            s_logger.warn("Failed to revoke static routes for vpc " + vpcId + " as a part of cleanup vpc process");
+            logger.warn("Failed to revoke static routes for vpc " + vpcId + " as a part of cleanup vpc process");
             return false;
         }
 
@@ -1471,12 +1469,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         if (gateways != null) {
             for (final PrivateGateway gateway : gateways) {
                 if (gateway != null) {
-                    s_logger.debug("Deleting private gateway " + gateway + " as a part of vpc " + vpcId + " resources cleanup");
+                    logger.debug("Deleting private gateway " + gateway + " as a part of vpc " + vpcId + " resources cleanup");
                     if (!deleteVpcPrivateGateway(gateway.getId())) {
                         success = false;
-                        s_logger.debug("Failed to delete private gateway " + gateway + " as a part of vpc " + vpcId + " resources cleanup");
+                        logger.debug("Failed to delete private gateway " + gateway + " as a part of vpc " + vpcId + " resources cleanup");
                     } else {
-                        s_logger.debug("Deleted private gateway " + gateway + " as a part of vpc " + vpcId + " resources cleanup");
+                        logger.debug("Deleted private gateway " + gateway + " as a part of vpc " + vpcId + " resources cleanup");
                     }
                 }
             }
@@ -1502,7 +1500,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         _accountMgr.checkAccess(caller, null, false, vpc);
 
-        s_logger.debug("Restarting VPC " + vpc);
+        logger.debug("Restarting VPC " + vpc);
         boolean restartRequired = false;
         try {
 
@@ -1522,26 +1520,26 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             }
 
             if (forceCleanup) {
-                s_logger.debug("Shutting down VPC " + vpc + " as a part of VPC restart process");
+                logger.debug("Shutting down VPC " + vpc + " as a part of VPC restart process");
                 if (!shutdownVpc(vpcId)) {
-                    s_logger.warn("Failed to shutdown vpc as a part of VPC " + vpc + " restart process");
+                    logger.warn("Failed to shutdown vpc as a part of VPC " + vpc + " restart process");
                     restartRequired = true;
                     return false;
                 }
             } else {
-                s_logger.info("Will not shutdown vpc as a part of VPC " + vpc + " restart process.");
+                logger.info("Will not shutdown vpc as a part of VPC " + vpc + " restart process.");
             }
 
-            s_logger.debug("Starting VPC " + vpc + " as a part of VPC restart process");
+            logger.debug("Starting VPC " + vpc + " as a part of VPC restart process");
             if (!startVpc(vpcId, false)) {
-                s_logger.warn("Failed to start vpc as a part of VPC " + vpc + " restart process");
+                logger.warn("Failed to start vpc as a part of VPC " + vpc + " restart process");
                 restartRequired = true;
                 return false;
             }
-            s_logger.debug("VPC " + vpc + " was restarted successfully");
+            logger.debug("VPC " + vpc + " was restarted successfully");
             return true;
         } finally {
-            s_logger.debug("Updating VPC " + vpc + " with restartRequired=" + restartRequired);
+            logger.debug("Updating VPC " + vpc + " with restartRequired=" + restartRequired);
             final VpcVO vo = _vpcDao.findById(vpcId);
             vo.setRestartRequired(restartRequired);
             _vpcDao.update(vpc.getId(), vo);
@@ -1617,7 +1615,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 @Override
                 public VpcGatewayVO doInTransaction(final TransactionStatus status) throws ResourceAllocationException, ConcurrentOperationException,
                 InsufficientCapacityException {
-                    s_logger.debug("Creating Private gateway for VPC " + vpc);
+                    logger.debug("Creating Private gateway for VPC " + vpc);
                     //1) create private network unless it is existing and lswitch'd
                     Network privateNtwk = null;
                     if (BroadcastDomainType.getSchemeValue(BroadcastDomainType.fromString(broadcastUri)) == BroadcastDomainType.Lswitch) {
@@ -1626,13 +1624,13 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                         // if the dcid is different we get no network so next we try to create it
                     }
                     if (privateNtwk == null) {
-                        s_logger.info("creating new network for vpc " + vpc + " using broadcast uri: " + broadcastUri);
+                        logger.info("creating new network for vpc " + vpc + " using broadcast uri: " + broadcastUri);
                         final String networkName = "vpc-" + vpc.getName() + "-privateNetwork";
                         privateNtwk =
                                 _ntwkSvc.createPrivateNetwork(networkName, networkName, physicalNetworkIdFinal, broadcastUri, ipAddress, null, gateway, netmask,
                                         gatewayOwnerId, vpcId, isSourceNat, networkOfferingId);
                     } else { // create the nic/ip as createPrivateNetwork doesn''t do that work for us now
-                        s_logger.info("found and using existing network for vpc " + vpc + ": " + broadcastUri);
+                        logger.info("found and using existing network for vpc " + vpc + ": " + broadcastUri);
                         final DataCenterVO dc = _dcDao.lockRow(physNetFinal.getDataCenterId(), true);
 
                         //add entry to private_ip_address table
@@ -1646,7 +1644,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                         final Long nextMac = mac + 1;
                         dc.setMacAddress(nextMac);
 
-                        s_logger.info("creating private ip adress for vpc (" + ipAddress + ", " + privateNtwk.getId() + ", " + nextMac + ", " + vpcId + ", " + isSourceNat + ")");
+                        logger.info("creating private ip adress for vpc (" + ipAddress + ", " + privateNtwk.getId() + ", " + nextMac + ", " + vpcId + ", " + isSourceNat + ")");
                         privateIp = new PrivateIpVO(ipAddress, privateNtwk.getId(), nextMac, vpcId, isSourceNat);
                         _privateIpDao.persist(privateIp);
 
@@ -1684,7 +1682,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                                     vpc.getAccountId(), vpc.getDomainId(), isSourceNat, networkAclId);
                     _vpcGatewayDao.persist(gatewayVO);
 
-                    s_logger.debug("Created vpc gateway entry " + gatewayVO);
+                    logger.debug("Created vpc gateway entry " + gatewayVO);
 
                     return gatewayVO;
                 }
@@ -1718,28 +1716,28 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 }
             }
             if (success) {
-                s_logger.debug("Private gateway " + gateway + " was applied succesfully on the backend");
+                logger.debug("Private gateway " + gateway + " was applied succesfully on the backend");
                 if (vo.getState() != VpcGateway.State.Ready) {
                     vo.setState(VpcGateway.State.Ready);
                     _vpcGatewayDao.update(vo.getId(), vo);
-                    s_logger.debug("Marke gateway " + gateway + " with state " + VpcGateway.State.Ready);
+                    logger.debug("Marke gateway " + gateway + " with state " + VpcGateway.State.Ready);
                 }
                 CallContext.current().setEventDetails("Private Gateway Id: " + gatewayId);
                 return getVpcPrivateGateway(gatewayId);
             } else {
-                s_logger.warn("Private gateway " + gateway + " failed to apply on the backend");
+                logger.warn("Private gateway " + gateway + " failed to apply on the backend");
                 return null;
             }
         } finally {
             //do cleanup
             if (!success) {
                 if (destroyOnFailure) {
-                    s_logger.debug("Destroying private gateway " + vo + " that failed to start");
+                    logger.debug("Destroying private gateway " + vo + " that failed to start");
                     // calling deleting from db because on createprivategateway fail, destroyPrivateGateway is already called
                     if (deletePrivateGatewayFromTheDB(getVpcPrivateGateway(gatewayId))) {
-                        s_logger.warn("Successfully destroyed vpc " + vo + " that failed to start");
+                        logger.warn("Successfully destroyed vpc " + vo + " that failed to start");
                     } else {
-                        s_logger.warn("Failed to destroy vpc " + vo + " that failed to start");
+                        logger.warn("Failed to destroy vpc " + vo + " that failed to start");
                     }
                 }
             }
@@ -1769,7 +1767,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
                     gatewayVO.setState(VpcGateway.State.Deleting);
                     _vpcGatewayDao.update(gatewayVO.getId(), gatewayVO);
-                    s_logger.debug("Marked gateway " + gatewayVO + " with state " + VpcGateway.State.Deleting);
+                    logger.debug("Marked gateway " + gatewayVO + " with state " + VpcGateway.State.Deleting);
                 }
             });
 
@@ -1779,12 +1777,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             for (final VpcProvider provider : getVpcElements()) {
                 if (providersToImplement.contains(provider.getProvider())) {
                     if (provider.deletePrivateGateway(gateway)) {
-                        s_logger.debug("Private gateway " + gateway + " was applied succesfully on the backend");
+                        logger.debug("Private gateway " + gateway + " was applied succesfully on the backend");
                     } else {
-                        s_logger.warn("Private gateway " + gateway + " failed to apply on the backend");
+                        logger.warn("Private gateway " + gateway + " failed to apply on the backend");
                         gatewayVO.setState(VpcGateway.State.Ready);
                         _vpcGatewayDao.update(gatewayVO.getId(), gatewayVO);
-                        s_logger.debug("Marked gateway " + gatewayVO + " with state " + VpcGateway.State.Ready);
+                        logger.debug("Marked gateway " + gatewayVO + " with state " + VpcGateway.State.Ready);
 
                         return false;
                     }
@@ -1819,12 +1817,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 final Account owner = _accountMgr.getAccount(Account.ACCOUNT_ID_SYSTEM);
                 final ReservationContext context = new ReservationContextImpl(null, null, callerUser, owner);
                 _ntwkMgr.destroyNetwork(networkId, context, false);
-                s_logger.debug("Deleted private network id=" + networkId);
+                logger.debug("Deleted private network id=" + networkId);
             }
         } catch (final InterruptedException e) {
-            s_logger.error("deletePrivateGatewayFromTheDB failed to delete network id " + networkId + "due to => ", e);
+            logger.error("deletePrivateGatewayFromTheDB failed to delete network id " + networkId + "due to => ", e);
         } catch (final ExecutionException e) {
-            s_logger.error("deletePrivateGatewayFromTheDB failed to delete network id " + networkId + "due to => ", e);
+            logger.error("deletePrivateGatewayFromTheDB failed to delete network id " + networkId + "due to => ", e);
         }
 
         return true;
@@ -1918,19 +1916,19 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             staticRouteProfiles.add(new StaticRouteProfile(route, gateway));
         }
         if (!applyStaticRoutes(staticRouteProfiles)) {
-            s_logger.warn("Routes are not completely applied");
+            logger.warn("Routes are not completely applied");
             return false;
         } else {
             if (updateRoutesInDB) {
                 for (final StaticRoute route : routes) {
                     if (route.getState() == StaticRoute.State.Revoke) {
                         _staticRouteDao.remove(route.getId());
-                        s_logger.debug("Removed route " + route + " from the DB");
+                        logger.debug("Removed route " + route + " from the DB");
                     } else if (route.getState() == StaticRoute.State.Add) {
                         final StaticRouteVO ruleVO = _staticRouteDao.findById(route.getId());
                         ruleVO.setState(StaticRoute.State.Active);
                         _staticRouteDao.update(ruleVO.getId(), ruleVO);
-                        s_logger.debug("Marked route " + route + " with state " + StaticRoute.State.Active);
+                        logger.debug("Marked route " + route + " with state " + StaticRoute.State.Active);
                     }
                 }
             }
@@ -1941,12 +1939,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     protected boolean applyStaticRoutes(final List<StaticRouteProfile> routes) throws ResourceUnavailableException {
         if (routes.isEmpty()) {
-            s_logger.debug("No static routes to apply");
+            logger.debug("No static routes to apply");
             return true;
         }
         final Vpc vpc = _vpcDao.findById(routes.get(0).getVpcId());
 
-        s_logger.debug("Applying static routes for vpc " + vpc);
+        logger.debug("Applying static routes for vpc " + vpc);
         final String staticNatProvider = _vpcSrvcDao.getProviderForServiceInVpc(vpc.getId(), Service.StaticNat);
 
         for (final VpcProvider provider : getVpcElements()) {
@@ -1955,9 +1953,9 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             }
 
             if (provider.applyStaticRoutes(vpc, routes)) {
-                s_logger.debug("Applied static routes for vpc " + vpc);
+                logger.debug("Applied static routes for vpc " + vpc);
             } else {
-                s_logger.warn("Failed to apply static routes for vpc " + vpc);
+                logger.warn("Failed to apply static routes for vpc " + vpc);
                 return false;
             }
         }
@@ -1986,7 +1984,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     protected boolean revokeStaticRoutesForVpc(final long vpcId, final Account caller) throws ResourceUnavailableException {
         //get all static routes for the vpc
         final List<StaticRouteVO> routes = _staticRouteDao.listByVpcId(vpcId);
-        s_logger.debug("Found " + routes.size() + " to revoke for the vpc " + vpcId);
+        logger.debug("Found " + routes.size() + " to revoke for the vpc " + vpcId);
         if (!routes.isEmpty()) {
             //mark all of them as revoke
             Transaction.execute(new TransactionCallbackNoReturn() {
@@ -2049,7 +2047,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             @Override
             public StaticRouteVO doInTransaction(final TransactionStatus status) throws NetworkRuleConflictException {
                 StaticRouteVO newRoute = new StaticRouteVO(gateway.getId(), cidr, vpc.getId(), vpc.getAccountId(), vpc.getDomainId());
-                s_logger.debug("Adding static route " + newRoute);
+                logger.debug("Adding static route " + newRoute);
                 newRoute = _staticRouteDao.persist(newRoute);
 
                 detectRoutesConflict(newRoute);
@@ -2170,20 +2168,20 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     }
 
     protected void markStaticRouteForRevoke(final StaticRouteVO route, final Account caller) {
-        s_logger.debug("Revoking static route " + route);
+        logger.debug("Revoking static route " + route);
         if (caller != null) {
             _accountMgr.checkAccess(caller, null, false, route);
         }
 
         if (route.getState() == StaticRoute.State.Staged) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Found a static route that is still in stage state so just removing it: " + route);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Found a static route that is still in stage state so just removing it: " + route);
             }
             _staticRouteDao.remove(route.getId());
         } else if (route.getState() == StaticRoute.State.Add || route.getState() == StaticRoute.State.Active) {
             route.setState(StaticRoute.State.Revoke);
             _staticRouteDao.update(route.getId(), route);
-            s_logger.debug("Marked static route " + route + " with state " + StaticRoute.State.Revoke);
+            logger.debug("Marked static route " + route + " with state " + StaticRoute.State.Revoke);
         }
     }
 
@@ -2193,12 +2191,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             try {
                 final GlobalLock lock = GlobalLock.getInternLock("VpcCleanup");
                 if (lock == null) {
-                    s_logger.debug("Couldn't get the global lock");
+                    logger.debug("Couldn't get the global lock");
                     return;
                 }
 
                 if (!lock.lock(30)) {
-                    s_logger.debug("Couldn't lock the db");
+                    logger.debug("Couldn't lock the db");
                     return;
                 }
 
@@ -2206,19 +2204,19 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                     // Cleanup inactive VPCs
                     final List<VpcVO> inactiveVpcs = _vpcDao.listInactiveVpcs();
                     if (inactiveVpcs != null) {
-                        s_logger.info("Found " + inactiveVpcs.size() + " removed VPCs to cleanup");
+                        logger.info("Found " + inactiveVpcs.size() + " removed VPCs to cleanup");
                         for (final VpcVO vpc : inactiveVpcs) {
-                            s_logger.debug("Cleaning up " + vpc);
+                            logger.debug("Cleaning up " + vpc);
                             destroyVpc(vpc, _accountMgr.getAccount(Account.ACCOUNT_ID_SYSTEM), User.UID_SYSTEM);
                         }
                     }
                 } catch (final Exception e) {
-                    s_logger.error("Exception ", e);
+                    logger.error("Exception ", e);
                 } finally {
                     lock.unlock();
                 }
             } catch (final Exception e) {
-                s_logger.error("Exception ", e);
+                logger.error("Exception ", e);
             }
         }
     }
@@ -2236,7 +2234,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             _accountMgr.checkAccess(caller, null, true, ipToAssoc);
             owner = _accountMgr.getAccount(ipToAssoc.getAllocatedToAccountId());
         } else {
-            s_logger.debug("Unable to find ip address by id: " + ipId);
+            logger.debug("Unable to find ip address by id: " + ipId);
             return null;
         }
 
@@ -2253,7 +2251,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             isSourceNat = true;
         }
 
-        s_logger.debug("Associating ip " + ipToAssoc + " to vpc " + vpc);
+        logger.debug("Associating ip " + ipToAssoc + " to vpc " + vpc);
 
         final boolean isSourceNatFinal = isSourceNat;
         Transaction.execute(new TransactionCallbackNoReturn() {
@@ -2271,7 +2269,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             }
         });
 
-        s_logger.debug("Successfully assigned ip " + ipToAssoc + " to vpc " + vpc);
+        logger.debug("Successfully assigned ip " + ipToAssoc + " to vpc " + vpc);
 
         return _ipAddressDao.findById(ipId);
     }
@@ -2287,7 +2285,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             return;
         }
 
-        s_logger.debug("Releasing VPC ip address " + ip + " from vpc network id=" + networkId);
+        logger.debug("Releasing VPC ip address " + ip + " from vpc network id=" + networkId);
 
         final long  vpcId = ip.getVpcId();
         boolean success = false;
@@ -2301,11 +2299,11 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         if (success) {
             ip.setAssociatedWithNetworkId(null);
             _ipAddressDao.update(ipId, ip);
-            s_logger.debug("IP address " + ip + " is no longer associated with the network inside vpc id=" + vpcId);
+            logger.debug("IP address " + ip + " is no longer associated with the network inside vpc id=" + vpcId);
         } else {
             throw new CloudRuntimeException("Failed to apply ip associations for network id=" + networkId + " as a part of unassigning ip " + ipId + " from vpc");
         }
-        s_logger.debug("Successfully released VPC ip address " + ip + " back to VPC pool ");
+        logger.debug("Successfully released VPC ip address " + ip + " back to VPC pool ");
     }
 
     @Override

--- a/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -24,7 +24,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.command.user.vpn.CreateVpnConnectionCmd;
@@ -83,7 +82,6 @@ import com.cloud.vm.DomainRouterVO;
 @Component
 @Local(value = {Site2SiteVpnManager.class, Site2SiteVpnService.class})
 public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpnManager {
-    private static final Logger s_logger = Logger.getLogger(Site2SiteVpnManagerImpl.class);
 
     List<Site2SiteVpnServiceProvider> _s2sProviders;
     @Inject
@@ -786,7 +784,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
                     startVpnConnection(conn.getId());
                 } catch (ResourceUnavailableException e) {
                     Site2SiteCustomerGatewayVO gw = _customerGatewayDao.findById(conn.getCustomerGatewayId());
-                    s_logger.warn("Site2SiteVpnManager: Fail to re-initiate VPN connection " + conn.getId() + " which connect to " + gw.getName());
+                    logger.warn("Site2SiteVpnManager: Fail to re-initiate VPN connection " + conn.getId() + " which connect to " + gw.getName());
                 }
             }
         }

--- a/server/src/com/cloud/resource/DiscovererBase.java
+++ b/server/src/com/cloud/resource/DiscovererBase.java
@@ -26,7 +26,6 @@ import com.cloud.network.NetworkModel;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.net.UrlUtil;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
@@ -38,7 +37,6 @@ import java.util.Map;
 
 public abstract class DiscovererBase extends AdapterBase implements Discoverer {
     protected Map<String, String> _params;
-    private static final Logger s_logger = Logger.getLogger(DiscovererBase.class);
     @Inject
     protected ClusterDao _clusterDao;
     @Inject
@@ -90,19 +88,19 @@ public abstract class DiscovererBase extends AdapterBase implements Discoverer {
             Constructor constructor = clazz.getConstructor();
             resource = (ServerResource)constructor.newInstance();
         } catch (ClassNotFoundException e) {
-            s_logger.warn("Unable to find class " + resourceName, e);
+            logger.warn("Unable to find class " + resourceName, e);
         } catch (InstantiationException e) {
-            s_logger.warn("Unablet to instantiate class " + resourceName, e);
+            logger.warn("Unablet to instantiate class " + resourceName, e);
         } catch (IllegalAccessException e) {
-            s_logger.warn("Illegal access " + resourceName, e);
+            logger.warn("Illegal access " + resourceName, e);
         } catch (SecurityException e) {
-            s_logger.warn("Security error on " + resourceName, e);
+            logger.warn("Security error on " + resourceName, e);
         } catch (NoSuchMethodException e) {
-            s_logger.warn("NoSuchMethodException error on " + resourceName, e);
+            logger.warn("NoSuchMethodException error on " + resourceName, e);
         } catch (IllegalArgumentException e) {
-            s_logger.warn("IllegalArgumentException error on " + resourceName, e);
+            logger.warn("IllegalArgumentException error on " + resourceName, e);
         } catch (InvocationTargetException e) {
-            s_logger.warn("InvocationTargetException error on " + resourceName, e);
+            logger.warn("InvocationTargetException error on " + resourceName, e);
         }
 
         return resource;
@@ -157,11 +155,11 @@ public abstract class DiscovererBase extends AdapterBase implements Discoverer {
             try {
                 resource.configure(host.getName(), params);
             } catch (ConfigurationException e) {
-                s_logger.warn("Unable to configure resource due to " + e.getMessage());
+                logger.warn("Unable to configure resource due to " + e.getMessage());
                 return null;
             }
             if (!resource.start()) {
-                s_logger.warn("Unable to start the resource");
+                logger.warn("Unable to start the resource");
                 return null;
             }
         }

--- a/server/src/com/cloud/resource/DummyHostDiscoverer.java
+++ b/server/src/com/cloud/resource/DummyHostDiscoverer.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.host.HostVO;
@@ -35,7 +34,6 @@ import com.cloud.utils.component.AdapterBase;
 @Component
 @Local(value = Discoverer.class)
 public class DummyHostDiscoverer extends AdapterBase implements Discoverer {
-    private static final Logger s_logger = Logger.getLogger(DummyHostDiscoverer.class);
 
     @Override
     public Map<ServerResource, Map<String, String>> find(long dcId, Long podId, Long clusterId, URI url, String username, String password, List<String> hostTags) {
@@ -62,7 +60,7 @@ public class DummyHostDiscoverer extends AdapterBase implements Discoverer {
         try {
             resource.configure("Dummy Host Server", params);
         } catch (ConfigurationException e) {
-            s_logger.warn("Unable to instantiate dummy host server resource");
+            logger.warn("Unable to instantiate dummy host server resource");
         }
         resource.start();
         resources.put(resource, details);

--- a/server/src/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/com/cloud/resource/ResourceManagerImpl.java
@@ -46,7 +46,6 @@ import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.commons.lang.ObjectUtils;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.AgentManager;
@@ -174,7 +173,6 @@ import com.google.gson.Gson;
 @Component
 @Local({ResourceManager.class, ResourceService.class})
 public class ResourceManagerImpl extends ManagerBase implements ResourceManager, ResourceService, Manager {
-    private static final Logger s_logger = Logger.getLogger(ResourceManagerImpl.class);
 
     Gson _gson;
 
@@ -356,7 +354,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             } else {
                 throw new CloudRuntimeException("Unknown resource event:" + event);
             }
-            s_logger.debug("Sent resource event " + eventName + " to listener " + l.getClass().getSimpleName());
+            logger.debug("Sent resource event " + eventName + " to listener " + l.getClass().getSimpleName());
         }
 
     }
@@ -420,7 +418,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         final Hypervisor.HypervisorType hypervisorType = Hypervisor.HypervisorType.getType(cmd.getHypervisor());
         if (hypervisorType == null) {
-            s_logger.error("Unable to resolve " + cmd.getHypervisor() + " to a valid supported hypervisor type");
+            logger.error("Unable to resolve " + cmd.getHypervisor() + " to a valid supported hypervisor type");
             throw new InvalidParameterValueException("Unable to resolve " + cmd.getHypervisor() + " to a supported ");
         }
 
@@ -534,12 +532,12 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     }
                     discoverer.postDiscovery(hosts, _nodeId);
                 }
-                s_logger.info("External cluster has been successfully discovered by " + discoverer.getName());
+                logger.info("External cluster has been successfully discovered by " + discoverer.getName());
                 success = true;
                 return result;
             }
 
-            s_logger.warn("Unable to find the server resources at " + url);
+            logger.warn("Unable to find the server resources at " + url);
             throw new DiscoveryException("Unable to add the external cluster");
         } finally {
             if (!success) {
@@ -730,7 +728,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         }
 
         final List<HostVO> hosts = new ArrayList<HostVO>();
-        s_logger.info("Trying to add a new host at " + url + " in data center " + dcId);
+        logger.info("Trying to add a new host at " + url + " in data center " + dcId);
         boolean isHypervisorTypeSupported = false;
         for (final Discoverer discoverer : _discoverers) {
             if (params != null) {
@@ -749,7 +747,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             } catch (final DiscoveryException e) {
                 throw e;
             } catch (final Exception e) {
-                s_logger.info("Exception in host discovery process with discoverer: " + discoverer.getName() + ", skip to another discoverer if there is any");
+                logger.info("Exception in host discovery process with discoverer: " + discoverer.getName() + ", skip to another discoverer if there is any");
             }
             processResourceEvent(ResourceListener.EVENT_DISCOVER_AFTER, resources);
 
@@ -767,8 +765,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                         for (final HostVO host : kvmHosts) {
                             if (host.getGuid().equalsIgnoreCase(guid)) {
                                 if (hostTags != null) {
-                                    if (s_logger.isTraceEnabled()) {
-                                        s_logger.trace("Adding Host Tags for KVM host, tags:  :" + hostTags);
+                                    if (logger.isTraceEnabled()) {
+                                        logger.trace("Adding Host Tags for KVM host, tags:  :" + hostTags);
                                     }
                                     _hostTagsDao.persist(host.getId(), hostTags);
                                 }
@@ -791,16 +789,16 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     discoverer.postDiscovery(hosts, _nodeId);
 
                 }
-                s_logger.info("server resources successfully discovered by " + discoverer.getName());
+                logger.info("server resources successfully discovered by " + discoverer.getName());
                 return hosts;
             }
         }
         if (!isHypervisorTypeSupported) {
             final String msg = "Do not support HypervisorType " + hypervisorType + " for " + url;
-            s_logger.warn(msg);
+            logger.warn(msg);
             throw new DiscoveryException(msg);
         }
-        s_logger.warn("Unable to find the server resources at " + url);
+        logger.warn("Unable to find the server resources at " + url);
         throw new DiscoveryException("Unable to add the host");
     }
 
@@ -879,7 +877,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 try {
                     resourceStateTransitTo(host, ResourceState.Event.DeleteHost, _nodeId);
                 } catch (final NoTransitionException e) {
-                    s_logger.debug("Cannot transmit host " + host.getId() + " to Enabled state", e);
+                    logger.debug("Cannot transmit host " + host.getId() + " to Enabled state", e);
                 }
 
                 // Delete the associated entries in host ref table
@@ -904,7 +902,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                         storagePool.setClusterId(null);
                         _storagePoolDao.update(poolId, storagePool);
                         _storagePoolDao.remove(poolId);
-                        s_logger.debug("Local storage id=" + poolId + " is removed as a part of host removal id=" + hostId);
+                        logger.debug("Local storage id=" + poolId + " is removed as a part of host removal id=" + hostId);
                     }
                 }
 
@@ -948,8 +946,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 public void doInTransactionWithoutResult(final TransactionStatus status) {
                     final ClusterVO cluster = _clusterDao.lockRow(cmd.getId(), true);
                     if (cluster == null) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Cluster: " + cmd.getId() + " does not even exist.  Delete call is ignored.");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Cluster: " + cmd.getId() + " does not even exist.  Delete call is ignored.");
                         }
                         throw new CloudRuntimeException("Cluster: " + cmd.getId() + " does not exist");
                     }
@@ -958,8 +956,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
                     final List<HostVO> hosts = listAllHostsInCluster(cmd.getId());
                     if (hosts.size() > 0) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Cluster: " + cmd.getId() + " still has hosts, can't remove");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Cluster: " + cmd.getId() + " still has hosts, can't remove");
                         }
                         throw new CloudRuntimeException("Cluster: " + cmd.getId() + " cannot be removed. Cluster still has hosts");
                     }
@@ -968,8 +966,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     // pools
                     final List<StoragePoolVO> storagePools = _storagePoolDao.listPoolsByCluster(cmd.getId());
                     if (storagePools.size() > 0) {
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Cluster: " + cmd.getId() + " still has storage pools, can't remove");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Cluster: " + cmd.getId() + " still has storage pools, can't remove");
                         }
                         throw new CloudRuntimeException("Cluster: " + cmd.getId() + " cannot be removed. Cluster still has storage pools");
                     }
@@ -995,7 +993,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         } catch (final CloudRuntimeException e) {
             throw e;
         } catch (final Throwable t) {
-            s_logger.error("Unable to delete cluster: " + cmd.getId(), t);
+            logger.error("Unable to delete cluster: " + cmd.getId(), t);
             return false;
         }
     }
@@ -1011,7 +1009,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         if (hypervisor != null && !hypervisor.isEmpty()) {
             final Hypervisor.HypervisorType hypervisorType = Hypervisor.HypervisorType.getType(hypervisor);
             if (hypervisorType == null) {
-                s_logger.error("Unable to resolve " + hypervisor + " to a valid supported hypervisor type");
+                logger.error("Unable to resolve " + hypervisor + " to a valid supported hypervisor type");
                 throw new InvalidParameterValueException("Unable to resolve " + hypervisor + " to a supported type");
             } else {
                 cluster.setHypervisorType(hypervisor);
@@ -1027,7 +1025,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 throw new InvalidParameterValueException("Unable to resolve " + clusterType + " to a supported type");
             }
             if (newClusterType == null) {
-                s_logger.error("Unable to resolve " + clusterType + " to a valid supported cluster type");
+                logger.error("Unable to resolve " + clusterType + " to a valid supported cluster type");
                 throw new InvalidParameterValueException("Unable to resolve " + clusterType + " to a supported type");
             } else {
                 cluster.setClusterType(newClusterType);
@@ -1043,7 +1041,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 throw new InvalidParameterValueException("Unable to resolve Allocation State '" + allocationState + "' to a supported state");
             }
             if (newAllocationState == null) {
-                s_logger.error("Unable to resolve " + allocationState + " to a valid supported allocation State");
+                logger.error("Unable to resolve " + allocationState + " to a valid supported allocation State");
                 throw new InvalidParameterValueException("Unable to resolve " + allocationState + " to a supported state");
             } else {
                 cluster.setAllocationState(newAllocationState);
@@ -1060,7 +1058,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 throw new InvalidParameterValueException("Unable to resolve Managed State '" + managedstate + "' to a supported state");
             }
             if (newManagedState == null) {
-                s_logger.error("Unable to resolve Managed State '" + managedstate + "' to a supported state");
+                logger.error("Unable to resolve Managed State '" + managedstate + "' to a supported state");
                 throw new InvalidParameterValueException("Unable to resolve Managed State '" + managedstate + "' to a supported state");
             } else {
                 doUpdate = true;
@@ -1179,7 +1177,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         final HostVO host = _hostDao.findById(hostId);
         final MaintainAnswer answer = (MaintainAnswer)_agentMgr.easySend(hostId, new MaintainCommand());
         if (answer == null || !answer.getResult()) {
-            s_logger.warn("Unable to send MaintainCommand to host: " + hostId);
+            logger.warn("Unable to send MaintainCommand to host: " + hostId);
             return false;
         }
 
@@ -1187,7 +1185,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             resourceStateTransitTo(host, ResourceState.Event.AdminAskMaintenace, _nodeId);
         } catch (final NoTransitionException e) {
             final String err = "Cannot transmit resource state of host " + host.getId() + " to " + ResourceState.Maintenance;
-            s_logger.debug(err, e);
+            logger.debug(err, e);
             throw new CloudRuntimeException(err + e.getMessage());
         }
 
@@ -1236,7 +1234,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         final HostVO host = _hostDao.findById(hostId);
 
         if (host == null) {
-            s_logger.debug("Unable to find host " + hostId);
+            logger.debug("Unable to find host " + hostId);
             throw new InvalidParameterValueException("Unable to find host with ID: " + hostId + ". Please specify a valid host ID.");
         }
 
@@ -1277,7 +1275,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 }
             }
         } catch (final NoTransitionException e) {
-            s_logger.debug("Cannot transmit host " + host.getId() + "to Maintenance state", e);
+            logger.debug("Cannot transmit host " + host.getId() + "to Maintenance state", e);
         }
         return hostInMaintenance;
     }
@@ -1331,8 +1329,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         final List<String> hostTags = cmd.getHostTags();
         if (hostTags != null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Updating Host Tags to :" + hostTags);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Updating Host Tags to :" + hostTags);
             }
             _hostTagsDao.persist(hostId, hostTags);
         }
@@ -1480,7 +1478,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 final ResourceStateAdapter adapter = item.getValue();
 
                 final String msg = "Dispatching resource state event " + event + " to " + item.getKey();
-                s_logger.debug(msg);
+                logger.debug(msg);
 
                 if (event == ResourceStateAdapter.Event.CREATE_HOST_VO_FOR_CONNECTED) {
                     result = adapter.createHostVOForConnectedAgent((HostVO)args[0], (StartupCommand[])args[1]);
@@ -1501,7 +1499,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                             break;
                         }
                     } catch (final UnableDeleteHostException e) {
-                        s_logger.debug("Adapter " + adapter.getName() + " says unable to delete host", e);
+                        logger.debug("Adapter " + adapter.getName() + " says unable to delete host", e);
                         result = new ResourceStateAdapter.DeleteHostAnswer(false, true);
                     }
                 } else {
@@ -1527,7 +1525,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         final String cidrSubnet = NetUtils.getCidrSubNet(cidrAddress, cidrSize);
         final String serverSubnet = NetUtils.getSubNet(serverPrivateIP, serverPrivateNetmask);
         if (!cidrSubnet.equals(serverSubnet)) {
-            s_logger.warn("The private ip address of the server (" + serverPrivateIP + ") is not compatible with the CIDR of pod: " + pod.getName() + " and zone: " +
+            logger.warn("The private ip address of the server (" + serverPrivateIP + ") is not compatible with the CIDR of pod: " + pod.getName() + " and zone: " +
                     dc.getName());
             throw new IllegalArgumentException("The private ip address of the server (" + serverPrivateIP + ") is not compatible with the CIDR of pod: " + pod.getName() +
                     " and zone: " + dc.getName());
@@ -1607,7 +1605,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 dcId = Long.parseLong(dataCenter);
                 dc = _dcDao.findById(dcId);
             } catch (final NumberFormatException e) {
-                s_logger.debug("Cannot parse " + dataCenter + " into Long.");
+                logger.debug("Cannot parse " + dataCenter + " into Long.");
             }
         }
         if (dc == null) {
@@ -1621,7 +1619,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 final long podId = Long.parseLong(pod);
                 p = _podDao.findById(podId);
             } catch (final NumberFormatException e) {
-                s_logger.debug("Cannot parse " + pod + " into Long.");
+                logger.debug("Cannot parse " + pod + " into Long.");
             }
         }
         /*
@@ -1708,12 +1706,12 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             /* Agent goes to Connecting status */
             _agentMgr.agentStatusTransitTo(host, Status.Event.AgentConnected, _nodeId);
         } catch (final Exception e) {
-            s_logger.debug("Cannot transmit host " + host.getId() + " to Creating state", e);
+            logger.debug("Cannot transmit host " + host.getId() + " to Creating state", e);
             _agentMgr.agentStatusTransitTo(host, Status.Event.Error, _nodeId);
             try {
                 resourceStateTransitTo(host, ResourceState.Event.Error, _nodeId);
             } catch (final NoTransitionException e1) {
-                s_logger.debug("Cannot transmit host " + host.getId() + "to Error state", e);
+                logger.debug("Cannot transmit host " + host.getId() + "to Error state", e);
             }
         }
 
@@ -1766,7 +1764,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         try {
             cmds = resource.initialize();
             if (cmds == null) {
-                s_logger.info("Unable to fully initialize the agent because no StartupCommands are returned");
+                logger.info("Unable to fully initialize the agent because no StartupCommands are returned");
                 return null;
             }
 
@@ -1779,7 +1777,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 }
             }
 
-            if (s_logger.isDebugEnabled()) {
+            if (logger.isDebugEnabled()) {
                 new Request(-1l, -1l, cmds, true, false).logD("Startup request from directly connected host: ", true);
             }
 
@@ -1790,7 +1788,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     host = findHostByGuid(firstCmd.getGuidWithoutResource());
                 }
                 if (host != null && host.getRemoved() == null) { // host already added, no need to add again
-                    s_logger.debug("Found the host " + host.getId() + " by guid: " + firstCmd.getGuid() + ", old host reconnected as new");
+                    logger.debug("Found the host " + host.getId() + " by guid: " + firstCmd.getGuid() + ", old host reconnected as new");
                     hostExists = true; // ensures that host status is left unchanged in case of adding same one again
                     return null;
                 }
@@ -1803,7 +1801,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 host = _hostDao.findById(host.getId());
             }
         } catch (final Exception e) {
-            s_logger.warn("Unable to connect due to ", e);
+            logger.warn("Unable to connect due to ", e);
         } finally {
             if (hostExists) {
                 if (cmds != null) {
@@ -1832,7 +1830,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         try {
             cmds = resource.initialize();
             if (cmds == null) {
-                s_logger.info("Unable to fully initialize the agent because no StartupCommands are returned");
+                logger.info("Unable to fully initialize the agent because no StartupCommands are returned");
                 return null;
             }
 
@@ -1845,7 +1843,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 }
             }
 
-            if (s_logger.isDebugEnabled()) {
+            if (logger.isDebugEnabled()) {
                 new Request(-1l, -1l, cmds, true, false).logD("Startup request from directly connected host: ", true);
             }
 
@@ -1859,7 +1857,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     // added, no
                     // need to add
                     // again
-                    s_logger.debug("Found the host " + host.getId() + " by guid: " + firstCmd.getGuid() + ", old host reconnected as new");
+                    logger.debug("Found the host " + host.getId() + " by guid: " + firstCmd.getGuid() + ", old host reconnected as new");
                     hostExists = true; // ensures that host status is left
                     // unchanged in case of adding same one
                     // again
@@ -1903,7 +1901,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 }
             }
         } catch (final Exception e) {
-            s_logger.warn("Unable to connect due to ", e);
+            logger.warn("Unable to connect due to ", e);
         } finally {
             if (hostExists) {
                 if (cmds != null) {
@@ -1990,7 +1988,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
     @Override
     public HostVO fillRoutingHostVO(final HostVO host, final StartupRoutingCommand ssCmd, final HypervisorType hyType, Map<String, String> details, final List<String> hostTags) {
         if (host.getPodId() == null) {
-            s_logger.error("Host " + ssCmd.getPrivateIpAddress() + " sent incorrect pod, pod id is null");
+            logger.error("Host " + ssCmd.getPrivateIpAddress() + " sent incorrect pod, pod id is null");
             throw new IllegalArgumentException("Host " + ssCmd.getPrivateIpAddress() + " sent incorrect pod, pod id is null");
         }
 
@@ -2031,8 +2029,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             throw new CloudRuntimeException("Non-Routing host gets in deleteRoutingHost, id is " + host.getId());
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deleting Host: " + host.getId() + " Guid:" + host.getGuid());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deleting Host: " + host.getId() + " Guid:" + host.getGuid());
         }
 
         if (forceDestroyStorage) {
@@ -2044,12 +2042,12 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     try {
                         final StoragePool pool = _storageSvr.preparePrimaryStorageForMaintenance(storagePool.getId());
                         if (pool == null) {
-                            s_logger.debug("Failed to set primary storage into maintenance mode");
+                            logger.debug("Failed to set primary storage into maintenance mode");
 
                             throw new UnableDeleteHostException("Failed to set primary storage into maintenance mode");
                         }
                     } catch (final Exception e) {
-                        s_logger.debug("Failed to set primary storage into maintenance mode, due to: " + e.toString());
+                        logger.debug("Failed to set primary storage into maintenance mode, due to: " + e.toString());
                         throw new UnableDeleteHostException("Failed to set primary storage into maintenance mode, due to: " + e.toString());
                     }
                 }
@@ -2060,7 +2058,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                         _vmMgr.destroy(vm.getUuid());
                     } catch (final Exception e) {
                         final String errorMsg = "There was an error Destory the vm: " + vm + " as a part of hostDelete id=" + host.getId();
-                        s_logger.debug(errorMsg, e);
+                        logger.debug(errorMsg, e);
                         throw new UnableDeleteHostException(errorMsg + "," + e.getMessage());
                     }
                 }
@@ -2074,16 +2072,16 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     // Restart HA enabled vms
                     for (final VMInstanceVO vm : vms) {
                         if (!vm.isHaEnabled() || vm.getState() == State.Stopping) {
-                            s_logger.debug("Stopping vm: " + vm + " as a part of deleteHost id=" + host.getId());
+                            logger.debug("Stopping vm: " + vm + " as a part of deleteHost id=" + host.getId());
                             try {
                                 _vmMgr.advanceStop(vm.getUuid(), false);
                             } catch (final Exception e) {
                                 final String errorMsg = "There was an error stopping the vm: " + vm + " as a part of hostDelete id=" + host.getId();
-                                s_logger.debug(errorMsg, e);
+                                logger.debug(errorMsg, e);
                                 throw new UnableDeleteHostException(errorMsg + "," + e.getMessage());
                             }
                         } else if (vm.isHaEnabled() && (vm.getState() == State.Running || vm.getState() == State.Starting)) {
-                            s_logger.debug("Scheduling restart for vm: " + vm + " " + vm.getState() + " on the host id=" + host.getId());
+                            logger.debug("Scheduling restart for vm: " + vm + " " + vm.getState() + " on the host id=" + host.getId());
                             _haMgr.scheduleRestart(vm, false);
                         }
                     }
@@ -2099,7 +2097,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         HostVO host;
         host = _hostDao.findById(hostId);
         if (host == null || host.getRemoved() != null) {
-            s_logger.warn("Unable to find host " + hostId);
+            logger.warn("Unable to find host " + hostId);
             return true;
         }
 
@@ -2117,7 +2115,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         final List<VMInstanceVO> vms = _haMgr.findTakenMigrationWork();
         for (final VMInstanceVO vm : vms) {
             if (vm != null && vm.getHostId() != null && vm.getHostId() == hostId) {
-                s_logger.info("Unable to cancel migration because the vm is being migrated: " + vm);
+                logger.info("Unable to cancel migration because the vm is being migrated: " + vm);
                 return false;
             }
         }
@@ -2131,7 +2129,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
                 final boolean sshToAgent = Boolean.parseBoolean(_configDao.getValue(Config.KvmSshToAgentEnabled.key()));
                 if (!sshToAgent) {
-                    s_logger.info("Configuration tells us not to SSH into Agents. Please restart the Agent (" + hostId + ")  manually");
+                    logger.info("Configuration tells us not to SSH into Agents. Please restart the Agent (" + hostId + ")  manually");
                     return true;
                 }
 
@@ -2139,12 +2137,12 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 final String password = host.getDetail("password");
                 final String username = host.getDetail("username");
                 if (password == null || username == null) {
-                    s_logger.debug("Can't find password/username");
+                    logger.debug("Can't find password/username");
                     return false;
                 }
                 final com.trilead.ssh2.Connection connection = SSHCmdHelper.acquireAuthorizedConnection(host.getPrivateIpAddress(), 22, username, password);
                 if (connection == null) {
-                    s_logger.debug("Failed to connect to host: " + host.getPrivateIpAddress());
+                    logger.debug("Failed to connect to host: " + host.getPrivateIpAddress());
                     return false;
                 }
 
@@ -2157,7 +2155,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
             return true;
         } catch (final NoTransitionException e) {
-            s_logger.debug("Cannot transmit host " + host.getId() + "to Enabled state", e);
+            logger.debug("Cannot transmit host " + host.getId() + "to Enabled state", e);
             return false;
         }
     }
@@ -2197,7 +2195,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
     private boolean doUmanageHost(final long hostId) {
         final HostVO host = _hostDao.findById(hostId);
         if (host == null) {
-            s_logger.debug("Cannot find host " + hostId + ", assuming it has been deleted, skip umanage");
+            logger.debug("Cannot find host " + hostId + ", assuming it has been deleted, skip umanage");
             return true;
         }
 
@@ -2241,7 +2239,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         final UpdateHostPasswordCommand cmd = new UpdateHostPasswordCommand(username, password, hostIpAddress);
         final Answer answer = _agentMgr.easySend(hostId, cmd);
 
-        s_logger.info("Result returned from update host password ==> " + answer.getDetails());
+        logger.info("Result returned from update host password ==> " + answer.getDetails());
         return answer.getResult();
     }
 
@@ -2261,7 +2259,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                     return result;
                 }
             } catch (final AgentUnavailableException e) {
-                s_logger.error("Agent is not availbale!", e);
+                logger.error("Agent is not availbale!", e);
             }
 
             if (shouldUpdateHostPasswd) {
@@ -2284,7 +2282,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                 return result;
             }
         } catch (final AgentUnavailableException e) {
-            s_logger.error("Agent is not availbale!", e);
+            logger.error("Agent is not availbale!", e);
         }
 
         final boolean shouldUpdateHostPasswd = command.getUpdatePasswdOnHost();
@@ -2311,8 +2309,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             return null;
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Propagating agent change request event:" + event.toString() + " to agent:" + agentId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Propagating agent change request event:" + event.toString() + " to agent:" + agentId);
         }
         final Command[] cmds = new Command[1];
         cmds[0] = new PropagateResourceEventCommand(agentId, event);
@@ -2324,8 +2322,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         final Answer[] answers = _gson.fromJson(AnsStr, Answer[].class);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Result for agent change is " + answers[0].getResult());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Result for agent change is " + answers[0].getResult());
         }
 
         return answers[0].getResult();
@@ -2335,15 +2333,15 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
     public boolean maintenanceFailed(final long hostId) {
         final HostVO host = _hostDao.findById(hostId);
         if (host == null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Cant not find host " + hostId);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Cant not find host " + hostId);
             }
             return false;
         } else {
             try {
                 return resourceStateTransitTo(host, ResourceState.Event.UnableToMigrate, _nodeId);
             } catch (final NoTransitionException e) {
-                s_logger.debug("No next resource state for host " + host.getId() + " while current state is " + host.getResourceState() + " with event " +
+                logger.debug("No next resource state for host " + host.getId() + " while current state is " + host.getResourceState() + " with event " +
                         ResourceState.Event.UnableToMigrate, e);
                 return false;
             }
@@ -2490,7 +2488,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
 
         if (answer == null || !answer.getResult()) {
             final String msg = "Unable to obtain host " + hostId + " statistics. ";
-            s_logger.warn(msg);
+            logger.warn(msg);
             return null;
         } else {
 
@@ -2589,8 +2587,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         if(!listAvailableGPUDevice(hostId, groupName, vgpuType).isEmpty()) {
             return true;
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Host ID: "+ hostId +" does not have GPU device available");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Host ID: "+ hostId +" does not have GPU device available");
             }
             return false;
         }
@@ -2620,7 +2618,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         }
         if (answer == null || !answer.getResult()) {
             final String msg = "Unable to obtain GPU stats for host " + host.getName();
-            s_logger.warn(msg);
+            logger.warn(msg);
             return null;
         } else {
             // now construct the result object
@@ -2644,8 +2642,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                         final long id = reservationEntry.getId();
                         final PlannerHostReservationVO hostReservation = _plannerHostReserveDao.lockRow(id, true);
                         if (hostReservation == null) {
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Host reservation for host: " + hostId + " does not even exist.  Release reservartion call is ignored.");
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Host reservation for host: " + hostId + " does not even exist.  Release reservartion call is ignored.");
                             }
                             return false;
                         }
@@ -2654,8 +2652,8 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
                         return true;
                     }
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Host reservation for host: " + hostId + " does not even exist.  Release reservartion call is ignored.");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Host reservation for host: " + hostId + " does not even exist.  Release reservartion call is ignored.");
                     }
 
                     return false;
@@ -2664,7 +2662,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
         } catch (final CloudRuntimeException e) {
             throw e;
         } catch (final Throwable t) {
-            s_logger.error("Unable to release host reservation for host: " + hostId, t);
+            logger.error("Unable to release host reservation for host: " + hostId, t);
             return false;
         }
     }

--- a/server/src/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -30,7 +30,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -110,7 +109,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Component
 @Local(value = {ResourceLimitService.class})
 public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLimitService {
-    public static final Logger s_logger = Logger.getLogger(ResourceLimitManagerImpl.class);
 
     @Inject
     private DomainDao _domainDao;
@@ -249,7 +247,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
             domainResourceLimitMap.put(Resource.ResourceType.primary_storage, Long.parseLong(_configDao.getValue(Config.DefaultMaxDomainPrimaryStorage.key())));
             domainResourceLimitMap.put(Resource.ResourceType.secondary_storage, Long.parseLong(_configDao.getValue(Config.DefaultMaxDomainSecondaryStorage.key())));
         } catch (NumberFormatException e) {
-            s_logger.error("NumberFormatException during configuration", e);
+            logger.error("NumberFormatException during configuration", e);
             throw new ConfigurationException("Configuration failed due to NumberFormatException, see log for the stacktrace");
         }
 
@@ -260,7 +258,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
     public void incrementResourceCount(long accountId, ResourceType type, Long... delta) {
         // don't upgrade resource count for system account
         if (accountId == Account.ACCOUNT_ID_SYSTEM) {
-            s_logger.trace("Not incrementing resource count for system accounts, returning");
+            logger.trace("Not incrementing resource count for system accounts, returning");
             return;
         }
 
@@ -276,7 +274,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
     public void decrementResourceCount(long accountId, ResourceType type, Long... delta) {
         // don't upgrade resource count for system account
         if (accountId == Account.ACCOUNT_ID_SYSTEM) {
-            s_logger.trace("Not decrementing resource count for system accounts, returning");
+            logger.trace("Not decrementing resource count for system accounts, returning");
             return;
         }
         long numToDecrement = (delta.length == 0) ? 1 : delta[0].longValue();
@@ -450,7 +448,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
                                 " has been exceeded.";
                 }
                 ResourceAllocationException e=  new ResourceAllocationException(message, type);;
-                s_logger.error(message, e);
+                logger.error(message, e);
                 throw e;
             }
 
@@ -795,7 +793,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
 
             for (ResourceCountVO rowToUpdate : rowsToUpdate) {
                 if (!_resourceCountDao.updateById(rowToUpdate.getId(), increment, delta)) {
-                    s_logger.trace("Unable to update resource count for the row " + rowToUpdate);
+                    logger.trace("Unable to update resource count for the row " + rowToUpdate);
                     result = false;
                 }
             }
@@ -804,7 +802,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
                 }
             });
         } catch (Exception ex) {
-            s_logger.error("Failed to update resource count for account id=" + accountId);
+            logger.error("Failed to update resource count for account id=" + accountId);
             return false;
         }
     }
@@ -850,7 +848,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
             _resourceCountDao.setResourceCount(domainId, ResourceOwnerType.Domain, type, newCount);
 
             if (oldCount != newCount) {
-                    s_logger.info("Discrepency in the resource count " + "(original count=" + oldCount + " correct count = " + newCount + ") for type " + type +
+                    logger.info("Discrepency in the resource count " + "(original count=" + oldCount + " correct count = " + newCount + ") for type " + type +
                         " for domain ID " + domainId + " is fixed during resource count recalculation.");
             }
 
@@ -912,7 +910,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
 
                 // No need to log message for primary and secondary storage because both are recalculating the resource count which will not lead to any discrepancy.
                 if (!Long.valueOf(oldCount).equals(newCount) && (type != Resource.ResourceType.primary_storage && type != Resource.ResourceType.secondary_storage)) {
-                    s_logger.info("Discrepency in the resource count " + "(original count=" + oldCount + " correct count = " + newCount + ") for type " + type +
+                    logger.info("Discrepency in the resource count " + "(original count=" + oldCount + " correct count = " + newCount + ") for type " + type +
                         " for account ID " + accountId + " is fixed during resource count recalculation.");
         }
 
@@ -1070,7 +1068,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
 
         @Override
         protected void runInContext() {
-            s_logger.info("Running resource count check periodic task");
+            logger.info("Running resource count check periodic task");
             List<DomainVO> domains = _domainDao.findImmediateChildrenForParent(Domain.ROOT_DOMAIN);
 
             // recalculateDomainResourceCount will take care of re-calculation of resource counts for sub-domains

--- a/server/src/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/com/cloud/server/ConfigurationServerImpl.java
@@ -46,7 +46,6 @@ import javax.naming.ConfigurationException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.config.ApiServiceConfiguration;
 import org.apache.cloudstack.framework.config.ConfigDepot;
@@ -121,7 +120,6 @@ import com.cloud.utils.nio.Link;
 import com.cloud.utils.script.Script;
 
 public class ConfigurationServerImpl extends ManagerBase implements ConfigurationServer {
-    public static final Logger s_logger = Logger.getLogger(ConfigurationServerImpl.class);
 
     @Inject
     private ConfigurationDao _configDao;
@@ -182,7 +180,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         String init = _configDao.getValue("init");
 
         if (init == null || init.equals("false")) {
-            s_logger.debug("ConfigurationServer is saving default values to the database.");
+            logger.debug("ConfigurationServer is saving default values to the database.");
 
             // Save default Configuration Table values
             List<String> categories = Config.getCategories();
@@ -212,19 +210,19 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             }
 
             _configDao.update(Config.UseSecondaryStorageVm.key(), Config.UseSecondaryStorageVm.getCategory(), "true");
-            s_logger.debug("ConfigurationServer made secondary storage vm required.");
+            logger.debug("ConfigurationServer made secondary storage vm required.");
 
             _configDao.update(Config.SecStorageEncryptCopy.key(), Config.SecStorageEncryptCopy.getCategory(), "false");
-            s_logger.debug("ConfigurationServer made secondary storage copy encrypt set to false.");
+            logger.debug("ConfigurationServer made secondary storage copy encrypt set to false.");
 
             _configDao.update("secstorage.secure.copy.cert", "realhostip");
-            s_logger.debug("ConfigurationServer made secondary storage copy use realhostip.");
+            logger.debug("ConfigurationServer made secondary storage copy use realhostip.");
 
             _configDao.update("user.password.encoders.exclude", "MD5,LDAP,PLAINTEXT");
-            s_logger.debug("Configuration server excluded insecure encoders");
+            logger.debug("Configuration server excluded insecure encoders");
 
             _configDao.update("user.authenticators.exclude", "PLAINTEXT");
-            s_logger.debug("Configuration server excluded plaintext authenticator");
+            logger.debug("Configuration server excluded plaintext authenticator");
 
             // Save default service offerings
             createServiceOffering(User.UID_SYSTEM, "Small Instance", 1, 512, 500, "Small Instance", ProvisioningType.THIN, false, false, null);
@@ -240,9 +238,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             String mountParent = getMountParent();
             if (mountParent != null) {
                 _configDao.update(Config.MountParent.key(), Config.MountParent.getCategory(), mountParent);
-                s_logger.debug("ConfigurationServer saved \"" + mountParent + "\" as mount.parent.");
+                logger.debug("ConfigurationServer saved \"" + mountParent + "\" as mount.parent.");
             } else {
-                s_logger.debug("ConfigurationServer could not detect mount.parent.");
+                logger.debug("ConfigurationServer could not detect mount.parent.");
             }
 
             String hostIpAdr = NetUtils.getDefaultHostIp();
@@ -258,7 +256,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
 
                 if (needUpdateHostIp) {
                     _configDepot.createOrUpdateConfigObject(ApiServiceConfiguration.class.getSimpleName(), ApiServiceConfiguration.ManagementHostIPAdr, hostIpAdr);
-                    s_logger.debug("ConfigurationServer saved \"" + hostIpAdr + "\" as host.");
+                    logger.debug("ConfigurationServer saved \"" + hostIpAdr + "\" as host.");
                 }
             }
 
@@ -362,7 +360,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             }
             txn.commit();
         } catch (Exception e) {
-            s_logger.warn("Unable to init template " + id + " datails: " + name, e);
+            logger.warn("Unable to init template " + id + " datails: " + name, e);
             throw new CloudRuntimeException("Unable to init template " + id + " datails: " + name);
         }
     }
@@ -409,7 +407,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                         }
                     }
                 } catch (Exception e) {
-                    s_logger.debug("initiateXenServerPVDriverVersion failed due to " + e.toString());
+                    logger.debug("initiateXenServerPVDriverVersion failed due to " + e.toString());
                     // ignore
                 }
             }
@@ -455,7 +453,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 try(final FileInputStream finputstream = new FileInputStream(propsFile);) {
                     props.load(finputstream);
                 }catch (IOException e) {
-                    s_logger.error("getEnvironmentProperty:Exception:" + e.getMessage());
+                    logger.error("getEnvironmentProperty:Exception:" + e.getMessage());
                 }
                 return props.getProperty("mount.parent");
             }
@@ -477,7 +475,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     PreparedStatement stmt = txn.prepareAutoCloseStatement(insertSql);
                     stmt.executeUpdate();
                 } catch (SQLException ex) {
-                    s_logger.debug("Looks like system account already exists");
+                    logger.debug("Looks like system account already exists");
                 }
                 // insert system user
                 insertSql = "INSERT INTO `cloud`.`user` (id, uuid, username, password, account_id, firstname, lastname, created, user.default)"
@@ -487,7 +485,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     PreparedStatement stmt = txn.prepareAutoCloseStatement(insertSql);
                     stmt.executeUpdate();
                 } catch (SQLException ex) {
-                    s_logger.debug("Looks like system user already exists");
+                    logger.debug("Looks like system user already exists");
                 }
 
                 // insert admin user, but leave the account disabled until we set a
@@ -504,7 +502,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     PreparedStatement stmt = txn.prepareAutoCloseStatement(insertSql);
                     stmt.executeUpdate();
                 } catch (SQLException ex) {
-                    s_logger.debug("Looks like admin account already exists");
+                    logger.debug("Looks like admin account already exists");
                 }
 
                 // now insert the user
@@ -515,7 +513,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     PreparedStatement stmt = txn.prepareAutoCloseStatement(insertSql);
                     stmt.executeUpdate();
                 } catch (SQLException ex) {
-                    s_logger.debug("Looks like admin user already exists");
+                    logger.debug("Looks like admin user already exists");
                 }
 
                 try {
@@ -546,12 +544,12 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                             stmt = txn.prepareAutoCloseStatement(insertSql);
                             stmt.executeUpdate();
                         } catch (SQLException ex) {
-                            s_logger.warn("Failed to create default security group for default admin account due to ", ex);
+                            logger.warn("Failed to create default security group for default admin account due to ", ex);
                         }
                     }
                     rs.close();
                 } catch (Exception ex) {
-                    s_logger.warn("Failed to create default security group for default admin account due to ", ex);
+                    logger.warn("Failed to create default security group for default admin account due to ", ex);
                 }
             }
         });
@@ -593,7 +591,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     ou = group[i] + "." + ou;
             }
         } catch (UnknownHostException ex) {
-            s_logger.info("Fail to get user's domain name. Would use cloud.com. ", ex);
+            logger.info("Fail to get user's domain name. Would use cloud.com. ", ex);
             ou = "cloud.com";
         }
 
@@ -615,8 +613,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
     }
 
     protected void updateSSLKeystore() {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Processing updateSSLKeyStore");
+        if (logger.isInfoEnabled()) {
+            logger.info("Processing updateSSLKeyStore");
         }
 
         String dbString = _configDao.getValue("ssl.keystore");
@@ -634,19 +632,19 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
 
         boolean dbExisted = (dbString != null && !dbString.isEmpty());
 
-        s_logger.info("SSL keystore located at " + keystorePath);
+        logger.info("SSL keystore located at " + keystorePath);
         try {
             if (!dbExisted && null != confFile) {
                 if (!keystoreFile.exists()) {
                     generateDefaultKeystore(keystorePath);
-                    s_logger.info("Generated SSL keystore.");
+                    logger.info("Generated SSL keystore.");
                 }
                 String base64Keystore = getBase64Keystore(keystorePath);
                 ConfigurationVO configVO =
                         new ConfigurationVO("Hidden", "DEFAULT", "management-server", "ssl.keystore", base64Keystore,
                                 "SSL Keystore for the management servers");
                 _configDao.persist(configVO);
-                s_logger.info("Stored SSL keystore to database.");
+                logger.info("Stored SSL keystore to database.");
             } else { // !keystoreFile.exists() and dbExisted
                 // Export keystore to local file
                 byte[] storeBytes = Base64.decodeBase64(dbString);
@@ -670,10 +668,10 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 } catch (Exception e) {
                     throw new IOException("Fail to create keystore file!", e);
                 }
-                s_logger.info("Stored database keystore to local.");
+                logger.info("Stored database keystore to local.");
             }
         } catch (Exception ex) {
-            s_logger.warn("Would use fail-safe keystore to continue.", ex);
+            logger.warn("Would use fail-safe keystore to continue.", ex);
         }
     }
 
@@ -698,9 +696,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 PreparedStatement stmt = txn.prepareAutoCloseStatement(wSql);
                 stmt.setString(1, DBEncryptionUtil.encrypt(rpassword));
                 stmt.executeUpdate();
-                s_logger.info("Updated systemvm password in database");
+                logger.info("Updated systemvm password in database");
             } catch (SQLException e) {
-                s_logger.error("Cannot retrieve systemvm password", e);
+                logger.error("Cannot retrieve systemvm password", e);
             }
         }
 
@@ -714,7 +712,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         String username = System.getProperty("user.name");
         Boolean devel = Boolean.valueOf(_configDao.getValue("developer"));
         if (!username.equalsIgnoreCase("cloud") && !devel) {
-            s_logger.warn("Systemvm keypairs could not be set. Management server should be run as cloud user, or in development mode.");
+            logger.warn("Systemvm keypairs could not be set. Management server should be run as cloud user, or in development mode.");
             return;
         }
         String already = _configDao.getValue("ssh.privatekey");
@@ -723,12 +721,12 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             throw new CloudRuntimeException("Cannot get home directory for account: " + username);
         }
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Processing updateKeyPairs");
+        if (logger.isInfoEnabled()) {
+            logger.info("Processing updateKeyPairs");
         }
 
         if (homeDir != null && homeDir.startsWith("~")) {
-            s_logger.error("No home directory was detected for the user '" + username + "'. Please check the profile of this user.");
+            logger.error("No home directory was detected for the user '" + username + "'. Please check the profile of this user.");
             throw new CloudRuntimeException("No home directory was detected for the user '" + username + "'. Please check the profile of this user.");
         }
 
@@ -744,8 +742,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         }
 
         if (already == null || already.isEmpty()) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Systemvm keypairs not found in database. Need to store them in the database");
+            if (logger.isInfoEnabled()) {
+                logger.info("Systemvm keypairs not found in database. Need to store them in the database");
             }
             // FIXME: take a global database lock here for safety.
             boolean onWindows = isOnWindows();
@@ -757,9 +755,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             try (DataInputStream dis = new DataInputStream(new FileInputStream(privkeyfile))) {
                 dis.readFully(arr1);
             } catch (EOFException e) {
-                s_logger.info("[ignored] eof reached");
+                logger.info("[ignored] eof reached");
             } catch (Exception e) {
-                s_logger.error("Cannot read the private key file", e);
+                logger.error("Cannot read the private key file", e);
                 throw new CloudRuntimeException("Cannot read the private key file");
             }
             String privateKey = new String(arr1).trim();
@@ -767,9 +765,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             try (DataInputStream dis = new DataInputStream(new FileInputStream(pubkeyfile))) {
                 dis.readFully(arr2);
             } catch (EOFException e) {
-                s_logger.info("[ignored] eof reached");
+                logger.info("[ignored] eof reached");
             } catch (Exception e) {
-                s_logger.warn("Cannot read the public key file", e);
+                logger.warn("Cannot read the public key file", e);
                 throw new CloudRuntimeException("Cannot read the public key file");
             }
             String publicKey = new String(arr2).trim();
@@ -791,32 +789,32 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     try {
                         PreparedStatement stmt1 = txn.prepareAutoCloseStatement(insertSql1);
                         stmt1.executeUpdate();
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Private key inserted into database");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Private key inserted into database");
                         }
                     } catch (SQLException ex) {
-                        s_logger.error("SQL of the private key failed", ex);
+                        logger.error("SQL of the private key failed", ex);
                         throw new CloudRuntimeException("SQL of the private key failed");
                     }
 
                     try {
                         PreparedStatement stmt2 = txn.prepareAutoCloseStatement(insertSql2);
                         stmt2.executeUpdate();
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug("Public key inserted into database");
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("Public key inserted into database");
                         }
                     } catch (SQLException ex) {
-                        s_logger.error("SQL of the public key failed", ex);
+                        logger.error("SQL of the public key failed", ex);
                         throw new CloudRuntimeException("SQL of the public key failed");
                     }
                 }
             });
 
         } else {
-            s_logger.info("Keypairs already in database, updating local copy");
+            logger.info("Keypairs already in database, updating local copy");
             updateKeyPairsOnDisk(homeDir);
         }
-        s_logger.info("Going to update systemvm iso with generated keypairs if needed");
+        logger.info("Going to update systemvm iso with generated keypairs if needed");
         try {
             injectSshKeysIntoSystemVmIsoPatch(pubkeyfile.getAbsolutePath(), privkeyfile.getAbsolutePath());
         } catch (CloudRuntimeException e) {
@@ -846,7 +844,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             try {
                 keyfile.createNewFile();
             } catch (IOException e) {
-                s_logger.warn("Failed to create file: " + e.toString());
+                logger.warn("Failed to create file: " + e.toString());
                 throw new CloudRuntimeException("Failed to update keypairs on disk: cannot create  key file " + keyPath);
             }
         }
@@ -857,10 +855,10 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     kStream.write(key.getBytes());
                 }
             } catch (FileNotFoundException e) {
-                s_logger.warn("Failed to write  key to " + keyfile.getAbsolutePath());
+                logger.warn("Failed to write  key to " + keyfile.getAbsolutePath());
                 throw new CloudRuntimeException("Failed to update keypairs on disk: cannot find  key file " + keyPath);
             } catch (IOException e) {
-                s_logger.warn("Failed to write  key to " + keyfile.getAbsolutePath());
+                logger.warn("Failed to write  key to " + keyfile.getAbsolutePath());
                 throw new CloudRuntimeException("Failed to update keypairs on disk: cannot write to  key file " + keyPath);
             }
         }
@@ -871,7 +869,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         File keyDir = new File(homeDir + "/.ssh");
         Boolean devel = Boolean.valueOf(_configDao.getValue("developer"));
         if (!keyDir.isDirectory()) {
-            s_logger.warn("Failed to create " + homeDir + "/.ssh for storing the SSH keypars");
+            logger.warn("Failed to create " + homeDir + "/.ssh for storing the SSH keypars");
             keyDir.mkdir();
         }
         String pubKey = _configDao.getValue("ssh.publickey");
@@ -888,7 +886,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
     }
 
     protected void injectSshKeysIntoSystemVmIsoPatch(String publicKeyPath, String privKeyPath) {
-        s_logger.info("Trying to inject public and private keys into systemvm iso");
+        logger.info("Trying to inject public and private keys into systemvm iso");
         String injectScript = getInjectScript();
         String scriptPath = Script.findScript("", injectScript);
         String systemVmIsoPath = Script.findScript("", "vms/systemvm.iso");
@@ -900,9 +898,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         }
         Script command = null;
         if(isOnWindows()) {
-            command = new Script("python", s_logger);
+            command = new Script("python", logger);
         } else {
-            command = new Script("/bin/bash", s_logger);
+            command = new Script("/bin/bash", logger);
         }
         if (isOnWindows()) {
             scriptPath = scriptPath.replaceAll("\\\\" ,"/" );
@@ -916,9 +914,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         command.add(systemVmIsoPath);
 
         final String result = command.execute();
-        s_logger.info("Injected public and private keys into systemvm iso with result : " + result);
+        logger.info("Injected public and private keys into systemvm iso with result : " + result);
         if (result != null) {
-            s_logger.warn("Failed to inject generated public key into systemvm iso " + result);
+            logger.warn("Failed to inject generated public key into systemvm iso " + result);
             throw new CloudRuntimeException("Failed to inject generated public key into systemvm iso " + result);
         }
     }
@@ -946,7 +944,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
 
         if (already == null) {
 
-            s_logger.info("Need to store secondary storage vm copy password in the database");
+            logger.info("Need to store secondary storage vm copy password in the database");
             String password = PasswordGenerator.generateRandomPassword(12);
 
             final String insertSql1 =
@@ -961,9 +959,9 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     try {
                         PreparedStatement stmt1 = txn.prepareAutoCloseStatement(insertSql1);
                         stmt1.executeUpdate();
-                        s_logger.debug("secondary storage vm copy password inserted into database");
+                        logger.debug("secondary storage vm copy password inserted into database");
                     } catch (SQLException ex) {
-                        s_logger.warn("Failed to insert secondary storage vm copy password", ex);
+                        logger.warn("Failed to insert secondary storage vm copy password", ex);
                     }
                 }
             });
@@ -974,7 +972,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         try {
             _configDao.update(Config.SSOKey.key(), Config.SSOKey.getCategory(), getPrivateKey());
         } catch (NoSuchAlgorithmException ex) {
-            s_logger.error("error generating sso key", ex);
+            logger.error("error generating sso key", ex);
         }
     }
 
@@ -987,14 +985,14 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             if(configInDB == null) {
                 ConfigurationVO configVO = new ConfigurationVO(Config.SSVMPSK.getCategory(), "DEFAULT", Config.SSVMPSK.getComponent(), Config.SSVMPSK.key(), getPrivateKey(),
                         Config.SSVMPSK.getDescription());
-                s_logger.info("generating a new SSVM PSK. This goes to SSVM on Start");
+                logger.info("generating a new SSVM PSK. This goes to SSVM on Start");
                 _configDao.persist(configVO);
             } else if (StringUtils.isEmpty(configInDB.getValue())) {
-                s_logger.info("updating the SSVM PSK with new value. This goes to SSVM on Start");
+                logger.info("updating the SSVM PSK with new value. This goes to SSVM on Start");
                 _configDao.update(Config.SSVMPSK.key(), Config.SSVMPSK.getCategory(), getPrivateKey());
             }
         } catch (NoSuchAlgorithmException ex) {
-            s_logger.error("error generating ssvm psk", ex);
+            logger.error("error generating ssvm psk", ex);
         }
     }
 
@@ -1062,7 +1060,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 }
             });
         } catch (Exception e) {
-            s_logger.error("Unable to create new pod due to " + e.getMessage(), e);
+            logger.error("Unable to create new pod due to " + e.getMessage(), e);
             throw new InternalErrorException("Failed to create new pod. Please contact Cloud Support.");
         }
 
@@ -1171,7 +1169,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     NetworkOfferingServiceMapVO offService =
                             new NetworkOfferingServiceMapVO(defaultSharedSGNetworkOffering.getId(), service, defaultSharedSGNetworkOfferingProviders.get(service));
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
 
                 // Offering #2
@@ -1186,7 +1184,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     NetworkOfferingServiceMapVO offService =
                             new NetworkOfferingServiceMapVO(defaultSharedNetworkOffering.getId(), service, defaultSharedNetworkOfferingProviders.get(service));
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
 
                 // Offering #3
@@ -1203,7 +1201,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                             new NetworkOfferingServiceMapVO(defaultIsolatedSourceNatEnabledNetworkOffering.getId(), service,
                                     defaultIsolatedSourceNatEnabledNetworkOfferingProviders.get(service));
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
 
                 // Offering #4
@@ -1218,7 +1216,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     NetworkOfferingServiceMapVO offService =
                             new NetworkOfferingServiceMapVO(defaultIsolatedEnabledNetworkOffering.getId(), service, defaultIsolatedNetworkOfferingProviders.get(service));
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
 
                 // Offering #5
@@ -1234,7 +1232,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     NetworkOfferingServiceMapVO offService =
                             new NetworkOfferingServiceMapVO(defaultNetscalerNetworkOffering.getId(), service, netscalerServiceProviders.get(service));
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
 
                 // Offering #6
@@ -1262,7 +1260,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                      NetworkOfferingServiceMapVO offService =
                             new NetworkOfferingServiceMapVO(defaultNetworkOfferingForVpcNetworks.getId(), entry.getKey(), entry.getValue());
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
 
                 // Offering #7
@@ -1289,7 +1287,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     NetworkOfferingServiceMapVO offService =
                             new NetworkOfferingServiceMapVO(defaultNetworkOfferingForVpcNetworksNoLB.getId(), entry.getKey(), entry.getValue());
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
 
                 //offering #8 - network offering with internal lb service
@@ -1313,7 +1311,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 for (Service service : internalLbOffProviders.keySet()) {
                     NetworkOfferingServiceMapVO offService = new NetworkOfferingServiceMapVO(internalLbOff.getId(), service, internalLbOffProviders.get(service));
                     _ntwkOfferingServiceMapDao.persist(offService);
-                    s_logger.trace("Added service for the network offering: " + offService);
+                    logger.trace("Added service for the network offering: " + offService);
                 }
             }
         });
@@ -1446,7 +1444,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         final int domainExpectedCount = domainSupportedResourceTypes.size();
 
         if ((domainResourceCount.size() < domainExpectedCount * domains.size())) {
-            s_logger.debug("resource_count table has records missing for some domains...going to insert them");
+            logger.debug("resource_count table has records missing for some domains...going to insert them");
             for (final DomainVO domain : domains) {
                 // Lock domain
                 Transaction.execute(new TransactionCallbackNoReturn() {
@@ -1463,7 +1461,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                             for (ResourceType resourceType : domainSupportedResourceTypes) {
                                 if (!domainCountStr.contains(resourceType.toString())) {
                                     ResourceCountVO resourceCountVO = new ResourceCountVO(resourceType, 0, domain.getId(), ResourceOwnerType.Domain);
-                                    s_logger.debug("Inserting resource count of type " + resourceType + " for domain id=" + domain.getId());
+                                    logger.debug("Inserting resource count of type " + resourceType + " for domain id=" + domain.getId());
                                     _resourceCountDao.persist(resourceCountVO);
                                 }
                             }
@@ -1475,7 +1473,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         }
 
         if ((accountResourceCount.size() < accountExpectedCount * accounts.size())) {
-            s_logger.debug("resource_count table has records missing for some accounts...going to insert them");
+            logger.debug("resource_count table has records missing for some accounts...going to insert them");
             for (final AccountVO account : accounts) {
                 // lock account
                 Transaction.execute(new TransactionCallbackNoReturn() {
@@ -1492,7 +1490,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                             for (ResourceType resourceType : accountSupportedResourceTypes) {
                                 if (!accountCountStr.contains(resourceType.toString())) {
                                     ResourceCountVO resourceCountVO = new ResourceCountVO(resourceType, 0, account.getId(), ResourceOwnerType.Account);
-                                    s_logger.debug("Inserting resource count of type " + resourceType + " for account id=" + account.getId());
+                                    logger.debug("Inserting resource count of type " + resourceType + " for account id=" + account.getId());
                                     _resourceCountDao.persist(resourceCountVO);
                                 }
                             }

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -514,7 +514,6 @@ import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.GetVncPortAnswer;
@@ -672,7 +671,6 @@ import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 public class ManagementServerImpl extends ManagerBase implements ManagementServer {
-    public static final Logger s_logger = Logger.getLogger(ManagementServerImpl.class.getName());
 
     @Inject
     public AccountManager _accountMgr;
@@ -887,7 +885,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public boolean start() {
-        s_logger.info("Startup CloudStack management server...");
+        logger.info("Startup CloudStack management server...");
 
         if (_lockMasterListener == null) {
             _lockMasterListener = new LockMasterListener(ManagementServerNode.getManagementServerId());
@@ -933,7 +931,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             throw new InvalidParameterValueException("privatePort is an invalid value");
         }
 
-        // s_logger.debug("Checking if " + privateIp +
+        // logger.debug("Checking if " + privateIp +
         // " is a valid private IP address. Guest IP address is: " +
         // _configs.get("guest.ip.network"));
         //
@@ -1102,8 +1100,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     public Ternary<Pair<List<? extends Host>, Integer>, List<? extends Host>, Map<Host, Boolean>> listHostsForMigrationOfVM(final Long vmId, final Long startIndex, final Long pageSize) {
         final Account caller = getCaller();
         if (!_accountMgr.isRootAdmin(caller.getId())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Caller is not a root admin, permission denied to migrate the VM");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Caller is not a root admin, permission denied to migrate the VM");
             }
             throw new PermissionDeniedException("No permission to migrate VM, Only Root Admin can migrate a VM!");
         }
@@ -1115,8 +1113,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         if (vm.getState() != State.Running) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("VM is not running, cannot migrate the vm" + vm);
+            if (logger.isDebugEnabled()) {
+                logger.debug("VM is not running, cannot migrate the vm" + vm);
             }
             final InvalidParameterValueException ex = new InvalidParameterValueException("VM is not Running, cannot " + "migrate the vm with specified id");
             ex.addProxyObject(vm.getUuid(), "vmId");
@@ -1124,7 +1122,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         if(_serviceOfferingDetailsDao.findDetail(vm.getServiceOfferingId(), GPU.Keys.pciDevice.toString()) != null) {
-            s_logger.info(" Live Migration of GPU enabled VM : " + vm.getInstanceName()+ " is not supported");
+            logger.info(" Live Migration of GPU enabled VM : " + vm.getInstanceName()+ " is not supported");
             // Return empty list.
             return new Ternary<Pair<List<? extends Host>, Integer>, List<? extends Host>, Map<Host, Boolean>>(new Pair<List <? extends Host>,
                     Integer>(new ArrayList<HostVO>(), new Integer(0)), new ArrayList<Host>(), new HashMap<Host, Boolean>());
@@ -1133,8 +1131,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         if (!vm.getHypervisorType().equals(HypervisorType.XenServer) && !vm.getHypervisorType().equals(HypervisorType.VMware) && !vm.getHypervisorType().equals(HypervisorType.KVM)
                 && !vm.getHypervisorType().equals(HypervisorType.Ovm) && !vm.getHypervisorType().equals(HypervisorType.Hyperv) && !vm.getHypervisorType().equals(HypervisorType.LXC)
                 && !vm.getHypervisorType().equals(HypervisorType.Simulator) && !vm.getHypervisorType().equals(HypervisorType.Ovm3)) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug(vm + " is not XenServer/VMware/KVM/Ovm/Hyperv/Ovm3, cannot migrate this VM.");
+            if (logger.isDebugEnabled()) {
+                logger.debug(vm + " is not XenServer/VMware/KVM/Ovm/Hyperv/Ovm3, cannot migrate this VM.");
             }
             throw new InvalidParameterValueException("Unsupported Hypervisor Type for VM migration, we support " + "XenServer/VMware/KVM/Ovm/Hyperv/Ovm3 only");
         }
@@ -1146,8 +1144,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final long srcHostId = vm.getHostId();
         final Host srcHost = _hostDao.findById(srcHostId);
         if (srcHost == null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Unable to find the host with id: " + srcHostId + " of this VM:" + vm);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Unable to find the host with id: " + srcHostId + " of this VM:" + vm);
             }
             final InvalidParameterValueException ex = new InvalidParameterValueException("Unable to find the host (with specified id) of VM with specified id");
             ex.addProxyObject(String.valueOf(srcHostId), "hostId");
@@ -1212,8 +1210,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             plan = new DataCenterDeployment(srcHost.getDataCenterId(), null, null, null, null, null);
         } else {
             final Long cluster = srcHost.getClusterId();
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Searching for all hosts in cluster " + cluster + " for migrating VM " + vm);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Searching for all hosts in cluster " + cluster + " for migrating VM " + vm);
             }
             allHostsPair = searchForServers(startIndex, pageSize, null, hostType, null, null, null, cluster, null, null, null, null, null, null);
             // Filter out the current host.
@@ -1248,11 +1246,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (suitableHosts.isEmpty()) {
-                s_logger.debug("No suitable hosts found");
+                logger.debug("No suitable hosts found");
             } else {
-                s_logger.debug("Hosts having capacity and suitable for migration: " + suitableHosts);
+                logger.debug("Hosts having capacity and suitable for migration: " + suitableHosts);
             }
         }
 
@@ -1279,8 +1277,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     public Pair<List<? extends StoragePool>, List<? extends StoragePool>> listStoragePoolsForMigrationOfVolume(final Long volumeId) {
         final Account caller = getCaller();
         if (!_accountMgr.isRootAdmin(caller.getId())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Caller is not a root admin, permission denied to migrate the volume");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Caller is not a root admin, permission denied to migrate the volume");
             }
             throw new PermissionDeniedException("No permission to migrate volume, only root admin can migrate a volume");
         }
@@ -1298,12 +1296,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
         // Volume must be in Ready state to be migrated.
         if (!Volume.State.Ready.equals(volume.getState())) {
-            s_logger.info("Volume " + volume + " must be in ready state for migration.");
+            logger.info("Volume " + volume + " must be in ready state for migration.");
             return new Pair<List<? extends StoragePool>, List<? extends StoragePool>>(allPools, suitablePools);
         }
 
         if (!_volumeMgr.volumeOnSharedStoragePool(volume)) {
-            s_logger.info("Volume " + volume + " is on local storage. It cannot be migrated to another pool.");
+            logger.info("Volume " + volume + " is on local storage. It cannot be migrated to another pool.");
             return new Pair<List<? extends StoragePool>, List<? extends StoragePool>>(allPools, suitablePools);
         }
 
@@ -1314,11 +1312,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         if (vm == null) {
-            s_logger.info("Volume " + volume + " isn't attached to any vm. Looking for storage pools in the " + "zone to which this volumes can be migrated.");
+            logger.info("Volume " + volume + " isn't attached to any vm. Looking for storage pools in the " + "zone to which this volumes can be migrated.");
         } else if (vm.getState() != State.Running) {
-            s_logger.info("Volume " + volume + " isn't attached to any running vm. Looking for storage pools in the " + "cluster to which this volumes can be migrated.");
+            logger.info("Volume " + volume + " isn't attached to any running vm. Looking for storage pools in the " + "cluster to which this volumes can be migrated.");
         } else {
-            s_logger.info("Volume " + volume + " is attached to any running vm. Looking for storage pools in the " + "cluster to which this volumes can be migrated.");
+            logger.info("Volume " + volume + " is attached to any running vm. Looking for storage pools in the " + "cluster to which this volumes can be migrated.");
             boolean storageMotionSupported = false;
             // Check if the underlying hypervisor supports storage motion.
             final Long hostId = vm.getHostId();
@@ -1328,18 +1326,18 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                 if (host != null) {
                     capabilities = _hypervisorCapabilitiesDao.findByHypervisorTypeAndVersion(host.getHypervisorType(), host.getHypervisorVersion());
                 } else {
-                    s_logger.error("Details of the host on which the vm " + vm + ", to which volume " + volume + " is " + "attached, couldn't be retrieved.");
+                    logger.error("Details of the host on which the vm " + vm + ", to which volume " + volume + " is " + "attached, couldn't be retrieved.");
                 }
 
                 if (capabilities != null) {
                     storageMotionSupported = capabilities.isStorageMotionSupported();
                 } else {
-                    s_logger.error("Capabilities for host " + host + " couldn't be retrieved.");
+                    logger.error("Capabilities for host " + host + " couldn't be retrieved.");
                 }
             }
 
             if (!storageMotionSupported) {
-                s_logger.info("Volume " + volume + " is attached to a running vm and the hypervisor doesn't support" + " storage motion.");
+                logger.info("Volume " + volume + " is attached to a running vm and the hypervisor doesn't support" + " storage motion.");
                 return new Pair<List<? extends StoragePool>, List<? extends StoragePool>>(allPools, suitablePools);
             }
         }
@@ -1719,10 +1717,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                         configVo.setValue(key.valueIn(id).toString());
                         configVOList.add(configVo);
                     } else {
-                        s_logger.warn("ConfigDepot could not find parameter " + param.getName() + " for scope " + scope);
+                        logger.warn("ConfigDepot could not find parameter " + param.getName() + " for scope " + scope);
                     }
                 } else {
-                    s_logger.warn("Configuration item  " + param.getName() + " not found in " + scope);
+                    logger.warn("Configuration item  " + param.getName() + " not found in " + scope);
                 }
             }
 
@@ -2224,12 +2222,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     @Override
     public Pair<String, Integer> getVncPort(final VirtualMachine vm) {
         if (vm.getHostId() == null) {
-            s_logger.warn("VM " + vm.getHostName() + " does not have host, return -1 for its VNC port");
+            logger.warn("VM " + vm.getHostName() + " does not have host, return -1 for its VNC port");
             return new Pair<String, Integer>(null, -1);
         }
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Trying to retrieve VNC port from agent about VM " + vm.getHostName());
+        if (logger.isTraceEnabled()) {
+            logger.trace("Trying to retrieve VNC port from agent about VM " + vm.getHostName());
         }
 
         final GetVncPortAnswer answer = (GetVncPortAnswer)_agentMgr.easySend(vm.getHostId(), new GetVncPortCommand(vm.getId(), vm.getInstanceName()));
@@ -3027,30 +3025,30 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             try {
                 final GlobalLock lock = GlobalLock.getInternLock("EventPurge");
                 if (lock == null) {
-                    s_logger.debug("Couldn't get the global lock");
+                    logger.debug("Couldn't get the global lock");
                     return;
                 }
                 if (!lock.lock(30)) {
-                    s_logger.debug("Couldn't lock the db");
+                    logger.debug("Couldn't lock the db");
                     return;
                 }
                 try {
                     final Calendar purgeCal = Calendar.getInstance();
                     purgeCal.add(Calendar.DAY_OF_YEAR, -_purgeDelay);
                     final Date purgeTime = purgeCal.getTime();
-                    s_logger.debug("Deleting events older than: " + purgeTime.toString());
+                    logger.debug("Deleting events older than: " + purgeTime.toString());
                     final List<EventVO> oldEvents = _eventDao.listOlderEvents(purgeTime);
-                    s_logger.debug("Found " + oldEvents.size() + " events to be purged");
+                    logger.debug("Found " + oldEvents.size() + " events to be purged");
                     for (final EventVO event : oldEvents) {
                         _eventDao.expunge(event.getId());
                     }
                 } catch (final Exception e) {
-                    s_logger.error("Exception ", e);
+                    logger.error("Exception ", e);
                 } finally {
                     lock.unlock();
                 }
             } catch (final Exception e) {
-                s_logger.error("Exception ", e);
+                logger.error("Exception ", e);
             }
         }
     }
@@ -3061,30 +3059,30 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             try {
                 final GlobalLock lock = GlobalLock.getInternLock("AlertPurge");
                 if (lock == null) {
-                    s_logger.debug("Couldn't get the global lock");
+                    logger.debug("Couldn't get the global lock");
                     return;
                 }
                 if (!lock.lock(30)) {
-                    s_logger.debug("Couldn't lock the db");
+                    logger.debug("Couldn't lock the db");
                     return;
                 }
                 try {
                     final Calendar purgeCal = Calendar.getInstance();
                     purgeCal.add(Calendar.DAY_OF_YEAR, -_alertPurgeDelay);
                     final Date purgeTime = purgeCal.getTime();
-                    s_logger.debug("Deleting alerts older than: " + purgeTime.toString());
+                    logger.debug("Deleting alerts older than: " + purgeTime.toString());
                     final List<AlertVO> oldAlerts = _alertDao.listOlderAlerts(purgeTime);
-                    s_logger.debug("Found " + oldAlerts.size() + " events to be purged");
+                    logger.debug("Found " + oldAlerts.size() + " events to be purged");
                     for (final AlertVO alert : oldAlerts) {
                         _alertDao.expunge(alert.getId());
                     }
                 } catch (final Exception e) {
-                    s_logger.error("Exception ", e);
+                    logger.error("Exception ", e);
                 } finally {
                     lock.unlock();
                 }
             } catch (final Exception e) {
-                s_logger.error("Exception ", e);
+                logger.error("Exception ", e);
             }
         }
     }
@@ -3291,8 +3289,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     private String signRequest(final String request, final String key) {
         try {
-            s_logger.info("Request: " + request);
-            s_logger.info("Key: " + key);
+            logger.info("Request: " + request);
+            logger.info("Key: " + key);
 
             if (key != null && request != null) {
                 final Mac mac = Mac.getInstance("HmacSHA1");
@@ -3303,7 +3301,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                 return new String(Base64.encodeBase64(encryptedBytes));
             }
         } catch (final Exception ex) {
-            s_logger.error("unable to sign request", ex);
+            logger.error("unable to sign request", ex);
         }
         return null;
     }
@@ -3336,7 +3334,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             final String input = cloudIdentifier;
             signature = signRequest(input, secretKey);
         } catch (final Exception e) {
-            s_logger.warn("Exception whilst creating a signature:" + e);
+            logger.warn("Exception whilst creating a signature:" + e);
         }
 
         final ArrayList<String> cloudParams = new ArrayList<String>();
@@ -3751,8 +3749,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) {
                 for (final HostVO h : hosts) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Changing password for host name = " + h.getName());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Changing password for host name = " + h.getName());
                     }
                     // update password for this host
                     final DetailVO nv = _detailsDao.findDetail(h.getId(), ApiConstants.USERNAME);
@@ -3807,8 +3805,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Changing password for host name = " + host.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Changing password for host name = " + host.getName());
                 }
                 // update password for this host
                 final DetailVO nv = _detailsDao.findDetail(host.getId(), ApiConstants.USERNAME);
@@ -3839,9 +3837,9 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             }
             return eventTypes;
         } catch (final IllegalArgumentException e) {
-            s_logger.error("Error while listing Event Types", e);
+            logger.error("Error while listing Event Types", e);
         } catch (final IllegalAccessException e) {
-            s_logger.error("Error while listing Event Types", e);
+            logger.error("Error while listing Event Types", e);
         }
         return null;
     }
@@ -3974,7 +3972,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final UserVO adminUser = _userDao.getUser(2);
         if (adminUser  == null) {
             final String msg = "CANNOT find admin user";
-            s_logger.error(msg);
+            logger.error(msg);
             throw new CloudRuntimeException(msg);
         }
         if (adminUser.getState() == Account.State.disabled) {
@@ -3991,7 +3989,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             adminUser.setPassword(encodedPassword);
             adminUser.setState(Account.State.enabled);
             _userDao.persist(adminUser);
-            s_logger.info("Admin user enabled");
+            logger.info("Admin user enabled");
         }
 
     }
@@ -4008,8 +4006,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public void cleanupVMReservations() {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Processing cleanupVMReservations");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Processing cleanupVMReservations");
         }
 
         _dpMgr.cleanupVMReservations();

--- a/server/src/com/cloud/storage/ImageStoreUploadMonitorImpl.java
+++ b/server/src/com/cloud/storage/ImageStoreUploadMonitorImpl.java
@@ -28,7 +28,6 @@ import javax.naming.ConfigurationException;
 
 import com.cloud.configuration.Resource;
 import com.cloud.user.ResourceLimitService;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -78,7 +77,6 @@ import com.cloud.utils.fsm.StateMachine2;
 @Local(value = {ImageStoreUploadMonitor.class})
 public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageStoreUploadMonitor, Listener, Configurable {
 
-    static final Logger s_logger = Logger.getLogger(ImageStoreUploadMonitorImpl.class);
 
     @Inject
     private VolumeDao _volumeDao;
@@ -186,12 +184,12 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                     DataStore dataStore = storeMgr.getDataStore(volumeDataStore.getDataStoreId(), DataStoreRole.Image);
                     EndPoint ep = _epSelector.select(dataStore, volumeDataStore.getExtractUrl());
                     if (ep == null) {
-                        s_logger.warn("There is no secondary storage VM for image store " + dataStore.getName());
+                        logger.warn("There is no secondary storage VM for image store " + dataStore.getName());
                         continue;
                     }
                     VolumeVO volume = _volumeDao.findById(volumeDataStore.getVolumeId());
                     if (volume == null) {
-                        s_logger.warn("Volume with id " + volumeDataStore.getVolumeId() + " not found");
+                        logger.warn("Volume with id " + volumeDataStore.getVolumeId() + " not found");
                         continue;
                     }
                     Host host = _hostDao.findById(ep.getId());
@@ -202,11 +200,11 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                             try {
                                 answer = ep.sendMessage(cmd);
                             } catch (CloudRuntimeException e) {
-                                s_logger.warn("Unable to get upload status for volume " + volume.getUuid() + ". Error details: " + e.getMessage());
+                                logger.warn("Unable to get upload status for volume " + volume.getUuid() + ". Error details: " + e.getMessage());
                                 answer = new UploadStatusAnswer(cmd, UploadStatus.UNKNOWN, e.getMessage());
                             }
                             if (answer == null || !(answer instanceof UploadStatusAnswer)) {
-                                s_logger.warn("No or invalid answer corresponding to UploadStatusCommand for volume " + volumeDataStore.getVolumeId());
+                                logger.warn("No or invalid answer corresponding to UploadStatusCommand for volume " + volumeDataStore.getVolumeId());
                                 continue;
                             }
                             handleVolumeStatusResponse((UploadStatusAnswer)answer, volume, volumeDataStore);
@@ -216,9 +214,9 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                         handleVolumeStatusResponse(new UploadStatusAnswer(cmd, UploadStatus.ERROR, error), volume, volumeDataStore);
                     }
                 } catch (Throwable th) {
-                    s_logger.warn("Exception while checking status for uploaded volume " + volumeDataStore.getExtractUrl() + ". Error details: " + th.getMessage());
-                    if (s_logger.isTraceEnabled()) {
-                        s_logger.trace("Exception details: ", th);
+                    logger.warn("Exception while checking status for uploaded volume " + volumeDataStore.getExtractUrl() + ". Error details: " + th.getMessage());
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Exception details: ", th);
                     }
                 }
             }
@@ -230,12 +228,12 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                     DataStore dataStore = storeMgr.getDataStore(templateDataStore.getDataStoreId(), DataStoreRole.Image);
                     EndPoint ep = _epSelector.select(dataStore, templateDataStore.getExtractUrl());
                     if (ep == null) {
-                        s_logger.warn("There is no secondary storage VM for image store " + dataStore.getName());
+                        logger.warn("There is no secondary storage VM for image store " + dataStore.getName());
                         continue;
                     }
                     VMTemplateVO template = _templateDao.findById(templateDataStore.getTemplateId());
                     if (template == null) {
-                        s_logger.warn("Template with id " + templateDataStore.getTemplateId() + " not found");
+                        logger.warn("Template with id " + templateDataStore.getTemplateId() + " not found");
                         continue;
                     }
                     Host host = _hostDao.findById(ep.getId());
@@ -246,11 +244,11 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                             try {
                                 answer = ep.sendMessage(cmd);
                             } catch (CloudRuntimeException e) {
-                                s_logger.warn("Unable to get upload status for template " + template.getUuid() + ". Error details: " + e.getMessage());
+                                logger.warn("Unable to get upload status for template " + template.getUuid() + ". Error details: " + e.getMessage());
                                 answer = new UploadStatusAnswer(cmd, UploadStatus.UNKNOWN, e.getMessage());
                             }
                             if (answer == null || !(answer instanceof UploadStatusAnswer)) {
-                                s_logger.warn("No or invalid answer corresponding to UploadStatusCommand for template " + templateDataStore.getTemplateId());
+                                logger.warn("No or invalid answer corresponding to UploadStatusCommand for template " + templateDataStore.getTemplateId());
                                 continue;
                             }
                             handleTemplateStatusResponse((UploadStatusAnswer)answer, template, templateDataStore);
@@ -260,9 +258,9 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                         handleTemplateStatusResponse(new UploadStatusAnswer(cmd, UploadStatus.ERROR, error), template, templateDataStore);
                     }
                 } catch (Throwable th) {
-                    s_logger.warn("Exception while checking status for uploaded template " + templateDataStore.getExtractUrl() + ". Error details: " + th.getMessage());
-                    if (s_logger.isTraceEnabled()) {
-                        s_logger.trace("Exception details: ", th);
+                    logger.warn("Exception while checking status for uploaded template " + templateDataStore.getExtractUrl() + ". Error details: " + th.getMessage());
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Exception details: ", th);
                     }
                 }
             }
@@ -291,8 +289,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                             stateMachine.transitTo(tmpVolume, Event.OperationSucceeded, null, _volumeDao);
                             _resourceLimitMgr.incrementResourceCount(volume.getAccountId(), Resource.ResourceType.secondary_storage, answer.getVirtualSize());
 
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Volume " + tmpVolume.getUuid() + " uploaded successfully");
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Volume " + tmpVolume.getUuid() + " uploaded successfully");
                             }
                             break;
                         case IN_PROGRESS:
@@ -305,8 +303,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                                     tmpVolumeDataStore.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOAD_ERROR);
                                     tmpVolumeDataStore.setState(State.Failed);
                                     stateMachine.transitTo(tmpVolume, Event.OperationFailed, null, _volumeDao);
-                                    if (s_logger.isDebugEnabled()) {
-                                        s_logger.debug("Volume " + tmpVolume.getUuid() + " failed to upload due to operation timed out");
+                                    if (logger.isDebugEnabled()) {
+                                        logger.debug("Volume " + tmpVolume.getUuid() + " failed to upload due to operation timed out");
                                     }
                                 } else {
                                     tmpVolumeDataStore.setDownloadPercent(answer.getDownloadPercent());
@@ -317,8 +315,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                             tmpVolumeDataStore.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOAD_ERROR);
                             tmpVolumeDataStore.setState(State.Failed);
                             stateMachine.transitTo(tmpVolume, Event.OperationFailed, null, _volumeDao);
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Volume " + tmpVolume.getUuid() + " failed to upload. Error details: " + answer.getDetails());
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Volume " + tmpVolume.getUuid() + " failed to upload. Error details: " + answer.getDetails());
                             }
                             break;
                         case UNKNOWN:
@@ -327,8 +325,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                                     tmpVolumeDataStore.setDownloadState(VMTemplateStorageResourceAssoc.Status.ABANDONED);
                                     tmpVolumeDataStore.setState(State.Failed);
                                     stateMachine.transitTo(tmpVolume, Event.OperationTimeout, null, _volumeDao);
-                                    if (s_logger.isDebugEnabled()) {
-                                        s_logger.debug("Volume " + tmpVolume.getUuid() + " failed to upload due to operation timed out");
+                                    if (logger.isDebugEnabled()) {
+                                        logger.debug("Volume " + tmpVolume.getUuid() + " failed to upload due to operation timed out");
                                     }
                                 }
                             }
@@ -336,7 +334,7 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                         }
                         _volumeDataStoreDao.update(tmpVolumeDataStore.getId(), tmpVolumeDataStore);
                     } catch (NoTransitionException e) {
-                        s_logger.error("Unexpected error " + e.getMessage());
+                        logger.error("Unexpected error " + e.getMessage());
                     }
                 }
             });
@@ -366,8 +364,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                             stateMachine.transitTo(tmpTemplate, VirtualMachineTemplate.Event.OperationSucceeded, null, _templateDao);
                             _resourceLimitMgr.incrementResourceCount(template.getAccountId(), Resource.ResourceType.secondary_storage, answer.getVirtualSize());
 
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Template " + tmpTemplate.getUuid() + " uploaded successfully");
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Template " + tmpTemplate.getUuid() + " uploaded successfully");
                             }
                             break;
                         case IN_PROGRESS:
@@ -380,8 +378,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                                     tmpTemplateDataStore.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOAD_ERROR);
                                     tmpTemplateDataStore.setState(State.Failed);
                                     stateMachine.transitTo(tmpTemplate, VirtualMachineTemplate.Event.OperationFailed, null, _templateDao);
-                                    if (s_logger.isDebugEnabled()) {
-                                        s_logger.debug("Template " + tmpTemplate.getUuid() + " failed to upload due to operation timed out");
+                                    if (logger.isDebugEnabled()) {
+                                        logger.debug("Template " + tmpTemplate.getUuid() + " failed to upload due to operation timed out");
                                     }
                                 } else {
                                     tmpTemplateDataStore.setDownloadPercent(answer.getDownloadPercent());
@@ -392,8 +390,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                             tmpTemplateDataStore.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOAD_ERROR);
                             tmpTemplateDataStore.setState(State.Failed);
                             stateMachine.transitTo(tmpTemplate, VirtualMachineTemplate.Event.OperationFailed, null, _templateDao);
-                            if (s_logger.isDebugEnabled()) {
-                                s_logger.debug("Template " + tmpTemplate.getUuid() + " failed to upload. Error details: " + answer.getDetails());
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Template " + tmpTemplate.getUuid() + " failed to upload. Error details: " + answer.getDetails());
                             }
                             break;
                         case UNKNOWN:
@@ -402,8 +400,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                                     tmpTemplateDataStore.setDownloadState(VMTemplateStorageResourceAssoc.Status.ABANDONED);
                                     tmpTemplateDataStore.setState(State.Failed);
                                     stateMachine.transitTo(tmpTemplate, VirtualMachineTemplate.Event.OperationTimeout, null, _templateDao);
-                                    if (s_logger.isDebugEnabled()) {
-                                        s_logger.debug("Template " + tmpTemplate.getUuid() + " failed to upload due to operation timed out");
+                                    if (logger.isDebugEnabled()) {
+                                        logger.debug("Template " + tmpTemplate.getUuid() + " failed to upload due to operation timed out");
                                     }
                                 }
                             }
@@ -411,7 +409,7 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                         }
                         _templateDataStoreDao.update(tmpTemplateDataStore.getId(), tmpTemplateDataStore);
                     } catch (NoTransitionException e) {
-                        s_logger.error("Unexpected error " + e.getMessage());
+                        logger.error("Unexpected error " + e.getMessage());
                     }
                 }
             });

--- a/server/src/com/cloud/storage/OCFS2ManagerImpl.java
+++ b/server/src/com/cloud/storage/OCFS2ManagerImpl.java
@@ -25,7 +25,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
@@ -55,7 +54,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {OCFS2Manager.class})
 public class OCFS2ManagerImpl extends ManagerBase implements OCFS2Manager, ResourceListener {
-    private static final Logger s_logger = Logger.getLogger(OCFS2ManagerImpl.class);
 
     @Inject
     ClusterDetailsDao _clusterDetailsDao;
@@ -109,11 +107,11 @@ public class OCFS2ManagerImpl extends ManagerBase implements OCFS2Manager, Resou
         for (HostVO h : hosts) {
             Answer ans = _agentMgr.easySend(h.getId(), cmd);
             if (ans == null) {
-                s_logger.debug("Host " + h.getId() + " is not in UP state, skip preparing OCFS2 node on it");
+                logger.debug("Host " + h.getId() + " is not in UP state, skip preparing OCFS2 node on it");
                 continue;
             }
             if (!ans.getResult()) {
-                s_logger.warn("PrepareOCFS2NodesCommand failed on host " + h.getId() + " " + ans.getDetails());
+                logger.warn("PrepareOCFS2NodesCommand failed on host " + h.getId() + " " + ans.getDetails());
                 return false;
             }
         }
@@ -154,7 +152,7 @@ public class OCFS2ManagerImpl extends ManagerBase implements OCFS2Manager, Resou
         sc.and(sc.entity().getType(), Op.EQ, Host.Type.Routing);
         List<HostVO> hosts = sc.list();
         if (hosts.isEmpty()) {
-            s_logger.debug("There is no host in cluster " + clusterId + ", no need to prepare OCFS2 nodes");
+            logger.debug("There is no host in cluster " + clusterId + ", no need to prepare OCFS2 nodes");
             return true;
         }
 
@@ -202,10 +200,10 @@ public class OCFS2ManagerImpl extends ManagerBase implements OCFS2Manager, Resou
         if (hasOcfs2) {
             try {
                 if (!prepareNodes(host.getClusterId())) {
-                    s_logger.warn(errMsg);
+                    logger.warn(errMsg);
                 }
             } catch (Exception e) {
-                s_logger.error(errMsg, e);
+                logger.error(errMsg, e);
             }
         }
     }

--- a/server/src/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/com/cloud/storage/VolumeApiServiceImpl.java
@@ -39,7 +39,6 @@ import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
 import org.apache.cloudstack.storage.command.TemplateOrVolumePostUploadCommand;
 import org.apache.cloudstack.utils.imagestore.ImageStoreUtil;
-import org.apache.log4j.Logger;
 import org.apache.cloudstack.api.command.user.volume.AttachVolumeCmd;
 import org.apache.cloudstack.api.command.user.volume.CreateVolumeCmd;
 import org.apache.cloudstack.api.command.user.volume.DetachVolumeCmd;
@@ -170,7 +169,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiService, VmWorkJobHandler {
-    private final static Logger s_logger = Logger.getLogger(VolumeApiServiceImpl.class);
     public static final String VM_WORK_JOB_HANDLER = VolumeApiServiceImpl.class.getSimpleName();
 
     @Inject
@@ -400,7 +398,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         try {
             ImageFormat.valueOf(format.toUpperCase());
         } catch (IllegalArgumentException e) {
-            s_logger.debug("ImageFormat IllegalArgumentException: " + e.getMessage());
+            logger.debug("ImageFormat IllegalArgumentException: " + e.getMessage());
             throw new IllegalArgumentException("Image format: " + format + " is incorrect. Supported formats are " + EnumUtils.listValues(ImageFormat.values()));
         }
 
@@ -761,8 +759,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                         message.append(cmd.getVirtualMachineId());
                         message.append(" due to error: ");
                         message.append(ex.getMessage());
-                        if (s_logger.isDebugEnabled()) {
-                            s_logger.debug(message, ex);
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(message, ex);
                         }
                         throw new CloudRuntimeException(message.toString());
                     }
@@ -776,7 +774,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new CloudRuntimeException("Failed to create volume: " + volume.getId(), e);
         } finally {
             if (!created) {
-                s_logger.trace("Decrementing volume resource count for account id=" + volume.getAccountId() + " as volume failed to create on the backend");
+                logger.trace("Decrementing volume resource count for account id=" + volume.getAccountId() + " as volume failed to create on the backend");
                 _resourceLimitMgr.decrementResourceCount(volume.getAccountId(), ResourceType.volume, cmd.getDisplayVolume());
                 _resourceLimitMgr.recalculateResourceCount(volume.getAccountId(), volume.getDomainId(), ResourceType.primary_storage.getOrdinal());
             }
@@ -979,7 +977,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         /* If this volume has never been beyond allocated state, short circuit everything and simply update the database. */
         if (volume.getState() == Volume.State.Allocated) {
-            s_logger.debug("Volume is in the allocated state, but has never been created. Simply updating database with new size and IOPS.");
+            logger.debug("Volume is in the allocated state, but has never been created. Simply updating database with new size and IOPS.");
 
             volume.setSize(newSize);
             volume.setMinIops(newMinIops);
@@ -1145,7 +1143,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             VolumeApiResult result = future.get();
 
             if (result.isFailed()) {
-                s_logger.warn("Failed to resize the volume " + volume);
+                logger.warn("Failed to resize the volume " + volume);
                 String details = "";
                 if (result.getResult() != null && !result.getResult().isEmpty()) {
                     details = result.getResult();
@@ -1169,13 +1167,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
             return volume;
         } catch (InterruptedException e) {
-            s_logger.warn("failed get resize volume result", e);
+            logger.warn("failed get resize volume result", e);
             throw new CloudRuntimeException(e.getMessage());
         } catch (ExecutionException e) {
-            s_logger.warn("failed get resize volume result", e);
+            logger.warn("failed get resize volume result", e);
             throw new CloudRuntimeException(e.getMessage());
         } catch (Exception e) {
-            s_logger.warn("failed get resize volume result", e);
+            logger.warn("failed get resize volume result", e);
             throw new CloudRuntimeException(e.getMessage());
         }
     }
@@ -1240,26 +1238,26 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             // expunge volume from primary if volume is on primary
             VolumeInfo volOnPrimary = volFactory.getVolume(volume.getId(), DataStoreRole.Primary);
             if (volOnPrimary != null) {
-                s_logger.info("Expunging volume " + volume.getId() + " from primary data store");
+                logger.info("Expunging volume " + volume.getId() + " from primary data store");
                 AsyncCallFuture<VolumeApiResult> future = volService.expungeVolumeAsync(volOnPrimary);
                 future.get();
             }
             // expunge volume from secondary if volume is on image store
             VolumeInfo volOnSecondary = volFactory.getVolume(volume.getId(), DataStoreRole.Image);
             if (volOnSecondary != null) {
-                s_logger.info("Expunging volume " + volume.getId() + " from secondary data store");
+                logger.info("Expunging volume " + volume.getId() + " from secondary data store");
                 AsyncCallFuture<VolumeApiResult> future2 = volService.expungeVolumeAsync(volOnSecondary);
                 future2.get();
             }
             // delete all cache entries for this volume
             List<VolumeInfo> cacheVols = volFactory.listVolumeOnCache(volume.getId());
             for (VolumeInfo volOnCache : cacheVols) {
-                s_logger.info("Delete volume from image cache store: " + volOnCache.getDataStore().getName());
+                logger.info("Delete volume from image cache store: " + volOnCache.getDataStore().getName());
                 volOnCache.delete();
             }
 
         } catch (Exception e) {
-            s_logger.warn("Failed to expunge volume:", e);
+            logger.warn("Failed to expunge volume:", e);
             return false;
         }
 
@@ -1320,7 +1318,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             try {
                 newVolumeOnPrimaryStorage = _volumeMgr.createVolumeOnPrimaryStorage(vm, volumeToAttach, rootDiskHyperType, destPrimaryStorage);
             } catch (NoTransitionException e) {
-                s_logger.debug("Failed to create volume on primary storage", e);
+                logger.debug("Failed to create volume on primary storage", e);
                 throw new CloudRuntimeException("Failed to create volume on primary storage", e);
             }
         }
@@ -1341,10 +1339,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 newVolumeOnPrimaryStorage = _volumeMgr.moveVolume(newVolumeOnPrimaryStorage, vmRootVolumePool.getDataCenterId(), vmRootVolumePool.getPodId(),
                         vmRootVolumePool.getClusterId(), volumeToAttachHyperType);
             } catch (ConcurrentOperationException e) {
-                s_logger.debug("move volume failed", e);
+                logger.debug("move volume failed", e);
                 throw new CloudRuntimeException("move volume failed", e);
             } catch (StorageUnavailableException e) {
-                s_logger.debug("move volume failed", e);
+                logger.debug("move volume failed", e);
                 throw new CloudRuntimeException("move volume failed", e);
             }
         }
@@ -1464,8 +1462,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (asyncExecutionContext != null) {
             AsyncJob job = asyncExecutionContext.getJob();
 
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Trying to attaching volume " + volumeId + " to vm instance:" + vm.getId() + ", update async job-" + job.getId() + " progress status");
+            if (logger.isInfoEnabled()) {
+                logger.info("Trying to attaching volume " + volumeId + " to vm instance:" + vm.getId() + ", update async job-" + job.getId() + " progress status");
             }
 
             _jobMgr.updateAsyncJobAttachment(job.getId(), "Volume", volumeId);
@@ -1672,8 +1670,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (asyncExecutionContext != null) {
             AsyncJob job = asyncExecutionContext.getJob();
 
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Trying to attaching volume " + volumeId + "to vm instance:" + vm.getId() + ", update async job-" + job.getId() + " progress status");
+            if (logger.isInfoEnabled()) {
+                logger.info("Trying to attaching volume " + volumeId + "to vm instance:" + vm.getId() + ", update async job-" + job.getId() + " progress status");
             }
 
             _jobMgr.updateAsyncJobAttachment(job.getId(), "Volume", volumeId);
@@ -1965,10 +1963,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 newVol = _volumeMgr.migrateVolume(vol, destPool);
             }
         } catch (StorageUnavailableException e) {
-            s_logger.debug("Failed to migrate volume", e);
+            logger.debug("Failed to migrate volume", e);
             throw new CloudRuntimeException(e.getMessage());
         }  catch (Exception e) {
-            s_logger.debug("Failed to migrate volume", e);
+            logger.debug("Failed to migrate volume", e);
             throw new CloudRuntimeException(e.getMessage());
         }
         return newVol;
@@ -1981,15 +1979,15 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         try {
             VolumeApiResult result = future.get();
             if (result.isFailed()) {
-                s_logger.debug("migrate volume failed:" + result.getResult());
+                logger.debug("migrate volume failed:" + result.getResult());
                 throw new StorageUnavailableException("Migrate volume failed: " + result.getResult(), destPool.getId());
             }
             return result.getVolume();
         } catch (InterruptedException e) {
-            s_logger.debug("migrate volume failed", e);
+            logger.debug("migrate volume failed", e);
             throw new CloudRuntimeException(e.getMessage());
         } catch (ExecutionException e) {
-            s_logger.debug("migrate volume failed", e);
+            logger.debug("migrate volume failed", e);
             throw new CloudRuntimeException(e.getMessage());
         }
     }
@@ -2160,7 +2158,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         // Extract activity only for detached volumes or for volumes whose
         // instance is stopped
         if (volume.getInstanceId() != null && ApiDBUtils.findVMInstanceById(volume.getInstanceId()).getState() != State.Stopped) {
-            s_logger.debug("Invalid state of the volume with ID: " + volumeId + ". It should be either detached or the VM should be in stopped state.");
+            logger.debug("Invalid state of the volume with ID: " + volumeId + ". It should be either detached or the VM should be in stopped state.");
             PermissionDeniedException ex = new PermissionDeniedException(
                     "Invalid state of the volume with specified ID. It should be either detached or the VM should be in stopped state.");
             ex.addProxyObject(volume.getUuid(), "volumeId");
@@ -2264,10 +2262,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         try {
             cvResult = cvAnswer.get();
         } catch (InterruptedException e1) {
-            s_logger.debug("failed copy volume", e1);
+            logger.debug("failed copy volume", e1);
             throw new CloudRuntimeException("Failed to copy volume", e1);
         } catch (ExecutionException e1) {
-            s_logger.debug("failed copy volume", e1);
+            logger.debug("failed copy volume", e1);
             throw new CloudRuntimeException("Failed to copy volume", e1);
         }
         if (cvResult == null || cvResult.isFailed()) {
@@ -2654,7 +2652,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         _jobMgr.submitAsyncJob(workJob, VmWorkConstants.VM_WORK_QUEUE, vm.getId());
 
         AsyncJobVO jobVo = _jobMgr.getAsyncJob(workJob.getId());
-        s_logger.debug("New job " + workJob.getId() + ", result field: " + jobVo.getResult());
+        logger.debug("New job " + workJob.getId() + ", result field: " + jobVo.getResult());
 
         AsyncJobExecutionContext.getCurrentExecutionContext().joinJob(workJob.getId());
 

--- a/server/src/com/cloud/storage/download/DownloadMonitorImpl.java
+++ b/server/src/com/cloud/storage/download/DownloadMonitorImpl.java
@@ -26,7 +26,6 @@ import java.util.Timer;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
@@ -67,7 +66,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 @Component
 @Local(value = {DownloadMonitor.class})
 public class DownloadMonitorImpl extends ManagerBase implements DownloadMonitor {
-    static final Logger s_logger = Logger.getLogger(DownloadMonitorImpl.class);
 
     @Inject
     private TemplateDataStoreDao _vmTemplateStoreDao;
@@ -96,7 +94,7 @@ public class DownloadMonitorImpl extends ManagerBase implements DownloadMonitor 
 
         String cert = configs.get("secstorage.ssl.cert.domain");
         if (!"realhostip.com".equalsIgnoreCase(cert)) {
-            s_logger.warn("Only realhostip.com ssl cert is supported, ignoring self-signed and other certs");
+            logger.warn("Only realhostip.com ssl cert is supported, ignoring self-signed and other certs");
         }
 
         _copyAuthPasswd = configs.get("secstorage.copy.password");
@@ -155,7 +153,7 @@ public class DownloadMonitorImpl extends ManagerBase implements DownloadMonitor 
             EndPoint ep = _epSelector.select(template);
             if (ep == null) {
                 String errMsg = "There is no secondary storage VM for downloading template to image store " + store.getName();
-                s_logger.warn(errMsg);
+                logger.warn(errMsg);
                 throw new CloudRuntimeException(errMsg);
             }
             DownloadListener dl = new DownloadListener(ep, store, template, _timer, this, dcmd, callback);
@@ -166,14 +164,14 @@ public class DownloadMonitorImpl extends ManagerBase implements DownloadMonitor 
                 // DownloadListener to use
                 // new ObjectInDataStore.State transition. TODO: fix this later
                 // to be able to remove downloadState from template_store_ref.
-                s_logger.info("found existing download job");
+                logger.info("found existing download job");
                 dl.setCurrState(vmTemplateStore.getDownloadState());
             }
 
             try {
                 ep.sendMessageAsync(dcmd, new UploadListener.Callback(ep.getId(), dl));
             } catch (Exception e) {
-                s_logger.warn("Unable to start /resume download of template " + template.getId() + " to " + store.getName(), e);
+                logger.warn("Unable to start /resume download of template " + template.getId() + " to " + store.getName(), e);
                 dl.setDisconnected();
                 dl.scheduleStatusCheck(RequestType.GET_OR_RESTART);
             }
@@ -189,12 +187,12 @@ public class DownloadMonitorImpl extends ManagerBase implements DownloadMonitor 
                 if (template.getUri() != null) {
                     initiateTemplateDownload(template, callback);
                 } else {
-                    s_logger.info("Template url is null, cannot download");
+                    logger.info("Template url is null, cannot download");
                     DownloadAnswer ans = new DownloadAnswer("Template url is null", Status.UNKNOWN);
                     callback.complete(ans);
                 }
             } else {
-                s_logger.info("Template download is already in progress or already downloaded");
+                logger.info("Template download is already in progress or already downloaded");
                 DownloadAnswer ans =
                         new DownloadAnswer("Template download is already in progress or already downloaded", Status.UNKNOWN);
                 callback.complete(ans);
@@ -239,7 +237,7 @@ public class DownloadMonitorImpl extends ManagerBase implements DownloadMonitor 
 
             EndPoint ep = _epSelector.select(volume);
             if (ep == null) {
-                s_logger.warn("There is no secondary storage VM for image store " + store.getName());
+                logger.warn("There is no secondary storage VM for image store " + store.getName());
                 return;
             }
             DownloadListener dl = new DownloadListener(ep, store, volume, _timer, this, dcmd, callback);
@@ -252,7 +250,7 @@ public class DownloadMonitorImpl extends ManagerBase implements DownloadMonitor 
             try {
                 ep.sendMessageAsync(dcmd, new UploadListener.Callback(ep.getId(), dl));
             } catch (Exception e) {
-                s_logger.warn("Unable to start /resume download of volume " + volume.getId() + " to " + store.getName(), e);
+                logger.warn("Unable to start /resume download of volume " + volume.getId() + " to " + store.getName(), e);
                 dl.setDisconnected();
                 dl.scheduleStatusCheck(RequestType.GET_OR_RESTART);
             }

--- a/server/src/com/cloud/storage/snapshot/SnapshotSchedulerImpl.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotSchedulerImpl.java
@@ -27,7 +27,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.ApiConstants;
@@ -69,7 +68,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {SnapshotScheduler.class})
 public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotScheduler {
-    private static final Logger s_logger = Logger.getLogger(SnapshotSchedulerImpl.class);
 
     @Inject
     protected AsyncJobDao _asyncJobDao;
@@ -117,7 +115,7 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
             nextTimestamp = DateUtil.getNextRunTime(type, schedule, timezone, currentTimestamp);
             final String currentTime = DateUtil.displayDateInTimezone(DateUtil.GMT_TIMEZONE, currentTimestamp);
             final String nextScheduledTime = DateUtil.displayDateInTimezone(DateUtil.GMT_TIMEZONE, nextTimestamp);
-            s_logger.debug("Current time is " + currentTime + ". NextScheduledTime of policyId " + policyId + " is " + nextScheduledTime);
+            logger.debug("Current time is " + currentTime + ". NextScheduledTime of policyId " + policyId + " is " + nextScheduledTime);
         }
         return nextTimestamp;
     }
@@ -224,10 +222,10 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
     @DB
     protected void scheduleSnapshots() {
         String displayTime = DateUtil.displayDateInTimezone(DateUtil.GMT_TIMEZONE, _currentTimestamp);
-        s_logger.debug("Snapshot scheduler.poll is being called at " + displayTime);
+        logger.debug("Snapshot scheduler.poll is being called at " + displayTime);
 
         final List<SnapshotScheduleVO> snapshotsToBeExecuted = _snapshotScheduleDao.getSchedulesToExecute(_currentTimestamp);
-        s_logger.debug("Got " + snapshotsToBeExecuted.size() + " snapshots to be executed at " + displayTime);
+        logger.debug("Got " + snapshotsToBeExecuted.size() + " snapshots to be executed at " + displayTime);
 
         for (final SnapshotScheduleVO snapshotToBeExecuted : snapshotsToBeExecuted) {
             SnapshotScheduleVO tmpSnapshotScheduleVO = null;
@@ -243,18 +241,18 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
                 Account volAcct = _acctDao.findById(volume.getAccountId());
                 if (volAcct == null || volAcct.getState() == Account.State.disabled) {
                     // this account has been removed, so don't trigger recurring snapshot
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Skip snapshot for volume " + volume.getUuid() + " since its account has been removed or disabled");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Skip snapshot for volume " + volume.getUuid() + " since its account has been removed or disabled");
                     }
                     continue;
                 }
                 if (_snapshotPolicyDao.findById(policyId) == null) {
                     _snapshotScheduleDao.remove(snapshotToBeExecuted.getId());
                 }
-                if (s_logger.isDebugEnabled()) {
+                if (logger.isDebugEnabled()) {
                     final Date scheduledTimestamp = snapshotToBeExecuted.getScheduledTimestamp();
                     displayTime = DateUtil.displayDateInTimezone(DateUtil.GMT_TIMEZONE, scheduledTimestamp);
-                    s_logger.debug("Scheduling 1 snapshot for volume id " + volumeId + " (volume name:" +
+                    logger.debug("Scheduling 1 snapshot for volume id " + volumeId + " (volume name:" +
                             volume.getName() + ") for schedule id: " + snapshotToBeExecuted.getId() + " at " + displayTime);
                 }
 
@@ -287,7 +285,7 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
                 _snapshotScheduleDao.update(snapshotScheId, tmpSnapshotScheduleVO);
             } catch (final Exception e) {
                 // TODO Logging this exception is enough?
-                s_logger.warn("Scheduling snapshot failed due to " + e.toString());
+                logger.warn("Scheduling snapshot failed due to " + e.toString());
             } finally {
                 if (tmpSnapshotScheduleVO != null) {
                     _snapshotScheduleDao.releaseFromLockTable(snapshotScheId);
@@ -379,7 +377,7 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
             success = _snapshotScheduleDao.remove(schedule.getId());
         }
         if (!success) {
-            s_logger.debug("Error while deleting Snapshot schedule with Id: " + schedule.getId());
+            logger.debug("Error while deleting Snapshot schedule with Id: " + schedule.getId());
         }
         return success;
     }
@@ -402,7 +400,7 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
         }
         _currentTimestamp = new Date();
 
-        s_logger.info("Snapshot Scheduler is configured.");
+        logger.info("Snapshot Scheduler is configured.");
 
         return true;
     }
@@ -430,7 +428,7 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
                         final Date currentTimestamp = new Date();
                         poll(currentTimestamp);
                     } catch (final Throwable t) {
-                        s_logger.warn("Catch throwable in snapshot scheduler ", t);
+                        logger.warn("Catch throwable in snapshot scheduler ", t);
                     }
                 }
             };

--- a/server/src/com/cloud/storage/upload/UploadMonitorImpl.java
+++ b/server/src/com/cloud/storage/upload/UploadMonitorImpl.java
@@ -32,7 +32,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -84,7 +83,6 @@ import com.cloud.vm.dao.SecondaryStorageVmDao;
 @Local(value = {UploadMonitor.class})
 public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
 
-    static final Logger s_logger = Logger.getLogger(UploadMonitorImpl.class);
 
     @Inject
     private UploadDao _uploadDao;
@@ -161,12 +159,12 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
             EndPoint ep = _epSelector.select(secStore);
             if (ep == null) {
                 String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
-                s_logger.error(errMsg);
+                logger.error(errMsg);
                 return;
             }
             ep.sendMessageAsync(ucmd, new UploadListener.Callback(ep.getId(), ul));
         } catch (Exception e) {
-            s_logger.warn("Unable to start upload of volume " + volume.getName() + " from " + secStore.getName() + " to " + url, e);
+            logger.warn("Unable to start upload of volume " + volume.getName() + " from " + secStore.getName() + " to " + url, e);
             ul.setDisconnected();
             ul.scheduleStatusCheck(RequestType.GET_OR_RESTART);
         }
@@ -194,12 +192,12 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
                 EndPoint ep = _epSelector.select(secStore);
                 if (ep == null) {
                     String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
-                    s_logger.error(errMsg);
+                    logger.error(errMsg);
                     return null;
                 }
                 ep.sendMessageAsync(ucmd, new UploadListener.Callback(ep.getId(), ul));
             } catch (Exception e) {
-                s_logger.warn("Unable to start upload of " + template.getUniqueName() + " from " + secStore.getName() + " to " + url, e);
+                logger.warn("Unable to start upload of " + template.getUniqueName() + " from " + secStore.getName() + " to " + url, e);
                 ul.setDisconnected();
                 ul.scheduleStatusCheck(RequestType.GET_OR_RESTART);
             }
@@ -220,7 +218,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
         EndPoint ep = _epSelector.select(store);
         if (ep == null) {
             String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
-            s_logger.error(errMsg);
+            logger.error(errMsg);
             return null;
         }
 
@@ -263,7 +261,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
             Answer ans = ep.sendMessage(cmd);
             if (ans == null || !ans.getResult()) {
                 errorString = "Unable to create a link for " + type + " id:" + template.getId() + "," + (ans == null ? "" : ans.getDetails());
-                s_logger.error(errorString);
+                logger.error(errorString);
                 throw new CloudRuntimeException(errorString);
             }
 
@@ -319,7 +317,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
             Answer ans = ep.sendMessage(cmd);
             if (ans == null || !ans.getResult()) {
                 errorString = "Unable to create a link for " + type + " id:" + entityId + "," + (ans == null ? "" : ans.getDetails());
-                s_logger.warn(errorString);
+                logger.warn(errorString);
                 throw new CloudRuntimeException(errorString);
             }
 
@@ -328,7 +326,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
                 SecondaryStorageVmVO ssVm = ssVms.get(0);
                 if (ssVm.getPublicIpAddress() == null) {
                     errorString = "A running secondary storage vm has a null public ip?";
-                    s_logger.error(errorString);
+                    logger.error(errorString);
                     throw new CloudRuntimeException(errorString);
                 }
                 //Construct actual URL locally now that the symlink exists at SSVM
@@ -378,7 +376,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
 
         String cert = configs.get("secstorage.secure.copy.cert");
         if ("realhostip.com".equalsIgnoreCase(cert)) {
-            s_logger.warn("Only realhostip.com ssl cert is supported, ignoring self-signed and other certs");
+            logger.warn("Only realhostip.com ssl cert is supported, ignoring self-signed and other certs");
         }
 
         _ssvmUrlDomain = configs.get("secstorage.ssl.cert.domain");
@@ -425,10 +423,10 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
 
         HostVO storageHost = _serverDao.findById(sserverId);
         if (storageHost == null) {
-            s_logger.warn("Huh? Agent id " + sserverId + " does not correspond to a row in hosts table?");
+            logger.warn("Huh? Agent id " + sserverId + " does not correspond to a row in hosts table?");
             return;
         }
-        s_logger.debug("Handling upload sserverId " + sserverId);
+        logger.debug("Handling upload sserverId " + sserverId);
         List<UploadVO> uploadsInProgress = new ArrayList<UploadVO>();
         uploadsInProgress.addAll(_uploadDao.listByHostAndUploadStatus(sserverId, UploadVO.Status.UPLOAD_IN_PROGRESS));
         uploadsInProgress.addAll(_uploadDao.listByHostAndUploadStatus(sserverId, UploadVO.Status.COPY_IN_PROGRESS));
@@ -466,7 +464,7 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
                 }
 
             } catch (Exception e) {
-                s_logger.error("Caught the following Exception", e);
+                logger.error("Caught the following Exception", e);
             }
         }
     }
@@ -494,17 +492,17 @@ public class UploadMonitorImpl extends ManagerBase implements UploadMonitor {
                     new DeleteEntityDownloadURLCommand(path, extractJob.getType(), extractJob.getUploadUrl(), ((ImageStoreVO)secStore).getParent());
                 EndPoint ep = _epSelector.select(secStore);
                 if (ep == null) {
-                    s_logger.warn("UploadMonitor cleanup: There is no secondary storage VM for secondary storage host " + extractJob.getDataStoreId());
+                    logger.warn("UploadMonitor cleanup: There is no secondary storage VM for secondary storage host " + extractJob.getDataStoreId());
                     continue; //TODO: why continue? why not break?
                 }
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("UploadMonitor cleanup: Sending deletion of extract URL " + extractJob.getUploadUrl() + " to ssvm " + ep.getHostAddr());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("UploadMonitor cleanup: Sending deletion of extract URL " + extractJob.getUploadUrl() + " to ssvm " + ep.getHostAddr());
                 }
                 Answer ans = ep.sendMessage(cmd);
                 if (ans != null && ans.getResult()) {
                     _uploadDao.remove(extractJob.getId());
                 } else {
-                    s_logger.warn("UploadMonitor cleanup: Unable to delete the link for " + extractJob.getType() + " id=" + extractJob.getTypeId() + " url=" +
+                    logger.warn("UploadMonitor cleanup: Unable to delete the link for " + extractJob.getType() + " id=" + extractJob.getTypeId() + " url=" +
                         extractJob.getUploadUrl() + " on ssvm " + ep.getHostAddr());
                 }
             }

--- a/server/src/com/cloud/tags/TaggedResourceManagerImpl.java
+++ b/server/src/com/cloud/tags/TaggedResourceManagerImpl.java
@@ -33,7 +33,6 @@ import org.apache.cloudstack.api.InternalIdentity;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import com.cloud.api.query.dao.ResourceTagJoinDao;
 import com.cloud.dc.DataCenterVO;
@@ -91,7 +90,6 @@ import com.cloud.vm.snapshot.VMSnapshotVO;
 
 @Local(value = {TaggedResourceService.class})
 public class TaggedResourceManagerImpl extends ManagerBase implements TaggedResourceService {
-    public static final Logger s_logger = Logger.getLogger(TaggedResourceManagerImpl.class);
 
     private static final Map<ResourceObjectType, Class<?>> s_typeMap = new HashMap<ResourceObjectType, Class<?>>();
     static {
@@ -354,7 +352,7 @@ public class TaggedResourceManagerImpl extends ManagerBase implements TaggedReso
             public void doInTransactionWithoutResult(TransactionStatus status) {
                 for (ResourceTag tagToRemove : tagsToRemove) {
                     _resourceTagDao.remove(tagToRemove.getId());
-                    s_logger.debug("Removed the tag " + tagToRemove);
+                    logger.debug("Removed the tag " + tagToRemove);
                 }
             }
         });

--- a/server/src/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/com/cloud/template/TemplateAdapterBase.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.api.command.user.template.GetUploadParamsForTemplateCmd;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.command.user.iso.DeleteIsoCmd;
@@ -74,7 +73,6 @@ import com.cloud.vm.UserVmVO;
 import com.cloud.vm.dao.UserVmDao;
 
 public abstract class TemplateAdapterBase extends AdapterBase implements TemplateAdapter {
-    private final static Logger s_logger = Logger.getLogger(TemplateAdapterBase.class);
     protected @Inject
     DomainDao _domainDao;
     protected @Inject
@@ -202,7 +200,7 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
         try {
             imgfmt = ImageFormat.valueOf(format.toUpperCase());
         } catch (IllegalArgumentException e) {
-            s_logger.debug("ImageFormat IllegalArgumentException: " + e.getMessage());
+            logger.debug("ImageFormat IllegalArgumentException: " + e.getMessage());
             throw new IllegalArgumentException("Image format: " + format + " is incorrect. Supported formats are " + EnumUtils.listValues(ImageFormat.values()));
         }
 

--- a/server/src/com/cloud/usage/UsageServiceImpl.java
+++ b/server/src/com/cloud/usage/UsageServiceImpl.java
@@ -64,7 +64,6 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.usage.Usage;
 import org.apache.cloudstack.usage.UsageService;
 import org.apache.cloudstack.usage.UsageTypes;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import javax.ejb.Local;
@@ -80,7 +79,6 @@ import java.util.TimeZone;
 @Component
 @Local(value = {UsageService.class})
 public class UsageServiceImpl extends ManagerBase implements UsageService, Manager {
-    public static final Logger s_logger = Logger.getLogger(UsageServiceImpl.class);
 
     //ToDo: Move implementation to ManagaerImpl
 
@@ -213,7 +211,7 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
             } else if (_accountService.isDomainAdmin(caller.getId())) {
                 isDomainAdmin = true;
             }
-            s_logger.debug("Account details not available. Using userContext accountId: " + accountId);
+            logger.debug("Account details not available. Using userContext accountId: " + accountId);
         }
 
         Date startDate = cmd.getStartDate();
@@ -225,8 +223,8 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
         Date adjustedStartDate = computeAdjustedTime(startDate, usageTZ);
         Date adjustedEndDate = computeAdjustedTime(endDate, usageTZ);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("getting usage records for account: " + accountId + ", domainId: " + domainId + ", between " + adjustedStartDate + " and " + adjustedEndDate +
+        if (logger.isDebugEnabled()) {
+            logger.debug("getting usage records for account: " + accountId + ", domainId: " + domainId + ", between " + adjustedStartDate + " and " + adjustedEndDate +
                 ", using pageSize: " + cmd.getPageSizeVal() + " and startIndex: " + cmd.getStartIndex());
         }
 
@@ -394,7 +392,7 @@ public class UsageServiceImpl extends ManagerBase implements UsageService, Manag
                     cal.set(Calendar.SECOND, 0);
                     cal.set(Calendar.MILLISECOND, 0);
                     long execTS = cal.getTimeInMillis();
-                    s_logger.debug("Trying to remove old raw cloud_usage records older than " + interval + " day(s), current time=" + curTS + " next job execution time=" + execTS);
+                    logger.debug("Trying to remove old raw cloud_usage records older than " + interval + " day(s), current time=" + curTS + " next job execution time=" + execTS);
                     // Let's avoid cleanup when job runs and around a 15 min interval
                     if (Math.abs(curTS - execTS) < 15 * 60 * 1000) {
                         return false;

--- a/server/src/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/com/cloud/user/AccountManagerImpl.java
@@ -41,7 +41,6 @@ import javax.naming.ConfigurationException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.QuerySelector;
@@ -171,7 +170,6 @@ import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 
 @Local(value = {AccountManager.class, AccountService.class})
 public class AccountManagerImpl extends ManagerBase implements AccountManager, Manager {
-    public static final Logger s_logger = Logger.getLogger(AccountManagerImpl.class);
 
     @Inject
     private AccountDao _accountDao;
@@ -397,8 +395,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             for (SecurityChecker checker : _securityCheckers) {
                 try {
                     if (checker.checkAccess(acct, null, null, "SystemCapability")) {
-                        if (s_logger.isTraceEnabled()) {
-                            s_logger.trace("Root Access granted to " + acct + " by " + checker.getName());
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Root Access granted to " + acct + " by " + checker.getName());
                         }
                         return true;
                     }
@@ -420,8 +418,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             for (SecurityChecker checker : _securityCheckers) {
                 try {
                     if (checker.checkAccess(acct, null, null, "DomainCapability")) {
-                        if (s_logger.isTraceEnabled()) {
-                            s_logger.trace("DomainAdmin Access granted to " + acct + " by " + checker.getName());
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("DomainAdmin Access granted to " + acct + " by " + checker.getName());
                         }
                         return true;
                     }
@@ -451,8 +449,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             for (SecurityChecker checker : _securityCheckers) {
                 try {
                     if (checker.checkAccess(acct, null, null, "DomainResourceCapability")) {
-                        if (s_logger.isTraceEnabled()) {
-                            s_logger.trace("ResourceDomainAdmin Access granted to " + acct + " by " + checker.getName());
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("ResourceDomainAdmin Access granted to " + acct + " by " + checker.getName());
                         }
                         return true;
                     }
@@ -479,8 +477,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     public void checkAccess(Account caller, Domain domain) throws PermissionDeniedException {
         for (SecurityChecker checker : _securityCheckers) {
             if (checker.checkAccess(caller, domain)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Access granted to " + caller + " to " + domain + " by " + checker.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Access granted to " + caller + " to " + domain + " by " + checker.getName());
                 }
                 return;
             }
@@ -517,8 +515,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
         if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || isRootAdmin(caller.getId())) {
             // no need to make permission checks if the system/root admin makes the call
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("No need to make permission check for System/RootAdmin account, returning true");
+            if (logger.isTraceEnabled()) {
+                logger.trace("No need to make permission check for System/RootAdmin account, returning true");
             }
             return;
         }
@@ -545,8 +543,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             boolean granted = false;
             for (SecurityChecker checker : _securityCheckers) {
                 if (checker.checkAccess(caller, entity, accessType, apiName)) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Access to " + entity + " granted to " + caller + " by " + checker.getName());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Access to " + entity + " granted to " + caller + " by " + checker.getName());
                     }
                     granted = true;
                     break;
@@ -621,7 +619,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 }
             });
         } catch (Exception e) {
-            s_logger.error("Failed to update login attempts for user with id " + id);
+            logger.error("Failed to update login attempts for user with id " + id);
         }
     }
 
@@ -652,12 +650,12 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 acctForUpdate.setState(State.locked);
                 success = _accountDao.update(Long.valueOf(accountId), acctForUpdate);
             } else {
-                if (s_logger.isInfoEnabled()) {
-                    s_logger.info("Attempting to lock a non-enabled account, current state is " + account.getState() + " (accountId: " + accountId + "), locking failed.");
+                if (logger.isInfoEnabled()) {
+                    logger.info("Attempting to lock a non-enabled account, current state is " + account.getState() + " (accountId: " + accountId + "), locking failed.");
                 }
             }
         } else {
-            s_logger.warn("Failed to lock account " + accountId + ", account not found.");
+            logger.warn("Failed to lock account " + accountId + ", account not found.");
         }
         return success;
     }
@@ -668,12 +666,12 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
         // delete the account record
         if (!_accountDao.remove(accountId)) {
-            s_logger.error("Unable to delete account " + accountId);
+            logger.error("Unable to delete account " + accountId);
             return false;
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Removed account " + accountId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Removed account " + accountId);
         }
 
         return cleanupAccount(account, callerUserId, caller);
@@ -688,7 +686,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             List<UserVO> users = _userDao.listByAccount(accountId);
             for (UserVO user : users) {
                 if (!_userDao.remove(user.getId())) {
-                    s_logger.error("Unable to delete user: " + user + " as a part of account " + account + " cleanup");
+                    logger.error("Unable to delete user: " + user + " as a part of account " + account + " cleanup");
                     accountCleanupNeeded = true;
                 }
             }
@@ -711,7 +709,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             List<InstanceGroupVO> groups = _vmGroupDao.listByAccountId(accountId);
             for (InstanceGroupVO group : groups) {
                 if (!_vmMgr.deleteVmGroup(group.getId())) {
-                    s_logger.error("Unable to delete group: " + group.getId());
+                    logger.error("Unable to delete group: " + group.getId());
                     accountCleanupNeeded = true;
                 }
             }
@@ -719,7 +717,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             // Delete the snapshots dir for the account. Have to do this before destroying the VMs.
             boolean success = _snapMgr.deleteSnapshotDirsForAccount(accountId);
             if (success) {
-                s_logger.debug("Successfully deleted snapshots directories for all volumes under account " + accountId + " across all zones");
+                logger.debug("Successfully deleted snapshots directories for all volumes under account " + accountId + " across all zones");
             }
 
             // clean up templates
@@ -730,14 +728,14 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                     try {
                         allTemplatesDeleted = _tmpltMgr.delete(callerUserId, template.getId(), null);
                     } catch (Exception e) {
-                        s_logger.warn("Failed to delete template while removing account: " + template.getName() + " due to: ", e);
+                        logger.warn("Failed to delete template while removing account: " + template.getName() + " due to: ", e);
                         allTemplatesDeleted = false;
                     }
                 }
             }
 
             if (!allTemplatesDeleted) {
-                s_logger.warn("Failed to delete templates while removing account id=" + accountId);
+                logger.warn("Failed to delete templates while removing account id=" + accountId);
                 accountCleanupNeeded = true;
             }
 
@@ -747,20 +745,20 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 try {
                     _vmSnapshotMgr.deleteVMSnapshot(vmSnapshot.getId());
                 } catch (Exception e) {
-                    s_logger.debug("Failed to cleanup vm snapshot " + vmSnapshot.getId() + " due to " + e.toString());
+                    logger.debug("Failed to cleanup vm snapshot " + vmSnapshot.getId() + " due to " + e.toString());
                 }
             }
 
             // Destroy the account's VMs
             List<UserVmVO> vms = _userVmDao.listByAccountId(accountId);
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Expunging # of vms (accountId=" + accountId + "): " + vms.size());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Expunging # of vms (accountId=" + accountId + "): " + vms.size());
             }
 
             // no need to catch exception at this place as expunging vm should pass in order to perform further cleanup
             for (UserVmVO vm : vms) {
                 if (!_vmMgr.expunge(vm, callerUserId, caller)) {
-                    s_logger.error("Unable to expunge vm: " + vm.getId());
+                    logger.error("Unable to expunge vm: " + vm.getId());
                     accountCleanupNeeded = true;
                 }
             }
@@ -772,7 +770,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                     try {
                         volumeService.deleteVolume(volume.getId(), caller);
                     } catch (Exception ex) {
-                        s_logger.warn("Failed to cleanup volumes as a part of account id=" + accountId + " cleanup due to Exception: ", ex);
+                        logger.warn("Failed to cleanup volumes as a part of account id=" + accountId + " cleanup due to Exception: ", ex);
                         accountCleanupNeeded = true;
                     }
                 }
@@ -791,21 +789,21 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                     _remoteAccessVpnMgr.destroyRemoteAccessVpnForIp(vpn.getServerAddressId(), caller);
                 }
             } catch (ResourceUnavailableException ex) {
-                s_logger.warn("Failed to cleanup remote access vpn resources as a part of account id=" + accountId + " cleanup due to Exception: ", ex);
+                logger.warn("Failed to cleanup remote access vpn resources as a part of account id=" + accountId + " cleanup due to Exception: ", ex);
                 accountCleanupNeeded = true;
             }
 
             // Cleanup security groups
             int numRemoved = _securityGroupDao.removeByAccountId(accountId);
-            s_logger.info("deleteAccount: Deleted " + numRemoved + " network groups for account " + accountId);
+            logger.info("deleteAccount: Deleted " + numRemoved + " network groups for account " + accountId);
 
             // Cleanup affinity groups
             int numAGRemoved = _affinityGroupDao.removeByAccountId(accountId);
-            s_logger.info("deleteAccount: Deleted " + numAGRemoved + " affinity groups for account " + accountId);
+            logger.info("deleteAccount: Deleted " + numAGRemoved + " affinity groups for account " + accountId);
 
             // Delete all the networks
             boolean networksDeleted = true;
-            s_logger.debug("Deleting networks for account " + account.getId());
+            logger.debug("Deleting networks for account " + account.getId());
             List<NetworkVO> networks = _networkDao.listByOwner(accountId);
             if (networks != null) {
                 for (NetworkVO network : networks) {
@@ -813,27 +811,27 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                     ReservationContext context = new ReservationContextImpl(null, null, getActiveUser(callerUserId), caller);
 
                     if (!_networkMgr.destroyNetwork(network.getId(), context, false)) {
-                        s_logger.warn("Unable to destroy network " + network + " as a part of account id=" + accountId + " cleanup.");
+                        logger.warn("Unable to destroy network " + network + " as a part of account id=" + accountId + " cleanup.");
                         accountCleanupNeeded = true;
                         networksDeleted = false;
                     } else {
-                        s_logger.debug("Network " + network.getId() + " successfully deleted as a part of account id=" + accountId + " cleanup.");
+                        logger.debug("Network " + network.getId() + " successfully deleted as a part of account id=" + accountId + " cleanup.");
                     }
                 }
             }
 
             // Delete all VPCs
             boolean vpcsDeleted = true;
-            s_logger.debug("Deleting vpcs for account " + account.getId());
+            logger.debug("Deleting vpcs for account " + account.getId());
             List<? extends Vpc> vpcs = _vpcMgr.getVpcsForAccount(account.getId());
             for (Vpc vpc : vpcs) {
 
                 if (!_vpcMgr.destroyVpc(vpc, caller, callerUserId)) {
-                    s_logger.warn("Unable to destroy VPC " + vpc + " as a part of account id=" + accountId + " cleanup.");
+                    logger.warn("Unable to destroy VPC " + vpc + " as a part of account id=" + accountId + " cleanup.");
                     accountCleanupNeeded = true;
                     vpcsDeleted = false;
                 } else {
-                    s_logger.debug("VPC " + vpc.getId() + " successfully deleted as a part of account id=" + accountId + " cleanup.");
+                    logger.debug("VPC " + vpc.getId() + " successfully deleted as a part of account id=" + accountId + " cleanup.");
                 }
             }
 
@@ -841,9 +839,9 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 // release ip addresses belonging to the account
                 List<? extends IpAddress> ipsToRelease = _ipAddressDao.listByAccount(accountId);
                 for (IpAddress ip : ipsToRelease) {
-                    s_logger.debug("Releasing ip " + ip + " as a part of account id=" + accountId + " cleanup");
+                    logger.debug("Releasing ip " + ip + " as a part of account id=" + accountId + " cleanup");
                     if (!_ipAddrMgr.disassociatePublicIpAddress(ip.getId(), callerUserId, caller)) {
-                        s_logger.warn("Failed to release ip address " + ip
+                        logger.warn("Failed to release ip address " + ip
                                 + " as a part of account id=" + accountId
                                 + " clenaup");
                         accountCleanupNeeded = true;
@@ -852,16 +850,16 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             }
 
             // Delete Site 2 Site VPN customer gateway
-            s_logger.debug("Deleting site-to-site VPN customer gateways for account " + accountId);
+            logger.debug("Deleting site-to-site VPN customer gateways for account " + accountId);
             if (!_vpnMgr.deleteCustomerGatewayByAccount(accountId)) {
-                s_logger.warn("Fail to delete site-to-site VPN customer gateways for account " + accountId);
+                logger.warn("Fail to delete site-to-site VPN customer gateways for account " + accountId);
             }
 
             // Delete autoscale resources if any
             try {
                 _autoscaleMgr.cleanUpAutoScaleResources(accountId);
             } catch (CloudRuntimeException ex) {
-                s_logger.warn("Failed to cleanup AutoScale resources as a part of account id=" + accountId + " cleanup due to exception:", ex);
+                logger.warn("Failed to cleanup AutoScale resources as a part of account id=" + accountId + " cleanup due to exception:", ex);
                 accountCleanupNeeded = true;
             }
 
@@ -871,7 +869,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 if (!_configMgr.releaseAccountSpecificVirtualRanges(accountId)) {
                     accountCleanupNeeded = true;
                 } else {
-                    s_logger.debug("Account specific Virtual IP ranges " + " are successfully released as a part of account id=" + accountId + " cleanup.");
+                    logger.debug("Account specific Virtual IP ranges " + " are successfully released as a part of account id=" + accountId + " cleanup.");
                 }
             }
 
@@ -881,14 +879,14 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 _dataCenterVnetDao.releaseDedicatedGuestVlans(map.getId());
             }
             int vlansReleased = _accountGuestVlanMapDao.removeByAccountId(accountId);
-            s_logger.info("deleteAccount: Released " + vlansReleased + " dedicated guest vlan ranges from account " + accountId);
+            logger.info("deleteAccount: Released " + vlansReleased + " dedicated guest vlan ranges from account " + accountId);
 
             // release account specific acquired portable IP's. Since all the portable IP's must have been already
             // disassociated with VPC/guest network (due to deletion), so just mark portable IP as free.
             List<? extends IpAddress> ipsToRelease = _ipAddressDao.listByAccount(accountId);
             for (IpAddress ip : ipsToRelease) {
                 if (ip.isPortable()) {
-                s_logger.debug("Releasing portable ip " + ip + " as a part of account id=" + accountId + " cleanup");
+                logger.debug("Releasing portable ip " + ip + " as a part of account id=" + accountId + " cleanup");
                 _ipAddrMgr.releasePortableIpAddress(ip.getId());
                 }
             }
@@ -896,10 +894,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             // release dedication if any
             List<DedicatedResourceVO> dedicatedResources = _dedicatedDao.listByAccountId(accountId);
             if (dedicatedResources != null && !dedicatedResources.isEmpty()) {
-                s_logger.debug("Releasing dedicated resources for account " + accountId);
+                logger.debug("Releasing dedicated resources for account " + accountId);
                 for (DedicatedResourceVO dr : dedicatedResources) {
                     if (!_dedicatedDao.remove(dr.getId())) {
-                        s_logger.warn("Fail to release dedicated resources for account " + accountId);
+                        logger.warn("Fail to release dedicated resources for account " + accountId);
                     }
                 }
             }
@@ -917,11 +915,11 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             _resourceLimitDao.removeEntriesByOwner(accountId, ResourceOwnerType.Account);
             return true;
         } catch (Exception ex) {
-            s_logger.warn("Failed to cleanup account " + account + " due to ", ex);
+            logger.warn("Failed to cleanup account " + account + " due to ", ex);
             accountCleanupNeeded = true;
             return true;
         } finally {
-            s_logger.info("Cleanup for account " + account.getId() + (accountCleanupNeeded ? " is needed." : " is not needed."));
+            logger.info("Cleanup for account " + account.getId() + (accountCleanupNeeded ? " is needed." : " is not needed."));
             if (accountCleanupNeeded) {
                 _accountDao.markForCleanup(accountId);
             } else {
@@ -935,8 +933,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     public boolean disableAccount(long accountId) throws ConcurrentOperationException, ResourceUnavailableException {
         boolean success = false;
         if (accountId <= 2) {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("disableAccount -- invalid account id: " + accountId);
+            if (logger.isInfoEnabled()) {
+                logger.info("disableAccount -- invalid account id: " + accountId);
             }
             return false;
         }
@@ -955,7 +953,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                     disableAccountResult = doDisableAccount(accountId);
                 } finally {
                     if (!disableAccountResult) {
-                        s_logger.warn("Failed to disable account " + account + " resources as a part of disableAccount call, marking the account for cleanup");
+                        logger.warn("Failed to disable account " + account + " resources as a part of disableAccount call, marking the account for cleanup");
                         _accountDao.markForCleanup(accountId);
                     } else {
                         acctForUpdate = _accountDao.createForUpdate();
@@ -976,13 +974,13 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 try {
                     _itMgr.advanceStop(vm.getUuid(), false);
                 } catch (OperationTimedoutException ote) {
-                    s_logger.warn(
+                    logger.warn(
                             "Operation for stopping vm timed out, unable to stop vm "
                                     + vm.getHostName(), ote);
                     success = false;
                 }
             } catch (AgentUnavailableException aue) {
-                s_logger.warn("Agent running on host " + vm.getHostId() + " is unavailable, unable to stop vm " + vm.getHostName(), aue);
+                logger.warn("Agent running on host " + vm.getHostId() + " is unavailable, unable to stop vm " + vm.getHostName(), aue);
                 success = false;
             }
         }
@@ -1233,8 +1231,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             user.setSecretKey(secretKey);
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("updating user with id: " + userId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("updating user with id: " + userId);
         }
         try {
             // check if the apiKey and secretKey are globally unique
@@ -1253,7 +1251,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
             _userDao.update(userId, user);
         } catch (Throwable th) {
-            s_logger.error("error updating user", th);
+            logger.error("error updating user", th);
             throw new CloudRuntimeException("Unable to update user " + userId);
         }
 
@@ -1421,8 +1419,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 success = (success && lockAccount(user.getAccountId()));
             }
         } else {
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Attempting to lock a non-enabled user, current state is " + user.getState() + " (userId: " + user.getId() + "), locking failed.");
+            if (logger.isInfoEnabled()) {
+                logger.info("Attempting to lock a non-enabled user, current state is " + user.getState() + " (userId: " + user.getId() + "), locking failed.");
             }
             success = false;
         }
@@ -1451,7 +1449,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
         if (account == null || account.getRemoved() != null) {
             if (account != null) {
-                s_logger.info("The account:" + account.getAccountName() + " is already removed");
+                logger.info("The account:" + account.getAccountName() + " is already removed");
             }
             return true;
         }
@@ -1601,7 +1599,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
         // Check if account exists
         if (account == null || account.getType() == Account.ACCOUNT_TYPE_PROJECT) {
-            s_logger.error("Unable to find account by accountId: " + accountId + " OR by name: " + accountName + " in domain " + domainId);
+            logger.error("Unable to find account by accountId: " + accountId + " OR by name: " + accountName + " in domain " + domainId);
             throw new InvalidParameterValueException("Unable to find account by accountId: " + accountId + " OR by name: " + accountName + " in domain " + domainId);
         }
 
@@ -1700,39 +1698,39 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             try {
                 GlobalLock lock = GlobalLock.getInternLock("AccountCleanup");
                 if (lock == null) {
-                    s_logger.debug("Couldn't get the global lock");
+                    logger.debug("Couldn't get the global lock");
                     return;
                 }
 
                 if (!lock.lock(30)) {
-                    s_logger.debug("Couldn't lock the db");
+                    logger.debug("Couldn't lock the db");
                     return;
                 }
 
                 try {
                     // Cleanup removed accounts
                     List<AccountVO> removedAccounts = _accountDao.findCleanupsForRemovedAccounts(null);
-                    s_logger.info("Found " + removedAccounts.size() + " removed accounts to cleanup");
+                    logger.info("Found " + removedAccounts.size() + " removed accounts to cleanup");
                     for (AccountVO account : removedAccounts) {
-                        s_logger.debug("Cleaning up " + account.getId());
+                        logger.debug("Cleaning up " + account.getId());
                         cleanupAccount(account, getSystemUser().getId(), getSystemAccount());
                     }
 
                     // cleanup disabled accounts
                     List<AccountVO> disabledAccounts = _accountDao.findCleanupsForDisabledAccounts();
-                    s_logger.info("Found " + disabledAccounts.size() + " disabled accounts to cleanup");
+                    logger.info("Found " + disabledAccounts.size() + " disabled accounts to cleanup");
                     for (AccountVO account : disabledAccounts) {
-                        s_logger.debug("Disabling account " + account.getId());
+                        logger.debug("Disabling account " + account.getId());
                         try {
                             disableAccount(account.getId());
                         } catch (Exception e) {
-                            s_logger.error("Skipping due to error on account " + account.getId(), e);
+                            logger.error("Skipping due to error on account " + account.getId(), e);
                         }
                     }
 
                     // cleanup inactive domains
                     List<? extends Domain> inactiveDomains = _domainMgr.findInactiveDomains();
-                    s_logger.info("Found " + inactiveDomains.size() + " inactive domains to cleanup");
+                    logger.info("Found " + inactiveDomains.size() + " inactive domains to cleanup");
                     for (Domain inactiveDomain : inactiveDomains) {
                         long domainId = inactiveDomain.getId();
                         try {
@@ -1741,47 +1739,47 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                                 // release dedication if any, before deleting the domain
                                 List<DedicatedResourceVO> dedicatedResources = _dedicatedDao.listByDomainId(domainId);
                                 if (dedicatedResources != null && !dedicatedResources.isEmpty()) {
-                                    s_logger.debug("Releasing dedicated resources for domain" + domainId);
+                                    logger.debug("Releasing dedicated resources for domain" + domainId);
                                     for (DedicatedResourceVO dr : dedicatedResources) {
                                         if (!_dedicatedDao.remove(dr.getId())) {
-                                            s_logger.warn("Fail to release dedicated resources for domain " + domainId);
+                                            logger.warn("Fail to release dedicated resources for domain " + domainId);
                                         }
                                     }
                                 }
-                                s_logger.debug("Removing inactive domain id=" + domainId);
+                                logger.debug("Removing inactive domain id=" + domainId);
                                 _domainMgr.removeDomain(domainId);
                             } else {
-                                s_logger.debug("Can't remove inactive domain id=" + domainId + " as it has accounts that need cleanup");
+                                logger.debug("Can't remove inactive domain id=" + domainId + " as it has accounts that need cleanup");
                             }
                         } catch (Exception e) {
-                            s_logger.error("Skipping due to error on domain " + domainId, e);
+                            logger.error("Skipping due to error on domain " + domainId, e);
                         }
                     }
 
                     // cleanup inactive projects
                     List<ProjectVO> inactiveProjects = _projectDao.listByState(Project.State.Disabled);
-                    s_logger.info("Found " + inactiveProjects.size() + " disabled projects to cleanup");
+                    logger.info("Found " + inactiveProjects.size() + " disabled projects to cleanup");
                     for (ProjectVO project : inactiveProjects) {
                         try {
                             Account projectAccount = getAccount(project.getProjectAccountId());
                             if (projectAccount == null) {
-                                s_logger.debug("Removing inactive project id=" + project.getId());
+                                logger.debug("Removing inactive project id=" + project.getId());
                                 _projectMgr.deleteProject(CallContext.current().getCallingAccount(), CallContext.current().getCallingUserId(), project);
                             } else {
-                                s_logger.debug("Can't remove disabled project " + project + " as it has non removed account id=" + project.getId());
+                                logger.debug("Can't remove disabled project " + project + " as it has non removed account id=" + project.getId());
                             }
                         } catch (Exception e) {
-                            s_logger.error("Skipping due to error on project " + project, e);
+                            logger.error("Skipping due to error on project " + project, e);
                         }
                     }
 
                 } catch (Exception e) {
-                    s_logger.error("Exception ", e);
+                    logger.error("Exception ", e);
                 } finally {
                     lock.unlock();
                 }
             } catch (Exception e) {
-                s_logger.error("Exception ", e);
+                logger.error("Exception ", e);
             }
         }
     }
@@ -1982,8 +1980,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
     protected UserVO createUser(long accountId, String userName, String password, String firstName, String lastName, String email, String timezone, String userUUID,
                                 User.Source source) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Creating user: " + userName + ", accountId: " + accountId + " timezone:" + timezone);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Creating user: " + userName + ", accountId: " + accountId + " timezone:" + timezone);
         }
 
         String encodedPassword = null;
@@ -2065,14 +2063,14 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                                 timestamp = Long.parseLong(timestampStr);
                                 long currentTime = System.currentTimeMillis();
                                 if (Math.abs(currentTime - timestamp) > tolerance) {
-                                    if (s_logger.isDebugEnabled()) {
-                                        s_logger.debug("Expired timestamp passed in to login, current time = " + currentTime + ", timestamp = " + timestamp);
+                                    if (logger.isDebugEnabled()) {
+                                        logger.debug("Expired timestamp passed in to login, current time = " + currentTime + ", timestamp = " + timestamp);
                                     }
                                     return null;
                                 }
                             } catch (NumberFormatException nfe) {
-                                if (s_logger.isDebugEnabled()) {
-                                    s_logger.debug("Invalid timestamp passed in to login: " + timestampStr);
+                                if (logger.isDebugEnabled()) {
+                                    logger.debug("Invalid timestamp passed in to login: " + timestampStr);
                                 }
                                 return null;
                             }
@@ -2086,8 +2084,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 }
 
                 if ((signature == null) || (timestamp == 0L)) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Missing parameters in login request, signature = " + signature + ", timestamp = " + timestamp);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Missing parameters in login request, signature = " + signature + ", timestamp = " + timestamp);
                     }
                     return null;
                 }
@@ -2102,12 +2100,12 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 String computedSignature = new String(Base64.encodeBase64(encryptedBytes));
                 boolean equalSig = ConstantTimeComparator.compareStrings(signature, computedSignature);
                 if (!equalSig) {
-                    s_logger.info("User signature: " + signature + " is not equaled to computed signature: " + computedSignature);
+                    logger.info("User signature: " + signature + " is not equaled to computed signature: " + computedSignature);
                 } else {
                     user = _userAccountDao.getUserAccount(username, domainId);
                 }
             } catch (Exception ex) {
-                s_logger.error("Exception authenticating user", ex);
+                logger.error("Exception authenticating user", ex);
                 return null;
             }
         }
@@ -2115,17 +2113,17 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         if (user != null) {
             // don't allow to authenticate system user
             if (user.getId() == User.UID_SYSTEM) {
-                s_logger.error("Failed to authenticate user: " + username + " in domain " + domainId);
+                logger.error("Failed to authenticate user: " + username + " in domain " + domainId);
                 return null;
             }
             // don't allow baremetal system user
             if (BaremetalUtils.BAREMETAL_SYSTEM_ACCOUNT_NAME.equals(user.getUsername())) {
-                s_logger.error("Won't authenticate user: " + username + " in domain " + domainId);
+                logger.error("Won't authenticate user: " + username + " in domain " + domainId);
                 return null;
             }
 
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("User: " + username + " in domain " + domainId + " has successfully logged in");
+            if (logger.isDebugEnabled()) {
+                logger.debug("User: " + username + " in domain " + domainId + " has successfully logged in");
             }
 
             ActionEventUtils.onActionEvent(user.getId(), user.getAccountId(), user.getDomainId(), EventTypes.EVENT_USER_LOGIN, "user has logged in from IP Address " +
@@ -2133,20 +2131,20 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
             return user;
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("User: " + username + " in domain " + domainId + " has failed to log in");
+            if (logger.isDebugEnabled()) {
+                logger.debug("User: " + username + " in domain " + domainId + " has failed to log in");
             }
             return null;
         }
     }
 
     private UserAccount getUserAccount(String username, String password, Long domainId, Map<String, Object[]> requestParameters) {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Attempting to log in user: " + username + " in domain " + domainId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Attempting to log in user: " + username + " in domain " + domainId);
         }
         UserAccount userAccount = _userAccountDao.getUserAccount(username, domainId);
         if (userAccount == null) {
-            s_logger.warn("Unable to find an user with username " + username + " in domain " + domainId);
+            logger.warn("Unable to find an user with username " + username + " in domain " + domainId);
             return null;
         }
 
@@ -2180,8 +2178,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
             if (!userAccount.getState().equalsIgnoreCase(Account.State.enabled.toString()) ||
                 !userAccount.getAccountState().equalsIgnoreCase(Account.State.enabled.toString())) {
-                if (s_logger.isInfoEnabled()) {
-                    s_logger.info("User " + username + " in domain " + domainName + " is disabled/locked (or account is disabled/locked)");
+                if (logger.isInfoEnabled()) {
+                    logger.info("User " + username + " in domain " + domainName + " is disabled/locked (or account is disabled/locked)");
                 }
                 throw new CloudAuthenticationException("User " + username + " in domain " + domainName + " is disabled/locked (or account is disabled/locked)");
                 // return null;
@@ -2192,8 +2190,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
             return userAccount;
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Unable to authenticate user with username " + username + " in domain " + domainId);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Unable to authenticate user with username " + username + " in domain " + domainId);
             }
 
             if (userAccount.getState().equalsIgnoreCase(Account.State.enabled.toString())) {
@@ -2203,15 +2201,15 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                     if (updateIncorrectLoginCount) {
                         if (attemptsMade < _allowedLoginAttempts) {
                             updateLoginAttempts(userAccount.getId(), attemptsMade, false);
-                            s_logger.warn("Login attempt failed. You have " + (_allowedLoginAttempts - attemptsMade) + " attempt(s) remaining");
+                            logger.warn("Login attempt failed. You have " + (_allowedLoginAttempts - attemptsMade) + " attempt(s) remaining");
                         } else {
                             updateLoginAttempts(userAccount.getId(), _allowedLoginAttempts, true);
-                            s_logger.warn("User " + userAccount.getUsername() + " has been disabled due to multiple failed login attempts." + " Please contact admin.");
+                            logger.warn("User " + userAccount.getUsername() + " has been disabled due to multiple failed login attempts." + " Please contact admin.");
                         }
                     }
                 }
             } else {
-                s_logger.info("User " + userAccount.getUsername() + " is disabled/locked");
+                logger.info("User " + userAccount.getUsername() + " is disabled/locked");
             }
             return null;
         }
@@ -2297,7 +2295,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             _userDao.update(userId, updatedUser);
             return encodedKey;
         } catch (NoSuchAlgorithmException ex) {
-            s_logger.error("error generating secret key for user id=" + userId, ex);
+            logger.error("error generating secret key for user id=" + userId, ex);
         }
         return null;
     }
@@ -2324,7 +2322,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             _userDao.update(userId, updatedUser);
             return encodedKey;
         } catch (NoSuchAlgorithmException ex) {
-            s_logger.error("error generating secret key for user id=" + userId, ex);
+            logger.error("error generating secret key for user id=" + userId, ex);
         }
         return null;
     }
@@ -2692,8 +2690,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             throws PermissionDeniedException {
         for (SecurityChecker checker : _securityCheckers) {
             if (checker.checkAccess(account, so)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Access granted to " + account + " to " + so + " by " + checker.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Access granted to " + account + " to " + so + " by " + checker.getName());
                 }
                 return;
             }
@@ -2708,8 +2706,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             throws PermissionDeniedException {
         for (SecurityChecker checker : _securityCheckers) {
             if (checker.checkAccess(account, dof)) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Access granted to " + account + " to " + dof + " by " + checker.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Access granted to " + account + " to " + dof + " by " + checker.getName());
                 }
                 return;
             }

--- a/server/src/com/cloud/user/DomainManagerImpl.java
+++ b/server/src/com/cloud/user/DomainManagerImpl.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.command.admin.domain.ListDomainChildrenCmd;
@@ -78,7 +77,6 @@ import com.cloud.vm.ReservationContextImpl;
 @Component
 @Local(value = {DomainManager.class, DomainService.class})
 public class DomainManagerImpl extends ManagerBase implements DomainManager, DomainService {
-    public static final Logger s_logger = Logger.getLogger(DomainManagerImpl.class);
 
     @Inject
     private DomainDao _domainDao;
@@ -256,7 +254,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
     @Override
     public boolean deleteDomain(DomainVO domain, Boolean cleanup) {
         // mark domain as inactive
-        s_logger.debug("Marking domain id=" + domain.getId() + " as " + Domain.State.Inactive + " before actually deleting it");
+        logger.debug("Marking domain id=" + domain.getId() + " as " + Domain.State.Inactive + " before actually deleting it");
         domain.setState(Domain.State.Inactive);
         _domainDao.update(domain.getId(), domain);
         boolean rollBackState = false;
@@ -279,7 +277,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
                 List<AccountVO> accountsForCleanup = _accountDao.findCleanupsForRemovedAccounts(domain.getId());
                 List<DedicatedResourceVO> dedicatedResources = _dedicatedDao.listByDomainId(domain.getId());
                 if (dedicatedResources != null && !dedicatedResources.isEmpty()) {
-                    s_logger.error("There are dedicated resources for the domain " + domain.getId());
+                    logger.error("There are dedicated resources for the domain " + domain.getId());
                     hasDedicatedResources = true;
                 }
                 if (accountsForCleanup.isEmpty() && networkIds.isEmpty() && !hasDedicatedResources) {
@@ -312,7 +310,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
             CallContext.current().putContextParameter(Domain.class, domain.getUuid());
             return true;
         } catch (Exception ex) {
-            s_logger.error("Exception deleting domain with id " + domain.getId(), ex);
+            logger.error("Exception deleting domain with id " + domain.getId(), ex);
             if (ex instanceof CloudRuntimeException)
                 throw (CloudRuntimeException)ex;
             else
@@ -320,7 +318,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
         } finally {
             //when success is false
             if (rollBackState) {
-                s_logger.debug("Changing domain id=" + domain.getId() + " state back to " + Domain.State.Active +
+                logger.debug("Changing domain id=" + domain.getId() + " state back to " + Domain.State.Active +
                     " because it can't be removed due to resources referencing to it");
                 domain.setState(Domain.State.Active);
                 _domainDao.update(domain.getId(), domain);
@@ -342,7 +340,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
     }
 
     private boolean cleanupDomain(Long domainId, Long ownerId) throws ConcurrentOperationException, ResourceUnavailableException {
-        s_logger.debug("Cleaning up domain id=" + domainId);
+        logger.debug("Cleaning up domain id=" + domainId);
         boolean success = true;
         {
             DomainVO domainHandle = _domainDao.findById(domainId);
@@ -367,7 +365,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
             for (DomainVO domain : domains) {
                 success = (success && cleanupDomain(domain.getId(), domain.getAccountId()));
                 if (!success) {
-                    s_logger.warn("Failed to cleanup domain id=" + domain.getId());
+                    logger.warn("Failed to cleanup domain id=" + domain.getId());
                 }
             }
         }
@@ -378,18 +376,18 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
         List<AccountVO> accounts = _accountDao.search(sc, null);
         for (AccountVO account : accounts) {
             if (account.getType() != Account.ACCOUNT_TYPE_PROJECT) {
-                s_logger.debug("Deleting account " + account + " as a part of domain id=" + domainId + " cleanup");
+                logger.debug("Deleting account " + account + " as a part of domain id=" + domainId + " cleanup");
                 boolean deleteAccount = _accountMgr.deleteAccount(account, CallContext.current().getCallingUserId(), CallContext.current().getCallingAccount());
                 if (!deleteAccount) {
-                    s_logger.warn("Failed to cleanup account id=" + account.getId() + " as a part of domain cleanup");
+                    logger.warn("Failed to cleanup account id=" + account.getId() + " as a part of domain cleanup");
                 }
                 success = (success && deleteAccount);
             } else {
                 ProjectVO project = _projectDao.findByProjectAccountId(account.getId());
-                s_logger.debug("Deleting project " + project + " as a part of domain id=" + domainId + " cleanup");
+                logger.debug("Deleting project " + project + " as a part of domain id=" + domainId + " cleanup");
                 boolean deleteProject = _projectMgr.deleteProject(CallContext.current().getCallingAccount(), CallContext.current().getCallingUserId(), project);
                 if (!deleteProject) {
-                    s_logger.warn("Failed to cleanup project " + project + " as a part of domain cleanup");
+                    logger.warn("Failed to cleanup project " + project + " as a part of domain cleanup");
                 }
                 success = (success && deleteProject);
             }
@@ -397,23 +395,23 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
 
         //delete the domain shared networks
         boolean networksDeleted = true;
-        s_logger.debug("Deleting networks for domain id=" + domainId);
+        logger.debug("Deleting networks for domain id=" + domainId);
         List<Long> networkIds = _networkDomainDao.listNetworkIdsByDomain(domainId);
         CallContext ctx = CallContext.current();
         ReservationContext context = new ReservationContextImpl(null, null, _accountMgr.getActiveUser(ctx.getCallingUserId()), ctx.getCallingAccount());
         for (Long networkId : networkIds) {
-            s_logger.debug("Deleting network id=" + networkId + " as a part of domain id=" + domainId + " cleanup");
+            logger.debug("Deleting network id=" + networkId + " as a part of domain id=" + domainId + " cleanup");
             if (!_networkMgr.destroyNetwork(networkId, context, false)) {
-                s_logger.warn("Unable to destroy network id=" + networkId + " as a part of domain id=" + domainId + " cleanup.");
+                logger.warn("Unable to destroy network id=" + networkId + " as a part of domain id=" + domainId + " cleanup.");
                 networksDeleted = false;
             } else {
-                s_logger.debug("Network " + networkId + " successfully deleted as a part of domain id=" + domainId + " cleanup.");
+                logger.debug("Network " + networkId + " successfully deleted as a part of domain id=" + domainId + " cleanup.");
             }
         }
 
         //don't proceed if networks failed to cleanup. The cleanup will be performed for inactive domain once again
         if (!networksDeleted) {
-            s_logger.debug("Failed to delete the shared networks as a part of domain id=" + domainId + " clenaup");
+            logger.debug("Failed to delete the shared networks as a part of domain id=" + domainId + " clenaup");
             return false;
         }
 
@@ -424,10 +422,10 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
             //release dedication if any, before deleting the domain
             List<DedicatedResourceVO> dedicatedResources = _dedicatedDao.listByDomainId(domainId);
             if (dedicatedResources != null && !dedicatedResources.isEmpty()) {
-                s_logger.debug("Releasing dedicated resources for domain" + domainId);
+                logger.debug("Releasing dedicated resources for domain" + domainId);
                 for (DedicatedResourceVO dr : dedicatedResources) {
                     if (!_dedicatedDao.remove(dr.getId())) {
-                        s_logger.warn("Fail to release dedicated resources for domain " + domainId);
+                        logger.warn("Fail to release dedicated resources for domain " + domainId);
                         return false;
                     }
                 }
@@ -439,7 +437,7 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
             _resourceCountDao.removeEntriesByOwner(domainId, ResourceOwnerType.Domain);
             _resourceLimitDao.removeEntriesByOwner(domainId, ResourceOwnerType.Domain);
         } else {
-            s_logger.debug("Can't delete the domain yet because it has " + accountsForCleanup.size() + "accounts that need a cleanup");
+            logger.debug("Can't delete the domain yet because it has " + accountsForCleanup.size() + "accounts that need a cleanup");
             return false;
         }
 

--- a/server/src/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
+++ b/server/src/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
@@ -27,7 +27,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.api.command.user.vmsnapshot.ListVMSnapshotCmd;
 import org.apache.cloudstack.context.CallContext;
@@ -102,7 +101,6 @@ import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 @Component
 @Local(value = { VMSnapshotManager.class, VMSnapshotService.class })
 public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotManager, VMSnapshotService, VmWorkJobHandler {
-    private static final Logger s_logger = Logger.getLogger(VMSnapshotManagerImpl.class);
 
     public static final String VM_WORK_JOB_HANDLER = VMSnapshotManagerImpl.class.getSimpleName();
 
@@ -341,7 +339,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
             return vmSnapshot;
         } catch (Exception e) {
             String msg = e.getMessage();
-            s_logger.error("Create vm snapshot record failed for vm: " + vmId + " due to: " + msg);
+            logger.error("Create vm snapshot record failed for vm: " + vmId + " due to: " + msg);
         }
         return null;
     }
@@ -437,7 +435,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
             VMSnapshot snapshot = strategy.takeVMSnapshot(vmSnapshot);
             return snapshot;
         } catch (Exception e) {
-            s_logger.debug("Failed to create vm snapshot: " + vmSnapshotId, e);
+            logger.debug("Failed to create vm snapshot: " + vmSnapshotId, e);
             return null;
         }
     }
@@ -474,7 +472,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
         if (hasActiveVMSnapshotTasks(vmSnapshot.getVmId())) {
             List<VMSnapshotVO> expungingSnapshots = _vmSnapshotDao.listByInstanceId(vmSnapshot.getVmId(), VMSnapshot.State.Expunging);
             if (expungingSnapshots.size() > 0 && expungingSnapshots.get(0).getId() == vmSnapshot.getId())
-                s_logger.debug("Target VM snapshot already in expunging state, go on deleting it: " + vmSnapshot.getDisplayName());
+                logger.debug("Target VM snapshot already in expunging state, go on deleting it: " + vmSnapshot.getDisplayName());
             else
                 throw new InvalidParameterValueException("There is other active vm snapshot tasks on the instance, please try again later");
         }
@@ -536,7 +534,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
         if (hasActiveVMSnapshotTasks(vmSnapshot.getVmId())) {
             List<VMSnapshotVO> expungingSnapshots = _vmSnapshotDao.listByInstanceId(vmSnapshot.getVmId(), VMSnapshot.State.Expunging);
             if (expungingSnapshots.size() > 0 && expungingSnapshots.get(0).getId() == vmSnapshot.getId())
-                s_logger.debug("Target VM snapshot already in expunging state, go on deleting it: " + vmSnapshot.getDisplayName());
+                logger.debug("Target VM snapshot already in expunging state, go on deleting it: " + vmSnapshot.getDisplayName());
             else
                 throw new InvalidParameterValueException("There is other active vm snapshot tasks on the instance, please try again later");
         }
@@ -548,7 +546,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
                 VMSnapshotStrategy strategy = findVMSnapshotStrategy(vmSnapshot);
                 return strategy.deleteVMSnapshot(vmSnapshot);
             } catch (Exception e) {
-                s_logger.debug("Failed to delete vm snapshot: " + vmSnapshotId, e);
+                logger.debug("Failed to delete vm snapshot: " + vmSnapshotId, e);
                 return false;
             }
         }
@@ -684,7 +682,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
                 vm = _userVMDao.findById(userVm.getId());
                 hostId = vm.getHostId();
             } catch (Exception e) {
-                s_logger.error("Start VM " + userVm.getInstanceName() + " before reverting failed due to " + e.getMessage());
+                logger.error("Start VM " + userVm.getInstanceName() + " before reverting failed due to " + e.getMessage());
                 throw new CloudRuntimeException(e.getMessage());
             }
         } else {
@@ -692,7 +690,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
                 try {
                     _itMgr.advanceStop(userVm.getUuid(), true);
                 } catch (Exception e) {
-                    s_logger.error("Stop VM " + userVm.getInstanceName() + " before reverting failed due to " + e.getMessage());
+                    logger.error("Stop VM " + userVm.getInstanceName() + " before reverting failed due to " + e.getMessage());
                     throw new CloudRuntimeException(e.getMessage());
                 }
             }
@@ -708,7 +706,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
             strategy.revertVMSnapshot(vmSnapshotVo);
             return userVm;
         } catch (Exception e) {
-            s_logger.debug("Failed to revert vmsnapshot: " + vmSnapshotId, e);
+            logger.debug("Failed to revert vmsnapshot: " + vmSnapshotId, e);
             throw new CloudRuntimeException(e.getMessage());
         }
     }
@@ -812,7 +810,7 @@ public class VMSnapshotManagerImpl extends ManagerBase implements VMSnapshotMana
                 }
             }
         } catch (Exception e) {
-            s_logger.error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
             if (_vmSnapshotDao.listByInstanceId(vm.getId(), VMSnapshot.State.Expunging).size() == 0)
                 return true;
             else

--- a/server/src/org/apache/cloudstack/affinity/AffinityGroupServiceImpl.java
+++ b/server/src/org/apache/cloudstack/affinity/AffinityGroupServiceImpl.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import com.cloud.utils.fsm.StateMachine2;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
@@ -73,7 +72,6 @@ import com.cloud.vm.dao.UserVmDao;
 @Local(value = {AffinityGroupService.class})
 public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGroupService, Manager, StateListener<State, VirtualMachine.Event, VirtualMachine> {
 
-    public static final Logger s_logger = Logger.getLogger(AffinityGroupServiceImpl.class);
     private String _name;
 
     @Inject
@@ -230,8 +228,8 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
             }
         });
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Created affinity group =" + affinityGroupName);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Created affinity group =" + affinityGroupName);
         }
 
         return group;
@@ -307,8 +305,8 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
         Pair<Class<?>, Long> params = new Pair<Class<?>, Long>(AffinityGroup.class, affinityGroupIdFinal);
         _messageBus.publish(_name, EntityManager.MESSAGE_REMOVE_ENTITY_EVENT, PublishScope.LOCAL, params);
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Deleted affinity group id=" + affinityGroupId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Deleted affinity group id=" + affinityGroupId);
         }
         return true;
     }
@@ -465,7 +463,7 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
 
         // Check that the VM is stopped
         if (!vmInstance.getState().equals(State.Stopped)) {
-            s_logger.warn("Unable to update affinity groups of the virtual machine " + vmInstance.toString() + " in state " + vmInstance.getState());
+            logger.warn("Unable to update affinity groups of the virtual machine " + vmInstance.toString() + " in state " + vmInstance.getState());
             throw new InvalidParameterValueException("Unable update affinity groups of the virtual machine " + vmInstance.toString() + " " + "in state " +
                 vmInstance.getState() + "; make sure the virtual machine is stopped and not in an error state before updating.");
         }
@@ -491,8 +489,8 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
             }
         }
         _affinityGroupVMMapDao.updateMap(vmId, affinityGroupIds);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Updated VM :" + vmId + " affinity groups to =" + affinityGroupIds);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Updated VM :" + vmId + " affinity groups to =" + affinityGroupIds);
         }
         // APIResponseHelper will pull out the updated affinitygroups.
         return vmInstance;

--- a/server/src/org/apache/cloudstack/network/lb/ApplicationLoadBalancerManagerImpl.java
+++ b/server/src/org/apache/cloudstack/network/lb/ApplicationLoadBalancerManagerImpl.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -81,7 +80,6 @@ import com.cloud.utils.net.NetUtils;
 @Component
 @Local(value = {ApplicationLoadBalancerService.class})
 public class ApplicationLoadBalancerManagerImpl extends ManagerBase implements ApplicationLoadBalancerService {
-    private static final Logger s_logger = Logger.getLogger(ApplicationLoadBalancerManagerImpl.class);
 
     @Inject
     NetworkModel _networkModel;
@@ -184,7 +182,7 @@ public class ApplicationLoadBalancerManagerImpl extends ManagerBase implements A
                     if (!_firewallDao.setStateToAdd(newRule)) {
                         throw new CloudRuntimeException("Unable to update the state to add for " + newRule);
                     }
-                    s_logger.debug("Load balancer " + newRule.getId() + " for Ip address " + newRule.getSourceIp().addr() + ", source port " +
+                    logger.debug("Load balancer " + newRule.getId() + " for Ip address " + newRule.getSourceIp().addr() + ", source port " +
                         newRule.getSourcePortStart().intValue() + ", instance port " + newRule.getDefaultPortStart() + " is added successfully.");
                     CallContext.current().setEventDetails("Load balancer Id: " + newRule.getId());
                     Network ntwk = _networkModel.getNetwork(newRule.getNetworkId());
@@ -261,7 +259,7 @@ public class ApplicationLoadBalancerManagerImpl extends ManagerBase implements A
 
         if (requestedIp != null) {
             if (_lbDao.countBySourceIp(new Ip(requestedIp), sourceIpNtwk.getId()) > 0)  {
-                s_logger.debug("IP address " + requestedIp + " is already used by existing LB rule, returning it");
+                logger.debug("IP address " + requestedIp + " is already used by existing LB rule, returning it");
                 return new Ip(requestedIp);
             }
 
@@ -532,8 +530,8 @@ public class ApplicationLoadBalancerManagerImpl extends ManagerBase implements A
             }
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("No network rule conflicts detected for " + newLbRule + " against " + (lbRules.size() - 1) + " existing rules");
+        if (logger.isDebugEnabled()) {
+            logger.debug("No network rule conflicts detected for " + newLbRule + " against " + (lbRules.size() - 1) + " existing rules");
         }
     }
 

--- a/server/src/org/apache/cloudstack/region/RegionManagerImpl.java
+++ b/server/src/org/apache/cloudstack/region/RegionManagerImpl.java
@@ -25,7 +25,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.command.admin.account.UpdateAccountCmd;
@@ -50,7 +49,6 @@ import com.cloud.utils.db.DbProperties;
 @Component
 @Local(value = {RegionManager.class})
 public class RegionManagerImpl extends ManagerBase implements RegionManager, Manager {
-    public static final Logger s_logger = Logger.getLogger(RegionManagerImpl.class);
 
     @Inject
     RegionDao _regionDao;

--- a/server/src/org/apache/cloudstack/region/RegionServiceImpl.java
+++ b/server/src/org/apache/cloudstack/region/RegionServiceImpl.java
@@ -23,7 +23,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.command.admin.account.DeleteAccountCmd;
@@ -49,7 +48,6 @@ import com.cloud.utils.component.ManagerBase;
 @Component
 @Local(value = {RegionService.class})
 public class RegionServiceImpl extends ManagerBase implements RegionService, Manager {
-    public static final Logger s_logger = Logger.getLogger(RegionServiceImpl.class);
 
     @Inject
     private RegionManager _regionMgr;

--- a/server/test/com/cloud/consoleproxy/ConsoleProxyManagerTest.java
+++ b/server/test/com/cloud/consoleproxy/ConsoleProxyManagerTest.java
@@ -43,6 +43,7 @@ public class ConsoleProxyManagerTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
         ReflectionTestUtils.setField(cpvmManager, "_allocProxyLock", globalLock);
+        ReflectionTestUtils.setField(cpvmManager, "logger", Logger.getLogger(ConsoleProxyManagerImpl.class));
         Mockito.doCallRealMethod().when(cpvmManager).expandPool(Mockito.anyLong(), Mockito.anyObject());
     }
 

--- a/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -34,7 +34,6 @@ import org.apache.cloudstack.api.command.user.network.ListNetworksCmd;
 import org.apache.cloudstack.api.command.user.network.RestartNetworkCmd;
 import org.apache.cloudstack.api.command.user.vm.ListNicsCmd;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.deploy.DataCenterDeployment;
@@ -93,7 +92,6 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     List<NetworkElement> _networkElements;
 
     private static HashMap<String, String> s_providerToNetworkElementMap = new HashMap<String, String>();
-    private static final Logger s_logger = Logger.getLogger(MockNetworkManagerImpl.class);
 
     /* (non-Javadoc)
      * @see com.cloud.utils.component.Manager#start()
@@ -104,7 +102,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
             Provider implementedProvider = element.getProvider();
             if (implementedProvider != null) {
                 if (s_providerToNetworkElementMap.containsKey(implementedProvider.getName())) {
-                    s_logger.error("Cannot start MapNetworkManager: Provider <-> NetworkElement must be a one-to-one map, " +
+                    logger.error("Cannot start MapNetworkManager: Provider <-> NetworkElement must be a one-to-one map, " +
                         "multiple NetworkElements found for Provider: " + implementedProvider.getName());
                     return false;
                 }

--- a/server/test/com/cloud/vpc/dao/MockNetworkOfferingDaoImpl.java
+++ b/server/test/com/cloud/vpc/dao/MockNetworkOfferingDaoImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.network.Network;
 import com.cloud.network.Network.GuestType;
@@ -37,7 +36,6 @@ import com.cloud.utils.db.DB;
 @Local(value = NetworkOfferingDao.class)
 @DB()
 public class MockNetworkOfferingDaoImpl extends NetworkOfferingDaoImpl implements NetworkOfferingDao {
-    private static final Logger s_logger = Logger.getLogger(MockNetworkOfferingDaoImpl.class);
 
     /* (non-Javadoc)
      * @see com.cloud.offerings.dao.NetworkOfferingDao#findByUniqueName(java.lang.String)
@@ -144,10 +142,10 @@ public class MockNetworkOfferingDaoImpl extends NetworkOfferingDaoImpl implement
             f.setAccessible(true);
             f.setLong(voToReturn, id);
         } catch (NoSuchFieldException ex) {
-            s_logger.warn(ex);
+            logger.warn(ex);
             return null;
         } catch (IllegalAccessException ex) {
-            s_logger.warn(ex);
+            logger.warn(ex);
             return null;
         }
 

--- a/server/test/com/cloud/vpc/dao/MockVpcDaoImpl.java
+++ b/server/test/com/cloud/vpc/dao/MockVpcDaoImpl.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.network.vpc.Vpc;
 import com.cloud.network.vpc.Vpc.State;
@@ -34,7 +33,6 @@ import com.cloud.utils.db.GenericDaoBase;
 @Local(value = VpcDao.class)
 @DB()
 public class MockVpcDaoImpl extends GenericDaoBase<VpcVO, Long> implements VpcDao {
-    private static final Logger s_logger = Logger.getLogger(MockNetworkOfferingDaoImpl.class);
 
     /* (non-Javadoc)
      * @see com.cloud.network.vpc.Dao.VpcDao#getVpcCountByOfferingId(long)
@@ -117,10 +115,10 @@ public class MockVpcDaoImpl extends GenericDaoBase<VpcVO, Long> implements VpcDa
             f.setAccessible(true);
             f.setLong(voToReturn, id);
         } catch (NoSuchFieldException ex) {
-            s_logger.warn(ex);
+            logger.warn(ex);
             return null;
         } catch (IllegalAccessException ex) {
-            s_logger.warn(ex);
+            logger.warn(ex);
             return null;
         }
 

--- a/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -44,7 +44,6 @@ import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreDao;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -164,7 +163,6 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Local(value = {SecondaryStorageVmManager.class})
 public class SecondaryStorageManagerImpl extends ManagerBase implements SecondaryStorageVmManager, VirtualMachineGuru, SystemVmLoadScanHandler<Long>,
         ResourceStateAdapter {
-    private static final Logger s_logger = Logger.getLogger(SecondaryStorageManagerImpl.class);
 
     private static final int DEFAULT_CAPACITY_SCAN_INTERVAL = 30000; // 30
     // seconds
@@ -262,16 +260,16 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             _itMgr.advanceStart(secStorageVm.getUuid(), null, null);
             return _secStorageVmDao.findById(secStorageVm.getId());
         } catch (StorageUnavailableException e) {
-            s_logger.warn("Exception while trying to start secondary storage vm", e);
+            logger.warn("Exception while trying to start secondary storage vm", e);
             return null;
         } catch (InsufficientCapacityException e) {
-            s_logger.warn("Exception while trying to start secondary storage vm", e);
+            logger.warn("Exception while trying to start secondary storage vm", e);
             return null;
         } catch (ResourceUnavailableException e) {
-            s_logger.warn("Exception while trying to start secondary storage vm", e);
+            logger.warn("Exception while trying to start secondary storage vm", e);
             return null;
         } catch (Exception e) {
-            s_logger.warn("Exception while trying to start secondary storage vm", e);
+            logger.warn("Exception while trying to start secondary storage vm", e);
             return null;
         }
     }
@@ -291,7 +289,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
             SecondaryStorageVmVO secStorageVm = _secStorageVmDao.findByInstanceName(cssHost.getName());
             if (secStorageVm == null) {
-                s_logger.warn("secondary storage VM " + cssHost.getName() + " doesn't exist");
+                logger.warn("secondary storage VM " + cssHost.getName() + " doesn't exist");
                 return false;
             }
 
@@ -322,12 +320,12 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                         svo.setParent(an.get_dir());
                         _imageStoreDao.update(ssStore.getId(), svo);
                     }
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Successfully programmed secondary storage " + ssStore.getName() + " in secondary storage VM " + secStorageVm.getInstanceName());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Successfully programmed secondary storage " + ssStore.getName() + " in secondary storage VM " + secStorageVm.getInstanceName());
                     }
                 } else {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Successfully programmed secondary storage " + ssStore.getName() + " in secondary storage VM " + secStorageVm.getInstanceName());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Successfully programmed secondary storage " + ssStore.getName() + " in secondary storage VM " + secStorageVm.getInstanceName());
                     }
                     return false;
                 }
@@ -342,12 +340,12 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 HostVO host = _resourceMgr.findHostByName(ssVm.getInstanceName());
                 Answer answer = _agentMgr.easySend(host.getId(), setupCmd);
                 if (answer != null && answer.getResult()) {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Successfully programmed secondary storage " + host.getName() + " in secondary storage VM " + ssVm.getInstanceName());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Successfully programmed secondary storage " + host.getName() + " in secondary storage VM " + ssVm.getInstanceName());
                     }
                 } else {
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Successfully programmed secondary storage " + host.getName() + " in secondary storage VM " + ssVm.getInstanceName());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Successfully programmed secondary storage " + host.getName() + " in secondary storage VM " + ssVm.getInstanceName());
                     }
                     return false;
                 }
@@ -365,7 +363,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         }
         SecondaryStorageVmVO secStorageVm = _secStorageVmDao.findByInstanceName(ssAHost.getName());
         if (secStorageVm == null) {
-            s_logger.warn("secondary storage VM " + ssAHost.getName() + " doesn't exist");
+            logger.warn("secondary storage VM " + ssAHost.getName() + " doesn't exist");
             return false;
         }
 
@@ -385,13 +383,13 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         setupCmd.setCopyUserName(TemplateConstants.DEFAULT_HTTP_AUTH_USER);
         Answer answer = _agentMgr.easySend(ssAHostId, setupCmd);
         if (answer != null && answer.getResult()) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Successfully programmed http auth into " + secStorageVm.getHostName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Successfully programmed http auth into " + secStorageVm.getHostName());
             }
             return true;
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("failed to program http auth into secondary storage vm : " + secStorageVm.getHostName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("failed to program http auth into secondary storage vm : " + secStorageVm.getHostName());
             }
             return false;
         }
@@ -411,7 +409,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         SecondaryStorageVmVO thisSecStorageVm = _secStorageVmDao.findByInstanceName(ssAHost.getName());
 
         if (thisSecStorageVm == null) {
-            s_logger.warn("secondary storage VM " + ssAHost.getName() + " doesn't exist");
+            logger.warn("secondary storage VM " + ssAHost.getName() + " doesn't exist");
             return false;
         }
 
@@ -429,12 +427,12 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             }
             Answer answer = _agentMgr.easySend(ssvm.getId(), thiscpc);
             if (answer != null && answer.getResult()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Successfully programmed firewall rules into SSVM " + ssvm.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Successfully programmed firewall rules into SSVM " + ssvm.getName());
                 }
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("failed to program firewall rules into secondary storage vm : " + ssvm.getName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("failed to program firewall rules into secondary storage vm : " + ssvm.getName());
                 }
                 return false;
             }
@@ -450,12 +448,12 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
         Answer answer = _agentMgr.easySend(ssAHostId, allSSVMIpList);
         if (answer != null && answer.getResult()) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Successfully programmed firewall rules into " + thisSecStorageVm.getHostName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Successfully programmed firewall rules into " + thisSecStorageVm.getHostName());
             }
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("failed to program firewall rules into secondary storage vm : " + thisSecStorageVm.getHostName());
+            if (logger.isDebugEnabled()) {
+                logger.debug("failed to program firewall rules into secondary storage vm : " + thisSecStorageVm.getHostName());
             }
             return false;
         }
@@ -477,21 +475,21 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
     public SecondaryStorageVmVO startNew(long dataCenterId, SecondaryStorageVm.Role role) {
 
         if (!isSecondaryStorageVmRequired(dataCenterId)) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Secondary storage vm not required in zone " + dataCenterId + " acc. to zone config");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Secondary storage vm not required in zone " + dataCenterId + " acc. to zone config");
             }
             return null;
         }
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Assign secondary storage vm from a newly started instance for request from data center : " + dataCenterId);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Assign secondary storage vm from a newly started instance for request from data center : " + dataCenterId);
         }
 
         Map<String, Object> context = createSecStorageVmInstance(dataCenterId, role);
 
         long secStorageVmId = (Long)context.get("secStorageVmId");
         if (secStorageVmId == 0) {
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("Creating secondary storage vm instance failed, data center id : " + dataCenterId);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Creating secondary storage vm instance failed, data center id : " + dataCenterId);
             }
 
             return null;
@@ -505,8 +503,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 new SecStorageVmAlertEventArgs(SecStorageVmAlertEventArgs.SSVM_CREATED, dataCenterId, secStorageVmId, secStorageVm, null));
             return secStorageVm;
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Unable to allocate secondary storage vm storage, remove the secondary storage vm record from DB, secondary storage vm id: " +
+            if (logger.isDebugEnabled()) {
+                logger.debug("Unable to allocate secondary storage vm storage, remove the secondary storage vm record from DB, secondary storage vm id: " +
                     secStorageVmId);
             }
             SubscriptionMgr.getInstance().notifySubscribers(ALERT_SUBJECT, this,
@@ -519,7 +517,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         DataStore secStore = _dataStoreMgr.getImageStore(dataCenterId);
         if (secStore == null) {
             String msg = "No secondary storage available in zone " + dataCenterId + ", cannot create secondary storage vm";
-            s_logger.warn(msg);
+            logger.warn(msg);
             throw new CloudRuntimeException(msg);
         }
 
@@ -565,7 +563,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 networks.put(_networkMgr.setupNetwork(systemAcct, offering, plan, null, null, false).get(0), new ArrayList<NicProfile>());
             }
         } catch (ConcurrentOperationException e) {
-            s_logger.info("Unable to setup due to concurrent operation. " + e);
+            logger.info("Unable to setup due to concurrent operation. " + e);
             return new HashMap<String, Object>();
         }
 
@@ -589,7 +587,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             _itMgr.allocate(name, template, serviceOffering, networks, plan, null);
             secStorageVm = _secStorageVmDao.findById(secStorageVm.getId());
         } catch (InsufficientCapacityException e) {
-            s_logger.warn("InsufficientCapacity", e);
+            logger.warn("InsufficientCapacity", e);
             throw new CloudRuntimeException("Insufficient capacity exception", e);
         }
 
@@ -614,18 +612,18 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
     public SecondaryStorageVmVO assignSecStorageVmFromRunningPool(long dataCenterId, SecondaryStorageVm.Role role) {
 
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Assign  secondary storage vm from running pool for request from data center : " + dataCenterId);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Assign  secondary storage vm from running pool for request from data center : " + dataCenterId);
         }
 
         SecondaryStorageVmAllocator allocator = getCurrentAllocator();
         assert (allocator != null);
         List<SecondaryStorageVmVO> runningList = _secStorageVmDao.getSecStorageVmListInStates(role, dataCenterId, State.Running);
         if (runningList != null && runningList.size() > 0) {
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("Running secondary storage vm pool size : " + runningList.size());
+            if (logger.isTraceEnabled()) {
+                logger.trace("Running secondary storage vm pool size : " + runningList.size());
                 for (SecondaryStorageVmVO secStorageVm : runningList) {
-                    s_logger.trace("Running secStorageVm instance : " + secStorageVm.getHostName());
+                    logger.trace("Running secStorageVm instance : " + secStorageVm.getHostName());
                 }
             }
 
@@ -633,8 +631,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
             return allocator.allocSecondaryStorageVm(runningList, loadInfo, dataCenterId);
         } else {
-            if (s_logger.isTraceEnabled()) {
-                s_logger.trace("Empty running secStorageVm pool for now in data center : " + dataCenterId);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Empty running secStorageVm pool for now in data center : " + dataCenterId);
             }
         }
         return null;
@@ -650,13 +648,13 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
     }
 
     private void allocCapacity(long dataCenterId, SecondaryStorageVm.Role role) {
-        if (s_logger.isTraceEnabled()) {
-            s_logger.trace("Allocate secondary storage vm standby capacity for data center : " + dataCenterId);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Allocate secondary storage vm standby capacity for data center : " + dataCenterId);
         }
 
         if (!isSecondaryStorageVmRequired(dataCenterId)) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Secondary storage vm not required in zone " + dataCenterId + " according to zone config");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Secondary storage vm not required in zone " + dataCenterId + " according to zone config");
             }
             return;
         }
@@ -666,8 +664,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             boolean secStorageVmFromStoppedPool = false;
             secStorageVm = assignSecStorageVmFromStoppedPool(dataCenterId, role);
             if (secStorageVm == null) {
-                if (s_logger.isInfoEnabled()) {
-                    s_logger.info("No stopped secondary storage vm is available, need to allocate a new secondary storage vm");
+                if (logger.isInfoEnabled()) {
+                    logger.info("No stopped secondary storage vm is available, need to allocate a new secondary storage vm");
                 }
 
                 if (_allocLock.lock(ACQUIRE_GLOBAL_LOCK_TIMEOUT_FOR_SYNC)) {
@@ -680,14 +678,14 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                         _allocLock.unlock();
                     }
                 } else {
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("Unable to acquire synchronization lock for secondary storage vm allocation, wait for next scan");
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Unable to acquire synchronization lock for secondary storage vm allocation, wait for next scan");
                     }
                     return;
                 }
             } else {
-                if (s_logger.isInfoEnabled()) {
-                    s_logger.info("Found a stopped secondary storage vm, starting it. Vm id : " + secStorageVm.getId());
+                if (logger.isInfoEnabled()) {
+                    logger.info("Found a stopped secondary storage vm, starting it. Vm id : " + secStorageVm.getId());
                 }
                 secStorageVmFromStoppedPool = true;
             }
@@ -703,8 +701,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                             secStorageVmLock.unlock();
                         }
                     } else {
-                        if (s_logger.isInfoEnabled()) {
-                            s_logger.info("Unable to acquire synchronization lock for starting secondary storage vm id : " + secStorageVm.getId());
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Unable to acquire synchronization lock for starting secondary storage vm id : " + secStorageVm.getId());
                         }
                         return;
                     }
@@ -713,8 +711,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 }
 
                 if (secStorageVm == null) {
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("Unable to start secondary storage vm for standby capacity, vm id : " + secStorageVmId + ", will recycle it and start a new one");
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Unable to start secondary storage vm for standby capacity, vm id : " + secStorageVmId + ", will recycle it and start a new one");
                     }
 
                     if (secStorageVmFromStoppedPool) {
@@ -723,8 +721,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 } else {
                     SubscriptionMgr.getInstance().notifySubscribers(ALERT_SUBJECT, this,
                             new SecStorageVmAlertEventArgs(SecStorageVmAlertEventArgs.SSVM_UP, dataCenterId, secStorageVmId, secStorageVm, null));
-                    if (s_logger.isInfoEnabled()) {
-                        s_logger.info("Secondary storage vm " + secStorageVm.getHostName() + " is started");
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Secondary storage vm " + secStorageVm.getHostName() + " is started");
                     }
                 }
             }
@@ -745,22 +743,22 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         if (zoneHostInfo != null && (zoneHostInfo.getFlags() & RunningHostInfoAgregator.ZoneHostInfo.ROUTING_HOST_MASK) != 0) {
             VMTemplateVO template = _templateDao.findSystemVMReadyTemplate(dataCenterId, HypervisorType.Any);
             if (template == null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("System vm template is not ready at data center " + dataCenterId + ", wait until it is ready to launch secondary storage vm");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("System vm template is not ready at data center " + dataCenterId + ", wait until it is ready to launch secondary storage vm");
                 }
                 return false;
             }
 
             List<DataStore> stores = _dataStoreMgr.getImageStoresByScope(new ZoneScope(dataCenterId));
             if (stores.size() < 1) {
-                s_logger.debug("No image store added  in zone " + dataCenterId + ", wait until it is ready to launch secondary storage vm");
+                logger.debug("No image store added  in zone " + dataCenterId + ", wait until it is ready to launch secondary storage vm");
                 return false;
             }
 
             DataStore store = templateMgr.getImageStore(dataCenterId, template.getId());
             if (store == null) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("No secondary storage available in zone " + dataCenterId + ", wait until it is ready to launch secondary storage vm");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("No secondary storage available in zone " + dataCenterId + ", wait until it is ready to launch secondary storage vm");
                 }
                 return false;
             }
@@ -774,8 +772,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             if (l != null && l.size() > 0 && l.get(0).second().intValue() > 0) {
                 return true;
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Primary storage is not ready, wait until it is ready to launch secondary storage vm. dcId: " + dataCenterId +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Primary storage is not ready, wait until it is ready to launch secondary storage vm. dcId: " + dataCenterId +
                         ", " + ConfigurationManagerImpl.SystemVMUseLocalStorage.key() + ": " + useLocalStorage + ". " +
                         "If you want to use local storage to start SSVM, need to set " + ConfigurationManagerImpl.SystemVMUseLocalStorage.key() + " to true");
                 }
@@ -801,8 +799,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
     @Override
     public boolean start() {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Start secondary storage vm manager");
+        if (logger.isInfoEnabled()) {
+            logger.info("Start secondary storage vm manager");
         }
 
         return true;
@@ -818,8 +816,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Start configuring secondary storage vm manager : " + name);
+        if (logger.isInfoEnabled()) {
+            logger.info("Start configuring secondary storage vm manager : " + name);
         }
 
         Map<String, String> configs = _configDao.getConfiguration("management-server", params);
@@ -839,7 +837,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         //default to HTTP in case of missing domain
         String ssvmUrlDomain = _configDao.getValue("secstorage.ssl.cert.domain");
         if(_useSSlCopy && (ssvmUrlDomain == null || ssvmUrlDomain.isEmpty())){
-            s_logger.warn("Empty secondary storage url domain, explicitly disabling SSL");
+            logger.warn("Empty secondary storage url domain, explicitly disabling SSL");
             _useSSlCopy = false;
         }
 
@@ -871,11 +869,11 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 try {
                     _serviceOffering = _offeringDao.findById(Long.parseLong(ssvmSrvcOffIdStr));
                 } catch (NumberFormatException ex) {
-                    s_logger.debug("The system service offering specified by global config is not id, but uuid=" + ssvmSrvcOffIdStr + " for secondary storage vm");
+                    logger.debug("The system service offering specified by global config is not id, but uuid=" + ssvmSrvcOffIdStr + " for secondary storage vm");
                 }
             }
             if (_serviceOffering == null) {
-                s_logger.warn("Can't find system service offering specified by global config, uuid=" + ssvmSrvcOffIdStr + " for secondary storage vm");
+                logger.warn("Can't find system service offering specified by global config, uuid=" + ssvmSrvcOffIdStr + " for secondary storage vm");
             }
         }
 
@@ -888,7 +886,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             // this can sometimes happen, if DB is manually or programmatically manipulated
             if (offerings == null || offerings.size() < 2) {
                 String msg = "Data integrity problem : System Offering For Secondary Storage VM has been removed?";
-                s_logger.error(msg);
+                logger.error(msg);
                 throw new ConfigurationException(msg);
             }
         }
@@ -917,13 +915,13 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 errMsg = e.toString();
             } finally {
                 if (!valid) {
-                    s_logger.debug("ssvm http proxy " + _httpProxy + " is invalid: " + errMsg);
+                    logger.debug("ssvm http proxy " + _httpProxy + " is invalid: " + errMsg);
                     throw new ConfigurationException("ssvm http proxy " + _httpProxy + "is invalid: " + errMsg);
                 }
             }
         }
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Secondary storage vm Manager is configured.");
+        if (logger.isInfoEnabled()) {
+            logger.info("Secondary storage vm Manager is configured.");
         }
         _resourceMgr.registerResourceStateAdapter(this.getClass().getSimpleName(), this);
         return true;
@@ -934,8 +932,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         SecondaryStorageVmVO secStorageVm = _secStorageVmDao.findById(secStorageVmId);
         if (secStorageVm == null) {
             String msg = "Stopping secondary storage vm failed: secondary storage vm " + secStorageVmId + " no longer exists";
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug(msg);
+            if (logger.isDebugEnabled()) {
+                logger.debug(msg);
             }
             return false;
         }
@@ -952,7 +950,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                         }
                     } else {
                         String msg = "Unable to acquire secondary storage vm lock : " + secStorageVm.toString();
-                        s_logger.debug(msg);
+                        logger.debug(msg);
                         return false;
                     }
                 } finally {
@@ -963,8 +961,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             // vm was already stopped, return true
             return true;
         } catch (ResourceUnavailableException e) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Stopping secondary storage vm " + secStorageVm.getHostName() + " faled : exception " + e.toString());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Stopping secondary storage vm " + secStorageVm.getHostName() + " faled : exception " + e.toString());
             }
             return false;
         }
@@ -983,8 +981,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             final Answer answer = _agentMgr.easySend(secStorageVm.getHostId(), cmd);
 
             if (answer != null && answer.getResult()) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Successfully reboot secondary storage vm " + secStorageVm.getHostName());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Successfully reboot secondary storage vm " + secStorageVm.getHostName());
                 }
 
                 SubscriptionMgr.getInstance().notifySubscribers(ALERT_SUBJECT, this,
@@ -993,8 +991,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 return true;
             } else {
                 String msg = "Rebooting Secondary Storage VM failed - " + secStorageVm.getHostName();
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug(msg);
+                if (logger.isDebugEnabled()) {
+                    logger.debug(msg);
                 }
                 return false;
             }
@@ -1012,7 +1010,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             _secStorageVmDao.remove(ssvm.getId());
             HostVO host = _hostDao.findByTypeNameAndZoneId(ssvm.getDataCenterId(), ssvm.getHostName(), Host.Type.SecondaryStorageVM);
             if (host != null) {
-                s_logger.debug("Removing host entry for ssvm id=" + vmId);
+                logger.debug("Removing host entry for ssvm id=" + vmId);
                 _hostDao.remove(host.getId());
                 //Expire the download urls in the entire zone for templates and volumes.
                 _tmplStoreDao.expireDnldUrlsForZone(host.getDataCenterId());
@@ -1021,7 +1019,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             }
             return false;
         } catch (ResourceUnavailableException e) {
-            s_logger.warn("Unable to expunge " + ssvm, e);
+            logger.warn("Unable to expunge " + ssvm, e);
             return false;
         }
     }
@@ -1064,7 +1062,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         buf.append(" workers=").append(_configDao.getValue("workers"));
 
         if (_configDao.isPremium()) {
-            s_logger.debug("VmWare hypervisor configured, telling the ssvm to load the PremiumSecondaryStorageResource");
+            logger.debug("VmWare hypervisor configured, telling the ssvm to load the PremiumSecondaryStorageResource");
             buf.append(" resource=com.cloud.storage.resource.PremiumSecondaryStorageResource");
         } else {
             buf.append(" resource=org.apache.cloudstack.storage.resource.NfsSecondaryStorageResource");
@@ -1129,8 +1127,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         }
 
         String bootArgs = buf.toString();
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Boot Args for " + profile + ": " + bootArgs);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Boot Args for " + profile + ": " + bootArgs);
         }
 
         return true;
@@ -1174,7 +1172,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
         if (controlNic == null) {
             if (managementNic == null) {
-                s_logger.error("Management network doesn't exist for the secondaryStorageVm " + profile.getVirtualMachine());
+                logger.error("Management network doesn't exist for the secondaryStorageVm " + profile.getVirtualMachine());
                 return false;
             }
             controlNic = managementNic;
@@ -1195,7 +1193,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
     public boolean finalizeStart(VirtualMachineProfile profile, long hostId, Commands cmds, ReservationContext context) {
         CheckSshAnswer answer = (CheckSshAnswer)cmds.getAnswer("checkSsh");
         if (!answer.getResult()) {
-            s_logger.warn("Unable to ssh to the VM: " + answer.getDetails());
+            logger.warn("Unable to ssh to the VM: " + answer.getDetails());
             return false;
         }
 
@@ -1210,7 +1208,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 _secStorageVmDao.update(secVm.getId(), secVm);
             }
         } catch (Exception ex) {
-            s_logger.warn("Failed to get system ip and enable static nat for the vm " + profile.getVirtualMachine() + " due to exception ", ex);
+            logger.warn("Failed to get system ip and enable static nat for the vm " + profile.getVirtualMachine() + " due to exception ", ex);
             return false;
         }
 
@@ -1226,7 +1224,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             try {
                 _rulesMgr.disableStaticNat(ip.getId(), ctx.getCallingAccount(), ctx.getCallingUserId(), true);
             } catch (Exception ex) {
-                s_logger.warn("Failed to disable static nat and release system ip " + ip + " as a part of vm " + profile.getVirtualMachine() + " stop due to exception ",
+                logger.warn("Failed to disable static nat and release system ip " + ip + " as a part of vm " + profile.getVirtualMachine() + " stop due to exception ",
                     ex);
             }
         }
@@ -1276,14 +1274,14 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         long dataCenterId = pool.longValue();
 
         if (!isZoneReady(_zoneHostInfoMap, dataCenterId)) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Zone " + dataCenterId + " is not ready to launch secondary storage VM yet");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Zone " + dataCenterId + " is not ready to launch secondary storage VM yet");
             }
             return false;
         }
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Zone " + dataCenterId + " is ready to launch secondary storage VM");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Zone " + dataCenterId + " is ready to launch secondary storage VM");
         }
         return true;
     }
@@ -1299,7 +1297,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         List<DataStore> ssStores = _dataStoreMgr.getImageStoresByScope(new ZoneScope(dataCenterId));
         int storeSize = (ssStores == null) ? 0 : ssStores.size();
         if (storeSize > vmSize) {
-            s_logger.info("No secondary storage vms found in datacenter id=" + dataCenterId + ", starting a new one");
+            logger.info("No secondary storage vms found in datacenter id=" + dataCenterId + ", starting a new one");
             return new Pair<AfterScanAction, Object>(AfterScanAction.expand, SecondaryStorageVm.Role.templateProcessor);
         }
 

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/SecondaryStorageDiscoverer.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/SecondaryStorageDiscoverer.java
@@ -30,7 +30,6 @@ import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.host.HostVO;
@@ -55,7 +54,6 @@ import com.cloud.utils.script.Script;
  */
 @Local(value = Discoverer.class)
 public class SecondaryStorageDiscoverer extends DiscovererBase implements Discoverer {
-    private static final Logger s_logger = Logger.getLogger(SecondaryStorageDiscoverer.class);
 
     long _timeout = 2 * 60 * 1000; // 2 minutes
     String _mountParent;
@@ -79,7 +77,7 @@ public class SecondaryStorageDiscoverer extends DiscovererBase implements Discov
         find(long dcId, Long podId, Long clusterId, URI uri, String username, String password, List<String> hostTags) {
         if (!uri.getScheme().equalsIgnoreCase("nfs") && !uri.getScheme().equalsIgnoreCase("cifs") && !uri.getScheme().equalsIgnoreCase("file") &&
             !uri.getScheme().equalsIgnoreCase("iso") && !uri.getScheme().equalsIgnoreCase("dummy")) {
-            s_logger.debug("It's not NFS or file or ISO, so not a secondary storage server: " + uri.toString());
+            logger.debug("It's not NFS or file or ISO, so not a secondary storage server: " + uri.toString());
             return null;
         }
 
@@ -101,7 +99,7 @@ public class SecondaryStorageDiscoverer extends DiscovererBase implements Discov
         }
         String mountStr = NfsUtils.uri2Mount(uri);
 
-        Script script = new Script(true, "mount", _timeout, s_logger);
+        Script script = new Script(true, "mount", _timeout, logger);
         String mntPoint = null;
         File file = null;
         do {
@@ -110,19 +108,19 @@ public class SecondaryStorageDiscoverer extends DiscovererBase implements Discov
         } while (file.exists());
 
         if (!file.mkdirs()) {
-            s_logger.warn("Unable to make directory: " + mntPoint);
+            logger.warn("Unable to make directory: " + mntPoint);
             return null;
         }
 
         script.add(mountStr, mntPoint);
         String result = script.execute();
         if (result != null && !result.contains("already mounted")) {
-            s_logger.warn("Unable to mount " + uri.toString() + " due to " + result);
+            logger.warn("Unable to mount " + uri.toString() + " due to " + result);
             file.delete();
             return null;
         }
 
-        script = new Script(true, "umount", 0, s_logger);
+        script = new Script(true, "umount", 0, logger);
         script.add(mntPoint);
         script.execute();
 
@@ -140,25 +138,25 @@ public class SecondaryStorageDiscoverer extends DiscovererBase implements Discov
                 constructor.setAccessible(true);
                 storage = (NfsSecondaryStorageResource)constructor.newInstance();
             } catch (final ClassNotFoundException e) {
-                s_logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to ClassNotFoundException");
+                logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to ClassNotFoundException");
                 return null;
             } catch (final SecurityException e) {
-                s_logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to SecurityException");
+                logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to SecurityException");
                 return null;
             } catch (final NoSuchMethodException e) {
-                s_logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to NoSuchMethodException");
+                logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to NoSuchMethodException");
                 return null;
             } catch (final IllegalArgumentException e) {
-                s_logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to IllegalArgumentException");
+                logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to IllegalArgumentException");
                 return null;
             } catch (final InstantiationException e) {
-                s_logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to InstantiationException");
+                logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to InstantiationException");
                 return null;
             } catch (final IllegalAccessException e) {
-                s_logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to IllegalAccessException");
+                logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to IllegalAccessException");
                 return null;
             } catch (final InvocationTargetException e) {
-                s_logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to InvocationTargetException");
+                logger.error("Unable to load com.cloud.storage.resource.PremiumSecondaryStorageResource due to InvocationTargetException");
                 return null;
             }
         } else {
@@ -183,7 +181,7 @@ public class SecondaryStorageDiscoverer extends DiscovererBase implements Discov
         try {
             storage.configure("Storage", params);
         } catch (ConfigurationException e) {
-            s_logger.warn("Unable to configure the storage ", e);
+            logger.warn("Unable to configure the storage ", e);
             return null;
         }
         srs.put(storage, details);
@@ -214,7 +212,7 @@ public class SecondaryStorageDiscoverer extends DiscovererBase implements Discov
         try {
             storage.configure("Storage", params);
         } catch (ConfigurationException e) {
-            s_logger.warn("Unable to configure the storage ", e);
+            logger.warn("Unable to configure the storage ", e);
             return null;
         }
         srs.put(storage, details);
@@ -244,7 +242,7 @@ public class SecondaryStorageDiscoverer extends DiscovererBase implements Discov
         try {
             storage.configure("Storage", params);
         } catch (ConfigurationException e) {
-            s_logger.warn("Unable to configure the storage ", e);
+            logger.warn("Unable to configure the storage ", e);
             return null;
         }
         srs.put(storage, details);

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -41,7 +41,6 @@ import java.util.concurrent.Executors;
 import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.storage.command.DownloadCommand;
 import org.apache.cloudstack.storage.command.DownloadCommand.ResourceType;
@@ -217,7 +216,6 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         }
     }
 
-    public static final Logger s_logger = Logger.getLogger(DownloadManagerImpl.class);
     private String _templateDir;
     private String _volumeDir;
     private String createTmpltScr;
@@ -250,12 +248,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     public void setDownloadStatus(String jobId, Status status) {
         DownloadJob dj = jobs.get(jobId);
         if (dj == null) {
-            s_logger.warn("setDownloadStatus for jobId: " + jobId + ", status=" + status + " no job found");
+            logger.warn("setDownloadStatus for jobId: " + jobId + ", status=" + status + " no job found");
             return;
         }
         TemplateDownloader td = dj.getTemplateDownloader();
-        s_logger.info("Download Completion for jobId: " + jobId + ", status=" + status);
-        s_logger.info("local: " + td.getDownloadLocalPath() + ", bytes=" + td.getDownloadedBytes() + ", error=" + td.getDownloadError() + ", pct=" +
+        logger.info("Download Completion for jobId: " + jobId + ", status=" + status);
+        logger.info("local: " + td.getDownloadLocalPath() + ", bytes=" + td.getDownloadedBytes() + ", error=" + td.getDownloadError() + ", pct=" +
                 td.getDownloadPercent());
 
         switch (status) {
@@ -268,7 +266,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         case UNKNOWN:
             return;
         case IN_PROGRESS:
-            s_logger.info("Resuming jobId: " + jobId + ", status=" + status);
+            logger.info("Resuming jobId: " + jobId + ", status=" + status);
             td.setResume(true);
             threadPool.execute(td);
             break;
@@ -282,7 +280,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                 td.setDownloadError("Download success, starting install ");
                 String result = postDownload(jobId);
                 if (result != null) {
-                    s_logger.error("Failed post download script: " + result);
+                    logger.error("Failed post download script: " + result);
                     td.setStatus(Status.UNRECOVERABLE_ERROR);
                     td.setDownloadError("Failed post download script: " + result);
                 } else {
@@ -357,7 +355,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         File originalTemplate = new File(td.getDownloadLocalPath());
         String checkSum = computeCheckSum(originalTemplate);
         if (checkSum == null) {
-            s_logger.warn("Something wrong happened when try to calculate the checksum of downloaded template!");
+            logger.warn("Something wrong happened when try to calculate the checksum of downloaded template!");
         }
         dnld.setCheckSum(checkSum);
 
@@ -366,7 +364,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         long timeout = (long)imgSizeGigs * installTimeoutPerGig;
         Script scr = null;
         String script = resourceType == ResourceType.TEMPLATE ? createTmpltScr : createVolScr;
-        scr = new Script(script, timeout, s_logger);
+        scr = new Script(script, timeout, logger);
         scr.add("-s", Integer.toString(imgSizeGigs));
         scr.add("-S", Long.toString(td.getMaxTemplateSizeInBytes()));
         if (dnld.getDescription() != null && dnld.getDescription().length() > 1) {
@@ -423,7 +421,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         try {
             loc.create(dnld.getId(), true, dnld.getTmpltName());
         } catch (IOException e) {
-            s_logger.warn("Something is wrong with template location " + resourcePath, e);
+            logger.warn("Something is wrong with template location " + resourcePath, e);
             loc.purge();
             return "Unable to download due to " + e.getMessage();
         }
@@ -436,7 +434,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             try {
                 info = processor.process(resourcePath, null, templateName);
             } catch (InternalErrorException e) {
-                s_logger.error("Template process exception ", e);
+                logger.error("Template process exception ", e);
                 return e.toString();
             }
             if (info != null) {
@@ -448,7 +446,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         }
 
         if (!loc.save()) {
-            s_logger.warn("Cleaning up because we're unable to save the formats");
+            logger.warn("Cleaning up because we're unable to save the formats");
             loc.purge();
         }
 
@@ -507,7 +505,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         try {
 
             if (!_storage.mkdirs(tmpDir)) {
-                s_logger.warn("Unable to create " + tmpDir);
+                logger.warn("Unable to create " + tmpDir);
                 return "Unable to create " + tmpDir;
             }
             // TO DO - define constant for volume properties.
@@ -519,7 +517,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                     }
 
                     if (!file.createNewFile()) {
-                        s_logger.warn("Unable to create new file: " + file.getAbsolutePath());
+                        logger.warn("Unable to create new file: " + file.getAbsolutePath());
                         return "Unable to create new file: " + file.getAbsolutePath();
                     }
 
@@ -559,7 +557,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
                     return jobId;
         } catch (IOException e) {
-            s_logger.warn("Unable to download to " + tmpDir, e);
+            logger.warn("Unable to download to " + tmpDir, e);
             return null;
         }
     }
@@ -753,24 +751,24 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     private List<String> listVolumes(String rootdir) {
         List<String> result = new ArrayList<String>();
 
-        Script script = new Script(listVolScr, s_logger);
+        Script script = new Script(listVolScr, logger);
         script.add("-r", rootdir);
         ZfsPathParser zpp = new ZfsPathParser(rootdir);
         script.execute(zpp);
         result.addAll(zpp.getPaths());
-        s_logger.info("found " + zpp.getPaths().size() + " volumes" + zpp.getPaths());
+        logger.info("found " + zpp.getPaths().size() + " volumes" + zpp.getPaths());
         return result;
     }
 
     private List<String> listTemplates(String rootdir) {
         List<String> result = new ArrayList<String>();
 
-        Script script = new Script(listTmpltScr, s_logger);
+        Script script = new Script(listTmpltScr, logger);
         script.add("-r", rootdir);
         ZfsPathParser zpp = new ZfsPathParser(rootdir);
         script.execute(zpp);
         result.addAll(zpp.getPaths());
-        s_logger.info("found " + zpp.getPaths().size() + " templates" + zpp.getPaths());
+        logger.info("found " + zpp.getPaths().size() + " templates" + zpp.getPaths());
         return result;
     }
 
@@ -789,13 +787,13 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             TemplateLocation loc = new TemplateLocation(_storage, path);
             try {
                 if (!loc.load()) {
-                    s_logger.warn("Post download installation was not completed for " + path);
+                    logger.warn("Post download installation was not completed for " + path);
                     // loc.purge();
                     _storage.cleanup(path, templateDir);
                     continue;
                 }
             } catch (IOException e) {
-                s_logger.warn("Unable to load template location " + path, e);
+                logger.warn("Unable to load template location " + path, e);
                 continue;
             }
 
@@ -810,12 +808,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                     loc.updateVirtualSize(vSize);
                     loc.save();
                 } catch (Exception e) {
-                    s_logger.error("Unable to get the virtual size of the template: " + tInfo.getInstallPath() + " due to " + e.getMessage());
+                    logger.error("Unable to get the virtual size of the template: " + tInfo.getInstallPath() + " due to " + e.getMessage());
                 }
             }
 
             result.put(tInfo.getTemplateName(), tInfo);
-            s_logger.debug("Added template name: " + tInfo.getTemplateName() + ", path: " + tmplt);
+            logger.debug("Added template name: " + tInfo.getTemplateName() + ", path: " + tmplt);
         }
         /*
         for (String tmplt : isoTmplts) {
@@ -824,7 +822,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             String tmpltName = tmp[tmp.length - 2];
             tmplt = tmplt.substring(tmplt.lastIndexOf("iso/"));
             TemplateInfo tInfo = new TemplateInfo(tmpltName, tmplt, false);
-            s_logger.debug("Added iso template name: " + tmpltName + ", path: " + tmplt);
+            logger.debug("Added iso template name: " + tmpltName + ", path: " + tmplt);
             result.put(tmpltName, tInfo);
         }
          */
@@ -846,13 +844,13 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             TemplateLocation loc = new TemplateLocation(_storage, path);
             try {
                 if (!loc.load()) {
-                    s_logger.warn("Post download installation was not completed for " + path);
+                    logger.warn("Post download installation was not completed for " + path);
                     // loc.purge();
                     _storage.cleanup(path, volumeDir);
                     continue;
                 }
             } catch (IOException e) {
-                s_logger.warn("Unable to load volume location " + path, e);
+                logger.warn("Unable to load volume location " + path, e);
                 continue;
             }
 
@@ -867,12 +865,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                     loc.updateVirtualSize(vSize);
                     loc.save();
                 } catch (Exception e) {
-                    s_logger.error("Unable to get the virtual size of the volume: " + vInfo.getInstallPath() + " due to " + e.getMessage());
+                    logger.error("Unable to get the virtual size of the volume: " + vInfo.getInstallPath() + " due to " + e.getMessage());
                 }
             }
 
             result.put(vInfo.getId(), vInfo);
-            s_logger.debug("Added volume name: " + vInfo.getTemplateName() + ", path: " + vol);
+            logger.debug("Added volume name: " + vInfo.getTemplateName() + ", path: " + vol);
         }
         return result;
     }
@@ -936,7 +934,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
         String inSystemVM = (String)params.get("secondary.storage.vm");
         if (inSystemVM != null && "true".equalsIgnoreCase(inSystemVM)) {
-            s_logger.info("DownloadManager: starting additional services since we are inside system vm");
+            logger.info("DownloadManager: starting additional services since we are inside system vm");
             startAdditionalServices();
             blockOutgoingOnPrivate();
         }
@@ -956,25 +954,25 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         if (listTmpltScr == null) {
             throw new ConfigurationException("Unable to find the listvmtmplt.sh");
         }
-        s_logger.info("listvmtmplt.sh found in " + listTmpltScr);
+        logger.info("listvmtmplt.sh found in " + listTmpltScr);
 
         createTmpltScr = Script.findScript(scriptsDir, "createtmplt.sh");
         if (createTmpltScr == null) {
             throw new ConfigurationException("Unable to find createtmplt.sh");
         }
-        s_logger.info("createtmplt.sh found in " + createTmpltScr);
+        logger.info("createtmplt.sh found in " + createTmpltScr);
 
         listVolScr = Script.findScript(scriptsDir, "listvolume.sh");
         if (listVolScr == null) {
             throw new ConfigurationException("Unable to find the listvolume.sh");
         }
-        s_logger.info("listvolume.sh found in " + listVolScr);
+        logger.info("listvolume.sh found in " + listVolScr);
 
         createVolScr = Script.findScript(scriptsDir, "createvolume.sh");
         if (createVolScr == null) {
             throw new ConfigurationException("Unable to find createvolume.sh");
         }
-        s_logger.info("createvolume.sh found in " + createVolScr);
+        logger.info("createvolume.sh found in " + createVolScr);
 
         _processors = new HashMap<String, Processor>();
 
@@ -1018,7 +1016,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     }
 
     private void blockOutgoingOnPrivate() {
-        Script command = new Script("/bin/bash", s_logger);
+        Script command = new Script("/bin/bash", logger);
         String intf = "eth1";
         command.add("-c");
         command.add("iptables -A OUTPUT -o " + intf + " -p tcp -m state --state NEW -m tcp --dport " + "80" + " -j REJECT;" + "iptables -A OUTPUT -o " + intf +
@@ -1026,7 +1024,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
         String result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in blocking outgoing to port 80/443 err=" + result);
+            logger.warn("Error in blocking outgoing to port 80/443 err=" + result);
             return;
         }
     }
@@ -1048,41 +1046,41 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
     private void startAdditionalServices() {
 
-        Script command = new Script("/bin/bash", s_logger);
+        Script command = new Script("/bin/bash", logger);
         command.add("-c");
         command.add("if [ -d /etc/apache2 ] ; then service apache2 stop; else service httpd stop; fi ");
         String result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in stopping httpd service err=" + result);
+            logger.warn("Error in stopping httpd service err=" + result);
         }
         String port = Integer.toString(TemplateConstants.DEFAULT_TMPLT_COPY_PORT);
         String intf = TemplateConstants.DEFAULT_TMPLT_COPY_INTF;
 
-        command = new Script("/bin/bash", s_logger);
+        command = new Script("/bin/bash", logger);
         command.add("-c");
         command.add("iptables -I INPUT -i " + intf + " -p tcp -m state --state NEW -m tcp --dport " + port + " -j ACCEPT;" + "iptables -I INPUT -i " + intf +
                 " -p tcp -m state --state NEW -m tcp --dport " + "443" + " -j ACCEPT;");
 
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in opening up httpd port err=" + result);
+            logger.warn("Error in opening up httpd port err=" + result);
             return;
         }
 
-        command = new Script("/bin/bash", s_logger);
+        command = new Script("/bin/bash", logger);
         command.add("-c");
         command.add("if [ -d /etc/apache2 ] ; then service apache2 start; else service httpd start; fi ");
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in starting httpd service err=" + result);
+            logger.warn("Error in starting httpd service err=" + result);
             return;
         }
-        command = new Script("mkdir", s_logger);
+        command = new Script("mkdir", logger);
         command.add("-p");
         command.add("/var/www/html/copy/template");
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in creating directory =" + result);
+            logger.warn("Error in creating directory =" + result);
             return;
         }
     }

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/template/UploadManagerImpl.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/template/UploadManagerImpl.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executors;
 import javax.naming.ConfigurationException;
 
 import com.cloud.agent.api.Answer;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.storage.resource.SecondaryStorageResource;
 
@@ -93,7 +92,6 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
 
     }
 
-    public static final Logger s_logger = Logger.getLogger(UploadManagerImpl.class);
     private ExecutorService threadPool;
     private final Map<String, UploadJob> jobs = new ConcurrentHashMap<String, UploadJob>();
     private String parentDir;
@@ -109,13 +107,13 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         String jobId = uuid.toString();
 
         String completePath = parentDir + File.separator + installPathPrefix;
-        s_logger.debug("Starting upload from " + completePath);
+        logger.debug("Starting upload from " + completePath);
 
         URI uri;
         try {
             uri = new URI(url);
         } catch (URISyntaxException e) {
-            s_logger.error("URI is incorrect: " + url);
+            logger.error("URI is incorrect: " + url);
             throw new CloudRuntimeException("URI is incorrect: " + url);
         }
         TemplateUploader tu;
@@ -123,11 +121,11 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
             if (uri.getScheme().equalsIgnoreCase("ftp")) {
                 tu = new FtpTemplateUploader(completePath, url, new Completion(jobId), templateSizeInBytes);
             } else {
-                s_logger.error("Scheme is not supported " + url);
+                logger.error("Scheme is not supported " + url);
                 throw new CloudRuntimeException("Scheme is not supported " + url);
             }
         } else {
-            s_logger.error("Unable to download from URL: " + url);
+            logger.error("Unable to download from URL: " + url);
             throw new CloudRuntimeException("Unable to download from URL: " + url);
         }
         UploadJob uj = new UploadJob(tu, jobId, id, name, format, hvm, accountId, descr, cksum, installPathPrefix);
@@ -240,7 +238,7 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
 
     @Override
     public UploadAnswer handleUploadCommand(SecondaryStorageResource resource, UploadCommand cmd) {
-        s_logger.warn("Handling the upload " + cmd.getInstallPath() + " " + cmd.getId());
+        logger.warn("Handling the upload " + cmd.getInstallPath() + " " + cmd.getId());
         if (cmd instanceof UploadProgressCommand) {
             return handleUploadProgressCmd((UploadProgressCommand)cmd);
         }
@@ -261,40 +259,40 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         boolean isApacheUp = checkAndStartApache();
         if (!isApacheUp) {
             String errorString = "Error in starting Apache server ";
-            s_logger.error(errorString);
+            logger.error(errorString);
             return new CreateEntityDownloadURLAnswer(errorString, CreateEntityDownloadURLAnswer.RESULT_FAILURE);
         }
         // Create the directory structure so that its visible under apache server root
         String extractDir = "/var/www/html/userdata/";
-        Script command = new Script("mkdir", s_logger);
+        Script command = new Script("mkdir", logger);
         command.add("-p");
         command.add(extractDir);
         String result = command.execute();
         if (result != null) {
             String errorString = "Error in creating directory =" + result;
-            s_logger.error(errorString);
+            logger.error(errorString);
             return new CreateEntityDownloadURLAnswer(errorString, CreateEntityDownloadURLAnswer.RESULT_FAILURE);
         }
 
         // Create a random file under the directory for security reasons.
         String uuid = cmd.getExtractLinkUUID();
-        command = new Script("touch", s_logger);
+        command = new Script("touch", logger);
         command.add(extractDir + uuid);
         result = command.execute();
         if (result != null) {
             String errorString = "Error in creating file " + uuid + " ,error: " + result;
-            s_logger.warn(errorString);
+            logger.warn(errorString);
             return new CreateEntityDownloadURLAnswer(errorString, CreateEntityDownloadURLAnswer.RESULT_FAILURE);
         }
 
         // Create a symbolic link from the actual directory to the template location. The entity would be directly visible under /var/www/html/userdata/cmd.getInstallPath();
-        command = new Script("/bin/bash", s_logger);
+        command = new Script("/bin/bash", logger);
         command.add("-c");
         command.add("ln -sf /mnt/SecStorage/" + cmd.getParent() + File.separator + cmd.getInstallPath() + " " + extractDir + uuid);
         result = command.execute();
         if (result != null) {
             String errorString = "Error in linking  err=" + result;
-            s_logger.error(errorString);
+            logger.error(errorString);
             return new CreateEntityDownloadURLAnswer(errorString, CreateEntityDownloadURLAnswer.RESULT_FAILURE);
         }
 
@@ -306,9 +304,9 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
     public Answer handleDeleteEntityDownloadURLCommand(DeleteEntityDownloadURLCommand cmd) {
 
         //Delete the soft link. Example path = volumes/8/74eeb2c6-8ab1-4357-841f-2e9d06d1f360.vhd
-        s_logger.warn("handleDeleteEntityDownloadURLCommand Path:" + cmd.getPath() + " Type:" + cmd.getType().toString());
+        logger.warn("handleDeleteEntityDownloadURLCommand Path:" + cmd.getPath() + " Type:" + cmd.getType().toString());
         String path = cmd.getPath();
-        Script command = new Script("/bin/bash", s_logger);
+        Script command = new Script("/bin/bash", logger);
         command.add("-c");
 
         //We just need to remove the UUID.vhd
@@ -318,19 +316,19 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         if (result != null) {
             // FIXME - Ideally should bail out if you cant delete symlink. Not doing it right now.
             // This is because the ssvm might already be destroyed and the symlinks do not exist.
-            s_logger.warn("Error in deleting symlink :" + result);
+            logger.warn("Error in deleting symlink :" + result);
         }
 
         // If its a volume also delete the Hard link since it was created only for the purpose of download.
         if (cmd.getType() == Upload.Type.VOLUME) {
-            command = new Script("/bin/bash", s_logger);
+            command = new Script("/bin/bash", logger);
             command.add("-c");
             command.add("rm -rf /mnt/SecStorage/" + cmd.getParentPath() + File.separator + path);
-            s_logger.warn(" " + parentDir + File.separator + path);
+            logger.warn(" " + parentDir + File.separator + path);
             result = command.execute();
             if (result != null) {
                 String errorString = "Error in deleting volume " + path + " : " + result;
-                s_logger.warn(errorString);
+                logger.warn(errorString);
                 return new Answer(cmd, false, errorString);
             }
         }
@@ -380,7 +378,7 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
 
         String inSystemVM = (String)params.get("secondary.storage.vm");
         if (inSystemVM != null && "true".equalsIgnoreCase(inSystemVM)) {
-            s_logger.info("UploadManager: starting additional services since we are inside system vm");
+            logger.info("UploadManager: starting additional services since we are inside system vm");
             startAdditionalServices();
             //blockOutgoingOnPrivate();
         }
@@ -401,29 +399,29 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
 
     private void startAdditionalServices() {
 
-        Script command = new Script("rm", s_logger);
+        Script command = new Script("rm", logger);
         command.add("-rf");
         command.add(extractMountPoint);
         String result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in creating file " + extractMountPoint + " ,error: " + result);
+            logger.warn("Error in creating file " + extractMountPoint + " ,error: " + result);
             return;
         }
 
-        command = new Script("touch", s_logger);
+        command = new Script("touch", logger);
         command.add(extractMountPoint);
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in creating file " + extractMountPoint + " ,error: " + result);
+            logger.warn("Error in creating file " + extractMountPoint + " ,error: " + result);
             return;
         }
 
-        command = new Script("/bin/bash", s_logger);
+        command = new Script("/bin/bash", logger);
         command.add("-c");
         command.add("ln -sf " + parentDir + " " + extractMountPoint);
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in linking  err=" + result);
+            logger.warn("Error in linking  err=" + result);
             return;
         }
 
@@ -440,12 +438,12 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
     public void setUploadStatus(String jobId, Status status) {
         UploadJob uj = jobs.get(jobId);
         if (uj == null) {
-            s_logger.warn("setUploadStatus for jobId: " + jobId + ", status=" + status + " no job found");
+            logger.warn("setUploadStatus for jobId: " + jobId + ", status=" + status + " no job found");
             return;
         }
         TemplateUploader tu = uj.getTemplateUploader();
-        s_logger.warn("Upload Completion for jobId: " + jobId + ", status=" + status);
-        s_logger.warn("UploadedBytes=" + tu.getUploadedBytes() + ", error=" + tu.getUploadError() + ", pct=" + tu.getUploadPercent());
+        logger.warn("Upload Completion for jobId: " + jobId + ", status=" + status);
+        logger.warn("UploadedBytes=" + tu.getUploadedBytes() + ", error=" + tu.getUploadError() + ", pct=" + tu.getUploadPercent());
 
         switch (status) {
         case ABORTED:
@@ -459,7 +457,7 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         case UNKNOWN:
             return;
         case IN_PROGRESS:
-            s_logger.info("Resuming jobId: " + jobId + ", status=" + status);
+            logger.info("Resuming jobId: " + jobId + ", status=" + status);
             tu.setResume(true);
             threadPool.execute(tu);
             break;
@@ -470,11 +468,11 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
             tu.setUploadError("Upload success, starting install ");
             String result = postUpload(jobId);
             if (result != null) {
-                s_logger.error("Failed post upload script: " + result);
+                logger.error("Failed post upload script: " + result);
                 tu.setStatus(Status.UNRECOVERABLE_ERROR);
                 tu.setUploadError("Failed post upload script: " + result);
             } else {
-                s_logger.warn("Upload completed successfully at " + new SimpleDateFormat().format(new Date()));
+                logger.warn("Upload completed successfully at " + new SimpleDateFormat().format(new Date()));
                 tu.setStatus(Status.POST_UPLOAD_FINISHED);
                 tu.setUploadError("Upload completed successfully at " + new SimpleDateFormat().format(new Date()));
             }
@@ -503,7 +501,7 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
     private boolean checkAndStartApache() {
 
         //Check whether the Apache server is running
-        Script command = new Script("/bin/bash", s_logger);
+        Script command = new Script("/bin/bash", logger);
         command.add("-c");
         command.add("if [ -d /etc/apache2 ] ; then service apache2 status | grep pid; else service httpd status | grep pid; fi ");
         String result = command.execute();
@@ -511,11 +509,11 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
         //Apache Server is not running. Try to start it.
         if (result != null) {
 
-            /*s_logger.warn("Apache server not running, trying to start it");
+            /*logger.warn("Apache server not running, trying to start it");
             String port = Integer.toString(TemplateConstants.DEFAULT_TMPLT_COPY_PORT);
             String intf = TemplateConstants.DEFAULT_TMPLT_COPY_INTF;
 
-            command = new Script("/bin/bash", s_logger);
+            command = new Script("/bin/bash", logger);
             command.add("-c");
             command.add("iptables -D INPUT -i " + intf + " -p tcp -m state --state NEW -m tcp --dport " + port + " -j DROP;" +
                         "iptables -D INPUT -i " + intf + " -p tcp -m state --state NEW -m tcp --dport " + port + " -j HTTP;" +
@@ -531,16 +529,16 @@ public class UploadManagerImpl extends ManagerBase implements UploadManager {
 
             result = command.execute();
             if (result != null) {
-                s_logger.warn("Error in opening up httpd port err=" + result );
+                logger.warn("Error in opening up httpd port err=" + result );
                 return false;
             }*/
 
-            command = new Script("/bin/bash", s_logger);
+            command = new Script("/bin/bash", logger);
             command.add("-c");
             command.add("if [ -d /etc/apache2 ] ; then service apache2 start; else service httpd start; fi ");
             result = command.execute();
             if (result != null) {
-                s_logger.warn("Error in starting httpd service err=" + result);
+                logger.warn("Error in starting httpd service err=" + result);
                 return false;
             }
         }

--- a/usage/src/com/cloud/usage/UsageAlertManagerImpl.java
+++ b/usage/src/com/cloud/usage/UsageAlertManagerImpl.java
@@ -33,7 +33,6 @@ import javax.mail.internet.InternetAddress;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.alert.AlertManager;
@@ -48,8 +47,6 @@ import com.sun.mail.smtp.SMTPTransport;
 @Component
 @Local(value = {AlertManager.class})
 public class UsageAlertManagerImpl extends ManagerBase implements AlertManager {
-    private static final Logger s_logger = Logger.getLogger(UsageAlertManagerImpl.class.getName());
-    private static final Logger s_alertsLogger = Logger.getLogger("org.apache.cloudstack.alerts");
 
     private EmailAlert _emailAlert;
     @Inject
@@ -92,7 +89,7 @@ public class UsageAlertManagerImpl extends ManagerBase implements AlertManager {
                 _emailAlert.clearAlert(alertType.getType(), dataCenterId, podId);
             }
         } catch (Exception ex) {
-            s_logger.error("Problem clearing email alert", ex);
+            logger.error("Problem clearing email alert", ex);
         }
     }
 
@@ -104,11 +101,11 @@ public class UsageAlertManagerImpl extends ManagerBase implements AlertManager {
             if (_emailAlert != null) {
                 _emailAlert.sendAlert(alertType, dataCenterId, podId, subject, body);
             } else {
-                s_alertsLogger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " + podId + " // clusterId:: " + null +
+                logger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " + podId + " // clusterId:: " + null +
                     " // message:: " + subject + " // body:: " + body);
             }
         } catch (Exception ex) {
-            s_logger.error("Problem sending email alert", ex);
+            logger.error("Problem sending email alert", ex);
         }
     }
 
@@ -130,7 +127,7 @@ public class UsageAlertManagerImpl extends ManagerBase implements AlertManager {
                     try {
                         _recipientList[i] = new InternetAddress(recipientList[i], recipientList[i]);
                     } catch (Exception ex) {
-                        s_logger.error("Exception creating address for: " + recipientList[i], ex);
+                        logger.error("Exception creating address for: " + recipientList[i], ex);
                     }
                 }
             }
@@ -177,7 +174,7 @@ public class UsageAlertManagerImpl extends ManagerBase implements AlertManager {
         // TODO:  make sure this handles SSL transport (useAuth is true) and regular
         protected void sendAlert(AlertType alertType, long dataCenterId, Long podId, String subject, String content) throws MessagingException,
             UnsupportedEncodingException {
-            s_alertsLogger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " +
+            logger.warn(" alertType:: " + alertType + " // dataCenterId:: " + dataCenterId + " // podId:: " +
                 podId + " // clusterId:: " + null + " // message:: " + subject);
             AlertVO alert = null;
             if ((alertType != AlertManager.AlertType.ALERT_TYPE_HOST) &&
@@ -202,8 +199,8 @@ public class UsageAlertManagerImpl extends ManagerBase implements AlertManager {
                 newAlert.setName(alertType.getName());
                 _alertDao.persist(newAlert);
             } else {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Have already sent: " + alert.getSentCount() + " emails for alert type '" + alertType + "' -- skipping send email");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Have already sent: " + alert.getSentCount() + " emails for alert type '" + alertType + "' -- skipping send email");
                 }
                 return;
             }
@@ -256,7 +253,7 @@ public class UsageAlertManagerImpl extends ManagerBase implements AlertManager {
             sendAlert(alertType, dataCenterId, podId, msg, msg);
             return true;
         } catch (Exception ex) {
-            s_logger.warn("Failed to generate an alert of type=" + alertType + "; msg=" + msg);
+            logger.warn("Failed to generate an alert of type=" + alertType + "; msg=" + msg);
             return false;
         }
     }

--- a/usage/src/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/com/cloud/usage/UsageManagerImpl.java
@@ -35,7 +35,6 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.utils.usage.UsageUtils;
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -92,7 +91,6 @@ import com.cloud.utils.db.TransactionLegacy;
 @Component
 @Local(value = {UsageManager.class})
 public class UsageManagerImpl extends ManagerBase implements UsageManager, Runnable {
-    public static final Logger s_logger = Logger.getLogger(UsageManagerImpl.class.getName());
 
     protected static final String DAILY = "DAILY";
     protected static final String WEEKLY = "WEEKLY";
@@ -176,16 +174,16 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
         final String run = "usage.vmops.pid";
 
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Checking to see if " + run + " exists.");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Checking to see if " + run + " exists.");
         }
 
         final Class<?> c = UsageServer.class;
         _version = c.getPackage().getImplementationVersion();
         if (_version == null) _version="unknown";
 
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Implementation Version is " + _version);
+        if (logger.isInfoEnabled()) {
+            logger.info("Implementation Version is " + _version);
         }
 
         Map<String, String> configs = _configDao.getConfiguration(params);
@@ -206,18 +204,18 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         if (aggreagationTimeZone != null && !aggreagationTimeZone.isEmpty()) {
             _usageTimezone = TimeZone.getTimeZone(aggreagationTimeZone);
         }
-        s_logger.debug("Usage stats aggregation time zone: " + aggreagationTimeZone);
+        logger.debug("Usage stats aggregation time zone: " + aggreagationTimeZone);
 
         try {
             if ((execTime == null) || (aggregationRange == null)) {
-                s_logger.error("missing configuration values for usage job, usage.stats.job.exec.time = " + execTime + ", usage.stats.job.aggregation.range = " +
+                logger.error("missing configuration values for usage job, usage.stats.job.exec.time = " + execTime + ", usage.stats.job.aggregation.range = " +
                         aggregationRange);
                 throw new ConfigurationException("Missing configuration values for usage job, usage.stats.job.exec.time = " + execTime +
                         ", usage.stats.job.aggregation.range = " + aggregationRange);
             }
             String[] execTimeSegments = execTime.split(":");
             if (execTimeSegments.length != 2) {
-                s_logger.error("Unable to parse usage.stats.job.exec.time");
+                logger.error("Unable to parse usage.stats.job.exec.time");
                 throw new ConfigurationException("Unable to parse usage.stats.job.exec.time '" + execTime + "'");
             }
             int hourOfDay = Integer.parseInt(execTimeSegments[0]);
@@ -238,13 +236,13 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 _jobExecTime.roll(Calendar.DAY_OF_YEAR, true);
             }
 
-            s_logger.debug("Execution Time: " + execDate.toString());
+            logger.debug("Execution Time: " + execDate.toString());
             Date currentDate = new Date(System.currentTimeMillis());
-            s_logger.debug("Current Time: " + currentDate.toString());
+            logger.debug("Current Time: " + currentDate.toString());
 
             _aggregationDuration = Integer.parseInt(aggregationRange);
             if (_aggregationDuration < UsageUtils.USAGE_AGGREGATION_RANGE_MIN) {
-                s_logger.warn("Usage stats job aggregation range is to small, using the minimum value of " + UsageUtils.USAGE_AGGREGATION_RANGE_MIN);
+                logger.warn("Usage stats job aggregation range is to small, using the minimum value of " + UsageUtils.USAGE_AGGREGATION_RANGE_MIN);
                 _aggregationDuration = UsageUtils.USAGE_AGGREGATION_RANGE_MIN;
             }
             _hostname = InetAddress.getLocalHost().getHostName() + "/" + InetAddress.getLocalHost().getHostAddress();
@@ -252,7 +250,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             throw new ConfigurationException("Unable to parse usage.stats.job.exec.time '" + execTime + "' or usage.stats.job.aggregation.range '" + aggregationRange +
                     "', please check configuration values");
         } catch (Exception e) {
-            s_logger.error("Unhandled exception configuring UsageManger", e);
+            logger.error("Unhandled exception configuring UsageManger", e);
             throw new ConfigurationException("Unhandled exception configuring UsageManager " + e.toString());
         }
         _pid = Integer.parseInt(System.getProperty("pid"));
@@ -261,8 +259,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
 
     @Override
     public boolean start() {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("Starting Usage Manager");
+        if (logger.isInfoEnabled()) {
+            logger.info("Starting Usage Manager");
         }
 
         // use the configured exec time and aggregation duration for scheduling the job
@@ -289,8 +287,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                     _heartbeatLock.unlock();
                 }
             } else {
-                if (s_logger.isTraceEnabled())
-                    s_logger.trace("Heartbeat lock is in use by others, returning true as someone else will take over the job if required");
+                if (logger.isTraceEnabled())
+                    logger.trace("Heartbeat lock is in use by others, returning true as someone else will take over the job if required");
             }
         } finally {
             usageTxn.close();
@@ -320,8 +318,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     }
 
     protected void runInContextInternal() {
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("starting usage job...");
+        if (logger.isInfoEnabled()) {
+            logger.info("starting usage job...");
         }
 
         // how about we update the job exec time when the job starts???
@@ -374,19 +372,19 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
 
             parse(job, startDate, endDate);
         } else {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Not owner of usage job, skipping...");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Not owner of usage job, skipping...");
             }
         }
-        if (s_logger.isInfoEnabled()) {
-            s_logger.info("usage job complete");
+        if (logger.isInfoEnabled()) {
+            logger.info("usage job complete");
         }
     }
 
     @Override
     public void scheduleParse() {
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Scheduling Usage job...");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Scheduling Usage job...");
         }
         _executor.schedule(this, 0, TimeUnit.MILLISECONDS);
     }
@@ -408,8 +406,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             }
 
             if (startDateMillis >= endDateMillis) {
-                if (s_logger.isInfoEnabled()) {
-                    s_logger.info("not parsing usage records since start time mills (" + startDateMillis + ") is on or after end time millis (" + endDateMillis + ")");
+                if (logger.isInfoEnabled()) {
+                    logger.info("not parsing usage records since start time mills (" + startDateMillis + ") is on or after end time millis (" + endDateMillis + ")");
                 }
 
                 TransactionLegacy jobUpdateTxn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
@@ -431,8 +429,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             }
             Date startDate = new Date(startDateMillis);
             Date endDate = new Date(endDateMillis);
-            if (s_logger.isInfoEnabled()) {
-                s_logger.info("Parsing usage records between " + startDate + " and " + endDate);
+            if (logger.isInfoEnabled()) {
+                logger.info("Parsing usage records between " + startDate + " and " + endDate);
             }
 
             List<AccountVO> accounts = null;
@@ -652,8 +650,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 }
                 _usageNetworkDao.saveUsageNetworks(usageNetworks);
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("created network stats helper entries for " + numAcctsProcessed + " accts");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("created network stats helper entries for " + numAcctsProcessed + " accts");
                 }
 
                 // get vm disk stats in order to compute vm disk usage
@@ -701,8 +699,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 }
                 _usageVmDiskDao.saveUsageVmDisks(usageVmDisks);
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("created vm disk stats helper entries for " + numAcctsProcessed + " accts");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("created vm disk stats helper entries for " + numAcctsProcessed + " accts");
                 }
 
                 // commit the helper records, then start a new transaction
@@ -741,8 +739,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                         offset = new Long(offset.longValue() + limit.longValue());
                     } while ((accounts != null) && !accounts.isEmpty());
 
-                    if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("processed VM/Network Usage for " + numAcctsProcessed + " ACTIVE accts");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("processed VM/Network Usage for " + numAcctsProcessed + " ACTIVE accts");
                     }
                     numAcctsProcessed = 0;
 
@@ -762,12 +760,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                                     //mark public templates owned by deleted accounts as deleted
                                     List<UsageStorageVO> storageVOs = _usageStorageDao.listById(account.getId(), templateId, StorageTypes.TEMPLATE);
                                     if (storageVOs.size() > 1) {
-                                        s_logger.warn("More that one usage entry for storage: " + templateId + " assigned to account: " + account.getId() +
+                                        logger.warn("More that one usage entry for storage: " + templateId + " assigned to account: " + account.getId() +
                                                 "; marking them all as deleted...");
                                     }
                                     for (UsageStorageVO storageVO : storageVOs) {
-                                        if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("deleting template: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
+                                        if (logger.isDebugEnabled()) {
+                                            logger.debug("deleting template: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
                                         }
                                         storageVO.setDeleted(account.getRemoved());
                                         _usageStorageDao.update(storageVO);
@@ -785,8 +783,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                     currentEndDate = aggregateCal.getTime();
                 }
 
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("processed Usage for " + numAcctsProcessed + " RECENTLY DELETED accts");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("processed Usage for " + numAcctsProcessed + " RECENTLY DELETED accts");
                 }
 
                 // FIXME: we don't break the above loop if something fails to parse, so it gets reset every account,
@@ -797,7 +795,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                     success = true;
                 }
             } catch (Exception ex) {
-                s_logger.error("Exception in usage manager", ex);
+                logger.error("Exception in usage manager", ex);
                 usageTxn.rollback();
             } finally {
                 // everything seemed to work...set endDate as the last success date
@@ -822,7 +820,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
 
             }
         } catch (Exception e) {
-            s_logger.error("Usage Manager error", e);
+            logger.error("Usage Manager error", e);
         }
     }
 
@@ -830,84 +828,84 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         boolean parsed = false;
 
         parsed = VMInstanceUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("vm usage instances successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("vm usage instances successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = NetworkUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("network usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("network usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = VmDiskUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("vm disk usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("vm disk usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = VolumeUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("volume usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("volume usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = StorageUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("storage usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("storage usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = SecurityGroupUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("Security Group usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("Security Group usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = LoadBalancerUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("load balancer usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("load balancer usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = PortForwardingUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("port forwarding usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("port forwarding usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = NetworkOfferingUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("network offering usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("network offering usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
 
         parsed = IPAddressUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("IPAddress usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("IPAddress usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
         parsed = VPNUserUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("VPN user usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("VPN user usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
         parsed = VMSnapshotUsageParser.parse(account, currentStartDate, currentEndDate);
-        if (s_logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
             if (!parsed) {
-                s_logger.debug("VM Snapshot usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
+                logger.debug("VM Snapshot usage successfully parsed? " + parsed + " (for account: " + account.getAccountName() + ", id: " + account.getId() + ")");
             }
         }
         return parsed;
@@ -1036,7 +1034,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 List<UsageVMInstanceVO> usageInstances = _usageInstanceDao.search(sc, null);
                 if (usageInstances != null) {
                     if (usageInstances.size() > 0) {
-                        s_logger.error("found entries for a vm running with id: " + vmId + ", which are not stopped. Ending them all...");
+                        logger.error("found entries for a vm running with id: " + vmId + ", which are not stopped. Ending them all...");
                         for (UsageVMInstanceVO usageInstance : usageInstances) {
                             usageInstance.setEndDate(event.getCreateDate());
                             _usageInstanceDao.update(usageInstance);
@@ -1050,7 +1048,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 sc.addAnd("usageType", SearchCriteria.Op.EQ, UsageTypes.ALLOCATED_VM);
                 usageInstances = _usageInstanceDao.search(sc, null);
                 if (usageInstances == null || (usageInstances.size() == 0)) {
-                    s_logger.error("Cannot find allocated vm entry for a vm running with id: " + vmId);
+                    logger.error("Cannot find allocated vm entry for a vm running with id: " + vmId);
                 } else if (usageInstances.size() == 1) {
                     UsageVMInstanceVO usageInstance = usageInstances.get(0);
                     if (usageInstance.getSerivceOfferingId() != soId) {
@@ -1074,7 +1072,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                                 null);
                 populateDynamicComputeOfferingDetailsAndPersist(usageInstanceNew, event.getId());
             } catch (Exception ex) {
-                s_logger.error("Error saving usage instance for vm: " + vmId, ex);
+                logger.error("Error saving usage instance for vm: " + vmId, ex);
             }
         } else if (EventTypes.EVENT_VM_STOP.equals(event.getType())) {
             // find the latest usage_VM_instance row, update the stop date (should be null) to the event date
@@ -1086,7 +1084,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             List<UsageVMInstanceVO> usageInstances = _usageInstanceDao.search(sc, null);
             if (usageInstances != null) {
                 if (usageInstances.size() > 1) {
-                    s_logger.warn("found multiple entries for a vm running with id: " + vmId + ", ending them all...");
+                    logger.warn("found multiple entries for a vm running with id: " + vmId + ", ending them all...");
                 }
                 for (UsageVMInstanceVO usageInstance : usageInstances) {
                     usageInstance.setEndDate(event.getCreateDate());
@@ -1105,7 +1103,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                         soId, templateId, hypervisorType, event.getCreateDate(), null);
                 populateDynamicComputeOfferingDetailsAndPersist(usageInstanceNew, event.getId());
             } catch (Exception ex) {
-                s_logger.error("Error saving usage instance for vm: " + vmId, ex);
+                logger.error("Error saving usage instance for vm: " + vmId, ex);
             }
         } else if (EventTypes.EVENT_VM_DESTROY.equals(event.getType())) {
             SearchCriteria<UsageVMInstanceVO> sc = _usageInstanceDao.createSearchCriteria();
@@ -1115,7 +1113,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             List<UsageVMInstanceVO> usageInstances = _usageInstanceDao.search(sc, null);
             if (usageInstances != null) {
                 if (usageInstances.size() > 1) {
-                    s_logger.warn("found multiple entries for a vm allocated with id: " + vmId + ", detroying them all...");
+                    logger.warn("found multiple entries for a vm allocated with id: " + vmId + ", detroying them all...");
                 }
                 for (UsageVMInstanceVO usageInstance : usageInstances) {
                     usageInstance.setEndDate(event.getCreateDate());
@@ -1130,7 +1128,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             List<UsageVMInstanceVO> usageInstances = _usageInstanceDao.search(sc, null);
             if (usageInstances != null) {
                 if (usageInstances.size() > 1) {
-                    s_logger.warn("found multiple entries for a vm allocated with id: " + vmId + ", updating end_date for all of them...");
+                    logger.warn("found multiple entries for a vm allocated with id: " + vmId + ", updating end_date for all of them...");
                 }
                 for (UsageVMInstanceVO usageInstance : usageInstances) {
                     usageInstance.setEndDate(event.getCreateDate());
@@ -1153,7 +1151,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             List<UsageVMInstanceVO> usageInstances = _usageInstanceDao.search(sc, null);
             if (usageInstances != null) {
                 if (usageInstances.size() > 1) {
-                    s_logger.warn("found multiple entries for a vm running with id: " + vmId + ", ending them all...");
+                    logger.warn("found multiple entries for a vm running with id: " + vmId + ", ending them all...");
                 }
                 for (UsageVMInstanceVO usageInstance : usageInstances) {
                     usageInstance.setEndDate(event.getCreateDate());
@@ -1167,7 +1165,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("usageType", SearchCriteria.Op.EQ, UsageTypes.ALLOCATED_VM);
             usageInstances = _usageInstanceDao.search(sc, null);
             if (usageInstances == null || (usageInstances.size() == 0)) {
-                s_logger.error("Cannot find allocated vm entry for a vm running with id: " + vmId);
+                logger.error("Cannot find allocated vm entry for a vm running with id: " + vmId);
             } else if (usageInstances.size() == 1) {
                 UsageVMInstanceVO usageInstance = usageInstances.get(0);
                 if (usageInstance.getSerivceOfferingId() != soId) {
@@ -1222,8 +1220,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long currentAccountedBytesSent = 0L;
         long currentAccountedBytesReceived = 0L;
         if (usageNetworkStats != null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("getting current accounted bytes for... accountId: " + usageNetworkStats.getAccountId() + " in zone: " + userStat.getDataCenterId() +
+            if (logger.isDebugEnabled()) {
+                logger.debug("getting current accounted bytes for... accountId: " + usageNetworkStats.getAccountId() + " in zone: " + userStat.getDataCenterId() +
                         "; abr: " + usageNetworkStats.getAggBytesReceived() + "; abs: " + usageNetworkStats.getAggBytesSent());
             }
             currentAccountedBytesSent = usageNetworkStats.getAggBytesSent();
@@ -1233,12 +1231,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long bytesReceived = userStat.getAggBytesReceived() - currentAccountedBytesReceived;
 
         if (bytesSent < 0) {
-            s_logger.warn("Calculated negative value for bytes sent: " + bytesSent + ", user stats say: " + userStat.getAggBytesSent() +
+            logger.warn("Calculated negative value for bytes sent: " + bytesSent + ", user stats say: " + userStat.getAggBytesSent() +
                     ", previous network usage was: " + currentAccountedBytesSent);
             bytesSent = 0;
         }
         if (bytesReceived < 0) {
-            s_logger.warn("Calculated negative value for bytes received: " + bytesReceived + ", user stats say: " + userStat.getAggBytesReceived() +
+            logger.warn("Calculated negative value for bytes received: " + bytesReceived + ", user stats say: " + userStat.getAggBytesReceived() +
                     ", previous network usage was: " + currentAccountedBytesReceived);
             bytesReceived = 0;
         }
@@ -1252,8 +1250,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         UsageNetworkVO usageNetworkVO =
                 new UsageNetworkVO(userStat.getAccountId(), userStat.getDataCenterId(), hostId, userStat.getDeviceType(), userStat.getNetworkId(), bytesSent, bytesReceived,
                         userStat.getAggBytesReceived(), userStat.getAggBytesSent(), timestamp);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("creating networkHelperEntry... accountId: " + userStat.getAccountId() + " in zone: " + userStat.getDataCenterId() + "; abr: " +
+        if (logger.isDebugEnabled()) {
+            logger.debug("creating networkHelperEntry... accountId: " + userStat.getAccountId() + " in zone: " + userStat.getDataCenterId() + "; abr: " +
                     userStat.getAggBytesReceived() + "; abs: " + userStat.getAggBytesSent() + "; curABS: " + currentAccountedBytesSent + "; curABR: " +
                     currentAccountedBytesReceived + "; ubs: " + bytesSent + "; ubr: " + bytesReceived);
         }
@@ -1266,8 +1264,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long currentAccountedBytesRead = 0L;
         long currentAccountedBytesWrite = 0L;
         if (usageVmDiskStat != null) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("getting current accounted bytes for... accountId: " + usageVmDiskStat.getAccountId() + " in zone: " + vmDiskStat.getDataCenterId() +
+            if (logger.isDebugEnabled()) {
+                logger.debug("getting current accounted bytes for... accountId: " + usageVmDiskStat.getAccountId() + " in zone: " + vmDiskStat.getDataCenterId() +
                         "; aiw: " + vmDiskStat.getAggIOWrite() + "; air: " + usageVmDiskStat.getAggIORead() + "; abw: " + vmDiskStat.getAggBytesWrite() + "; abr: " +
                         usageVmDiskStat.getAggBytesRead());
             }
@@ -1282,22 +1280,22 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long bytesWrite = vmDiskStat.getAggBytesWrite() - currentAccountedBytesWrite;
 
         if (ioRead < 0) {
-            s_logger.warn("Calculated negative value for io read: " + ioRead + ", vm disk stats say: " + vmDiskStat.getAggIORead() + ", previous vm disk usage was: " +
+            logger.warn("Calculated negative value for io read: " + ioRead + ", vm disk stats say: " + vmDiskStat.getAggIORead() + ", previous vm disk usage was: " +
                     currentAccountedIORead);
             ioRead = 0;
         }
         if (ioWrite < 0) {
-            s_logger.warn("Calculated negative value for io write: " + ioWrite + ", vm disk stats say: " + vmDiskStat.getAggIOWrite() + ", previous vm disk usage was: " +
+            logger.warn("Calculated negative value for io write: " + ioWrite + ", vm disk stats say: " + vmDiskStat.getAggIOWrite() + ", previous vm disk usage was: " +
                     currentAccountedIOWrite);
             ioWrite = 0;
         }
         if (bytesRead < 0) {
-            s_logger.warn("Calculated negative value for bytes read: " + bytesRead + ", vm disk stats say: " + vmDiskStat.getAggBytesRead() +
+            logger.warn("Calculated negative value for bytes read: " + bytesRead + ", vm disk stats say: " + vmDiskStat.getAggBytesRead() +
                     ", previous vm disk usage was: " + currentAccountedBytesRead);
             bytesRead = 0;
         }
         if (bytesWrite < 0) {
-            s_logger.warn("Calculated negative value for bytes write: " + bytesWrite + ", vm disk stats say: " + vmDiskStat.getAggBytesWrite() +
+            logger.warn("Calculated negative value for bytes write: " + bytesWrite + ", vm disk stats say: " + vmDiskStat.getAggBytesWrite() +
                     ", previous vm disk usage was: " + currentAccountedBytesWrite);
             bytesWrite = 0;
         }
@@ -1311,8 +1309,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         UsageVmDiskVO usageVmDiskVO =
                 new UsageVmDiskVO(vmDiskStat.getAccountId(), vmDiskStat.getDataCenterId(), vmId, vmDiskStat.getVolumeId(), ioRead, ioWrite, vmDiskStat.getAggIORead(),
                         vmDiskStat.getAggIOWrite(), bytesRead, bytesWrite, vmDiskStat.getAggBytesRead(), vmDiskStat.getAggBytesWrite(), timestamp);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("creating vmDiskHelperEntry... accountId: " + vmDiskStat.getAccountId() + " in zone: " + vmDiskStat.getDataCenterId() + "; aiw: " +
+        if (logger.isDebugEnabled()) {
+            logger.debug("creating vmDiskHelperEntry... accountId: " + vmDiskStat.getAccountId() + " in zone: " + vmDiskStat.getDataCenterId() + "; aiw: " +
                     vmDiskStat.getAggIOWrite() + "; air: " + vmDiskStat.getAggIORead() + "; curAIR: " + currentAccountedIORead + "; curAIW: " + currentAccountedIOWrite +
                     "; uir: " + ioRead + "; uiw: " + ioWrite + "; abw: " + vmDiskStat.getAggBytesWrite() + "; abr: " + vmDiskStat.getAggBytesRead() + "; curABR: " +
                     currentAccountedBytesRead + "; curABW: " + currentAccountedBytesWrite + "; ubr: " + bytesRead + "; ubw: " + bytesWrite);
@@ -1325,8 +1323,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         String ipAddress = event.getResourceName();
 
         if (EventTypes.EVENT_NET_IP_ASSIGN.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("assigning ip address: " + ipAddress + " to account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("assigning ip address: " + ipAddress + " to account: " + event.getAccountId());
             }
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
             long zoneId = event.getZoneId();
@@ -1344,12 +1342,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("released", SearchCriteria.Op.NULL);
             List<UsageIPAddressVO> ipAddressVOs = _usageIPAddressDao.search(sc, null);
             if (ipAddressVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for ip address: " + ipAddress + " assigned to account: " + event.getAccountId() +
+                logger.warn("More that one usage entry for ip address: " + ipAddress + " assigned to account: " + event.getAccountId() +
                         "; marking them all as released...");
             }
             for (UsageIPAddressVO ipAddressVO : ipAddressVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("releasing ip address: " + ipAddressVO.getAddress() + " from account: " + ipAddressVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("releasing ip address: " + ipAddressVO.getAddress() + " from account: " + ipAddressVO.getAccountId());
                 }
                 ipAddressVO.setReleased(event.getCreateDate()); // there really shouldn't be more than one
                 _usageIPAddressDao.update(ipAddressVO);
@@ -1369,18 +1367,18 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             List<UsageVolumeVO> volumesVOs = _usageVolumeDao.search(sc, null);
             if (volumesVOs.size() > 0) {
                 //This is a safeguard to avoid double counting of volumes.
-                s_logger.error("Found duplicate usage entry for volume: " + volId + " assigned to account: " + event.getAccountId() + "; marking as deleted...");
+                logger.error("Found duplicate usage entry for volume: " + volId + " assigned to account: " + event.getAccountId() + "; marking as deleted...");
             }
             //an entry exists if it is a resize volume event. marking the existing deleted and creating a new one in the case of resize.
             for (UsageVolumeVO volumesVO : volumesVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting volume: " + volumesVO.getId() + " from account: " + volumesVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting volume: " + volumesVO.getId() + " from account: " + volumesVO.getAccountId());
                 }
                 volumesVO.setDeleted(event.getCreateDate());
                 _usageVolumeDao.update(volumesVO);
             }
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("create volume with id : " + volId + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("create volume with id : " + volId + " for account: " + event.getAccountId());
             }
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
             UsageVolumeVO volumeVO = new UsageVolumeVO(volId, event.getZoneId(), event.getAccountId(), acct.getDomainId(), event.getOfferingId(), event.getTemplateId(), event.getSize(), event.getCreateDate(), null);
@@ -1392,11 +1390,11 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsageVolumeVO> volumesVOs = _usageVolumeDao.search(sc, null);
             if (volumesVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for volume: " + volId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
+                logger.warn("More that one usage entry for volume: " + volId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
             }
             for (UsageVolumeVO volumesVO : volumesVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting volume: " + volumesVO.getId() + " from account: " + volumesVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting volume: " + volumesVO.getId() + " from account: " + volumesVO.getAccountId());
                 }
                 volumesVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageVolumeDao.update(volumesVO);
@@ -1415,22 +1413,22 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         if (EventTypes.EVENT_TEMPLATE_CREATE.equals(event.getType()) || EventTypes.EVENT_TEMPLATE_COPY.equals(event.getType())) {
             templateSize = event.getSize();
             if (templateSize < 1) {
-                s_logger.error("Incorrect size for template with Id " + templateId);
+                logger.error("Incorrect size for template with Id " + templateId);
                 return;
             }
             if (zoneId == -1L) {
-                s_logger.error("Incorrect zoneId for template with Id " + templateId);
+                logger.error("Incorrect zoneId for template with Id " + templateId);
                 return;
             }
         }
 
         if (EventTypes.EVENT_TEMPLATE_CREATE.equals(event.getType()) || EventTypes.EVENT_TEMPLATE_COPY.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("create template with id : " + templateId + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("create template with id : " + templateId + " for account: " + event.getAccountId());
             }
             List<UsageStorageVO> storageVOs = _usageStorageDao.listByIdAndZone(event.getAccountId(), templateId, StorageTypes.TEMPLATE, zoneId);
             if (storageVOs.size() > 0) {
-                s_logger.warn("Usage entry for Template: " + templateId + " assigned to account: " + event.getAccountId() + "already exists in zone " + zoneId);
+                logger.warn("Usage entry for Template: " + templateId + " assigned to account: " + event.getAccountId() + "already exists in zone " + zoneId);
                 return;
             }
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
@@ -1446,12 +1444,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 storageVOs = _usageStorageDao.listById(event.getAccountId(), templateId, StorageTypes.TEMPLATE);
             }
             if (storageVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for storage: " + templateId + " assigned to account: " + event.getAccountId() +
+                logger.warn("More that one usage entry for storage: " + templateId + " assigned to account: " + event.getAccountId() +
                         "; marking them all as deleted...");
             }
             for (UsageStorageVO storageVO : storageVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting template: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting template: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
                 }
                 storageVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageStorageDao.update(storageVO);
@@ -1469,12 +1467,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         }
 
         if (EventTypes.EVENT_ISO_CREATE.equals(event.getType()) || EventTypes.EVENT_ISO_COPY.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("create iso with id : " + isoId + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("create iso with id : " + isoId + " for account: " + event.getAccountId());
             }
             List<UsageStorageVO> storageVOs = _usageStorageDao.listByIdAndZone(event.getAccountId(), isoId, StorageTypes.ISO, zoneId);
             if (storageVOs.size() > 0) {
-                s_logger.warn("Usage entry for ISO: " + isoId + " assigned to account: " + event.getAccountId() + "already exists in zone " + zoneId);
+                logger.warn("Usage entry for ISO: " + isoId + " assigned to account: " + event.getAccountId() + "already exists in zone " + zoneId);
                 return;
             }
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
@@ -1490,11 +1488,11 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             }
 
             if (storageVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for storage: " + isoId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
+                logger.warn("More that one usage entry for storage: " + isoId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
             }
             for (UsageStorageVO storageVO : storageVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting iso: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting iso: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
                 }
                 storageVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageStorageDao.update(storageVO);
@@ -1513,8 +1511,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         }
 
         if (EventTypes.EVENT_SNAPSHOT_CREATE.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("create snapshot with id : " + snapId + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("create snapshot with id : " + snapId + " for account: " + event.getAccountId());
             }
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
             UsageStorageVO storageVO =
@@ -1523,11 +1521,11 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         } else if (EventTypes.EVENT_SNAPSHOT_DELETE.equals(event.getType())) {
             List<UsageStorageVO> storageVOs = _usageStorageDao.listById(event.getAccountId(), snapId, StorageTypes.SNAPSHOT);
             if (storageVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for storage: " + snapId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
+                logger.warn("More that one usage entry for storage: " + snapId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
             }
             for (UsageStorageVO storageVO : storageVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting snapshot: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting snapshot: " + storageVO.getId() + " from account: " + storageVO.getAccountId());
                 }
                 storageVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageStorageDao.update(storageVO);
@@ -1542,8 +1540,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long id = event.getResourceId();
 
         if (EventTypes.EVENT_LOAD_BALANCER_CREATE.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Creating load balancer : " + id + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Creating load balancer : " + id + " for account: " + event.getAccountId());
             }
             zoneId = event.getZoneId();
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
@@ -1556,12 +1554,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsageLoadBalancerPolicyVO> lbVOs = _usageLoadBalancerPolicyDao.search(sc, null);
             if (lbVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for load balancer policy: " + id + " assigned to account: " + event.getAccountId() +
+                logger.warn("More that one usage entry for load balancer policy: " + id + " assigned to account: " + event.getAccountId() +
                         "; marking them all as deleted...");
             }
             for (UsageLoadBalancerPolicyVO lbVO : lbVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting load balancer policy: " + lbVO.getId() + " from account: " + lbVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting load balancer policy: " + lbVO.getId() + " from account: " + lbVO.getAccountId());
                 }
                 lbVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageLoadBalancerPolicyDao.update(lbVO);
@@ -1576,8 +1574,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long id = event.getResourceId();
 
         if (EventTypes.EVENT_NET_RULE_ADD.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Creating port forwarding rule : " + id + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Creating port forwarding rule : " + id + " for account: " + event.getAccountId());
             }
             zoneId = event.getZoneId();
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
@@ -1590,12 +1588,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsagePortForwardingRuleVO> pfVOs = _usagePortForwardingRuleDao.search(sc, null);
             if (pfVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for port forwarding rule: " + id + " assigned to account: " + event.getAccountId() +
+                logger.warn("More that one usage entry for port forwarding rule: " + id + " assigned to account: " + event.getAccountId() +
                         "; marking them all as deleted...");
             }
             for (UsagePortForwardingRuleVO pfVO : pfVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting port forwarding rule: " + pfVO.getId() + " from account: " + pfVO.getAccountId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting port forwarding rule: " + pfVO.getId() + " from account: " + pfVO.getAccountId());
                 }
                 pfVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usagePortForwardingRuleDao.update(pfVO);
@@ -1613,12 +1611,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         try {
             nicId = Long.parseLong(event.getResourceName());
         } catch (Exception e) {
-            s_logger.warn("failed to get nic id from resource name, resource name is: " + event.getResourceName());
+            logger.warn("failed to get nic id from resource name, resource name is: " + event.getResourceName());
         }
 
         if (EventTypes.EVENT_NETWORK_OFFERING_CREATE.equals(event.getType()) || EventTypes.EVENT_NETWORK_OFFERING_ASSIGN.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Creating networking offering: " + networkOfferingId + " for Vm: " + vmId + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Creating networking offering: " + networkOfferingId + " for Vm: " + vmId + " for account: " + event.getAccountId());
             }
             zoneId = event.getZoneId();
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
@@ -1635,12 +1633,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsageNetworkOfferingVO> noVOs = _usageNetworkOfferingDao.search(sc, null);
             if (noVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for networking offering: " + networkOfferingId + " for Vm: " + vmId + " assigned to account: " +
+                logger.warn("More that one usage entry for networking offering: " + networkOfferingId + " for Vm: " + vmId + " assigned to account: " +
                         event.getAccountId() + "; marking them all as deleted...");
             }
             for (UsageNetworkOfferingVO noVO : noVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting network offering: " + noVO.getNetworkOfferingId() + " from Vm: " + noVO.getVmInstanceId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting network offering: " + noVO.getNetworkOfferingId() + " from Vm: " + noVO.getVmInstanceId());
                 }
                 noVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageNetworkOfferingDao.update(noVO);
@@ -1655,8 +1653,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long userId = event.getResourceId();
 
         if (EventTypes.EVENT_VPN_USER_ADD.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Creating VPN user: " + userId + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Creating VPN user: " + userId + " for account: " + event.getAccountId());
             }
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
             String userName = event.getResourceName();
@@ -1669,11 +1667,11 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsageVPNUserVO> vuVOs = _usageVPNUserDao.search(sc, null);
             if (vuVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for vpn user: " + userId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
+                logger.warn("More that one usage entry for vpn user: " + userId + " assigned to account: " + event.getAccountId() + "; marking them all as deleted...");
             }
             for (UsageVPNUserVO vuVO : vuVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting vpn user: " + vuVO.getUserId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting vpn user: " + vuVO.getUserId());
                 }
                 vuVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageVPNUserDao.update(vuVO);
@@ -1689,8 +1687,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         long sgId = event.getOfferingId();
 
         if (EventTypes.EVENT_SECURITY_GROUP_ASSIGN.equals(event.getType())) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Assigning : security group" + sgId + " to Vm: " + vmId + " for account: " + event.getAccountId());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Assigning : security group" + sgId + " to Vm: " + vmId + " for account: " + event.getAccountId());
             }
             zoneId = event.getZoneId();
             Account acct = _accountDao.findByIdIncludingRemoved(event.getAccountId());
@@ -1704,12 +1702,12 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             sc.addAnd("deleted", SearchCriteria.Op.NULL);
             List<UsageSecurityGroupVO> sgVOs = _usageSecurityGroupDao.search(sc, null);
             if (sgVOs.size() > 1) {
-                s_logger.warn("More that one usage entry for security group: " + sgId + " for Vm: " + vmId + " assigned to account: " + event.getAccountId() +
+                logger.warn("More that one usage entry for security group: " + sgId + " for Vm: " + vmId + " assigned to account: " + event.getAccountId() +
                         "; marking them all as deleted...");
             }
             for (UsageSecurityGroupVO sgVO : sgVOs) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("deleting security group: " + sgVO.getSecurityGroupId() + " from Vm: " + sgVO.getVmInstanceId());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("deleting security group: " + sgVO.getSecurityGroupId() + " from Vm: " + sgVO.getVmInstanceId());
                 }
                 sgVO.setDeleted(event.getCreateDate()); // there really shouldn't be more than one
                 _usageSecurityGroupDao.update(sgVO);
@@ -1738,8 +1736,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
             TransactionLegacy usageTxn = TransactionLegacy.open(TransactionLegacy.USAGE_DB);
             try {
                 if (!_heartbeatLock.lock(3)) { // 3 second timeout
-                    if (s_logger.isTraceEnabled())
-                        s_logger.trace("Heartbeat lock is in use by others, returning true as someone else will take over the job if required");
+                    if (logger.isTraceEnabled())
+                        logger.trace("Heartbeat lock is in use by others, returning true as someone else will take over the job if required");
                     return;
                 }
 
@@ -1769,8 +1767,8 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
 
                         if ((timeSinceJob > 0) && (timeSinceJob > (aggregationDurationMillis - 100))) {
                             if (timeToJob > (aggregationDurationMillis / 2)) {
-                                if (s_logger.isDebugEnabled()) {
-                                    s_logger.debug("it's been " + timeSinceJob + " ms since last usage job and " + timeToJob +
+                                if (logger.isDebugEnabled()) {
+                                    logger.debug("it's been " + timeSinceJob + " ms since last usage job and " + timeToJob +
                                             " ms until next job, scheduling an immediate job to catch up (aggregation duration is " + _aggregationDuration + " minutes)");
                                 }
                                 scheduleParse();
@@ -1786,7 +1784,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                     _heartbeatLock.unlock();
                 }
             } catch (Exception ex) {
-                s_logger.error("error in heartbeat", ex);
+                logger.error("error in heartbeat", ex);
             } finally {
                 usageTxn.close();
             }
@@ -1821,7 +1819,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                 txn.commit();
             } catch (Exception dbEx) {
                 txn.rollback();
-                s_logger.error("error updating usage job", dbEx);
+                logger.error("error updating usage job", dbEx);
             }
             return changeOwner;
         }
@@ -1852,7 +1850,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
                     _alertMgr.clearAlert(AlertManager.AlertType.ALERT_TYPE_USAGE_SANITY_RESULT, 0, 0);
                 }
             } catch (SQLException e) {
-                s_logger.error("Error in sanity check", e);
+                logger.error("Error in sanity check", e);
             }
         }
     }

--- a/utils/src/main/java/com/cloud/utils/component/ComponentLifecycleBase.java
+++ b/utils/src/main/java/com/cloud/utils/component/ComponentLifecycleBase.java
@@ -27,7 +27,7 @@ import javax.naming.ConfigurationException;
 import org.apache.log4j.Logger;
 
 public class ComponentLifecycleBase implements ComponentLifecycle {
-    private static final Logger s_logger = Logger.getLogger(ComponentLifecycleBase.class);
+    protected Logger logger = Logger.getLogger(getClass());
 
     protected String _name;
     protected int _runLevel;

--- a/utils/src/main/java/org/apache/cloudstack/utils/identity/ManagementServerNode.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/identity/ManagementServerNode.java
@@ -21,7 +21,6 @@ package org.apache.cloudstack.utils.identity;
 
 import javax.ejb.Local;
 
-import org.apache.log4j.Logger;
 
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.component.ComponentLifecycle;
@@ -31,7 +30,6 @@ import com.cloud.utils.net.MacAddress;
 
 @Local(value = {SystemIntegrityChecker.class})
 public class ManagementServerNode extends AdapterBase implements SystemIntegrityChecker {
-    private static final Logger s_logger = Logger.getLogger(ManagementServerNode.class);
 
     private static final long s_nodeId = MacAddress.getMacAddress().toLong();
 
@@ -55,7 +53,7 @@ public class ManagementServerNode extends AdapterBase implements SystemIntegrity
         try {
             check();
         } catch (Exception e) {
-            s_logger.error("System integrity check exception", e);
+            logger.error("System integrity check exception", e);
             System.exit(1);
         }
         return true;


### PR DESCRIPTION
Hi guys, 
We have noticed that every single class that is a subclass of “ComponentLifecycleBase” instantiate their on “logger” manually and uses a nonstandard name. We fixed that by changing the variable in “ComponentLifecycleBase” to protected and non-static and instantiated it using the method “getClass” from Object class. Therefore, we can reduce the code in a few hundred lines and use a more intuitive name for the logger variable.

During that process we found a static method that used the “s_logger” variable in classes:
com.cloud.network.element.VirtualRouterElement 
org.apache.cloudstack.network.element.InternalLoadBalancerElement 

To fix that we had to create a new class “com.cloud.network.element.HAProxyLBRule”, instantiate it with @Componente and inject into the aforementioned classes.

The class that we create is “com.cloud.network.element.HAProxyLBRule” and has the following methods:
com.cloud.network.element.HAProxyLBRule.containsOnlyNumbers(String, String)
com.cloud.network.element.HAProxyLBRule.validateHAProxyLBRule(LoadBalancingRule)

Sadly we could not write test cases to it; hence we did not fully understand those methods. However, if anyone out there understands it, we would appreciate some code to be added to it.

As minor this change may seem; we believe that it enhances a little bit the ACS code by using standard name to logger variable.

