### PR TITLE
CLOUDSTACK-8766: Fix infinite scrolling pagination for zonal iso/temp…

### DIFF
--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -586,6 +586,9 @@
                     dataProvider: function(args) {
                         var data = {};
                         listViewDataProvider(args, data);
+                        // Due to zonal grouping, low pagesize can result lower
+                        // aggregated items, resulting in no scroll shown
+                        data.pagesize = 200;
 
                         var ignoreProject = false;
                         if (args.filterBy != null) { //filter dropdown
@@ -1727,6 +1730,9 @@
                     dataProvider: function(args) {
                         var data = {};
                         listViewDataProvider(args, data);
+                        // Due to zonal grouping, low pagesize can result lower
+                        // aggregated items, resulting in no scroll shown
+                        data.pagesize = 200;
 
                         var ignoreProject = false;
                         if (args.filterBy != null) { //filter dropdown


### PR DESCRIPTION
…late listing

Due to aggregation of templates and isos on the UI/client side, it could result
that for each page we could end up having lesser templates/isos listed to have
the scroll shown that triggers infinite scrolling. The fix is to use similar
approach as in projects.js, to use the maximum pagesize of 500. In theory, there
is still a chance if there are 500 zones with the same template being listed
resulting in only one aggregated template which could cause the scroll to not
get shown; but in practice I believe this fix should work for most users.