### PR TITLE
Made following fixes in simulator

### DIFF
--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManager.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManager.java
@@ -81,23 +81,23 @@ public interface MockVmManager extends Manager {
 
     Answer setVmData(VmDataCommand cmd);
 
-    Answer CheckConsoleProxyLoad(CheckConsoleProxyLoadCommand cmd);
+    Answer checkConsoleProxyLoad(CheckConsoleProxyLoadCommand cmd);
 
-    Answer WatchConsoleProxyLoad(WatchConsoleProxyLoadCommand cmd);
+    Answer watchConsoleProxyLoad(WatchConsoleProxyLoadCommand cmd);
 
-    Answer SavePassword(SavePasswordCommand cmd);
+    Answer savePassword(SavePasswordCommand cmd);
 
-    MigrateAnswer Migrate(MigrateCommand cmd, SimulatorInfo info);
+    MigrateAnswer migrate(MigrateCommand cmd, SimulatorInfo info);
 
     PrepareForMigrationAnswer prepareForMigrate(PrepareForMigrationCommand cmd);
 
-    SecurityGroupRuleAnswer AddSecurityGroupRules(SecurityGroupRulesCmd cmd, SimulatorInfo info);
+    SecurityGroupRuleAnswer addSecurityGroupRules(SecurityGroupRulesCmd cmd, SimulatorInfo info);
 
     GetDomRVersionAnswer getDomRVersion(GetDomRVersionCmd cmd);
 
     CheckRouterAnswer checkRouter(CheckRouterCommand cmd);
 
-    Answer CleanupNetworkRules(CleanupNetworkRulesCmd cmd, SimulatorInfo info);
+    Answer cleanupNetworkRules(CleanupNetworkRulesCmd cmd, SimulatorInfo info);
 
     Answer scaleVm(ScaleVmCommand cmd);
 

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/MockVmManagerImpl.java
@@ -57,6 +57,7 @@ import com.cloud.agent.api.RebootAnswer;
 import com.cloud.agent.api.RebootCommand;
 import com.cloud.agent.api.RevertToVMSnapshotAnswer;
 import com.cloud.agent.api.RevertToVMSnapshotCommand;
+import com.cloud.agent.api.ScaleVmAnswer;
 import com.cloud.agent.api.ScaleVmCommand;
 import com.cloud.agent.api.SecurityGroupRuleAnswer;
 import com.cloud.agent.api.SecurityGroupRulesCmd;
@@ -248,7 +249,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
             return vmMap;
         } catch (final Exception ex) {
             txn.rollback();
-            throw new CloudRuntimeException("unable to fetch vms  from host " + hostGuid, ex);
+            throw new CloudRuntimeException("unable to fetch vms from host " + hostGuid, ex);
         } finally {
             txn.close();
             txn = TransactionLegacy.open(TransactionLegacy.CLOUD_DB);
@@ -292,7 +293,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
             return states;
         } catch (final Exception ex) {
             txn.rollback();
-            throw new CloudRuntimeException("unable to fetch vms  from host " + hostGuid, ex);
+            throw new CloudRuntimeException("unable to fetch vms from host " + hostGuid, ex);
         } finally {
             txn.close();
             txn = TransactionLegacy.open(TransactionLegacy.CLOUD_DB);
@@ -369,7 +370,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
     }
 
     @Override
-    public MigrateAnswer Migrate(final MigrateCommand cmd, final SimulatorInfo info) {
+    public MigrateAnswer migrate(final MigrateCommand cmd, final SimulatorInfo info) {
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.SIMULATOR_DB);
         try {
             txn.start();
@@ -382,7 +383,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
 
             final MockHost destHost = _mockHostDao.findByGuid(destGuid);
             if (destHost == null) {
-                return new MigrateAnswer(cmd, false, "can;t find host:" + info.getHostUuid(), null);
+                return new MigrateAnswer(cmd, false, "can't find destination host:" + destGuid, null);
             }
             vm.setHostId(destHost.getId());
             _mockVmDao.update(vm.getId(), vm);
@@ -424,7 +425,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
     }
 
     @Override
-    public Answer CleanupNetworkRules(final CleanupNetworkRulesCmd cmd, final SimulatorInfo info) {
+    public Answer cleanupNetworkRules(final CleanupNetworkRulesCmd cmd, final SimulatorInfo info) {
         TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.SIMULATOR_DB);
         try {
             txn.start();
@@ -449,12 +450,34 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
 
     @Override
     public Answer scaleVm(final ScaleVmCommand cmd) {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        TransactionLegacy txn = TransactionLegacy.open(TransactionLegacy.SIMULATOR_DB);
+        try {
+            txn.start();
+            final String vmName = cmd.getVmName();
+            final MockVMVO vm = _mockVmDao.findByVmName(vmName);
+            if (vm == null) {
+                return new ScaleVmAnswer(cmd, false, "Can't find VM " + vmName);
+            }
+            vm.setCpu(cmd.getCpus() * cmd.getMaxSpeed());
+            vm.setMemory(cmd.getMaxRam());
+            _mockVmDao.update(vm.getId(), vm);
+            s_logger.debug("Scaled up VM " + vmName);
+            txn.commit();
+            return new ScaleVmAnswer(cmd, true, null);
+        } catch (final Exception ex) {
+            txn.rollback();
+            throw new CloudRuntimeException("Unable to scale up VM", ex);
+        } finally {
+            txn.close();
+            txn = TransactionLegacy.open(TransactionLegacy.CLOUD_DB);
+            txn.close();
+        }
     }
 
     @Override
     public Answer plugSecondaryIp(final NetworkRulesVmSecondaryIpCommand cmd) {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        s_logger.debug("Plugged secondary IP to VM " + cmd.getVmName());
+        return new Answer(cmd, true, null);
     }
 
     @Override
@@ -527,12 +550,12 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
     }
 
     @Override
-    public Answer CheckConsoleProxyLoad(final CheckConsoleProxyLoadCommand cmd) {
+    public Answer checkConsoleProxyLoad(final CheckConsoleProxyLoadCommand cmd) {
         return Answer.createUnsupportedCommandAnswer(cmd);
     }
 
     @Override
-    public Answer WatchConsoleProxyLoad(final WatchConsoleProxyLoadCommand cmd) {
+    public Answer watchConsoleProxyLoad(final WatchConsoleProxyLoadCommand cmd) {
         return Answer.createUnsupportedCommandAnswer(cmd);
     }
 
@@ -543,7 +566,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
     }
 
     @Override
-    public SecurityGroupRuleAnswer AddSecurityGroupRules(final SecurityGroupRulesCmd cmd, final SimulatorInfo info) {
+    public SecurityGroupRuleAnswer addSecurityGroupRules(final SecurityGroupRulesCmd cmd, final SimulatorInfo info) {
         if (!info.isEnabled()) {
             return new SecurityGroupRuleAnswer(cmd, false, "Disabled", SecurityGroupRuleAnswer.FailureReason.CANNOT_BRIDGE_FIREWALL);
         }
@@ -611,7 +634,7 @@ public class MockVmManagerImpl extends ManagerBase implements MockVmManager {
     }
 
     @Override
-    public Answer SavePassword(final SavePasswordCommand cmd) {
+    public Answer savePassword(final SavePasswordCommand cmd) {
         return new Answer(cmd);
     }
 

--- a/plugins/hypervisors/simulator/src/com/cloud/agent/manager/SimulatorManagerImpl.java
+++ b/plugins/hypervisors/simulator/src/com/cloud/agent/manager/SimulatorManagerImpl.java
@@ -286,7 +286,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                 } else if (cmd instanceof PrepareForMigrationCommand) {
                     answer = _mockVmMgr.prepareForMigrate((PrepareForMigrationCommand)cmd);
                 } else if (cmd instanceof MigrateCommand) {
-                    answer = _mockVmMgr.Migrate((MigrateCommand)cmd, info);
+                    answer = _mockVmMgr.migrate((MigrateCommand)cmd, info);
                 } else if (cmd instanceof StartCommand) {
                     answer = _mockVmMgr.startVM((StartCommand)cmd, info);
                 } else if (cmd instanceof CheckSshCommand) {
@@ -310,7 +310,7 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                 } else if (cmd instanceof VmDataCommand) {
                     answer = _mockVmMgr.setVmData((VmDataCommand)cmd);
                 } else if (cmd instanceof CleanupNetworkRulesCmd) {
-                    answer = _mockVmMgr.CleanupNetworkRules((CleanupNetworkRulesCmd)cmd, info);
+                    answer = _mockVmMgr.cleanupNetworkRules((CleanupNetworkRulesCmd)cmd, info);
                 } else if (cmd instanceof CheckNetworkCommand) {
                     answer = _mockAgentMgr.checkNetworkCommand((CheckNetworkCommand)cmd);
                 } else if (cmd instanceof StopCommand) {
@@ -320,13 +320,13 @@ public class SimulatorManagerImpl extends ManagerBase implements SimulatorManage
                 } else if (cmd instanceof GetVncPortCommand) {
                     answer = _mockVmMgr.getVncPort((GetVncPortCommand)cmd);
                 } else if (cmd instanceof CheckConsoleProxyLoadCommand) {
-                    answer = _mockVmMgr.CheckConsoleProxyLoad((CheckConsoleProxyLoadCommand)cmd);
+                    answer = _mockVmMgr.checkConsoleProxyLoad((CheckConsoleProxyLoadCommand)cmd);
                 } else if (cmd instanceof WatchConsoleProxyLoadCommand) {
-                    answer = _mockVmMgr.WatchConsoleProxyLoad((WatchConsoleProxyLoadCommand)cmd);
+                    answer = _mockVmMgr.watchConsoleProxyLoad((WatchConsoleProxyLoadCommand)cmd);
                 } else if (cmd instanceof SecurityGroupRulesCmd) {
-                    answer = _mockVmMgr.AddSecurityGroupRules((SecurityGroupRulesCmd)cmd, info);
+                    answer = _mockVmMgr.addSecurityGroupRules((SecurityGroupRulesCmd)cmd, info);
                 } else if (cmd instanceof SavePasswordCommand) {
-                    answer = _mockVmMgr.SavePassword((SavePasswordCommand)cmd);
+                    answer = _mockVmMgr.savePassword((SavePasswordCommand)cmd);
                 } else if (cmd instanceof PrimaryStorageDownloadCommand) {
                     answer = _mockStorageMgr.primaryStorageDownload((PrimaryStorageDownloadCommand)cmd);
                 } else if (cmd instanceof CreateCommand) {

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -1500,7 +1500,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         Account caller = CallContext.current().getCallingAccount();
         VMInstanceVO vmInstance = _vmInstanceDao.findById(vmId);
-        if (vmInstance.getHypervisorType() != HypervisorType.XenServer && vmInstance.getHypervisorType() != HypervisorType.VMware) {
+        if (vmInstance.getHypervisorType() != HypervisorType.XenServer && vmInstance.getHypervisorType() != HypervisorType.VMware && vmInstance.getHypervisorType() != HypervisorType.Simulator) {
             s_logger.info("Scaling the VM dynamically is not supported for VMs running on Hypervisor "+vmInstance.getHypervisorType());
             throw new InvalidParameterValueException("Scaling the VM dynamically is not supported for VMs running on Hypervisor "+vmInstance.getHypervisorType());
         }

--- a/setup/dev/advanced.cfg
+++ b/setup/dev/advanced.cfg
@@ -211,6 +211,10 @@
         {
             "name": "direct.agent.load.size",
             "value": "1000"
+        },
+        {
+            "name": "enable.dynamic.scale.vm",
+            "value": "true"
         }
     ],
     "mgtSvr": [

--- a/test/integration/smoke/test_scale_vm.py
+++ b/test/integration/smoke/test_scale_vm.py
@@ -174,7 +174,79 @@ class TestScaleVm(cloudstackTestCase):
         self.assertNotEqual(
             list_vm_response,
             None,
-            "Check virtual machine is listVirtualMachines"
+            "Check virtual machine is in listVirtualMachines"
+        )
+
+        vm_response = list_vm_response[0]
+        self.assertEqual(
+            vm_response.id,
+            self.virtual_machine.id,
+            "Check virtual machine ID of scaled VM"
+        )
+
+        self.debug(
+            "Scaling VM-ID: %s from service offering: %s to new service\
+                    offering %s and the response says %s" %
+            (self.virtual_machine.id,
+             self.virtual_machine.serviceofferingid,
+             self.big_offering.id,
+             vm_response.serviceofferingid))
+        self.assertEqual(
+            vm_response.serviceofferingid,
+            self.big_offering.id,
+            "Check service offering of the VM"
+        )
+
+        self.assertEqual(
+            vm_response.state,
+            'Running',
+            "Check the state of VM"
+        )
+        return
+
+    @attr(tags=["advanced", "basic"], required_hardware="false")
+    def test_02_scale_vm_without_hypervisor_specifics(self):
+        # Validate the following
+        # Scale up the vm and see if it scales to the new svc offering and is
+        # finally in running state
+
+        #        VirtualMachine should be updated to tell cloudstack
+        #        it has PV tools
+        #        available and successfully scaled. We will only mock
+        #        that behaviour
+        #        here but it is not expected in production since the VM
+        #        scaling is not
+        #        guaranteed until tools are installed, vm rebooted
+
+        self.virtual_machine.update(
+            self.apiclient,
+            isdynamicallyscalable='true')
+
+        self.debug("Scaling VM-ID: %s to service offering: %s and state %s" % (
+            self.virtual_machine.id,
+            self.big_offering.id,
+            self.virtual_machine.state
+        ))
+
+        cmd = scaleVirtualMachine.scaleVirtualMachineCmd()
+        cmd.serviceofferingid = self.big_offering.id
+        cmd.id = self.virtual_machine.id
+        self.apiclient.scaleVirtualMachine(cmd)
+
+        list_vm_response = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine.id
+        )
+        self.assertEqual(
+            isinstance(list_vm_response, list),
+            True,
+            "Check list response returns a valid list"
+        )
+
+        self.assertNotEqual(
+            list_vm_response,
+            None,
+            "Check virtual machine is in listVirtualMachines"
         )
 
         vm_response = list_vm_response[0]


### PR DESCRIPTION
- Support for ScaleVmCommand/NetworkRulesVmSecondaryIpCommand in resource layer
- Added support for scaling up a running VM in simulator
- Fixed some method names not following convention

In order to test PR https://github.com/apache/cloudstack/pull/725 using simulator some of these changes are needed.

Based on the way HV check is present in the scale VM API, had to explicitly put simulator related check to allow support. The ideal way would be to remove all these HV specific check from code and made them some configuration (by putting them in hypervisor_capabilities table in DB). But that will be a bigger effort outside the scope of this PR.