### PR TITLE
CLOUDSTACK-9003 Make VirtualMachineName into an injectable service class

### DIFF
--- a/api/src/com/cloud/vm/VirtualMachineName.java
+++ b/api/src/com/cloud/vm/VirtualMachineName.java
@@ -24,7 +24,7 @@ import java.util.Formatter;
 public class VirtualMachineName {
     public static final String SEPARATOR = "-";
 
-    public static boolean isValidCloudStackVmName(String name, String instance) {
+    public boolean isValidCloudStackVmName(String name, String instance) {
         String[] parts = name.split(SEPARATOR);
         if (parts.length <= 1) {
             return false;
@@ -37,18 +37,18 @@ public class VirtualMachineName {
         return true;
     }
 
-    public static String getVnetName(long vnetId) {
+    public String getVnetName(long vnetId) {
         StringBuilder vnet = new StringBuilder();
         Formatter formatter = new Formatter(vnet);
         formatter.format("%04x", vnetId);
         return vnet.toString();
     }
 
-    public static boolean isValidVmName(String vmName) {
+    public boolean isValidVmName(String vmName) {
         return isValidVmName(vmName, null);
     }
 
-    public static boolean isValidVmName(String vmName, String instance) {
+    public boolean isValidVmName(String vmName, String instance) {
         String[] tokens = vmName.split(SEPARATOR);
 
         if (tokens.length <= 1) {
@@ -62,65 +62,65 @@ public class VirtualMachineName {
         return true;
     }
 
-    public static String getVmName(long vmId, long userId, String instance) {
+    public String getVmName(long vmId, long userId, String instance) {
         StringBuilder vmName = new StringBuilder("i");
         vmName.append(SEPARATOR).append(userId).append(SEPARATOR).append(vmId);
         vmName.append(SEPARATOR).append(instance);
         return vmName.toString();
     }
 
-    public static long getVmId(String vmName) {
+    public long getVmId(String vmName) {
         int begin = vmName.indexOf(SEPARATOR);
         begin = vmName.indexOf(SEPARATOR, begin + SEPARATOR.length());
         int end = vmName.indexOf(SEPARATOR, begin + SEPARATOR.length());
         return Long.parseLong(vmName.substring(begin + 1, end));
     }
 
-    public static long getRouterId(String routerName) {
+    public long getRouterId(String routerName) {
         int begin = routerName.indexOf(SEPARATOR);
         int end = routerName.indexOf(SEPARATOR, begin + SEPARATOR.length());
         return Long.parseLong(routerName.substring(begin + 1, end));
     }
 
-    public static long getConsoleProxyId(String vmName) {
+    public long getConsoleProxyId(String vmName) {
         int begin = vmName.indexOf(SEPARATOR);
         int end = vmName.indexOf(SEPARATOR, begin + SEPARATOR.length());
         return Long.parseLong(vmName.substring(begin + 1, end));
     }
 
-    public static long getSystemVmId(String vmName) {
+    public long getSystemVmId(String vmName) {
         int begin = vmName.indexOf(SEPARATOR);
         int end = vmName.indexOf(SEPARATOR, begin + SEPARATOR.length());
         return Long.parseLong(vmName.substring(begin + 1, end));
     }
 
-    public static String getRouterName(long routerId, String instance) {
+    public String getRouterName(long routerId, String instance) {
         StringBuilder builder = new StringBuilder("r");
         builder.append(SEPARATOR).append(routerId).append(SEPARATOR).append(instance);
         return builder.toString();
     }
 
-    public static String getConsoleProxyName(long vmId, String instance) {
+    public String getConsoleProxyName(long vmId, String instance) {
         StringBuilder builder = new StringBuilder("v");
         builder.append(SEPARATOR).append(vmId).append(SEPARATOR).append(instance);
         return builder.toString();
     }
 
-    public static String getSystemVmName(long vmId, String instance, String prefix) {
+    public String getSystemVmName(long vmId, String instance, String prefix) {
         StringBuilder builder = new StringBuilder(prefix);
         builder.append(SEPARATOR).append(vmId).append(SEPARATOR).append(instance);
         return builder.toString();
     }
 
-    public static String attachVnet(String name, String vnet) {
+    public String attachVnet(String name, String vnet) {
         return name + SEPARATOR + vnet;
     }
 
-    public static boolean isValidRouterName(String name) {
+    public boolean isValidRouterName(String name) {
         return isValidRouterName(name, null);
     }
 
-    public static boolean isValidRouterName(String name, String instance) {
+    public boolean isValidRouterName(String name, String instance) {
         String[] tokens = name.split(SEPARATOR);
         if (tokens.length != 3 && tokens.length != 4) {
             return false;
@@ -139,11 +139,11 @@ public class VirtualMachineName {
         return instance == null || tokens[2].equals(instance);
     }
 
-    public static boolean isValidConsoleProxyName(String name) {
+    public boolean isValidConsoleProxyName(String name) {
         return isValidConsoleProxyName(name, null);
     }
 
-    public static boolean isValidConsoleProxyName(String name, String instance) {
+    public boolean isValidConsoleProxyName(String name, String instance) {
         String[] tokens = name.split(SEPARATOR);
         if (tokens.length != 3) {
             return false;
@@ -162,11 +162,11 @@ public class VirtualMachineName {
         return instance == null || tokens[2].equals(instance);
     }
 
-    public static boolean isValidSecStorageVmName(String name, String instance) {
+    public boolean isValidSecStorageVmName(String name, String instance) {
         return isValidSystemVmName(name, instance, "s");
     }
 
-    public static boolean isValidSystemVmName(String name, String instance, String prefix) {
+    public boolean isValidSystemVmName(String name, String instance, String prefix) {
         String[] tokens = name.split(SEPARATOR);
         if (tokens.length != 3) {
             return false;

--- a/api/src/com/cloud/vm/VirtualMachineNameService.java
+++ b/api/src/com/cloud/vm/VirtualMachineNameService.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.vm;
+
+/**
+ * VM Name Service generates and checks VM names for use on hypervisors (separate
+ * from display name and hostname of the VM).
+ */
+public interface VirtualMachineNameService {
+
+    public boolean isValidCloudStackVmName(String name, String instance);
+    public String getVnetName(long vnetId);
+
+    public boolean isValidVmName(String vmName);
+
+    public boolean isValidVmName(String vmName, String instance);
+
+    public String getVmName(long vmId, long userId, String instance);
+
+    public long getVmId(String vmName);
+
+    public long getRouterId(String routerName);
+
+    public long getConsoleProxyId(String vmName);
+
+    public long getSystemVmId(String vmName);
+
+    public String getRouterName(long routerId, String instance);
+
+    public String getConsoleProxyName(long vmId, String instance);
+
+    public String getSystemVmName(long vmId, String instance, String prefix);
+
+    public String attachVnet(String name, String vnet);
+
+    public boolean isValidRouterName(String name);
+
+    public boolean isValidRouterName(String name, String instance);
+
+    public boolean isValidConsoleProxyName(String name);
+
+    public boolean isValidConsoleProxyName(String name, String instance);
+
+    public boolean isValidSecStorageVmName(String name, String instance);
+
+    public boolean isValidSystemVmName(String name, String instance, String prefix);
+}

--- a/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
@@ -155,7 +155,7 @@ import com.cloud.utils.net.NetUtils;
 import com.cloud.utils.ssh.SshHelper;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.PowerState;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 
 
 /**
@@ -192,7 +192,7 @@ public class HypervDirectConnectResource extends ServerResourceBase implements S
     @Inject
     HypervManager _hypervMgr;
     @Inject
-    VirtualMachineName _vmNameService;
+    VirtualMachineNameService _vmNameService;
     protected VirtualRoutingResource _vrResource;
 
     @PostConstruct

--- a/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
@@ -191,6 +191,8 @@ public class HypervDirectConnectResource extends ServerResourceBase implements S
     private static HypervManager s_hypervMgr;
     @Inject
     HypervManager _hypervMgr;
+    @Inject
+    VirtualMachineName _vmNameService;
     protected VirtualRoutingResource _vrResource;
 
     @PostConstruct
@@ -2144,7 +2146,7 @@ public class HypervDirectConnectResource extends ServerResourceBase implements S
             s_logger.debug("Ping command port succeeded for vm " + vmName);
         }
 
-        if (VirtualMachineName.isValidRouterName(vmName)) {
+        if (_vmNameService.isValidRouterName(vmName)) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Execute network usage setup command on " + vmName);
             }

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -274,14 +274,14 @@ import com.cloud.utils.net.NetUtils;
 import com.cloud.utils.ssh.SshHelper;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.PowerState;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.VmDetailConstants;
 
 public class VmwareResource implements StoragePoolResource, ServerResource, VmwareHostService, VirtualRouterDeployer {
     private static final Logger s_logger = Logger.getLogger(VmwareResource.class);
 
     @Inject
-    protected VirtualMachineName _vmNameService;
+    protected VirtualMachineNameService _vmNameService;
 
     protected String _name;
 

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.log4j.Logger;
@@ -279,6 +280,9 @@ import com.cloud.vm.VmDetailConstants;
 public class VmwareResource implements StoragePoolResource, ServerResource, VmwareHostService, VirtualRouterDeployer {
     private static final Logger s_logger = Logger.getLogger(VmwareResource.class);
 
+    @Inject
+    protected VirtualMachineName _vmNameService;
+
     protected String _name;
 
     protected final long _opsTimeout = 900000;   // 15 minutes time out to time
@@ -327,6 +331,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     protected VirtualRoutingResource _vrResource;
 
     protected final static HashMap<VirtualMachinePowerState, PowerState> s_powerStatesTable = new HashMap<VirtualMachinePowerState, PowerState>();
+
     static {
         s_powerStatesTable.put(VirtualMachinePowerState.POWERED_ON, PowerState.PowerOn);
         s_powerStatesTable.put(VirtualMachinePowerState.POWERED_OFF, PowerState.PowerOff);
@@ -1234,7 +1239,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             s_logger.debug("Ping command port succeeded for vm " + vmName);
         }
 
-        if (VirtualMachineName.isValidRouterName(vmName)) {
+        if (_vmNameService.isValidRouterName(vmName)) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Execute network usage setup command on " + vmName);
             }

--- a/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
+++ b/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
@@ -35,7 +35,7 @@ import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.hypervisor.vmware.mo.VirtualMachineMO;
 import com.cloud.hypervisor.vmware.mo.VmwareHypervisorHost;
 import com.cloud.hypervisor.vmware.util.VmwareContext;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 
 public class VmwareResourceTest {
 
@@ -66,7 +66,7 @@ public class VmwareResourceTest {
     @Mock
     VirtualMachineConfigSpec vmConfigSpec;
     @Mock
-    VirtualMachineName _vmName;
+    VirtualMachineNameService _vmName;
 
     @Before
     public void setup() {

--- a/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
+++ b/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
@@ -35,6 +35,7 @@ import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.hypervisor.vmware.mo.VirtualMachineMO;
 import com.cloud.hypervisor.vmware.mo.VmwareHypervisorHost;
 import com.cloud.hypervisor.vmware.util.VmwareContext;
+import com.cloud.vm.VirtualMachineName;
 
 public class VmwareResourceTest {
 
@@ -64,6 +65,8 @@ public class VmwareResourceTest {
     VirtualMachineMO vmMo;
     @Mock
     VirtualMachineConfigSpec vmConfigSpec;
+    @Mock
+    VirtualMachineName _vmName;
 
     @Before
     public void setup() {

--- a/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/LoadBalanceRuleHandler.java
+++ b/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/LoadBalanceRuleHandler.java
@@ -93,7 +93,7 @@ import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.VirtualMachineProfile.Param;
 import com.cloud.vm.dao.DomainRouterDao;
@@ -131,7 +131,7 @@ public class LoadBalanceRuleHandler {
     @Inject
     private VirtualMachineManager _itMgr;
     @Inject
-    private VirtualMachineName _vmNameService;
+    private VirtualMachineNameService _vmNameService;
     @Inject
     private AccountService _accountService;
     @Inject

--- a/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/LoadBalanceRuleHandler.java
+++ b/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/LoadBalanceRuleHandler.java
@@ -131,6 +131,8 @@ public class LoadBalanceRuleHandler {
     @Inject
     private VirtualMachineManager _itMgr;
     @Inject
+    private VirtualMachineName _vmNameService;
+    @Inject
     private AccountService _accountService;
     @Inject
     private LoadBalancerDao _lbDao;
@@ -287,9 +289,10 @@ public class LoadBalanceRuleHandler {
                 }
 
                 ServiceOfferingVO elasticLbVmOffering = _serviceOfferingDao.findDefaultSystemOffering(ServiceOffering.elbVmDefaultOffUniqueName, ConfigurationManagerImpl.SystemVMUseLocalStorage.valueIn(dest.getDataCenter().getId()));
-                elbVm = new DomainRouterVO(id, elasticLbVmOffering.getId(), vrProvider.getId(), VirtualMachineName.getSystemVmName(id, _instance, ELB_VM_NAME_PREFIX),
+                elbVm = new DomainRouterVO(id, elasticLbVmOffering.getId(), vrProvider.getId(), _vmNameService.getSystemVmName(id, _instance, ELB_VM_NAME_PREFIX),
                         template.getId(), template.getHypervisorType(), template.getGuestOSId(), owner.getDomainId(), owner.getId(), userId, false, RedundantState.UNKNOWN,
                         elasticLbVmOffering.getOfferHA(), false, null);
+
                 elbVm.setRole(Role.LB);
                 elbVm = _routerDao.persist(elbVm);
                 _itMgr.allocate(elbVm.getInstanceName(), template, elasticLbVmOffering, networks, plan, null);

--- a/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/lb/InternalLoadBalancerVMManagerImpl.java
+++ b/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/lb/InternalLoadBalancerVMManagerImpl.java
@@ -135,6 +135,8 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
     @Inject
     VirtualMachineManager _itMgr;
     @Inject
+    VirtualMachineName _vmNameService;
+    @Inject
     DomainRouterDao _internalLbVmDao;
     @Inject
     ConfigurationDao _configDao;
@@ -780,7 +782,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
                 }
 
                 internalLbVm =
-                        new DomainRouterVO(id, routerOffering.getId(), internalLbProviderId, VirtualMachineName.getSystemVmName(id, _instance, InternalLbVmNamePrefix),
+                        new DomainRouterVO(id, routerOffering.getId(), internalLbProviderId, _vmNameService.getSystemVmName(id, _instance, InternalLbVmNamePrefix),
                                 template.getId(), template.getHypervisorType(), template.getGuestOSId(), owner.getDomainId(), owner.getId(), userId, false, RedundantState.UNKNOWN, false, false, VirtualMachine.Type.InternalLoadBalancerVm, vpcId);
                 internalLbVm.setRole(Role.INTERNAL_LB_VM);
                 internalLbVm = _internalLbVmDao.persist(internalLbVm);

--- a/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/lb/InternalLoadBalancerVMManagerImpl.java
+++ b/plugins/network-elements/internal-loadbalancer/src/org/apache/cloudstack/network/lb/InternalLoadBalancerVMManagerImpl.java
@@ -114,7 +114,7 @@ import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineGuru;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.VirtualMachineProfile.Param;
 import com.cloud.vm.dao.DomainRouterDao;
@@ -135,7 +135,7 @@ public class InternalLoadBalancerVMManagerImpl extends ManagerBase implements In
     @Inject
     VirtualMachineManager _itMgr;
     @Inject
-    VirtualMachineName _vmNameService;
+    VirtualMachineNameService _vmNameService;
     @Inject
     DomainRouterDao _internalLbVmDao;
     @Inject

--- a/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMManagerTest.java
+++ b/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMManagerTest.java
@@ -69,6 +69,7 @@ import com.cloud.vm.NicVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineManager;
+import com.cloud.vm.VirtualMachineName;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
 
@@ -87,6 +88,8 @@ public class InternalLBVMManagerTest extends TestCase {
     InternalLoadBalancerVMManager _lbVmMgr;
 
     //Mocked interfaces
+    @Inject
+    VirtualMachineName _vmName;
     @Inject
     AccountManager _accountMgr;
     @Inject

--- a/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMManagerTest.java
+++ b/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/InternalLBVMManagerTest.java
@@ -69,7 +69,7 @@ import com.cloud.vm.NicVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
 
@@ -88,8 +88,7 @@ public class InternalLBVMManagerTest extends TestCase {
     InternalLoadBalancerVMManager _lbVmMgr;
 
     //Mocked interfaces
-    @Inject
-    VirtualMachineName _vmName;
+    VirtualMachineNameService _vmName;
     @Inject
     AccountManager _accountMgr;
     @Inject

--- a/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/LbChildTestConfiguration.java
+++ b/plugins/network-elements/internal-loadbalancer/test/org/apache/cloudstack/internallbvmmgr/LbChildTestConfiguration.java
@@ -50,6 +50,7 @@ import com.cloud.user.AccountManager;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.VirtualMachineManager;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
 
@@ -69,6 +70,11 @@ public class LbChildTestConfiguration {
         @Bean
         public VirtualMachineManager virtualMachineManager() {
             return Mockito.mock(VirtualMachineManager.class);
+        }
+
+        @Bean
+        public VirtualMachineNameService virtualMachineNameService() {
+            return Mockito.mock(VirtualMachineNameService.class);
         }
 
         @Bean

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_mgr.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_mgr.xml
@@ -37,8 +37,6 @@
     </property>
   </bean>
   
-  <bean id="vmNameService" class="com.cloud.vm.VirtualMachineName" />
-
     <bean id="InternalLoadBalancerVMManager" class="org.apache.cloudstack.network.lb.InternalLoadBalancerVMManagerImpl">
         <property name="name" value="InternalLoadBalancerVMManager"/>
     </bean>

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_mgr.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_mgr.xml
@@ -36,6 +36,8 @@
         </list>
     </property>
   </bean>
+  
+  <bean id="vmNameService" class="com.cloud.vm.VirtualMachineName" />
 
     <bean id="InternalLoadBalancerVMManager" class="org.apache.cloudstack.network.lb.InternalLoadBalancerVMManagerImpl">
         <property name="name" value="InternalLoadBalancerVMManager"/>

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_svc.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_svc.xml
@@ -36,6 +36,8 @@
         </list>
     </property>
   </bean>
+  
+  <bean id="vmNameService" class="com.cloud.vm.VirtualMachineName" />
 
     <bean id="InternalLoadBalancerVMService" class="org.apache.cloudstack.network.lb.InternalLoadBalancerVMManagerImpl">
         <property name="name" value="InternalLoadBalancerVMService"/>

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_svc.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_svc.xml
@@ -37,7 +37,7 @@
     </property>
   </bean>
   
-  <bean id="vmNameService" class="com.cloud.vm.VirtualMachineName" />
+  <bean id="vmNameService" class="com.cloud.vm.VirtualMachineNameServiceImpl" />
 
     <bean id="InternalLoadBalancerVMService" class="org.apache.cloudstack.network.lb.InternalLoadBalancerVMManagerImpl">
         <property name="name" value="InternalLoadBalancerVMService"/>

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ServiceManagerImpl.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ServiceManagerImpl.java
@@ -59,7 +59,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.dao.UserVmDao;
 import com.google.gson.Gson;
 
@@ -78,7 +78,7 @@ public class ServiceManagerImpl implements ServiceManager {
     @Inject
     AccountService _accountService;
     @Inject
-    VirtualMachineName _vmNameService;
+    VirtualMachineNameService _vmNameService;
     @Inject
     ContrailManager _manager;
 

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ServiceManagerImpl.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ServiceManagerImpl.java
@@ -78,6 +78,8 @@ public class ServiceManagerImpl implements ServiceManager {
     @Inject
     AccountService _accountService;
     @Inject
+    VirtualMachineName _vmNameService;
+    @Inject
     ContrailManager _manager;
 
     /**
@@ -109,7 +111,8 @@ public class ServiceManagerImpl implements ServiceManager {
         networks.put(linklocal, new ArrayList<NicProfile>());
         networks.put((NetworkVO)left, new ArrayList<NicProfile>());
         networks.put((NetworkVO)right, new ArrayList<NicProfile>());
-        String instanceName = VirtualMachineName.getVmName(id, owner.getId(), "SRV");
+
+        String instanceName = _vmNameService.getVmName(id, owner.getId(), "SRV");
 
         long userId = CallContext.current().getCallingUserId();
         if (CallContext.current().getCallingAccount().getId() != owner.getId()) {

--- a/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
+++ b/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
@@ -84,6 +84,8 @@
     <bean id="configurationServerImpl" class="com.cloud.server.ConfigurationServerImpl" />
 
     <bean id="userVmManagerImpl" class="com.cloud.vm.UserVmManagerImpl" />
+    
+    <bean id="vmNameService" class="com.cloud.vm.VirtualMachineNameServiceImpl" />
 
     <bean id="consoleProxyManagerImpl" class="com.cloud.consoleproxy.ConsoleProxyManagerImpl">
         <property name="consoleProxyAllocators"

--- a/server/resources/META-INF/cloudstack/core/spring-server-core-misc-context.xml
+++ b/server/resources/META-INF/cloudstack/core/spring-server-core-misc-context.xml
@@ -78,7 +78,4 @@
     <bean id="ExternalIpAddressAllocator" class="com.cloud.network.ExternalIpAddressAllocator">
         <property name="name" value="Basic" />
     </bean>
-    
-    <bean id="vmNameService" class="com.cloud.vm.VirtualMachineName" />
-    
 </beans>

--- a/server/resources/META-INF/cloudstack/core/spring-server-core-misc-context.xml
+++ b/server/resources/META-INF/cloudstack/core/spring-server-core-misc-context.xml
@@ -79,4 +79,6 @@
         <property name="name" value="Basic" />
     </bean>
     
+    <bean id="vmNameService" class="com.cloud.vm.VirtualMachineName" />
+    
 </beans>

--- a/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -132,7 +132,7 @@ import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineGuru;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.ConsoleProxyDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
@@ -212,7 +212,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
     @Inject
     private VirtualMachineManager _itMgr;
     @Inject
-    private VirtualMachineName _vmNameService;
+    private VirtualMachineNameService _vmNameService;
 
     private ConsoleProxyListener _listener;
 

--- a/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -211,6 +211,8 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
     private KeysManager _keysMgr;
     @Inject
     private VirtualMachineManager _itMgr;
+    @Inject
+    private VirtualMachineName _vmNameService;
 
     private ConsoleProxyListener _listener;
 
@@ -671,7 +673,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
     protected Map<String, Object> createProxyInstance(long dataCenterId, VMTemplateVO template) throws ConcurrentOperationException {
 
         long id = _consoleProxyDao.getNextInSequence(Long.class, "id");
-        String name = VirtualMachineName.getConsoleProxyName(id, _instance);
+        String name = _vmNameService.getConsoleProxyName(id, _instance);
         DataCenterVO dc = _dcDao.findById(dataCenterId);
         Account systemAcct = _accountMgr.getSystemAccount();
 

--- a/server/src/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/com/cloud/network/router/NetworkHelperImpl.java
@@ -94,7 +94,7 @@ import com.cloud.vm.NicProfile;
 import com.cloud.vm.NicVO;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.VirtualMachineProfile.Param;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
@@ -146,7 +146,7 @@ public class NetworkHelperImpl implements NetworkHelper {
     @Inject
     protected VirtualMachineManager _itMgr;
     @Inject
-    protected VirtualMachineName _vmNameService;
+    protected VirtualMachineNameService _vmNameService;
     @Inject
     protected IpAddressManager _ipAddrMgr;
 

--- a/server/src/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/com/cloud/network/router/NetworkHelperImpl.java
@@ -146,6 +146,8 @@ public class NetworkHelperImpl implements NetworkHelper {
     @Inject
     protected VirtualMachineManager _itMgr;
     @Inject
+    protected VirtualMachineName _vmNameService;
+    @Inject
     protected IpAddressManager _ipAddrMgr;
 
     protected final Map<HypervisorType, ConfigKey<String>> hypervisorsMap = new HashMap<>();
@@ -493,7 +495,7 @@ public class NetworkHelperImpl implements NetworkHelper {
                     }
                 }
 
-                router = new DomainRouterVO(id, routerOffering.getId(), routerDeploymentDefinition.getVirtualProvider().getId(), VirtualMachineName.getRouterName(id,
+                router = new DomainRouterVO(id, routerOffering.getId(), routerDeploymentDefinition.getVirtualProvider().getId(), _vmNameService.getRouterName(id,
                         s_vmInstanceName), template.getId(), template.getHypervisorType(), template.getGuestOSId(), owner.getDomainId(), owner.getId(),
                         userId, routerDeploymentDefinition.isRedundant(), RedundantState.UNKNOWN, offerHA, false, vpcId);
 

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -381,6 +381,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     @Inject
     protected VirtualMachineManager _itMgr;
     @Inject
+    protected VirtualMachineName _vmNameService;
+    @Inject
     protected NetworkDao _networkDao;
     @Inject
     protected NicDao _nicDao;
@@ -3208,7 +3210,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             // Check is hostName is RFC compliant
             checkNameForRFCCompliance(hostName);
         }
-        instanceName = VirtualMachineName.getVmName(id, owner.getId(), _instance);
+        instanceName = _vmNameService.getVmName(id, owner.getId(), _instance);
 
         // Check if VM with instanceName already exists.
         VMInstanceVO vmObj = _vmInstanceDao.findVMByInstanceName(instanceName);

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -381,7 +381,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     @Inject
     protected VirtualMachineManager _itMgr;
     @Inject
-    protected VirtualMachineName _vmNameService;
+    protected VirtualMachineNameService _vmNameService;
     @Inject
     protected NetworkDao _networkDao;
     @Inject

--- a/server/src/com/cloud/vm/VirtualMachineNameServiceImpl.java
+++ b/server/src/com/cloud/vm/VirtualMachineNameServiceImpl.java
@@ -1,4 +1,4 @@
-// Licensed to the Apache Software Foundation (ASF) under one
+// Licensed to the Apacohe Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
 // regarding copyright ownership.  The ASF licenses this file
@@ -18,10 +18,7 @@ package com.cloud.vm;
 
 import java.util.Formatter;
 
-/**
- * VM Name.
- */
-public class VirtualMachineName {
+public class VirtualMachineNameServiceImpl implements VirtualMachineNameService {
     public static final String SEPARATOR = "-";
 
     public boolean isValidCloudStackVmName(String name, String instance) {

--- a/server/test/com/cloud/network/element/VirtualRouterElementTest.java
+++ b/server/test/com/cloud/network/element/VirtualRouterElementTest.java
@@ -104,6 +104,7 @@ import com.cloud.vm.ReservationContextImpl;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
+import com.cloud.vm.VirtualMachineName;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
@@ -165,6 +166,7 @@ public class VirtualRouterElementTest {
     @Mock private ResourceManager _resourceMgr;
     @Mock private UserVmManager _userVmMgr;
     @Mock private VirtualMachineManager _itMgr;
+    @Mock private VirtualMachineName _vmName;
 
     @InjectMocks
     private RouterDeploymentDefinitionBuilder routerDeploymentDefinitionBuilder;

--- a/server/test/com/cloud/network/element/VirtualRouterElementTest.java
+++ b/server/test/com/cloud/network/element/VirtualRouterElementTest.java
@@ -104,7 +104,7 @@ import com.cloud.vm.ReservationContextImpl;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
@@ -166,7 +166,7 @@ public class VirtualRouterElementTest {
     @Mock private ResourceManager _resourceMgr;
     @Mock private UserVmManager _userVmMgr;
     @Mock private VirtualMachineManager _itMgr;
-    @Mock private VirtualMachineName _vmName;
+    @Mock private VirtualMachineNameService _vmName;
 
     @InjectMocks
     private RouterDeploymentDefinitionBuilder routerDeploymentDefinitionBuilder;

--- a/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -137,7 +137,7 @@ import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineGuru;
 import com.cloud.vm.VirtualMachineManager;
-import com.cloud.vm.VirtualMachineName;
+import com.cloud.vm.VirtualMachineNameService;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.SecondaryStorageVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
@@ -208,7 +208,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
     @Inject
     private VirtualMachineManager _itMgr;
     @Inject
-    private VirtualMachineName _vmNameService;
+    private VirtualMachineNameService _vmNameService;
     @Inject
     protected VMInstanceDao _vmDao;
     @Inject

--- a/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -208,6 +208,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
     @Inject
     private VirtualMachineManager _itMgr;
     @Inject
+    private VirtualMachineName _vmNameService;
+    @Inject
     protected VMInstanceDao _vmDao;
     @Inject
     protected CapacityDao _capacityDao;
@@ -524,7 +526,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         }
 
         long id = _secStorageVmDao.getNextInSequence(Long.class, "id");
-        String name = VirtualMachineName.getSystemVmName(id, _instance, "s").intern();
+        String name = _vmNameService.getSystemVmName(id, _instance, "s").intern();
         Account systemAcct = _accountMgr.getSystemAccount();
 
         DataCenterDeployment plan = new DataCenterDeployment(dataCenterId);


### PR DESCRIPTION
This pull request refactors the VirtualMachineName class into an injectable dependency. It is one of the few remaining classes that appears to be spaghetti tangled through many places in the code, and it hasn't been updated in years. These two commits introduce a VirtualMachineNameService which is injected everywhere it's relevant.

The rationale for this is to separate concerns better and remove spaghetti dependencies on static methods. It also opens up the door to easier extensibility in the future.

Some potential issues with this pull request:

* Should the VirtualMachineNameService go into spring-core-managers-context.xml?
* I have added an injection to both VMWare and HypervDirectConnectResource. HyperV already had an inject, but VMWare did not. Both of these are direct agents which means they run in the management server... so injection should work. But I don't know if this violates some guideline or not.