### PR TITLE
Create test cases to getPatchFilePath method and class names changed 

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -2869,7 +2869,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         }
     }
 
-    private List<File> getPatchFiles() {
+    protected List<File> getPatchFiles() {
         String patch = getPatchFilePath();
         String patchfilePath = Script.findScript("", patch);
         if (patchfilePath == null) {

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixResourceBaseTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixResourceBaseTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloud.hypervisor.xenserver.resource;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+
+import com.cloud.utils.script.Script;
+
+public abstract class CitrixResourceBaseTest {
+
+    public void testGetPathFilesExeption(CitrixResourceBase citrixResourceBase) {
+        String patch = citrixResourceBase.getPatchFilePath();
+
+        PowerMockito.mockStatic(Script.class);
+        Mockito.when(Script.findScript("", patch)).thenReturn(null);
+
+        citrixResourceBase.getPatchFiles();
+
+    }
+
+    public void testGetPathFilesListReturned(CitrixResourceBase citrixResourceBase) {
+        String patch = citrixResourceBase.getPatchFilePath();
+
+        PowerMockito.mockStatic(Script.class);
+        Mockito.when(Script.findScript("", patch)).thenReturn(patch);
+
+        File expected = new File(patch);
+        String pathExpected = expected.getAbsolutePath();
+
+        List<File> files = citrixResourceBase.getPatchFiles();
+        String receivedPath = files.get(0).getAbsolutePath();
+        Assert.assertEquals(receivedPath, pathExpected);
+    }
+}

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpOssResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpOssResourceTest.java
@@ -17,8 +17,14 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XcpOssResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+@RunWith(PowerMockRunner.class)
+public class XcpOssResourceTest extends CitrixResourceBaseTest{
 
     private XcpOssResource xcpOssResource = new XcpOssResource();
 
@@ -28,5 +34,17 @@ public class XcpOssResourcePathTest {
         String patch = "scripts/vm/hypervisor/xenserver/xcposs/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFiles(){
+        testGetPathFilesExeption(xcpOssResource);
+    }
+
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xcpOssResource);
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpServerResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpServerResourceTest.java
@@ -17,8 +17,15 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XcpServerResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+
+@RunWith(PowerMockRunner.class)
+public class XcpServerResourceTest extends CitrixResourceBaseTest{
 
     private XcpServerResource xcpServerResource = new XcpServerResource();
 
@@ -28,5 +35,17 @@ public class XcpServerResourcePathTest {
         String patch = "scripts/vm/hypervisor/xenserver/xcpserver/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFilesExeption(){
+        testGetPathFilesExeption(xcpServerResource);
+    }
+
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xcpServerResource);
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56FP1ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56FP1ResourceTest.java
@@ -17,16 +17,32 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XenServer56SP2ResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+@RunWith(PowerMockRunner.class)
+public class XenServer56FP1ResourceTest extends CitrixResourceBaseTest{
 
-    private XenServer56SP2Resource xenServer56SP2Resource = new XenServer56SP2Resource();
+    private XenServer56FP1Resource xenServer56FP1Resource = new XenServer56FP1Resource();
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer56SP2Resource.getPatchFilePath();
+        String patchFilePath = xenServer56FP1Resource.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver56fp1/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFiles(){
+        testGetPathFilesExeption(xenServer56FP1Resource);
+    }
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xenServer56FP1Resource);
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56ResourceTest.java
@@ -17,8 +17,14 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XenServer56ResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+@RunWith(PowerMockRunner.class)
+public class XenServer56ResourceTest extends CitrixResourceBaseTest {
 
     private XenServer56Resource xenServer56Resource = new XenServer56Resource();
 
@@ -28,5 +34,16 @@ public class XenServer56ResourcePathTest {
         String patch = "scripts/vm/hypervisor/xenserver/xenserver56/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFiles(){
+        testGetPathFilesExeption(xenServer56Resource);
+    }
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xenServer56Resource);
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56SP2ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56SP2ResourceTest.java
@@ -17,16 +17,32 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XenServer56FP1ResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+@RunWith(PowerMockRunner.class)
+public class XenServer56SP2ResourceTest extends CitrixResourceBaseTest{
 
-    private XenServer56FP1Resource xenServer56FP1Resource = new XenServer56FP1Resource();
+    private XenServer56SP2Resource xenServer56SP2Resource = new XenServer56SP2Resource();
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer56FP1Resource.getPatchFilePath();
+        String patchFilePath = xenServer56SP2Resource.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver56fp1/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFiles(){
+        testGetPathFilesExeption(xenServer56SP2Resource);
+    }
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xenServer56SP2Resource);
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer600ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer600ResourceTest.java
@@ -17,8 +17,14 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XenServer600ResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+@RunWith(PowerMockRunner.class)
+public class XenServer600ResourceTest extends CitrixResourceBaseTest{
 
     private XenServer600Resource xenServer600Resource = new XenServer600Resource();
 
@@ -28,5 +34,15 @@ public class XenServer600ResourcePathTest {
         String patch = "scripts/vm/hypervisor/xenserver/xenserver60/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFiles(){
+        testGetPathFilesExeption(xenServer600Resource);
+    }
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xenServer600Resource);
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer625ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer625ResourceTest.java
@@ -17,8 +17,14 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XenServer625ResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+@RunWith(PowerMockRunner.class)
+public class XenServer625ResourceTest extends CitrixResourceBaseTest{
 
     private Xenserver625Resource xenServer625Resource = new Xenserver625Resource();
 
@@ -28,5 +34,15 @@ public class XenServer625ResourcePathTest {
         String patch = "scripts/vm/hypervisor/xenserver/xenserver62/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFiles(){
+        testGetPathFilesExeption(xenServer625Resource);
+    }
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xenServer625Resource);
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer650ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer650ResourceTest.java
@@ -17,8 +17,14 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class XenServer650ResourcePathTest {
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+@RunWith(PowerMockRunner.class)
+public class XenServer650ResourceTest extends CitrixResourceBaseTest{
 
     private XenServer650Resource xenServer650Resource = new XenServer650Resource();
 
@@ -28,5 +34,16 @@ public class XenServer650ResourcePathTest {
         String patch = "scripts/vm/hypervisor/xenserver/xenserver65/patch";
 
         Assert.assertEquals(patch, patchFilePath);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    @PrepareForTest(Script.class )
+    public void testGetFiles(){
+        testGetPathFilesExeption(xenServer650Resource);
+    }
+    @Test
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned(xenServer650Resource);
     }
 }


### PR DESCRIPTION
In this commit we created tests cases for the respective classes in package  “com.cloud.hypervisor.xenserver.resource”.
 
We added test cases to check the implementation of  “com.cloud.hypervisor.xenserver.resource.CitrixResourceBase.getPatchFiles”. Therefore, we test in a more comprehensive way the tests that already exist to check the code of “com.cloud.hypervisor.xenserver.resource.CitrixResourceBase.getPatchFilePath”.
 
We added a new abstract class, called com.cloud.hypervisor.xenserver.resource.CitrixResourceBaseTest.java
 
This class has two tests methods:
 
* com.cloud.hypervisor.xenserver.resource.CitrixResourceBaseTest.testGetPathFilesExeption(CitrixResourceBase), this method tests if the getPatchFilePath() method throws the com.cloud.utils.exception.CloudRuntimeException.CloudRuntimeException when the com.cloud.utils.script.Script.findScript(String, String) return a null value;
* com.cloud.hypervisor.xenserver.resource.CitrixResourceBaseTest.testGetPathFilesListReturned(CitrixResourceBase), this method tests the correct return value from getPatchFilePath() method, basically, verify if the returned list contain the file with the same absolute path that was retrieved from the findScript method.
 
We also changed the name of those test classes, the change was basically remove the “Path” word from the name of classes.
