### PR TITLE
Configured dnsmasq to listen on all interfaces so that vpn  client gets dns

### DIFF
--- a/systemvm/patches/debian/config/etc/dnsmasq.conf.tmpl
+++ b/systemvm/patches/debian/config/etc/dnsmasq.conf.tmpl
@@ -87,7 +87,7 @@ local=/2.vmops-test.vmops.com/
 # specified interfaces (and the loopback) give the name of the
 # interface (eg eth0) here.
 # Repeat the line for more than one interface.
-interface=eth0
+#interface=eth0
 # Or you can specify which interface _not_ to listen on
 except-interface=eth1
 except-interface=eth2
@@ -108,7 +108,7 @@ no-dhcp-interface=eth2
 # want dnsmasq to really bind only the interfaces it is listening on,
 # uncomment this option. About the only time you may need this is when
 # running another nameserver on the same machine.
-bind-interfaces
+#bind-interfaces
 
 # If you don't want dnsmasq to read /etc/hosts, uncomment the
 # following line.

--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -706,7 +706,7 @@ setup_dnsmasq() {
     sed -i -e "s/^dhcp-range_ip6=.*$//" /etc/dnsmasq.conf
   fi
 
-  sed -i -e "s/^[#]*listen-address=.*$/listen-address=$LOCAL_ADDRS/" /etc/dnsmasq.conf
+  #sed -i -e "s/^[#]*listen-address=.*$/listen-address=$LOCAL_ADDRS/" /etc/dnsmasq.conf
 
   if [ "$RROUTER" == "1" ]
   then


### PR DESCRIPTION
1. Dnsmasq is not listening on the ppp+ interfaces due to this remote access vpn clients dns requests are  dropped.

2. Configured the dnsmasq to listen on all the interfaces except public. There is firewall to allow only specific cidr to allow the dns requests.

Tested from windows client nslookup.