### PR TITLE
[4.7] CLOUDSTACK-8958: add dedicated ips to domain (account for now)

### DIFF
--- a/api/src/com/cloud/configuration/ConfigurationService.java
+++ b/api/src/com/cloud/configuration/ConfigurationService.java
@@ -48,6 +48,7 @@ import org.apache.cloudstack.region.PortableIpRange;
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.Pod;
 import com.cloud.dc.Vlan;
+import com.cloud.domain.Domain;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.InvalidParameterValueException;
@@ -254,6 +255,8 @@ public interface ConfigurationService {
     boolean deleteNetworkOffering(DeleteNetworkOfferingCmd cmd);
 
     Account getVlanAccount(long vlanId);
+
+    Domain getVlanDomain(long vlanId);
 
     List<? extends NetworkOffering> listNetworkOfferings(TrafficType trafficType, boolean systemOnly);
 

--- a/api/src/org/apache/cloudstack/api/command/admin/vlan/DedicatePublicIpRangeCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/vlan/DedicatePublicIpRangeCmd.java
@@ -47,7 +47,7 @@ public class DedicatePublicIpRangeCmd extends BaseCmd {
     @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = VlanIpRangeResponse.class, required = true, description = "the id of the VLAN IP range")
     private Long id;
 
-    @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, required = true, description = "account who will own the VLAN")
+    @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, description = "account who will own the VLAN")
     private String accountName;
 
     @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "project who will own the VLAN")

--- a/engine/components-api/src/com/cloud/configuration/ConfigurationManager.java
+++ b/engine/components-api/src/com/cloud/configuration/ConfigurationManager.java
@@ -26,6 +26,7 @@ import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.HostPodVO;
 import com.cloud.dc.Pod;
 import com.cloud.dc.Vlan;
+import com.cloud.domain.Domain;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.InvalidParameterValueException;
@@ -213,7 +214,7 @@ public interface ConfigurationManager {
         Map<NetworkOffering.Detail, String> details, boolean egressDefaultPolicy, Integer maxconn, boolean enableKeepAlive);
 
     Vlan createVlanAndPublicIpRange(long zoneId, long networkId, long physicalNetworkId, boolean forVirtualNetwork, Long podId, String startIP, String endIP,
-        String vlanGateway, String vlanNetmask, String vlanId, Account vlanOwner, String startIPv6, String endIPv6, String vlanIp6Gateway, String vlanIp6Cidr)
+        String vlanGateway, String vlanNetmask, String vlanId, Domain domain, Account vlanOwner, String startIPv6, String endIPv6, String vlanIp6Gateway, String vlanIp6Cidr)
         throws InsufficientCapacityException, ConcurrentOperationException, InvalidParameterValueException;
 
     void createDefaultSystemNetworks(long zoneId) throws ConcurrentOperationException;

--- a/engine/schema/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -140,6 +140,7 @@
   <bean id="dataCenterLinkLocalIpAddressDaoImpl" class="com.cloud.dc.dao.DataCenterLinkLocalIpAddressDaoImpl" />
   <bean id="dataCenterVnetDaoImpl" class="com.cloud.dc.dao.DataCenterVnetDaoImpl" />
   <bean id="dataCenterDetailsDaoImpl" class="com.cloud.dc.dao.DataCenterDetailsDaoImpl" />
+  <bean id="domainVlanMapDaoImpl" class="com.cloud.dc.dao.DomainVlanMapDaoImpl" />
   <bean id="engineDcDetailsDaoImpl" class="org.apache.cloudstack.engine.datacenter.entity.api.db.dao.DcDetailsDaoImpl" />
   <bean id="diskOfferingJoinDaoImpl" class="com.cloud.api.query.dao.DiskOfferingJoinDaoImpl" />
   <bean id="domainDaoImpl" class="com.cloud.domain.dao.DomainDaoImpl" />

--- a/engine/schema/src/com/cloud/dc/DomainVlanMapVO.java
+++ b/engine/schema/src/com/cloud/dc/DomainVlanMapVO.java
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.dc;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.apache.cloudstack.api.InternalIdentity;
+
+@Entity
+@Table(name="domain_vlan_map")
+public class DomainVlanMapVO implements InternalIdentity {
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    @Column(name="id")
+    private long id;
+
+    @Column(name="domain_id")
+    private long domainId;
+
+    @Column(name="vlan_db_id")
+    private long vlanDbId;
+
+    public DomainVlanMapVO(long domainId, long vlanDbId) {
+        this.domainId = domainId;
+        this.vlanDbId = vlanDbId;
+    }
+
+    public DomainVlanMapVO() {
+
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getDomainId() {
+        return domainId;
+    }
+
+    public long getVlanDbId() {
+        return vlanDbId;
+    }
+}

--- a/engine/schema/src/com/cloud/dc/dao/DomainVlanMapDao.java
+++ b/engine/schema/src/com/cloud/dc/dao/DomainVlanMapDao.java
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.dc.dao;
+
+import java.util.List;
+
+import com.cloud.dc.DomainVlanMapVO;
+import com.cloud.utils.db.GenericDao;
+
+public interface DomainVlanMapDao extends GenericDao<DomainVlanMapVO, Long> {
+    public List<DomainVlanMapVO> listDomainVlanMapsByDomain(long domainId);
+    public List<DomainVlanMapVO> listDomainVlanMapsByVlan(long vlanDbId);
+    public DomainVlanMapVO findDomainVlanMap(long domainId, long vlanDbId);
+}

--- a/engine/schema/src/com/cloud/dc/dao/DomainVlanMapDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/DomainVlanMapDaoImpl.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.dc.dao;
+
+import java.util.List;
+
+import javax.ejb.Local;
+
+import org.springframework.stereotype.Component;
+
+import com.cloud.dc.DomainVlanMapVO;
+import com.cloud.utils.db.GenericDaoBase;
+import com.cloud.utils.db.SearchBuilder;
+import com.cloud.utils.db.SearchCriteria;
+
+@Component
+@Local(value={DomainVlanMapDao.class})
+public class DomainVlanMapDaoImpl extends GenericDaoBase<DomainVlanMapVO, Long> implements DomainVlanMapDao {
+    protected SearchBuilder<DomainVlanMapVO> DomainSearch;
+    protected SearchBuilder<DomainVlanMapVO> VlanSearch;
+    protected SearchBuilder<DomainVlanMapVO> DomainVlanSearch;
+
+    @Override
+    public List<DomainVlanMapVO> listDomainVlanMapsByDomain(long domainId) {
+            SearchCriteria<DomainVlanMapVO> sc = DomainSearch.create();
+            sc.setParameters("domainId", domainId);
+            return listIncludingRemovedBy(sc);
+    }
+
+    @Override
+    public List<DomainVlanMapVO> listDomainVlanMapsByVlan(long vlanDbId) {
+        SearchCriteria<DomainVlanMapVO> sc = VlanSearch.create();
+        sc.setParameters("vlanDbId", vlanDbId);
+        return listIncludingRemovedBy(sc);
+    }
+
+    @Override
+    public DomainVlanMapVO findDomainVlanMap(long domainId, long vlanDbId) {
+        SearchCriteria<DomainVlanMapVO> sc = DomainVlanSearch.create();
+        sc.setParameters("domainId", domainId);
+        sc.setParameters("vlanDbId", vlanDbId);
+        return findOneIncludingRemovedBy(sc);
+    }
+
+    public DomainVlanMapDaoImpl() {
+        DomainSearch = createSearchBuilder();
+        DomainSearch.and("domainId", DomainSearch.entity().getDomainId(), SearchCriteria.Op.EQ);
+        DomainSearch.done();
+
+        VlanSearch = createSearchBuilder();
+        VlanSearch.and("vlanDbId", VlanSearch.entity().getVlanDbId(), SearchCriteria.Op.EQ);
+        VlanSearch.done();
+
+        DomainVlanSearch = createSearchBuilder();
+        DomainVlanSearch.and("domainId", DomainVlanSearch.entity().getDomainId(), SearchCriteria.Op.EQ);
+        DomainVlanSearch.and("vlanDbId", DomainVlanSearch.entity().getVlanDbId(), SearchCriteria.Op.EQ);
+        DomainVlanSearch.done();
+    }
+
+}

--- a/engine/schema/src/com/cloud/dc/dao/VlanDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/VlanDaoImpl.java
@@ -30,6 +30,7 @@ import javax.naming.ConfigurationException;
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.AccountVlanMapVO;
+import com.cloud.dc.DomainVlanMapVO;
 import com.cloud.dc.PodVlanMapVO;
 import com.cloud.dc.Vlan;
 import com.cloud.dc.Vlan.VlanType;
@@ -64,11 +65,14 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
     protected SearchBuilder<VlanVO> DedicatedVlanSearch;
 
     protected SearchBuilder<AccountVlanMapVO> AccountVlanMapSearch;
+    protected SearchBuilder<DomainVlanMapVO> DomainVlanMapSearch;
 
     @Inject
     protected PodVlanMapDao _podVlanMapDao;
     @Inject
     protected AccountVlanMapDao _accountVlanMapDao;
+    @Inject
+    protected DomainVlanMapDao _domainVlanMapDao;
     @Inject
     protected IPAddressDao _ipAddressDao;
 
@@ -216,8 +220,12 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
         AccountVlanMapSearch.and("accountId", AccountVlanMapSearch.entity().getAccountId(), SearchCriteria.Op.NULL);
         ZoneWideNonDedicatedVlanSearch.join("AccountVlanMapSearch", AccountVlanMapSearch, ZoneWideNonDedicatedVlanSearch.entity().getId(), AccountVlanMapSearch.entity()
             .getVlanDbId(), JoinBuilder.JoinType.LEFTOUTER);
+        DomainVlanMapSearch = _domainVlanMapDao.createSearchBuilder();
+        DomainVlanMapSearch.and("domainId", DomainVlanMapSearch.entity().getDomainId(), SearchCriteria.Op.NULL);
+        ZoneWideNonDedicatedVlanSearch.join("DomainVlanMapSearch", DomainVlanMapSearch, ZoneWideNonDedicatedVlanSearch.entity().getId(), DomainVlanMapSearch.entity().getVlanDbId(), JoinBuilder.JoinType.LEFTOUTER);
         ZoneWideNonDedicatedVlanSearch.done();
         AccountVlanMapSearch.done();
+        DomainVlanMapSearch.done();
 
         DedicatedVlanSearch = createSearchBuilder();
         AccountVlanMapSearch = _accountVlanMapDao.createSearchBuilder();

--- a/server/src/com/cloud/api/ApiDBUtils.java
+++ b/server/src/com/cloud/api/ApiDBUtils.java
@@ -139,6 +139,7 @@ import com.cloud.dc.dao.ClusterDao;
 import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.dc.dao.HostPodDao;
 import com.cloud.dc.dao.VlanDao;
+import com.cloud.domain.Domain;
 import com.cloud.domain.DomainVO;
 import com.cloud.domain.dao.DomainDao;
 import com.cloud.event.Event;
@@ -1243,6 +1244,10 @@ public class ApiDBUtils {
 
     public static Account getVlanAccount(long vlanId) {
         return s_configSvc.getVlanAccount(vlanId);
+    }
+
+    public static Domain getVlanDomain(long vlanId) {
+        return s_configSvc.getVlanDomain(vlanId);
     }
 
     public static boolean isSecurityGroupEnabledInZone(long zoneId) {

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -666,6 +666,21 @@ public class ApiResponseHelper implements ResponseGenerator {
         if (owner != null) {
             populateAccount(vlanResponse, owner.getId());
             populateDomain(vlanResponse, owner.getDomainId());
+        } else {
+            Domain domain = ApiDBUtils.getVlanDomain(vlan.getId());
+            if (domain != null) {
+                populateDomain(vlanResponse, domain.getId());
+            } else {
+                Long networkId = vlan.getNetworkId();
+                if (networkId != null) {
+                    Network network = _ntwkModel.getNetwork(networkId);
+                    if (network != null) {
+                        Long accountId = network.getAccountId();
+                        populateAccount(vlanResponse, accountId);
+                        populateDomain(vlanResponse, ApiDBUtils.findAccountById(accountId).getDomainId());
+                    }
+                }
+            }
         }
 
         if (vlan.getPhysicalNetworkId() != null) {

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -2618,6 +2618,9 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
 
             vlanOwner = _accountMgr.getAccount(project.getProjectAccountId());
+            if (vlanOwner == null) {
+                throw new InvalidParameterValueException("Please specify a valid projectId");
+            }
         }
 
         Domain domain = null;
@@ -3329,6 +3332,9 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 throw new InvalidParameterValueException("Unable to find project by id " + projectId);
             }
             vlanOwner = _accountMgr.getAccount(project.getProjectAccountId());
+            if (vlanOwner == null) {
+                throw new InvalidParameterValueException("Please specify a valid projectId");
+            }
         }
 
         Domain domain = null;

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -101,6 +101,7 @@ import com.cloud.dc.DataCenterIpAddressVO;
 import com.cloud.dc.DataCenterLinkLocalIpAddressVO;
 import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.DedicatedResourceVO;
+import com.cloud.dc.DomainVlanMapVO;
 import com.cloud.dc.HostPodVO;
 import com.cloud.dc.Pod;
 import com.cloud.dc.PodVlanMapVO;
@@ -114,6 +115,7 @@ import com.cloud.dc.dao.DataCenterDetailsDao;
 import com.cloud.dc.dao.DataCenterIpAddressDao;
 import com.cloud.dc.dao.DataCenterLinkLocalIpAddressDao;
 import com.cloud.dc.dao.DedicatedResourceDao;
+import com.cloud.dc.dao.DomainVlanMapDao;
 import com.cloud.dc.dao.HostPodDao;
 import com.cloud.dc.dao.PodVlanMapDao;
 import com.cloud.dc.dao.VlanDao;
@@ -238,6 +240,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     //VmwareDatacenterZoneMapDao _vmwareDatacenterZoneMapDao;
     @Inject
     AccountVlanMapDao _accountVlanMapDao;
+    @Inject
+    DomainVlanMapDao _domainVlanMapDao;
     @Inject
     PodVlanMapDao _podVlanMapDao;
     @Inject
@@ -2616,6 +2620,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             vlanOwner = _accountMgr.getAccount(project.getProjectAccountId());
         }
 
+        Domain domain = null;
         if (accountName != null && domainId != null) {
             vlanOwner = _accountDao.findActiveAccount(accountName, domainId);
             if (vlanOwner == null) {
@@ -2623,6 +2628,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             } else if (vlanOwner.getId() == Account.ACCOUNT_ID_SYSTEM) {
                 // by default vlan is dedicated to system account
                 vlanOwner = null;
+            }
+        } else if (domainId != null) {
+            domain = _domainDao.findById(domainId);
+            if (domain == null) {
+                throw new InvalidParameterValueException("Please specify a valid domain id");
             }
         }
 
@@ -2782,12 +2792,12 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         return commitVlan(zoneId, podId, startIP, endIP, newVlanGateway, newVlanNetmask, vlanId, forVirtualNetwork, networkId, physicalNetworkId, startIPv6, endIPv6, ip6Gateway,
-                ip6Cidr, vlanOwner, network, sameSubnet);
+                ip6Cidr, domain, vlanOwner, network, sameSubnet);
     }
 
     private Vlan commitVlan(final Long zoneId, final Long podId, final String startIP, final String endIP, final String newVlanGatewayFinal, final String newVlanNetmaskFinal,
             final String vlanId, final Boolean forVirtualNetwork, final Long networkId, final Long physicalNetworkId, final String startIPv6, final String endIPv6,
-            final String ip6Gateway, final String ip6Cidr, final Account vlanOwner, final Network network, final Pair<Boolean, Pair<String, String>> sameSubnet) {
+            final String ip6Gateway, final String ip6Cidr, final Domain domain, final Account vlanOwner, final Network network, final Pair<Boolean, Pair<String, String>> sameSubnet) {
         return Transaction.execute(new TransactionCallback<Vlan>() {
             @Override
             public Vlan doInTransaction(final TransactionStatus status) {
@@ -2811,7 +2821,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     newVlanNetmask = sameSubnet.second().second();
                 }
                 final Vlan vlan = createVlanAndPublicIpRange(zoneId, networkId, physicalNetworkId, forVirtualNetwork, podId, startIP, endIP, newVlanGateway, newVlanNetmask, vlanId,
-                        vlanOwner, startIPv6, endIPv6, ip6Gateway, ip6Cidr);
+                        domain, vlanOwner, startIPv6, endIPv6, ip6Gateway, ip6Cidr);
                 // create an entry in the nic_secondary table. This will be the new
                 // gateway that will be configured on the corresponding routervm.
                 return vlan;
@@ -2918,7 +2928,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @Override
     @DB
     public Vlan createVlanAndPublicIpRange(final long zoneId, final long networkId, final long physicalNetworkId, final boolean forVirtualNetwork, final Long podId, final String startIP, final String endIP,
-            final String vlanGateway, final String vlanNetmask, String vlanId, final Account vlanOwner, final String startIPv6, final String endIPv6, final String vlanIp6Gateway, final String vlanIp6Cidr) {
+            final String vlanGateway, final String vlanNetmask, String vlanId, Domain domain, final Account vlanOwner, final String startIPv6, final String endIPv6, final String vlanIp6Gateway, final String vlanIp6Cidr) {
         final Network network = _networkModel.getNetwork(networkId);
 
         boolean ipv4 = false, ipv6 = false;
@@ -2996,7 +3006,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         final VlanType vlanType = forVirtualNetwork ? VlanType.VirtualNetwork : VlanType.DirectAttached;
 
-        if (vlanOwner != null && zone.getNetworkType() != NetworkType.Advanced) {
+        if ((domain != null || vlanOwner != null) && zone.getNetworkType() != NetworkType.Advanced) {
             throw new InvalidParameterValueException("Vlan owner can be defined only in the zone of type " + NetworkType.Advanced);
         }
 
@@ -3150,14 +3160,14 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         // Everything was fine, so persist the VLAN
-        final VlanVO vlan = commitVlanAndIpRange(zoneId, networkId, physicalNetworkId, podId, startIP, endIP, vlanGateway, vlanNetmask, vlanId, vlanOwner, vlanIp6Gateway, vlanIp6Cidr,
+        final VlanVO vlan = commitVlanAndIpRange(zoneId, networkId, physicalNetworkId, podId, startIP, endIP, vlanGateway, vlanNetmask, vlanId, domain, vlanOwner, vlanIp6Gateway, vlanIp6Cidr,
                 ipv4, zone, vlanType, ipv6Range, ipRange);
 
         return vlan;
     }
 
     private VlanVO commitVlanAndIpRange(final long zoneId, final long networkId, final long physicalNetworkId, final Long podId, final String startIP, final String endIP,
-            final String vlanGateway, final String vlanNetmask, final String vlanId, final Account vlanOwner, final String vlanIp6Gateway, final String vlanIp6Cidr,
+            final String vlanGateway, final String vlanNetmask, final String vlanId, final Domain domain, final Account vlanOwner, final String vlanIp6Gateway, final String vlanIp6Cidr,
             final boolean ipv4, final DataCenterVO zone, final VlanType vlanType, final String ipv6Range, final String ipRange) {
         return Transaction.execute(new TransactionCallback<VlanVO>() {
             @Override
@@ -3189,6 +3199,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     }
                     // increment resource count for dedicated public ip's
                     _resourceLimitMgr.incrementResourceCount(vlanOwner.getId(), ResourceType.public_ip, new Long(ips.size()));
+                } else if (domain != null) {
+                    // This VLAN is domain-wide, so create a DomainVlanMapVO entry
+                    final DomainVlanMapVO domainVlanMapVO = new DomainVlanMapVO(domain.getId(), vlan.getId());
+                    _domainVlanMapDao.persist(domainVlanMapVO);
                 } else if (podId != null) {
                     // This VLAN is pod-wide, so create a PodVlanMapVO entry
                     final PodVlanMapVO podVlanMapVO = new PodVlanMapVO(podId, vlan.getId());
@@ -3214,6 +3228,13 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         // account_vlan_map.
         if (acctVln != null && !acctVln.isEmpty()) {
             isAccountSpecific = true;
+        }
+
+        boolean isDomainSpecific = false;
+        List<DomainVlanMapVO> domainVln = _domainVlanMapDao.listDomainVlanMapsByVlan(vlanRange.getId());
+        // Check for domain wide pool. It will have an entry for domain_vlan_map.
+        if (domainVln != null && !domainVln.isEmpty()) {
+            isDomainSpecific = true;
         }
 
         // Check if the VLAN has any allocated public IPs
@@ -3310,13 +3331,19 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             vlanOwner = _accountMgr.getAccount(project.getProjectAccountId());
         }
 
+        Domain domain = null;
         if (accountName != null && domainId != null) {
             vlanOwner = _accountDao.findActiveAccount(accountName, domainId);
-        }
-        if (vlanOwner == null) {
-            throw new InvalidParameterValueException("Unable to find account by name " + accountName);
-        } else if (vlanOwner.getId() == Account.ACCOUNT_ID_SYSTEM) {
-            throw new InvalidParameterValueException("Please specify a valid account. Cannot dedicate IP range to system account");
+            if (vlanOwner == null) {
+                throw new InvalidParameterValueException("Unable to find account by name " + accountName);
+            } else if (vlanOwner.getId() == Account.ACCOUNT_ID_SYSTEM) {
+                throw new InvalidParameterValueException("Please specify a valid account. Cannot dedicate IP range to system account");
+            }
+        } else if (domainId != null) {
+            domain = _domainDao.findById(domainId);
+            if (domain == null) {
+                throw new InvalidParameterValueException("Please specify a valid domain id");
+            }
         }
 
         // Check if range is valid
@@ -3331,6 +3358,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             throw new InvalidParameterValueException("Specified Public IP range has already been dedicated");
         }
 
+        List<DomainVlanMapVO> domainmaps = _domainVlanMapDao.listDomainVlanMapsByVlan(vlanDbId);
+        if (domainmaps != null && !domainmaps.isEmpty()) {
+            throw new InvalidParameterValueException("Specified Public IP range has already been dedicated to a domain");
+        }
+
         // Verify that zone exists and is advanced
         final Long zoneId = vlan.getDataCenterId();
         final DataCenterVO zone = _zoneDao.findById(zoneId);
@@ -3342,8 +3374,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         // Check Public IP resource limits
-        final int accountPublicIpRange = _publicIpAddressDao.countIPs(zoneId, vlanDbId, false);
-        _resourceLimitMgr.checkResourceLimit(vlanOwner, ResourceType.public_ip, accountPublicIpRange);
+        if (vlanOwner != null) {
+            final int accountPublicIpRange = _publicIpAddressDao.countIPs(zoneId, vlanDbId, false);
+            _resourceLimitMgr.checkResourceLimit(vlanOwner, ResourceType.public_ip, accountPublicIpRange);
+        }
 
         // Check if any of the Public IP addresses is allocated to another
         // account
@@ -3355,21 +3389,33 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 if (!accountAllocatedTo.getAccountName().equalsIgnoreCase(accountName)) {
                     throw new InvalidParameterValueException(ip.getAddress() + " Public IP address in range is allocated to another account ");
                 }
+                if (vlanOwner == null && domain != null && domain.getId() != accountAllocatedTo.getDomainId()){
+                    throw new InvalidParameterValueException(ip.getAddress()
+                            + " Public IP address in range is allocated to another domain/account ");
+                }
             }
         }
 
-        // Create an AccountVlanMapVO entry
-        final AccountVlanMapVO accountVlanMapVO = new AccountVlanMapVO(vlanOwner.getId(), vlan.getId());
-        _accountVlanMapDao.persist(accountVlanMapVO);
+        if (vlanOwner != null) {
+            // Create an AccountVlanMapVO entry
+            final AccountVlanMapVO accountVlanMapVO = new AccountVlanMapVO(vlanOwner.getId(), vlan.getId());
+            _accountVlanMapDao.persist(accountVlanMapVO);
 
-        // generate usage event for dedication of every ip address in the range
-        for (final IPAddressVO ip : ips) {
-            UsageEventUtils.publishUsageEvent(EventTypes.EVENT_NET_IP_ASSIGN, vlanOwner.getId(), ip.getDataCenterId(), ip.getId(), ip.getAddress().toString(), ip.isSourceNat(),
-                    vlan.getVlanType().toString(), ip.getSystem(), ip.getClass().getName(), ip.getUuid());
+           // generate usage event for dedication of every ip address in the range
+            for (final IPAddressVO ip : ips) {
+                UsageEventUtils.publishUsageEvent(EventTypes.EVENT_NET_IP_ASSIGN, vlanOwner.getId(), ip.getDataCenterId(), ip.getId(), ip.getAddress().toString(), ip.isSourceNat(),
+                        vlan.getVlanType().toString(), ip.getSystem(), ip.getClass().getName(), ip.getUuid());
+            }
+        } else if (domain != null) {
+            // Create an DomainVlanMapVO entry
+            DomainVlanMapVO domainVlanMapVO = new DomainVlanMapVO(domain.getId(), vlan.getId());
+            _domainVlanMapDao.persist(domainVlanMapVO);
         }
 
         // increment resource count for dedicated public ip's
-        _resourceLimitMgr.incrementResourceCount(vlanOwner.getId(), ResourceType.public_ip, new Long(ips.size()));
+        if (vlanOwner != null) {
+            _resourceLimitMgr.incrementResourceCount(vlanOwner.getId(), ResourceType.public_ip, new Long(ips.size()));
+        }
 
         return vlan;
     }
@@ -3391,12 +3437,25 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     public boolean releasePublicIpRange(final long vlanDbId, final long userId, final Account caller) {
         VlanVO vlan = _vlanDao.findById(vlanDbId);
 
+        // Verify range is dedicated
+        boolean isAccountSpecific = false;
         final List<AccountVlanMapVO> acctVln = _accountVlanMapDao.listAccountVlanMapsByVlan(vlanDbId);
         // Verify range is dedicated
-        if (acctVln == null || acctVln.isEmpty()) {
-            throw new InvalidParameterValueException("Can't release Public IP range " + vlanDbId + " as it not dedicated to any account");
+        if (acctVln != null && !acctVln.isEmpty()) {
+            isAccountSpecific = true;
         }
 
+        boolean isDomainSpecific = false;
+        final List<DomainVlanMapVO> domainVln = _domainVlanMapDao.listDomainVlanMapsByVlan(vlanDbId);
+        // Check for domain wide pool. It will have an entry for domain_vlan_map.
+        if (domainVln != null && !domainVln.isEmpty()) {
+            isDomainSpecific = true;
+        }
+
+        if (!isAccountSpecific && !isDomainSpecific) {
+            throw new InvalidParameterValueException("Can't release Public IP range " + vlanDbId
+                    + " as it not dedicated to any domain and any account");
+        }
         // Check if range has any allocated public IPs
         final long allocIpCount = _publicIpAddressDao.countIPs(vlan.getDataCenterId(), vlanDbId, true);
         final List<IPAddressVO> ips = _publicIpAddressDao.listByVlanId(vlanDbId);
@@ -3431,7 +3490,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         // A Public IP range can only be dedicated to one account at a time
-        if (_accountVlanMapDao.remove(acctVln.get(0).getId())) {
+        if (isAccountSpecific && _accountVlanMapDao.remove(acctVln.get(0).getId())) {
             // generate usage events to remove dedication for every ip in the range that has been disassociated
             for (final IPAddressVO ip : ips) {
                 if (!ipsInUse.contains(ip)) {
@@ -3441,6 +3500,9 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
             // decrement resource count for dedicated public ip's
             _resourceLimitMgr.decrementResourceCount(acctVln.get(0).getAccountId(), ResourceType.public_ip, new Long(ips.size()));
+            return true;
+        } else if (isDomainSpecific && _domainVlanMapDao.remove(domainVln.get(0).getId())) {
+            s_logger.debug("Remove the vlan from domain_vlan_map successfully.");
             return true;
         } else {
             return false;
@@ -4823,13 +4885,24 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
         }
 
-        final Long networkId = vlan.getNetworkId();
-        if (networkId != null) {
-            final Network network = _networkModel.getNetwork(networkId);
-            if (network != null) {
-                return _accountMgr.getAccount(network.getAccountId());
+        return null;
+    }
+
+    @Override
+    public Domain getVlanDomain(long vlanId) {
+        Vlan vlan = _vlanDao.findById(vlanId);
+        Long domainId = null;
+
+        // if vlan is Virtual Domain specific, get vlan information from the
+        // accountVlanMap; otherwise get account information
+        // from the network
+        if (vlan.getVlanType() == VlanType.VirtualNetwork) {
+            List<DomainVlanMapVO> maps = _domainVlanMapDao.listDomainVlanMapsByVlan(vlanId);
+            if (maps != null && !maps.isEmpty()) {
+                return _domainDao.findById(maps.get(0).getDomainId());
             }
         }
+
         return null;
     }
 

--- a/server/src/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/com/cloud/network/IpAddressManagerImpl.java
@@ -50,6 +50,7 @@ import com.cloud.configuration.Resource.ResourceType;
 import com.cloud.dc.AccountVlanMapVO;
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenter.NetworkType;
+import com.cloud.dc.DomainVlanMapVO;
 import com.cloud.dc.Pod;
 import com.cloud.dc.PodVlanMapVO;
 import com.cloud.dc.Vlan;
@@ -58,6 +59,7 @@ import com.cloud.dc.VlanVO;
 import com.cloud.dc.dao.AccountVlanMapDao;
 import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.dc.dao.DataCenterVnetDao;
+import com.cloud.dc.dao.DomainVlanMapDao;
 import com.cloud.dc.dao.PodVlanMapDao;
 import com.cloud.dc.dao.VlanDao;
 import com.cloud.deploy.DeployDestination;
@@ -198,6 +200,8 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
     ConfigurationManager _configMgr;
     @Inject
     AccountVlanMapDao _accountVlanMapDao;
+    @Inject
+    DomainVlanMapDao _domainVlanMapDao;
     @Inject
     NetworkOfferingDao _networkOfferingDao = null;
     @Inject
@@ -682,6 +686,11 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         // Otherwise fetch IP from the system pool
         List<AccountVlanMapVO> maps = _accountVlanMapDao.listAccountVlanMapsByAccount(owner.getId());
         for (AccountVlanMapVO map : maps) {
+            if (vlanDbIds == null || vlanDbIds.contains(map.getVlanDbId()))
+                dedicatedVlanDbIds.add(map.getVlanDbId());
+        }
+        List<DomainVlanMapVO> domainMaps = _domainVlanMapDao.listDomainVlanMapsByDomain(owner.getDomainId());
+        for (DomainVlanMapVO map : domainMaps) {
             if (vlanDbIds == null || vlanDbIds.contains(map.getVlanDbId()))
                 dedicatedVlanDbIds.add(map.getVlanDbId());
         }

--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -1395,7 +1395,7 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
                     if (_accountMgr.isRootAdmin(caller.getId()) && createVlan && network != null) {
                         // Create vlan ip range
                         _configMgr.createVlanAndPublicIpRange(pNtwk.getDataCenterId(), network.getId(), physicalNetworkId, false, null, startIP, endIP, gateway, netmask, vlanId,
-                                null, startIPv6, endIPv6, ip6Gateway, ip6Cidr);
+                                null, null, startIPv6, endIPv6, ip6Gateway, ip6Cidr);
                     }
                     return network;
                 }

--- a/server/test/com/cloud/configuration/ConfigurationManagerTest.java
+++ b/server/test/com/cloud/configuration/ConfigurationManagerTest.java
@@ -59,6 +59,7 @@ import com.cloud.dc.dao.AccountVlanMapDao;
 import com.cloud.dc.dao.ClusterDao;
 import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.dc.dao.DataCenterIpAddressDao;
+import com.cloud.dc.dao.DomainVlanMapDao;
 import com.cloud.dc.dao.HostPodDao;
 import com.cloud.dc.dao.VlanDao;
 import com.cloud.exception.InvalidParameterValueException;
@@ -115,6 +116,8 @@ public class ConfigurationManagerTest {
     @Mock
     AccountVlanMapDao _accountVlanMapDao;
     @Mock
+    DomainVlanMapDao _domainVlanMapDao;
+    @Mock
     IPAddressDao _publicIpAddressDao;
     @Mock
     DataCenterDao _zoneDao;
@@ -156,6 +159,7 @@ public class ConfigurationManagerTest {
         configurationMgr._accountDao = _accountDao;
         configurationMgr._vlanDao = _vlanDao;
         configurationMgr._accountVlanMapDao = _accountVlanMapDao;
+        configurationMgr._domainVlanMapDao = _domainVlanMapDao;
         configurationMgr._publicIpAddressDao = _publicIpAddressDao;
         configurationMgr._zoneDao = _zoneDao;
         configurationMgr._firewallDao = _firewallDao;
@@ -470,10 +474,11 @@ public class ConfigurationManagerTest {
         when(configurationMgr._vlanDao.findById(anyLong())).thenReturn(vlan);
 
         when(configurationMgr._accountVlanMapDao.listAccountVlanMapsByVlan(anyLong())).thenReturn(null);
+        when(configurationMgr._domainVlanMapDao.listDomainVlanMapsByVlan(anyLong())).thenReturn(null);
         try {
             configurationMgr.releasePublicIpRange(releasePublicIpRangesCmd);
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("as it not dedicated to any account"));
+            Assert.assertTrue(e.getMessage().contains("as it not dedicated to any domain and any account"));
         } finally {
             txn.close("runReleaseNonDedicatedPublicIpRange");
         }
@@ -559,15 +564,6 @@ public class ConfigurationManagerTest {
         public long getEntityOwnerId() {
             return 1;
         }
-    }
-
-    @Test
-    public void getVlanAccount() {
-        Mockito.when(_vlanDao.findById(42l)).thenReturn(vlan);
-        Mockito.when(_networkModel.getNetwork(1l)).thenReturn(network);
-        Mockito.when(network.getAccountId()).thenReturn(1l);
-        Mockito.when(_accountMgr.getAccount(1l)).thenReturn(account);
-        Assert.assertNotNull(configurationMgr.getVlanAccount(42l));
     }
 
     @Test

--- a/server/test/com/cloud/vpc/MockConfigurationManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockConfigurationManagerImpl.java
@@ -61,6 +61,7 @@ import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.HostPodVO;
 import com.cloud.dc.Pod;
 import com.cloud.dc.Vlan;
+import com.cloud.domain.Domain;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.InvalidParameterValueException;
@@ -441,7 +442,7 @@ public class MockConfigurationManagerImpl extends ManagerBase implements Configu
      */
     @Override
     public Vlan createVlanAndPublicIpRange(long zoneId, long networkId, long physicalNetworkId, boolean forVirtualNetwork, Long podId, String startIP, String endIP,
-        String vlanGateway, String vlanNetmask, String vlanId, Account vlanOwner, String startIPv6, String endIPv6, String vlanGatewayv6, String vlanCidrv6)
+        String vlanGateway, String vlanNetmask, String vlanId, Domain domain, Account vlanOwner, String startIPv6, String endIPv6, String vlanGatewayv6, String vlanCidrv6)
         throws InsufficientCapacityException, ConcurrentOperationException, InvalidParameterValueException {
         // TODO Auto-generated method stub
         return null;
@@ -522,6 +523,12 @@ public class MockConfigurationManagerImpl extends ManagerBase implements Configu
     public boolean releasePublicIpRange(ReleasePublicIpRangeCmd cmd) {
         // TODO Auto-generated method stub
         return false;
+    }
+
+    @Override
+    public Domain getVlanDomain(long vlanId) {
+        // TODO Auto-generated method stub
+        return null;
     }
 
 }

--- a/server/test/com/cloud/vpc/VpcTestConfiguration.java
+++ b/server/test/com/cloud/vpc/VpcTestConfiguration.java
@@ -44,6 +44,7 @@ import com.cloud.dc.dao.DataCenterDetailsDaoImpl;
 import com.cloud.dc.dao.DataCenterIpAddressDaoImpl;
 import com.cloud.dc.dao.DataCenterLinkLocalIpAddressDaoImpl;
 import com.cloud.dc.dao.DataCenterVnetDaoImpl;
+import com.cloud.dc.dao.DomainVlanMapDaoImpl;
 import com.cloud.dc.dao.HostPodDaoImpl;
 import com.cloud.dc.dao.PodVlanDaoImpl;
 import com.cloud.dc.dao.PodVlanMapDaoImpl;
@@ -110,7 +111,7 @@ import com.cloud.vpc.dao.MockVpcOfferingServiceMapDaoImpl;
 @ComponentScan(basePackageClasses = {VpcManagerImpl.class, NetworkElement.class, VpcOfferingDao.class, ConfigurationDaoImpl.class, IPAddressDaoImpl.class,
     DomainRouterDaoImpl.class, VpcGatewayDaoImpl.class, PrivateIpDaoImpl.class, StaticRouteDaoImpl.class, PhysicalNetworkDaoImpl.class,
     ResourceTagsDaoImpl.class, FirewallRulesDaoImpl.class, VlanDaoImpl.class, AccountDaoImpl.class, ResourceCountDaoImpl.class,
-    Site2SiteVpnGatewayDaoImpl.class, PodVlanMapDaoImpl.class, AccountVlanMapDaoImpl.class, HostDaoImpl.class, HostDetailsDaoImpl.class,
+    Site2SiteVpnGatewayDaoImpl.class, PodVlanMapDaoImpl.class, AccountVlanMapDaoImpl.class, DomainVlanMapDaoImpl.class, HostDaoImpl.class, HostDetailsDaoImpl.class,
     HostTagsDaoImpl.class, HostTransferMapDaoImpl.class, ClusterDaoImpl.class, HostPodDaoImpl.class, RouterNetworkDaoImpl.class,
     UserStatisticsDaoImpl.class, PhysicalNetworkTrafficTypeDaoImpl.class, FirewallRulesCidrsDaoImpl.class, ResourceLimitManagerImpl.class,
     ResourceLimitDaoImpl.class, ResourceCountDaoImpl.class, DomainDaoImpl.class, UserVmDaoImpl.class, UserVmDetailsDaoImpl.class, NicDaoImpl.class,

--- a/server/test/org/apache/cloudstack/networkoffering/ChildTestConfiguration.java
+++ b/server/test/org/apache/cloudstack/networkoffering/ChildTestConfiguration.java
@@ -58,6 +58,7 @@ import com.cloud.dc.dao.DataCenterIpAddressDaoImpl;
 import com.cloud.dc.dao.DataCenterLinkLocalIpAddressDao;
 import com.cloud.dc.dao.DataCenterVnetDaoImpl;
 import com.cloud.dc.dao.DedicatedResourceDao;
+import com.cloud.dc.dao.DomainVlanMapDaoImpl;
 import com.cloud.dc.dao.HostPodDaoImpl;
 import com.cloud.dc.dao.PodVlanDaoImpl;
 import com.cloud.dc.dao.PodVlanMapDaoImpl;
@@ -121,7 +122,7 @@ import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDaoImpl;
 
 @Configuration
-@ComponentScan(basePackageClasses = {AccountVlanMapDaoImpl.class, VolumeDaoImpl.class, HostPodDaoImpl.class, DomainDaoImpl.class, ServiceOfferingDaoImpl.class,
+@ComponentScan(basePackageClasses = {AccountVlanMapDaoImpl.class, DomainVlanMapDaoImpl.class, VolumeDaoImpl.class, HostPodDaoImpl.class, DomainDaoImpl.class, ServiceOfferingDaoImpl.class,
     ServiceOfferingDetailsDaoImpl.class, VlanDaoImpl.class, IPAddressDaoImpl.class, ResourceTagsDaoImpl.class, AccountDaoImpl.class,
     InstanceGroupDaoImpl.class, UserAccountJoinDaoImpl.class, CapacityDaoImpl.class, SnapshotDaoImpl.class, HostDaoImpl.class, VMInstanceDaoImpl.class,
     HostTransferMapDaoImpl.class, PortForwardingRulesDaoImpl.class, PrivateIpDaoImpl.class, UsageEventDaoImpl.class, PodVlanMapDaoImpl.class,

--- a/setup/db/db/schema-460to470.sql
+++ b/setup/db/db/schema-460to470.sql
@@ -18,3 +18,15 @@
 --;
 -- Schema upgrade from 4.6.0 to 4.7.0;
 --;
+
+CREATE TABLE IF NOT EXISTS `cloud`.`domain_vlan_map` (
+  `id` bigint unsigned NOT NULL UNIQUE AUTO_INCREMENT,
+  `domain_id` bigint unsigned NOT NULL COMMENT 'domain id. foreign key to domain table',
+  `vlan_db_id` bigint unsigned NOT NULL COMMENT 'database id of vlan. foreign key to vlan table',
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_domain_vlan_map__domain_id` FOREIGN KEY (`domain_id`) REFERENCES `domain` (`id`) ON DELETE CASCADE,
+  INDEX `i_account_vlan_map__domain_id`(`domain_id`),
+  CONSTRAINT `fk_domain_vlan_map__vlan_id` FOREIGN KEY (`vlan_db_id`) REFERENCES `vlan` (`id`) ON DELETE CASCADE,
+  INDEX `i_account_vlan_map__vlan_id`(`vlan_db_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/setup/db/db/schema-461to470.sql
+++ b/setup/db/db/schema-461to470.sql
@@ -18,3 +18,15 @@
 --;
 -- Schema upgrade from 4.6.1 to 4.7.0;
 --;
+
+CREATE TABLE IF NOT EXISTS `cloud`.`domain_vlan_map` (
+  `id` bigint unsigned NOT NULL UNIQUE AUTO_INCREMENT,
+  `domain_id` bigint unsigned NOT NULL COMMENT 'domain id. foreign key to domain table',
+  `vlan_db_id` bigint unsigned NOT NULL COMMENT 'database id of vlan. foreign key to vlan table',
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_domain_vlan_map__domain_id` FOREIGN KEY (`domain_id`) REFERENCES `domain` (`id`) ON DELETE CASCADE,
+  INDEX `i_account_vlan_map__domain_id`(`domain_id`),
+  CONSTRAINT `fk_domain_vlan_map__vlan_id` FOREIGN KEY (`vlan_db_id`) REFERENCES `vlan` (`id`) ON DELETE CASCADE,
+  INDEX `i_account_vlan_map__vlan_id`(`vlan_db_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -83,9 +83,14 @@
                         success: function (json) {
                             var domain = json.listdomainsresponse.domain[0];
 
-                            cloudStack.dialog.notice({
-                                message: '<ul><li>' + _l('label.account') + ': ' + data.account + '</li>' + '<li>' + _l('label.domain') + ': ' + domain.path + '</li></ul>'
-                            });
+                            if (data.account != null)
+                                cloudStack.dialog.notice({
+                                    message: '<ul><li>' + _l('label.account') + ': ' + data.account + '</li>' + '<li>' + _l('label.domain') + ': ' + domain.path + '</li></ul>'
+                                });
+                            else
+                                cloudStack.dialog.notice({
+                                    message: '<ul><li>' + _l('label.domain') + ': ' + domain.path + '</li></ul>'
+                                });
                         }
                     });
                 } else {
@@ -743,7 +748,8 @@
                                                 array1.push("&endip=" + args.data.endip);
 
                                                 if (args.data.account) {
-                                                    array1.push("&account=" + args.data.account.account);
+                                                    if (args.data.account.account)
+                                                        array1.push("&account=" + args.data.account.account);
                                                     array1.push("&domainid=" + args.data.account.domainid);
                                                 }
 
@@ -774,7 +780,7 @@
                                         },
                                         actionPreFilter: function (args) {
                                             var actionsToShow =[ 'destroy'];
-                                            if (args.context.multiRule[0].domain == 'ROOT' && args.context.multiRule[0].account.account == 'system')
+                                            if (args.context.multiRule[0].domain == 'ROOT' && args.context.multiRule[0].account != null && args.context.multiRule[0].account.account == 'system')
                                             actionsToShow.push('addAccount'); else
                                             actionsToShow.push('releaseFromAccount');
                                             return actionsToShow;
@@ -865,8 +871,12 @@
                                                         id: args.context.multiRule[0].id,
                                                         zoneid: args.context.multiRule[0].zoneid,
                                                         domainid: args.data.domainid,
-                                                        account: args.data.account
                                                     };
+                                                    if (args.data.account) {
+                                                        $.extend(data, {
+                                                            account: args.data.account
+                                                        });
+                                                    }
                                                     $.ajax({
                                                         url: createURL('dedicatePublicIpRange'),
                                                         data: data,
@@ -898,7 +908,7 @@
                                                         data: $.map(items, function (item) {
                                                             return $.extend(item, {
                                                                 account: {
-                                                                    _buttonLabel: item.account,
+                                                                    _buttonLabel: item.account ? '[' + item.domain + '] ' + item.account: item.domain,
                                                                     account: item.account,
                                                                     domainid: item.domainid
                                                                 }


### PR DESCRIPTION
For now, we dedicate ip pool to account, however, other accounts in the same domain cannot fetch the ip from this ip pool.
By dedicating ip pool to domain, accounts in the domain can fetch the public ip from same ip pool.