### PR TITLE
CLOUDSTACK-8993: DHCP fails with "no address available" when an IP is…

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -37,6 +37,8 @@ class CsDhcp(CsDataBag):
         self.cloud = CsFile(DHCP_HOSTS)
         self.conf = CsFile(CLOUD_CONF)
 
+        self.cloud.repopulate()
+
         for item in self.dbag:
             if item == "id":
                 continue


### PR DESCRIPTION
… reused

Repopulate /etc/dhcphosts.txt to remove old entries with the same IP address.