### PR TITLE
Fix findbugs issue: 76, DM_DEFAULT_ENCODING, Priority: High

### DIFF
--- a/utils/src/main/java/com/cloud/utils/log/CglibThrowableRenderer.java
+++ b/utils/src/main/java/com/cloud/utils/log/CglibThrowableRenderer.java
@@ -19,7 +19,6 @@
 
 package com.cloud.utils.log;
 
-import java.io.PrintWriter;
 import java.util.ArrayList;
 
 import org.apache.log4j.spi.ThrowableRenderer;
@@ -73,10 +72,7 @@ public class CglibThrowableRenderer implements ThrowableRenderer {
             } while (throwable != null);
             return lines.toArray(new String[lines.size()]);
         } catch (Exception ex) {
-            PrintWriter pw = new PrintWriter(System.err);
-            ex.printStackTrace(pw);
-            pw = new PrintWriter(System.out);
-            ex.printStackTrace(pw);
+            ex.printStackTrace(System.out);
             ex.printStackTrace();
             return null;
         }


### PR DESCRIPTION
ex.printStacktrace prints to System.err by default. Used it and removed
the printwriter which was causing the findbugs issue.

Also, I do not see a reason to write the stacktrace both to stdout and
stderr. But, keeping it as is for now

This fixes the findbugs issues which is reported as new in http://jenkins.buildacloud.org/job/build-master-slowbuild/2191/findbugsResult/new/