### PR TITLE
[4.6][BLOCKER]CLOUDSTACK-8763: Resolved POD/ZONE deletion failure.

### DIFF
--- a/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDao.java
+++ b/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDao.java
@@ -43,6 +43,8 @@ public interface DataCenterIpAddressDao extends GenericDao<DataCenterIpAddressVO
 
     int countIPs(long podId, long dcId, boolean onlyCountAllocated);
 
+    int countIPs(long dcId, boolean onlyCountAllocated);
+
     boolean deleteIpAddressByPod(long podId);
 
 }

--- a/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
@@ -45,6 +45,7 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
 
     private final SearchBuilder<DataCenterIpAddressVO> AllFieldsSearch;
     private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllIpCount;
+    private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllIpCountForDc;
     private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllAllocatedIpCount;
     private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllAllocatedIpCountForDc;
 
@@ -228,7 +229,7 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
         if (onlyCountAllocated) {
             sc = AllAllocatedIpCountForDc.create();
         } else {
-            sc = AllIpCount.create();
+            sc = AllIpCountForDc.create();
         }
 
         sc.setParameters("data_center_id", dcId);
@@ -253,6 +254,11 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
         AllIpCount.select(null, Func.COUNT, AllIpCount.entity().getId());
         AllIpCount.and("pod", AllIpCount.entity().getPodId(), SearchCriteria.Op.EQ);
         AllIpCount.done();
+
+        AllIpCountForDc = createSearchBuilder(Integer.class);
+        AllIpCountForDc.select(null, Func.COUNT, AllIpCountForDc.entity().getId());
+        AllIpCountForDc.and("data_center_id", AllIpCountForDc.entity().getPodId(), SearchCriteria.Op.EQ);
+        AllIpCountForDc.done();
 
         AllAllocatedIpCount = createSearchBuilder(Integer.class);
         AllAllocatedIpCount.select(null, Func.COUNT, AllAllocatedIpCount.entity().getId());

--- a/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/DataCenterIpAddressDaoImpl.java
@@ -46,6 +46,7 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
     private final SearchBuilder<DataCenterIpAddressVO> AllFieldsSearch;
     private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllIpCount;
     private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllAllocatedIpCount;
+    private final GenericSearchBuilder<DataCenterIpAddressVO, Integer> AllAllocatedIpCountForDc;
 
     @Override
     @DB
@@ -221,6 +222,20 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
         return count.get(0);
     }
 
+    @Override
+    public int countIPs(long dcId, boolean onlyCountAllocated) {
+        SearchCriteria<Integer> sc;
+        if (onlyCountAllocated) {
+            sc = AllAllocatedIpCountForDc.create();
+        } else {
+            sc = AllIpCount.create();
+        }
+
+        sc.setParameters("data_center_id", dcId);
+        List<Integer> count = customSearch(sc, null);
+        return count.get(0);
+    }
+
     public DataCenterIpAddressDaoImpl() {
         super();
 
@@ -244,5 +259,11 @@ public class DataCenterIpAddressDaoImpl extends GenericDaoBase<DataCenterIpAddre
         AllAllocatedIpCount.and("pod", AllAllocatedIpCount.entity().getPodId(), SearchCriteria.Op.EQ);
         AllAllocatedIpCount.and("removed", AllAllocatedIpCount.entity().getTakenAt(), SearchCriteria.Op.NNULL);
         AllAllocatedIpCount.done();
+
+        AllAllocatedIpCountForDc = createSearchBuilder(Integer.class);
+        AllAllocatedIpCountForDc.select(null, Func.COUNT, AllAllocatedIpCountForDc.entity().getId());
+        AllAllocatedIpCountForDc.and("data_center_id", AllAllocatedIpCountForDc.entity().getDataCenterId(), SearchCriteria.Op.EQ);
+        AllAllocatedIpCountForDc.and("removed", AllAllocatedIpCountForDc.entity().getTakenAt(), SearchCriteria.Op.NNULL);
+        AllAllocatedIpCountForDc.done();
     }
 }

--- a/engine/schema/src/com/cloud/network/dao/IPAddressDao.java
+++ b/engine/schema/src/com/cloud/network/dao/IPAddressDao.java
@@ -40,6 +40,8 @@ public interface IPAddressDao extends GenericDao<IPAddressVO, Long> {
 
     List<IPAddressVO> listStaticNatPublicIps(long networkId);
 
+    int countIPs(long dcId, boolean onlyCountAllocated);
+
     int countIPs(long dcId, long vlanDbId, boolean onlyCountAllocated);
 
     int countIPs(long dcId, Long accountId, String vlanId, String vlanGateway, String vlanNetmask);

--- a/engine/schema/src/com/cloud/network/dao/IPAddressDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/IPAddressDaoImpl.java
@@ -55,6 +55,7 @@ public class IPAddressDaoImpl extends GenericDaoBase<IPAddressVO, Long> implemen
     protected SearchBuilder<IPAddressVO> AllFieldsSearch;
     protected SearchBuilder<IPAddressVO> VlanDbIdSearchUnallocated;
     protected GenericSearchBuilder<IPAddressVO, Integer> AllIpCount;
+    protected GenericSearchBuilder<IPAddressVO, Integer> AllIpCountForDc;
     protected GenericSearchBuilder<IPAddressVO, Integer> AllocatedIpCount;
     protected GenericSearchBuilder<IPAddressVO, Integer> AllocatedIpCountForDc;
     protected GenericSearchBuilder<IPAddressVO, Integer> AllIpCountForDashboard;
@@ -100,6 +101,11 @@ public class IPAddressDaoImpl extends GenericDaoBase<IPAddressVO, Long> implemen
         AllIpCount.and("dc", AllIpCount.entity().getDataCenterId(), Op.EQ);
         AllIpCount.and("vlan", AllIpCount.entity().getVlanId(), Op.EQ);
         AllIpCount.done();
+
+        AllIpCountForDc = createSearchBuilder(Integer.class);
+        AllIpCountForDc.select(null, Func.COUNT, AllIpCountForDc.entity().getAddress());
+        AllIpCountForDc.and("dc", AllIpCountForDc.entity().getDataCenterId(), Op.EQ);
+        AllIpCountForDc.done();
 
         AllocatedIpCount = createSearchBuilder(Integer.class);
         AllocatedIpCount.select(null, Func.COUNT, AllocatedIpCount.entity().getAddress());
@@ -290,7 +296,7 @@ public class IPAddressDaoImpl extends GenericDaoBase<IPAddressVO, Long> implemen
 
     @Override
     public int countIPs(long dcId, boolean onlyCountAllocated) {
-        SearchCriteria<Integer> sc = onlyCountAllocated ? AllocatedIpCount.create() : AllIpCount.create();
+        SearchCriteria<Integer> sc = onlyCountAllocated ? AllocatedIpCountForDc.create() : AllIpCountForDc.create();
         sc.setParameters("dc", dcId);
 
         return customSearch(sc, null).get(0);

--- a/engine/schema/src/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDao.java
@@ -47,6 +47,8 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
 
     List<VolumeVO> findByPod(long podId);
 
+    List<VolumeVO> findByDc(long dcId);
+
     List<VolumeVO> findByAccountAndPod(long accountId, long podId);
 
     List<VolumeVO> findByTemplateAndZone(long templateId, long zoneId);

--- a/engine/schema/src/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDao.java
@@ -45,6 +45,8 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
 
     List<VolumeVO> findByInstanceIdDestroyed(long vmId);
 
+    List<VolumeVO> findByPod(long podId);
+
     List<VolumeVO> findByAccountAndPod(long accountId, long podId);
 
     List<VolumeVO> findByTemplateAndZone(long templateId, long zoneId);

--- a/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -200,7 +200,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     @Override
     public List<VolumeVO> findByDc(long dcId) {
         SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
-        sc.setParameters("data_center_id", dcId);
+        sc.setParameters("dcId", dcId);
 
         return listBy(sc);
     }
@@ -322,6 +322,7 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
         AllFieldsSearch = createSearchBuilder();
         AllFieldsSearch.and("state", AllFieldsSearch.entity().getState(), Op.EQ);
         AllFieldsSearch.and("accountId", AllFieldsSearch.entity().getAccountId(), Op.EQ);
+        AllFieldsSearch.and("dcId", AllFieldsSearch.entity().getDataCenterId(), Op.EQ);
         AllFieldsSearch.and("pod", AllFieldsSearch.entity().getPodId(), Op.EQ);
         AllFieldsSearch.and("instanceId", AllFieldsSearch.entity().getInstanceId(), Op.EQ);
         AllFieldsSearch.and("deviceId", AllFieldsSearch.entity().getDeviceId(), Op.EQ);

--- a/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -198,6 +198,14 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     }
 
     @Override
+    public List<VolumeVO> findByDc(long dcId) {
+        SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
+        sc.setParameters("data_center_id", dcId);
+
+        return listBy(sc);
+    }
+
+    @Override
     public List<VolumeVO> findByAccountAndPod(long accountId, long podId) {
         SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
         sc.setParameters("accountId", accountId);

--- a/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -190,6 +190,14 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     }
 
     @Override
+    public List<VolumeVO> findByPod(long podId) {
+        SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
+        sc.setParameters("pod", podId);
+
+        return listBy(sc);
+    }
+
+    @Override
     public List<VolumeVO> findByAccountAndPod(long accountId, long podId) {
         SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
         sc.setParameters("accountId", accountId);

--- a/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -155,6 +155,7 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         AllFieldsSearch.and("lastHost", AllFieldsSearch.entity().getLastHostId(), Op.EQ);
         AllFieldsSearch.and("state", AllFieldsSearch.entity().getState(), Op.EQ);
         AllFieldsSearch.and("zone", AllFieldsSearch.entity().getDataCenterId(), Op.EQ);
+        AllFieldsSearch.and("pod", AllFieldsSearch.entity().getPodIdToDeployIn(), Op.EQ);
         AllFieldsSearch.and("type", AllFieldsSearch.entity().getType(), Op.EQ);
         AllFieldsSearch.and("account", AllFieldsSearch.entity().getAccountId(), Op.EQ);
         AllFieldsSearch.done();

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -19,8 +19,6 @@ package com.cloud.configuration;
 import java.net.URI;
 import java.sql.Date;
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -236,6 +234,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     VolumeDao _volumeDao;
     @Inject
     VMInstanceDao _vmInstanceDao;
+    //@Inject
+    //VmwareDatacenterZoneMapDao _vmwareDatacenterZoneMapDao;
     @Inject
     AccountVlanMapDao _accountVlanMapDao;
     @Inject
@@ -894,7 +894,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         // Check if there are allocated private IP addresses in the pod
         if (_privateIpAddressDao.countIPs(podId, pod.getDataCenterId(), true) != 0) {
-            throw new CloudRuntimeException(errorMsg + "there are private IP addresses allocated in this pod");
+            throw new CloudRuntimeException(errorMsg + "there are private IP addresses allocated in this pod.");
         }
 
         // Check if there are any non-removed volumes in the pod.
@@ -1296,104 +1296,49 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
     @DB
     protected void checkIfZoneIsDeletable(final long zoneId) {
-        final List<List<String>> tablesToCheck = new ArrayList<List<String>>();
+        final String errorMsg = "The zone cannot be deleted because ";
 
-        final List<String> host = new ArrayList<String>();
-        host.add(0, "host");
-        host.add(1, "data_center_id");
-        host.add(2, "there are servers running in this zone");
-        tablesToCheck.add(host);
 
-        final List<String> hostPodRef = new ArrayList<String>();
-        hostPodRef.add(0, "host_pod_ref");
-        hostPodRef.add(1, "data_center_id");
-        hostPodRef.add(2, "there are pods in this zone");
-        tablesToCheck.add(hostPodRef);
 
-        final List<String> privateIP = new ArrayList<String>();
-        privateIP.add(0, "op_dc_ip_address_alloc");
-        privateIP.add(1, "data_center_id");
-        privateIP.add(2, "there are private IP addresses allocated for this zone");
-        tablesToCheck.add(privateIP);
-
-        final List<String> publicIP = new ArrayList<String>();
-        publicIP.add(0, "user_ip_address");
-        publicIP.add(1, "data_center_id");
-        publicIP.add(2, "there are public IP addresses allocated for this zone");
-        tablesToCheck.add(publicIP);
-
-        final List<String> vmInstance = new ArrayList<String>();
-        vmInstance.add(0, "vm_instance");
-        vmInstance.add(1, "data_center_id");
-        vmInstance.add(2, "there are virtual machines running in this zone");
-        tablesToCheck.add(vmInstance);
-
-        final List<String> volumes = new ArrayList<String>();
-        volumes.add(0, "volumes");
-        volumes.add(1, "data_center_id");
-        volumes.add(2, "there are storage volumes for this zone");
-        tablesToCheck.add(volumes);
-
-        final List<String> physicalNetworks = new ArrayList<String>();
-        physicalNetworks.add(0, "physical_network");
-        physicalNetworks.add(1, "data_center_id");
-        physicalNetworks.add(2, "there are physical networks in this zone");
-        tablesToCheck.add(physicalNetworks);
-
-        final List<String> vmwareDcs = new ArrayList<String>();
-        vmwareDcs.add(0, "vmware_data_center_zone_map");
-        vmwareDcs.add(1, "zone_id");
-        vmwareDcs.add(2, "there are VMware datacenters associated with this zone. Remove VMware DC from this zone.");
-        tablesToCheck.add(vmwareDcs);
-
-        for (final List<String> table : tablesToCheck) {
-            final String tableName = table.get(0);
-            final String column = table.get(1);
-            final String errorMsg = table.get(2);
-
-            final String dbName = "cloud";
-
-            String selectSql = "SELECT * FROM `?`.`?` WHERE ? = ?";
-
-            if (tableName.equals("op_dc_vnet_alloc")) {
-                selectSql += " AND taken IS NOT NULL";
-            }
-
-            if (tableName.equals("user_ip_address")) {
-                selectSql += " AND state!='Free'";
-            }
-
-            if (tableName.equals("op_dc_ip_address_alloc")) {
-                selectSql += " AND taken IS NOT NULL";
-            }
-
-            if (tableName.equals("host_pod_ref") || tableName.equals("host") || tableName.equals("volumes") || tableName.equals("physical_network")) {
-                selectSql += " AND removed is NULL";
-            }
-
-            if (tableName.equals("vm_instance")) {
-                selectSql += " AND state != ? AND removed IS NULL";
-            }
-
-            final TransactionLegacy txn = TransactionLegacy.currentTxn();
-            try {
-                final PreparedStatement stmt = txn.prepareAutoCloseStatement(selectSql);
-                stmt.setString(1,dbName);
-                stmt.setString(2,tableName);
-                stmt.setString(3,column);
-                stmt.setLong(4, zoneId);
-                if (tableName.equals("vm_instance")) {
-                    stmt.setString(5, VirtualMachine.State.Expunging.toString());
-                }
-                final ResultSet rs = stmt.executeQuery();
-                if (rs != null && rs.next()) {
-                    throw new CloudRuntimeException("The zone is not deletable because " + errorMsg);
-                }
-            } catch (final SQLException ex) {
-                throw new CloudRuntimeException("The Management Server failed to detect if zone is deletable. Please contact Cloud Support.");
-            }
+        // Check if there are any non-removed hosts in the zone.
+        if (!_hostDao.listByDataCenterId(zoneId).isEmpty()) {
+            throw new CloudRuntimeException(errorMsg + "there are servers in this zone.");
         }
 
+        // Check if there are any non-removed pods in the zone.
+        if (!_podDao.listByDataCenterId(zoneId).isEmpty()) {
+            throw new CloudRuntimeException(errorMsg + "there are pods in this zone.");
+        }
+
+        // Check if there are allocated private IP addresses in the zone.
+        if (_privateIpAddressDao.countIPs(zoneId, true) != 0) {
+            throw new CloudRuntimeException(errorMsg + "there are private IP addresses allocated in this zone.");
+        }
+
+        // Check if there are allocated public IP addresses in the zone.
+        if (_publicIpAddressDao.countIPs(zoneId, true) != 0) {
+            throw new CloudRuntimeException(errorMsg + "there are public IP addresses allocated in this zone.");
+        }
+
+        // Check if there are any non-removed vms in the zone.
+        if (!_vmInstanceDao.listByZoneId(zoneId).isEmpty()) {
+            throw new CloudRuntimeException(errorMsg + "there are virtual machines in this zone.");
+        }
+
+        // Check if there are any non-removed volumes in the zone.
+        if (!_volumeDao.findByDc(zoneId).isEmpty()) {
+            throw new CloudRuntimeException(errorMsg + "there are storage volumes in this zone.");
+        }
+
+        // Check if there are any non-removed physical networks in the zone.
+        if (!_physicalNetworkDao.listByZone(zoneId).isEmpty()) {
+            throw new CloudRuntimeException(errorMsg + "there are physical networks in this zone.");
+        }
+
+        // Check if there are any non-removed VMware datacenters in the zone.
+        //if (_vmwareDatacenterZoneMapDao.findByZoneId(zoneId) != null) {
+        //    throw new CloudRuntimeException(errorMsg + "there are VMware datacenters in this zone.");
+        //}
     }
 
     private void checkZoneParameters(final String zoneName, final String dns1, final String dns2, final String internalDns1, final String internalDns2, final boolean checkForDuplicates, final Long domainId,


### PR DESCRIPTION
Instead of having both checkIfPodIsDeletable() and checkIfZoneIsDeletable have there own SQL query, I've refactored them so they use DAO SQL Queries.

This resolves the SQL Exception thrown by both classes.

Test to confirm working order:
- deploy ACS
- Add zones / pods. -> Try to delete without resources. -> Direct success.
- Add resources to zones / pods. -> Try to delete with resources in the pod / zone. -> Correct exception thrown. (Error message is why it cannot remove the zone / pod. IE: There is still a hosts or vm or .... )