### PR TITLE
CLOUDSTACK-8960: Remove Citrix Resources from test_data.py

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -780,7 +780,7 @@ test_data = {
         "name": "Centos",
         "passwordenabled": False,
         "ostype": "CentOS 6.3 (64-bit)",
-        "url": "http://10.147.28.7/templates/centos63.ova",
+        "url": "http://people.apache.org/~sanjeev/centos63.ova",
         "format": "OVA",
         "ispublic": "true"
     },
@@ -798,7 +798,7 @@ test_data = {
         "displaytext": "Windows 7 (64-bit)",
         "name": "Windows 7 (64-bit)",
         "passwordenabled": False,
-        "url": "http://10.147.28.7/templates/windows7.vhd",
+        "url": "http://people.apache.org/~sanjeev/windows7.vhd",
         "format": "VHD",
         "ostype": "Windows 7 (64-bit)",
         "ispublic": "true",
@@ -830,7 +830,7 @@ test_data = {
         "displaytext": "win2012",
         "name": "win2012",
         "passwordenabled": False,
-        "url": "http://nfs1.lab.vmops.com/templates/vmware/new-test-win.ova",
+        "url": "http://people.apache.org/~sanjeev/new-test-win.ova",
         "format": "OVA",
         "ostype": "Windows 8 (64-bit)",
     },
@@ -838,7 +838,7 @@ test_data = {
         "displaytext": "Rhel60",
         "name": "Rhel60",
         "passwordenabled": False,
-        "url": "http://10.147.28.7/templates/Rhel/Rhel6-64bit.ova",
+        "url": "http://people.apache.org/~sanjeev/Rhel6-64bit.ova",
         "format": "OVA",
         "ostype": "Red Hat Enterprise Linux 6.0 (64-bit)"
     },
@@ -846,7 +846,7 @@ test_data = {
         "displaytext": "xs",
         "name": "xs",
         "passwordenabled": False,
-        "url": "http://10.147.28.7/templates/ttylinux_pv.vhd.bz2",
+        "url": "http://people.apache.org/~sanjeev/ttylinux_pv.vhd.bz2",
         "format": "VHD"
     },
     "security_group": {"name": "custom_Sec_Grp"},
@@ -1058,7 +1058,7 @@ test_data = {
                               "displaytext": "RHEL7 (64-bit)",
                               "name": "RHEL 7 Insta1",
                               "passwordenabled": False,
-                              "url": "http://10.147.28.7/templates/Rhel/RHEL764bit.vhd",
+                              "url": "http://people.apache.org/~sanjeev/RHEL764bitwithtools.vhd",
                               "format": "VHD" ,
                               "ostype": "RHEL 7 (64-bit)",
                               "ispublic": "true",
@@ -1512,7 +1512,7 @@ test_data = {
                               "displaytext": "Windows 8 (64-bit)",
                               "name": "win8withpvxen",
                               "passwordenabled": False,
-                              "url": "http://10.147.28.7/templates/sailajaxd/XS65pvtemplates/win8/79211594-1d4a-4dee-ae6c-c5c315ded2be.vhd",
+                              "url": "http://people.apache.org/~sanjeev/79211594-1d4a-4dee-ae6c-c5c315ded2be.vhd",
                               "format": "VHD" ,
                               "ostype": "Windows 8 (64-bit)",
                               "ispublic": "true",
@@ -1541,17 +1541,17 @@ test_data = {
     "browser_upload_volume":{
           "VHD": {
         "diskname": "XenUploadVol",
-        "url": "http://10.147.28.7/templates/rajani-thin-volume.vhd",
+        "url": "http://people.apache.org/~sanjeev/rajani-thin-volume.vhd",
         "checksum": "09b08b6abb1b903fca7711d3ac8d6598",
                 },
           "OVA": {
         "diskname": "VMwareUploadVol",
-        "url": "http://10.147.28.7/templates/Autoscale_Template/CentOS5.5(64bit)-vmware-autoscale.ova",
+        "url": "http://people.apache.org/~sanjeev/CentOS5.5(64bit)-vmware-autoscale.ova",
         "checksum": "da997b697feaa2f1f6e0d4785b0cece2",
                 },
           "QCOW2": {
         "diskname": "KVMUploadVol",
-        "url": "http://10.147.28.7/templates/rajani-thin-volume.qcow2",
+        "url": "http://people.apache.org/~sanjeev/rajani-thin-volume.qcow2",
         "checksum": "02de0576dd3a61ab59c03fd795fc86ac",
                 },
     'browser_resized_disk_offering': {
@@ -1564,7 +1564,7 @@ test_data = {
           "VHD": {
         "templatename": "XenUploadtemplate",
         "displaytext": "XenUploadtemplate",
-        "url": "http://10.147.28.7/templates/builtin/centos56-x86_64.vhd.bz2",
+        "url": "http://people.apache.org/~sanjeev/centos56-x86_64.vhd.bz2",
         "hypervisor":"XenServer",
         "checksum": "09b08b6abb1b903fca7711d3ac8d6598",
         "ostypeid":"74affaea-c658-11e4-ad38-a6d1374244b4"
@@ -1572,7 +1572,7 @@ test_data = {
           "OVA": {
         "templatename": "VMwareUploadtemplate",
         "displaytext": "VMwareUploadtemplate",
-        "url": "http://nfs1.lab.vmops.com/templates/vmware/CentOS5.3-x86_64.ova",
+        "url": "http://people.apache.org/~sanjeev/CentOS5.3-x86_64.ova",
         "checksum": "02de0576dd3a61ab59c03fd795fc86ac",
         "hypervisor":"VMware",
         "ostypeid":"74affaea-c658-11e4-ad38-a6d1374244b4"
@@ -1580,7 +1580,7 @@ test_data = {
           "QCOW2": {
         "templatename": "KVMUploadtemplate",
         "displaytext": "VMwareUploadtemplate",
-        "url": "http://10.147.28.7/templates/builtin/eec2209b-9875-3c8d-92be-c001bd8a0faf.qcow2.bz2",
+        "url": "http://people.apache.org/~sanjeev/eec2209b-9875-3c8d-92be-c001bd8a0faf.qcow2.bz2",
         "checksum": "da997b697feaa2f1f6e0d4785b0cece2",
         "hypervisor":"KVM",
         "ostypeid":"2e02e376-cdf3-11e4-beb3-8aa6272b57ef"
@@ -1655,7 +1655,7 @@ test_data = {
                     "name": "testISO",
                     "bootable": True,
                     "ispublic": False,
-                    "url": "http://10.147.40.145/ISO/CentOS-6.3-x86_64-bin-DVD1.iso",
+                    "url": "http://people.apache.org/~sanjeev/CentOS-6.3-x86_64-bin-DVD1.iso",
                     "ostype": 'CentOS 6.3 (64-bit)',
                     "mode": 'HTTP_DOWNLOAD'
         },
@@ -1670,7 +1670,7 @@ test_data = {
             "isextractable": True,
             "mode": "HTTP_DOWNLOAD",
             "templatefilter": "self",
-            "url": "http://10.147.28.7/templates/4.3.0.2/systemvm64template-2014-09-30-4.3-vmware.ova",
+            "url": "http://people.apache.org/~sanjeev/systemvm64template-2014-09-30-4.3-vmware.ova",
             "hypervisor": "vmware",
             "format": "OVA",
             "nicadapter": "vmxnet3",


### PR DESCRIPTION
Replace URLs related to templates and ISOs with the ones accessbile to everybody in the community.

I have copied all the templates and ISOs to my webspace at http://people.apache.org/~sanjeev/ so they can be accessible from anywhere.