### PR TITLE
CLOUDSTACK-8868: use PasswordGenerator.generateRandomPassword() to generate systemvm passwords

### DIFF
--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -899,14 +899,6 @@ public enum Config {
             "0",
             "Default disk I/O read rate in requests per second allowed in User vm's disk.",
             null),
-    VmPasswordLength(
-            "Advanced",
-            ManagementServer.class,
-            Integer.class,
-            "vm.password.length",
-            "6",
-            "Specifies the length of a randomly generated password",
-            null),
     VmDiskThrottlingIopsWriteRate(
             "Advanced",
             ManagementServer.class,

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -770,7 +770,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     throw new InvalidParameterValueException("Please enter a positive value for the configuration parameter:" + name);
                 }
                 //TODO - better validation for all password pamameters
-                if ("vm.password.length".equalsIgnoreCase(name) && val < 6) {
+                if ("vm.password.length".equalsIgnoreCase(name) && val < 10) {
                     throw new InvalidParameterValueException("Please enter a value greater than 6 for the configuration parameter:" + name);
                 }
             } catch (final NumberFormatException e) {

--- a/server/src/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/com/cloud/server/ConfigurationServerImpl.java
@@ -416,30 +416,6 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         });
     }
 
-    /*
-    private void updateUuids() {
-        _identityDao.initializeDefaultUuid("disk_offering");
-        _identityDao.initializeDefaultUuid("network_offerings");
-        _identityDao.initializeDefaultUuid("vm_template");
-        _identityDao.initializeDefaultUuid("user");
-        _identityDao.initializeDefaultUuid("domain");
-        _identityDao.initializeDefaultUuid("account");
-        _identityDao.initializeDefaultUuid("guest_os");
-        _identityDao.initializeDefaultUuid("guest_os_category");
-        _identityDao.initializeDefaultUuid("hypervisor_capabilities");
-        _identityDao.initializeDefaultUuid("snapshot_policy");
-        _identityDao.initializeDefaultUuid("security_group");
-        _identityDao.initializeDefaultUuid("security_group_rule");
-        _identityDao.initializeDefaultUuid("physical_network");
-        _identityDao.initializeDefaultUuid("physical_network_traffic_types");
-        _identityDao.initializeDefaultUuid("physical_network_service_providers");
-        _identityDao.initializeDefaultUuid("virtual_router_providers");
-        _identityDao.initializeDefaultUuid("networks");
-        _identityDao.initializeDefaultUuid("user_ip_address");
-        _identityDao.initializeDefaultUuid("counter");
-    }
-     */
-
     private String getMountParent() {
         return getEnvironmentProperty("mount.parent");
     }

--- a/server/src/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/com/cloud/server/ConfigurationServerImpl.java
@@ -155,6 +155,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
     protected ConfigDepot _configDepot;
     @Inject
     protected ConfigurationManager _configMgr;
+    @Inject
+    protected ManagementService _mgrService;
 
 
     public ConfigurationServerImpl() {
@@ -668,7 +670,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         if (already == null) {
             TransactionLegacy txn = TransactionLegacy.currentTxn();
             try {
-                String rpassword = PasswordGenerator.generatePresharedKey(8);
+                String rpassword = _mgrService.generateRandomPassword();
                 String wSql = "INSERT INTO `cloud`.`configuration` (category, instance, component, name, value, description) "
                 + "VALUES ('Secure','DEFAULT', 'management-server','system.vm.password', ?,'randmon password generated each management server starts for system vm')";
                 PreparedStatement stmt = txn.prepareAutoCloseStatement(wSql);

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -504,6 +504,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.framework.config.ConfigDepot;
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
 import org.apache.cloudstack.framework.security.keystore.KeystoreManager;
@@ -671,9 +672,11 @@ import com.cloud.vm.dao.SecondaryStorageVmDao;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
-public class ManagementServerImpl extends ManagerBase implements ManagementServer {
+public class ManagementServerImpl extends ManagerBase implements ManagementServer, Configurable {
     public static final Logger s_logger = Logger.getLogger(ManagementServerImpl.class.getName());
 
+    static final ConfigKey<Integer> vmPasswordLength = new ConfigKey<Integer>("Advanced", Integer.class, "vm.password.length", "10",
+                                                                                      "Specifies the length of a randomly generated password", false);
     @Inject
     public AccountManager _accountMgr;
     @Inject
@@ -905,7 +908,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public String generateRandomPassword() {
-        final Integer passwordLength = Integer.parseInt(_configDao.getValue("vm.password.length"));
+        final Integer passwordLength = vmPasswordLength.value();
         return PasswordGenerator.generateRandomPassword(passwordLength);
     }
 
@@ -3019,6 +3022,16 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(GetUploadParamsForTemplateCmd.class);
         cmdList.add(GetUploadParamsForVolumeCmd.class);
         return cmdList;
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return ManagementServer.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {vmPasswordLength};
     }
 
     protected class EventPurgeTask extends ManagedContextRunnable {


### PR DESCRIPTION
generateRandomPassword() is supposed to create root user passwords. Right now it is only used on the guest VMs. The format of the passwords it creates are of the form "random 3-character string with a lowercase character, uppercase character, and a digit" + random n-character string with only lowercase characters".

For whatever reason it was that we use generateRandomPassword() for guest VM root user passwords(maybe more secure?) we should use the same function for system VM root user passwords.

Tests:
manually tested that password is generated in proper format and am able to login to cpvm with the new password. ex: zD2ztm, tR8snbwhq

```
$ mvn -pl server test -Dtest=ConfigurationServerImplTest#testUpdateSystemvmPassword
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.cloud.server.ConfigurationServerImplTest
log4j:WARN No appenders could be found for logger (com.cloud.utils.crypt.EncryptionSecretKeyChecker).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.487 sec - in com.cloud.server.ConfigurationServerImplTest

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 7.781 s
[INFO] Finished at: 2015-09-16T14:17:07+05:30
[INFO] Final Memory: 60M/466M
[INFO] ------------------------------------------------------------------------
```