### PR TITLE
CLOUDSTACK-9901 secure and hidden config values are returned as plaintext string

### DIFF
--- a/framework/config/src/org/apache/cloudstack/config/Configuration.java
+++ b/framework/config/src/org/apache/cloudstack/config/Configuration.java
@@ -81,4 +81,10 @@ public interface Configuration {
      * parameter is no longer used and can be deleted.
      */
     Date getUpdated();
+
+    /**
+     *
+     * @return returns true if the configuration is encrypted else false.
+     */
+    boolean isEncrypted();
 }

--- a/framework/config/src/org/apache/cloudstack/framework/config/impl/ConfigurationVO.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/impl/ConfigurationVO.java
@@ -122,7 +122,7 @@ public class ConfigurationVO implements Configuration {
 
     @Override
     public String getValue() {
-        if(isEncryptedConfig()) {
+        if(isEncrypted()) {
             return DBEncryptionUtil.decrypt(value);
         } else {
             return value;
@@ -130,14 +130,15 @@ public class ConfigurationVO implements Configuration {
     }
 
     public void setValue(String value) {
-        if(isEncryptedConfig()) {
+        if(isEncrypted()) {
             this.value = DBEncryptionUtil.encrypt(value);
         } else {
             this.value = value;
         }
     }
 
-    private boolean isEncryptedConfig() {
+    @Override
+    public boolean isEncrypted() {
         return "Hidden".equals(getCategory()) || "Secure".equals(getCategory());
     }
 

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.api;
 
+import com.cloud.utils.crypt.DBEncryptionUtil;
 import com.cloud.agent.api.VgpuTypesInfo;
 import com.cloud.api.query.ViewResponseHelper;
 import com.cloud.api.query.vo.AccountJoinVO;
@@ -455,7 +456,11 @@ public class ApiResponseHelper implements ResponseGenerator {
         cfgResponse.setCategory(cfg.getCategory());
         cfgResponse.setDescription(cfg.getDescription());
         cfgResponse.setName(cfg.getName());
-        cfgResponse.setValue(cfg.getValue());
+        if(cfg.isEncrypted()) {
+            cfgResponse.setValue(DBEncryptionUtil.encrypt(cfg.getValue()));
+        } else {
+            cfgResponse.setValue(cfg.getValue());
+        }
         cfgResponse.setObjectName("configuration");
 
         return cfgResponse;

--- a/test/integration/smoke/test_internal_lb.py
+++ b/test/integration/smoke/test_internal_lb.py
@@ -705,8 +705,12 @@ class TestInternalLb(cloudstackTestCase):
                 self.apiclient, name="network.loadbalancer.haproxy.stats.port")[0].value
             settings["stats_uri"] = Configurations.list(
                 self.apiclient, name="network.loadbalancer.haproxy.stats.uri")[0].value
-            settings["username"], settings["password"] = Configurations.list(
-                self.apiclient, name="network.loadbalancer.haproxy.stats.auth")[0].value.split(":")
+            # Update global setting network.loadbalancer.haproxy.stats.auth to a known value
+            haproxy_auth = "admin:password"
+            Configurations.update(self.apiclient, "network.loadbalancer.haproxy.stats.auth", haproxy_auth)
+            self.logger.debug(
+                "Updated global setting stats network.loadbalancer.haproxy.stats.auth to %s" % (haproxy_auth))
+            settings["username"], settings["password"] = haproxy_auth.split(":")
             settings["visibility"] = Configurations.list(
                 self.apiclient, name="network.loadbalancer.haproxy.stats.visibility")[0].value
             self.logger.debug(settings)


### PR DESCRIPTION
secure and hidden config values are first unencrypted before returning
them in the api. This is not desired as they are secure configs
returning encrypted strings for secure and hidden configs if encryption
is enabled.

