### PR TITLE
debian: Updated dependencies for Packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: cloudstack
 Section: libs
 Priority: extra
 Maintainer: Wido den Hollander <wido@widodh.nl>
-Build-Depends: debhelper (>= 7), openjdk-7-jdk | openjdk-8-jdk, genisoimage,
- python-mysqldb, maven (>= 3) | maven3, python (>= 2.6.6-3~)
+Build-Depends: debhelper (>= 9), openjdk-8-jdk | openjdk-7-jdk, genisoimage,
+ python-mysqldb, maven (>= 3) | maven3, python (>= 2.7)
 Standards-Version: 3.8.1
 Homepage: http://www.cloudstack.org/
 
@@ -15,14 +15,14 @@ Description: A common package which contains files which are shared by several C
 
 Package: cloudstack-management
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, cloudstack-common (= ${source:Version}), tomcat6 | tomcat7 | tomcat8, sudo, jsvc, python-mysqldb, libmysql-java, python-paramiko, augeas-tools, mysql-client, adduser
+Depends: ${misc:Depends}, ${python:Depends}, cloudstack-common (= ${source:Version}), tomcat8 | tomcat7 | tomcat6, sudo, jsvc, python-mysqldb, libmysql-java, augeas-tools, mysql-client, adduser
 Conflicts: cloud-server, cloud-client, cloud-client-ui
 Description: CloudStack server library
  The CloudStack management server
 
 Package: cloudstack-agent
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, openjdk-7-jre-headless | openjdk-8-jre-headless, cloudstack-common (= ${source:Version}), lsb-base (>= 3.2), libcommons-daemon-java, openssh-client, libvirt0, qemu-system-x86 | qemu-kvm, libvirt-bin, uuid-runtime, rsync, iproute, perl-modules, ebtables, vlan, wget, jsvc, ipset, python-libvirt, ethtool, iptables
+Depends: ${misc:Depends}, ${python:Depends}, openjdk-8-jre-headless | openjdk-7-jre-headless, cloudstack-common (= ${source:Version}), lsb-base (>= 4.0), libcommons-daemon-java, openssh-client, qemu-kvm (>= 1.0), libvirt-bin (>= 0.9.8), uuid-runtime, iproute, ebtables, vlan, jsvc, ipset, python-libvirt, ethtool, iptables
 Conflicts: cloud-agent, cloud-agent-libs, cloud-agent-deps, cloud-agent-scripts
 Description: CloudStack agent
  The CloudStack agent is in charge of managing shared computing resources in
@@ -31,7 +31,7 @@ Description: CloudStack agent
 
 Package: cloudstack-usage
 Architecture: all
-Depends: ${misc:Depends}, openjdk-7-jre-headless | openjdk-8-jre-headless, cloudstack-common (= ${source:Version}), jsvc, libmysql-java
+Depends: ${misc:Depends}, openjdk-8-jre-headless | openjdk-7-jre-headless, cloudstack-common (= ${source:Version}), jsvc, libmysql-java
 Description: CloudStack usage monitor
  The CloudStack usage monitor provides usage accounting across the entire cloud for
  cloud operators to charge based on usage parameters.


### PR DESCRIPTION
A few dependencies have been updated to their latest version and some
have been removed.

The ordering for some dependencies has been changed so that we will
depend on Java 8 over Java 7 when doing a new install.