### PR TITLE
Bug-ID: CLOUDSTACK-8870: Skip external device usage collection if no external devices exist

### DIFF
--- a/engine/schema/src/com/cloud/host/dao/HostDao.java
+++ b/engine/schema/src/com/cloud/host/dao/HostDao.java
@@ -97,4 +97,6 @@ public interface HostDao extends GenericDao<HostVO, Long>, StateDao<Status, Stat
     List<HostVO> listAllHostsByType(Host.Type type);
 
     HostVO findByPublicIp(String publicIp);
+
+    List<HostVO> listByType(Type type);
 }

--- a/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
@@ -1137,4 +1137,11 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
 
         return listBy(sc);
     }
+
+    @Override
+    public List<HostVO> listByType(Host.Type type) {
+        SearchCriteria<HostVO> sc = TypeSearch.create();
+        sc.setParameters("type", type);
+        return listBy(sc);
+    }
 }

--- a/server/src/com/cloud/network/ExternalDeviceUsageManagerImpl.java
+++ b/server/src/com/cloud/network/ExternalDeviceUsageManagerImpl.java
@@ -340,6 +340,15 @@ public class ExternalDeviceUsageManagerImpl extends ManagerBase implements Exter
 
         @Override
         protected void runInContext() {
+
+            // Check if there are any external devices
+            // Skip external device usage collection if none exist
+
+            if(_hostDao.listByType(Host.Type.ExternalFirewall).isEmpty() && _hostDao.listByType(Host.Type.ExternalLoadBalancer).isEmpty()){
+                s_logger.debug("External devices are not used. Skipping external device usage collection");
+                return;
+            }
+
             GlobalLock scanLock = GlobalLock.getInternLock("ExternalDeviceNetworkUsageManagerImpl");
             try {
                 if (scanLock.lock(20)) {
@@ -356,7 +365,7 @@ public class ExternalDeviceUsageManagerImpl extends ManagerBase implements Exter
             }
         }
 
-        private void runExternalDeviceNetworkUsageTask() {
+        protected void runExternalDeviceNetworkUsageTask() {
             s_logger.debug("External devices stats collector is running...");
 
             for (DataCenterVO zone : _dcDao.listAll()) {

--- a/server/test/com/cloud/network/ExternalLoadBalancerDeviceManagerImplTest.java
+++ b/server/test/com/cloud/network/ExternalLoadBalancerDeviceManagerImplTest.java
@@ -20,11 +20,13 @@ package com.cloud.network;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
 import javax.inject.Inject;
 
+import com.cloud.host.Host;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.junit.Assert;
@@ -206,5 +208,16 @@ public class ExternalLoadBalancerDeviceManagerImplTest {
         Mockito.when(lbDevice.getHostId()).thenReturn(99l);
         HostVO hostVo = Mockito.mock(HostVO.class);
         Mockito.when(_hostDao.findById(Mockito.anyLong())).thenReturn(hostVo);
+    }
+
+
+    @Test
+    public void testUsageTask()  {
+        ExternalDeviceUsageManagerImpl.ExternalDeviceNetworkUsageTask usageTask = Mockito
+                .mock(ExternalDeviceUsageManagerImpl.ExternalDeviceNetworkUsageTask.class);
+        Mockito.when(_hostDao.listByType(Host.Type.ExternalFirewall)).thenReturn(new ArrayList<HostVO>());
+        Mockito.when(_hostDao.listByType(Host.Type.ExternalLoadBalancer)).thenReturn(new ArrayList<HostVO>());
+        usageTask.runInContext();
+        Mockito.verify(usageTask, Mockito.times(0)).runExternalDeviceNetworkUsageTask();
     }
 }


### PR DESCRIPTION
external network device usage monitor thread that runs every 5mins by default (based on global config external.network.stats.interval) and runs coalesce query to acquire a lock. When there are no external devices exist, there is no need to run usage collection.
Added test case to verify that usage collection task is not run when there are no External LB or External FW