### PR TITLE
config: doc: add default value 10 in description for vm.network.nic.m…

### DIFF
--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -405,7 +405,7 @@ public enum Config {
     MaxNumberOfSecondaryIPsPerNIC(
             "Network", ManagementServer.class, Integer.class,
             "vm.network.nic.max.secondary.ipaddresses", "256",
-            "Specify the number of secondary ip addresses per nic per vm", null),
+            "Specify the number of secondary ip addresses per nic per vm. Default value 10 is used, if not specified.", null),
 
     EnableServiceMonitoring(
             "Network", ManagementServer.class, Boolean.class,


### PR DESCRIPTION
…ax.secondary.ipaddresses

value hardcoded by commit 4925b9f6a126454215531998c461bf376ac6ab67