### PR TITLE
Fixing syntax error introduced in PR #717

### DIFF
--- a/core/src/com/cloud/agent/api/CreateVMSnapshotCommand.java
+++ b/core/src/com/cloud/agent/api/CreateVMSnapshotCommand.java
@@ -25,8 +25,14 @@ import org.apache.cloudstack.storage.to.VolumeObjectTO;
 
 
 public class CreateVMSnapshotCommand extends VMSnapshotBaseCommand {
+    private String vmUuid;
 
-    public CreateVMSnapshotCommand(String vmName, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
+    public CreateVMSnapshotCommand(String vmName, String vmUuid, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
         super(vmName, snapshot, volumeTOs, guestOSType);
+        this.vmUuid = vmUuid;
+    }
+
+    public String getVmUuid() {
+        return vmUuid;
     }
 }

--- a/core/src/com/cloud/agent/api/RevertToVMSnapshotCommand.java
+++ b/core/src/com/cloud/agent/api/RevertToVMSnapshotCommand.java
@@ -25,16 +25,18 @@ import org.apache.cloudstack.storage.to.VolumeObjectTO;
 
 public class RevertToVMSnapshotCommand extends VMSnapshotBaseCommand {
 
-    public RevertToVMSnapshotCommand(String vmName, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
+    public RevertToVMSnapshotCommand(String vmName, String vmUuid, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType) {
         super(vmName, snapshot, volumeTOs, guestOSType);
+        this.vmUuid = vmUuid;
     }
 
-    public RevertToVMSnapshotCommand(String vmName, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType, boolean reloadVm) {
-        this(vmName, snapshot, volumeTOs, guestOSType);
+    public RevertToVMSnapshotCommand(String vmName, String vmUuid, VMSnapshotTO snapshot, List<VolumeObjectTO> volumeTOs, String guestOSType, boolean reloadVm) {
+        this(vmName, vmUuid, snapshot, volumeTOs, guestOSType);
         setReloadVm(reloadVm);
     }
 
     private boolean reloadVm = false;
+    private String vmUuid;
 
     public boolean isReloadVm() {
         return reloadVm;
@@ -42,5 +44,9 @@ public class RevertToVMSnapshotCommand extends VMSnapshotBaseCommand {
 
     public void setReloadVm(boolean reloadVm) {
         this.reloadVm = reloadVm;
+    }
+
+    public String getVmUuid() {
+        return vmUuid;
     }
 }

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
@@ -137,7 +137,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
             HostVO host = hostDao.findById(hostId);
             GuestOSHypervisorVO guestOsMapping = guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), host.getHypervisorType().toString(), host.getHypervisorVersion());
 
-            CreateVMSnapshotCommand ccmd = new CreateVMSnapshotCommand(userVm.getInstanceName(), target, volumeTOs, guestOS.getDisplayName());
+            CreateVMSnapshotCommand ccmd = new CreateVMSnapshotCommand(userVm.getInstanceName(), userVm.getUuid(), target, volumeTOs, guestOS.getDisplayName());
             if (guestOsMapping == null) {
                 ccmd.setPlatformEmulator(null);
             } else {
@@ -350,7 +350,7 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
                     snapshot.getCurrent(), parent, true);
             Long hostId = vmSnapshotHelper.pickRunningHost(vmSnapshot.getVmId());
             GuestOSVO guestOS = guestOSDao.findById(userVm.getGuestOSId());
-            RevertToVMSnapshotCommand revertToSnapshotCommand = new RevertToVMSnapshotCommand(vmInstanceName, vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
+            RevertToVMSnapshotCommand revertToSnapshotCommand = new RevertToVMSnapshotCommand(vmInstanceName, userVm.getUuid(), vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
             HostVO host = hostDao.findById(hostId);
             GuestOSHypervisorVO guestOsMapping = guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), host.getHypervisorType().toString(), host.getHypervisorVersion());
             if (guestOsMapping == null) {

--- a/engine/storage/src/org/apache/cloudstack/storage/helper/HypervisorHelperImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/helper/HypervisorHelperImpl.java
@@ -124,7 +124,7 @@ public class HypervisorHelperImpl implements HypervisorHelper {
         GuestOSVO guestOS = guestOSDao.findById(virtualMachine.getGuestOSId());
         List<VolumeObjectTO> volumeTOs = vmSnapshotHelper.getVolumeTOList(virtualMachine.getId());
         CreateVMSnapshotCommand ccmd =
-            new CreateVMSnapshotCommand(virtualMachine.getInstanceName(), vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
+            new CreateVMSnapshotCommand(virtualMachine.getInstanceName(), virtualMachine.getUuid(), vmSnapshotTO, volumeTOs, guestOS.getDisplayName());
         HostVO host = hostDao.findById(hostId);
         GuestOSHypervisorVO guestOsMapping = guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), host.getHypervisorType().toString(), host.getHypervisorVersion());
         ccmd.setPlatformEmulator(guestOsMapping.getGuestOsName());

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
@@ -144,7 +144,6 @@ import com.xensource.xenapi.Types.XenAPIException;
 import com.xensource.xenapi.VM;
 import com.xensource.xenapi.VMGuestMetrics;
 
-
 @RunWith(MockitoJUnitRunner.class)
 public class CitrixRequestWrapperTest {
 
@@ -471,7 +470,7 @@ public class CitrixRequestWrapperTest {
         final StoragePoolVO poolVO = Mockito.mock(StoragePoolVO.class);
 
         final UpgradeSnapshotCommand upgradeSnapshotCommand = new UpgradeSnapshotCommand(poolVO, "http", 1l, 1l, 1l, 1l, 1l, "/", "58c5778b-7dd1-47cc-a7b5-f768541bf278", "Test",
-                "2.1");
+                        "2.1");
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -487,7 +486,7 @@ public class CitrixRequestWrapperTest {
         final StoragePoolVO poolVO = Mockito.mock(StoragePoolVO.class);
 
         final UpgradeSnapshotCommand upgradeSnapshotCommand = new UpgradeSnapshotCommand(poolVO, "http", 1l, 1l, 1l, 1l, 1l, "/", "58c5778b-7dd1-47cc-a7b5-f768541bf278", "Test",
-                "3.1");
+                        "3.1");
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -832,8 +831,9 @@ public class CitrixRequestWrapperTest {
         try {
             when(network.getBridge(conn)).thenReturn(bridge);
             when(
-                    citrixResourceBase.callHostPlugin(conn, "ovsgre", "ovs_create_gre", "bridge", bridge, "remoteIP", createGreCommand.getRemoteIp(), "greKey",
-                            createGreCommand.getKey(), "from", Long.toString(createGreCommand.getFrom()), "to", Long.toString(createGreCommand.getTo()))).thenReturn("1:2");
+                            citrixResourceBase.callHostPlugin(conn, "ovsgre", "ovs_create_gre", "bridge", bridge, "remoteIP", createGreCommand.getRemoteIp(), "greKey",
+                                            createGreCommand.getKey(), "from", Long.toString(createGreCommand.getFrom()), "to", Long.toString(createGreCommand.getTo()))).thenReturn(
+                            "1:2");
 
         } catch (final BadServerResponse e) {
             fail(e.getMessage());
@@ -938,8 +938,9 @@ public class CitrixRequestWrapperTest {
             when(network.getBridge(conn)).thenReturn(bridge);
 
             when(
-                    citrixResourceBase.callHostPlugin(conn, "ovstunnel", "configure_ovs_bridge_for_network_topology", "bridge", bridge, "config",
-                            physicalTopology.getVpcConfigInJson(), "host-id", ((Long) physicalTopology.getHostId()).toString(), "seq-no", Long.toString(1))).thenReturn("SUCCESS");
+                            citrixResourceBase.callHostPlugin(conn, "ovstunnel", "configure_ovs_bridge_for_network_topology", "bridge", bridge, "config",
+                                            physicalTopology.getVpcConfigInJson(), "host-id", ((Long) physicalTopology.getHostId()).toString(), "seq-no", Long.toString(1))).thenReturn(
+                            "SUCCESS");
 
         } catch (final BadServerResponse e) {
             fail(e.getMessage());
@@ -976,8 +977,9 @@ public class CitrixRequestWrapperTest {
             when(network.getBridge(conn)).thenReturn(bridge);
 
             when(
-                    citrixResourceBase.callHostPlugin(conn, "ovstunnel", "configure_ovs_bridge_for_routing_policies", "bridge", bridge, "host-id",
-                            ((Long) routingPolicy.getHostId()).toString(), "config", routingPolicy.getVpcConfigInJson(), "seq-no", Long.toString(1))).thenReturn("SUCCESS");
+                            citrixResourceBase.callHostPlugin(conn, "ovstunnel", "configure_ovs_bridge_for_routing_policies", "bridge", bridge, "host-id",
+                                            ((Long) routingPolicy.getHostId()).toString(), "config", routingPolicy.getVpcConfigInJson(), "seq-no", Long.toString(1))).thenReturn(
+                            "SUCCESS");
 
         } catch (final BadServerResponse e) {
             fail(e.getMessage());
@@ -1129,9 +1131,9 @@ public class CitrixRequestWrapperTest {
             when(network.getBridge(conn)).thenReturn(bridge);
 
             when(citrixResourceBase.callHostPlugin(conn, "ovstunnel", "create_tunnel", "bridge", bridge, "remote_ip", createTunnel.getRemoteIp(),
-                    "key", createTunnel.getKey().toString(), "from",
-                    createTunnel.getFrom().toString(), "to", createTunnel.getTo().toString(), "cloudstack-network-id",
-                    createTunnel.getNetworkUuid())).thenReturn("SUCCESS:0");
+                            "key", createTunnel.getKey().toString(), "from",
+                            createTunnel.getFrom().toString(), "to", createTunnel.getTo().toString(), "cloudstack-network-id",
+                            createTunnel.getNetworkUuid())).thenReturn("SUCCESS:0");
 
         } catch (final BadServerResponse e) {
             fail(e.getMessage());
@@ -1166,9 +1168,9 @@ public class CitrixRequestWrapperTest {
             when(network.getBridge(conn)).thenReturn(bridge);
 
             when(citrixResourceBase.callHostPlugin(conn, "ovstunnel", "create_tunnel", "bridge", bridge, "remote_ip", createTunnel.getRemoteIp(),
-                    "key", createTunnel.getKey().toString(), "from",
-                    createTunnel.getFrom().toString(), "to", createTunnel.getTo().toString(), "cloudstack-network-id",
-                    createTunnel.getNetworkUuid())).thenReturn("FAIL:1");
+                            "key", createTunnel.getKey().toString(), "from",
+                            createTunnel.getFrom().toString(), "to", createTunnel.getTo().toString(), "cloudstack-network-id",
+                            createTunnel.getNetworkUuid())).thenReturn("FAIL:1");
 
         } catch (final BadServerResponse e) {
             fail(e.getMessage());
@@ -1216,7 +1218,6 @@ public class CitrixRequestWrapperTest {
 
         when(citrixResourceBase.getConnection()).thenReturn(conn);
 
-
         final Answer answer = wrapper.execute(setupBridge, citrixResourceBase);
 
         verify(citrixResourceBase, times(1)).getConnection();
@@ -1260,7 +1261,7 @@ public class CitrixRequestWrapperTest {
         final Connection conn = Mockito.mock(Connection.class);
         final Network network = Mockito.mock(Network.class);
 
-        final OvsDestroyTunnelCommand destroyTunnel = new OvsDestroyTunnelCommand(1l,  "net01", "port11");
+        final OvsDestroyTunnelCommand destroyTunnel = new OvsDestroyTunnelCommand(1l, "net01", "port11");
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -1293,7 +1294,7 @@ public class CitrixRequestWrapperTest {
         final Connection conn = Mockito.mock(Connection.class);
         final Network network = Mockito.mock(Network.class);
 
-        final OvsDestroyTunnelCommand destroyTunnel = new OvsDestroyTunnelCommand(1l,  "net01", "port11");
+        final OvsDestroyTunnelCommand destroyTunnel = new OvsDestroyTunnelCommand(1l, "net01", "port11");
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -1339,7 +1340,8 @@ public class CitrixRequestWrapperTest {
         cmdLine.append(XenServerUtilitiesHelper.SCRIPT_CMD_PATH).append(VRScripts.UPDATE_HOST_PASSWD).append(' ').append(username).append(' ').append(newPassword);
 
         when(citrixResourceBase.getXenServerUtilitiesHelper()).thenReturn(xenServerUtilitiesHelper);
-        when(xenServerUtilitiesHelper.buildCommandLine(XenServerUtilitiesHelper.SCRIPT_CMD_PATH, VRScripts.UPDATE_HOST_PASSWD, username, newPassword)).thenReturn(cmdLine.toString());
+        when(xenServerUtilitiesHelper.buildCommandLine(XenServerUtilitiesHelper.SCRIPT_CMD_PATH, VRScripts.UPDATE_HOST_PASSWD, username, newPassword)).thenReturn(
+                        cmdLine.toString());
 
         try {
             when(xenServerUtilitiesHelper.executeSshWrapper(hostIp, 22, username, null, hostPasswd, cmdLine.toString())).thenReturn(result);
@@ -1387,7 +1389,8 @@ public class CitrixRequestWrapperTest {
         cmdLine.append(XenServerUtilitiesHelper.SCRIPT_CMD_PATH).append(VRScripts.UPDATE_HOST_PASSWD).append(' ').append(username).append(' ').append(newPassword);
 
         when(citrixResourceBase.getXenServerUtilitiesHelper()).thenReturn(xenServerUtilitiesHelper);
-        when(xenServerUtilitiesHelper.buildCommandLine(XenServerUtilitiesHelper.SCRIPT_CMD_PATH, VRScripts.UPDATE_HOST_PASSWD, username, newPassword)).thenReturn(cmdLine.toString());
+        when(xenServerUtilitiesHelper.buildCommandLine(XenServerUtilitiesHelper.SCRIPT_CMD_PATH, VRScripts.UPDATE_HOST_PASSWD, username, newPassword)).thenReturn(
+                        cmdLine.toString());
 
         try {
             when(xenServerUtilitiesHelper.executeSshWrapper(hostIp, 22, username, null, hostPasswd, cmdLine.toString())).thenReturn(result);
@@ -1433,7 +1436,8 @@ public class CitrixRequestWrapperTest {
         cmdLine.append(XenServerUtilitiesHelper.SCRIPT_CMD_PATH).append(VRScripts.UPDATE_HOST_PASSWD).append(' ').append(username).append(' ').append(newPassword);
 
         when(citrixResourceBase.getXenServerUtilitiesHelper()).thenReturn(xenServerUtilitiesHelper);
-        when(xenServerUtilitiesHelper.buildCommandLine(XenServerUtilitiesHelper.SCRIPT_CMD_PATH, VRScripts.UPDATE_HOST_PASSWD, username, newPassword)).thenReturn(cmdLine.toString());
+        when(xenServerUtilitiesHelper.buildCommandLine(XenServerUtilitiesHelper.SCRIPT_CMD_PATH, VRScripts.UPDATE_HOST_PASSWD, username, newPassword)).thenReturn(
+                        cmdLine.toString());
 
         try {
             when(xenServerUtilitiesHelper.executeSshWrapper(hostIp, 22, username, null, hostPasswd, cmdLine.toString())).thenThrow(new Exception("testing failure"));
@@ -1468,7 +1472,7 @@ public class CitrixRequestWrapperTest {
         final Pool pool = PowerMockito.mock(Pool.class);
         final Pool.Record poolr = Mockito.mock(Pool.Record.class);
         final Host.Record hostr = Mockito.mock(Host.Record.class);
-        final Host master =  Mockito.mock(Host.class);
+        final Host master = Mockito.mock(Host.class);
 
         final ClusterVMMetaDataSyncCommand vmDataSync = new ClusterVMMetaDataSyncCommand(10, 1l);
 
@@ -1645,7 +1649,7 @@ public class CitrixRequestWrapperTest {
 
         when(citrixResourceBase.getConnection()).thenReturn(conn);
         when(citrixResourceBase.callHostPlugin(conn, "vmops", "network_rules_vmSecondaryIp", "vmName", rulesVm.getVmName(), "vmMac", rulesVm.getVmMac(),
-                "vmSecIp", rulesVm.getVmSecIp(), "action", rulesVm.getAction())).thenReturn("true");
+                        "vmSecIp", rulesVm.getVmSecIp(), "action", rulesVm.getAction())).thenReturn("true");
 
         final Answer answer = wrapper.execute(rulesVm, citrixResourceBase);
 
@@ -1665,7 +1669,7 @@ public class CitrixRequestWrapperTest {
 
         when(citrixResourceBase.getConnection()).thenReturn(conn);
         when(citrixResourceBase.callHostPlugin(conn, "vmops", "network_rules_vmSecondaryIp", "vmName", rulesVm.getVmName(), "vmMac", rulesVm.getVmMac(),
-                "vmSecIp", rulesVm.getVmSecIp(), "action", rulesVm.getAction())).thenReturn("false");
+                        "vmSecIp", rulesVm.getVmSecIp(), "action", rulesVm.getAction())).thenReturn("false");
 
         final Answer answer = wrapper.execute(rulesVm, citrixResourceBase);
 
@@ -1681,7 +1685,7 @@ public class CitrixRequestWrapperTest {
         final VirtualMachineTO machineTO = Mockito.mock(VirtualMachineTO.class);
         final Connection conn = Mockito.mock(Connection.class);
         final XsHost xsHost = Mockito.mock(XsHost.class);
-        final Host host =  Mockito.mock(Host.class);
+        final Host host = Mockito.mock(Host.class);
 
         final ScaleVmCommand scaleVm = new ScaleVmCommand(machineTO);
 
@@ -1739,7 +1743,7 @@ public class CitrixRequestWrapperTest {
         }
 
         when(citrixResourceBase.callHostPlugin(conn, "ovs-pvlan", "setup-pvlan-dhcp", "op", op, "nw-label", label, "primary-pvlan", primaryPvlan, "isolated-pvlan",
-                isolatedPvlan, "dhcp-name", dhcpName, "dhcp-ip", dhcpIp, "dhcp-mac", dhcpMac)).thenReturn("true");
+                        isolatedPvlan, "dhcp-name", dhcpName, "dhcp-ip", dhcpIp, "dhcp-mac", dhcpMac)).thenReturn("true");
 
         final Answer answer = wrapper.execute(lanSetup, citrixResourceBase);
 
@@ -1780,7 +1784,7 @@ public class CitrixRequestWrapperTest {
         }
 
         when(citrixResourceBase.callHostPlugin(conn, "ovs-pvlan", "setup-pvlan-dhcp", "op", op, "nw-label", label, "primary-pvlan", primaryPvlan, "isolated-pvlan",
-                isolatedPvlan, "dhcp-name", dhcpName, "dhcp-ip", dhcpIp, "dhcp-mac", dhcpMac)).thenReturn("false");
+                        isolatedPvlan, "dhcp-name", dhcpName, "dhcp-ip", dhcpIp, "dhcp-mac", dhcpMac)).thenReturn("false");
 
         final Answer answer = wrapper.execute(lanSetup, citrixResourceBase);
 
@@ -1819,7 +1823,7 @@ public class CitrixRequestWrapperTest {
         }
 
         when(citrixResourceBase.callHostPlugin(conn, "ovs-pvlan", "setup-pvlan-vm", "op", op, "nw-label", label, "primary-pvlan", primaryPvlan, "isolated-pvlan",
-                isolatedPvlan, "vm-mac", vmMac)).thenReturn("true");
+                        isolatedPvlan, "vm-mac", vmMac)).thenReturn("true");
 
         final Answer answer = wrapper.execute(lanSetup, citrixResourceBase);
 
@@ -1858,7 +1862,7 @@ public class CitrixRequestWrapperTest {
         }
 
         when(citrixResourceBase.callHostPlugin(conn, "ovs-pvlan", "setup-pvlan-vm", "op", op, "nw-label", label, "primary-pvlan", primaryPvlan, "isolated-pvlan",
-                isolatedPvlan, "vm-mac", vmMac)).thenReturn("false");
+                        isolatedPvlan, "vm-mac", vmMac)).thenReturn("false");
 
         final Answer answer = wrapper.execute(lanSetup, citrixResourceBase);
 
@@ -1908,7 +1912,7 @@ public class CitrixRequestWrapperTest {
     @Test
     public void testIpAssocVpcCommand() {
         final VirtualRoutingResource routingResource = Mockito.mock(VirtualRoutingResource.class);
-        final IpAddressTO [] ips = new IpAddressTO[0];
+        final IpAddressTO[] ips = new IpAddressTO[0];
 
         final IpAssocVpcCommand ipAssociation = new IpAssocVpcCommand(ips);
 
@@ -1928,7 +1932,7 @@ public class CitrixRequestWrapperTest {
     @Test
     public void testIpAssocCommand() {
         final VirtualRoutingResource routingResource = Mockito.mock(VirtualRoutingResource.class);
-        final IpAddressTO [] ips = new IpAddressTO[0];
+        final IpAddressTO[] ips = new IpAddressTO[0];
 
         final IpAssocCommand ipAssociation = new IpAssocCommand(ips);
 
@@ -1979,7 +1983,6 @@ public class CitrixRequestWrapperTest {
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
-
 
         when(citrixResourceBase.getConnection()).thenReturn(conn);
         when(citrixResourceBase.getVM(conn, getVmIpAddrCmd.getVmName())).thenReturn(vm);

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
@@ -1582,7 +1582,7 @@ public class CitrixRequestWrapperTest {
         final VMSnapshotTO snapshotTO = Mockito.mock(VMSnapshotTO.class);
         final List<VolumeObjectTO> volumeTOs = new ArrayList<VolumeObjectTO>();
 
-        final CreateVMSnapshotCommand vmSnapshot = new CreateVMSnapshotCommand("Test", snapshotTO, volumeTOs, "Debian");
+        final CreateVMSnapshotCommand vmSnapshot = new CreateVMSnapshotCommand("Test", "uuid", snapshotTO, volumeTOs, "Debian");
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -1624,7 +1624,7 @@ public class CitrixRequestWrapperTest {
         final VMSnapshotTO snapshotTO = Mockito.mock(VMSnapshotTO.class);
         final List<VolumeObjectTO> volumeTOs = new ArrayList<VolumeObjectTO>();
 
-        final RevertToVMSnapshotCommand vmSnapshot = new RevertToVMSnapshotCommand("Test", snapshotTO, volumeTOs, "Debian");
+        final RevertToVMSnapshotCommand vmSnapshot = new RevertToVMSnapshotCommand("Test", "uuid", snapshotTO, volumeTOs, "Debian");
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);


### PR DESCRIPTION
Commit 0062ff2672e257f2a4290e054e23ef4333a34983 in PR #717 introduced a new parameter in two constructors. However, there is a test class (CitrixRequestWrapperTest) that uses these constructors and the respective calls needed to be updated with the new parameter.

Testing:
-  ran full maven build: `mvn clean install -P developer,systemvm`