### PR TITLE
CLOUDSTACK-8897: baremetal:addHost:make host tag info mandtory in bar…

### DIFF
--- a/server/src/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/com/cloud/resource/ResourceManagerImpl.java
@@ -679,6 +679,12 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             }
         }
 
+        if ((hypervisorType.equalsIgnoreCase(HypervisorType.BareMetal.toString()))) {
+            if (hostTags.isEmpty()) {
+                throw new InvalidParameterValueException("hosttag is mandatory while adding host of type Baremetal");
+            }
+        }
+
         if (clusterName != null) {
             final HostPodVO pod = _podDao.findById(podId);
             if (pod == null) {


### PR DESCRIPTION
CLOUDSTACK-8897: baremetal:addHost:make host tag info mandtory in baremetal addhost Api call

addhost api is successful with out providing the host tag info and we recommend host tag is mandatory for bare-metal.
In the current implementation host tag check is happening at vm deployment stage but it will be good to have host tag field as mandatory field during adding of the host 
