### PR TITLE
use fakelocalhost in BasicRestClientTest

### DIFF
--- a/utils/src/test/java/com/cloud/utils/rest/BasicRestClientTest.java
+++ b/utils/src/test/java/com/cloud/utils/rest/BasicRestClientTest.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 public class BasicRestClientTest {
 
-    private static final String LOCALHOST = "localhost";
+    private static final String LOCALHOST = "fakelocalhost";
     private static final String HTTPS = HttpConstants.HTTPS;
 
     private static final StatusLine HTTP_200_REPSONSE = new BasicStatusLine(new ProtocolVersion(HTTPS, 1, 1), 200, "OK");


### PR DESCRIPTION
BasicRestClientTest will fail if the port 443 is open on localhost.
use fakelocalhost instead of localhost can fix it.
Please see the latest discussion in https://github.com/apache/cloudstack/pull/737