### PR TITLE
Fix bugs on last step on Wizard zone and Adv Search box

### DIFF
--- a/ui/dictionary2.jsp
+++ b/ui/dictionary2.jsp
@@ -1098,6 +1098,7 @@ under the License.
 'label.remove.this.physical.network': '<fmt:message key="label.remove.this.physical.network" />',
 'label.physical.network.name': '<fmt:message key="label.physical.network.name" />',
 'label.save.changes': '<fmt:message key="label.save.changes" />',
+'label.launch.zone': '<fmt:message key="label.launch.zone" />',
 'label.autoscale.configuration.wizard': '<fmt:message key="label.autoscale.configuration.wizard" />',
 'label.health.check.wizard': '<fmt:message key="label.health.check.wizard" />',
 'label.health.check.message.desc': '<fmt:message key="label.health.check.message.desc" />',

--- a/ui/scripts/ui-custom/zoneWizard.js
+++ b/ui/scripts/ui-custom/zoneWizard.js
@@ -1211,7 +1211,7 @@
 
                 // Show launch button if last step
                 if ($targetStep.index() == $steps.size() - 1 || options.nextStep) {
-                    $nextButton.find('span').html(options.nextStep ? _('label.save.changes') : _('label.launch.zone'));
+                    $nextButton.find('span').html(options.nextStep ? _l('label.save.changes') : _l('label.launch.zone'));
                     $nextButton.addClass('final');
 
                     if (options.nextStep) {

--- a/ui/scripts/ui/widgets/listView.js
+++ b/ui/scripts/ui/widgets/listView.js
@@ -1974,7 +1974,7 @@
             $form.find('input[type=submit]')
                 .show()
                 .appendTo($form)
-                .val(_('label.search'));
+                .val(_l('label.search'));
 
             // Cancel button
             $form.append(


### PR DESCRIPTION
Javascript error: Uncaught ReferenceError: _ is not defined
Missing 'l' (to call the _l() function)

Bug introduce by me (#712)

For the zone wizard, the Next button isn't replace by Finish button and the steps don't display in the box.
For the Adv Search box, the label of search button is "submit" instead of "Search" (in en_US localization)
