### PR TITLE
CLOUDSTACK-8851 Redundant VR getting started in the same cluster or h…

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VmWorkStart.java
+++ b/engine/orchestration/src/com/cloud/vm/VmWorkStart.java
@@ -56,7 +56,7 @@ public class VmWorkStart extends VmWork {
 
     public DeploymentPlan getPlan() {
 
-        if (podId != null || clusterId != null || hostId != null || poolId != null || physicalNetworkId != null) {
+        if (podId != null || clusterId != null || hostId != null || poolId != null || physicalNetworkId != null || avoids !=null) {
             // this is ugly, to work with legacy code, we need to re-construct the DeploymentPlan hard-codely
             // this has to be refactored together with migrating legacy code into the new way
             ReservationContext context = null;
@@ -70,6 +70,7 @@ public class VmWorkStart extends VmWork {
             DeploymentPlan plan = new DataCenterDeployment(
                     dcId, podId, clusterId, hostId, poolId, physicalNetworkId,
                     context);
+            plan.setAvoids(avoids);
             return plan;
         }
 


### PR DESCRIPTION
we are not populating the deployment destination of the previous rvr in the avoid set of the rvr that is being created. This was resulting in both the rvrs getting deployed to same host sometimes even when it 
could have gone to a different one.

Now we are updating the avoids set of the deployment plan  to fix this issue.