### PR TITLE
sysctl: don't modify /etc/sysctl.conf

### DIFF
--- a/plugins/hypervisors/ovm/scripts/vm/hypervisor/ovm/OvmSecurityGroupModule.py
+++ b/plugins/hypervisors/ovm/scripts/vm/hypervisor/ovm/OvmSecurityGroupModule.py
@@ -75,13 +75,9 @@ class OvmSecurityGroup(OvmObject):
     @staticmethod
     def add_fw_framework(bridge_name):
         try:
-            cfo = ConfigFileOps("/etc/sysctl.conf")
-            cfo.addEntry("net.bridge.bridge-nf-call-arptables", "1")
-            cfo.addEntry("net.bridge.bridge-nf-call-iptables", "1")
-            cfo.addEntry("net.bridge.bridge-nf-call-ip6tables", "1")
-            cfo.save()
-
-            execute("sysctl -p /etc/sysctl.conf")
+            execute("sysctl -w net.bridge.bridge-nf-call-arptables=1")
+            execute("sysctl -w net.bridge.bridge-nf-call-iptables=1")
+            execute("sysctl -w net.bridge.bridge-nf-call-ip6tables=1")
         except:
             logging.debug("failed to turn on bridge netfilter")
             return False

--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -960,13 +960,9 @@ def getBrfw(brname):
 
 def addFWFramework(brname):
     try:
-        cfo = configFileOps("/etc/sysctl.conf")
-        cfo.addEntry("net.bridge.bridge-nf-call-arptables", "1")
-        cfo.addEntry("net.bridge.bridge-nf-call-iptables", "1")
-        cfo.addEntry("net.bridge.bridge-nf-call-ip6tables", "1")
-        cfo.save()
-
-        execute("sysctl -p /etc/sysctl.conf")
+        execute("sysctl -w net.bridge.bridge-nf-call-arptables=1")
+        execute("sysctl -w net.bridge.bridge-nf-call-iptables=1")
+        execute("sysctl -w net.bridge.bridge-nf-call-ip6tables=1")
     except:
         logging.debug("failed to turn on bridge netfilter")
         return False


### PR DESCRIPTION
To configure firewall rules, CloudStack modifies `/etc/sysctl.conf` and
execute those modifications. This may be harmful for several reasons:

 1. `/etc/sysctl.conf` may be managed by some configuration management
    system. Such a system will constantly restore the previous version.

 2. `/etc/sysctl.conf` may contain additional properties that have been
    changed later by some system administrator (for example, once a
    firewall has been configured, forwarding may have been activated
    while it is disabled in `/etc/sysctl.conf`). Executing the file
    again at a later time may disrupt the system.

 3. Entries are added again and again. `/etc/sysctl.conf` will contain
    the same directives repeated several times.

Using a configuration file is not needed as `sysctl` is able to directly
modify sysctl values with `-w` flag.

Signed-off-by: Vincent Bernat <Vincent.Bernat@exoscale.ch>