### PR TITLE
CLOUDSTACK-8947 - Load Balancer not working with Isolated Networks

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -148,7 +148,7 @@ class CsAcl(CsDataBag):
                                " -m %s " % rule['protocol'] + \
                                " --dport %s" % rnge
                     
-                    self.fw.append(["filter", "front", "%s -j %s" % (fwr, rule['action'])])
+                    self.fw.append(["filter", "", "%s -j %s" % (fwr, rule['action'])])
 
                 logging.debug("EGRESS rule configured for protocol ==> %s, action ==> %s", rule['protocol'], rule['action'])
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -141,13 +141,13 @@ class CsAcl(CsDataBag):
                                     " -m %s " % rule['protocol'] +
                                     " --icmp-type %s -j %s" % (icmp_type, self.rule['action'])])
                 else:
-                    fwr = " -A FW_EGRESS_RULES" + \
-                          " -s %s " % cidr
+                    fwr = " -A FW_EGRESS_RULES"
                     if rule['protocol'] != "all":
-                        fwr += "-p %s " % rule['protocol'] + \
+                        fwr += " -s %s " % cidr + \
+                               " -p %s " % cidr, rule['protocol'] + \
                                " -m %s " % rule['protocol'] + \
                                " --dport %s" % rnge
-                    
+
                     self.fw.append(["filter", "", "%s -j %s" % (fwr, rule['action'])])
 
                 logging.debug("EGRESS rule configured for protocol ==> %s, action ==> %s", rule['protocol'], rule['action'])

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
@@ -150,6 +150,8 @@ class CsNetfilters(object):
             new_rule.set_table(fw[0])
             if isinstance(fw[1], int):
                 new_rule.set_count(fw[1])
+
+            logging.debug("Checking if the rule already exists: rule=%s table=%s chain=%s", new_rule.get_rule(), new_rule.get_table(), new_rule.get_chain())
             if self.has_rule(new_rule):
                 logging.debug("Exists: rule=%s table=%s", fw[2], new_rule.get_table())
             else:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsProcess.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsProcess.py
@@ -46,6 +46,8 @@ class CsProcess(object):
             matches = len([m for m in proc if m in self.search])
             if matches == items:
                 self.pid.append(re.split("\s+", i)[1])
+
+        logging.debug("CsProcess:: Searching for process ==> %s and found PIDs ==> %s", self.search, self.pid)
         return self.pid
 
     def find(self):

--- a/test/integration/smoke/test_loadbalance.py
+++ b/test/integration/smoke/test_loadbalance.py
@@ -120,7 +120,7 @@ class TestLoadBalance(cloudstackTestCase):
         cleanup_resources(cls.apiclient, cls._cleanup)
         return
 
-    def try_ssh(self, ip_addr, hostnames):
+    def try_ssh(self, ip_addr, unameCmd):
         try:
             self.debug(
                 "SSH into VM (IPaddress: %s) & NAT Rule (Public IP: %s)" %
@@ -136,8 +136,8 @@ class TestLoadBalance(cloudstackTestCase):
                 self.vm_1.password,
                 retries=5
             )
-            hostnames.append(ssh_1.execute("hostname")[0])
-            self.debug(hostnames)
+            unameCmd.append(ssh_1.execute("uname")[0])
+            self.debug(unameCmd)
         except Exception as e:
             self.fail("%s: SSH failed for VM with IP Address: %s" %
                                     (e, ip_addr))
@@ -151,7 +151,7 @@ class TestLoadBalance(cloudstackTestCase):
         # Validate the Following:
         #1. listLoadBalancerRules should return the added rule
         #2. attempt to ssh twice on the load balanced IP
-        #3. verify using the hostname of the VM
+        #3. verify using the UNAME of the VM
         #   that round robin is indeed happening as expected
         src_nat_ip_addrs = PublicIPAddress.list(
                                     self.apiclient,
@@ -255,30 +255,30 @@ class TestLoadBalance(cloudstackTestCase):
             )
 
 
-        hostnames = []
-        self.try_ssh(src_nat_ip_addr.ipaddress, hostnames)
-        self.try_ssh(src_nat_ip_addr.ipaddress, hostnames)
-        self.try_ssh(src_nat_ip_addr.ipaddress, hostnames)
-        self.try_ssh(src_nat_ip_addr.ipaddress, hostnames)
-        self.try_ssh(src_nat_ip_addr.ipaddress, hostnames)
+        unameResults = []
+        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
+        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
+        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
+        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
+        self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
 
-        self.debug("Hostnames: %s" % str(hostnames))
+        self.debug("UNAME: %s" % str(unameResults))
         self.assertIn(
-              self.vm_1.name,
-              hostnames,
+              "Linux",
+              unameResults,
               "Check if ssh succeeded for server1"
             )
         self.assertIn(
-              self.vm_2.name,
-              hostnames,
+              "Linux",
+              unameResults,
               "Check if ssh succeeded for server2"
               )
 
         #SSH should pass till there is a last VM associated with LB rule
         lb_rule.remove(self.apiclient, [self.vm_2])
 
-        # making hostnames list empty
-        hostnames[:] = []
+        # making unameResultss list empty
+        unameResults[:] = []
 
         try:
             self.debug("SSHing into IP address: %s after removing VM (ID: %s)" %
@@ -287,10 +287,10 @@ class TestLoadBalance(cloudstackTestCase):
                                              self.vm_2.id
                                              ))
 
-            self.try_ssh(src_nat_ip_addr.ipaddress, hostnames)
+            self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
             self.assertIn(
-                          self.vm_1.name,
-                          hostnames,
+                          "Linux",
+                          unameResults,
                           "Check if ssh succeeded for server1"
                           )
         except Exception as e:
@@ -301,7 +301,7 @@ class TestLoadBalance(cloudstackTestCase):
 
         with self.assertRaises(Exception):
             self.debug("Removed all VMs, trying to SSH")
-            self.try_ssh(src_nat_ip_addr.ipaddress, hostnames)
+            self.try_ssh(src_nat_ip_addr.ipaddress, unameResults)
         return
 
     @attr(tags = ["advanced", "advancedns", "smoke"], required_hardware="true")
@@ -311,7 +311,7 @@ class TestLoadBalance(cloudstackTestCase):
         # Validate the Following:
         #1. listLoadBalancerRules should return the added rule
         #2. attempt to ssh twice on the load balanced IP
-        #3. verify using the hostname of the VM that
+        #3. verify using the UNAME of the VM that
         #   round robin is indeed happening as expected
 
         #Create Load Balancer rule and assign VMs to rule
@@ -372,22 +372,22 @@ class TestLoadBalance(cloudstackTestCase):
             "Check List Load Balancer instances Rules returns valid VM ID"
         )
         try:
-            hostnames = []
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
+            unameResults = []
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
 
-            self.debug("Hostnames: %s" % str(hostnames))
+            self.debug("UNAME: %s" % str(unameResults))
             self.assertIn(
-                    self.vm_1.name,
-                    hostnames,
+                    "Linux",
+                    unameResults,
                     "Check if ssh succeeded for server1"
                     )
             self.assertIn(
-                    self.vm_2.name,
-                    hostnames,
+                    "Linux",
+                    unameResults,
                     "Check if ssh succeeded for server2"
                     )
 
@@ -399,15 +399,15 @@ class TestLoadBalance(cloudstackTestCase):
                            self.vm_2.id
                            ))
             # Making host list empty
-            hostnames[:] = []
+            unameResults[:] = []
 
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
             self.assertIn(
-                self.vm_1.name,
-                hostnames,
+                "Linux",
+                unameResults,
                 "Check if ssh succeeded for server1"
             )
-            self.debug("Hostnames after removing VM2: %s" % str(hostnames))
+            self.debug("UNAME after removing VM2: %s" % str(unameResults))
         except Exception as e:
             self.fail("%s: SSH failed for VM with IP Address: %s" %
                       (e, self.non_src_nat_ip.ipaddress.ipaddress))
@@ -419,7 +419,7 @@ class TestLoadBalance(cloudstackTestCase):
                            self.non_src_nat_ip.ipaddress.ipaddress,
                            self.vm_1.id
                            ))
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
         return
 
     @attr(tags = ["advanced", "advancedns", "smoke"], required_hardware="true")
@@ -467,29 +467,29 @@ class TestLoadBalance(cloudstackTestCase):
                               )
         lb_rule.assign(self.apiclient, [self.vm_1, self.vm_2])
 
-        hostnames = []
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
+        unameResults = []
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
 
-        self.debug("Hostnames: %s" % str(hostnames))
+        self.debug("UNAME: %s" % str(unameResults))
         self.assertIn(
-                  self.vm_1.name,
-                  hostnames,
+                  "Linux",
+                  unameResults,
                   "Check if ssh succeeded for server1"
                 )
         self.assertIn(
-                  self.vm_2.name,
-                  hostnames,
+                  "Linux",
+                  unameResults,
                   "Check if ssh succeeded for server2"
                   )
         #Removing VM and assigning another VM to LB rule
         lb_rule.remove(self.apiclient, [self.vm_2])
 
-        # making hostnames list empty
-        hostnames[:] = []
+        # making unameResults list empty
+        unameResults[:] = []
 
         try:
             self.debug("SSHing again into IP address: %s with VM (ID: %s) added to LB rule" %
@@ -497,11 +497,11 @@ class TestLoadBalance(cloudstackTestCase):
                                              self.non_src_nat_ip.ipaddress.ipaddress,
                                              self.vm_1.id,
                                              ))
-            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
+            self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
 
             self.assertIn(
-                          self.vm_1.name,
-                          hostnames,
+                          "Linux",
+                          unameResults,
                           "Check if ssh succeeded for server1"
                           )
         except Exception as e:
@@ -510,22 +510,22 @@ class TestLoadBalance(cloudstackTestCase):
 
         lb_rule.assign(self.apiclient, [self.vm_3])
 
-#        # Making hostnames list empty
-        hostnames[:] = []
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, hostnames)
-        self.debug("Hostnames: %s" % str(hostnames))
+#        # Making unameResults list empty
+        unameResults[:] = []
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.try_ssh(self.non_src_nat_ip.ipaddress.ipaddress, unameResults)
+        self.debug("UNAME: %s" % str(unameResults))
         self.assertIn(
-                  self.vm_1.name,
-                  hostnames,
+                  "Linux",
+                  unameResults,
                   "Check if ssh succeeded for server1"
                 )
         self.assertIn(
-                  self.vm_3.name,
-                  hostnames,
+                  "Linux",
+                  unameResults,
                   "Check if ssh succeeded for server3"
                   )
         return

--- a/test/integration/smoke/test_loadbalance.py
+++ b/test/integration/smoke/test_loadbalance.py
@@ -133,7 +133,8 @@ class TestLoadBalance(cloudstackTestCase):
                 ip_addr,
                 self.services['lbrule']["publicport"],
                 self.vm_1.username,
-                self.vm_1.password
+                self.vm_1.password,
+                retries=5
             )
             hostnames.append(ssh_1.execute("hostname")[0])
             self.debug(hostnames)


### PR DESCRIPTION
This PR fixes the Load Balance feature by adding iptables rules for the public IP and port of the LB.

In order to cover the changes, I improved and executed the smoke/test_loadbalance.py. In addition, I also executed many other tests to make sure the main network/VM functionalities are working as expected.

Test report will follow.