### PR TITLE
Bug-ID: CLOUDSTACK-8880: calculate free memory on host before deploying Vm.  free memory = total memory - (all vm memory)

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -268,6 +268,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     protected int _rngRateBytes = 2048;
     private File _qemuSocketsPath;
     private final String _qemuGuestAgentSocketName = "org.qemu.guest_agent.0";
+    private long _totalMemory;
 
     private final Map <String, String> _pifs = new HashMap<String, String>();
     private final Map<String, VmStats> _vmStats = new ConcurrentHashMap<String, VmStats>();
@@ -2453,6 +2454,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     public StartupCommand[] initialize() {
 
         final List<Object> info = getHostInfo();
+        _totalMemory = (Long)info.get(2);
 
         final StartupRoutingCommand cmd =
                 new StartupRoutingCommand((Integer)info.get(0), (Long)info.get(1), (Long)info.get(2), (Long)info.get(4), (String)info.get(3), _hypervisorType,
@@ -3585,5 +3587,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 continue;
             }
         }
+    }
+
+    public long getTotalMemory() {
+        return _totalMemory;
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 import org.libvirt.Connect;
+import org.libvirt.Domain;
 import org.libvirt.DomainInfo.DomainState;
 import org.libvirt.LibvirtException;
 
@@ -60,6 +61,17 @@ public final class LibvirtStartCommandWrapper extends CommandWrapper<StartComman
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = libvirtComputingResource.getLibvirtUtilitiesHelper();
         Connect conn = null;
         try {
+
+            vm = libvirtComputingResource.createVMFromSpec(vmSpec);
+            conn = libvirtUtilitiesHelper.getConnectionByType(vm.getHvsType());
+
+            Long remainingMem = getFreeMemory(conn, libvirtComputingResource);
+            if (remainingMem == null){
+                return new StartAnswer(command, "failed to get free memory");
+            } else if (remainingMem < vmSpec.getMinRam()) {
+                return new StartAnswer(command, "Not enough memory on the host, remaining: " + remainingMem + ", asking: " + vmSpec.getMinRam());
+            }
+
             final NicTO[] nics = vmSpec.getNics();
 
             for (final NicTO nic : nics) {
@@ -68,8 +80,6 @@ public final class LibvirtStartCommandWrapper extends CommandWrapper<StartComman
                 }
             }
 
-            vm = libvirtComputingResource.createVMFromSpec(vmSpec);
-            conn = libvirtUtilitiesHelper.getConnectionByType(vm.getHvsType());
             libvirtComputingResource.createVbd(conn, vmSpec, vmName, vm);
 
             if (!storagePoolMgr.connectPhysicalDisksViaVmSpec(vmSpec)) {
@@ -148,6 +158,24 @@ public final class LibvirtStartCommandWrapper extends CommandWrapper<StartComman
             if (state != DomainState.VIR_DOMAIN_RUNNING) {
                 storagePoolMgr.disconnectPhysicalDisksViaVmSpec(vmSpec);
             }
+        }
+    }
+
+    private Long getFreeMemory(final Connect conn, final LibvirtComputingResource libvirtComputingResource){
+        try {
+            long allocatedMem = 0;
+            int[] ids = conn.listDomains();
+            for(int id :ids) {
+                Domain dm = conn.domainLookupByID(id);
+                allocatedMem += dm.getMaxMemory() * 1024L;
+                s_logger.debug("vm: " + dm.getName() + " mem: " + dm.getMaxMemory() * 1024L);
+            }
+            Long remainingMem = libvirtComputingResource.getTotalMemory() - allocatedMem;
+            s_logger.debug("remaining mem" + remainingMem);
+            return remainingMem;
+        } catch (Exception e) {
+            s_logger.debug("failed to get free memory", e);
+            return null;
         }
     }
 }


### PR DESCRIPTION
With memory over-provisioning set to 1, when mgmt server starts VMs in parallel on one host, then the memory allocated on that kvm can be larger than the actual physcial memory of the kvm host.

Fixed by checking free memory on host before starting Vm.
Added test case to check memory usage on Host.
Verified Vm deploy on Host with enough capacity and also without capacity
