### PR TITLE
CLOUDSTACK-8715: Add VirtIO channel to all Instances for the Qemu Gue…

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1209,25 +1209,95 @@ public class LibvirtVMDef {
         }
     }
 
-    public static class VirtioSerialDef {
-        private final String _name;
-        private String _path;
+    public static class ChannelDef {
+        enum ChannelType {
+            UNIX("unix"), SERIAL("serial");
+            String _type;
 
-        public VirtioSerialDef(String name, String path) {
+            ChannelType(String type) {
+                _type = type;
+            }
+
+            @Override
+            public String toString() {
+                return _type;
+            }
+        }
+
+        enum ChannelState {
+            DISCONNECTED("disconnected"), CONNECTED("connected");
+            String _type;
+
+            ChannelState(String type) {
+                _type = type;
+            }
+
+            @Override
+            public String toString() {
+                return _type;
+            }
+        }
+
+        private String _name;
+        private String _path;
+        private ChannelType _type;
+        private ChannelState _state;
+
+        public ChannelDef(String name, ChannelType type) {
+            _name = name;
+            _type = type;
+        }
+
+        public ChannelDef(String name, ChannelType type, String path) {
             _name = name;
             _path = path;
+            _type = type;
+        }
+
+        public ChannelDef(String name, ChannelType type, ChannelState state) {
+            _name = name;
+            _state = state;
+            _type = type;
+        }
+
+        public ChannelDef(String name, ChannelType type, ChannelState state, String path) {
+            _name = name;
+            _path = path;
+            _state = state;
+            _type = type;
+        }
+
+        public ChannelType getChannelType() {
+            return _type;
+        }
+
+        public ChannelState getChannelState() {
+            return _state;
+        }
+
+        public String getName() {
+            return _name;
+        }
+
+        public String getPath() {
+            return _path;
         }
 
         @Override
         public String toString() {
             StringBuilder virtioSerialBuilder = new StringBuilder();
+            virtioSerialBuilder.append("<channel type='" + _type.toString() + "'>\n");
             if (_path == null) {
-                _path = "/var/lib/libvirt/qemu";
+                virtioSerialBuilder.append("<source mode='bind'/>\n");
+            } else {
+                virtioSerialBuilder.append("<source mode='bind' path='" + _path + "'/>\n");
             }
-            virtioSerialBuilder.append("<channel type='unix'>\n");
-            virtioSerialBuilder.append("<source mode='bind' path='" + _path + "/" + _name + ".agent'/>\n");
-            virtioSerialBuilder.append("<target type='virtio' name='" + _name + ".vport'/>\n");
             virtioSerialBuilder.append("<address type='virtio-serial'/>\n");
+            if (_state == null) {
+                virtioSerialBuilder.append("<target type='virtio' name='" + _name + "'/>\n");
+            } else {
+                virtioSerialBuilder.append("<target type='virtio' name='" + _name + "' state='" + _state.toString() + "'/>\n");
+            }
             virtioSerialBuilder.append("</channel>\n");
             return virtioSerialBuilder.toString();
         }

--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/api/guestagent/GuestAgentAnswer.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/api/guestagent/GuestAgentAnswer.java
@@ -1,0 +1,24 @@
+package org.apache.cloudstack.api.guestagent;
+
+import com.google.gson.annotations.SerializedName;
+
+public class GuestAgentAnswer {
+
+    public static class GuestAgentIntegerAnswer extends GuestAgentAnswer {
+        @SerializedName("return")
+        int answer;
+
+        public int getAnswer() {
+            return answer;
+        }
+    }
+
+    public static class GuestAgentStringAnswer extends GuestAgentAnswer {
+        @SerializedName("return")
+        String answer;
+
+        public String getAnswer() {
+            return answer;
+        }
+    }
+}

--- a/plugins/hypervisors/kvm/src/org/apache/cloudstack/api/guestagent/GuestAgentCommand.java
+++ b/plugins/hypervisors/kvm/src/org/apache/cloudstack/api/guestagent/GuestAgentCommand.java
@@ -1,0 +1,24 @@
+package org.apache.cloudstack.api.guestagent;
+
+import java.util.HashMap;
+
+public class GuestAgentCommand {
+    String execute;
+    @SuppressWarnings("rawtypes")
+    HashMap arguments;
+
+    @SuppressWarnings("rawtypes")
+    public GuestAgentCommand(String execute, HashMap arguments) {
+        this.execute = execute;
+        this.arguments = arguments;
+    }
+
+    public String getCommand() {
+        return execute;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public HashMap getArguments() {
+        return arguments;
+    }
+}

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -149,6 +149,7 @@ import com.cloud.agent.api.to.VolumeTO;
 import com.cloud.agent.resource.virtualnetwork.VirtualRoutingResource;
 import com.cloud.exception.InternalErrorException;
 import com.cloud.hypervisor.kvm.resource.KVMHABase.NfsStoragePool;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.ChannelDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef;
 import com.cloud.hypervisor.kvm.resource.wrapper.LibvirtRequestWrapper;
@@ -334,6 +335,9 @@ public class LibvirtComputingResourceTest {
         assertXpath(domainDoc, "/domain/devices/console/target/@port", "0");
         assertXpath(domainDoc, "/domain/devices/input/@type", "tablet");
         assertXpath(domainDoc, "/domain/devices/input/@bus", "usb");
+
+        assertNodeExists(domainDoc, "/domain/devices/channel");
+        assertXpath(domainDoc, "/domain/devices/channel/@type", ChannelDef.ChannelType.UNIX.toString());
 
         assertXpath(domainDoc, "/domain/memory/text()", String.valueOf( to.getMaxRam() / 1024 ));
         assertXpath(domainDoc, "/domain/currentMemory/text()", String.valueOf( to.getMinRam() / 1024 ));

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
@@ -23,6 +23,7 @@ import junit.framework.TestCase;
 import java.util.List;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.ChannelDef;
 
 public class LibvirtDomainXMLParserTest extends TestCase {
 
@@ -37,6 +38,11 @@ public class LibvirtDomainXMLParserTest extends TestCase {
 
         InterfaceDef.NicModel ifModel = InterfaceDef.NicModel.VIRTIO;
         InterfaceDef.GuestNetType ifType = InterfaceDef.GuestNetType.BRIDGE;
+
+        ChannelDef.ChannelType channelType = ChannelDef.ChannelType.UNIX;
+        ChannelDef.ChannelState channelState = ChannelDef.ChannelState.DISCONNECTED;
+        String guestAgentPath = "/var/lib/libvirt/qemu/guest-agent.org.qemu.guest_agent.0";
+        String guestAgentName = "org.qemu.guest_agent.0";
 
         String diskLabel ="vda";
         String diskPath = "/var/lib/libvirt/images/my-test-image.qcow2";
@@ -144,7 +150,7 @@ public class LibvirtDomainXMLParserTest extends TestCase {
                      "</console>" +
                      "<channel type='unix'>" +
                      "<source mode='bind' path='/var/lib/libvirt/qemu/s-2970-VM.agent'/>" +
-                     "<target type='virtio' name='s-2970-VM.vport'/>" +
+                     "<target type='virtio' name='s-2970-VM.vport' state='disconnected'/>" +
                      "<alias name='channel0'/>" +
                      "<address type='virtio-serial' controller='0' bus='0' port='1'/>" +
                      "</channel>" +
@@ -164,6 +170,12 @@ public class LibvirtDomainXMLParserTest extends TestCase {
                      "<alias name='balloon0'/>" +
                      "<address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>" +
                      "</memballoon>" +
+                     "<channel type='unix'>" +
+                     "<source mode='bind' path='" + guestAgentPath + "'/>" +
+                     "<target type='virtio' name='" + guestAgentName + "'/>" +
+                     "<alias name='channel0'/>" +
+                     "<address type='virtio-serial' controller='0' bus='0' port='1'/>" +
+                     "</channel>" +
                      "</devices>" +
                      "<seclabel type='none'/>" +
                      "</domain>";
@@ -184,6 +196,16 @@ public class LibvirtDomainXMLParserTest extends TestCase {
         assertEquals(diskType, disks.get(diskId).getDiskType());
         assertEquals(deviceType, disks.get(diskId).getDeviceType());
         assertEquals(diskFormat, disks.get(diskId).getDiskFormatType());
+
+        List<ChannelDef> channels = parser.getChannels();
+        for (int i = 0; i < channels.size(); i++) {
+            assertEquals(channelType, channels.get(i).getChannelType());
+            assertEquals(channelType, channels.get(i).getChannelType());
+        }
+
+        assertEquals(channelState, channels.get(0).getChannelState());
+        assertEquals(guestAgentPath, channels.get(1).getPath());
+        assertEquals(guestAgentName, channels.get(1).getName());
 
         List<InterfaceDef> ifs = parser.getInterfaces();
         for (int i = 0; i < ifs.size(); i++) {

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
@@ -21,6 +21,7 @@ package com.cloud.hypervisor.kvm.resource;
 
 import junit.framework.TestCase;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.ChannelDef;
 import com.cloud.utils.Pair;
 
 public class LibvirtVMDefTest extends TestCase {
@@ -116,6 +117,20 @@ public class LibvirtVMDefTest extends TestCase {
         assertTrue((hostOsVersion.first() == 6 && hostOsVersion.second() >= 5) || (hostOsVersion.first() >= 7));
         hostOsVersion = new Pair<Integer,Integer>(7,1);
         assertTrue((hostOsVersion.first() == 6 && hostOsVersion.second() >= 5) || (hostOsVersion.first() >= 7));
+    }
+
+    public void testChannelDef() {
+        ChannelDef.ChannelType type = ChannelDef.ChannelType.UNIX;
+        ChannelDef.ChannelState state = ChannelDef.ChannelState.CONNECTED;
+        String name = "v-136-VM.vport";
+        String path = "/var/lib/libvirt/qemu/" + name;
+
+        ChannelDef channelDef = new ChannelDef(name, type, state, path);
+
+        assertEquals(state, channelDef.getChannelState());
+        assertEquals(type, channelDef.getChannelType());
+        assertEquals(name, channelDef.getName());
+        assertEquals(path, channelDef.getPath());
     }
 
 }

--- a/plugins/hypervisors/kvm/test/org/apache/cloudstack/api/guestagent/GuestAgentCommandTest.java
+++ b/plugins/hypervisors/kvm/test/org/apache/cloudstack/api/guestagent/GuestAgentCommandTest.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.guestagent;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class GuestAgentCommandTest {
+
+    @Test
+    public void testWithoutArgument() {
+        String command = "guest-sync";
+        Gson gson = new GsonBuilder().create();
+        GuestAgentCommand cmd = new GuestAgentCommand(command, null);
+        String data = gson.toJson(cmd);
+        assertEquals("{\"execute\":\"" + command + "\"}", data);
+    }
+
+    @Test
+    public void testWithArgument() {
+        HashMap arguments = new HashMap();
+        int id = (int)(Math.random() * 1000000) + 1;
+        arguments.put("id", id);
+        String command = "guest-sync";
+        Gson gson = new GsonBuilder().create();
+        GuestAgentCommand cmd = new GuestAgentCommand(command, arguments);
+        String data = gson.toJson(cmd);
+        assertEquals("{\"execute\":\"" + command + "\",\"arguments\":{\"id\":" + id + "}}", data);
+    }
+}

--- a/tools/appliance/definitions/systemvmtemplate/install_systemvm_packages.sh
+++ b/tools/appliance/definitions/systemvmtemplate/install_systemvm_packages.sh
@@ -75,7 +75,7 @@ function install_packages() {
     radvd \
     sharutils
 
-  ${apt_get} -t wheezy-backports install keepalived irqbalance open-vm-tools
+  ${apt_get} -t wheezy-backports install keepalived irqbalance open-vm-tools qemu-guest-agent
 
   # hold on installed openswan version, upgrade rest of the packages (if any)
   apt-mark hold openswan


### PR DESCRIPTION
…st Agent

This commit adds a additional VirtIO channel with the name 'org.qemu.guest_agent.0'
to all Instances.

With the Qemu Guest Agent the Hypervisor gains more control over the Instance if
these tools are present inside the Instance, for example:

* Power control
* Flushing filesystems

In the future this should allow safer snapshots on KVM since we can instruct the
Instance to flush the filesystems prior to snapshotting the disk.

More information: http://wiki.qemu.org/Features/QAPI/GuestAgent