### PR TITLE
CLOUDSTACK-8915 - Cannot SSH into VMs deployed Redundant VPC routers

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -663,7 +663,7 @@ class CsForwardingRules(CsDataBag):
                 elif rule["type"] == "staticnat":
                     self.processStaticNatRule(rule)
 
-    #return the VR guest interface ipo
+    #return the VR guest interface ip
     def getGuestIp(self):
         ipr = []
         ipAddr = None

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -142,16 +142,16 @@ class CsAddress(CsDataBag):
                         "Address %s on device %s not configured", ip.ip(), dev)
                     if CsDevice(dev, self.config).waitfordevice():
                         ip.configure()
+                        
+                        route.add_route(dev, network)
 
-                route.add_route(dev, network)
-
-                # The code looks redundant here, but we actually have to cater for routers and
-                # VPC routers in a different manner. Please do not remove this block otherwise
-                # The VPC default route will be broken.
-                if address["nw_type"] == "public" and not found_defaultroute:
-                    if not route.defaultroute_exists():
-                        if route.add_defaultroute(gateway):
-                            found_defaultroute = True
+                        # The code looks redundant here, but we actually have to cater for routers and
+                        # VPC routers in a different manner. Please do not remove this block otherwise
+                        # The VPC default route will be broken.
+                        if address["nw_type"] == "public" and not found_defaultroute:
+                            if not route.defaultroute_exists():
+                                if route.add_defaultroute(gateway):
+                                    found_defaultroute = True
 
         # once we start processing public ip's we need to verify there
         # is a default route and add if needed

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -292,8 +292,8 @@ class CsIP:
 
     def post_configure(self, address):
         """ The steps that must be done after a device is configured """
+        route = CsRoute()
         if not self.get_type() in ["control"]:
-            route = CsRoute()
             route.add_table(self.dev)
             
             CsRule(self.dev).addMark()

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -112,9 +112,6 @@ class CsAddress(CsDataBag):
             return False
 
     def process(self):
-        route = CsRoute()
-        found_defaultroute = False
-
         for dev in self.dbag:
             if dev == "id":
                 continue
@@ -123,11 +120,8 @@ class CsAddress(CsDataBag):
             for address in self.dbag[dev]:
                 #check if link is up
                 if not self.check_if_link_up(dev):
-                   cmd="ip link set %s up"%dev
+                   cmd="ip link set %s up" % dev
                    CsHelper.execute(cmd)
-
-                gateway = str(address["gateway"])
-                network = str(address["network"])
 
                 ip.setAddress(address)
 
@@ -135,30 +129,12 @@ class CsAddress(CsDataBag):
                     logging.info(
                         "Address %s on device %s already configured", ip.ip(), dev)
 
-                    ip.post_configure()
-
+                    ip.post_configure(address)
                 else:
                     logging.info(
                         "Address %s on device %s not configured", ip.ip(), dev)
                     if CsDevice(dev, self.config).waitfordevice():
-                        ip.configure()
-                        
-                        route.add_route(dev, network)
-
-                        # The code looks redundant here, but we actually have to cater for routers and
-                        # VPC routers in a different manner. Please do not remove this block otherwise
-                        # The VPC default route will be broken.
-                        if address["nw_type"] == "public" and not found_defaultroute:
-                            if not route.defaultroute_exists():
-                                if route.add_defaultroute(gateway):
-                                    found_defaultroute = True
-
-        # once we start processing public ip's we need to verify there
-        # is a default route and add if needed
-        if not route.defaultroute_exists():
-            cmdline = self.config.cmdline()
-            if(cmdline.get_gateway()):
-                route.add_defaultroute(cmdline.get_gateway())
+                        ip.configure(address)
 
 
 class CsInterface:
@@ -307,28 +283,43 @@ class CsIP:
     def getAddress(self):
         return self.address
 
-    def configure(self):
+    def configure(self, address):
         logging.info(
             "Configuring address %s on device %s", self.ip(), self.dev)
         cmd = "ip addr add dev %s %s brd +" % (self.dev, self.ip())
         subprocess.call(cmd, shell=True)
-        self.post_configure()
+        self.post_configure(address)
 
-    def post_configure(self):
+    def post_configure(self, address):
         """ The steps that must be done after a device is configured """
         if not self.get_type() in ["control"]:
             route = CsRoute()
             route.add_table(self.dev)
+            
             CsRule(self.dev).addMark()
             self.check_is_up()
             self.set_mark()
             self.arpPing()
+            
             CsRpsrfs(self.dev).enable()
             self.post_config_change("add")
 
         '''For isolated/redundant and dhcpsrvr routers, call this method after the post_config is complete '''
         if not self.config.is_vpc():
             self.setup_router_control()
+        
+        if self.config.is_vpc():
+            # The code looks redundant here, but we actually have to cater for routers and
+            # VPC routers in a different manner. Please do not remove this block otherwise
+            # The VPC default route will be broken.
+            if self.get_type() in ["public"]:
+                gateway = str(address["gateway"])
+                route.add_defaultroute(gateway)
+        else:
+            # once we start processing public ip's we need to verify there
+            # is a default route and add if needed
+            if(self.cl.get_gateway()):
+                route.add_defaultroute(self.cl.get_gateway())
 
     def check_is_up(self):
         """ Ensure device is up """
@@ -543,19 +534,20 @@ class CsIP:
             CsDevice(self.dev, self.config).configure_rp()
 
             logging.error(
-                "Not able to setup sourcenat for a regular router yet")
+                "Not able to setup source-nat for a regular router yet")
             dns = CsDnsmasq(self)
             dns.add_firewall_rules()
             app = CsApache(self)
             app.setup()
 
+        cmdline = self.config.cmdline()
         # If redundant then this is dealt with by the master backup functions
-        if self.get_type() in ["guest"] and not self.config.cl.is_redundant():
+        if self.get_type() in ["guest"] and not cmdline.is_redundant():
             pwdsvc = CsPasswdSvc(self.address['public_ip']).start()
 
         if self.get_type() == "public" and self.config.is_vpc():
             if self.address["source_nat"]:
-                vpccidr = self.config.cmdline().get_vpccidr()
+                vpccidr = cmdline.get_vpccidr()
                 self.fw.append(
                     ["filter", "", "-A FORWARD -s %s ! -d %s -j ACCEPT" % (vpccidr, vpccidr)])
                 self.fw.append(
@@ -567,7 +559,15 @@ class CsIP:
         for i in CsHelper.execute(cmd):
             vals = i.lstrip().split()
             if (vals[0] == 'inet'):
-                self.iplist[vals[1]] = self.dev
+                
+                cidr = vals[1]
+                for ip, device in self.iplist.iteritems():
+                    logging.info(
+                                 "Iterating over the existing IPs. CIDR to be configured ==> %s, existing IP ==> %s on device ==> %s",
+                                 cidr, ip, device)
+
+                    if cidr[0] != ip[0] and device != self.dev:
+                        self.iplist[cidr] = self.dev
 
     def configured(self):
         if self.address['cidr'] in self.iplist.keys():
@@ -635,8 +635,13 @@ class CsIP:
         interface = CsInterface(bag, self.config)
         if not self.config.cl.is_redundant():
             return False
+
         rip = ip.split('/')[0]
+        logging.info("Checking if cidr is a gateway for rVPC. IP ==> %s / device ==> %s", ip, self.dev)
+
         gw = interface.get_gateway()
+        logging.info("Interface has the following gateway ==> %s", gw)
+        
         if bag['nw_type'] == "guest" and rip == gw:
             return True
         return False

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -213,12 +213,7 @@ def copy_if_needed(src, dest):
     """
     if os.path.isfile(dest):
         return
-    try:
-        shutil.copy2(src, dest)
-    except IOError:
-        logging.Error("Could not copy %s to %s" % (src, dest))
-    else:
-        logging.info("Copied %s to %s" % (src, dest))
+    copy(src, dest)
 
 def copy(src, dest):
     """

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -310,7 +310,7 @@ class CsRedundant(object):
                 if(cmdline.get_type()=='router'):
                     str = "        %s brd %s dev %s\n" % (cmdline.get_guest_gw(), o.get_broadcast(), o.get_device())
                 else:
-                    str = "        %s brd %s dev %s\n" % (o.get_ip(), o.get_broadcast(), o.get_device())
+                    str = "        %s brd %s dev %s\n" % (o.get_gateway_cidr(), o.get_broadcast(), o.get_device())
                 lines.append(str)
                 self.check_is_up(o.get_device())
         return lines

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -100,9 +100,11 @@ class CsRedundant(object):
         CsHelper.copy_if_needed(
             "%s/%s" % (self.CS_TEMPLATES_DIR, "keepalived.conf.templ"), self.KEEPALIVED_CONF)
         CsHelper.copy_if_needed(
-            "%s/%s" % (self.CS_TEMPLATES_DIR, "conntrackd.conf.templ"), self.CONNTRACKD_CONF)
-        CsHelper.copy_if_needed(
             "%s/%s" % (self.CS_TEMPLATES_DIR, "checkrouter.sh.templ"), "/opt/cloud/bin/checkrouter.sh")
+        #The file is always copied so the RVR doesn't't get the wrong config.
+        #Concerning the r-VPC, the configuration will be applied in a different manner
+        CsHelper.copy(
+            "%s/%s" % (self.CS_TEMPLATES_DIR, "conntrackd.conf.templ"), self.CONNTRACKD_CONF)
 
         CsHelper.execute(
             'sed -i "s/--exec\ \$DAEMON;/--exec\ \$DAEMON\ --\ --vrrp;/g" /etc/init.d/keepalived')

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -96,7 +96,8 @@ class CsRedundant(object):
                 d = s.replace(".templ", "")
             CsHelper.copy_if_needed(
                 "%s/%s" % (self.CS_TEMPLATES_DIR, s), "%s/%s" % (self.CS_ROUTER_DIR, d))
-        CsHelper.copy(
+
+        CsHelper.copy_if_needed(
             "%s/%s" % (self.CS_TEMPLATES_DIR, "keepalived.conf.templ"), self.KEEPALIVED_CONF)
         CsHelper.copy_if_needed(
             "%s/%s" % (self.CS_TEMPLATES_DIR, "conntrackd.conf.templ"), self.CONNTRACKD_CONF)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
@@ -71,13 +71,16 @@ class CsRoute:
         :param str gateway
         :return: bool
         """
-        if gateway is not None:
+        if not gateway:
+            raise Exception("Gateway cannot be None.")
+        
+        if self.defaultroute_exists():
+            return False
+        else:
             cmd = "default via " + gateway
             logging.info("Adding default route")
             self.set_route(cmd)
             return True
-        else:
-            return False
 
     def defaultroute_exists(self):
         """ Return True if a default route is present

--- a/test/integration/component/test_routers_network_ops.py
+++ b/test/integration/component/test_routers_network_ops.py
@@ -52,7 +52,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.testClient = super(TestRouterStopCreatePF, cls).getClsTestClient()
+        cls.testClient = super(TestCreatePFOnStoppedRouter, cls).getClsTestClient()
         cls.api_client = cls.testClient.getApiClient()
 
         cls.services = cls.testClient.getParsedTestDataConfig()
@@ -96,7 +96,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
     def tearDownClass(cls):
         try:
             cls.api_client = super(
-                TestRouterStopCreatePF,
+                TestCreatePFOnStoppedRouter,
                 cls).getClsTestClient().getApiClient()
             # Clean up, terminate the created resources
             cleanup_resources(cls.api_client, cls._cleanup)
@@ -258,7 +258,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.testClient = super(TestRouterStopCreateLB, cls).getClsTestClient()
+        cls.testClient = super(TestCreateLBOnStoppedRouter, cls).getClsTestClient()
         cls.api_client = cls.testClient.getApiClient()
 
         cls.services = cls.testClient.getParsedTestDataConfig()
@@ -302,7 +302,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
     def tearDownClass(cls):
         try:
             cls.api_client = super(
-                TestRouterStopCreateLB,
+                TestCreateLBOnStoppedRouter,
                 cls).getClsTestClient().getApiClient()
             # Clean up, terminate the created resources
             cleanup_resources(cls.api_client, cls._cleanup)
@@ -467,7 +467,7 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.testClient = super(TestRouterStopCreateFW, cls).getClsTestClient()
+        cls.testClient = super(TestCreateFWOnStoppedRouter, cls).getClsTestClient()
         cls.api_client = cls.testClient.getApiClient()
 
         cls.services = cls.testClient.getParsedTestDataConfig()
@@ -510,7 +510,7 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
     def tearDownClass(cls):
         try:
             cls.api_client = super(
-                TestRouterStopCreateFW,
+                TestCreateFWOnStoppedRouter,
                 cls).getClsTestClient().getApiClient()
             # Clean up, terminate the created templates
             cleanup_resources(cls.api_client, cls._cleanup)

--- a/test/integration/component/test_routers_network_ops.py
+++ b/test/integration/component/test_routers_network_ops.py
@@ -110,6 +110,11 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.cleanup = []
+        return
+
     def tearDown(self):
         try:
             # Clean up, terminate the created resources
@@ -118,10 +123,6 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    def setUp(self):
-        self.apiclient = self.testClient.getApiClient()
-        self.cleanup = []
-        return
 
     @attr(tags=["advanced", "advancedns"], required_hardware="true")
     def test_01_CreatePFOnStoppedRouter(self):
@@ -322,16 +323,16 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.cleanup = []
+        return
+
     def tearDown(self):
         try:
             cleanup_resources(self.apiclient, self.cleanup)
         except Exception as e:
             raise Exception("Warning: Exception during cleanup : %s" % e)
-        return
-
-    def setUp(self):
-        self.apiclient = self.testClient.getApiClient()
-        self.cleanup = []
         return
 
     @attr(tags=["advanced", "advancedns"], required_hardware="true")

--- a/test/integration/component/test_routers_network_ops.py
+++ b/test/integration/component/test_routers_network_ops.py
@@ -1,0 +1,707 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+""" P1 tests for routers
+"""
+# Import Local Modules
+from nose.plugins.attrib import attr
+from marvin.cloudstackTestCase import cloudstackTestCase
+from marvin.cloudstackAPI import (stopVirtualMachine,
+                                  stopRouter,
+                                  startRouter)
+from marvin.lib.utils import (cleanup_resources,
+                              get_process_status)
+from marvin.lib.base import (ServiceOffering,
+                             VirtualMachine,
+                             Account,
+                             LoadBalancerRule,
+                             FireWallRule,
+                             NATRule)
+from marvin.lib.common import (get_zone,
+                               get_template,
+                               get_domain,
+                               list_virtual_machines,
+                               list_networks,
+                               list_configurations,
+                               list_routers,
+                               list_nat_rules,
+                               list_publicIP,
+                               list_lb_rules,
+                               list_firewall_rules,
+                               list_hosts)
+
+# Import System modules
+import time
+
+
+class TestCreatePFOnStoppedRouter(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.testClient = super(TestRouterStopCreatePF, cls).getClsTestClient()
+        cls.api_client = cls.testClient.getApiClient()
+
+        cls.services = cls.testClient.getParsedTestDataConfig()
+        # Get Zone, Domain and templates
+        cls.domain = get_domain(cls.api_client)
+        cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+        template = get_template(
+            cls.api_client,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        cls.services["virtual_machine"]["zoneid"] = cls.zone.id
+
+        # Create an account, network, VM and IP addresses
+        cls.account = Account.create(
+            cls.api_client,
+            cls.services["account"],
+            admin=True,
+            domainid=cls.domain.id
+        )
+        cls.service_offering = ServiceOffering.create(
+            cls.api_client,
+            cls.services["service_offering"]
+        )
+        cls.vm_1 = VirtualMachine.create(
+            cls.api_client,
+            cls.services["virtual_machine"],
+            templateid=template.id,
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.service_offering.id
+        )
+        cls._cleanup = [
+            cls.account,
+            cls.service_offering
+        ]
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.api_client = super(
+                TestRouterStopCreatePF,
+                cls).getClsTestClient().getApiClient()
+            # Clean up, terminate the created resources
+            cleanup_resources(cls.api_client, cls._cleanup)
+
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def tearDown(self):
+        try:
+            # Clean up, terminate the created resources
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.cleanup = []
+        return
+
+    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    def test_01_CreatePFOnStoppedRouter(self):
+        """Stop existing router, add a PF rule and check we can access the VM """
+
+        # Get router details associated for that account
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+        self.assertNotEqual(
+            len(routers),
+            0,
+            "Check list router response"
+        )
+        router = routers[0]
+
+        self.debug("Stopping router ID: %s" % router.id)
+
+        # Stop the router
+        cmd = stopRouter.stopRouterCmd()
+        cmd.id = router.id
+        self.apiclient.stopRouter(cmd)
+
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+        router = routers[0]
+
+        self.assertEqual(
+            router.state,
+            'Stopped',
+            "Check list router response for router state"
+        )
+
+        public_ips = list_publicIP(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            zoneid=self.zone.id
+        )
+        self.assertEqual(
+            isinstance(public_ips, list),
+            True,
+            "Check for list public IPs response return valid data"
+        )
+
+        public_ip = public_ips[0]
+
+        # Open up firewall port for SSH
+        FireWallRule.create(
+            self.apiclient,
+            ipaddressid=public_ip.id,
+            protocol=self.services["natrule"]["protocol"],
+            cidrlist=['0.0.0.0/0'],
+            startport=self.services["natrule"]["publicport"],
+            endport=self.services["natrule"]["publicport"]
+        )
+
+        self.debug("Creating NAT rule for VM ID: %s" % self.vm_1.id)
+        # Create NAT rule
+        nat_rule = NATRule.create(
+            self.apiclient,
+            self.vm_1,
+            self.services["natrule"],
+            public_ip.id
+        )
+
+        self.debug("Starting router ID: %s" % router.id)
+        # Start the router
+        cmd = startRouter.startRouterCmd()
+        cmd.id = router.id
+        self.apiclient.startRouter(cmd)
+
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            zoneid=self.zone.id
+        )
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+        router = routers[0]
+
+        self.assertEqual(
+            router.state,
+            'Running',
+            "Check list router response for router state"
+        )
+        # NAT Rule should be in Active state after router start
+        nat_rules = list_nat_rules(
+            self.apiclient,
+            id=nat_rule.id
+        )
+        self.assertEqual(
+            isinstance(nat_rules, list),
+            True,
+            "Check for list NAT rules response return valid data"
+        )
+        self.assertEqual(
+            nat_rules[0].state,
+            'Active',
+            "Check list port forwarding rules"
+        )
+        try:
+
+            self.debug("SSH into VM with ID: %s" % nat_rule.ipaddress)
+
+            self.vm_1.get_ssh_client(
+                ipaddress=nat_rule.ipaddress,
+                port=self.services["natrule"]["publicport"])
+        except Exception as e:
+            self.fail(
+                "SSH Access failed for %s: %s" %
+                (nat_rule.ipaddress, e)
+            )
+        return
+
+
+class TestCreateLBOnStoppedRouter(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.testClient = super(TestRouterStopCreateLB, cls).getClsTestClient()
+        cls.api_client = cls.testClient.getApiClient()
+
+        cls.services = cls.testClient.getParsedTestDataConfig()
+        # Get Zone, Domain and templates
+        cls.domain = get_domain(cls.api_client)
+        cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+        template = get_template(
+            cls.api_client,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        cls.services["virtual_machine"]["zoneid"] = cls.zone.id
+
+        # Create an account, network, VM and IP addresses
+        cls.account = Account.create(
+            cls.api_client,
+            cls.services["account"],
+            admin=True,
+            domainid=cls.domain.id
+        )
+        cls.service_offering = ServiceOffering.create(
+            cls.api_client,
+            cls.services["service_offering"]
+        )
+        cls.vm_1 = VirtualMachine.create(
+            cls.api_client,
+            cls.services["virtual_machine"],
+            templateid=template.id,
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.service_offering.id
+        )
+        cls._cleanup = [
+            cls.account,
+            cls.service_offering
+        ]
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.api_client = super(
+                TestRouterStopCreateLB,
+                cls).getClsTestClient().getApiClient()
+            # Clean up, terminate the created resources
+            cleanup_resources(cls.api_client, cls._cleanup)
+
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.cleanup = []
+        return
+
+    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    def test_01_CreateLBOnStoppedRouter(self):
+        """Stop existing Router, add LB rule and check we can reach the VM"""
+
+        # Get router details associated for that account
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+
+        self.assertNotEqual(
+            len(routers),
+            0,
+            "Check list router response"
+        )
+
+        router = routers[0]
+
+        self.debug("Stopping router with ID: %s" % router.id)
+        # Stop the router
+        cmd = stopRouter.stopRouterCmd()
+        cmd.id = router.id
+        self.apiclient.stopRouter(cmd)
+
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+        router = routers[0]
+
+        self.assertEqual(
+            router.state,
+            'Stopped',
+            "Check list router response for router state"
+        )
+
+        public_ips = list_publicIP(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.assertEqual(
+            isinstance(public_ips, list),
+            True,
+            "Check for list public IPs response return valid data"
+        )
+        public_ip = public_ips[0]
+
+        # Open up firewall port for SSH
+        FireWallRule.create(
+            self.apiclient,
+            ipaddressid=public_ip.id,
+            protocol=self.services["lbrule"]["protocol"],
+            cidrlist=['0.0.0.0/0'],
+            startport=self.services["lbrule"]["publicport"],
+            endport=self.services["lbrule"]["publicport"]
+        )
+        self.debug("Creating LB rule for public IP: %s" % public_ip.id)
+        # Create Load Balancer rule and assign VMs to rule
+        lb_rule = LoadBalancerRule.create(
+            self.apiclient,
+            self.services["lbrule"],
+            public_ip.id,
+            accountid=self.account.name
+        )
+        self.debug("Assigning VM %s to LB rule: %s" % (
+            self.vm_1.id,
+            lb_rule.id
+        ))
+        lb_rule.assign(self.apiclient, [self.vm_1])
+
+        # Start the router
+        cmd = startRouter.startRouterCmd()
+        cmd.id = router.id
+        self.apiclient.startRouter(cmd)
+
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+        router = routers[0]
+
+        self.assertEqual(
+            router.state,
+            'Running',
+            "Check list router response for router state"
+        )
+        # After router start, LB RUle should be in Active state
+        lb_rules = list_lb_rules(
+            self.apiclient,
+            id=lb_rule.id
+        )
+        self.assertEqual(
+            isinstance(lb_rules, list),
+            True,
+            "Check for list LB rules response return valid data"
+        )
+        self.assertEqual(
+            lb_rules[0].state,
+            'Active',
+            "Check list load balancing rules"
+        )
+        self.assertEqual(
+            lb_rules[0].publicport,
+            str(self.services["lbrule"]["publicport"]),
+            "Check list load balancing rules"
+        )
+
+        try:
+            self.debug("SSH into VM with IP: %s" % public_ip.ipaddress)
+            self.vm_1.ssh_port = self.services["lbrule"]["publicport"]
+            self.vm_1.get_ssh_client(public_ip.ipaddress)
+        except Exception as e:
+            self.fail(
+                "SSH Access failed for %s: %s" %
+                (self.vm_1.ipaddress, e)
+            )
+        return
+
+
+class TestCreateFWOnStoppedRouter(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.testClient = super(TestRouterStopCreateFW, cls).getClsTestClient()
+        cls.api_client = cls.testClient.getApiClient()
+
+        cls.services = cls.testClient.getParsedTestDataConfig()
+        # Get Zone, Domain and templates
+        cls.domain = get_domain(cls.api_client)
+        cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+        template = get_template(
+            cls.api_client,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        cls.services["virtual_machine"]["zoneid"] = cls.zone.id
+
+        # Create an account, network, VM and IP addresses
+        cls.account = Account.create(
+            cls.api_client,
+            cls.services["account"],
+            domainid=cls.domain.id
+        )
+        cls.service_offering = ServiceOffering.create(
+            cls.api_client,
+            cls.services["service_offering"]
+        )
+        cls.vm_1 = VirtualMachine.create(
+            cls.api_client,
+            cls.services["virtual_machine"],
+            templateid=template.id,
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.service_offering.id
+        )
+        cls._cleanup = [
+            cls.account,
+            cls.service_offering
+        ]
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.api_client = super(
+                TestRouterStopCreateFW,
+                cls).getClsTestClient().getApiClient()
+            # Clean up, terminate the created templates
+            cleanup_resources(cls.api_client, cls._cleanup)
+
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.hypervisor = self.testClient.getHypervisorInfo()
+        self.cleanup = []
+        return
+
+    @attr(tags=["advanced", "advancedns"], required_hardware="true")
+    def test_01_CreateFWOnStoppedRouter(self):
+        """Stop existing Router, create Firewall rules and check that the rules are applied to the router"""
+
+        # Get the router details associated with account
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+
+        self.assertNotEqual(
+            len(routers),
+            0,
+            "Check list router response"
+        )
+
+        router = routers[0]
+
+        self.debug("Stopping the router: %s" % router.id)
+        # Stop the router
+        cmd = stopRouter.stopRouterCmd()
+        cmd.id = router.id
+        self.apiclient.stopRouter(cmd)
+
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+        router = routers[0]
+
+        self.assertEqual(
+            router.state,
+            'Stopped',
+            "Check list router response for router state"
+        )
+
+        public_ips = list_publicIP(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.assertEqual(
+            isinstance(public_ips, list),
+            True,
+            "Check for list public IP response return valid data"
+        )
+        public_ip = public_ips[0]
+
+        # Create Firewall rule with configurations from settings file
+        fw_rule = FireWallRule.create(
+            self.apiclient,
+            ipaddressid=public_ip.id,
+            protocol='TCP',
+            cidrlist=[self.services["fwrule"]["cidr"]],
+            startport=self.services["fwrule"]["startport"],
+            endport=self.services["fwrule"]["endport"]
+        )
+        self.debug("Created firewall rule: %s" % fw_rule.id)
+
+        self.debug("Starting the router: %s" % router.id)
+        # Start the router
+        cmd = startRouter.startRouterCmd()
+        cmd.id = router.id
+        self.apiclient.startRouter(cmd)
+
+        routers = list_routers(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+        )
+        self.assertEqual(
+            isinstance(routers, list),
+            True,
+            "Check for list routers response return valid data"
+        )
+
+        router = routers[0]
+
+        self.assertEqual(
+            router.state,
+            'Running',
+            "Check list router response for router state"
+        )
+        # After Router start, FW rule should be in Active state
+        fw_rules = list_firewall_rules(
+            self.apiclient,
+            id=fw_rule.id,
+        )
+        self.assertEqual(
+            isinstance(fw_rules, list),
+            True,
+            "Check for list FW rules response return valid data"
+        )
+
+        self.assertEqual(
+            fw_rules[0].state,
+            'Active',
+            "Check list load balancing rules"
+        )
+        self.assertEqual(
+            fw_rules[0].startport,
+            str(self.services["fwrule"]["startport"]),
+            "Check start port of firewall rule"
+        )
+
+        self.assertEqual(
+            fw_rules[0].endport,
+            str(self.services["fwrule"]["endport"]),
+            "Check end port of firewall rule"
+        )
+        # For DNS and DHCP check 'dnsmasq' process status
+        if (self.hypervisor.lower() == 'vmware'
+                or self.hypervisor.lower() == 'hyperv'):
+            result = get_process_status(
+                self.apiclient.connection.mgtSvr,
+                22,
+                self.apiclient.connection.user,
+                self.apiclient.connection.passwd,
+                router.linklocalip,
+                'iptables -t nat -L',
+                hypervisor=self.hypervisor
+            )
+        else:
+            hosts = list_hosts(
+                self.apiclient,
+                id=router.hostid,
+            )
+            self.assertEqual(
+                isinstance(hosts, list),
+                True,
+                "Check for list hosts response return valid data"
+            )
+            host = hosts[0]
+            host.user = self.services["configurableData"]["host"]["username"]
+            host.passwd = self.services["configurableData"]["host"]["password"]
+            try:
+                result = get_process_status(
+                    host.ipaddress,
+                    22,
+                    host.user,
+                    host.passwd,
+                    router.linklocalip,
+                    'iptables -t nat -L'
+                )
+            except KeyError:
+                self.skipTest(
+                    "Provide a marvin config file with host\
+                            credentials to run %s" %
+                    self._testMethodName)
+
+        self.debug("iptables -t nat -L: %s" % result)
+        self.debug("Public IP: %s" % public_ip.ipaddress)
+        res = str(result)
+        self.assertEqual(
+            res.count(str(public_ip.ipaddress)),
+            1,
+            "Check public IP address"
+        )
+
+        return

--- a/test/integration/component/test_routers_network_ops.py
+++ b/test/integration/component/test_routers_network_ops.py
@@ -14,8 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-""" P1 tests for routers
-"""
+
 # Import Local Modules
 from nose.plugins.attrib import attr
 from marvin.cloudstackTestCase import cloudstackTestCase
@@ -45,7 +44,7 @@ from marvin.lib.common import (get_zone,
 
 # Import System modules
 import time
-
+import logging
 
 class TestCreatePFOnStoppedRouter(cloudstackTestCase):
 
@@ -90,6 +89,12 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
             cls.account,
             cls.service_offering
         ]
+        
+        cls.logger = logging.getLogger('TestCreatePFOnStoppedRouter')
+        cls.stream_handler = logging.StreamHandler()
+        cls.logger.setLevel(logging.DEBUG)
+        cls.logger.addHandler(cls.stream_handler)
+
         return
 
     @classmethod
@@ -126,7 +131,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
 
         self.assertEqual(
@@ -141,7 +146,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
         )
         router = routers[0]
 
-        self.debug("Stopping router ID: %s" % router.id)
+        self.logger.debug("Stopping router ID: %s" % router.id)
 
         # Stop the router
         cmd = stopRouter.stopRouterCmd()
@@ -151,7 +156,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
         self.assertEqual(
             isinstance(routers, list),
@@ -190,7 +195,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
             endport=self.services["natrule"]["publicport"]
         )
 
-        self.debug("Creating NAT rule for VM ID: %s" % self.vm_1.id)
+        self.logger.debug("Creating NAT rule for VM ID: %s" % self.vm_1.id)
         # Create NAT rule
         nat_rule = NATRule.create(
             self.apiclient,
@@ -199,7 +204,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
             public_ip.id
         )
 
-        self.debug("Starting router ID: %s" % router.id)
+        self.logger.debug("Starting router ID: %s" % router.id)
         # Start the router
         cmd = startRouter.startRouterCmd()
         cmd.id = router.id
@@ -240,7 +245,7 @@ class TestCreatePFOnStoppedRouter(cloudstackTestCase):
         )
         try:
 
-            self.debug("SSH into VM with ID: %s" % nat_rule.ipaddress)
+            self.logger.debug("SSH into VM with ID: %s" % nat_rule.ipaddress)
 
             self.vm_1.get_ssh_client(
                 ipaddress=nat_rule.ipaddress,
@@ -296,6 +301,12 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
             cls.account,
             cls.service_offering
         ]
+
+        cls.logger = logging.getLogger('TestCreateLBOnStoppedRouter')
+        cls.stream_handler = logging.StreamHandler()
+        cls.logger.setLevel(logging.DEBUG)
+        cls.logger.addHandler(cls.stream_handler)
+
         return
 
     @classmethod
@@ -331,7 +342,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
 
         self.assertEqual(
@@ -348,7 +359,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
 
         router = routers[0]
 
-        self.debug("Stopping router with ID: %s" % router.id)
+        self.logger.debug("Stopping router with ID: %s" % router.id)
         # Stop the router
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
@@ -357,7 +368,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
         self.assertEqual(
             isinstance(routers, list),
@@ -393,7 +404,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
             startport=self.services["lbrule"]["publicport"],
             endport=self.services["lbrule"]["publicport"]
         )
-        self.debug("Creating LB rule for public IP: %s" % public_ip.id)
+        self.logger.debug("Creating LB rule for public IP: %s" % public_ip.id)
         # Create Load Balancer rule and assign VMs to rule
         lb_rule = LoadBalancerRule.create(
             self.apiclient,
@@ -401,7 +412,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
             public_ip.id,
             accountid=self.account.name
         )
-        self.debug("Assigning VM %s to LB rule: %s" % (
+        self.logger.debug("Assigning VM %s to LB rule: %s" % (
             self.vm_1.id,
             lb_rule.id
         ))
@@ -415,7 +426,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
         self.assertEqual(
             isinstance(routers, list),
@@ -451,7 +462,7 @@ class TestCreateLBOnStoppedRouter(cloudstackTestCase):
         )
 
         try:
-            self.debug("SSH into VM with IP: %s" % public_ip.ipaddress)
+            self.logger.debug("SSH into VM with IP: %s" % public_ip.ipaddress)
             self.vm_1.ssh_port = self.services["lbrule"]["publicport"]
             self.vm_1.get_ssh_client(public_ip.ipaddress)
         except Exception as e:
@@ -504,6 +515,12 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
             cls.account,
             cls.service_offering
         ]
+
+        cls.logger = logging.getLogger('TestCreateFWOnStoppedRouter')
+        cls.stream_handler = logging.StreamHandler()
+        cls.logger.setLevel(logging.DEBUG)
+        cls.logger.addHandler(cls.stream_handler)
+
         return
 
     @classmethod
@@ -540,7 +557,7 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
 
         self.assertEqual(
@@ -557,7 +574,7 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
 
         router = routers[0]
 
-        self.debug("Stopping the router: %s" % router.id)
+        self.logger.debug("Stopping the router: %s" % router.id)
         # Stop the router
         cmd = stopRouter.stopRouterCmd()
         cmd.id = router.id
@@ -566,7 +583,7 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
         self.assertEqual(
             isinstance(routers, list),
@@ -602,9 +619,9 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
             startport=self.services["fwrule"]["startport"],
             endport=self.services["fwrule"]["endport"]
         )
-        self.debug("Created firewall rule: %s" % fw_rule.id)
+        self.logger.debug("Created firewall rule: %s" % fw_rule.id)
 
-        self.debug("Starting the router: %s" % router.id)
+        self.logger.debug("Starting the router: %s" % router.id)
         # Start the router
         cmd = startRouter.startRouterCmd()
         cmd.id = router.id
@@ -613,7 +630,7 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
         routers = list_routers(
             self.apiclient,
             account=self.account.name,
-            domainid=self.account.domainid,
+            domainid=self.account.domainid
         )
         self.assertEqual(
             isinstance(routers, list),
@@ -695,8 +712,8 @@ class TestCreateFWOnStoppedRouter(cloudstackTestCase):
                             credentials to run %s" %
                     self._testMethodName)
 
-        self.debug("iptables -t nat -L: %s" % result)
-        self.debug("Public IP: %s" % public_ip.ipaddress)
+        self.logger.debug("iptables -t nat -L: %s" % result)
+        self.logger.debug("Public IP: %s" % public_ip.ipaddress)
         res = str(result)
         self.assertEqual(
             res.count(str(public_ip.ipaddress)),

--- a/test/integration/component/test_vpc_redundant.py
+++ b/test/integration/component/test_vpc_redundant.py
@@ -236,7 +236,7 @@ class TestVPCRedundancy(cloudstackTestCase):
             admin=True,
             domainid=self.domain.id)
 
-        self.cleanup = [self.account]
+        self._cleanup = [self.account]
         self.debug("Creating a VPC offering..")
         self.vpc_off = VpcOffering.create(
             self.apiclient,
@@ -254,13 +254,6 @@ class TestVPCRedundancy(cloudstackTestCase):
             zoneid=self.zone.id,
             account=self.account.name,
             domainid=self.account.domainid)
-        return
-
-    def tearDown(self):
-        try:
-            cleanup_resources(self.apiclient, self.cleanup)
-        except Exception as e:
-            self.debug("Warning: Exception during cleanup : %s" % e)
         return
 
     def query_routers(self, count=2, showall=False):
@@ -318,7 +311,6 @@ class TestVPCRedundancy(cloudstackTestCase):
                 conservemode=False)
 
             nw_off.update(self.apiclient, state='Enabled')
-            self._cleanup.append(nw_off)
             self.debug('Created and Enabled NetworkOffering')
 
             self.services["network"]["name"] = "NETWORK-" + str(gateway)
@@ -333,6 +325,7 @@ class TestVPCRedundancy(cloudstackTestCase):
                 gateway=gateway,
                 vpcid=vpc.id if vpc else self.vpc.id
             )
+
             self.debug("Created network with ID: %s" % obj_network.id)
         except Exception, e:
             self.fail('Unable to create a Network with offering=%s because of %s ' % (net_offerring, e))
@@ -419,16 +412,16 @@ class TestVPCRedundancy(cloudstackTestCase):
                 self.fail("Failed to SSH into VM - %s" % (public_ip.ipaddress.ipaddress))
 
     @attr(tags=["advanced", "intervlan"], required_hardware="true")
-    def test_01a_create_redundant_VPC(self):
-        """ Create a redundant vpc with two networks with two vms in each network """
-        self.debug("Starting est 1a")
+    def test_01_create_redundant_VPC_2tiers_4VMs_4IPs_4PF_ACL(self):
+        """ Create a redundant VPC with two networks with two VMs in each network """
+        self.debug("Starting test_01_create_redundant_VPC_2tiers_4VMs_4IPs_4PF_ACL")
         self.query_routers()
         self.networks.append(self.create_network(self.services["network_offering"], "10.1.1.1"))
         self.networks.append(self.create_network(self.services["network_offering_no_lb"], "10.1.2.1"))
+        time.sleep(30)
         self.check_master_status(2)
         self.add_nat_rules()
         self.do_vpc_test(False)
-        time.sleep(15)
 
         self.stop_router("MASTER")
         # wait for the backup router to transit to master state
@@ -437,14 +430,28 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.do_vpc_test(False)
 
         self.delete_nat_rules()
+        time.sleep(45)
         self.check_master_status(1)
         self.do_vpc_test(True)
 
         self.start_router()
         self.add_nat_rules()
-        time.sleep(15)
+        time.sleep(45)
         self.check_master_status(2)
         self.do_vpc_test(False)
+
+    @attr(tags=["advanced", "intervlan"], required_hardware="true")
+    def test_02_redundant_VPC_default_routes(self):
+        """ Create a redundant VPC with two networks with two VMs in each network and check default routes"""
+        self.debug("Starting test_02_redundant_VPC_default_routes")
+        self.query_routers()
+        self.networks.append(self.create_network(self.services["network_offering"], "10.1.1.1"))
+        self.networks.append(self.create_network(self.services["network_offering_no_lb"], "10.1.2.1"))
+        time.sleep(30)
+        self.check_master_status(2)
+        self.add_nat_rules()
+        self.test_default_routes()
+
 
     def delete_nat_rules(self):
         for o in self.networks:
@@ -469,6 +476,35 @@ class TestVPCRedundancy(cloudstackTestCase):
         for o in self.networks:
             for vm in o.get_vms():
                 self.check_ssh_into_vm(vm.get_vm(), vm.get_ip(), expectFail=expectFail, retries=retries)
+
+    def test_default_routes(self):
+        for o in self.networks:
+            for vmObj in o.get_vms():
+                ssh_command = "ping -c 3 8.8.8.8"
+
+                # Should be able to SSH VM
+                result = 'failed'
+                try:
+                    vm = vmObj.get_vm()
+                    public_ip = vmObj.get_ip()
+                    self.debug("SSH into VM: %s" % public_ip.ipaddress.ipaddress)
+                    
+                    ssh = vm.get_ssh_client(ipaddress=public_ip.ipaddress.ipaddress)
+        
+                    self.debug("Ping to google.com from VM")
+                    result = ssh.execute(ssh_command)
+
+                    self.debug("SSH result: %s" % str(result))
+                except Exception as e:
+                    self.fail("SSH Access failed for %s: %s" % \
+                              (vmObj.get_ip(), e)
+                              )
+        
+                self.assertEqual(
+                                 result.count("0% packet loss"),
+                                 1,
+                                 "Ping to outside world from VM should be successful"
+                                 )
 
 
 class networkO(object):

--- a/test/integration/component/test_vpc_redundant.py
+++ b/test/integration/component/test_vpc_redundant.py
@@ -287,8 +287,6 @@ class TestVPCRedundancy(cloudstackTestCase):
                 cnts[vals.index(router.redundantstate)] += 1
         if cnts[vals.index('MASTER')] != 1:
             self.fail("No Master or too many master routers found %s" % cnts[vals.index('MASTER')])
-        # if cnts[vals.index('UNKNOWN')] > 0:
-            # self.fail("Router has unknown status")
 
     def stop_router(self, type):
         self.check_master_status(2)
@@ -430,6 +428,7 @@ class TestVPCRedundancy(cloudstackTestCase):
         self.check_master_status(2)
         self.add_nat_rules()
         self.do_vpc_test(False)
+        time.sleep(15)
 
         self.stop_router("MASTER")
         # wait for the backup router to transit to master state
@@ -443,6 +442,7 @@ class TestVPCRedundancy(cloudstackTestCase):
 
         self.start_router()
         self.add_nat_rules()
+        time.sleep(15)
         self.check_master_status(2)
         self.do_vpc_test(False)
 

--- a/test/integration/component/test_vpc_redundant.py
+++ b/test/integration/component/test_vpc_redundant.py
@@ -507,7 +507,7 @@ class TestVPCRedundancy(cloudstackTestCase):
                               )
         
                 self.assertEqual(
-                                 result.count("0% packet loss"),
+                                 result.count("3 packets received"),
                                  1,
                                  "Ping to outside world from VM should be successful"
                                  )

--- a/test/integration/component/test_vpc_router_nics.py
+++ b/test/integration/component/test_vpc_router_nics.py
@@ -456,7 +456,7 @@ class TestVPCNics(cloudstackTestCase):
                               )
         
                 self.assertEqual(
-                                 result.count("0% packet loss"),
+                                 result.count("3 packets received"),
                                  1,
                                  "Ping to outside world from VM should be successful"
                                  )


### PR DESCRIPTION
In order to reproduce the problem, I did the following

* Create a Redundant VPC
* Add a tier
* Add a new VM to the tier
* Add an ACL, open port 22 and associate the ACL with the tier
* Acquire a pub IP
* Add a PF rule to port 22 towards the VM
* Try to SSH to the VM through the Pub IP

It failed with "No route to host".

This PR contains the following:

* Fix for the keepalived (vrrp) configuration;
* Refactor the default router code for both isolated and [r]VPC routers
* Revert CsRedundant changes
* Add default route tests
* Add logging to tests - so we see what's happening during test execution.