### PR TITLE
[4.5] CLOUDSTACK-9000: logrotate cloudstack-agent out and err logs

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -92,6 +92,12 @@
                     </filterreader>
                   </filterchain>
                 </copy>
+                <copy
+                  todir="${basedir}/target/transformed">
+                  <fileset dir="${basedir}/conf">
+                    <include name="cloudstack-agent.logrotate" />
+                  </fileset>
+                </copy>
               </target>
             </configuration>
           </execution>

--- a/debian/cloudstack-agent.install
+++ b/debian/cloudstack-agent.install
@@ -19,6 +19,7 @@
 /etc/cloudstack/agent/environment.properties
 /etc/cloudstack/agent/log4j-cloud.xml
 /etc/profile.d/cloudstack-agent-profile.sh
+/etc/logrotate.d/cloudstack-agent
 /etc/init.d/cloudstack-agent
 /usr/bin/cloudstack-setup-agent
 /usr/bin/cloudstack-ssh

--- a/debian/rules
+++ b/debian/rules
@@ -74,6 +74,7 @@ install:
 	install -D agent/target/transformed/cloud-setup-agent $(DESTDIR)/usr/bin/cloudstack-setup-agent
 	install -D agent/target/transformed/cloud-ssh $(DESTDIR)/usr/bin/cloudstack-ssh
 	install -D agent/target/transformed/cloudstack-agent-profile.sh $(DESTDIR)/$(SYSCONFDIR)/profile.d/cloudstack-agent-profile.sh
+	install -D agent/target/transformed/cloudstack-agent.logrotate $(DESTDIR)/$(SYSCONFDIR)/logrotate.d/cloudstack-agent
 	install -D agent/target/transformed/cloudstack-agent-upgrade $(DESTDIR)/usr/bin/cloudstack-agent-upgrade
 	install -D agent/target/transformed/libvirtqemuhook $(DESTDIR)/usr/share/$(PACKAGE)-agent/lib/
 	install -D agent/target/transformed/* $(DESTDIR)/$(SYSCONFDIR)/$(PACKAGE)/agent

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -347,7 +347,7 @@ install -D agent/target/transformed/cloudstack-agent-upgrade ${RPM_BUILD_ROOT}%{
 install -D agent/target/transformed/libvirtqemuhook ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib/libvirtqemuhook
 install -D agent/target/transformed/cloud-ssh ${RPM_BUILD_ROOT}%{_bindir}/%{name}-ssh
 install -D agent/target/transformed/cloudstack-agent-profile.sh ${RPM_BUILD_ROOT}%{_sysconfdir}/profile.d/%{name}-agent-profile.sh
-install -D agent/target/transformed/cloudstack-agent.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/cloudstack-agent
+install -D agent/target/transformed/cloudstack-agent.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-agent
 install -D plugins/hypervisors/kvm/target/cloud-plugin-hypervisor-kvm-%{_maventag}.jar ${RPM_BUILD_ROOT}%{_datadir}/%name-agent/lib/cloud-plugin-hypervisor-kvm-%{_maventag}.jar
 cp plugins/hypervisors/kvm/target/dependencies/*  ${RPM_BUILD_ROOT}%{_datadir}/%{name}-agent/lib
 
@@ -652,6 +652,7 @@ fi
 %attr(0755,root,root) %{_bindir}/%{name}-ssh
 %attr(0755,root,root) %{_sysconfdir}/init.d/%{name}-agent
 %attr(0644,root,root) %{_sysconfdir}/profile.d/%{name}-agent-profile.sh
+%attr(0644,root,root) %{_sysconfdir}/logrotate.d/%{name}-agent
 %attr(0755,root,root) %{_datadir}/%{name}-common/scripts/network/cisco
 %config(noreplace) %{_sysconfdir}/%{name}/agent
 %dir %{_localstatedir}/log/%{name}/agent


### PR DESCRIPTION
Adds logrotate rules for cloudstack-agent.{err,out} log files

cc @remibergsma @wido @wilderrodrigues and others