### PR TITLE
Support live migration on older version of Libvirt

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -87,8 +87,12 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
                 CVE-2015-3252: Get XML with sensitive information suitable for migration by using
                                VIR_DOMAIN_XML_MIGRATABLE flag (value = 8)
                                https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainXMLFlags
+
+                               Use VIR_DOMAIN_XML_SECURE (value = 1) prior to v1.0.0.
              */
-            xmlDesc = dm.getXMLDesc(8).replace(libvirtComputingResource.getPrivateIp(), command.getDestinationIp());
+            int xmlFlag = conn.getLibVirVersion() >= 1000000 ? 8 : 1; // 1000000 equals v1.0.0
+
+            xmlDesc = dm.getXMLDesc(xmlFlag).replace(libvirtComputingResource.getPrivateIp(), command.getDestinationIp());
 
             dconn = libvirtUtilitiesHelper.retrieveQemuConnection("qemu+tcp://" + command.getDestinationIp() + "/system");
 

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -1246,6 +1246,7 @@ public class LibvirtComputingResourceTest {
 
             when(libvirtComputingResource.getPrivateIp()).thenReturn("127.0.0.1");
             when(dm.getXMLDesc(8)).thenReturn("host_domain");
+            when(dm.getXMLDesc(1)).thenReturn("host_domain");
             when(dm.isPersistent()).thenReturn(1);
             doNothing().when(dm).undefine();
 
@@ -1273,9 +1274,19 @@ public class LibvirtComputingResourceTest {
         verify(libvirtComputingResource, times(1)).getDisks(conn, vmName);
         try {
             verify(conn, times(1)).domainLookupByName(vmName);
-            verify(dm, times(1)).getXMLDesc(8);
         } catch (final LibvirtException e) {
             fail(e.getMessage());
+        }
+
+        try {
+            verify(dm, times(1)).getXMLDesc(8);
+        } catch (final Throwable t) {
+            try {
+                verify(dm, times(1)).getXMLDesc(1);
+            }
+            catch (final LibvirtException e) {
+                fail(e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-8792

A flag being passed to Libvirt assumes v1.0.0 or later.

We need to put a check in the code to pass in a different flag if the version of Libvirt is < 1.0.0.