### PR TITLE
CLOUDSTACK-8906: /var/log/cloud/ doesn't get logrotated on xenserver

### DIFF
--- a/scripts/vm/hypervisor/xenserver/logrotate
+++ b/scripts/vm/hypervisor/xenserver/logrotate
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Version @VERSION@
+#
+# script to perform logrotation on xenserver 6.0.2 and later
+
+/usr/sbin/logrotate  /etc/logrotate.d/cloudlog
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+/usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+fi
+[ -f /opt/xensource/bin/delete_old_logs_by_space ] && /opt/xensource/bin/delete_old_logs_by_space
+exit 0

--- a/scripts/vm/hypervisor/xenserver/setupxenserver.sh
+++ b/scripts/vm/hypervisor/xenserver/setupxenserver.sh
@@ -49,7 +49,7 @@ sed -i 's/0\.0\.0\.0/127\.0\.0\.1/' /opt/xensource/libexec/qemu-dm-wrapper 2>&1
 sed -i /NOZEROCONF/d /etc/sysconfig/network
 echo "NOZEROCONF=yes" >> /etc/sysconfig/network
 
-mv -n /etc/cron.daily/logrotate /etc/cron.hourly 2>&1
+[ -f /etc/cron.hourly/logrotate ] || mv /etc/cron.daily/logrotate /etc/cron.hourly 2>&1
 
 # more aio thread
 echo 1048576 >/proc/sys/fs/aio-max-nr

--- a/scripts/vm/hypervisor/xenserver/xenserver60/patch
+++ b/scripts/vm/hypervisor/xenserver/xenserver60/patch
@@ -69,3 +69,4 @@ ovs-get-dhcp-iface.sh=..,0755,/opt/cloud/bin
 ovs-get-bridge.sh=..,0755,/opt/cloud/bin
 cloudlog=..,0644,/etc/logrotate.d
 update_host_passwd.sh=../..,0755,/opt/cloud/bin
+logrotate=..,0755,/etc/cron.hourly

--- a/scripts/vm/hypervisor/xenserver/xenserver62/patch
+++ b/scripts/vm/hypervisor/xenserver/xenserver62/patch
@@ -65,3 +65,4 @@ ovs-get-dhcp-iface.sh=..,0755,/opt/cloud/bin
 ovs-get-bridge.sh=..,0755,/opt/cloud/bin
 cloudlog=..,0644,/etc/logrotate.d
 update_host_passwd.sh=../..,0755,/opt/cloud/bin
+logrotate=..,0755,/etc/cron.hourly

--- a/scripts/vm/hypervisor/xenserver/xenserver65/patch
+++ b/scripts/vm/hypervisor/xenserver/xenserver65/patch
@@ -65,3 +65,4 @@ ovs-get-dhcp-iface.sh=..,0755,/opt/cloud/bin
 ovs-get-bridge.sh=..,0755,/opt/cloud/bin
 cloudlog=..,0644,/etc/logrotate.d
 update_host_passwd.sh=../..,0755,/opt/cloud/bin
+logrotate=..,0755,/etc/cron.hourly


### PR DESCRIPTION
After integrating XS with CCP the following folder gets created: /var/log/cloud/ however the logs in that are not rotated resulting in root file system fill up. It was a known issue and link http://support.citrix.com/article/CTX138064 describes the issue and solution. Used the article and added corresponding changes to Cloudstack. 
