### PR TITLE
CLOUDSTACK-8799 fixed the defalut routes

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -95,6 +95,14 @@ class CsAddress(CsDataBag):
                 return ip
         return None
 
+    def check_if_link_exists(self,dev):
+        cmd="ip link show dev %s"%dev
+        result=CsHelper.execute(cmd)
+        if(len(result)!=0):
+           return True
+        else:
+           return False
+
     def check_if_link_up(self,dev):
         cmd="ip link show dev %s | tr '\n' ' ' | cut -d ' ' -f 9"%dev
         result=CsHelper.execute(cmd)
@@ -117,6 +125,9 @@ class CsAddress(CsDataBag):
                     continue
 
                 #check if link is up
+                if (not self.check_if_link_exists(dev)):
+                    logging.info("link %s does not exist, so not processing"%dev)
+                    continue
                 if not self.check_if_link_up(dev):
                    cmd="ip link set %s up"%dev
                    CsHelper.execute(cmd)
@@ -142,7 +153,8 @@ class CsAddress(CsDataBag):
         # is a default route and add if needed
         if not route.defaultroute_exists():
             cmdline=self.config.get_cmdline_instance()
-            route.add_defaultroute(cmdline.get_gateway())
+            if(cmdline.get_gateway()):
+                route.add_defaultroute(cmdline.get_gateway())
 
 
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
@@ -134,3 +134,7 @@ class CsCmdLine(CsDataBag):
         md5 = hashlib.md5()
         md5.update(passwd)
         return md5.hexdigest()
+    def get_gateway(self):
+        if "gateway" in self.idata():
+            return self.idata()['gateway']
+        return False

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -262,7 +262,7 @@ class CsRedundant(object):
         self.set_lock()
         logging.debug("Setting router to master")
         self.address.process()
-        logging.info("added default rotue")
+        logging.info("added default routes")
 
         # ip route add default via $gw table Table_$dev proto static
         cmd = "%s -C %s" % (self.CONNTRACKD_BIN, self.CONNTRACKD_CONF)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -261,20 +261,9 @@ class CsRedundant(object):
 
         self.set_lock()
         logging.debug("Setting router to master")
-        ads = [o for o in self.address.get_ips() if o.is_public()]
-        dev = ''
-        for o in ads:
-            if dev == o.get_device():
-                continue
-            cmd2 = "ip link set %s up" % o.get_device()
-            if CsDevice(o.get_device(), self.config).waitfordevice():
-                CsHelper.execute(cmd2)
-                dev = o.get_device()
-                logging.info("Bringing public interface %s up" %
-                             o.get_device())
-            else:
-                logging.error(
-                    "Device %s was not ready could not bring it up" % o.get_device())
+        self.address.process()
+        logging.info("added default rotue")
+
         # ip route add default via $gw table Table_$dev proto static
         cmd = "%s -C %s" % (self.CONNTRACKD_BIN, self.CONNTRACKD_CONF)
         CsHelper.execute("%s -c" % cmd)


### PR DESCRIPTION
CLOUDSTACK-8799 made changes to fix the default routes
modified the CsRedundant.py to configure default routes correctly when rvr changes state from backup to master.