### PR TITLE
CLOUDSTACK-8939 VM Snapshot size with memory correctly calculated in cloud.usage_event (XenServer)

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateVMSnapshotCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateVMSnapshotCommandWrapper.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.log4j.Logger;
 
@@ -142,8 +143,11 @@ public final class CitrixCreateVMSnapshotCommandWrapper extends CommandWrapper<C
             }
             // calculate used capacity for this VM snapshot
             for (final VolumeObjectTO volumeTo : command.getVolumeTOs()) {
-                final long size = citrixResourceBase.getVMSnapshotChainSize(conn, volumeTo, command.getVmName());
-                volumeTo.setSize(size);
+                try {
+                    final long size = citrixResourceBase.getVMSnapshotChainSize(conn, volumeTo, command.getVmName(), vmSnapshotName);
+                    volumeTo.setSize(size);
+                } catch (final CloudRuntimeException cre) {
+                }
             }
 
             success = true;

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixDeleteVMSnapshotCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixDeleteVMSnapshotCommandWrapper.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.log4j.Logger;
 
@@ -79,8 +80,12 @@ public final class CitrixDeleteVMSnapshotCommandWrapper extends CommandWrapper<D
             }
             // re-calculate used capacify for this VM snapshot
             for (final VolumeObjectTO volumeTo : command.getVolumeTOs()) {
-                final long size = citrixResourceBase.getVMSnapshotChainSize(conn, volumeTo, command.getVmName());
-                volumeTo.setSize(size);
+                try {
+                    final long size = citrixResourceBase.getVMSnapshotChainSize(conn, volumeTo, command.getVmName(), snapshotName);
+                    volumeTo.setSize(size);
+                } catch (final CloudRuntimeException cre) {
+
+                }
             }
 
             return new DeleteVMSnapshotAnswer(command, command.getVolumeTOs());


### PR DESCRIPTION
Fixing the error  with snapshot size calculation  in a vm with memory
