### PR TITLE
CLOUDSTACK-8969 VPN customer gateway can't be registered with hostname

### DIFF
--- a/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -179,8 +179,8 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
 
         String name = cmd.getName();
         String gatewayIp = cmd.getGatewayIp();
-        if (!NetUtils.isValidIp(gatewayIp)) {
-            throw new InvalidParameterValueException("The customer gateway ip " + gatewayIp + " is invalid!");
+        if (!NetUtils.isValidIp(gatewayIp) && !NetUtils.verifyDomainName(gatewayIp)) {
+            throw new InvalidParameterValueException("The customer gateway ip/Domain " + gatewayIp + " is invalid!");
         }
         if (name == null) {
             name = "VPN-" + gatewayIp;
@@ -428,8 +428,8 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         }
         String name = cmd.getName();
         String gatewayIp = cmd.getGatewayIp();
-        if (!NetUtils.isValidIp(gatewayIp)) {
-            throw new InvalidParameterValueException("The customer gateway ip " + gatewayIp + " is invalid!");
+        if (!NetUtils.isValidIp(gatewayIp) && !NetUtils.verifyDomainName(gatewayIp)) {
+            throw new InvalidParameterValueException("The customer gateway ip/Domain " + gatewayIp + " is invalid!");
         }
         if (name == null) {
             name = "VPN-" + gatewayIp;


### PR DESCRIPTION
When we have VPN customer gateway which is resolved by a hostname , we should be able to register the VPN customer gateway with its hostname instead of the IP address, this would be useful in case where the remote device IP is dynamically assigned , where customers use DDNS to resolve it.
