### PR TITLE
squashed commit for dockerfiles part#2 including comments from PR#910

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -52,7 +52,8 @@ RUN (/usr/bin/mysqld_safe &); \
     sleep 3; \
     mvn -Pdeveloper -pl developer -Ddeploydb; \
     mvn -Pdeveloper -pl developer -Ddeploydb-simulator; \
-    pip install tools/marvin/dist/Marvin-4.6.0-SNAPSHOT.tar.gz
+    MARVIN_FILE=`find tools/marvin/dist/ -name "Marvin*.tar.gz"` \
+    pip install $MARVIN_FILE
 
 EXPOSE 8080 8096
 

--- a/tools/docker/Dockerfile.centos6
+++ b/tools/docker/Dockerfile.centos6
@@ -23,15 +23,19 @@ LABEL Vendor="Apache.org" License="ApacheV2" Version="4.6.0"
 ENV PKG_URL=http://jenkins.buildacloud.org/job/package-rhel63-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64
 
 # install CloudStack
-RUN yum install -y \
+RUN yum install -y nc wget \
     ${PKG_URL}/cloudstack-common-4.6.0-SNAPSHOT.el6.x86_64.rpm \
     ${PKG_URL}/cloudstack-management-4.6.0-SNAPSHOT.el6.x86_64.rpm
 
 RUN cd /etc/cloudstack/management; \
     ln -s tomcat6-nonssl.conf tomcat6.conf; \
     ln -s server-nonssl.xml server.xml; \
-    ln -s log4j-cloud.xml log4j.xml
+    ln -s log4j-cloud.xml log4j.xml; \
+    wget -O /usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util \
+    http://download.cloud.com.s3.amazonaws.com/tools/vhd-util
+
 COPY init.sh_centos6 /root/init.sh
+COPY systemtpl.sh /root/systemtpl.sh
 
 RUN yum clean all
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -81,6 +81,7 @@ tag:latest = master branch
    docker commit -m "init system.iso" -a "Apache CloudStack" cloudstack cloudstack/management_centos6
    ```
 
+
 ### Marvin
 
 Build Marvin container usable to deploy cloud in the CloudStack management server container.

--- a/tools/docker/init.sh_centos6
+++ b/tools/docker/init.sh_centos6
@@ -17,27 +17,41 @@
 # under the License.
 #
 # update database connection
+# /usr/bin/cloudstack-setup-databases cloud:password@$MYSQL_PORT_3306_TCP_ADDR
 # start cloudstack-management server
-#/usr/bin/cloudstack-setup-databases cloud:password@$MYSQL_PORT_3306_TCP_ADDR
 
 # initial startup of the container to generage ssh_key
 # performed as privileged
 if [ ! -d /var/cloudstack/management/.ssh ]; then
 	mknod /dev/loop6 -m0660 b 7 6
 fi
-sleep 5
 
-mysql -p"$MYSQL_ENV_MYSQL_ROOT_PASSWORD" -h"$MYSQL_PORT_3306_TCP_ADDR" \
+# if global setting are changed, it will restart the management server
+RESTART_REQUIRED=false
+
+if [ ! $MYSQL_PORT_3306_TCP_ADDR ]; then
+	echo "variable MYSQL_PORT_3306_TCP_ADDR not define"
+	exit 12
+fi
+
+until nc -z $MYSQL_PORT_3306_TCP_ADDR 3306; do
+    echo "waiting for mysql-server..."
+    sleep 1
+done
+
+mysql -p"$MYSQL_ENV_MYSQL_ROOT_PASSWORD" -h "$MYSQL_PORT_3306_TCP_ADDR" \
    -e "show databases;"|grep -q cloud
 
 case $? in
   1)
 	echo "deploying new cloud databases"
+	INITIATED=false
 	cloudstack-setup-databases cloud:password@${MYSQL_PORT_3306_TCP_ADDR} \
 	--deploy-as=root:${MYSQL_ENV_MYSQL_ROOT_PASSWORD} -i localhost
     ;;
   0)
 	echo "using existing databases"
+	INITIATED=true
 	cloudstack-setup-databases cloud:password@${MYSQL_PORT_3306_TCP_ADDR}
     ;;
   *)
@@ -47,4 +61,27 @@ case $? in
 esac
 
 service cloudstack-management start
-tail -f /var/log/cloudstack/management/catalina.out
+sleep 10
+
+if [ $HYPERVISOR_TEMPLATE ]; then
+	#download the systemvm template into /exports
+	/root/systemtpl.sh $HYPERVISOR_TEMPLATE
+fi
+
+if [ $CLOUDSTACK_HOST ]; then
+	mysql -u root -p${MYSQL_ENV_MYSQL_ROOT_PASSWORD} -h ${MYSQL_PORT_3306_TCP_ADDR} -e \
+	"UPDATE cloud.configuration SET value='${CLOUDSTACK_HOST}' where name = 'host';"
+	RESTART_REQUIRED=true
+fi
+
+if [ $DEV_API ] && [ $INITIATED == false ]; then
+	mysql -u root -p${MYSQL_ENV_MYSQL_ROOT_PASSWORD} -h ${MYSQL_PORT_3306_TCP_ADDR} -e \
+	"UPDATE cloud.configuration SET value='8096' where name = 'integration.api.port';"
+	mysql -u root -p${MYSQL_ENV_MYSQL_ROOT_PASSWORD} -h ${MYSQL_PORT_3306_TCP_ADDR} -e \
+	"UPDATE cloud.configuration SET value='true' where name = 'system.vm.use.local.storage';"
+	RESTART_REQUIRED=true
+fi
+
+[ $RESTART_REQUIRED == true ] && service cloudstack-management restart
+
+tail -f /var/log/cloudstack/management/management-server.log

--- a/tools/docker/systemtpl.sh
+++ b/tools/docker/systemtpl.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#set -x
+
+usage() {
+  echo "Usage:"
+  echo "  `basename $0`: <hypervisor>"
+  echo "  `basename $0`: {xenserver, kvm, vmware, lxc, ovm}"
+  exit 2
+}
+
+[ $# -lt 1 ] && usage
+
+
+HYPERVISOR=$1
+
+INSTALL_SYS_TMPLT=/usr/share/cloudstack-common/scripts/storage/secondary/cloud-install-sys-tmplt
+EXPORT_PATH=/exports/secondary
+
+if [ ! -d ${EXPORT_PATH} ]; then
+	echo "ERROR: Secondary Storage path '${EXPORT_PATH}' not found."
+	exit 3
+fi
+
+URL="http://jenkins.buildacloud.org/job/build-systemvm64-master/lastSuccessfulBuild/artifact/tools/appliance/dist"
+case $HYPERVISOR in
+ 	kvm)
+		TO_DOWNLOAD=${URL}/systemvm64template-master-4.6.0-kvm.qcow2.bz2
+		;;
+	xenserver)
+		TO_DOWNLOAD=${URL}/systemvm64template-master-4.6.0-xen.vhd.bz2
+		;;
+	vmware)
+		TO_DOWNLOAD=${URL}/systemvm64template-master-4.6.0-vmware.ova
+		;;
+	lxc)
+		TO_DOWNLOAD=${URL}/systemvm64template-master-4.6.0-kvm.qcow2.bz2
+		;;
+	ovm)
+		TO_DOWNLOAD=${URL}/systemvm64template-master-4.6.0-ovm.raw.bz2
+		;;
+	*)
+		echo "ERROR: hypervisor not found"
+		exit 4
+		;;
+esac
+
+${INSTALL_SYS_TMPLT} -m ${EXPORT_PATH} -u ${TO_DOWNLOAD} -h $HYPERVISOR
+
+exit 0


### PR DESCRIPTION
This PR replace PR#910 which include fix from comments in PR#910.

This PR simplify download of systemvm templates, work with docker-compose and enable integration-api port and use of localstorage without reconfiguration of cloudstack.

Rebased on Oct28.