### PR TITLE
[4.6] CLOUDSTACK-8992 Allow 32 disks to be attached to a KVM VM.

### DIFF
--- a/setup/db/db/schema-452to460.sql
+++ b/setup/db/db/schema-452to460.sql
@@ -418,3 +418,5 @@ CREATE TABLE `cloud`.`ldap_trust_map` (
 
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Red Hat Enterprise Linux 7', 245, utc_timestamp(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'CentOS 7', 246, utc_timestamp(), 0);
+
+UPDATE  `cloud`.`hypervisor_capabilities` SET  `max_data_volumes_limit` =  '32' WHERE  `hypervisor_capabilities`.`hypervisor_type` =  'KVM';


### PR DESCRIPTION
Tested manually.

Added 32 disks to a VM, booted the VM, formatted all disks and mounted them all. Also created volume group and wrote all disks full. Also checked UI for glitches, which weren't present.

![2015-10-26-140843_423x583_scrot](https://cloud.githubusercontent.com/assets/5996146/10730545/ee9ae862-7bf0-11e5-94c1-f43341a84d2b.png)
![2015-10-26-140930_505x320_scrot](https://cloud.githubusercontent.com/assets/5996146/10730552/fd20887e-7bf0-11e5-9351-fbe38289b7f0.png)
![2015-10-26-140950_645x122_scrot](https://cloud.githubusercontent.com/assets/5996146/10730554/fe7aad94-7bf0-11e5-8546-d4b6f8279f3d.png)
![screenshot from 2015-10-26 14 52 35](https://cloud.githubusercontent.com/assets/5996146/10730591/378ebe7c-7bf1-11e5-90b8-8ce3f395279e.png)