### PR TITLE
Pass LbProtocol down to the HAProxyConfigurator

### DIFF
--- a/api/src/com/cloud/agent/api/to/LoadBalancerTO.java
+++ b/api/src/com/cloud/agent/api/to/LoadBalancerTO.java
@@ -150,6 +150,10 @@ public class LoadBalancerTO {
         return lbProtocol;
     }
 
+    public void setLbProtocol(String lbProtocol) {
+        this.lbProtocol = lbProtocol;
+    }
+
     public boolean isRevoked() {
         return revoked;
     }

--- a/core/src/com/cloud/network/HAProxyConfigurator.java
+++ b/core/src/com/cloud/network/HAProxyConfigurator.java
@@ -503,6 +503,9 @@ public class HAProxyConfigurator implements LoadBalancerConfigurator {
             .append(":")
             .append(dest.getDestPort())
             .append(" check");
+            if(lbTO.getLbProtocol() != null && lbTO.getLbProtocol().equals("tcp-proxy")) {
+                sb.append(" send-proxy");
+            }
             dstSubRule.add(sb.toString());
             if (stickinessSubRule != null) {
                 sb.append(" cookie ").append(dest.getDestIp().replace(".", "_")).append('-').append(dest.getDestPort()).toString();

--- a/core/test/com/cloud/network/HAProxyConfiguratorTest.java
+++ b/core/test/com/cloud/network/HAProxyConfiguratorTest.java
@@ -29,6 +29,10 @@ import org.junit.Test;
 
 import com.cloud.agent.api.routing.LoadBalancerConfigCommand;
 import com.cloud.agent.api.to.LoadBalancerTO;
+import com.cloud.network.lb.LoadBalancingRule.LbDestination;
+
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * @author dhoogland
@@ -85,6 +89,24 @@ public class HAProxyConfiguratorTest {
         // setup tests for
         // maxconn (test for maxpipes as well)
         // httpmode
+    }
+
+    /**
+     * Test method for {@link com.cloud.network.HAProxyConfigurator#generateConfiguration(com.cloud.agent.api.routing.LoadBalancerConfigCommand)}.
+     */
+    @Test
+    public void testGenerateConfigurationLoadBalancerProxyProtocolConfigCommand() {
+        final List<LbDestination> dests = new ArrayList<>();
+        dests.add(new LbDestination(443, 8443, "10.1.10.2", false));
+        dests.add(new LbDestination(443, 8443, "10.1.10.2", true));
+        LoadBalancerTO lb = new LoadBalancerTO("1", "10.2.0.1", 443, "tcp", "http", false, false, false, dests);
+        lb.setLbProtocol("tcp-proxy");
+        LoadBalancerTO[] lba = new LoadBalancerTO[1];
+        lba[0] = lb;
+        HAProxyConfigurator hpg = new HAProxyConfigurator();
+        LoadBalancerConfigCommand cmd = new LoadBalancerConfigCommand(lba, "10.0.0.1", "10.1.0.1", "10.1.1.1", null, 1L, "12", false);
+        String result = genConfig(hpg, cmd);
+        assertTrue("'send-proxy' should result if protocol is 'tcp-proxy'", result.contains("send-proxy"));
     }
 
     private String genConfig(HAProxyConfigurator hpg, LoadBalancerConfigCommand cmd) {

--- a/server/src/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VirtualRouterElement.java
@@ -602,7 +602,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         final Map<Capability, String> lbCapabilities = new HashMap<Capability, String>();
         lbCapabilities.put(Capability.SupportedLBAlgorithms, "roundrobin,leastconn,source");
         lbCapabilities.put(Capability.SupportedLBIsolation, "dedicated");
-        lbCapabilities.put(Capability.SupportedProtocols, "tcp, udp");
+        lbCapabilities.put(Capability.SupportedProtocols, "tcp, udp, tcp-proxy");
         lbCapabilities.put(Capability.SupportedStickinessMethods, getHAProxyStickinessCapability());
         lbCapabilities.put(Capability.LbSchemes, LoadBalancerContainer.Scheme.Public.toString());
 

--- a/server/src/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/com/cloud/network/router/CommandSetupHelper.java
@@ -301,6 +301,7 @@ public class CommandSetupHelper {
         for (final LoadBalancingRule rule : rules) {
             final boolean revoked = rule.getState().equals(FirewallRule.State.Revoke);
             final String protocol = rule.getProtocol();
+            final String lb_protocol = rule.getLbProtocol();
             final String algorithm = rule.getAlgorithm();
             final String uuid = rule.getUuid();
 
@@ -309,6 +310,7 @@ public class CommandSetupHelper {
             final List<LbDestination> destinations = rule.getDestinations();
             final List<LbStickinessPolicy> stickinessPolicies = rule.getStickinessPolicies();
             final LoadBalancerTO lb = new LoadBalancerTO(uuid, srcIp, srcPort, protocol, algorithm, revoked, false, inline, destinations, stickinessPolicies);
+            lb.setLbProtocol(lb_protocol);
             lbs[i++] = lb;
         }
         String routerPublicIp = null;


### PR DESCRIPTION
This will let us specify a new load balancer protocol (tcp-proxy) which enables HAProxy's `send-proxy` functionality.

`send-proxy` / [the PROXY protocol][1] will send the real connection origin IP through to the servers behind HAProxy, without requiring any protocol specific changes (such as HTTP header rewriting).

[1]: http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt

This is also inline with what [Amazon ELB now supports][2].

[2]: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-proxy-protocol.html