### PR TITLE
[4.6] CLOUDSTACK-8984: VPC Network offerings tab missing from UI

### DIFF
--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -28,7 +28,7 @@
         sectionSelect: {
             preFilter: function(args) {
                if(isAdmin())
-                   return ["serviceOfferings", "systemServiceOfferings", "diskOfferings", "networkOfferings"];
+                   return ["serviceOfferings", "systemServiceOfferings", "diskOfferings", "networkOfferings", "vpcOfferings"];
                else if(isDomainAdmin())
                    return ["serviceOfferings", "diskOfferings"];
                else


### PR DESCRIPTION
This is a regression from commit af2f21894ce061faadc8cec29b901719303a29dc

added vpcofferings to the select list

Before the change (from the bug):
![offerings_46](https://cloud.githubusercontent.com/assets/186833/10781847/34ae9bc4-7d71-11e5-8159-b90422ef34f6.png)

After the change:
![screen shot 2015-10-28 at 12 32 59 pm](https://cloud.githubusercontent.com/assets/186833/10781850/3ef96500-7d71-11e5-84c5-34589ec10bf9.png)
