### PR TITLE
[4.5] ui/instances: show IP address of the VM on the instances page

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -160,12 +160,11 @@
                 instancename: {
                     label: 'label.internal.name'
                 },
-                displayname: {
-                    label: 'label.display.name',
-                    truncate: true
-                },
                 zonename: {
                     label: 'label.zone.name'
+                },
+                ipaddress: {
+                    label: 'label.ip.address'
                 },
                 state: {
                     label: 'label.state',
@@ -355,6 +354,11 @@
                     data: data,
                     success: function(json) {
                         var items = json.listvirtualmachinesresponse.virtualmachine;
+                        $.each(items, function(idx, vm) {
+                            if (vm.nic.length > 0) {
+                                items[idx].ipaddress = vm.nic[0].ipaddress;
+                            }
+                        });
                         args.response.success({
                             data: items
                         });


### PR DESCRIPTION
The UI hides information regarding the IP address of the VM instance in its
detail view, the patch add the IP address column and removes the redundant
display name column.

See #1003 for screenshot