### PR TITLE
CLOUDSTACK-8962: Dedicated cluster is used for virtual routers that belong to non-dedicated account

### DIFF
--- a/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
+++ b/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import org.apache.cloudstack.affinity.dao.AffinityGroupDomainMapDao;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -259,6 +260,11 @@ public class DeploymentPlanningManagerImplTest {
         @Bean
         public ServiceOfferingDetailsDao serviceOfferingDetailsDao() {
             return Mockito.mock(ServiceOfferingDetailsDao.class);
+        }
+
+        @Bean
+        public AffinityGroupDomainMapDao affinityGroupDomainMapDao() {
+            return Mockito.mock(AffinityGroupDomainMapDao.class);
         }
 
         @Bean


### PR DESCRIPTION

Earlier the deployment planner was not handling the case of virtual routers.(In Explicit Dedication)
It was only handling for all instance VMs/user VMs.
Added code for checking the case of Virtual Routers.