### PR TITLE
CLOUDSTACK-8863: VM doesn't reconnect to internet post VR RESTART/STO…

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
@@ -93,4 +93,15 @@ done < $cfg
 #remove the configuration file, log file should have all the records as well
 rm -f $cfg
 
+# Flush kernel conntrack table
+log_it "VR config: Flushing conntrack table"
+conntrackd -d 2> /dev/null
+if [ $? -eq 0 ]; then
+    conntrackd -F
+    conntrackd -k
+else
+   conntrackd -F
+fi
+log_it "VR config: Flushing conntrack table completed"
+
 exit 0


### PR DESCRIPTION
…P-START/RECREATE

The ongoing ICMP request reply session is broken when the VR is down, the expectation is that it would resume once the VR is up. Investigations revealed that the ongoing ICMP packets are sent out of eth2 without being NATed post VR stop/start or restart or recreate.

TCPDUMP output from VR post restart/stop-start/recreate on eth2:

root@r-4-VM:~# tcpdump -i eth2 icmp -n -vvv
tcpdump: listening on eth2, link-type EN10MB (Ethernet), capture size 65535 bytes
06:22:52.749770 IP (tos 0x0, ttl 63, id 0, offset 0, flags [DF], proto ICMP (1), length 84)
    192.168.200.67 > 173.194.33.163: ICMP echo request, id 30996, seq 81, length 64
06:22:53.749782 IP (tos 0x0, ttl 63, id 0, offset 0, flags [DF], proto ICMP (1), length 84)
    192.168.200.67 > 173.194.33.163: ICMP echo request, id 30996, seq 82, length 64
06:22:54.749771 IP (tos 0x0, ttl 63, id 0, offset 0, flags [DF], proto ICMP (1), length 84)
    192.168.200.67 > 173.194.33.163: ICMP echo request, id 30996, seq 83, length 64
06:22:55.749775 IP (tos 0x0, ttl 63, id 0, offset 0, flags [DF], proto ICMP (1), length 84)
    192.168.200.67 > 173.194.33.163: ICMP echo request, id 30996, seq 84, length 64
06:22:56.749765 IP (tos 0x0, ttl 63, id 0, offset 0, flags [DF], proto ICMP (1), length 84)
    192.168.200.67 > 173.194.33.163: ICMP echo request, id 30996, seq 85, length 64
06:22:57.749776 IP (tos 0x0, ttl 63, id 0, offset 0, flags [DF], proto ICMP (1), length 84)
    192.168.200.67 > 173.194.33.163: ICMP echo request, id 30996, seq 86, length 64
^C
6 packets captured
6 packets received by filter
0 packets dropped by kernel
root@r-4-VM:~#
root@r-4-VM:~# grep icmp /proc/net/ip_conntrack
icmp     1 29 src=192.168.200.67 dst=173.194.33.163 type=8 code=0 id=30996 [UNREPLIED] src=173.194.33.163 dst=192.168.200.67 type=0 code=0 id=30996 mark=0 use=2

This get fixed after flushing the conntrack table. 

Screenshots:

Before fix (ping session doesn't resume, stop and starting the ping works, 120 packets lost):
![image](https://cloud.githubusercontent.com/assets/12229259/9897800/4de7488e-5c6a-11e5-98eb-3bd79cc3a8b1.png)

After fix(ping session resumes, 27 packets lost):
![image](https://cloud.githubusercontent.com/assets/12229259/9897822/9112e866-5c6a-11e5-95b3-1b20600d2e44.png)
