### PR TITLE
CLOUDSTACK-8944 Template download possible from new nfs secondary storage before download is 100 % complete

### DIFF
--- a/server/src/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/com/cloud/template/TemplateManagerImpl.java
@@ -520,7 +520,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             for (DataStore store : ssStores) {
                 tmpltStoreRef = _tmplStoreDao.findByStoreTemplate(store.getId(), templateId);
                 if (tmpltStoreRef != null) {
-                    if (tmpltStoreRef.getDownloadState() == com.cloud.storage.VMTemplateStorageResourceAssoc.Status.DOWNLOADED) {
+                    if (tmpltStoreRef.getDownloadState() == com.cloud.storage.VMTemplateStorageResourceAssoc.Status.DOWNLOADED && tmpltStoreRef.getDownloadPercent() == 100) {
                         tmpltStore = (ImageStoreEntity)store;
                         break;
                     }


### PR DESCRIPTION
Steps to test This
1. Add a new NFS storage
2. Start dowloading any public template before it is full dowloaded to new nfs storage
3. The link should always be from any of the older storages where it is fully downloaded
