### PR TITLE
CLOUDSTACK-8924: Enable dynamic scaling to run test_scale_vm.py test on simulator

### DIFF
--- a/setup/dev/basic.cfg
+++ b/setup/dev/basic.cfg
@@ -168,6 +168,10 @@
         {
             "name": "check.pod.cidrs",
             "value": "true"
+        },
+        {
+            "name": "enable.dynamic.scale.vm",
+            "value": "true"
         }
     ],
     "mgtSvr": [


### PR DESCRIPTION
Simulator setup uses the config file from following location:
tools/marvin/marvin/config/setup.cfg
Added global setting parameter "enable.dynamic.scale.vm" to above config file, so that dynamic scale vm tests can be run on simulator.