### PR TITLE
cloud-apidoc module depends on cloud-client-ui

### DIFF
--- a/tools/apidoc/pom.xml
+++ b/tools/apidoc/pom.xml
@@ -32,6 +32,12 @@
         <artifactId>cloud-server</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.cloudstack</groupId>
+        <artifactId>cloud-client-ui</artifactId>
+        <version>${project.version}</version>
+	<type>pom</type>
+      </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
When building the cloud-apidoc module a script called `./build-apidoc.sh` is executed with an argument that points to `../../client/target/cloud-client-ui-${project.version}/WEB-INF/lib`. The script uses that argument to build a Java classpath. However, since the cloud-apidoc module does not explicitly depend on cloud-client-ui, a parallel maven build will often fail because the required jars are not present when needed.

Error message when build fails:
```
Error: Could not find or load main class com.cloud.api.doc.ApiXmlDocWriter
```

This PR makes the dependency explicit.

Resulting build:
```
mvn clean install -T4 -Pdeveloper,systemvm
....
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 09:02 min (Wall Clock)
[INFO] Finished at: 2015-10-20T13:31:30+02:00
[INFO] Final Memory: 98M/1526M
[INFO] ------------------------------------------------------------------------
```