### PR TITLE
CLOUDSTACK-8798 Fixed the vrrp virtual ip config in case of rvr enabl…

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
@@ -97,6 +97,12 @@ class CsCmdLine(CsDataBag):
         else:
             return "unknown"
 
+    def get_eth2_ip(self):
+        if "eth2ip" in self.idata():
+            return self.idata()['eth2ip']
+        else:
+            return "unknown"
+
     def is_master(self):
         if not self.is_redundant():
             return False
@@ -130,7 +136,10 @@ class CsCmdLine(CsDataBag):
         This is slightly difficult to happen, but if it does, destroy the router with the password generated with the
         code below and restart the VPC with out the clean up option.
         '''
-        passwd = "%s-%s" % (self.get_vpccidr, self.get_router_id())
+        if(self.get_type()=='router'):
+            passwd="%s-%s" % (self.get_eth2_ip(), self.get_router_id())
+        else:
+            passwd = "%s-%s" % (self.get_vpccidr(), self.get_router_id())
         md5 = hashlib.md5()
         md5.update(passwd)
         return md5.hexdigest()

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -236,7 +236,7 @@ class CsRedundant(object):
             if dev == o.get_device():
                 continue
             logging.info("Bringing public interface %s down" % o.get_device())
-            cmd2 = "ip link set %s up" % o.get_device()
+            cmd2 = "ip link set %s down" % o.get_device()
             CsHelper.execute(cmd2)
             dev = o.get_device()
         cmd = "%s -C %s" % (self.CONNTRACKD_BIN, self.CONNTRACKD_CONF)
@@ -317,8 +317,11 @@ class CsRedundant(object):
         lines = []
         for o in self.address.get_ips():
             if o.needs_vrrp():
-                str = "        %s brd %s dev %s\n" % (
-                    o.get_gateway_cidr(), o.get_broadcast(), o.get_device())
+                cmdline=self.config.get_cmdline_instance()
+                if(cmdline.get_type()=='router'):
+                    str = "        %s brd %s dev %s\n" % (cmdline.get_guest_gw(), o.get_broadcast(), o.get_device())
+                else:
+                    str = "        %s brd %s dev %s\n" % (o.get_ip(), o.get_broadcast(), o.get_device())
                 lines.append(str)
                 self.check_is_up(o.get_device())
         return lines


### PR DESCRIPTION
Fixed the vrrp virtual ip config in case of rvr enabled isolated networks.
changed the CsRedundant.py to bring down the public interface when rvr changes state to
backup. Also fixed vrrp authentication for isolated networks.

This fix dose not effect the vpc networks. it is only meant for rvr isolated networks.

manullay deployed a vm in rvr enabled isolated network and ran the tests below.

nosetests --with-marvin --marvin-config=/marvin-config test/integration/component/test_redundant_router_services.py

Test redundant router internals ... === TestName: test_enableVPNOverRvR | Status : SUCCESS ===

----------------------------------------------------------------------
Ran 1 test in 633.336s

nosetests --with-marvin --marvin-config=/marvin-config test/integration/component/test_redundant_router_cleanups.py

Test network garbage collection with RVR ... === TestName: test_network_gc | Status : SUCCESS ===
ok
Test restarting RvR network without cleanup ... === TestName: test_restart_ntwk_no_cleanup | Status : SUCCESS ===
ok
Test restart RvR network with cleanup ... === TestName: test_restart_ntwk_with_cleanup | Status : SUCCESS ===

----------------------------------------------------------------------
Ran 3 tests in 2120.263s
