### PR TITLE
Cloudstack-8816 some of the events do not have resource uuids

### DIFF
--- a/api/src/org/apache/cloudstack/api/ApiCommandJobType.java
+++ b/api/src/org/apache/cloudstack/api/ApiCommandJobType.java
@@ -53,5 +53,6 @@ public enum ApiCommandJobType {
     IAMPolicy,
     IAMGroup,
     GuestOs,
-    GuestOsMapping
+    GuestOsMapping,
+    Network
 }

--- a/api/src/org/apache/cloudstack/api/command/user/network/DeleteNetworkCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/network/DeleteNetworkCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.network;
 
+import org.apache.cloudstack.api.ApiCommandJobType;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -105,6 +106,15 @@ public class DeleteNetworkCmd extends BaseAsyncCmd {
         return "Deleting network: " + id;
     }
 
+    @Override
+    public Long getInstanceId() {
+        return getId();
+    }
+
+    @Override
+    public ApiCommandJobType getInstanceType() {
+        return ApiCommandJobType.Network;
+    }
     @Override
     public long getEntityOwnerId() {
         Network network = _networkService.getNetwork(id);

--- a/api/src/org/apache/cloudstack/context/CallContext.java
+++ b/api/src/org/apache/cloudstack/context/CallContext.java
@@ -89,8 +89,19 @@ public class CallContext {
         context.put(key, value);
     }
 
+    /**
+     * @param key any not null key object
+     * @return the value of the key from context map
+     * @throws NullPointerException if the specified key is nul
+     */
     public Object getContextParameter(Object key) {
-        return context.get(key);
+        Object value = context.get(key);
+        //check if the value is present in the toString value of the key
+        //due to a bug in the way we update the key by serializing and deserializing, it sometimes gets toString value of the key. @see com.cloud.api.ApiAsyncJobDispatcher#runJob
+        if(value == null ) {
+            value = context.get(key.toString());
+        }
+        return value;
     }
 
     public long getCallingUserId() {

--- a/api/test/org/apache/cloudstack/context/CallContextTest.java
+++ b/api/test/org/apache/cloudstack/context/CallContextTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cloudstack.context;
+
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.cloud.user.Account;
+import com.cloud.user.User;
+import com.cloud.utils.db.EntityManager;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CallContextTest {
+
+    @Mock
+    EntityManager entityMgr;
+
+    @Before
+    public void setUp() {
+        CallContext.init(entityMgr);
+        CallContext.register(Mockito.mock(User.class), Mockito.mock(Account.class));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        CallContext.unregisterAll();
+    }
+
+    @Test
+    public void testGetContextParameter() {
+        CallContext currentContext = CallContext.current();
+
+        Assert.assertEquals("There is nothing in the context. It should return null", null, currentContext.getContextParameter("key"));
+        Assert.assertTrue("There is nothing in the context. The map should be empty", currentContext.getContextParameters().isEmpty());
+
+        UUID objectUUID = UUID.randomUUID();
+        UUID stringUUID = UUID.randomUUID();
+
+        //Case1: when an entry with the object class is present
+        currentContext.putContextParameter(User.class, objectUUID);
+        Assert.assertEquals("it should return objectUUID: " + objectUUID, objectUUID, currentContext.getContextParameter(User.class));
+        Assert.assertEquals("current context map should have exactly one entry", 1, currentContext.getContextParameters().size());
+
+        //Case2: when an entry with the object class name as String is present
+        currentContext.putContextParameter(Account.class.toString(), stringUUID);
+        //object is put with key as Account.class.toString but get with key as Account.class
+        Assert.assertEquals("it should return stringUUID: " + stringUUID, stringUUID, currentContext.getContextParameter(Account.class));
+        Assert.assertEquals("current context map should have exactly two entries", 2, currentContext.getContextParameters().size());
+
+        //Case3: when an entry with both object class and object class name as String is present
+        //put an entry of account class object in the context
+        currentContext.putContextParameter(Account.class, objectUUID);
+        //since both object and string a present in the current context, it should return object value
+        Assert.assertEquals("it should return objectUUID: " + objectUUID, objectUUID, currentContext.getContextParameter(Account.class));
+        Assert.assertEquals("current context map should have exactly three entries", 3, currentContext.getContextParameters().size());
+    }
+
+}

--- a/server/src/com/cloud/api/ApiDBUtils.java
+++ b/server/src/com/cloud/api/ApiDBUtils.java
@@ -1217,7 +1217,7 @@ public class ApiDBUtils {
     }
 
     public static NetworkVO findNetworkById(long id) {
-        return s_networkDao.findById(id);
+        return s_networkDao.findByIdIncludingRemoved(id);
     }
 
     public static Map<Service, Map<Capability, String>> getNetworkCapabilities(long networkId, long zoneId) {
@@ -1598,6 +1598,11 @@ public class ApiDBUtils {
             AutoScaleVmGroupVO group = ApiDBUtils.findAutoScaleVmGroupById(job.getInstanceId());
             if (group != null) {
                 jobInstanceId = group.getUuid();
+            }
+        } else if (jobInstanceType == ApiCommandJobType.Network) {
+            NetworkVO networkVO = ApiDBUtils.findNetworkById(job.getInstanceId());
+            if(networkVO != null) {
+                jobInstanceId = networkVO.getUuid();
             }
         } else if (jobInstanceType != ApiCommandJobType.None) {
             // TODO : when we hit here, we need to add instanceType -> UUID

--- a/server/src/com/cloud/api/ApiDBUtils.java
+++ b/server/src/com/cloud/api/ApiDBUtils.java
@@ -1033,12 +1033,7 @@ public class ApiDBUtils {
     }
 
     public static Snapshot findSnapshotById(long snapshotId) {
-        SnapshotVO snapshot = s_snapshotDao.findById(snapshotId);
-        if (snapshot != null && snapshot.getRemoved() == null && snapshot.getState() == Snapshot.State.BackedUp) {
-            return snapshot;
-        } else {
-            return null;
-        }
+        return s_snapshotDao.findByIdIncludingRemoved(snapshotId);
     }
 
     public static StoragePoolVO findStoragePoolById(Long storagePoolId) {

--- a/server/src/com/cloud/api/ApiDBUtils.java
+++ b/server/src/com/cloud/api/ApiDBUtils.java
@@ -778,7 +778,7 @@ public class ApiDBUtils {
     // ///////////////////////////////////////////////////////////
 
     public static VMInstanceVO findVMInstanceById(long vmId) {
-        return s_vmDao.findById(vmId);
+        return s_vmDao.findByIdIncludingRemoved(vmId);
     }
 
     public static long getStorageCapacitybyPool(Long poolId, short capacityType) {

--- a/server/src/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/com/cloud/user/AccountManagerImpl.java
@@ -991,6 +991,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     }
 
     @Override
+    @ActionEvents({
+        @ActionEvent(eventType = EventTypes.EVENT_ACCOUNT_CREATE, eventDescription = "creating Account"),
+        @ActionEvent(eventType = EventTypes.EVENT_USER_CREATE, eventDescription = "creating User")
+    })
     public UserAccount createUserAccount(final String userName, final String password, final String firstName, final String lastName, final String email, final String timezone,
             String accountName, final short accountType, Long domainId, final String networkDomain, final Map<String, String> details, String accountUUID, final String userUUID) {
 
@@ -1132,6 +1136,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     }
 
     @Override
+    @ActionEvent(eventType = EventTypes.EVENT_USER_CREATE, eventDescription = "creating User")
     public UserVO createUser(String userName, String password, String firstName, String lastName, String email, String timeZone, String accountName, Long domainId,
         String userUUID) {
 
@@ -1263,6 +1268,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     }
 
     @Override
+    @ActionEvent(eventType = EventTypes.EVENT_USER_UPDATE, eventDescription = "updating User")
     public UserAccount updateUser(UpdateUserCmd cmd) {
         Long id = cmd.getId();
         String apiKey = cmd.getApiKey();

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -3247,6 +3247,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             _affinityGroupVMMapDao.updateMap(vm.getId(), affinityGroupIdList);
         }
 
+        CallContext.current().putContextParameter(VirtualMachine.class, vm.getUuid());
         return vm;
     }
 


### PR DESCRIPTION
The key objects in the context map are sometimes String and sometimes object. This causes missing uuids when an entity put in the context map with key entity.toString is queried with key entity

Testing:
manually tested by deploying a vm and checked that the created events in rabbitmq now has uuids.
events before and after the change are update at https://issues.apache.org/jira/browse/CLOUDSTACK-8816?focusedCommentId=14805239

unittests
```
$ mvn -pl :cloud-api test -Dtest=CallContextTest
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.cloudstack.context.CallContextTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.152 sec - in org.apache.cloudstack.context.CallContextTest

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11.445 s
[INFO] Finished at: 2015-09-18T14:58:53+05:30
[INFO] Final Memory: 55M/448M
[INFO] ------------------------------------------------------------------------
```