### PR TITLE
CLOUDSTACK-8901: PrepareTemplate job thread hard-coded to max 8 threads

### DIFF
--- a/engine/components-api/src/com/cloud/template/TemplateManager.java
+++ b/engine/components-api/src/com/cloud/template/TemplateManager.java
@@ -38,8 +38,15 @@ import com.cloud.vm.VirtualMachineProfile;
  */
 public interface TemplateManager {
     static final String AllowPublicUserTemplatesCK = "allow.public.user.templates";
+    static final String TemplatePreloaderPoolSizeCK = "template.preloader.pool.size";
+
     static final ConfigKey<Boolean> AllowPublicUserTemplates = new ConfigKey<Boolean>("Advanced", Boolean.class, AllowPublicUserTemplatesCK, "true",
         "If false, users will not be able to create public templates.", true, ConfigKey.Scope.Account);
+
+    static final ConfigKey<Integer> TemplatePreloaderPoolSize = new ConfigKey<Integer>("Advanced", Integer.class, TemplatePreloaderPoolSizeCK, "8",
+            "Size of the TemplateManager threadpool", false, ConfigKey.Scope.Global);
+
+
 
     /**
      * Prepares a template for vm creation for a certain storage pool.

--- a/server/src/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/com/cloud/template/TemplateManagerImpl.java
@@ -926,7 +926,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         String disableExtraction = _configDao.getValue(Config.DisableExtraction.toString());
         _disableExtraction = (disableExtraction == null) ? false : Boolean.parseBoolean(disableExtraction);
 
-        _preloadExecutor = Executors.newFixedThreadPool(8, new NamedThreadFactory("Template-Preloader"));
+        _preloadExecutor = Executors.newFixedThreadPool(TemplatePreloaderPoolSize.value(), new NamedThreadFactory("Template-Preloader"));
 
         return true;
     }
@@ -1975,7 +1975,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {AllowPublicUserTemplates};
+        return new ConfigKey<?>[] {AllowPublicUserTemplates, TemplatePreloaderPoolSize};
     }
 
     public List<TemplateAdapter> getTemplateAdapters() {


### PR DESCRIPTION
 The thread pool was hardcoded to use 8 threads,
com.cloud.template.TemplateManagerImpl.configure(String, Map<String, Object>):
_preloadExecutor = Executors.newFixedThreadPool(8, new NamedThreadFactory("Template-Preloader"));

Added the change to pick threadpool size from configuration.

