### PR TITLE
CLOUDSTACK-8940: Wrong value is inserted into nics table netmask fiel…

### DIFF
--- a/server/src/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/com/cloud/network/IpAddressManagerImpl.java
@@ -1932,9 +1932,9 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
 
                         }
 
-                        // nic ip address isn ot set here. Because the DHCP is external to cloudstack
+                        // nic ip address is not set here. Because the DHCP is external to cloudstack
                         nic.setIPv4Gateway(network.getGateway());
-                        nic.setIPv4Netmask(network.getCidr());
+                        nic.setIPv4Netmask(NetUtils.getCidrNetmask(network.getCidr()));
 
                         List<VlanVO> vlan = _vlanDao.listVlansByNetworkId(network.getId());
 


### PR DESCRIPTION
…d when creating a VM - Fixed

Problem: When creating a VM in shared network with no service, the value of netmask is added in the table in the CIDR format unlike other cases where it is added as normal string in the format xxx.xxx.xxx.xxx. The netmask column in the nics table has a length of 15 chars which gets violated if the CIDR exceeds it(Max CIDR length can be 18). 

Fix: Before storing the netmask convert from CIDR to native format. 