### PR TITLE
CLOUDSTACK-8848: ensure power state is up to date when handling missi…

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
@@ -111,7 +111,14 @@ public class VirtualMachinePowerStateSyncImpl implements VirtualMachinePowerStat
 
             for (VMInstanceVO instance : vmsThatAreMissingReport) {
 
-                Date vmStateUpdateTime = instance.getUpdateTime();
+                // Make sure powerState is up to date for missing VMs
+                if (!_instanceDao.isPowerStateUpToDate(instance.getId())) {
+                    s_logger.warn("Detected missing VM but power state is outdated, wait for another process report run for VM id: " + instance.getId());
+                    _instanceDao.resetVmPowerStateTracking(instance.getId());
+                    continue;
+                }
+
+                Date vmStateUpdateTime = instance.getPowerStateUpdateTime();
                 if (vmStateUpdateTime == null) {
                     s_logger.warn("VM state was updated but update time is null?! vm id: " + instance.getId());
                     vmStateUpdateTime = currentTime;

--- a/engine/schema/src/com/cloud/vm/dao/VMInstanceDao.java
+++ b/engine/schema/src/com/cloud/vm/dao/VMInstanceDao.java
@@ -138,4 +138,6 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
     HashMap<String, Long> countVgpuVMs(Long dcId, Long podId, Long clusterId);
 
     VMInstanceVO findVMByHostNameInZone(String hostName, long zoneId);
+
+    boolean isPowerStateUpToDate(long instanceId);
 }

--- a/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -805,6 +805,12 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
     }
 
     @Override
+    public boolean isPowerStateUpToDate(final long instanceId) {
+        VMInstanceVO instance = findById(instanceId);
+        return instance.getPowerStateUpdateCount() < MAX_CONSECUTIVE_SAME_STATE_UPDATE_COUNT;
+    }
+
+    @Override
     public void resetVmPowerStateTracking(final long instanceId) {
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override


### PR DESCRIPTION
…ng VMs in powerReport

There 2 things which has been changed. 

* We look on power_state_update_time instead of update_time. Didn't make sense to me to look at the update_time.
* Due DB update optimisation, powerState will only be updated if < MAX_CONSECUTIVE_SAME_STATE_UPDATE_COUNT; so we can not really rely on these information if we can not make sure these are up to date.