### PR TITLE
CLOUDSTACK-8748: VM UUID accessible in CreateVMSnapshotCommand and Re…

### DIFF
--- a/core/src/com/cloud/agent/api/CreateVMSnapshotCommand.java
+++ b/core/src/com/cloud/agent/api/CreateVMSnapshotCommand.java
@@ -25,8 +25,14 @@ import org.apache.cloudstack.storage.to.VolumeObjectTO;
 
 
 public class CreateVMSnapshotCommand extends VMSnapshotBaseCommand {
+    private String vmUuid;
 
-    public CreateVMSnapshotCommand(String vmName, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
+    public CreateVMSnapshotCommand(String vmName, String vmUuid, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
         super(vmName, snapshot, volumeTOs, guestOSType);
+        this.vmUuid = vmUuid;
+    }
+
+    public String getVmUuid() {
+        return vmUuid;
     }
 }

--- a/core/src/com/cloud/agent/api/RevertToVMSnapshotCommand.java
+++ b/core/src/com/cloud/agent/api/RevertToVMSnapshotCommand.java
@@ -25,16 +25,18 @@ import org.apache.cloudstack.storage.to.VolumeObjectTO;
 
 public class RevertToVMSnapshotCommand extends VMSnapshotBaseCommand {
 
-    public RevertToVMSnapshotCommand(String vmName, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
+    public RevertToVMSnapshotCommand(String vmName, String vmUuid, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
         super(vmName, snapshot, volumeTOs, guestOSType);
+        this.vmUuid = vmUuid;
     }
 
-    public RevertToVMSnapshotCommand(String vmName, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType, boolean reloadVm) {
-        this(vmName, snapshot, volumeTOs, guestOSType);
+    public RevertToVMSnapshotCommand(String vmName, String vmUuid, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType, boolean reloadVm) {
+        this(vmName, vmUuid, snapshot, volumeTOs, guestOSType);
         setReloadVm(reloadVm);
     }
 
     private boolean reloadVm = false;
+    private String vmUuid;
 
     public boolean isReloadVm() {
         return reloadVm;
@@ -42,5 +44,9 @@ public class RevertToVMSnapshotCommand extends VMSnapshotBaseCommand {
 
     public void setReloadVm(boolean reloadVm) {
         this.reloadVm = reloadVm;
+    }
+
+    public String getVmUuid() {
+        return vmUuid;
     }
 }

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
@@ -137,7 +137,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
             HostVO host = hostDao.findById(hostId);
             GuestOSHypervisorVO guestOsMapping = guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), host.getHypervisorType().toString(), host.getHypervisorVersion());
 
-            CreateVMSnapshotCommand ccmd = new CreateVMSnapshotCommand(userVm.getInstanceName(), target, volumeTOs, guestOS.getDisplayName());
+            CreateVMSnapshotCommand ccmd = new CreateVMSnapshotCommand(userVm.getInstanceName(), userVm.getUuid(), target, volumeTOs, guestOS.getDisplayName());
             if (guestOsMapping == null) {
                 ccmd.setPlatformEmulator(null);
             } else {
@@ -350,7 +350,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
                     snapshot.getCurrent(), parent, true);
             Long hostId = vmSnapshotHelper.pickRunningHost(vmSnapshot.getVmId());
             GuestOSVO guestOS = guestOSDao.findById(userVm.getGuestOSId());
-            RevertToVMSnapshotCommand revertToSnapshotCommand = new RevertToVMSnapshotCommand(vmInstanceName, vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
+            RevertToVMSnapshotCommand revertToSnapshotCommand = new RevertToVMSnapshotCommand(vmInstanceName, userVm.getUuid(), vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
             HostVO host = hostDao.findById(hostId);
             GuestOSHypervisorVO guestOsMapping = guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), host.getHypervisorType().toString(), host.getHypervisorVersion());
             if (guestOsMapping == null) {

--- a/engine/storage/src/org/apache/cloudstack/storage/helper/HypervisorHelperImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/helper/HypervisorHelperImpl.java
@@ -124,7 +124,7 @@ public class HypervisorHelperImpl implements HypervisorHelper {
         GuestOSVO guestOS = guestOSDao.findById(virtualMachine.getGuestOSId());
         List<VolumeObjectTO> volumeTOs = vmSnapshotHelper.getVolumeTOList(virtualMachine.getId());
         CreateVMSnapshotCommand ccmd =
-            new CreateVMSnapshotCommand(virtualMachine.getInstanceName(), vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
+            new CreateVMSnapshotCommand(virtualMachine.getInstanceName(), virtualMachine.getUuid(), vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
         HostVO host = hostDao.findById(hostId);
         GuestOSHypervisorVO guestOsMapping = guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), host.getHypervisorType().toString(), host.getHypervisorVersion());
         ccmd.setPlatformEmulator(guestOsMapping.getGuestOsName());


### PR DESCRIPTION
…vertToVMSnapshotCommand

This patch makes it possible to expose VM UUID to subsystems, this can be
useful for implementing VM Snapshots for KVM in future.