### PR TITLE
CLOUDSTACK-8821: UI Change

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1410,6 +1410,7 @@
                                 title: 'label.egress.rules',
                                 custom: function(args) {
                                     var context = args.context;
+                                    var isConfigRulesMsgShown = false;
 
                                     return $('<div>').multiEdit({
                                         context: context,
@@ -1612,6 +1613,36 @@
                                                     });
                                                 }
                                             });
+
+                                            if (!isConfigRulesMsgShown) {
+                                                isConfigRulesMsgShown = true;
+                                                $.ajax({
+                                                    url: createURL('listNetworkOfferings'),
+                                                    data: {
+                                                        id: args.context.networks[0].networkofferingid
+                                                    },
+                                                    dataType: 'json',
+                                                    async: true,
+                                                    success: function(json) {
+                                                        var response = json.listnetworkofferingsresponse.networkoffering ?
+                                                        json.listnetworkofferingsresponse.networkoffering[0] : null;
+
+                                                        if (response != null) {
+                                                            var egressdefaultpolicy;
+
+                                                            if (response.egressdefaultpolicy == true) {
+                                                                egressdefaultpolicy = 'Block';
+                                                            } else {
+                                                                egressdefaultpolicy = 'Allow';
+                                                            }
+
+                                                            cloudStack.dialog.notice({
+                                                                message: _l('Configure the rules to ' + egressdefaultpolicy + ' Traffic.')
+                                                            });
+                                                        }
+                                                    }
+                                                });
+                                            }
                                         }
                                     });
                                 }


### PR DESCRIPTION
It provides appropriate message in the UI when configuring the firewall rules in Network page.
If the default egress policy is allow, then it says to block traffic. If the default egress policy is deny, then it says to allow traffic.