### PR TITLE
Cloudstack-8885 added blocked connection listener for rabbitmqeventbus 

### DIFF
--- a/plugins/event-bus/rabbitmq/pom.xml
+++ b/plugins/event-bus/rabbitmq/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
     <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-        <version>3.4.2</version>
+        <version>3.5.4</version>
     </dependency>
     <dependency>
     <groupId>org.apache.cloudstack</groupId>


### PR DESCRIPTION
When rabbitmq connections are blocked(for example when rabbitmq is
server is out of space), all the cloudstack threads which does any
action and publishes to rabbitmq(for example login, launch vm etc.) are
all blocked.

Added a blocked connection listener to handle this and unblock the
parent thread.

also updated rabbitmq amqp client to 3.5.4 from 3.4.2 

Testing:
I didnt find a way to write tests for this change as of now. 
manually tested that login and other cloudstack apis work when the configured rabbitmq server goes out of space and publish actions are blocked.