### PR TITLE
CLOUDSTACK-8930: Showing blank screen when click 'Next' link in final step of Add Zone wizard.

### DIFF
--- a/ui/dictionary2.jsp
+++ b/ui/dictionary2.jsp
@@ -1098,6 +1098,7 @@ under the License.
 'label.remove.this.physical.network': '<fmt:message key="label.remove.this.physical.network" />',
 'label.physical.network.name': '<fmt:message key="label.physical.network.name" />',
 'label.save.changes': '<fmt:message key="label.save.changes" />',
+'label.launch.zone': '<fmt:message key="label.launch.zone" />',
 'label.autoscale.configuration.wizard': '<fmt:message key="label.autoscale.configuration.wizard" />',
 'label.health.check.wizard': '<fmt:message key="label.health.check.wizard" />',
 'label.health.check.message.desc': '<fmt:message key="label.health.check.message.desc" />',

--- a/ui/scripts/ui-custom/zoneWizard.js
+++ b/ui/scripts/ui-custom/zoneWizard.js
@@ -1211,7 +1211,7 @@
 
                 // Show launch button if last step
                 if ($targetStep.index() == $steps.size() - 1 || options.nextStep) {
-                    $nextButton.find('span').html(options.nextStep ? _('label.save.changes') : _('label.launch.zone'));
+                    $nextButton.find('span').html(options.nextStep ? _l('label.save.changes') : _l('label.launch.zone'));
                     $nextButton.addClass('final');
 
                     if (options.nextStep) {


### PR DESCRIPTION
Issue:
Showing blank screen with 'Next' and 'Cancel' are showing when click 'Next' link in final step of Add Zone wizard. Navigate to 1st step of Add Zone wizard when click 'Next' link in blank screen.