### PR TITLE
Marvin module depends on APIdoc module

### DIFF
--- a/tools/marvin/pom.xml
+++ b/tools/marvin/pom.xml
@@ -19,6 +19,16 @@
     <version>4.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-apidoc</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+
   <build>
     <defaultGoal>install</defaultGoal>
     <plugins>


### PR DESCRIPTION
When building the developer tools, if the build is sequential then the marvin module always gets build after the apidoc module. However, it the build is parallelised (-Tn option in maven) it sometimes happens that maven tries to build the marvin module before building the apidoc module. That difference in the order makes it impossible to build marvin because it depends on the artefacts of the apidoc module.

This PR makes the dependency between marvin an apidoc explicit.