### PR TITLE
Fixed issue: UI labels are display with key. ex: label.yes

### DIFF
--- a/ui/dictionary2.jsp
+++ b/ui/dictionary2.jsp
@@ -1069,7 +1069,7 @@ under the License.
 'label.link.domain.to.ldap': '<fmt:message key="label.link.domain.to.ldap" />',
 'message.link.domain.to.ldap': '<fmt:message key="message.link.domain.to.ldap" />',
 'label.ldap.link.type': '<fmt:message key="label.ldap.link.type" />',
-'label.account.type': '<fmt:message key="label.account.type" />'
+'label.account.type': '<fmt:message key="label.account.type" />',
 'label.create.ssh.key.pair': '<fmt:message key="label.create.ssh.key.pair" />',
 'label.fingerprint': '<fmt:message key="label.fingerprint" />',
 'label.host.tag': '<fmt:message key="label.host.tag" />',


### PR DESCRIPTION
due to missing comma in the jsp, all the labels below it are broken leading to showing keys instead of strings in UI