### PR TITLE
CLOUDSTACK-8783: specify ciphersuite SSL_DH_anon_WITH_3DES_EDE_CBC_SHA in MockServerTest.java

### DIFF
--- a/services/console-proxy-rdp/rdpconsole/src/test/java/rdpclient/MockServerTest.java
+++ b/services/console-proxy-rdp/rdpconsole/src/test/java/rdpclient/MockServerTest.java
@@ -161,7 +161,8 @@ public class MockServerTest extends TestCase {
 
                 final SSLSocketFactory sslSocketFactory = (SSLSocketFactory)SSLSocketFactory.getDefault();
                 SSLSocket sslSocket = (SSLSocket)sslSocketFactory.createSocket(socket, address.getHostName(), address.getPort(), true);
-                sslSocket.setEnabledCipherSuites(sslSocket.getSupportedCipherSuites());
+                //sslSocket.setEnabledCipherSuites(sslSocket.getSupportedCipherSuites());
+                sslSocket.setEnabledCipherSuites(new String[] { "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA" });
                 sslSocket.startHandshake();
 
                 InputStream is = sslSocket.getInputStream();


### PR DESCRIPTION
The ciphersuite could be different on os. 
Sometimes the MockServerTest fails due to the ciphersuite does not work (for instance misconfiguration).
SSL_DH_anon_WITH_3DES_EDE_CBC_SHA has 168-bit encryption and anonymous auth, which is suitable for SSL testing.