### PR TITLE
[4.5] CLOUDSTACK-8999: Don't override resource if provided by agent.properties

### DIFF
--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -678,7 +678,8 @@ class cloudAgentConfig(serviceCfgBase):
             cfo.addEntry("guid", str(self.syscfg.env.uuid))
             if cfo.getEntry("local.storage.uuid") == "":
                 cfo.addEntry("local.storage.uuid", str(bash("uuidgen").getStdout()))
-            cfo.addEntry("resource", "com.cloud.hypervisor.kvm.resource.LibvirtComputingResource")
+            if cfo.getEntry("resource") == "":
+                cfo.addEntry("resource", "com.cloud.hypervisor.kvm.resource.LibvirtComputingResource")
             cfo.save()
 
             self.syscfg.svo.stopService("cloudstack-agent")


### PR DESCRIPTION
If a custom resource (kvm/libvirt implementation) is defined in agent.properties
don't override with the default, but check and fallback to the default if
resource property not defined

A simple if-else fix, cc @remibergsma @wido @wilderrodrigues @borisroman and others