### PR TITLE
CLOUDSTACK-8959: Option to attach the config drive.

### DIFF
--- a/engine/api/src/com/cloud/vm/VirtualMachineManager.java
+++ b/engine/api/src/com/cloud/vm/VirtualMachineManager.java
@@ -55,6 +55,9 @@ public interface VirtualMachineManager extends Manager {
     static final ConfigKey<String> VmConfigDriveLabel = new ConfigKey<String>("Hidden", String.class, "vm.configdrive.label", "config",
             "The default lable name for the config drive", false);
 
+    static final ConfigKey<Boolean> ConfigDriveCreation = new ConfigKey<Boolean>("Advanced", Boolean.class, "use.config.drive", "true",
+            "If true, use config drives for data transfer else don't use. Default is true", true);
+
     public interface Topics {
         public static final String VM_POWER_STATE = "vm.powerstate";
     }

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2247,8 +2247,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     final String zoneName = _dcDao.findById(vm.getDataCenterId()).getName();
                     boolean isWindows = _guestOSCategoryDao.findById(_guestOSDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
 
-                    vmData = _networkModel.generateVmData(userVm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
-                            (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
+                    vmData = (ConfigDriveCreation.value())?_networkModel.generateVmData(userVm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
+                            (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows):null;
                     String vmName = vm.getInstanceName();
                     String configDriveIsoRootFolder = "/tmp";
                     String isoFile = configDriveIsoRootFolder + "/" + vmName + "/configDrive/" + vmName + ".iso";
@@ -2260,10 +2260,12 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     // At source host detach the config drive iso.
                     AttachOrDettachConfigDriveCommand dettachCommand = new AttachOrDettachConfigDriveCommand(vm.getInstanceName(), vmData, VmConfigDriveLabel.value(), false);
                     try {
-                        _agentMgr.send(srcHost.getId(), dettachCommand);
-                        s_logger.debug("Deleted config drive ISO for  vm " + vm.getInstanceName() + " In host " + srcHost);
+                        if(ConfigDriveCreation.value()) {
+                            _agentMgr.send(srcHost.getId(), dettachCommand);
+                            s_logger.debug("Deleted config drive ISO for  vm " + vm.getInstanceName() + " In host " + srcHost);
+                        }
                     } catch (OperationTimedoutException e) {
-                        s_logger.debug("TIme out occured while exeuting command AttachOrDettachConfigDrive " + e.getMessage());
+                        s_logger.debug("Time out occured while exeuting command AttachOrDettachConfigDrive " + e.getMessage());
 
                     }
 
@@ -3669,7 +3671,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {ClusterDeltaSyncInterval, StartRetry, VmDestroyForcestop, VmOpCancelInterval, VmOpCleanupInterval, VmOpCleanupWait,
                 VmOpLockStateRetry,
-                VmOpWaitInterval, ExecuteInSequence, VmJobCheckInterval, VmJobTimeout, VmJobStateReportInterval, VmConfigDriveLabel};
+                VmOpWaitInterval, ExecuteInSequence, VmJobCheckInterval, VmJobTimeout, VmJobStateReportInterval, VmConfigDriveLabel, ConfigDriveCreation};
     }
 
     public List<StoragePoolAllocator> getStoragePoolAllocators() {

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -3675,8 +3675,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 final String zoneName = _dcDao.findById(vm.getDataCenterId()).getName();
                 boolean isWindows = _guestOSCategoryDao.findById(_guestOSDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
 
-                List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
-                        (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
+                List<String[]> vmData = (VirtualMachineManager.ConfigDriveCreation.value())? (_networkModel.generateVmData(vm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
+                        (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows)):null;
                 String vmName = vm.getInstanceName();
                 String configDriveIsoRootFolder = "/tmp";
                 String isoFile = configDriveIsoRootFolder + "/" + vmName + "/configDrive/" + vmName + ".iso";


### PR DESCRIPTION
Config Drive was added as a part of DNS/DHCP offload feature. The main aim was to provide a way to send user data to VM instances in case of no Virtual Routers. The present implementation checks for the case when there is no service available in Network offering. This leads to attaching of config drives even in the case when user doesn’t  want to send the data to VM instances. Providing a way so that attaching config drives is optional can solve this.

Added a global setting(which is by default true) to make sure that users have a choice to attach the config drives.
