### PR TITLE
CLOUDSTACK-9001: Modifying snapshot results validation 

### DIFF
--- a/test/integration/testpaths/testpath_uuid_event.py
+++ b/test/integration/testpaths/testpath_uuid_event.py
@@ -167,9 +167,15 @@ class TestVerifyEventsTable(cloudstackTestCase):
             self.apiclient,
             root_volume.id)
 
-        self.assertNotEqual(
-            len(snapshot),
-            0,
+        snapshots_list = Snapshot.list(self.userapiclient,
+                                        id=snapshot.id)
+
+        status = validateList(snapshots_list)
+        self.assertEqual(status[0], PASS, "Snapshots List Validation Failed")
+
+        self.assertEqual(
+            snapshot.state,
+            "BackedUp",
             "Check if snapshot gets created properly"
         )
 


### PR DESCRIPTION
Currently snapshots results validation is based on length of snapshot result but if snapshot creation fails then None type object will not have "len" attribute hence modifying the validation.