### PR TITLE
Removing unit test that was failing to cover the resolution of the nano time

### DIFF
--- a/utils/src/test/java/com/cloud/utils/TestProfiler.java
+++ b/utils/src/test/java/com/cloud/utils/TestProfiler.java
@@ -96,21 +96,4 @@ public class TestProfiler extends Log4jEnabledTestCase {
         Assert.assertTrue(pf.getDurationInMillis() == -1);
         Assert.assertFalse(pf.isStopped());
     }
-
-    @Test
-    public void testResolution() {
-        long nanoTime1 = 0l;
-        long nanoTime2 = 0l;
-        nanoTime1 = System.nanoTime();
-        nanoTime2 = System.nanoTime();
-
-        // Using sysout here because is faster than the logger and we don't want to
-        // waste time.
-        System.out.println("Nano time 1: " + nanoTime1);
-        System.out.println("Nano time 2: " + nanoTime2);
-
-        // We are measuring the elapsed time in 2 consecutive calls of System.nanoTime()
-        // That's the same as 0.002 milliseconds or 2000 nanoseconds.
-        Assert.assertTrue("Expected exactly 2 but it took more than 3 microseconds between 2 consecutive calls to System.nanoTime().", nanoTime2 - nanoTime1 <= 3000);
-    }
 }


### PR DESCRIPTION
   - The difference between 2 consecutive calls to System.nanoTime() returns a resolution that depends on the OS implementation. Due to that, the test was failing in an intermittent manner.
   - Today we decided to remove the test since it was not testing a direct feature of ACS

I did not create an issue on Jira because it's only about removing an unit test. There is no bug fix involved or feature developed.

@miguelaferreira @remibergsma @bhaisaab @DaanHoogland 

Could you have a look at this change, please?

Cheers,
Wilder