### PR TITLE
Add MySQL connector dependency to developer profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1067,6 +1067,13 @@
         <module>developer</module>
         <module>tools</module>
       </modules>
+      <dependencies>
+        <dependency>
+	  <groupId>mysql</groupId>
+	  <artifactId>mysql-connector-java</artifactId>
+	  <version>${cs.mysql.version}</version>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>impatient</id>


### PR DESCRIPTION
The most common way to run the management server while developing is to start up Jetty via maven. However, in a continuous integration pipeline it is best to actually deploy the WAR file in a tomcat instance to make the setup as close as possible to a production environment. 

This PR adds the MySQL connector dependency to the maven developer profile in order to make it easier to deploy a WAR file in the context of a continuous integration pipeline.