### PR TITLE
[4.6/master] ui/instances: show IP address of the VM on the instances page

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -166,12 +166,11 @@
                 instancename: {
                     label: 'label.internal.name'
                 },
-                displayname: {
-                    label: 'label.display.name',
-                    truncate: true
-                },
                 zonename: {
                     label: 'label.zone.name'
+                },
+                ipaddress: {
+                    label: 'label.ip.address'
                 },
                 state: {
                     label: 'label.state',
@@ -381,6 +380,11 @@
                     data: data,
                     success: function(json) {
                         var items = json.listvirtualmachinesresponse.virtualmachine;
+                        $.each(items, function(idx, vm) {
+                            if (vm.nic.length > 0) {
+                                items[idx].ipaddress = vm.nic[0].ipaddress;
+                            }
+                        });
                         args.response.success({
                             data: items
                         });


### PR DESCRIPTION
The UI hides information regarding the IP address of the VM instance in its
detail view, the patch add the IP address column and removes the redundant
display name column.

cc @remibergsma @karuturi @wido @wilderrodrigues @NuxRo

![screenshot from 2015-10-29 16-24-38](https://cloud.githubusercontent.com/assets/95203/10816559/a752edae-7e59-11e5-92ea-52ff1e5981ea.png)
