### PR TITLE
CLOUDSTACK-8991 - IP address is not removed from VR even after disabling static NAT

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -610,8 +610,8 @@ class CsIP:
             if self.dev in bag.keys():
                 for address in bag[self.dev]:
                     self.setAddress(address)
-                    if (self.hasIP(ip) or self.is_guest_gateway(address, ip)) and addess["add"]:
-                        logging.debig("The IP address in '%s' will be configured" % address)
+                    if (self.hasIP(ip) or self.is_guest_gateway(address, ip)) and address["add"]:
+                        logging.debug("The IP address in '%s' will be configured" % address)
                         found = True
             if not found:
                 self.delete(ip)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -103,6 +103,7 @@ class CsAddress(CsDataBag):
 
             for address in self.dbag[dev]:
                 ip.setAddress(address)
+                logging.info("Address found in DataBag ==> %s" % address)
 
                 if ip.configured():
                     logging.info(
@@ -263,10 +264,17 @@ class CsIP:
         return self.address
 
     def configure(self, address):
-        logging.info(
-            "Configuring address %s on device %s", self.ip(), self.dev)
-        cmd = "ip addr add dev %s %s brd +" % (self.dev, self.ip())
-        subprocess.call(cmd, shell=True)
+        # When "add" is false, it means that the IP has to be removed.
+        if address["add"]:
+            try:
+                logging.info("Configuring address %s on device %s", self.ip(), self.dev)
+                cmd = "ip addr add dev %s %s brd +" % (self.dev, self.ip())
+                subprocess.call(cmd, shell=True)
+            except Exception as e:
+                logging.info("Exception occurred ==> %s" % e)
+
+        else:
+            self.delete(self.ip())
         self.post_configure(address)
 
     def post_configure(self, address):
@@ -602,9 +610,8 @@ class CsIP:
             if self.dev in bag.keys():
                 for address in bag[self.dev]:
                     self.setAddress(address)
-                    if self.hasIP(ip):
-                        found = True
-                    if self.is_guest_gateway(address, ip):
+                    if (self.hasIP(ip) or self.is_guest_gateway(address, ip)) and addess["add"]:
+                        logging.debig("The IP address in '%s' will be configured" % address)
                         found = True
             if not found:
                 self.delete(ip)
@@ -620,7 +627,7 @@ class CsIP:
 
         gw = interface.get_gateway()
         logging.info("Interface has the following gateway ==> %s", gw)
-        
+
         if bag['nw_type'] == "guest" and rip == gw:
             return True
         return False

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
@@ -27,17 +27,18 @@ def merge(dbag, ip):
         for address in dbag[dev]:
             if address['public_ip'] == ip['public_ip']:
                 dbag[dev].remove(address)
-    if ip['add']:
-        ipo = IPNetwork(ip['public_ip'] + '/' + ip['netmask'])
-        ip['device'] = 'eth' + str(ip['nic_dev_id'])
-        ip['broadcast'] = str(ipo.broadcast)
-        ip['cidr'] = str(ipo.ip) + '/' + str(ipo.prefixlen)
-        ip['size'] = str(ipo.prefixlen)
-        ip['network'] = str(ipo.network) + '/' + str(ipo.prefixlen)
-        if 'nw_type' not in ip.keys():
-            ip['nw_type'] = 'public'
-        if ip['nw_type'] == 'control':
-            dbag['eth' + str(ip['nic_dev_id'])] = [ip]
-        else:
-            dbag.setdefault('eth' + str(ip['nic_dev_id']), []).append(ip)
+
+    ipo = IPNetwork(ip['public_ip'] + '/' + ip['netmask'])
+    ip['device'] = 'eth' + str(ip['nic_dev_id'])
+    ip['broadcast'] = str(ipo.broadcast)
+    ip['cidr'] = str(ipo.ip) + '/' + str(ipo.prefixlen)
+    ip['size'] = str(ipo.prefixlen)
+    ip['network'] = str(ipo.network) + '/' + str(ipo.prefixlen)
+    if 'nw_type' not in ip.keys():
+        ip['nw_type'] = 'public'
+    if ip['nw_type'] == 'control':
+        dbag['eth' + str(ip['nic_dev_id'])] = [ip]
+    else:
+        dbag.setdefault('eth' + str(ip['nic_dev_id']), []).append(ip)
+
     return dbag

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -1177,7 +1177,7 @@ class TestRouterRules(cloudstackTestCase):
             )
         return
 
-    def removeNetworkRules(self, rule, ipaddressobj):
+    def removeNetworkRules(self, rule):
         """ Remove specified rule on acquired public IP and
         default network of virtual machine
         """
@@ -1186,14 +1186,15 @@ class TestRouterRules(cloudstackTestCase):
         if rule == STATIC_NAT_RULE:
             StaticNATRule.disable(
                 self.apiclient,
-                ipaddressobj.ipaddress.id)
+                self.ipaddress.ipaddress.id)
 
         elif rule == LB_RULE:
             self.lb_rule.delete(self.apiclient)
         else:
             self.nat_rule.delete(self.apiclient)
 
-        ipaddressobj.delete(self.apiclient)
+        logger.debug("Releasing IP %s from account %s" % (self.ipaddress.ipaddress.ipaddress, self.account.name))
+        self.ipaddress.delete(self.apiclient)
 
         return
 
@@ -1213,7 +1214,6 @@ class TestRouterRules(cloudstackTestCase):
             domainid=self.account.domainid,
             networkid=self.defaultNetworkId
         )
-        self.cleanup.append(self.ipaddress)
 
         self.createNetworkRules(rule=value,
                                 ipaddressobj=self.ipaddress,
@@ -1247,7 +1247,7 @@ class TestRouterRules(cloudstackTestCase):
         # 1. listIpForwardingRules should not return the deleted rule anymore
         # 2. attempt to do ssh should now fail
 
-        self.removeNetworkRules(rule=value, ipaddressobj=self.ipaddress)
+        self.removeNetworkRules(rule=value)
 
         response = self.getCommandResultFromRouter(router, "ip addr")
         logger.debug(response)


### PR DESCRIPTION
This PR fixes the Public IP removal form the virtual routers. It also improves the existing test_network.py.