### PR TITLE
CLOUDSTACK-9012 :automation of cores feature test path

### DIFF
--- a/test/integration/component/test_coreos.py
+++ b/test/integration/component/test_coreos.py
@@ -114,7 +114,7 @@ class TestDeployVmWithCoreosTemplate(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
 
-    @attr(tags=["advanced"], required_hardware="true")
+    @attr(tags=["advanced","tt"], required_hardware="true")
     def test1_coreos_VM_creation(self):
 
         self.hypervisor = str(get_hypervisor_type(self.api_client)).lower()
@@ -226,7 +226,7 @@ class TestDeployVmWithCoreosTemplate(cloudstackTestCase):
             )
         else:
             list_router_response = list_routers(
-                self.api_Client,
+                self.api_client,
                 account=self.account.name,
                 domainid=self.account.domainid
             )
@@ -287,5 +287,6 @@ class TestDeployVmWithCoreosTemplate(cloudstackTestCase):
             res.__contains__("name: docker.service"),
             True,
             "Userdata Not applied Check the failures")
+        self.account.delete(self.api_client)
 
         return

--- a/test/integration/component/test_coreos.py
+++ b/test/integration/component/test_coreos.py
@@ -1,0 +1,291 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" P1 tests for coreos template and vm
+"""
+
+from marvin.lib.base import (
+    VirtualMachine,
+    ServiceOffering,
+    Account,
+    SSHKeyPair,
+    Host, Template)
+from marvin.lib.common import (
+    get_zone,
+    get_template,
+    list_routers)
+from marvin.lib.utils import (
+    cleanup_resources,
+    get_hypervisor_type,
+    get_process_status)
+from marvin.cloudstackTestCase import cloudstackTestCase
+# Import System modules
+import tempfile
+import time
+import os
+import base64
+from nose.plugins.attrib import attr
+from marvin.sshClient import SshClient
+
+
+class TestDeployVmWithCoreosTemplate(cloudstackTestCase):
+    """Tests for deploying VM  using coreos template
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._cleanup = []
+        cls.testClient = super(
+            TestDeployVmWithCoreosTemplate,
+            cls).getClsTestClient()
+        cls.api_client = cls.testClient.getApiClient()
+        cls.services = cls.testClient.getParsedTestDataConfig()
+        cls.zone = get_zone(cls.api_client, cls.testClient.getZoneForTests())
+        cls.service_offering = ServiceOffering.create(
+            cls.api_client, services=cls.services["service_offerings"]["medium"])
+        cls.account = Account.create(
+            cls.api_client, services=cls.services["account"])
+        cls.cleanup = [cls.account]
+        cls.template = get_template(
+            cls.api_client,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        cls.services["coreos"][
+            "hypervisor"] = cls.testClient.getHypervisorInfo()
+        cls.userdata = '#cloud-config\n\ncoreos:\n  units:\n    - name: docker.service\n      command: start\n    ' \
+                       '- name: web.service\n      command: start\n      content: |\n        [Unit]\n        ' \
+                       'After=docker.service\n        Requires=docker.service\n        Description=Starts web server ' \
+                       'container\n        [Service]\n        TimeoutStartSec=0\n        ' \
+                       'ExecStartPre=/usr/bin/docker pull httpd:2.4\n        ' \
+                       'ExecStart=/usr/bin/docker run -d -p 8000:80 httpd:2.4'
+        cls.services["virtual_machine"]["userdata"] = cls.userdata
+
+        cls.keypair = SSHKeyPair.create(
+            cls.api_client,
+            name="coreos",
+            account=cls.account.name,
+            domainid=cls.account.domainid
+        )
+        cls.debug("Created a new keypair with name: %s" % cls.keypair.name)
+
+        cls.debug("Writing the private key to local file")
+        cls.keyPairFilePath = tempfile.gettempdir() + os.sep + cls.keypair.name
+        # Clenaup at end of execution
+        cls.cleanup.append(cls.keyPairFilePath)
+
+        cls.debug("File path: %s" % cls.keyPairFilePath)
+
+        f = open(cls.keyPairFilePath, "w+")
+        f.write(cls.keypair.privatekey)
+        f.close()
+        os.system("chmod 400 " + cls.keyPairFilePath)
+        cls.mgtSvrDetails = cls.config.__dict__["mgtSvr"][0].__dict__
+        return
+
+    def setUp(self):
+        self.api_client = self.testClient.getApiClient()
+        return
+
+    def tearDown(self):
+        # Clean up, terminate the created volumes
+        cleanup_resources(self.api_client, self.cleanup)
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cleanup_resources(cls.api_client, cls._cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    @attr(tags=["advanced"], required_hardware="true")
+    def test1_coreos_VM_creation(self):
+
+        self.hypervisor = str(get_hypervisor_type(self.api_client)).lower()
+        self.services["virtual_machine"][
+            "hypervisor"] = self.hypervisor.upper()
+        if self.hypervisor == "vmware":
+            self.services["coreos"][
+                "url"] = self.services["coreos"]["urlvmware"]
+            self.services["coreos"]["format"] = "OVA"
+        elif self.hypervisor == "xenserver":
+            self.services["coreos"][
+                "url"] = self.services["coreos"]["urlxen"]
+            self.services["coreos"]["format"] = "VHD"
+        elif self.hypervisor == "kvm":
+            self.services["coreos"][
+                "url"] = self.services["coreos"]["urlkvm"]
+            self.services["coreos"]["format"] = "QCOW2"
+        elif self.hypervisor == "hyperv":
+            self.services["coreos"][
+                "url"] = self.services["coreos"]["urlxen"]
+            self.services["coreos"]["format"] = "VHD"
+
+        template_created = Template.register(
+            self.api_client,
+            self.services["coreos"],
+            self.zone.id,
+            account=self.account.name,
+            domainid=self.account.domainid)
+        self.assertIsNotNone(template_created, "Template creation failed")
+        # Wait for template to download
+        template_created.download(self.api_client)
+        self.cleanup.append(template_created)
+        # Wait for template status to be changed across
+        time.sleep(self.services["sleep"])
+
+        self.debug("Deploying instance in the account: %s" % self.account.name)
+
+        virtual_machine = VirtualMachine.create(
+            self.api_client,
+            self.services["virtual_machine"],
+            templateid=template_created.id,
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            zoneid=self.zone.id,
+            serviceofferingid=self.service_offering.id,
+            keypair=self.keypair.name,
+            hypervisor=self.hypervisor,
+            mode=self.zone.networktype,
+            method="POST"
+
+        )
+
+        self.debug("Check if the VM is properly deployed or not?")
+        vms = VirtualMachine.list(
+            self.api_client,
+            id=virtual_machine.id,
+            listall=True
+        )
+        self.assertEqual(
+            isinstance(vms, list),
+            True,
+            "List VMs should return the valid list"
+        )
+        vm = vms[0]
+        self.assertEqual(
+            vm.state,
+            "Running",
+            "VM state should be running after deployment"
+        )
+        virtual_machine.stop(self.api_client)
+        virtual_machine.update(
+            self.api_client,
+            userdata=base64.b64encode(
+                self.userdata))
+        virtual_machine.start(self.api_client)
+        self.assertEqual(
+            vm.state,
+            "Running",
+            "VM state should be running"
+        )
+        # Wait for docker service to start
+        time.sleep(300)
+
+        # Should be able to SSH VM
+        try:
+
+            self.debug("SSH into VM: %s" % virtual_machine.ssh_ip)
+            cmd = "docker ps"
+            ssh = SshClient(virtual_machine.ssh_ip, 22, "core",
+                            "", keyPairFiles=self.keyPairFilePath)
+            result = ssh.execute(cmd)
+
+        except Exception as e:
+            self.fail(
+                "SSH Access failed for %s: %s" %
+                (virtual_machine.ssh_ip, e)
+            )
+
+        res = str(result)
+        self.assertEqual(
+            res.__contains__("httpd"),
+            True,
+            "docker web service not started in coreos vm ")
+
+        if self.zone.networktype == "Basic":
+            list_router_response = list_routers(
+                self.api_client,
+                listall="true"
+            )
+        else:
+            list_router_response = list_routers(
+                self.api_Client,
+                account=self.account.name,
+                domainid=self.account.domainid
+            )
+
+        self.assertEqual(
+            isinstance(list_router_response, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        router = list_router_response[0]
+        hosts = Host.list(self.api_client, id=router.hostid)
+        self.assertEqual(
+            isinstance(hosts, list),
+            True,
+            "Check list host returns a valid list"
+        )
+        host = hosts[0]
+        self.debug("Router ID: %s, state: %s" % (router.id, router.state))
+
+        self.assertEqual(
+            router.state,
+            'Running',
+            "Check list router response for router state"
+        )
+        cmd = "cat /var/www/html/userdata/" + virtual_machine.ipaddress + "/user-data"
+
+        if self.hypervisor.lower() in ('vmware', 'hyperv'):
+
+            try:
+                result = get_process_status(
+                    self.api_client.connection.mgtSvr,
+                    22,
+                    self.api_client.connection.user,
+                    self.api_client.connection.passwd,
+                    router.linklocalip,
+                    cmd,
+                    hypervisor=self.hypervisor
+                )
+
+            except KeyError:
+                self.skipTest(
+                    "Marvin configuration has no host credentials to check USERDATA")
+
+        else:
+            try:
+                result = get_process_status(
+                    host.ipaddress,
+                    22,
+                    self.services["configurableData"]["host"]["username"],
+                    self.services["configurableData"]["host"]["password"],
+                    router.linklocalip, cmd
+                )
+            except KeyError:
+                self.skipTest(
+                    "Marvin configuration has no host credentials to check router user data")
+        res = str(result)
+        self.assertEqual(
+            res.__contains__("name: docker.service"),
+            True,
+            "Userdata Not applied Check the failures")
+
+        return

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -784,6 +784,19 @@ test_data = {
         "format": "OVA",
         "ispublic": "true"
     },
+    "coreos": {
+        "displaytext": "coreos",
+        "name": "coreos",
+        "passwordenabled": False,
+        "ostype": "Coreos",
+        "urlvmware":"http://dl.openvm.eu/cloudstack/coreos/x86_64/" \
+                         "coreos_production_cloudstack_image-vmware.vmdk.bz2",
+        "urlxen":"http://dl.openvm.eu/cloudstack/coreos/x86_64/"
+                 "coreos_production_cloudstack_image-xen.vhd.bz2",
+        "urlkvm": "http://dl.openvm.eu/cloudstack/coreos/x86_64/" \
+                         "coreos_production_cloudstack_image-kvm.qcow2.bz2",
+        "urlhyperv":"http://dl.openvm.eu/cloudstack/coreos/x86_64/coreos_production_cloudstack_image-hyperv.vhd.zip"
+        },
     "template_2": {
         "displaytext": "Public Template",
         "name": "Public template",

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -789,8 +789,7 @@ test_data = {
         "name": "coreos",
         "passwordenabled": False,
         "ostype": "Coreos",
-        "urlvmware":"http://dl.openvm.eu/cloudstack/coreos/x86_64/" \
-                         "coreos_production_cloudstack_image-vmware.vmdk.bz2",
+        "urlvmware":"http://10.147.28.7/templates/coreos/coreos_production_vmware.ova",
         "urlxen":"http://dl.openvm.eu/cloudstack/coreos/x86_64/"
                  "coreos_production_cloudstack_image-xen.vhd.bz2",
         "urlkvm": "http://dl.openvm.eu/cloudstack/coreos/x86_64/" \

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -551,7 +551,7 @@ class VirtualMachine:
 
     def get_ssh_client(
             self, ipaddress=None, reconnect=False, port=None,
-            keyPairFileLocation=None, retries=20):
+            keyPairFileLocation=None,username=None,password=None, retries=20):
         """Get SSH object of VM"""
 
         # If NAT Rules are not created while VM deployment in Advanced mode
@@ -563,6 +563,12 @@ class VirtualMachine:
 
         if keyPairFileLocation is not None:
             self.password = None
+
+        if username is not None:
+            self.username=username
+
+        if password is not None:
+            self.password=password
 
         if reconnect:
             self.ssh_client = is_server_ssh_ready(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9012
Automated a full scenario of coreos guest OS support:
it includes registering coreos templates present at http://dl.openvm.eu/cloudstack/coreos/x86_64/
1. based on hypervisor types of zone
2. creating ssh key pair
3. creating a sample user data
4. creating a coreos virtual machine using this ssh keypair and userdata
5. verifying ssh access to coreo os machine using keypair and core username
6. verifying userdata is applied on virtual machine and the service asked in sample data is actually running
7. Verifying userdata in router vm as well