### PR TITLE
Fixed: Network Update from RVR offering to Standalone offering fails

### DIFF
--- a/engine/schema/src/com/cloud/network/dao/NetworkVO.java
+++ b/engine/schema/src/com/cloud/network/dao/NetworkVO.java
@@ -619,4 +619,9 @@ public class NetworkVO implements Network {
     public void setVpcId(Long vpcId) {
         this.vpcId = vpcId;
     }
+
+    public void setIsReduntant(boolean reduntant) {
+        this.isRedundant = reduntant;
+    }
+
 }

--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -2100,6 +2100,9 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
                 }
                 restartNetwork = true;
                 networkOfferingChanged = true;
+
+                //Setting the new network's isReduntant to the new network offering's RedundantRouter.
+                network.setIsReduntant(_networkOfferingDao.findById(networkOfferingId).getRedundantRouter());
             }
         }
 


### PR DESCRIPTION
Problem: Moving a RVR network offering to standalone makes the status of VR's as UNKNOWN and Redundant Router marked with YES. 
Fix: The network's isRedundant was not getting updated.