### PR TITLE
CLOUDSTACK-8867: Added retry logic to reconnect to host on connection termination

### DIFF
--- a/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxyClientParam.java
+++ b/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxyClientParam.java
@@ -115,7 +115,7 @@ public class ConsoleProxyClientParam {
 
     public String getClientMapKey() {
         if (clientTag != null && !clientTag.isEmpty())
-            return clientTag;
+            return clientTag + ":" + clientHostPort;
 
         return clientHostAddress + ":" + clientHostPort;
     }


### PR DESCRIPTION
Also changed  viewer/console identifier to vm uuid + vnc port to avoid using same connection console if vm's vnc port is changed