### PR TITLE
CLOUDSTACK-8935 - Cannot remove [r]VPC networks due to RTNETLINK error

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -71,7 +71,8 @@ class CsDhcp(CsDataBag):
             # DNS search order
             if gn.get_dns() and device:
                 sline = "dhcp-option=tag:interface-%s,6" % device
-                line = "dhcp-option=tag:interface-%s,6,%s" % (device, ','.join(gn.get_dns()))
+                dns_list = [x for x in gn.get_dns() if x is not None]
+                line = "dhcp-option=tag:interface-%s,6,%s" % (device, ','.join(dns_list))
                 self.conf.search(sline, line)
             # Gateway
             gateway = ''

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -69,9 +69,10 @@ class CsDhcp(CsDataBag):
             line = "dhcp-option=tag:interface-%s,15,%s" % (device, gn.get_domain())
             self.conf.search(sline, line)
             # DNS search order
-            sline = "dhcp-option=tag:interface-%s,6" % device
-            line = "dhcp-option=tag:interface-%s,6,%s" % (device, ','.join(gn.get_dns()))
-            self.conf.search(sline, line)
+            if gn.get_dns() and device:
+                sline = "dhcp-option=tag:interface-%s,6" % device
+                line = "dhcp-option=tag:interface-%s,6,%s" % (device, ','.join(gn.get_dns()))
+                self.conf.search(sline, line)
             # Gateway
             gateway = ''
             if self.config.is_vpc():

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsGuestNetwork.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsGuestNetwork.py
@@ -39,7 +39,7 @@ class CsGuestNetwork:
         if not self.guest:
             return self.config.get_dns()
         # Can a router provide dhcp but not dns?
-        if 'dns' in self.data:
+        if 'dns' in self.data and 'router_guest_gateway' in self.data:
             return [self.data['router_guest_gateway']] + self.data['dns'].split(',')
         elif "router_guest_gateway" in self.data:
             return [self.data['router_guest_gateway']]

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -432,7 +432,9 @@ class TestPortForwarding(cloudstackTestCase):
                 src_nat_ip_addr.ipaddress,
                 self.virtual_machine.ssh_port,
                 self.virtual_machine.username,
-                self.virtual_machine.password
+                self.virtual_machine.password,
+                retries=2,
+                delay=0
             )
         return
 
@@ -726,7 +728,8 @@ class TestRebootRouter(cloudstackTestCase):
                 self.public_ip.ipaddress.ipaddress,
                 self.services["natrule"]["publicport"],
                 self.vm_1.username,
-                self.vm_1.password
+                self.vm_1.password,
+                retries=5
             )
         except Exception as e:
             self.fail(


### PR DESCRIPTION
This PR fixes the "sequence item 0: expected string, NoneType found" error found in the CsDhcp.py file when attempting to remo a network from a VPC.
