### PR TITLE
Have HyperV behave in 4.4 and return null instead of false

### DIFF
--- a/plugins/hypervisors/hyperv/src/com/cloud/ha/HypervInvestigator.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/ha/HypervInvestigator.java
@@ -45,9 +45,9 @@ public class HypervInvestigator extends AdapterBase implements Investigator {
     public Boolean isVmAlive(com.cloud.vm.VirtualMachine vm, Host host) {
         Status status = isAgentAlive(host);
         if (status == null) {
-            return false;
+            return null;
         }
-        return status == Status.Up ? true : false;
+        return status == Status.Up ? true : null;
     }
 
     @Override


### PR DESCRIPTION
Commit 6a4927f660f776bcbd12ae45f4e63ae2c2e96774 made the HyperV investigator return false instead of null.

Returning false means the VM is NOT running, returning null means "I don't know". In 4.4 I experienced corruption because of HyperV returning false, instead of null.

Tonight I experienced corruption when one of our management servers went down (out-of-memory, not root caused yet). While all hypervisors that were connected to this management server were connecting the other, HA work started as well with investigators. HyperV happily reported everything as down (while it was still running), causing a mess.

In 4.5 and master this was already fixed. If you know a better way to fix this, please let me know!
This may cause another FindBugs alert, not sure how to resolve that. I just want this out ASAP. Maybe @DaanHoogland @wilderrodrigues or @miguelaferreira can advise on how to fix this properly.