### PR TITLE
CLOUDSTACK-8976 - Sorting of security groups

### DIFF
--- a/ui/scripts/instanceWizard.js
+++ b/ui/scripts/instanceWizard.js
@@ -679,6 +679,11 @@
                                 for (var i = 0; i < items.length; i++) {
                                     securityGroupArray.push(items[i]);
                                 }
+                                securityGroupArray.sort(function(a, b){
+                                    if(a.name < b.name) return -1;
+                                    if(a.name > b.name) return 1;
+                                    return 0;
+                                })
                             }
                         }
                     });


### PR DESCRIPTION
Simple change to sort the security groups in alphabetical order within the instance creation wizard. 
This makes it much easier to find a security group when the user is presented with a long list.  