### PR TITLE
CLOUDSTACK-8843: Fixed issue in default iptables rules on shared network VR

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
@@ -176,6 +176,8 @@ class CsNetfilters(object):
         These standard firewall rules vary according to the device type
         """
         type = CsCmdLine("cmdline").get_type()
+        if type == 'dhcpsrvr':
+            type = 'router'
 
         try:
             table = ''


### PR DESCRIPTION
On basic zone share network VR default iptables rules are not applied correctly. Due to this ssh to VR got failed.
In shared network the VR type is 'dhcpsrvr' not router. So corrected it in the ''del_standard' method to select the correct type.

Testing:
1. VR is deployed correctly.
2. Tested restart, stop, start VR.
3. New VM deployment is success.
4. ssh to VR from the host is successful.
5. iptables rules on the VR came up correctly.
below is the output from the VR:
iptables -L INPUT -nv
Chain INPUT (policy DROP 16 packets, 1056 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            224.0.0.18
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            225.0.0.50
  104  9800 ACCEPT     all  --  eth0   *       0.0.0.0/0            0.0.0.0/0            state RELATED,ESTABLISHED
  281 36500 ACCEPT     all  --  eth1   *       0.0.0.0/0            0.0.0.0/0            state RELATED,ESTABLISHED
    0     0 ACCEPT     all  --  eth2   *       0.0.0.0/0            0.0.0.0/0            state RELATED,ESTABLISHED
    6   504 ACCEPT     icmp --  *      *       0.0.0.0/0            0.0.0.0/0
    0     0 ACCEPT     all  --  lo     *       0.0.0.0/0            0.0.0.0/0
    2   656 ACCEPT     udp  --  eth0   *       0.0.0.0/0            0.0.0.0/0            udp dpt:67
   13   780 ACCEPT     tcp  --  eth1   *       0.0.0.0/0            0.0.0.0/0            tcp dpt:3922 state NEW,ESTABLISHED
    0     0 ACCEPT     tcp  --  eth0   *       0.0.0.0/0            0.0.0.0/0            tcp dpt:80 state NEW
    0     0 ACCEPT     tcp  --  eth0   *       10.147.40.0/23       0.0.0.0/0            state NEW tcp dpt:8080