### PR TITLE
CLOUDSTACK-8956: NSX/Nicira Plugin does not support NSX v4.2.1

### DIFF
--- a/deps/install-non-oss.sh
+++ b/deps/install-non-oss.sh
@@ -32,3 +32,6 @@ mvn install:install-file -Dfile=manageontap.jar   -DgroupId=com.cloud.com.netapp
 # From https://my.vmware.com/group/vmware/get-download?downloadGroup=VSP510-WEBSDK-510
 # Version: 5.1, Release-date: 2012-09-10, Build: 774886
 mvn install:install-file -Dfile=vim25_51.jar        -DgroupId=com.cloud.com.vmware -DartifactId=vmware-vim25    -Dversion=5.1   -Dpackaging=jar
+
+# From https://my.vmware.com/group/vmware/get-download?downloadGroup=WEBSDK550
+mvn install:install-file -Dfile=vim25_55.jar        -DgroupId=com.cloud.com.vmware -DartifactId=vmware-vim25    -Dversion=5.5   -Dpackaging=jar

--- a/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/nicira/ControlClusterStatus.java
+++ b/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/nicira/ControlClusterStatus.java
@@ -29,6 +29,11 @@ public class ControlClusterStatus {
     private Stats zoneStats;
     private Stats routerStats;
     private Stats securityProfileStats;
+    private ClusterRoleConfig[] configuredRoles;
+
+    public ClusterRoleConfig[] getConfiguredRoles() {
+        return configuredRoles;
+    }
 
     public String getClusterStatus() {
         return clusterStatus;
@@ -83,5 +88,18 @@ public class ControlClusterStatus {
             return activeCount;
         }
 
+    }
+
+    public class ClusterRoleConfig {
+        public String majorityVersion;
+        public String role;
+
+        public String getMajorityVersion(){
+            return majorityVersion;
+        }
+
+        public String getRole(){
+            return role;
+        }
     }
 }

--- a/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/resource/NiciraNvpResource.java
+++ b/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/resource/NiciraNvpResource.java
@@ -37,6 +37,7 @@ import com.cloud.agent.api.StartupNiciraNvpCommand;
 import com.cloud.host.Host;
 import com.cloud.host.Host.Type;
 import com.cloud.network.nicira.ControlClusterStatus;
+import com.cloud.network.nicira.ControlClusterStatus.ClusterRoleConfig;
 import com.cloud.network.nicira.DestinationNatRule;
 import com.cloud.network.nicira.Match;
 import com.cloud.network.nicira.NatRule;
@@ -47,6 +48,7 @@ import com.cloud.network.utils.CommandRetryUtility;
 import com.cloud.resource.ServerResource;
 import com.cloud.utils.rest.CloudstackRESTException;
 import com.cloud.utils.rest.HttpClientHelper;
+import com.cloud.utils.nicira.nvp.plugin.NiciraNvpApiVersion;
 
 public class NiciraNvpResource implements ServerResource {
 
@@ -172,6 +174,7 @@ public class NiciraNvpResource implements ServerResource {
     public PingCommand getCurrentStatus(final long id) {
         try {
             final ControlClusterStatus ccs = niciraNvpApi.getControlClusterStatus();
+            getApiProviderMajorityVersion(ccs);
             if (!"stable".equals(ccs.getClusterStatus())) {
                 s_logger.error("ControlCluster state is not stable: " + ccs.getClusterStatus());
                 return null;
@@ -181,6 +184,24 @@ public class NiciraNvpResource implements ServerResource {
             return null;
         }
         return new PingCommand(Host.Type.L2Networking, id);
+    }
+
+    private void getApiProviderMajorityVersion(ControlClusterStatus ccs) {
+        ClusterRoleConfig[] configuredRoles = ccs.getConfiguredRoles();
+        if (configuredRoles != null){
+            String apiProviderMajorityVersion = searchApiProvider(configuredRoles);
+            NiciraNvpApiVersion.pingNiciraApiVersion(apiProviderMajorityVersion);
+            NiciraNvpApiVersion.logNiciraApiVersion();
+        }
+    }
+
+    private String searchApiProvider(ClusterRoleConfig[] configuredRoles) {
+        for (int i = 0; i < configuredRoles.length; i++) {
+            if (configuredRoles[i].getRole() != null && configuredRoles[i].getRole().equals("api_provider")){
+                return configuredRoles[i].getMajorityVersion();
+            }
+        }
+        return null;
     }
 
     @Override

--- a/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/resource/NiciraNvpResource.java
+++ b/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/resource/NiciraNvpResource.java
@@ -190,7 +190,7 @@ public class NiciraNvpResource implements ServerResource {
         ClusterRoleConfig[] configuredRoles = ccs.getConfiguredRoles();
         if (configuredRoles != null){
             String apiProviderMajorityVersion = searchApiProvider(configuredRoles);
-            NiciraNvpApiVersion.pingNiciraApiVersion(apiProviderMajorityVersion);
+            NiciraNvpApiVersion.setNiciraApiVersion(apiProviderMajorityVersion);
             NiciraNvpApiVersion.logNiciraApiVersion();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <cs.servlet.version>2.5</cs.servlet.version>
     <cs.jstl.version>1.2</cs.jstl.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
-    <cs.vmware.api.version>5.1</cs.vmware.api.version>
+    <cs.vmware.api.version>5.5</cs.vmware.api.version>
     <org.springframework.version>3.2.12.RELEASE</org.springframework.version>
     <cs.mockito.version>1.9.5</cs.mockito.version>
     <cs.powermock.version>1.5.3</cs.powermock.version>

--- a/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
+++ b/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
@@ -26,34 +26,19 @@ import com.cloud.maint.Version;
 public class NiciraNvpApiVersion {
     private static final Logger s_logger = Logger.getLogger(NiciraNvpApiVersion.class);
 
-    private static String niciraApiVersion = null;
+    private static String niciraApiVersion;
 
-    public static void pingNiciraApiVersion(String apiVersion){
-        if (apiVersion == null){
-            niciraApiVersion = null;
-        }
-        else{
-            if (niciraApiVersion == null){
-                setNiciraApiVersion(apiVersion);
-            }
-            else {
-                if (! apiVersion.equals(niciraApiVersion)){
-                    setNiciraApiVersion(apiVersion);
-                }
-            }
-        }
-    }
-
-    private static void setNiciraApiVersion(String apiVersion){
+    public static synchronized void setNiciraApiVersion(String apiVersion){
         niciraApiVersion = apiVersion;
     }
 
-    public static boolean isApiVersionLowerThan(String apiVersion){
+    public static synchronized boolean isApiVersionLowerThan(String apiVersion){
+        if (niciraApiVersion == null) return false;
         int compare = Version.compare(niciraApiVersion, apiVersion);
         return (compare < 0);
     }
 
-    public static void logNiciraApiVersion(){
+    public static synchronized void logNiciraApiVersion(){
         s_logger.info("NSX API VERSION: " + ((niciraApiVersion != null) ? niciraApiVersion : " NOT PRESENT"));
     }
 

--- a/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
+++ b/utils/src/main/java/com/cloud/utils/nicira/nvp/plugin/NiciraNvpApiVersion.java
@@ -1,0 +1,60 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.utils.nicira.nvp.plugin;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.maint.Version;
+
+public class NiciraNvpApiVersion {
+    private static final Logger s_logger = Logger.getLogger(NiciraNvpApiVersion.class);
+
+    private static String niciraApiVersion = null;
+
+    public static void pingNiciraApiVersion(String apiVersion){
+        if (apiVersion == null){
+            niciraApiVersion = null;
+        }
+        else{
+            if (niciraApiVersion == null){
+                setNiciraApiVersion(apiVersion);
+            }
+            else {
+                if (! apiVersion.equals(niciraApiVersion)){
+                    setNiciraApiVersion(apiVersion);
+                }
+            }
+        }
+    }
+
+    private static void setNiciraApiVersion(String apiVersion){
+        niciraApiVersion = apiVersion;
+    }
+
+    public static boolean isApiVersionLowerThan(String apiVersion){
+        int compare = Version.compare(niciraApiVersion, apiVersion);
+        return (compare < 0);
+    }
+
+    public static void logNiciraApiVersion(){
+        s_logger.info("NSX API VERSION: " + ((niciraApiVersion != null) ? niciraApiVersion : " NOT PRESENT"));
+    }
+
+}

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/HostMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/HostMO.java
@@ -46,6 +46,7 @@ import com.vmware.vim25.HostNetworkInfo;
 import com.vmware.vim25.HostNetworkPolicy;
 import com.vmware.vim25.HostNetworkSecurityPolicy;
 import com.vmware.vim25.HostNetworkTrafficShapingPolicy;
+import com.vmware.vim25.HostOpaqueNetworkInfo;
 import com.vmware.vim25.HostPortGroup;
 import com.vmware.vim25.HostPortGroupSpec;
 import com.vmware.vim25.HostRuntimeInfo;
@@ -62,7 +63,6 @@ import com.vmware.vim25.PropertySpec;
 import com.vmware.vim25.TraversalSpec;
 import com.vmware.vim25.VirtualMachineConfigSpec;
 import com.vmware.vim25.VirtualNicManagerNetConfig;
-
 import com.cloud.hypervisor.vmware.util.VmwareContext;
 import com.cloud.hypervisor.vmware.util.VmwareHelper;
 import com.cloud.utils.Pair;
@@ -355,6 +355,23 @@ public class HostMO extends BaseMO implements VmwareHypervisorHost {
         }
 
         return null;
+    }
+
+    public boolean hasOpaqueNSXNetwork() throws Exception{
+        HostNetworkInfo netInfo = getHostNetworkInfo();
+        List<HostOpaqueNetworkInfo> opaqueNetworks = netInfo.getOpaqueNetwork();
+        if (opaqueNetworks != null){
+            for (HostOpaqueNetworkInfo opaqueNetwork : opaqueNetworks){
+                if (opaqueNetwork.getOpaqueNetworkId() != null && opaqueNetwork.getOpaqueNetworkId().equals("br-int")
+                        && opaqueNetwork.getOpaqueNetworkType() != null && opaqueNetwork.getOpaqueNetworkType().equals("nsx.network")){
+                    return true;
+                }
+            }
+            throw new Exception("NSX API VERSION >= 4.2 BUT br-int (nsx.network) NOT FOUND");
+        }
+        else {
+            throw new Exception("NSX API VERSION >= 4.2 BUT br-int (nsx.network) NOT FOUND");
+        }
     }
 
     public boolean hasPortGroup(HostVirtualSwitch vSwitch, String portGroupName) throws Exception {

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualDiskManagerMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualDiskManagerMO.java
@@ -131,7 +131,7 @@ public class VirtualDiskManagerMO extends BaseMO {
 
     public void moveVirtualDisk(String srcName, ManagedObjectReference morSrcDc, String destName, ManagedObjectReference morDestDc, boolean force) throws Exception {
 
-        ManagedObjectReference morTask = _context.getService().moveVirtualDiskTask(_mor, srcName, morSrcDc, destName, morDestDc, force);
+        ManagedObjectReference morTask = _context.getService().moveVirtualDiskTask(_mor, srcName, morSrcDc, destName, morDestDc, force, null);
 
         boolean result = _context.getVimClient().waitForTask(morTask);
         if (!result)

--- a/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -103,7 +103,6 @@ public class VmwareHelper {
             break;
 
         default:
-            assert (false);
             nic = new VirtualE1000();
         }
 


### PR DESCRIPTION
JIRA Ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-8956

### Description of the problem:
Prior to version 4.2. Nicira/VmWare NSX used a variation of Open vSwitch as means of integrating SDN into hypervisor layer. Cloudstack NiciraNVP plugin was written to support OVS as a bridge to NSX.
In version 4.2 VMware introduced NSX vSwitch as a replacement for OVS in ESX hypervisors. It is a fork of distributed vSwitch leveraging one of the recent features of ESX called opaque networks. Because of that change the current version of NiciraNVP plugin doesn’t support versions of NSX-MH above 4.2 specifically in Vsphere environment. Proposed fix will analyze a version of NVP/NSX API and use proper support for ESX hypervisors.

vSphere hypervisor mode operations when NV is deployed onto NSX managed network changes:
* Current mode. A portgroup = UUID of CS VM NIC is created on a local standard switch of the Hypervisor where VM is starting. VM nic is attached to that port group.
* New mode. No additional port group is created on a HW. No port group cleanup is needed after VM/NIC is destroyed. VM is attached to 1st port group having the following attributes:
** opaqueNetworkId string "br-int”
** opaqueNetworkType string "nsx.network"

If portgroup with such attributes is not found a deployment should fail with exception.

### VMware vSphere API version from 5.1 to 5.5:
Since vSphere API version 5.5, [OpaqueNetworks](https://www.vmware.com/support/developer/converter-sdk/conv55_apireference/vim.OpaqueNetwork.html) are introduced. 
Its description says: 
> This interface defines an opaque network, in the sense that the detail and configuration of the network is unknown to vShpere and is managed by a management plane outside of vSphere. However, the identifier and name of these networks is made available to vSphere so that host and virtual machine virtual ethernet device can connect to them.

In order to connect a vm's virtual ethernet device to the proper opaque network when deploying a vm into a NSX managed network, we first need to look for a particular opaque network on hosts. This opaque network's id has to be **"br-int"** and its type **"nsx.network"**.

Since vSphere API version 5.5 [HostNetworkInfo](https://www.vmware.com/support/developer/converter-sdk/conv55_apireference/vim.host.NetworkInfo.html#opaqueNetwork) introduces a list of available opaque networks for each host. 
If NSX API version >= 4.2 we look for a [OpaqueNetworkInfo](https://www.vmware.com/support/developer/converter-sdk/conv55_apireference/vim.host.OpaqueNetworkInfo.html) which satisfies:
* opaqueNetworkId = "br-int"
* opaqueNetworkType = "nsx.netork"

If that opaque network is found, then we need to attach vm's NIC to a virtual ethernet device which support this, so we use [VirtualEthernetCardOpaqueNetworkBackingInfo](https://www.vmware.com/support/developer/converter-sdk/conv55_apireference/vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo.html) setting:
* opaqueNetworkId = "br-int"
* opaqueNetworkType = "nsx.netork"