### PR TITLE
Bug-ID: CLOUDSTACK-8882: calculate network offering usage per nic instead of per network offering

### DIFF
--- a/engine/schema/src/com/cloud/usage/UsageVO.java
+++ b/engine/schema/src/com/cloud/usage/UsageVO.java
@@ -136,6 +136,25 @@ public class UsageVO implements Usage, InternalIdentity {
         this.endDate = endDate  == null ? null : new Date(endDate.getTime());
     }
 
+    //Network Offering Usage
+    public UsageVO(Long zoneId, Long accountId, Long domainId, String description, String usageDisplay, int usageType, Double rawUsage, Long vmId,
+                   Long offeringId, Long usageId, Long networkId, Date startDate, Date endDate) {
+        this.zoneId = zoneId;
+        this.accountId = accountId;
+        this.domainId = domainId;
+        this.description = description;
+        this.usageDisplay = usageDisplay;
+        this.usageType = usageType;
+        this.rawUsage = rawUsage;
+        this.vmInstanceId = vmId;
+        this.offeringId = offeringId;
+        this.usageId = usageId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.networkId = networkId;
+    }
+
+
     public UsageVO(Long zoneId, Long accountId, Long domainId, String description, String usageDisplay, int usageType, Double rawUsage, Long vmId, String vmName,
             Long offeringId, Long templateId, Long usageId, Long size, Long virtualSize, Date startDate, Date endDate) {
         this.zoneId = zoneId;

--- a/usage/test/com/cloud/usage/parser/UsageNetworkOfferingTest.java
+++ b/usage/test/com/cloud/usage/parser/UsageNetworkOfferingTest.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.usage.parser;
+
+import com.cloud.usage.UsageNetworkOfferingVO;
+import com.cloud.usage.UsageVO;
+import com.cloud.usage.dao.UsageDao;
+import com.cloud.usage.dao.UsageNetworkOfferingDao;
+import com.cloud.user.AccountVO;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.naming.ConfigurationException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+public class UsageNetworkOfferingTest extends TestCase {
+    @Mock
+    UsageNetworkOfferingDao usageNetworkOfferingDao;
+    @Mock
+    UsageDao usageDao;
+
+    Date startDate = null;
+    Date endDate = null;
+
+    @Before
+    public void setup() throws Exception {
+        Calendar calendar = Calendar.getInstance();
+        endDate = new Date(calendar.getTime().getTime());
+        calendar.roll(Calendar.DAY_OF_YEAR, false);
+        startDate = new Date(calendar.getTime().getTime());
+    }
+
+    @Test
+    public void testNetworkOfferingAggregation() throws ConfigurationException {
+        AccountVO account = new AccountVO();
+        account.setId(2L);
+        account.setDomainId(1L);
+        UsageNetworkOfferingVO usageNo1 = new UsageNetworkOfferingVO(1L, 2L, 1L, 1L, 1L, 1L, false, startDate, null);
+        UsageNetworkOfferingVO usageNo2 = new UsageNetworkOfferingVO(1L, 2L, 1L, 1L, 1L, 2L, false, startDate, null);
+        List<UsageNetworkOfferingVO> usageNOs = new ArrayList<UsageNetworkOfferingVO>();
+        usageNOs.add(usageNo1);
+        usageNOs.add(usageNo2);
+        PowerMockito.mockStatic(NetworkOfferingUsageParser.class);
+        NetworkOfferingUsageParser.s_usageNetworkOfferingDao = usageNetworkOfferingDao;
+        NetworkOfferingUsageParser.s_usageDao = usageDao;
+        Mockito.when(usageNetworkOfferingDao.getUsageRecords(Mockito.anyLong(), Mockito.anyLong(), Mockito.any(Date.class),
+                Mockito.any(Date.class), Mockito.anyBoolean(), Mockito.anyInt())).thenReturn(usageNOs);
+        NetworkOfferingUsageParser.parse(account, startDate, endDate);
+        //Verify that 2 usage records are created for the same network Offering. One for each nicId
+        Mockito.verify(usageDao, Mockito.times(2)).persist(Mockito.any(UsageVO.class));
+    }
+}


### PR DESCRIPTION
Issues occurs when:
A Vm is created with mutiple nics:
If 2 networks use same network offering, network offering usage will be 48hrs (assuming 24hrs aggregation)

Usage should be reported per Nic instead of network offering

Added test case to verify
