### PR TITLE
CLOUDSTACK-8815 : Issues with cloudstack-management init script

### DIFF
--- a/packaging/centos63/cloud-ipallocator.rc
+++ b/packaging/centos63/cloud-ipallocator.rc
@@ -25,7 +25,7 @@
 
 # set environment variables
 
-SHORTNAME=`basename $0`
+SHORTNAME="$(basename $(readlink -f $0))"
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
 LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log

--- a/packaging/centos63/cloud-management.rc
+++ b/packaging/centos63/cloud-management.rc
@@ -42,7 +42,7 @@ if [ -r /lib/lsb/init-functions ]; then
 fi
 
 
-NAME="$(basename $0)"
+NAME="$(basename $(readlink -f $0))"
 export SERVICE_NAME="$NAME"
 stop() {
 	SHUTDOWN_WAIT="30"

--- a/packaging/centos7/cloud-ipallocator.rc
+++ b/packaging/centos7/cloud-ipallocator.rc
@@ -25,7 +25,7 @@
 
 # set environment variables
 
-SHORTNAME=`basename $0`
+SHORTNAME="$(basename $(readlink -f $0))"
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
 LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log

--- a/packaging/fedora20/cloud-ipallocator.rc
+++ b/packaging/fedora20/cloud-ipallocator.rc
@@ -25,7 +25,7 @@
 
 # set environment variables
 
-SHORTNAME=`basename $0`
+SHORTNAME="$(basename $(readlink -f $0))"
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
 LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log

--- a/packaging/fedora20/cloud-management.rc
+++ b/packaging/fedora20/cloud-management.rc
@@ -42,7 +42,7 @@ if [ -r /lib/lsb/init-functions ]; then
 fi
 
 
-NAME="$(basename $0)"
+NAME="$(basename $(readlink -f $0))"
 export SERVICE_NAME="$NAME"
 stop() {
 	SHUTDOWN_WAIT="30"

--- a/packaging/fedora21/cloud-ipallocator.rc
+++ b/packaging/fedora21/cloud-ipallocator.rc
@@ -25,7 +25,7 @@
 
 # set environment variables
 
-SHORTNAME=`basename $0`
+SHORTNAME="$(basename $(readlink -f $0))"
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
 LOGFILE=/var/log/cloudstack/ipallocator/ipallocator.log

--- a/packaging/fedora21/cloud-management.rc
+++ b/packaging/fedora21/cloud-management.rc
@@ -42,7 +42,7 @@ if [ -r /lib/lsb/init-functions ]; then
 fi
 
 
-NAME="$(basename $0)"
+NAME="$(basename $(readlink -f $0))"
 export SERVICE_NAME="$NAME"
 stop() {
 	SHUTDOWN_WAIT="30"


### PR DESCRIPTION


When a management server is halted or rebooted, the cloudstack-management init script does not successfully kill the associated java process. There will always be an error about "Cannot find PID file". The script should be reworked so that there are no errors and java is killed correctly.

This appears to be due to the script using the basename of the script:

NAME="$(basename $0)"

To look for the pid file:

if [ -f /var/run/$
{NAME}

.pid ]; then

This does work correctly if the script is run directly (basename will be "cloudstack-management", so "cloudstack-management.pid" file is found). However when a server is halted or rebooted, the script is not run directly but via the symlinks in /etc/rc.d/rc0.d/ and /etc/rc.d/rc0.d/, respectively. The symlinks are named "K20cloudstack-management" so the script looks for a pid file named "K20cloudstack-management.pid" which does not exist.

screenshots:

Before fix: 
![screen shot 2015-09-10 at 12 33 08 am](https://cloud.githubusercontent.com/assets/1062642/9791113/207412f0-57f7-11e5-8d21-b7ef383747bd.png)

After fix:
![screen shot 2015-09-10 at 5 46 50 pm](https://cloud.githubusercontent.com/assets/1062642/9791136/31c9ca90-57f7-11e5-98c5-9ad18f25788b.png)
