### PR TITLE
CLOUDSTACK-8931: Fail to deploy VM instance when use.system.public.ip…

### DIFF
--- a/server/src/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/com/cloud/network/IpAddressManagerImpl.java
@@ -667,6 +667,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         boolean fetchFromDedicatedRange = false;
         List<Long> dedicatedVlanDbIds = new ArrayList<Long>();
         List<Long> nonDedicatedVlanDbIds = new ArrayList<Long>();
+        DataCenter zone = _entityMgr.findById(DataCenter.class, dcId);
 
         SearchCriteria<IPAddressVO> sc = null;
         if (podId != null) {
@@ -680,10 +681,14 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
 
         // If owner has dedicated Public IP ranges, fetch IP from the dedicated range
         // Otherwise fetch IP from the system pool
-        List<AccountVlanMapVO> maps = _accountVlanMapDao.listAccountVlanMapsByAccount(owner.getId());
-        for (AccountVlanMapVO map : maps) {
-            if (vlanDbIds == null || vlanDbIds.contains(map.getVlanDbId()))
-                dedicatedVlanDbIds.add(map.getVlanDbId());
+        Network network = _networksDao.findById(guestNetworkId);
+        //Checking if network is null in the case of system VM's. At the time of allocation of IP address to systemVm, no network is present.
+        if(network == null || !(network.getGuestType() == GuestType.Shared && zone.getNetworkType() == NetworkType.Advanced)) {
+            List<AccountVlanMapVO> maps = _accountVlanMapDao.listAccountVlanMapsByAccount(owner.getId());
+            for (AccountVlanMapVO map : maps) {
+                if (vlanDbIds == null || vlanDbIds.contains(map.getVlanDbId()))
+                    dedicatedVlanDbIds.add(map.getVlanDbId());
+            }
         }
         List<VlanVO> nonDedicatedVlans = _vlanDao.listZoneWideNonDedicatedVlans(dcId);
         for (VlanVO nonDedicatedVlan : nonDedicatedVlans) {
@@ -711,7 +716,6 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
 
         sc.setParameters("dc", dcId);
 
-        DataCenter zone = _entityMgr.findById(DataCenter.class, dcId);
 
         // for direct network take ip addresses only from the vlans belonging to the network
         if (vlanUse == VlanType.DirectAttached) {


### PR DESCRIPTION
…s=false - FIXED

Root Cause Analysis: 
In the present case, if the IP addresses are dedicated to the account then on deploying the VM's with shared network (SNAT enabled), it tries to give the IP addresses from the dedicated pool of account. Ideally it should give it from IP's assigned for the network. Added an additional check for this.
