### PR TITLE
This is the fix for the JIRA issue CLOUDSTACK-8817.

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/FirewallResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/FirewallResponse.java
@@ -37,11 +37,11 @@ public class FirewallResponse extends BaseResponse {
 
     @SerializedName(ApiConstants.START_PORT)
     @Param(description = "the starting port of firewall rule's port range")
-    private String startPort;
+    private Integer startPort;
 
     @SerializedName(ApiConstants.END_PORT)
     @Param(description = "the ending port of firewall rule's port range")
-    private String endPort;
+    private Integer endPort;
 
     @SerializedName(ApiConstants.IP_ADDRESS_ID)
     @Param(description = "the public ip address id for the firewall rule")

--- a/api/src/org/apache/cloudstack/api/response/FirewallResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/FirewallResponse.java
@@ -87,11 +87,11 @@ public class FirewallResponse extends BaseResponse {
         this.protocol = protocol;
     }
 
-    public void setStartPort(String startPort) {
+    public void setStartPort(Integer startPort) {
         this.startPort = startPort;
     }
 
-    public void setEndPort(String endPort) {
+    public void setEndPort(Integer endPort) {
         this.endPort = endPort;
     }
 

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -2124,11 +2124,11 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setId(fwRule.getUuid());
         response.setProtocol(fwRule.getProtocol());
         if (fwRule.getSourcePortStart() != null) {
-            response.setStartPort(Integer.toString(fwRule.getSourcePortStart()));
+            response.setStartPort(fwRule.getSourcePortStart());
         }
 
         if (fwRule.getSourcePortEnd() != null) {
-            response.setEndPort(Integer.toString(fwRule.getSourcePortEnd()));
+            response.setEndPort(fwRule.getSourcePortEnd());
         }
 
         List<String> cidrs = ApiDBUtils.findFirewallSourceCidrs(fwRule.getId());


### PR DESCRIPTION
This is my first contribution to Apache CloudStack. The return values for endpoint and startpoint have now been changed to Integer instead of String. Please let me know if this is the only change that is required or if there are additional files which will be impacted by this change which require modification also.