### PR TITLE
CLOUDSTACK-8754: VM migration triggered by dynamic scaling is failing

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -4297,7 +4297,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             workJob = new VmWorkJobVO(context.getContextId());
 
             workJob.setDispatcher(VmWorkConstants.VM_WORK_JOB_DISPATCHER);
-            workJob.setCmd(VmWorkMigrate.class.getName());
+            workJob.setCmd(VmWorkMigrateWithStorage.class.getName());
 
             workJob.setAccountId(account.getId());
             workJob.setUserId(user.getId());
@@ -4340,7 +4340,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             workJob = new VmWorkJobVO(context.getContextId());
 
             workJob.setDispatcher(VmWorkConstants.VM_WORK_JOB_DISPATCHER);
-            workJob.setCmd(VmWorkMigrate.class.getName());
+            workJob.setCmd(VmWorkMigrateForScale.class.getName());
 
             workJob.setAccountId(account.getId());
             workJob.setUserId(user.getId());

--- a/engine/orchestration/src/com/cloud/vm/VmWorkMigrateForScale.java
+++ b/engine/orchestration/src/com/cloud/vm/VmWorkMigrateForScale.java
@@ -18,28 +18,16 @@ package com.cloud.vm;
 
 import com.cloud.deploy.DeployDestination;
 
-public class VmWorkMigrateForScale extends VmWork {
+public class VmWorkMigrateForScale extends VmWorkMigrate {
     private static final long serialVersionUID = 6854870395568389613L;
 
-    long srcHostId;
-    DeployDestination deployDestination;
     Long newSvcOfferingId;
 
     public VmWorkMigrateForScale(long userId, long accountId, long vmId, String handlerName, long srcHostId,
             DeployDestination dest, Long newSvcOfferingId) {
 
-        super(userId, accountId, vmId, handlerName);
-        this.srcHostId = srcHostId;
-        deployDestination = dest;
+        super(userId, accountId, vmId, handlerName, srcHostId, dest);
         this.newSvcOfferingId = newSvcOfferingId;
-    }
-
-    public long getSrcHostId() {
-        return srcHostId;
-    }
-
-    public DeployDestination getDeployDestination() {
-        return deployDestination;
     }
 
     public Long getNewServiceOfferringId() {


### PR DESCRIPTION
This is caused by serialization failure for VmWorkMigrateForScale object. Replaced DeployDestination member present in VmWorkMigrateForScale with serializable types.

Haven't added any unit test as couldn't find a clean way to do it. Simply adding a test to do (de)serialization won't help catch any new member addition to the type which breaks serializability.