### PR TITLE
CLOUDSTACK-8987 call s3xen/swiftxen plugins with their name

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -1017,7 +1017,7 @@ public class XenServerStorageProcessor implements StorageProcessor {
         String result = null;
         try {
             result =
-                    hypervisorResource.callHostPluginAsync(conn, "swiftxenserver", "swift", wait, "op", "upload", "url", swift.getUrl(), "account", swift.getAccount(), "username",
+                    hypervisorResource.callHostPluginAsync(conn, "swiftxen", "swift", wait, "op", "upload", "url", swift.getUrl(), "account", swift.getAccount(), "username",
                             swift.getUserName(), "key", swift.getKey(), "container", container, "ldir", ldir, "lfilename", lfilename, "isISCSI", isISCSI.toString());
             if (result != null && result.equals("true")) {
                 return true;

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -1067,7 +1067,7 @@ public class XenServerStorageProcessor implements StorageProcessor {
 
             parameters.addAll(Arrays.asList("operation", "put", "filename", dir + "/" + filename, "iSCSIFlag", iSCSIFlag.toString(), "bucket", s3.getBucketName(), "key",
                     key, "https", s3.isHttps() != null ? s3.isHttps().toString() : "null", "maxSingleUploadSizeInBytes", String.valueOf(s3.getMaxSingleUploadSizeInBytes())));
-            final String result = hypervisorResource.callHostPluginAsync(connection, "s3xenserver", "s3", wait, parameters.toArray(new String[parameters.size()]));
+            final String result = hypervisorResource.callHostPluginAsync(connection, "s3xen", "s3", wait, parameters.toArray(new String[parameters.size()]));
 
             if (result != null && result.equals("true")) {
                 return key;

--- a/scripts/installer/windows/client.wxs
+++ b/scripts/installer/windows/client.wxs
@@ -1165,7 +1165,7 @@
                                             <File Id="fil5C88104CC07D3894D5C6618F2480D894" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\swift" />
                                         </Component>
                                         <Component Id="cmp29E6175F9E42A05F0ACA5E9DEC427DA9" Guid="{08A3A34A-662E-40F5-AC4C-6224AF8E3204}">
-                                            <File Id="fil30689D2F97C68DD797DC8681851DC4A0" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\swiftxenserver" />
+                                            <File Id="fil30689D2F97C68DD797DC8681851DC4A0" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\swiftxen" />
                                         </Component>
                                         <Component Id="cmp795E37CA1E2B235A5F5500D0CFC92E07" Guid="{4CAFC2DE-B603-485C-B8ED-A6A016962788}">
                                             <File Id="filAD37A67E4680F1FFC939AE9759EA6193" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\upgrade_snapshot.sh" />

--- a/scripts/installer/windows/client.wxs
+++ b/scripts/installer/windows/client.wxs
@@ -1144,7 +1144,7 @@
                                             <File Id="fil4573D848D63904E25199DFC7C5F3C630" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\perfmon.py" />
                                         </Component>
                                         <Component Id="cmpD76E671ADB5BD6A4D78727948C10979D" Guid="{EA4A8C61-6B09-4489-ACE6-00B9A0F1A4BC}">
-                                            <File Id="filD3A7AE13D824593E31FF5468A9B764AB" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\s3xenserver" />
+                                            <File Id="filD3A7AE13D824593E31FF5468A9B764AB" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\s3xen" />
                                         </Component>
                                         <Component Id="cmpA5ACE2ABDAD485164B610A43CF7260AC" Guid="{D6BC09D7-775E-4DBE-8E97-603B00B26BC2}">
                                             <File Id="filA1C0191B48050912F371A13BC75AD95A" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\classes\scripts\vm\hypervisor\xenserver\setupxenserver.sh" />

--- a/scripts/vm/hypervisor/xenserver/cloudlog
+++ b/scripts/vm/hypervisor/xenserver/cloudlog
@@ -29,7 +29,7 @@
     rotate 20
 }
 
-/var/log/cloud/ovstunnel.log /var/log/cloud/ovs-pvlan.log /var/log/cloud/swiftxenserver.log /var/log/cloud/s3xenserver /var/log/cloud/storageplugin {
+/var/log/cloud/ovstunnel.log /var/log/cloud/ovs-pvlan.log /var/log/cloud/swiftxen.log /var/log/cloud/s3xenserver /var/log/cloud/storageplugin {
     daily
     size 1M
     rotate 2

--- a/scripts/vm/hypervisor/xenserver/cloudlog
+++ b/scripts/vm/hypervisor/xenserver/cloudlog
@@ -29,7 +29,7 @@
     rotate 20
 }
 
-/var/log/cloud/ovstunnel.log /var/log/cloud/ovs-pvlan.log /var/log/cloud/swiftxen.log /var/log/cloud/s3xenserver /var/log/cloud/storageplugin {
+/var/log/cloud/ovstunnel.log /var/log/cloud/ovs-pvlan.log /var/log/cloud/swiftxen.log /var/log/cloud/s3xen.log /var/log/cloud/storageplugin {
     daily
     size 1M
     rotate 2


### PR DESCRIPTION
It's called `s3xen`, not `s3xenserver`. While investigating, I found the same issue for `swiftxen`.

Regresion from a8212d9ef458dd7ac64b021e6fa33fcf64b3cce0 where things were massively renamed, without proper verification.

Error seen:
```
2015-10-22 21:42:30,372 WARN  [c.c.h.x.r.CitrixResourceBase] (DirectAgent-261:ctx-862ebceb) callHostPlugin failed for cmd: s3 with args maxErrorRetry: 10, secretKey: +XGy4yPPbAH9AijYxFTr1yVCCiVQuSfXWWj1Invs, 
connectionTtl: null, iSCSIFlag: false, maxSingleUploadSizeInBytes: 5368709120, bucket: mccx-nl2, endPoint: s3.storage.acc.schubergphilis.com, filename: /var/run/sr-mount/9414f970-0afd-42db-972f-aa4743293430/2
cf0c24b-a596-4039-b50a-7ce87da4f273.vhd, accessKey: 16efbc4e870f24338141, socketTimeout: null, https: false, connectionTimeout: 300000, operation: put, key: snapshots/2/10/2cf0c24b-a596-4039-b50a-7ce87da4f273
.vhd, useTCPKeepAlive: null,  due to Task failed! Task record:                 uuid: 4be8a515-1e2a-59de-6301-029fb0326651
           nameLabel: Async.host.call_plugin
     nameDescription: 
   allowedOperations: []
   currentOperations: {}
             created: Thu Oct 22 21:42:44 CEST 2015
            finished: Thu Oct 22 21:42:44 CEST 2015
              status: failure
          residentOn: com.xensource.xenapi.Host@9c7aad90
            progress: 1.0
                type: <none/>
              result: 
           errorInfo: [XENAPI_MISSING_PLUGIN, s3xenserver]
         otherConfig: {}
           subtaskOf: com.xensource.xenapi.Task@aaf13f6f
            subtasks: []
Task failed! Task record:                 uuid: 4be8a515-1e2a-59de-6301-029fb0326651
           nameLabel: Async.host.call_plugin
     nameDescription: 
   allowedOperations: []
   currentOperations: {}
             created: Thu Oct 22 21:42:44 CEST 2015
            finished: Thu Oct 22 21:42:44 CEST 2015
              status: failure
          residentOn: com.xensource.xenapi.Host@9c7aad90
            progress: 1.0
                type: <none/>
              result: 
           errorInfo: [XENAPI_MISSING_PLUGIN, s3xenserver]
         otherConfig: {}
           subtaskOf: com.xensource.xenapi.Task@aaf13f6f
            subtasks: []
```

Here we see the correct name:

```
scripts/vm/hypervisor/xenserver/s3xen:lib.setup_logging("/var/log/cloud/s3xen.log")
scripts/vm/hypervisor/xenserver/xenserver56/patch:s3xen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver56fp1/patch:s3xen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver60/patch:s3xen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver62/patch:s3xen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver65/patch:s3xen=..,0755,/etc/xapi.d/plugins
```

And:

```
scripts/vm/hypervisor/xenserver/xenserver56/patch:swiftxen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver56fp1/patch:swiftxen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver60/patch:swiftxen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver62/patch:swiftxen=..,0755,/etc/xapi.d/plugins
scripts/vm/hypervisor/xenserver/xenserver65/patch:swiftxen=..,0755,/etc/xapi.d/plugins
```

These plugins are pushed to the hypervisor.

Finally, s3xen logrotate wasn't setup properly as the logfile was missing `.log`.

Build succeeds:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 6:27.763s
[INFO] Finished at: Fri Oct 23 09:08:14 GMT 2015
[INFO] Final Memory: 92M/415M
[INFO] ------------------------------------------------------------------------
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Apache CloudStack Developer Mode 4.6.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
```

After this, S3 works as expected on XenServer. Couldn't test swift but it's the same issue. Pinging @pdion891 to have look at swift.