### PR TITLE
CLOUDSTACK-8988: Removed unused adapters from async-job-component.xml.

### DIFF
--- a/server/test/async-job-component.xml
+++ b/server/test/async-job-component.xml
@@ -108,11 +108,7 @@
     </adapters>
     <adapters key="com.cloud.agent.manager.allocator.StorageAllocator">
       <adapter name="Storage"
-        class="com.cloud.agent.manager.allocator.impl.FirstFitStorageAllocator">
-        <param name="storage.overprovisioning.factor">2</param>
-      </adapter>
-      <adapter name="Storage"
-        class="com.cloud.agent.manager.allocator.impl.RandomStoragePoolAllocator">
+        class="org.apache.cloudstack.storage.allocator.RandomStoragePoolAllocator">
         <param name="storage.overprovisioning.factor">2</param>
       </adapter>
     </adapters>


### PR DESCRIPTION
I was looking the file /cloud-server/test/async-job-component.xml, and I found an adapter configuration that seems to have no use. The reason for that is explained as follows.

The adapter configuration is the following:
<*adapters key="com.cloud.agent.manager.allocator.StorageAllocator"*>
      <*adapter name="Storage"
        class="com.cloud.agent.manager.allocator.impl.FirstFitStorageAllocator"*>
        <*param name="storage.overprovisioning.factor"*>2<*/param*>
      <*/adapter*>
      <*adapter name="
        class="com.cloud.agent.manager.allocator.impl.RandomStoragePoolAllocator"*>
        <*param name="storage.overprovisioning.factor"*>2<*/param*>
      <*/adapter*>
<*/adapters*>

•	class="com.cloud.agent.manager.allocator.impl.FirstFitStorageAllocator"

The class "com.cloud.agent.manager.allocator.impl.FirstFitStorageAllocator" does not exist. The only reference for it is found in the following file:
          -	/cloud-server/test/async-job-component.xml
Therefore, we can conclude that there is no need for this line at that file.

•	class="com.cloud.agent.manager.allocator.impl.RandomStoragePoolAllocator"

Additionally, the class RandomStoragePoolAllocator.java is never used. The only reference is found in the following file:
-	/cloud-server/test/async-job-component.xml

I found a project called “cloud-plugin-storage-allocator-random”. This project has only one package that contains only one class, which is the RandomStoragePoolAllocator.java. Despite the names that are the same, the class in “cloud-plugin-storage-allocator-random”  project and the class referenced in -	/cloud-server/test/async-job-component.xml have different packages. Therefore, I removed that configuration from async-job-component.xml and the project that contains only the RandomStoragePoolAllocator class that is never used.
Consequently, I had to remove the following lines from the */cloud-client-ui/pom.xml*:
    <*dependency*>
      <*groupId*>org.apache.cloudstack<*/groupId*>
      <*artifactId*>cloud-plugin-storage-allocator-random<*/artifactId*>
      <*version*>${project.version}<*/version*>
    <*/dependency*>

Furthermore, after I removed that configuration I noticed that there is no such class StorageAllocator.java. However, it appears that exists test for it, like the following classes: 
-	StorageAllocatorTestConfiguration.java
-	StorageAllocatorTest.java. 

I am not sure if these classes are tests for the class StorageAllocator.java and for the possible configuration I have just removed. If they are, we can remove both classes. Can someone help me on checking that? 

