### PR TITLE
CLOUDSTACK-8950 Hypervisor Parameter check is not performed for registerTemplate and getUploadParamsForTemplate API's

### DIFF
--- a/server/src/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/com/cloud/template/TemplateAdapterBase.java
@@ -270,10 +270,15 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
             zoneId = -1L;
         }
 
-        return prepare(false, CallContext.current().getCallingUserId(), cmd.getTemplateName(), cmd.getDisplayText(), cmd.getBits(), cmd.isPasswordEnabled(),
-            cmd.getRequiresHvm(), cmd.getUrl(), cmd.isPublic(), cmd.isFeatured(), cmd.isExtractable(), cmd.getFormat(), cmd.getOsTypeId(), zoneId,
-            HypervisorType.getType(cmd.getHypervisor()), cmd.getChecksum(), true, cmd.getTemplateTag(), owner, cmd.getDetails(), cmd.isSshKeyEnabled(), null,
-            cmd.isDynamicallyScalable(), isRouting ? TemplateType.ROUTING : TemplateType.USER);
+        HypervisorType hypervisorType = HypervisorType.getType(cmd.getHypervisor());
+        if(hypervisorType == HypervisorType.None) {
+            throw new InvalidParameterValueException("Hypervisor Type: " + cmd.getHypervisor() + " is invalid. Supported Hypervisor types are "
+                    + EnumUtils.listValues(HypervisorType.values()).replace("None, ", ""));
+        }
+
+        return prepare(false, CallContext.current().getCallingUserId(), cmd.getTemplateName(), cmd.getDisplayText(), cmd.getBits(), cmd.isPasswordEnabled(), cmd.getRequiresHvm(),
+                cmd.getUrl(), cmd.isPublic(), cmd.isFeatured(), cmd.isExtractable(), cmd.getFormat(), cmd.getOsTypeId(), zoneId, hypervisorType, cmd.getChecksum(), true,
+                cmd.getTemplateTag(), owner, cmd.getDetails(), cmd.isSshKeyEnabled(), null, cmd.isDynamicallyScalable(), isRouting ? TemplateType.ROUTING : TemplateType.USER);
 
     }
 
@@ -293,9 +298,15 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
             zoneId = -1L;
         }
 
+        HypervisorType hypervisorType = HypervisorType.getType(cmd.getHypervisor());
+        if(hypervisorType == HypervisorType.None) {
+            throw new InvalidParameterValueException("Hypervisor Type: " + cmd.getHypervisor() + " is invalid. Supported Hypervisor types are "
+                                                         + EnumUtils.listValues(HypervisorType.values()).replace("None, ", ""));
+        }
+
         return prepare(false, CallContext.current().getCallingUserId(), cmd.getName(), cmd.getDisplayText(), cmd.getBits(), cmd.isPasswordEnabled(),
                        cmd.getRequiresHvm(), null, cmd.isPublic(), cmd.isFeatured(), cmd.isExtractable(), cmd.getFormat(), cmd.getOsTypeId(), zoneId,
-                       HypervisorType.getType(cmd.getHypervisor()), cmd.getChecksum(), true, cmd.getTemplateTag(), owner, cmd.getDetails(), cmd.isSshKeyEnabled(), null,
+                       hypervisorType, cmd.getChecksum(), true, cmd.getTemplateTag(), owner, cmd.getDetails(), cmd.isSshKeyEnabled(), null,
                        cmd.isDynamicallyScalable(), isRouting ? TemplateType.ROUTING : TemplateType.USER);
 
     }


### PR DESCRIPTION
Any string is allowed as hypervisor type from the api.
HypervisorType.getType() tries to validates with the enums and if nothing
matches sets the type as None.

Added a check to not allow None hypervisor type when registering.

will update test results and testing done later.
