### PR TITLE
Use java.io.tmpdir instead of hardcoded /tmp

### DIFF
--- a/core/src/com/cloud/storage/template/LocalTemplateDownloader.java
+++ b/core/src/com/cloud/storage/template/LocalTemplateDownloader.java
@@ -38,7 +38,7 @@ public class LocalTemplateDownloader extends TemplateDownloaderBase implements T
 
     public LocalTemplateDownloader(StorageLayer storageLayer, String downloadUrl, String toDir, long maxTemplateSizeInBytes, DownloadCompleteCallback callback) {
         super(storageLayer, downloadUrl, toDir, maxTemplateSizeInBytes, callback);
-        String filename = downloadUrl.substring(downloadUrl.lastIndexOf(File.separator));
+        String filename = new File(downloadUrl).getName();
         _toFile = toDir.endsWith(File.separator) ? (toDir + filename) : (toDir + File.separator + filename);
     }
 

--- a/core/test/com/cloud/storage/template/LocalTemplateDownloaderTest.java
+++ b/core/test/com/cloud/storage/template/LocalTemplateDownloaderTest.java
@@ -29,9 +29,9 @@ import org.junit.Test;
 public class LocalTemplateDownloaderTest {
 
     @Test
-    public void localTemplateDownloaderTest() {
-        String url =  "file://" + new File("pom.xml").getAbsolutePath();
-        TemplateDownloader td = new LocalTemplateDownloader(null, url, "/tmp", TemplateDownloader.DEFAULT_MAX_TEMPLATE_SIZE_IN_BYTES, null);
+    public void localTemplateDownloaderTest() throws Exception {
+        String url = new File("pom.xml").toURI().toURL().toString();
+        TemplateDownloader td = new LocalTemplateDownloader(null, url, System.getProperty("java.io.tmpdir"), TemplateDownloader.DEFAULT_MAX_TEMPLATE_SIZE_IN_BYTES, null);
         long bytes = td.download(true, null);
         if (!(bytes > 0)) {
             fail("Failed download");


### PR DESCRIPTION
This was submitted earlier in PR #884 but that did not merge
properly.

This is a new PR with the same change.