### PR TITLE
CLOUDSTACK-8852 Database shows that management server is UP when it i…

### DIFF
--- a/client/distro/centos/SYSCONFDIR/rc.d/init.d/cloud-management.in
+++ b/client/distro/centos/SYSCONFDIR/rc.d/init.d/cloud-management.in
@@ -44,7 +44,7 @@ fi
 
 NAME="$(basename $0)"
 stop() {
-	SHUTDOWN_WAIT="30"
+	SHUTDOWN_WAIT="40"
 	count="0"
 	if [ -f /var/run/cloud-management.pid ]; then
 		pid=`cat /var/run/cloud-management.pid`

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
@@ -99,6 +99,7 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
         with(new WithComponentLifeCycle() {
             @Override
             public void with(ComponentLifecycle lifecycle) {
+                log.info("stopping bean " + lifecycle.getName());
                 lifecycle.stop();
             }
         });

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,10 +72,14 @@ public class CloudStackSpringContext {
     }
 
     public void registerShutdownHook() {
-        ApplicationContext base = moduleDefinitionSet.getApplicationContext(baseName);
+        Map<String, ApplicationContext> contextMap= moduleDefinitionSet.getContextMap();
 
-        if (base instanceof ConfigurableApplicationContext) {
-            ((ConfigurableApplicationContext)base).registerShutdownHook();
+        for (String appName : contextMap.keySet()) {
+            ApplicationContext contex = contextMap.get(appName);
+            if (contex instanceof ConfigurableApplicationContext) {
+                log.trace("registering shutdown hook for bean "+ appName);
+                ((ConfigurableApplicationContext)contex).registerShutdownHook();
+            }
         }
     }
 

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/ModuleDefinitionSet.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/ModuleDefinitionSet.java
@@ -21,11 +21,15 @@ package org.apache.cloudstack.spring.module.model;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 
+import java.util.Map;
+
 public interface ModuleDefinitionSet {
 
     ModuleDefinition getModuleDefinition(String name);
 
     ApplicationContext getApplicationContext(String name);
+
+    Map<String, ApplicationContext> getContextMap();
 
     Resource[] getConfigResources(String name);
 

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
@@ -279,6 +279,11 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
     }
 
     @Override
+    public Map<String, ApplicationContext> getContextMap() {
+        return contexts;
+    }
+
+    @Override
     public Resource[] getConfigResources(String name) {
         Set<Resource> resources = new LinkedHashSet<Resource>();
 

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/web/CloudStackContextLoaderListener.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/web/CloudStackContextLoaderListener.java
@@ -50,6 +50,7 @@ public class CloudStackContextLoaderListener extends ContextLoaderListener {
     public void contextInitialized(ServletContextEvent event) {
         try {
             cloudStackContext = new CloudStackSpringContext();
+            cloudStackContext.registerShutdownHook();
             event.getServletContext().setAttribute(CloudStackSpringContext.CLOUDSTACK_CONTEXT_SERVLET_KEY, cloudStackContext);
         } catch (IOException e) {
             log.error("Failed to start CloudStack", e);

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailManagerImpl.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ContrailManagerImpl.java
@@ -183,7 +183,9 @@ public class ContrailManagerImpl extends ManagerBase implements ContrailManager 
 
     @Override
     public boolean stop() {
-        _dbSyncTimer.cancel();
+        if (_dbSyncTimer != null) {
+            _dbSyncTimer.cancel();
+        }
         return true;
     }
 


### PR DESCRIPTION
Database shows that management server is UP when it is actually stopped.

 This was happening as the stop method in clusterMnanagerImpl was not getting callled. Added shutdown hooks to all spring sub contexts, this enables spring to call the stop mehtods of the beans when management server is shutting down.

Conflicts:
	framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/web/CloudStackContextLoaderListener.java