### PR TITLE
CLOUDSTACK-8857 listProjects doesn't return tags vmstopped or vmrunning when their value is zero

### DIFF
--- a/server/src/com/cloud/api/query/dao/AccountJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/AccountJoinDaoImpl.java
@@ -162,8 +162,8 @@ public class AccountJoinDaoImpl extends GenericDaoBase<AccountJoinVO, Long> impl
         response.setTemplateAvailable(templateAvail);
 
         // Get stopped and running VMs
-        response.setVmStopped(account.getVmStopped());
-        response.setVmRunning(account.getVmRunning());
+        response.setVmStopped(account.getVmStopped()!=null ? account.getVmStopped() : 0);
+        response.setVmRunning(account.getVmRunning()!=null ? account.getVmRunning() : 0);
 
         //get resource limits for networks
         long networkLimit = ApiDBUtils.findCorrectResourceLimit(account.getNetworkLimit(), account.getId(), ResourceType.network);


### PR DESCRIPTION
 listProjects doesn't return tags vmstopped or vmrunning when their value is zero
added the the appropriate tags to response.

tested this manually by creating projects, launching vms from project accounts and then listing the projects.
