### PR TITLE
CLOUDSTACK-8891: Fixed default iptables rules on VR  for guest traffic

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -818,50 +818,65 @@ def main(argv):
                         format=config.get_format())
     config.set_address()
 
+    logging.debug("Configuring ip addresses")
     # IP configuration
     config.address().compare()
     config.address().process()
 
+    logging.debug("Configuring vmpassword")
     password = CsPassword("vmpassword", config)
     password.process()
 
+    logging.debug("Configuring vmdata")
     metadata = CsVmMetadata('vmdata', config)
     metadata.process()
 
+    logging.debug("Configuring networkacl")
     acls = CsAcl('networkacl', config)
     acls.process()
 
+    logging.debug("Configuring firewall rules")
     acls = CsAcl('firewallrules', config)
     acls.process()
 
+    logging.debug("Configuring PF rules")
     fwd = CsForwardingRules("forwardingrules", config)
     fwd.process()
 
     red = CsRedundant(config)
     red.set()
 
+    logging.debug("Configuring s2s vpn")
     vpns = CsSite2SiteVpn("site2sitevpn", config)
     vpns.process()
 
+    logging.debug("Configuring remote access vpn")
     #remote access vpn
     rvpn = CsRemoteAccessVpn("remoteaccessvpn", config)
     rvpn.process()
 
+    logging.debug("Configuring vpn users list")
     #remote access vpn users
     vpnuser = CsVpnUser("vpnuserlist", config)
     vpnuser.process()
 
+    logging.debug("Configuring dhcp entry")
     dhcp = CsDhcp("dhcpentry", config)
     dhcp.process()
 
+    logging.debug("Configuring load balancer")
     lb = CsLoadBalancer("loadbalancer", config)
     lb.process()
 
+    logging.debug("Configuring monitor service")
     mon = CsMonitor("monitorservice", config)
     mon.process()
 
+    logging.debug("Configuring iptables rules .....")
     nf = CsNetfilters()
     nf.compare(config.get_fw())
+
+    logging.debug("Configuring iptables rules done ...saving rules")
 
     # Save iptables configuration - will be loaded on reboot by the iptables-restore that is configured on /etc/rc.local
     CsHelper.save_iptables("iptables-save", "/etc/iptables/router_rules.v4")

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -121,8 +121,8 @@ class CsAddress(CsDataBag):
             ip = CsIP(dev, self.config)
 
             for address in self.dbag[dev]:
-                if(address["nw_type"]!="public"):
-                    continue
+               # if(address["nw_type"]!="public"):
+               #     continue
 
                 #check if link is up
                 if (not self.check_if_link_exists(dev)):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
@@ -126,6 +126,7 @@ class CsNetfilters(object):
         del_list = [x for x in self.rules if x.unseen()]
         for r in del_list:
             cmd = "iptables -t %s %s" % (r.get_table(), r.to_str(True))
+            logging.debug("unseen cmd:  %s ", cmd)
             CsHelper.execute(cmd)
             # print "Delete rule %s from table %s" % (r.to_str(True), r.get_table())
             logging.info("Delete rule %s from table %s", r.to_str(True), r.get_table())
@@ -150,10 +151,10 @@ class CsNetfilters(object):
             if isinstance(fw[1], int):
                 new_rule.set_count(fw[1])
             if self.has_rule(new_rule):
-                logging.debug("rule %s exists in table %s", fw[2], new_rule.get_table())
+                logging.debug("Exists: rule=%s table=%s", fw[2], new_rule.get_table())
             else:
                 # print "Add rule %s in table %s" % ( fw[2], new_rule.get_table())
-                logging.info("Add rule %s in table %s", fw[2], new_rule.get_table())
+                logging.info("Add: rule=%s table=%s", fw[2], new_rule.get_table())
                 # front means insert instead of append
                 cpy = fw[2]
                 if fw[1] == "front":
@@ -185,6 +186,7 @@ class CsNetfilters(object):
                 if i.startswith('-A'):  # Rule
                     self.del_rule(table, i.strip())
         except IOError:
+            logging.debug("Exception in del_standard, returning")
             # Nothing can be done
             return
 


### PR DESCRIPTION
VR default iptables rules in INPUT chain are configured partially.
In CsAddress.py rules are configured while configuring public interface, guest interface post configuration is missed. Fixed to configure guest post configuration so that iptables rules are configured.

Testing:
1. Deployed vm in the network.
2.iptables rules on the VR configured correctly.
3.VM got the dhcp ip address from the VR.