### PR TITLE
CLOUDSTACK-8928: While adding VMs to LB rule, default NIC IP is always displayed rather than the IP corresponding to the NIC where LB is being created

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -173,7 +173,7 @@
                 url: createURL('listNics'),
                 data: {
                     virtualmachineid: instance.id,
-                    nicId: instance.nic[0].id
+                    networkid: network.id
                 },
                 success: function(json) {
                     var nic = json.listnicsresponse.nic[0];


### PR DESCRIPTION
While calling the listNics API, instead of sending the default nic id as parameter, it should send the network id as a parameter.

So, replaced that nicid parameter as networkid parameter.