### PR TITLE
CLOUDSTACK-8841: Storage XenMotion from XS 6.2 to XS 6.5 fails.

### DIFF
--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -4717,8 +4717,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         // Check if the source and destination hosts are of the same type and support storage motion.
-        if (!(srcHost.getHypervisorType().equals(destinationHost.getHypervisorType()) && srcHost.getHypervisorVersion().equals(destinationHost.getHypervisorVersion()))) {
-            throw new CloudRuntimeException("The source and destination hosts are not of the same type and version. " + "Source hypervisor type and version: "
+        if (!(srcHost.getHypervisorType().equals(destinationHost.getHypervisorType()))) {
+            throw new CloudRuntimeException("The source and destination hosts are not of the same type. " + "Source hypervisor type and version: "
                     + srcHost.getHypervisorType().toString() + " " + srcHost.getHypervisorVersion() + ", Destination hypervisor type and version: "
                     + destinationHost.getHypervisorType().toString() + " " + destinationHost.getHypervisorVersion());
         }


### PR DESCRIPTION
Removed Host version check in API. Because 
Case 1:(Lower to Higher Version)
Migration from lower version to higher version is valid.
Case 2:(Higher to Lower Version)
In this case system(Host) will not allow.
So no need to check version in API. Additionally,  CLOUDSTACK User Interface(UI) does  not allow  migration between different version of hyper-visors. But sometimes user wants to do migration from  Lower to Higher Version. Now he can do it via API.

ACS Link ==>
https://issues.apache.org/jira/browse/CLOUDSTACK-8841
