### PR TITLE
Security group ingress/egress issues with xenserver 6.2

### DIFF
--- a/scripts/vm/hypervisor/xenserver/vmops
+++ b/scripts/vm/hypervisor/xenserver/vmops
@@ -356,10 +356,21 @@ def allow_egress_traffic(session):
                 return 'false'
     return 'true'
 
+def getIpsetType():
+    try:
+        out = util.pread2(['/bin/bash', '-c', "ipset -v | awk '{print $5}'"])
+        out.replace(".","")
+        if int(out) < 6:
+            return 'iptreemap'
+        else:
+            return 'nethash'
+    except:
+        return 'iptreemap'
 
 def ipset(ipsetname, proto, start, end, cidrs):
+    type = getIpsetType()
     try:
-        util.pread2(['ipset', '-N', ipsetname, 'nethash'])
+        util.pread2(['ipset', '-N', ipsetname, type])
     except:
         logging.debug("ipset chain already exists: " + ipsetname)
 
@@ -367,7 +378,7 @@ def ipset(ipsetname, proto, start, end, cidrs):
     ipsettmp = ''.join(''.join(ipsetname.split('-')).split('_')) + str(int(time.time()) % 1000)
 
     try:
-        util.pread2(['ipset', '-N', ipsettmp, 'nethash'])
+        util.pread2(['ipset', '-N', ipsettmp, type])
     except:
         logging.debug("Failed to create temp ipset, reusing old name= " + ipsettmp)
         try:
@@ -396,7 +407,7 @@ def ipset(ipsetname, proto, start, end, cidrs):
         # the old ipset entry could be of iphash type, try to delete and recreate
         try:
             util.pread2(['ipset', '-X', ipsetname])
-            util.pread2(['ipset', '-N', ipsetname, 'nethash'])
+            util.pread2(['ipset', '-N', ipsetname, type])
             util.pread2(['ipset', '-W', ipsettmp, ipsetname])
         except:
             logging.debug("Failed to swap ipset " + ipsetname)
@@ -672,14 +683,15 @@ def default_network_rules_systemvm(session, args):
 @echo
 def create_ipset_forvm (ipsetname):
     result = True
+    type = getIpsetType()
     try:
         logging.debug("Creating ipset chain .... " + ipsetname)
         util.pread2(['ipset', '-F', ipsetname])
         util.pread2(['ipset', '-X', ipsetname])
-        util.pread2(['ipset', '-N', ipsetname, 'iphash'])
+        util.pread2(['ipset', '-N', ipsetname, type])
     except:
         logging.debug("ipset chain not exists creating.... " + ipsetname)
-        util.pread2(['ipset', '-N', ipsetname, 'iphash'])
+        util.pread2(['ipset', '-N', ipsetname, type])
 
     return result
 
@@ -1252,9 +1264,10 @@ def inflate_rules (zipped):
 
 @echo
 def cache_ipset_keyword():
+    type = getIpsetType()
     tmpname = 'ipsetqzvxtmp'
     try:
-        util.pread2(['/bin/bash', '-c', 'ipset -N ' + tmpname + ' iphash'])
+        util.pread2(['/bin/bash', '-c', 'ipset -N ' + tmpname + type])
     except:
         util.pread2(['/bin/bash', '-c', 'ipset -F ' + tmpname])
 


### PR DESCRIPTION
There is issue with the xenserver 6.2 ipset type nethash. Fixed it by adding nethash for ipset version 6 which is xenserver 6.5. For ipset version 4.x use iptreemap. 
1. Tested configuring egress/ingress rules.
2. Tested the traffic for the configured rules from the VM.
