### PR TITLE
Fixed user_vm_view to only display keypairs belonging to the account.

### DIFF
--- a/setup/db/db/schema-452to460.sql
+++ b/setup/db/db/schema-452to460.sql
@@ -335,7 +335,7 @@ CREATE VIEW `cloud`.`user_vm_view` AS
         `cloud`.`user_vm_details` as ssh_details ON ssh_details.vm_id = vm_instance.id
             and ssh_details.name = 'SSH.PublicKey'
             left join
-        `cloud`.`ssh_keypairs` ON ssh_keypairs.public_key = ssh_details.value
+        `cloud`.`ssh_keypairs` ON ssh_keypairs.public_key = ssh_details.value AND ssh_keypairs.account_id = account.id
             left join
         `cloud`.`resource_tags` ON resource_tags.resource_id = vm_instance.id
             and resource_tags.resource_type = 'UserVm'


### PR DESCRIPTION
The user_vm_view displayes the keypair information by joining vm_details with ssh_keypairs on the key value exclusively. 

We found a scenario in which this can cause information leakage. If there are two accounts using the same key, but create a different key name for it, and then a vm is created using one of the keys, the view will list both keypairs as belonging to the vm, which can in turn cause confusion to the users who see a keypair name which they did not create. 

The fix simply limits the view to displaying keypairs which belong to vm's account. 

I added it to the latest schema migration only; should I also include it in the previous ones? 