### PR TITLE
Apply RHEL 7 fix for comounted cgroups to CentOS 7 KVM hypervisors as well

### DIFF
--- a/scripts/vm/hypervisor/kvm/setup-cgroups.sh
+++ b/scripts/vm/hypervisor/kvm/setup-cgroups.sh
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,20 +21,17 @@
 # Script to fix cgroups co-mounted issue
 # Applies to RHEL7 versions only
 # Detect if cpu,cpuacct cgroups are co-mounted
-# If co-mounted, unmount and mount them seperately 
+# If co-mounted, unmount and mount them seperately
 
 #set -x
 
-#Check distribution version for RHEL 
-if [ -f '/etc/redhat-release' ];
-then
-    #Check RHEL version for 7 
-   if grep 'Red Hat Enterprise Linux Server release 7' /etc/redhat-release > /dev/null
-   then
-        # Check if cgroups if co-mounted 
-        if [ -d '/sys/fs/cgroup/cpu,cpuacct' ];
-        then
-   	    # cgroups co-mounted. Requires remount
+# Check distribution version for RHEL
+if [ -f '/etc/redhat-release' ]; then
+    # Check RHEL version for 7
+    if grep 'Red Hat Enterprise Linux Server release 7' /etc/redhat-release > /dev/null; then
+        # Check if cgroups if co-mounted
+        if [ -d '/sys/fs/cgroup/cpu,cpuacct' ]; then
+            # cgroups co-mounted. Requires remount
             umount /sys/fs/cgroup/cpu,cpuacct
             rm /sys/fs/cgroup/cpu
             rm /sys/fs/cgroup/cpuacct
@@ -43,14 +40,13 @@ then
             mkdir -p /sys/fs/cgroup/cpuacct
             mount -t cgroup -o cpu cpu "/sys/fs/cgroup/cpu"
             mount -t cgroup -o cpuacct cpuacct "/sys/fs/cgroup/cpuacct"
-            # Verify that cgroups are not co-mounted 
-            if [ -d '/sys/fs/cgroup/cpu,cpuacct' ];
-            then
-   	        echo "cgroups still co-mounted"
-		exit 1;
-	    fi
-	fi    
-   fi
+            # Verify that cgroups are not co-mounted
+            if [ -d '/sys/fs/cgroup/cpu,cpuacct' ]; then
+               echo "cgroups still co-mounted"
+               exit 1;
+            fi
+        fi
+    fi
 fi
 
 exit 0

--- a/scripts/vm/hypervisor/kvm/setup-cgroups.sh
+++ b/scripts/vm/hypervisor/kvm/setup-cgroups.sh
@@ -19,7 +19,7 @@
 
 
 # Script to fix cgroups co-mounted issue
-# Applies to RHEL7 versions only
+# Applies to RHEL 7 versions (and family member CentOS 7) only
 # Detect if cpu,cpuacct cgroups are co-mounted
 # If co-mounted, unmount and mount them seperately
 
@@ -28,7 +28,7 @@
 # Check distribution version for RHEL
 if [ -f '/etc/redhat-release' ]; then
     # Check RHEL version for 7
-    if grep 'Red Hat Enterprise Linux Server release 7' /etc/redhat-release > /dev/null; then
+    if grep -E 'Red Hat Enterprise Linux Server release 7|CentOS Linux release 7' /etc/redhat-release > /dev/null; then
         # Check if cgroups if co-mounted
         if [ -d '/sys/fs/cgroup/cpu,cpuacct' ]; then
             # cgroups co-mounted. Requires remount


### PR DESCRIPTION
The RHEL 7 version string is hard coded and misses CentOS 7.