### PR TITLE
CLOUDSTACK-8929

### DIFF
--- a/ui/scripts/ui/widgets/multiEdit.js
+++ b/ui/scripts/ui/widgets/multiEdit.js
@@ -104,7 +104,7 @@
                         $(data).each(function() {
                             var item = this;
                             var $itemRow = _medit.multiItem.itemRow(item, options.itemActions, multiRule, $tbody);
-
+                            $itemRow.data('json-obj', item);
                             $itemRow.appendTo($tbody);
                             newItemRows.push($itemRow);
 


### PR DESCRIPTION
 After a load balancer rule is created and if another VM is assigned to it, it still shows up in the list of VMs that can be assigned to it