### PR TITLE
CLOUDSTACK-8933 SSVm and CPVM do not survive a reboot from API

### DIFF
--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -117,7 +117,7 @@ get_boot_params() {
           if [ ! -e /dev/vport0p1 ]; then
             log_it "/dev/vport0p1 not loaded, perhaps guest kernel is too old." && exit 2
           fi
-          while [ -z "$cmd" ]; do
+	  while [ -z "$cmd" ]; do         
             while read line; do
               if [[ $line == cmdline:* ]]; then
                 cmd=${line//cmdline:/}
@@ -128,7 +128,14 @@ get_boot_params() {
                 echo $pubkey > /root/.ssh/authorized_keys
               fi
             done < /dev/vport0p1
-	  done
+            # In case of reboot we do not send the boot args again.
+            # so need not wait for them, as the boot args are already set at startup
+            if [ -s /var/cache/cloud/cmdline  ]
+            then
+                log_it "found a non empty cmdline file continuing"
+                break;
+            fi
+	 done
           chmod go-rwx /root/.ssh/authorized_keys
           ;;
      vmware)


### PR DESCRIPTION
The issue is because we loop infinitely when we do not receive any cmdline data during reboots. The current fix is to attempt one time to read the commadline data, if the data is not there we check if the cmdline is already populated. If it is already there we continue with the existing command line data.

This fix will work in case of reboots, but in case of stop and start if the cmdline changes and we do not get it on first read we will end up using the old cmdline data instead of the new one. I am not sure if the cmdline data will change on start stop. if the data dose change,  One way to fix this will be to send some data in the cmdline on reboot to say that we can use the existing data in the cmdline(not need to wait or loop). I am not sure if this a good way to fix it.

Please let me know if there is a better way to do this.