### PR TITLE
CLOUDSTACK-8855 Improve Error Message for Host Alert State and reconnect host API.

### DIFF
--- a/api/src/com/cloud/resource/ResourceService.java
+++ b/api/src/com/cloud/resource/ResourceService.java
@@ -18,6 +18,8 @@ package com.cloud.resource;
 
 import java.util.List;
 
+import com.cloud.exception.AgentUnavailableException;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.dc.DataCenter;
 import org.apache.cloudstack.api.command.admin.cluster.AddClusterCmd;
 import org.apache.cloudstack.api.command.admin.cluster.DeleteClusterCmd;
@@ -50,7 +52,7 @@ public interface ResourceService {
 
     Host cancelMaintenance(CancelMaintenanceCmd cmd);
 
-    Host reconnectHost(ReconnectHostCmd cmd);
+    Host reconnectHost(ReconnectHostCmd cmd) throws CloudRuntimeException, AgentUnavailableException;
 
     /**
      * We will automatically create a cloud.com cluster to attach to the external cluster and return a hyper host to perform

--- a/api/src/org/apache/cloudstack/api/command/admin/host/ReconnectHostCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/host/ReconnectHostCmd.java
@@ -16,6 +16,9 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.host;
 
+import com.cloud.exception.AgentUnavailableException;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -100,17 +103,18 @@ public class ReconnectHostCmd extends BaseAsyncCmd {
     @Override
     public void execute() {
         try {
-            Host result = _resourceService.reconnectHost(this);
-            if (result != null) {
-                HostResponse response = _responseGenerator.createHostResponse(result);
-                response.setResponseName(getCommandName());
-                this.setResponseObject(response);
-            } else {
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to reconnect host");
-            }
-        } catch (Exception ex) {
-            s_logger.warn("Exception: ", ex);
-            throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, ex.getMessage());
+            Host result =_resourceService.reconnectHost(this);
+            HostResponse response = _responseGenerator.createHostResponse(result);
+            response.setResponseName(getCommandName());
+            this.setResponseObject(response);
+        }catch (InvalidParameterValueException e) {
+            throw new ServerApiException(ApiErrorCode.PARAM_ERROR, e.getMessage());
+        }
+        catch (CloudRuntimeException e) {
+            s_logger.warn("Exception: ", e);
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());
+        }catch (AgentUnavailableException e) {
+            throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, e.getMessage());
         }
     }
 }

--- a/engine/components-api/src/com/cloud/agent/AgentManager.java
+++ b/engine/components-api/src/com/cloud/agent/AgentManager.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.agent;
 
+import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.cloudstack.framework.config.ConfigKey;
 
 import com.cloud.agent.api.Answer;
@@ -141,7 +142,7 @@ public interface AgentManager {
 
     public void pullAgentOutMaintenance(long hostId);
 
-    boolean reconnect(long hostId);
+    void reconnect(long hostId) throws CloudRuntimeException, AgentUnavailableException;
 
     void rescan();
 

--- a/engine/orchestration/src/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
@@ -357,19 +357,12 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     }
 
     @Override
-    public boolean reconnect(final long hostId) {
-        Boolean result;
-        try {
-            result = propagateAgentEvent(hostId, Event.ShutdownRequested);
-            if (result != null) {
-                return result;
-            }
-        } catch (final AgentUnavailableException e) {
-            s_logger.debug("cannot propagate agent reconnect because agent is not available", e);
-            return false;
+    public void reconnect(final long hostId) throws CloudRuntimeException, AgentUnavailableException {
+        Boolean result = propagateAgentEvent(hostId, Event.ShutdownRequested);
+        if (result!=null && !result) {
+            throw new CloudRuntimeException("Failed to propagating agent change request event:" + Event.ShutdownRequested + " to host:" + hostId);
         }
-
-        return super.reconnect(hostId);
+        super.reconnect(hostId);
     }
 
     public void notifyNodesInCluster(final AgentAttache attache) {

--- a/plugins/network-elements/netscaler/src/com/cloud/network/element/NetscalerElement.java
+++ b/plugins/network-elements/netscaler/src/com/cloud/network/element/NetscalerElement.java
@@ -512,7 +512,11 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
         });
         HostVO host = _hostDao.findById(lbDeviceVo.getHostId());
 
-        _agentMgr.reconnect(host.getId());
+        try {
+            _agentMgr.reconnect(host.getId());
+        } catch (Exception e ) {
+            s_logger.debug("failed to reconnect host "+host);
+        }
         return lbDeviceVo;
     }
 

--- a/server/src/com/cloud/alert/AlertManagerImpl.java
+++ b/server/src/com/cloud/alert/AlertManagerImpl.java
@@ -767,7 +767,9 @@ public class AlertManagerImpl extends ManagerBase implements AlertManager, Confi
                 // set up a new alert
                 AlertVO newAlert = new AlertVO();
                 newAlert.setType(alertType.getType());
-                newAlert.setSubject(subject);
+                //do not have a seperate column for content.
+                //appending the message to the subject for now.
+                newAlert.setSubject(subject+content);
                 newAlert.setClusterId(clusterId);
                 newAlert.setPodId(podId);
                 newAlert.setDataCenterId(dataCenterId);

--- a/server/src/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/com/cloud/resource/ResourceManagerImpl.java
@@ -1157,15 +1157,16 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
     }
 
     @Override
-    public Host reconnectHost(final ReconnectHostCmd cmd) {
-        final Long hostId = cmd.getId();
+    public Host reconnectHost(ReconnectHostCmd cmd) throws CloudRuntimeException, AgentUnavailableException{
+        Long hostId = cmd.getId();
 
         final HostVO host = _hostDao.findById(hostId);
         if (host == null) {
             throw new InvalidParameterValueException("Host with id " + hostId.toString() + " doesn't exist");
         }
 
-        return _agentMgr.reconnect(hostId) ? host : null;
+        _agentMgr.reconnect(hostId);
+        return host;
     }
 
     @Override


### PR DESCRIPTION
earlier we were eating up exceptions from the lower layer which resulted in improper error messages. fixed partially by throwing exceptions and catching them at the appropriate layer.

This also fixes the host alters. Earlier in the host alerts window we are listing only the alters, this dose not tell why the host when to alert state. This is fixed by adding the alert message to the host alerts.
(changes in AlertManagerImpl.java). 

tested manually.
