### PR TITLE
[wip][4.6] CLOUDSTACK-8994 Add logging for the password server.

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip
+++ b/systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip
@@ -21,7 +21,7 @@ addr=$1;
 ENABLED=1
 while [ "$ENABLED" == "1" ]
 do
-    python /opt/cloud/bin/passwd_server_ip.py $addr >/dev/null 2>/dev/null
+    python /opt/cloud/bin/passwd_server_ip.py $addr >> /var/log/cloud.log 2>&1 &
     rc=$?
     if [ $rc -ne 0 ]
     then


### PR DESCRIPTION
Activity of the password server is now logged.

```
nosetests --with-marvin --marvin-config=/data/shared/marvin/mct-zone1-kvm1-basic.cfg -s -a tags=basic,required_hardware=false smoke/test_vm_life_cycle.py
```
```
==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp//MarvinLogs//Oct_26_2015_17_55_20_4DHFOS. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
=== TestName: test_deploy_vm | Status : SUCCESS ===

=== TestName: test_deploy_vm_multiple | Status : SUCCESS ===

=== TestName: test_01_stop_vm | Status : SUCCESS ===

=== TestName: test_02_start_vm | Status : SUCCESS ===

=== TestName: test_03_reboot_vm | Status : SUCCESS ===

=== TestName: test_06_destroy_vm | Status : SUCCESS ===

=== TestName: test_07_restore_vm | Status : SUCCESS ===

=== TestName: test_09_expunge_vm | Status : SUCCESS ===

===final results are now copied to: /tmp//MarvinLogs/test_vm_life_cycle_2TE6D4===
```