### PR TITLE
CLOUDSTACk-9002: VM deployment is successful even when dhcp entry com…

### DIFF
--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -744,7 +744,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
                         Pair<NicProfile, Integer> vmNicPair = allocateNic(requested, config, isDefaultNic, deviceId, vm);
                         NicProfile vmNic = null;
-                        if(vmNicPair != null) {
+                        if (vmNicPair != null) {
                             vmNic = vmNicPair.first();
                             if (vmNic == null) {
                                 continue;
@@ -1244,12 +1244,16 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                         return false;
                     }
                 }
-                sp.addDhcpEntry(network, profile, vmProfile, dest, context);
+                if(!sp.addDhcpEntry(network, profile, vmProfile, dest, context)) {
+                    return false;
+                }
             }
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.UserData)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.UserData, element.getProvider()) && element instanceof UserDataServiceProvider) {
                 UserDataServiceProvider sp = (UserDataServiceProvider)element;
-                sp.addPasswordAndUserdata(network, profile, vmProfile, dest, context);
+                if(!sp.addPasswordAndUserdata(network, profile, vmProfile, dest, context)){
+                    return false;
+                }
             }
         }
         return true;

--- a/server/src/org/apache/cloudstack/network/topology/BasicNetworkTopology.java
+++ b/server/src/org/apache/cloudstack/network/topology/BasicNetworkTopology.java
@@ -384,8 +384,7 @@ public class BasicNetworkTopology implements NetworkTopology {
                 }
 
                 try {
-                    ruleApplier.accept(getVisitor(), router);
-
+                    result = ruleApplier.accept(getVisitor(), router);
                     connectedRouters.add(router);
                 } catch (final AgentUnavailableException e) {
                     s_logger.warn(msg + router.getInstanceName(), e);


### PR DESCRIPTION
…mand fails - Fixed

Reason: The return value of the call to accept() function in the applyRules() function of BasicNetworkTopology.java was not checked for success or failure. As a result even if it fails, exception was not thrown and VM deployment went ahead without any errors. 

Fix: Added the necessary checks. 