### PR TITLE
Load mysql driver before connecting to db

### DIFF
--- a/framework/db/src/com/cloud/utils/db/TransactionLegacy.java
+++ b/framework/db/src/com/cloud/utils/db/TransactionLegacy.java
@@ -1011,6 +1011,13 @@ public class TransactionLegacy implements Closeable {
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static void initDataSource(Properties dbProps) {
         try {
+            Class.forName("com.mysql.jdbc.Driver");
+            s_logger.debug("MySQL driver loaded");
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Cannot find MySQL driver in the classpath", e);
+        }
+
+        try {
             if (dbProps.size() == 0)
                 return;
 

--- a/pom.xml
+++ b/pom.xml
@@ -1067,6 +1067,13 @@
         <module>developer</module>
         <module>tools</module>
       </modules>
+      <dependencies>
+        <dependency>
+	  <groupId>mysql</groupId>
+	  <artifactId>mysql-connector-java</artifactId>
+	  <version>${cs.mysql.version}</version>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>impatient</id>


### PR DESCRIPTION
When deploying ACS as a WAR file in a vanilla tomcat installation, I always get an error reporting that the JDBC driver for MySQL can't be found. This PR loads said driver before establishing a connection.

I tried to figure out how this is done in the ACS rpm but I couldn't. Therefore I open this PR to enable anyone that wants to deploy ACS as a WAR file.
The PR also adds a dependency on mysql connector in the developer profile. Without this dependency the build will fail because the driver manager won't be able to load the driver class.

I have tested this PR by deploying the resulting WAR several times, and I have to say to reviewers, that the war needs to be rename to client.war, otherwise the UI will not work.