### PR TITLE
another typo that appears when monitoring the java process via JMX

### DIFF
--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobMBeanImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobMBeanImpl.java
@@ -62,16 +62,16 @@ public class AsyncJobMBeanImpl extends StandardMBean implements AsyncJobMBean {
                 return "Completed";
 
             case IN_PROGRESS:
-                return "In preogress";
+                return "In progress";
 
             case FAILED:
-                return "failed";
+                return "Failed";
 
             case CANCELLED:
-                return "cancelled";
+                return "Cancelled";
         }
 
-        return "Unknow";
+        return "Unknown";
     }
 
     @Override


### PR DESCRIPTION
Status : in preogress instead of in progress and some other small typos .