### PR TITLE
CLOUDSTACK-8749: KVM - cleanup linklocal interface based on names

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -287,7 +287,7 @@ public class BridgeVifDriver extends VifDriverBase {
             for (String line : lines) {
                 String[] tokens = line.split(" ");
                 if (!tokens[2].equalsIgnoreCase(linkLocalBr)) {
-                    Script.runSimpleBashScript("ip route del " + NetUtils.getLinkLocalCIDR());
+                    Script.runSimpleBashScript("ip route del " + NetUtils.getLinkLocalCIDR() + " dev " + tokens[2]);
                 } else {
                     foundLinkLocalBr = true;
                 }


### PR DESCRIPTION
This tries to avoid cleaning by a device name.