### PR TITLE
CLOUDSTACK-8923: Do not send zoneId with createStorageNetworkIpRange command.

### DIFF
--- a/server/src/com/cloud/network/StorageNetworkManagerImpl.java
+++ b/server/src/com/cloud/network/StorageNetworkManagerImpl.java
@@ -112,11 +112,13 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
                     stmt_insert.setLong(3, zoneId);
                     stmt_insert.setNull(4, java.sql.Types.DATE);
                     stmt_insert.executeUpdate();
+                    stmt_insert.close();
                 }
 
                 try (PreparedStatement stmt_update = txn.prepareStatement(updateSql);) {
                     stmt_update.setLong(1, zoneId);
                     stmt_update.executeUpdate();
+                    stmt_update.close();
                 }
             }
         }
@@ -223,7 +225,7 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
         checkOverlapPrivateIpRange(podId, startIp, endIp);
         checkOverlapStorageIpRange(podId, startIp, endIp);
 
-        StorageNetworkIpRangeVO range = null;
+        //StorageNetworkIpRangeVO range = null;
 
         final String endIpFinal = endIp;
         return Transaction.execute(new TransactionCallbackWithException<StorageNetworkIpRangeVO, SQLException>() {

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -1007,7 +1007,6 @@
                                             label: 'label.add',
                                             action: function (args) {
                                                 var array1 =[];
-                                                array1.push("&zoneId=" + args.context.zones[0].id);
                                                 array1.push("&podid=" + args.data.podid);
 
                                                 array1.push("&gateway=" + args.data.gateway);

--- a/ui/scripts/zoneWizard.js
+++ b/ui/scripts/zoneWizard.js
@@ -3938,7 +3938,6 @@
                         $.ajax({
                             url: createURL('createStorageNetworkIpRange'),
                             data: $.extend(true, {}, item, {
-                                zoneid: args.data.returnedZone.id,
                                 podid: args.data.returnedPod.id
                             }),
                             success: function(json) {


### PR DESCRIPTION
The zoneId was send with the createStorageNetworkIpRange from the wizard. This isn't necessary. It will only remove the warning. It doesn't fix the transaction issue from CLOUDSTACK-8923 itself.

>>> Please hold testing or merging!