### PR TITLE
[4.6][BLOCKER] CLOUDSTACK-8923: Create storage network IP range failed

### DIFF
--- a/server/src/com/cloud/network/StorageNetworkManagerImpl.java
+++ b/server/src/com/cloud/network/StorageNetworkManagerImpl.java
@@ -104,20 +104,19 @@ public class StorageNetworkManagerImpl extends ManagerBase implements StorageNet
         String insertSql =
             "INSERT INTO `cloud`.`op_dc_storage_network_ip_address` (range_id, ip_address, mac_address, taken) VALUES (?, ?, (select mac_address from `cloud`.`data_center` where id=?), ?)";
         String updateSql = "UPDATE `cloud`.`data_center` set mac_address = mac_address+1 where id=?";
-        try (Connection conn = txn.getConnection();) {
-            while (startIPLong <= endIPLong) {
-                try (PreparedStatement stmt_insert = conn.prepareStatement(insertSql); ) {
-                    stmt_insert.setLong(1, rangeId);
-                    stmt_insert.setString(2, NetUtils.long2Ip(startIPLong++));
-                    stmt_insert.setLong(3, zoneId);
-                    stmt_insert.setNull(4, java.sql.Types.DATE);
-                    stmt_insert.executeUpdate();
-                }
+        Connection conn = txn.getConnection();
+        while (startIPLong <= endIPLong) {
+            try (PreparedStatement stmt_insert = conn.prepareStatement(insertSql);) {
+                stmt_insert.setLong(1, rangeId);
+                stmt_insert.setString(2, NetUtils.long2Ip(startIPLong++));
+                stmt_insert.setLong(3, zoneId);
+                stmt_insert.setNull(4, java.sql.Types.DATE);
+                stmt_insert.executeUpdate();
+            }
 
-                try (PreparedStatement stmt_update = txn.prepareStatement(updateSql);) {
-                    stmt_update.setLong(1, zoneId);
-                    stmt_update.executeUpdate();
-                }
+            try (PreparedStatement stmt_update = txn.prepareStatement(updateSql);) {
+                stmt_update.setLong(1, zoneId);
+                stmt_update.executeUpdate();
             }
         }
     }


### PR DESCRIPTION
This is a regression from commit 0cd8c06f7dceaf999acf202862c5d1d580e7aa0e
try-with-resource used at https://github.com/apache/cloudstack/blob/master/server/src/com/cloud/network/StorageNetworkManagerImpl.java#L107 is closing the transaction.
At later point when the transaction is actually committed, it doesn't find the transaction and hence the exception.

testing:
manually tested that create storage network api succeeds.

```
cloudmonkey🐵 > create storagenetworkiprange gateway=192.168.200.67 netmask=255.255.255.0 startip=192.168.200.200 endip=192.168.200.202 podid=544e3be0-9bc6-428f-9237-bf777053ab2e
\

accountid = 120b521c-725c-11e5-9244-7278fd1d2943
cmd = org.apache.cloudstack.api.command.admin.network.CreateStorageNetworkIpRangeCmd
created = 2015-10-15T09:31:22+0000
jobid = c86c4968-bc6e-4255-aa11-39221eb2277f
jobprocstatus = 0
jobresult:
storagenetworkiprange:
id = df491e87-7a00-4b5e-9bfe-e811fe78c9cd
endip = 192.168.200.202
gateway = 192.168.200.67
netmask = 255.255.255.0
startip = 192.168.200.200
jobresultcode = 0
jobresulttype = object
jobstatus = 1
userid = 120b6414-725c-11e5-9244-7278fd1d2943
```

```
cloudmonkey🐵 > list storagenetworkiprange
count = 1
storagenetworkiprange:
id = df491e87-7a00-4b5e-9bfe-e811fe78c9cd
endip = 192.168.200.202
gateway = 192.168.200.67
netmask = 255.255.255.0
networkid = a0f7faf9-83a1-4af5-b420-d8a78f2f59d8
podid = 544e3be0-9bc6-428f-9237-bf777053ab2e
startip = 192.168.200.200
zoneid = 34b9a0a1-758c-442b-9bc6-7bce03157d4c
```

