### PR TITLE
CLOUDSTACK-8896: allocated percentage of storage pool going beyond 100%

### DIFF
--- a/server/src/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/com/cloud/storage/StorageManagerImpl.java
@@ -1719,6 +1719,9 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         }
 
         // allocated space includes templates
+        if(s_logger.isDebugEnabled()) {
+            s_logger.debug("Destination pool id: " + pool.getId());
+        }
         StoragePoolVO poolVO = _storagePoolDao.findById(pool.getId());
         long allocatedSizeWithTemplate = _capacityMgr.getAllocatedPoolCapacity(poolVO, null);
         long totalAskingSize = 0;
@@ -1746,10 +1749,12 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                     allocatedSizeWithTemplate = _capacityMgr.getAllocatedPoolCapacity(poolVO, tmpl);
                 }
             }
-
-            if (volumeVO.getState() != Volume.State.Ready) {
-                totalAskingSize += getDataObjectSizeIncludingHypervisorSnapshotReserve(volumeVO, pool);
-
+            // A ready state volume is already allocated in a pool. so the asking size is zero for it.
+            // In case the volume is moving across pools or is not ready yet, the asking size has to be computed
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug("pool id for the volume with id: " + volumeVO.getId() + " is " + volumeVO.getPoolId());
+            }
+            if ((volumeVO.getState() != Volume.State.Ready) || (volumeVO.getPoolId() != pool.getId())) {
                 if (ScopeType.ZONE.equals(poolVO.getScope()) && volumeVO.getTemplateId() != null) {
                     VMTemplateVO tmpl = _templateDao.findByIdIncludingRemoved(volumeVO.getTemplateId());
 


### PR DESCRIPTION
This issue occurs when a volume in Ready state is moved across storage
pools.

While finding if the storage pool has enough space, it has a check to
consider the size of non Ready volumes only. This is true if the volume
to be attached to a vm is in the same storage pool. But, if the volume
is in another storage pool and has to be moved to a vm's storage pool,
the size of the volume should be considered in doing the space check.

computing the asking size when volume is not in ready state or when the 
volume is on a different storage pool.

Testing:
I couldnt write unittests for it. This class is not in a unittestable state.

manually tested in the below environment
1. xenserver 6.5 setup with 2 clusters and a host each in each of them.
2. added storage tags for the primary storage.
3. created two service offerings with the storage tags.
4. deployed two vms using newly created offerings in step 3.
5. at this stage, there are two vms one on each host with root disks on the corresponding primary.
6. create a data disk and attach it to vm1
7. detach the data disk. now the data disk is in the primary storage of the cluster of vm1 (let us say primary1)
8. attach this data disk to vm2(running on a host in different cluster)
9. the volume should be moved to the primary storage of another cluster and op_host_capacity should be accordingly updated.
