### PR TITLE
Cloudstack 8816 entityuuid missing in some of the events

### DIFF
--- a/api/src/com/cloud/event/EventTypes.java
+++ b/api/src/com/cloud/event/EventTypes.java
@@ -63,10 +63,8 @@ import com.cloud.storage.snapshot.SnapshotPolicy;
 import com.cloud.template.VirtualMachineTemplate;
 import com.cloud.user.Account;
 import com.cloud.user.User;
-import com.cloud.vm.ConsoleProxy;
 import com.cloud.vm.Nic;
 import com.cloud.vm.NicSecondaryIp;
-import com.cloud.vm.SecondaryStorageVm;
 import com.cloud.vm.VirtualMachine;
 import org.apache.cloudstack.config.Configuration;
 import org.apache.cloudstack.usage.Usage;
@@ -557,13 +555,13 @@ public class EventTypes {
         entityEventDetails.put(EVENT_ROUTER_HA, VirtualRouter.class);
         entityEventDetails.put(EVENT_ROUTER_UPGRADE, VirtualRouter.class);
 
-        entityEventDetails.put(EVENT_PROXY_CREATE, ConsoleProxy.class);
-        entityEventDetails.put(EVENT_PROXY_DESTROY, ConsoleProxy.class);
-        entityEventDetails.put(EVENT_PROXY_START, ConsoleProxy.class);
-        entityEventDetails.put(EVENT_PROXY_STOP, ConsoleProxy.class);
-        entityEventDetails.put(EVENT_PROXY_REBOOT, ConsoleProxy.class);
-        entityEventDetails.put(EVENT_ROUTER_HA, ConsoleProxy.class);
-        entityEventDetails.put(EVENT_PROXY_HA, ConsoleProxy.class);
+        entityEventDetails.put(EVENT_PROXY_CREATE, VirtualMachine.class);
+        entityEventDetails.put(EVENT_PROXY_DESTROY, VirtualMachine.class);
+        entityEventDetails.put(EVENT_PROXY_START, VirtualMachine.class);
+        entityEventDetails.put(EVENT_PROXY_STOP, VirtualMachine.class);
+        entityEventDetails.put(EVENT_PROXY_REBOOT, VirtualMachine.class);
+        entityEventDetails.put(EVENT_ROUTER_HA, VirtualMachine.class);
+        entityEventDetails.put(EVENT_PROXY_HA, VirtualMachine.class);
 
         entityEventDetails.put(EVENT_VNC_CONNECT, "VNC");
         entityEventDetails.put(EVENT_VNC_DISCONNECT, "VNC");
@@ -668,12 +666,12 @@ public class EventTypes {
         entityEventDetails.put(EVENT_ISO_UPLOAD, "Iso");
 
         // SSVM
-        entityEventDetails.put(EVENT_SSVM_CREATE, SecondaryStorageVm.class);
-        entityEventDetails.put(EVENT_SSVM_DESTROY, SecondaryStorageVm.class);
-        entityEventDetails.put(EVENT_SSVM_START, SecondaryStorageVm.class);
-        entityEventDetails.put(EVENT_SSVM_STOP, SecondaryStorageVm.class);
-        entityEventDetails.put(EVENT_SSVM_REBOOT, SecondaryStorageVm.class);
-        entityEventDetails.put(EVENT_SSVM_HA, SecondaryStorageVm.class);
+        entityEventDetails.put(EVENT_SSVM_CREATE, VirtualMachine.class);
+        entityEventDetails.put(EVENT_SSVM_DESTROY, VirtualMachine.class);
+        entityEventDetails.put(EVENT_SSVM_START, VirtualMachine.class);
+        entityEventDetails.put(EVENT_SSVM_STOP, VirtualMachine.class);
+        entityEventDetails.put(EVENT_SSVM_REBOOT, VirtualMachine.class);
+        entityEventDetails.put(EVENT_SSVM_HA, VirtualMachine.class);
 
         // Service Offerings
         entityEventDetails.put(EVENT_SERVICE_OFFERING_CREATE, ServiceOffering.class);

--- a/api/src/org/apache/cloudstack/api/command/admin/account/DeleteAccountCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/account/DeleteAccountCmd.java
@@ -114,4 +114,9 @@ public class DeleteAccountCmd extends BaseAsyncCmd {
     public ApiCommandJobType getInstanceType() {
         return ApiCommandJobType.Account;
     }
+
+    @Override
+    public Long getInstanceId() {
+        return id;
+    }
 }

--- a/api/src/org/apache/cloudstack/context/CallContext.java
+++ b/api/src/org/apache/cloudstack/context/CallContext.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.UUID;
 
+import com.cloud.projects.Project;
 import org.apache.log4j.Logger;
 import org.apache.log4j.NDC;
 
@@ -59,6 +60,7 @@ public class CallContext {
     private User user;
     private long userId;
     private final Map<Object, Object> context = new HashMap<Object, Object>();
+    private Project project;
 
     static EntityManager s_entityMgr;
 
@@ -312,6 +314,14 @@ public class CallContext {
 
     public void setEventDescription(String eventDescription) {
         this.eventDescription = eventDescription;
+    }
+
+    public Project getProject() {
+        return this.project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
     }
 
     /**

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2083,6 +2083,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         });
 
         CallContext.current().setEventDetails("Network Id: " + network.getId());
+        CallContext.current().putContextParameter(Network.class, network.getUuid());
         return network;
     }
 

--- a/server/src/com/cloud/api/ApiDispatcher.java
+++ b/server/src/com/cloud/api/ApiDispatcher.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import com.cloud.projects.Project;
+import com.cloud.utils.db.EntityManager;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.ControlledEntity;
@@ -53,6 +55,9 @@ public class ApiDispatcher {
 
     @Inject
     AccountManager _accountMgr;
+
+    @Inject
+    EntityManager _entityMgr;
 
     @Inject()
     protected DispatchChainFactory dispatchChainFactory;
@@ -102,6 +107,10 @@ public class ApiDispatcher {
 
         final CallContext ctx = CallContext.current();
         ctx.setEventDisplayEnabled(cmd.isDisplay());
+        if(params.get(ApiConstants.PROJECT_ID) != null) {
+            Project project = _entityMgr.findByUuidIncludingRemoved(Project.class, params.get(ApiConstants.PROJECT_ID));
+            ctx.setProject(project);
+        }
 
         // TODO This if shouldn't be here. Use polymorphism and move it to validateSpecificParameters
         if (cmd instanceof BaseAsyncCmd) {

--- a/server/src/com/cloud/api/ApiServer.java
+++ b/server/src/com/cloud/api/ApiServer.java
@@ -277,11 +277,10 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             }
         }
         // For some reason, the instanceType / instanceId are not abstract, which means we may get null values.
-        org.apache.cloudstack.framework.events.Event event = new org.apache.cloudstack.framework.events.Event(
-                "management-server",
-                EventCategory.ASYNC_JOB_CHANGE_EVENT.getName(),
-                jobEvent,
-                (job.getInstanceType() != null ? job.getInstanceType().toString() : "unknown"), null);
+        String instanceType = job.getInstanceType() != null ? job.getInstanceType() : "unknown";
+        String instanceUuid = job.getInstanceId() != null ? ApiDBUtils.findJobInstanceUuid(job) : "";
+        org.apache.cloudstack.framework.events.Event event = new org.apache.cloudstack.framework.events.Event("management-server", EventCategory.ASYNC_JOB_CHANGE_EVENT.getName(),
+                jobEvent, instanceType, instanceUuid);
 
         Map<String, String> eventDescription = new HashMap<String, String>();
         eventDescription.put("command", job.getCmd());
@@ -289,8 +288,8 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         eventDescription.put("account", jobOwner.getUuid());
         eventDescription.put("processStatus", "" + job.getProcessStatus());
         eventDescription.put("resultCode", "" + job.getResultCode());
-        eventDescription.put("instanceUuid", (job.getInstanceId() != null ? ApiDBUtils.findJobInstanceUuid(job) : "" ) );
-        eventDescription.put("instanceType", (job.getInstanceType() != null ? job.getInstanceType().toString() : "unknown"));
+        eventDescription.put("instanceUuid", instanceUuid);
+        eventDescription.put("instanceType", instanceType);
         eventDescription.put("commandEventType", cmdEventType);
         eventDescription.put("jobId", job.getUuid());
         eventDescription.put("jobResult", job.getResult());
@@ -638,7 +637,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 params.put("id", objectId.toString());
                 Class entityClass = EventTypes.getEntityClassForEvent(createCmd.getEventType());
                 if (entityClass != null)
-                    ctx.putContextParameter(entityClass.getName(), objectUuid);
+                    ctx.putContextParameter(entityClass, objectUuid);
             } else {
                 // Extract the uuid before params are processed and id reflects internal db id
                 objectUuid = params.get(ApiConstants.ID);

--- a/server/src/com/cloud/api/dispatch/ParamProcessWorker.java
+++ b/server/src/com/cloud/api/dispatch/ParamProcessWorker.java
@@ -410,7 +410,7 @@ public class ParamProcessWorker implements DispatchWorker {
             if (internalId != null){
                 // Populate CallContext for each of the entity.
                 for (final Class<?> entity : entities) {
-                    CallContext.current().putContextParameter(entity.getName(), internalId);
+                    CallContext.current().putContextParameter(entity, internalId);
                 }
                 return internalId;
             }
@@ -434,7 +434,7 @@ public class ParamProcessWorker implements DispatchWorker {
             }
             // Return on first non-null Id for the uuid entity
             if (internalId != null){
-                CallContext.current().putContextParameter(entity.getName(), uuid);
+                CallContext.current().putContextParameter(entity, uuid);
                 break;
             }
         }

--- a/server/src/com/cloud/event/ActionEventInterceptor.java
+++ b/server/src/com/cloud/event/ActionEventInterceptor.java
@@ -84,7 +84,7 @@ public class ActionEventInterceptor implements ComponentMethodInterceptor, Metho
         for (ActionEvent actionEvent : getActionEvents(method)) {
             CallContext ctx = CallContext.current();
             long userId = ctx.getCallingUserId();
-            long accountId = ctx.getCallingAccountId();
+            long accountId = ctx.getProject() != null ? ctx.getProject().getProjectAccountId() : ctx.getCallingAccountId();    //This should be the entity owner id rather than the Calling User Account Id.
             long startEventId = ctx.getStartEventId();
             String eventDescription = getEventDescription(actionEvent, ctx);
             String eventType = getEventType(actionEvent, ctx);

--- a/server/src/com/cloud/event/ActionEventUtils.java
+++ b/server/src/com/cloud/event/ActionEventUtils.java
@@ -120,7 +120,7 @@ public class ActionEventUtils {
     public static void onStartedActionEventFromContext(String eventType, String eventDescription, boolean eventDisplayEnabled) {
         CallContext ctx = CallContext.current();
         long userId = ctx.getCallingUserId();
-        long accountId = ctx.getCallingAccountId();
+        long accountId = ctx.getProject() != null ? ctx.getProject().getProjectAccountId() : ctx.getCallingAccountId();    //This should be the entity owner id rather than the Calling User Account Id.
         long startEventId = ctx.getStartEventId();
 
         if (!eventType.equals(""))

--- a/server/src/com/cloud/event/ActionEventUtils.java
+++ b/server/src/com/cloud/event/ActionEventUtils.java
@@ -37,7 +37,6 @@ import org.apache.cloudstack.framework.events.EventBus;
 import org.apache.cloudstack.framework.events.EventBusException;
 
 import com.cloud.configuration.Config;
-import com.cloud.domain.Domain;
 import com.cloud.event.dao.EventDao;
 import com.cloud.server.ManagementService;
 import com.cloud.user.Account;
@@ -204,20 +203,15 @@ public class ActionEventUtils {
         String entityType = null;
         String entityUuid = null;
         CallContext context = CallContext.current();
-        Class<?> entityKey = getEntityKey(eventType);
-        if (entityKey != null){
-            //FIXME - Remove this since it should be covered by the else if condition below.
-            entityUuid = (String)context.getContextParameter(entityKey);
-            if (entityUuid != null)
-                entityType = entityKey.getName();
-        }else if (EventTypes.getEntityClassForEvent(eventType) != null){
-            //Get entity Class(Example - VirtualMachine.class) from the event Type eg. - VM.CREATE
-            Class<?> entityClass = EventTypes.getEntityClassForEvent(eventType);
-
+        //Get entity Class(Example - VirtualMachine.class) from the event Type eg. - VM.CREATE
+        Class<?> entityClass = EventTypes.getEntityClassForEvent(eventType);
+        if (entityClass != null){
             //Get uuid from id
-            if(context.getContextParameter(entityClass.getName()) != null){
+            Object param = context.getContextParameter(entityClass);
+            if(param != null){
                 try {
-                    entityUuid = getEntityUuid(entityClass, context.getContextParameter(entityClass.getName()));
+                    entityUuid = getEntityUuid(entityClass, param);
+                    entityType = entityClass.getName();
                 } catch (Exception e){
                     s_logger.debug("Caught exception while finding entityUUID, moving on");
                 }
@@ -312,22 +306,4 @@ public class ActionEventUtils {
 
     }
 
-    private static Class<?> getEntityKey(String eventType)
-    {
-        // FIXME - Remove this
-        if (eventType.startsWith("DOMAIN."))
-        {
-            return Domain.class;
-        }
-        else if (eventType.startsWith("ACCOUNT."))
-        {
-            return Account.class;
-        }
-        else if (eventType.startsWith("USER."))
-        {
-            return User.class;
-        }
-
-        return null;
-    }
 }

--- a/server/src/com/cloud/projects/ProjectManagerImpl.java
+++ b/server/src/com/cloud/projects/ProjectManagerImpl.java
@@ -222,6 +222,7 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager {
 
         if (project != null) {
             CallContext.current().setEventDetails("Project id=" + project.getId());
+            CallContext.current().putContextParameter(Project.class, project.getUuid());
         }
 
         //Increment resource count

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -3250,7 +3250,6 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     }
 
     @Override
-    @ActionEvent(eventType = EventTypes.EVENT_PROXY_REBOOT, eventDescription = "", async = true)
     public VMInstanceVO rebootSystemVM(final RebootSystemVmCmd cmd) {
         final VMInstanceVO systemVm = _vmInstanceDao.findByIdTypes(cmd.getId(), VirtualMachine.Type.ConsoleProxy, VirtualMachine.Type.SecondaryStorageVm);
 

--- a/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -777,7 +777,7 @@ public class SnapshotManagerImpl extends ManagerBase implements SnapshotManager,
 
         }
         // TODO - Make createSnapshotPolicy - BaseAsyncCreate and remove this.
-        CallContext.current().putContextParameter(SnapshotPolicy.class.getName(), policy.getUuid());
+        CallContext.current().putContextParameter(SnapshotPolicy.class, policy.getUuid());
         return policy;
     }
 

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -1212,7 +1212,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (guestNic == null) {
             throw new CloudRuntimeException("Unable to add NIC to " + vmInstance);
         }
-        CallContext.current().putContextParameter(Nic.class.getName(), guestNic.getUuid());
+        CallContext.current().putContextParameter(Nic.class, guestNic.getUuid());
         s_logger.debug("Successful addition of " + network + " from " + vmInstance);
         return _vmDao.findById(vmInstance.getId());
     }


### PR DESCRIPTION
In some of the events generated, entity uuid was missing making it difficult to find the entity. Fixed the same.

Tested it on rabbitmq instance.
There are the events before after the fix:

Before
--------------------------------------------------------------------------------

routing_key: management-server.ActionEvent.ACCOUNT-DELETE.Account.*
exchange: cloudstack-events
message_count: 2
payload:
{"eventDateTime":"2015-09-04 17:59:24 +0530","status":"Scheduled","description":"deleting User test4 (id: 28) and accountId \u003d 28","event":"ACCOUNT.DELETE","Account":"c09e2e81-8edc-4c27-b072-25005b522b63","account":"bd73dc2e-35c0-11e5-b094-d4ae52cb9af0","user":"bd7ea748-35c0-11e5-b094-d4ae52cb9af0"}

payload_bytes: 304
payload_encoding: string
redelivered: False

--------------------------------------------------------------------------------

routing_key: management-server.AsyncJobEvent.complete.Account.*
exchange: cloudstack-events
message_count: 0
payload: {"cmdInfo":"{\"id\":\"9dd3abc2-3f8b-4852-aa60-a74b234acb13\",\"response\":\"json\",\"sessionkey\":\"5ig1ItP2_5v-mgY4cVJbJN5hw_w\",\"ctxDetails\":\"
{\\\"interface com.cloud.user.Account\\\":\\\"9dd3abc2-3f8b-4852-aa60-a74b234acb13\\\"}

\",\"cmdEventType\":\"ACCOUNT.DELETE\",\"expires\":\"2015-09-07T11:11:56+0000\",\"ctxUserId\":\"2\",\"signatureversion\":\"3\",\"httpmethod\":\"GET\",\"uuid\":\"9dd3abc2-3f8b-4852-aa60-a74b234acb13\",\"ctxAccountId\":\"2\",\"ctxStartEventId\":\"447\"}","instanceType":"Account","jobId":"5004989d-0cde-4922-8afa-66bf38b75ea7","status":"SUCCEEDED","processStatus":"0","commandEventType":"ACCOUNT.DELETE","resultCode":"0","command":"org.apache.cloudstack.api.command.admin.account.DeleteAccountCmd","jobResult":"org.apache.cloudstack.api.response.SuccessResponse/null/
{\"success\":true}

","account":"bd73dc2e-35c0-11e5-b094-d4ae52cb9af0","user":"bd7ea748-35c0-11e5-b094-d4ae52cb9af0"}
payload_bytes: 914
payload_encoding: string
redelivered: False

--------------------------------------------------------------------------------

After
--------------------------------------------------------------------------------

 routing_key: management-server.ActionEvent.ACCOUNT-DELETE.Account.e5e2db91-414d-484c-99d5-c4e265c14ad8
exchange: cloudstack-events
message_count: 13
payload: {"eventDateTime":"2015-09-07 17:32:26 +0530","status":"Completed","description":"Successfully completed deleting account. Account Id: 45","event":"ACCOUNT.DELETE","entityuuid":"e5e2db91-414d-484c-99d5-c4e265c14ad8","entity":"com.cloud.user.Account","account":"bd73dc2e-35c0-11e5-b094-d4ae52cb9af0","user":"bd7ea748-35c0-11e5-b094-d4ae52cb9af0"}
payload_bytes: 344
payload_encoding: string
redelivered: True

--------------------------------------------------------------------------------

routing_key: management-server.AsyncJobEvent.complete.Account.e5e2db91-414d-484c-99d5-c4e265c14ad8
exchange: cloudstack-events
message_count: 12
payload: {"cmdInfo":"{\"id\":\"e5e2db91-414d-484c-99d5-c4e265c14ad8\",\"response\":\"json\",\"sessionkey\":\"8AJVbn8HIpg5LZ_VaVfSPs_QN2k\",\"ctxDetails\":\"{\\\"interface com.cloud.user.Account\\\":\\\"e5e2db91-414d-484c-99d5-c4e265c14ad8\\\"}\",\"cmdEventType\":\"ACCOUNT.DELETE\",\"expires\":\"2015-09-07T12:17:42+0000\",\"ctxUserId\":\"2\",\"signatureversion\":\"3\",\"httpmethod\":\"GET\",\"uuid\":\"e5e2db91-414d-484c-99d5-c4e265c14ad8\",\"ctxAccountId\":\"2\",\"ctxStartEventId\":\"465\"}","instanceType":"Account","instanceUuid":"e5e2db91-414d-484c-99d5-c4e265c14ad8","jobId":"0bb08486-6d9f-4e9f-bfef-b7463c42e71b","status":"SUCCEEDED","processStatus":"0","commandEventType":"ACCOUNT.DELETE","resultCode":"0","command":"org.apache.cloudstack.api.command.admin.account.DeleteAccountCmd","jobResult":"org.apache.cloudstack.api.response.SuccessResponse/null/{\"success\":true}","account":"bd73dc2e-35c0-11e5-b094-d4ae52cb9af0","user":"bd7ea748-35c0-11e5-b094-d4ae52cb9af0"}
payload_bytes: 968
payload_encoding: string
redelivered: True

--------------------------------------------------------------------------------