### PR TITLE
CLOUDSTACK-8827: Move the VM snapshots stuck in transitional states to stable states during managment server restart

### DIFF
--- a/api/src/com/cloud/vm/snapshot/VMSnapshotService.java
+++ b/api/src/com/cloud/vm/snapshot/VMSnapshotService.java
@@ -47,10 +47,12 @@ public interface VMSnapshotService {
 
     VirtualMachine getVMBySnapshotId(Long id);
 
+    void cleanupVmSnapshotJobs();
+
     /**
      * Delete vm snapshots only from database. Introduced as a Vmware optimization in which vm snapshots are deleted when
      * the vm gets deleted on hypervisor (no need to delete each vm snapshot before deleting vm, just mark them as deleted on DB)
-     * @param id vm id
+     * @param vmId vm id
      */
     boolean deleteVMSnapshotsFromDB(Long vmId);
 }

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -578,6 +578,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         cancelWorkItems(_nodeId);
 
         volumeMgr.cleanupStorageJobs();
+        _vmSnapshotMgr.cleanupVmSnapshotJobs();
         // cleanup left over place holder works
         _workJobDao.expungeLeftoverWorkJobs(ManagementServerNode.getManagementServerId());
         return true;


### PR DESCRIPTION
i.e. If snapshot in creating state move it to Error state and if it is in reverting state move it to Ready state.

Manual tests performed

Take VM snapshot of VM
stop the management server
Verify in DB that VM snapshot is in  creating state
Start the management server
Verify that snapshot moves to ERROR state.
