### PR TITLE
Fix dockerbuild because hardcoded filename for marvin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN (/usr/bin/mysqld_safe &); \
     sleep 3; \
     mvn -Pdeveloper -pl developer -Ddeploydb; \
     mvn -Pdeveloper -pl developer -Ddeploydb-simulator; \
-    pip install tools/marvin/dist/Marvin-4.5.2.tar.gz
+    MARVIN_FILE=`find tools/marvin/dist/ -name "Marvin*.tar.gz"` \
+    pip install $MARVIN_FILE
 
 EXPOSE 8080
 


### PR DESCRIPTION
This fix docker simulator build of latest 4.5.x.

This PR only go in 4.5 branch.

Thanks