### PR TITLE
CLOUDSTACK-8933 SSVm and CPVM do not survive a reboot from API

### DIFF
--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -117,7 +117,7 @@ get_boot_params() {
           if [ ! -e /dev/vport0p1 ]; then
             log_it "/dev/vport0p1 not loaded, perhaps guest kernel is too old." && exit 2
           fi
-          while [ -z "$cmd" ]; do
+	  while [ -z "$cmd" ]; do         
             while read line; do
               if [[ $line == cmdline:* ]]; then
                 cmd=${line//cmdline:/}
@@ -128,7 +128,14 @@ get_boot_params() {
                 echo $pubkey > /root/.ssh/authorized_keys
               fi
             done < /dev/vport0p1
-	  done
+            # In case of reboot we do not send the boot args again.
+            # so need not wait for them, as the boot args are already set at startup
+            if [ -s /var/cache/cloud/cmdline  ]
+            then
+                log_it "found a non empty cmdline file continuing"
+                break;
+            fi
+	 done
           chmod go-rwx /root/.ssh/authorized_keys
           ;;
      vmware)

--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -117,25 +117,31 @@ get_boot_params() {
           if [ ! -e /dev/vport0p1 ]; then
             log_it "/dev/vport0p1 not loaded, perhaps guest kernel is too old." && exit 2
           fi
-	  while [ -z "$cmd" ]; do         
-            while read line; do
-              if [[ $line == cmdline:* ]]; then
-                cmd=${line//cmdline:/}
+
+	      local factor=2
+	      local progress=1
+		  for i in {1..5}
+		  do
+	        while read line; do
+	          if [[ $line == cmdline:* ]]; then
+	            cmd=${line//cmdline:/}
                 echo $cmd > /var/cache/cloud/cmdline
-              elif [[ $line == pubkey:* ]]; then
-                pubkey=${line//pubkey:/}
-                echo $pubkey > /var/cache/cloud/authorized_keys
-                echo $pubkey > /root/.ssh/authorized_keys
+	          elif [[ $line == pubkey:* ]]; then
+	            pubkey=${line//pubkey:/}
+	            echo $pubkey > /var/cache/cloud/authorized_keys
+	            echo $pubkey > /root/.ssh/authorized_keys
               fi
-            done < /dev/vport0p1
-            # In case of reboot we do not send the boot args again.
-            # so need not wait for them, as the boot args are already set at startup
-            if [ -s /var/cache/cloud/cmdline  ]
-            then
-                log_it "found a non empty cmdline file continuing"
-                break;
+	        done < /dev/vport0p1
+	        # In case of reboot we do not send the boot args again.
+	        # So, no need to wait for them, as the boot args are already set at startup
+	        if [ -s /var/cache/cloud/cmdline  ]
+	        then
+              log_it "Found a non empty cmdline file. Will now exit the loop and proceed with configuration."
+              break;
             fi
-	 done
+            sleep ${progress}s
+            progress=$[ progress * factor ]
+		  done
           chmod go-rwx /root/.ssh/authorized_keys
           ;;
      vmware)


### PR DESCRIPTION
This closes PR #930 as well.

I Rebased @bvbharat's PR with latest Master and tested the SSVM/CPVM and the routers: rVPC; VPC; VR; and RVR.