### PR TITLE
Support live migration on older version of Libvirt

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3096,8 +3096,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                                VIR_DOMAIN_XML_MIGRATABLE flag (value = 8)
                                https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainXMLFlags
 
+                               Use VIR_DOMAIN_XML_SECURE (value = 1) prior to v1.0.0.
+
              */
-            xmlDesc = dm.getXMLDesc(8).replace(_privateIp, cmd.getDestinationIp());
+            int xmlFlag = conn.getLibVirVersion() >= 1000000 ? 8 : 1; // 1000000 equals v1.0.0
+
+            xmlDesc = dm.getXMLDesc(xmlFlag).replace(_privateIp, cmd.getDestinationIp());
 
             dconn = new Connect("qemu+tcp://" + cmd.getDestinationIp() + "/system");
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-8792

A flag being passed to Libvirt assumes v1.0.0 or later.

We need to put a check in the code to pass in a different flag if the version of Libvirt is < 1.0.0.