### PR TITLE
Fix for CLOUDSTACK-8937 - XenServer migrations with storage failing i…

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer610Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer610Resource.java
@@ -41,6 +41,7 @@ import com.xensource.xenapi.VM;
 
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 
+import com.cloud.utils.Pair;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.MigrateWithStorageAnswer;
@@ -126,7 +127,7 @@ public class XenServer610Resource extends XenServer600Resource {
     protected MigrateWithStorageAnswer execute(MigrateWithStorageCommand cmd) {
         Connection connection = getConnection();
         VirtualMachineTO vmSpec = cmd.getVirtualMachine();
-        Map<VolumeTO, StorageFilerTO> volumeToFiler = cmd.getVolumeToFiler();
+        List<Pair<VolumeTO, StorageFilerTO>> volToFiler = cmd.getVolumeToFilerAsList();
         final String vmName = vmSpec.getName();
         Task task = null;
 
@@ -151,8 +152,8 @@ public class XenServer610Resource extends XenServer600Resource {
             // Create the vif map. The vm stays in the same cluster so we have to pass an empty vif map.
             Map<VIF, Network> vifMap = new HashMap<VIF, Network>();
             Map<VDI, SR> vdiMap = new HashMap<VDI, SR>();
-            for (Map.Entry<VolumeTO, StorageFilerTO> entry : volumeToFiler.entrySet()) {
-                vdiMap.put(getVDIbyUuid(connection, entry.getKey().getPath()), getStorageRepository(connection, entry.getValue().getUuid()));
+            for (Pair<VolumeTO, StorageFilerTO> entry : volToFiler) {
+                vdiMap.put(getVDIbyUuid(connection, entry.first().getPath()), getStorageRepository(connection, entry.second().getUuid()));
             }
 
             // Check migration with storage is possible.

--- a/plugins/hypervisors/xenserver/src/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
+++ b/plugins/hypervisors/xenserver/src/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.cloudstack.storage.motion;
 
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -55,6 +56,7 @@ import com.cloud.exception.AgentUnavailableException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.host.Host;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
+import com.cloud.utils.Pair;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
@@ -193,15 +195,15 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
 
         // Initiate migration of a virtual machine with it's volumes.
         try {
-            Map<VolumeTO, StorageFilerTO> volumeToFilerto = new HashMap<VolumeTO, StorageFilerTO>();
+            List<Pair<VolumeTO, StorageFilerTO>> volumeToFilerto = new ArrayList<Pair<VolumeTO, StorageFilerTO>>();
             for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
                 VolumeInfo volume = entry.getKey();
                 VolumeTO volumeTo = new VolumeTO(volume, storagePoolDao.findById(volume.getPoolId()));
                 StorageFilerTO filerTo = new StorageFilerTO((StoragePool)entry.getValue());
-                volumeToFilerto.put(volumeTo, filerTo);
+                volumeToFilerto.add(new Pair<VolumeTO, StorageFilerTO>(volumeTo, filerTo));
             }
 
-            MigrateWithStorageCommand command = new MigrateWithStorageCommand(to, volumeToFilerto);
+            MigrateWithStorageCommand command = new MigrateWithStorageCommand(to, volumeToFilerto,destHost.getGuid());
             MigrateWithStorageAnswer answer = (MigrateWithStorageAnswer)agentMgr.send(destHost.getId(), command);
             if (answer == null) {
                 s_logger.error("Migration with storage of vm " + vm + " failed.");


### PR DESCRIPTION
…n clustered management server environment

This pull request relates to the following Jira bug report:
https://issues.apache.org/jira/browse/CLOUDSTACK-8937

This has been tested by checking out the tagged 4.5.2 release, making the changes detailed, compiling and then copying the webapps/client/WEB-INF/lib/cloud-plugin-hypervisor-xenserver-4.5.2.jar file into a 4.5.2 cluster of 4 management servers. The cluster is running two xenserver pods, the hosts of which are running Xenserver 6.5. 

Live migrations have then been tested with vm's which have single and multiple disks on local storage. Tests have only been performed on live migrations within the same pod. 

Prior to this fix, migrations would intermittently fail (details in the above jira link). With this fix in place, no further issues have been seen. 
