### PR TITLE
BUG-ID:CLOUDSTACK-8921 snapshot_store_ref table should store actual size of backup snapshot in secondary storage

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -348,6 +348,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
                 hypervisorResource.waitForTask(conn, task, 1000, wait * 1000);
                 hypervisorResource.checkForSuccess(conn, task);
                 dvdi = Types.toVDI(task, conn);
+                ssSR.scan(conn);
                 // copied = true;
             } finally {
                 if (task != null) {
@@ -486,6 +487,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
                     hypervisorResource.checkForSuccess(conn, task);
                     final VDI backedVdi = Types.toVDI(task, conn);
                     snapshotBackupUuid = backedVdi.getUuid(conn);
+                    snapshotSr.scan(conn);
                     physicalSize = backedVdi.getPhysicalUtilisation(conn);
 
                     if (destStore instanceof SwiftTO) {
@@ -571,6 +573,9 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             } else {
                 newSnapshot.setParentSnapshotPath(prevBackupUuid);
             }
+            s_logger.info("New snapshot details: " + newSnapshot.toString());
+            s_logger.info("New snapshot physical utilization: "+physicalSize);
+
             return new CopyCmdAnswer(newSnapshot);
         } catch (final Types.XenAPIException e) {
             details = "BackupSnapshot Failed due to " + e.toString();


### PR DESCRIPTION
Summary: CLOUDSTACK-8921
     snapshot_store_ref table should store actual size of back snapshot in secondary storage
Calling SR scan to make sure size is updated correctly

This scenario is tested with this bug fix. Unit tests are not added as the methods that are fixed are too long to add unit tests and there is no existing unit test to change
