### PR TITLE
CLOUDSTACK-8485: listAPIs are taking too long to return results

### DIFF
--- a/api/src/com/cloud/serializer/Param.java
+++ b/api/src/com/cloud/serializer/Param.java
@@ -37,4 +37,6 @@ public @interface Param {
     String since() default "";
 
     RoleType[] authorized() default {};
+
+    boolean isSensitive() default false;
 }

--- a/api/src/org/apache/cloudstack/api/response/CreateSSHKeyPairResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/CreateSSHKeyPairResponse.java
@@ -17,13 +17,12 @@
 package org.apache.cloudstack.api.response;
 
 import com.google.gson.annotations.SerializedName;
-
 import com.cloud.serializer.Param;
 
 public class CreateSSHKeyPairResponse extends SSHKeyPairResponse {
 
     @SerializedName("privatekey")
-    @Param(description = "Private key")
+    @Param(description = "Private key", isSensitive = true)
     private String privateKey;
 
     public CreateSSHKeyPairResponse() {

--- a/api/src/org/apache/cloudstack/api/response/GetVMPasswordResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/GetVMPasswordResponse.java
@@ -25,7 +25,7 @@ import com.cloud.serializer.Param;
 public class GetVMPasswordResponse extends BaseResponse {
 
     @SerializedName("encryptedpassword")
-    @Param(description = "The base64 encoded encrypted password of the VM")
+    @Param(description = "The base64 encoded encrypted password of the VM", isSensitive = true)
     private String encryptedPassword;
 
     public GetVMPasswordResponse() {

--- a/api/src/org/apache/cloudstack/api/response/LoginCmdResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/LoginCmdResponse.java
@@ -63,7 +63,7 @@ public class LoginCmdResponse extends AuthenticationCmdResponse {
     private String registered;
 
     @SerializedName(value = ApiConstants.SESSIONKEY)
-    @Param(description = "Session key that can be passed in subsequent Query command calls")
+    @Param(description = "Session key that can be passed in subsequent Query command calls", isSensitive = true)
     private String sessionKey;
 
     public String getUsername() {

--- a/api/src/org/apache/cloudstack/api/response/RegisterResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/RegisterResponse.java
@@ -24,11 +24,11 @@ import com.cloud.serializer.Param;
 
 public class RegisterResponse extends BaseResponse {
     @SerializedName("apikey")
-    @Param(description = "the api key of the registered user")
+    @Param(description = "the api key of the registered user", isSensitive = true)
     private String apiKey;
 
     @SerializedName("secretkey")
-    @Param(description = "the secret key of the registered user")
+    @Param(description = "the secret key of the registered user", isSensitive = true)
     private String secretKey;
 
     public String getApiKey() {

--- a/api/src/org/apache/cloudstack/api/response/RemoteAccessVpnResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/RemoteAccessVpnResponse.java
@@ -42,7 +42,7 @@ public class RemoteAccessVpnResponse extends BaseResponse implements ControlledE
     private String ipRange;
 
     @SerializedName("presharedkey")
-    @Param(description = "the ipsec preshared key")
+    @Param(description = "the ipsec preshared key", isSensitive = true)
     private String presharedKey;
 
     @SerializedName(ApiConstants.ACCOUNT)

--- a/api/src/org/apache/cloudstack/api/response/Site2SiteCustomerGatewayResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/Site2SiteCustomerGatewayResponse.java
@@ -51,7 +51,7 @@ public class Site2SiteCustomerGatewayResponse extends BaseResponse implements Co
     private String guestCidrList;
 
     @SerializedName(ApiConstants.IPSEC_PSK)
-    @Param(description = "IPsec preshared-key of customer gateway")
+    @Param(description = "IPsec preshared-key of customer gateway", isSensitive = true)
     private String ipsecPsk;
 
     @SerializedName(ApiConstants.IKE_POLICY)

--- a/api/src/org/apache/cloudstack/api/response/Site2SiteVpnConnectionResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/Site2SiteVpnConnectionResponse.java
@@ -58,7 +58,7 @@ public class Site2SiteVpnConnectionResponse extends BaseResponse implements Cont
     private String guestCidrList;
 
     @SerializedName(ApiConstants.IPSEC_PSK)
-    @Param(description = "IPsec Preshared-Key of the customer gateway")
+    @Param(description = "IPsec Preshared-Key of the customer gateway", isSensitive = true)
     //from CustomerGateway
     private String ipsecPsk;
 

--- a/api/src/org/apache/cloudstack/api/response/UserResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/UserResponse.java
@@ -78,11 +78,11 @@ public class UserResponse extends BaseResponse {
     private String timezone;
 
     @SerializedName("apikey")
-    @Param(description = "the api key of the user")
+    @Param(description = "the api key of the user", isSensitive = true)
     private String apiKey;
 
     @SerializedName("secretkey")
-    @Param(description = "the secret key of the user")
+    @Param(description = "the secret key of the user", isSensitive = true)
     private String secretKey;
 
     @SerializedName("accountid")

--- a/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -221,7 +221,7 @@ public class UserVmResponse extends BaseResponse implements ControlledEntityResp
     private Set<SecurityGroupResponse> securityGroupList;
 
     @SerializedName(ApiConstants.PASSWORD)
-    @Param(description = "the password (if exists) of the virtual machine")
+    @Param(description = "the password (if exists) of the virtual machine", isSensitive = true)
     private String password;
 
     @SerializedName("nic")

--- a/plugins/network-elements/bigswitch/src/com/cloud/api/response/BigSwitchBcfDeviceResponse.java
+++ b/plugins/network-elements/bigswitch/src/com/cloud/api/response/BigSwitchBcfDeviceResponse.java
@@ -54,7 +54,7 @@ public class BigSwitchBcfDeviceResponse extends BaseResponse {
     @SerializedName(ApiConstants.USERNAME) @Param(description="the controller username")
     private String username;
 
-    @SerializedName(ApiConstants.PASSWORD) @Param(description="the controller password")
+    @SerializedName(ApiConstants.PASSWORD) @Param(description="the controller password", isSensitive = true)
     private String password;
 
     @SerializedName(BcfConstants.BIGSWITCH_BCF_DEVICE_NAT)

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/api/response/LDAPConfigResponse.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/api/response/LDAPConfigResponse.java
@@ -53,7 +53,7 @@ public class LDAPConfigResponse extends BaseResponse {
     private String bindDN;
 
     @SerializedName(ApiConstants.BIND_PASSWORD)
-    @Param(description = "DN password")
+    @Param(description = "DN password", isSensitive = true)
     private String bindPassword;
 
     public String getHostname() {

--- a/server/src/com/cloud/api/ApiServlet.java
+++ b/server/src/com/cloud/api/ApiServlet.java
@@ -147,8 +147,9 @@ public class ApiServlet extends HttpServlet {
 
         // logging the request start and end in management log for easy debugging
         String reqStr = "";
+        String cleanQueryString = StringUtils.cleanString(req.getQueryString());
         if (s_logger.isDebugEnabled()) {
-            reqStr = auditTrailSb.toString() + " " + StringUtils.cleanString(req.getQueryString());
+            reqStr = auditTrailSb.toString() + " " + cleanQueryString;
             s_logger.debug("===START=== " + reqStr);
         }
 
@@ -233,7 +234,7 @@ public class ApiServlet extends HttpServlet {
                 }
             }
 
-            auditTrailSb.append(StringUtils.cleanString(req.getQueryString()));
+            auditTrailSb.append(cleanQueryString);
             final boolean isNew = ((session == null) ? true : session.isNew());
 
             // Initialize an empty context and we will update it after we have verified the request below,


### PR DESCRIPTION
- Removed regex. based search/replace of sensitive data on API response introduced as part of commit b0c6d4734724358df97b6fa4d8c5beb0f447745e
- Added new response serializer to skip sensitive data from getting logged based on annotation present in resposne object fields
- Added annotation (@LogLevel(Log4jLevel.Off)) to sensitive response object fields

Ran the following tests on simulator:

test_vm_life_cycle.py

Test advanced zone virtual router ... === TestName: test_advZoneVirtualRouter | Status : SUCCESS ===
ok
Test Deploy Virtual Machine ... === TestName: test_deploy_vm | Status : SUCCESS ===
ok
Test Multiple Deploy Virtual Machine ... === TestName: test_deploy_vm_multiple | Status : SUCCESS ===
ok
Test Stop Virtual Machine ... === TestName: test_01_stop_vm | Status : SUCCESS ===
ok
Test Start Virtual Machine ... === TestName: test_02_start_vm | Status : SUCCESS ===
ok
Test Reboot Virtual Machine ... === TestName: test_03_reboot_vm | Status : SUCCESS ===
ok
Test destroy Virtual Machine ... === TestName: test_06_destroy_vm | Status : SUCCESS ===
ok
Test recover Virtual Machine ... === TestName: test_07_restore_vm | Status : SUCCESS ===
ok
Test migrate VM ... === TestName: test_08_migrate_vm | Status : SUCCESS ===
ok
Test destroy(expunge) Virtual Machine ... === TestName: test_09_expunge_vm | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 10 tests in 306.429s

OK

test_volumes.py

Download a Volume attached to a VM ... === TestName: test_03_download_attached_volume | Status : SUCCESS ===
ok
Delete a Volume attached to a VM ... === TestName: test_04_delete_attached_volume | Status : SUCCESS ===
ok
Detach a Volume attached to a VM ... === TestName: test_05_detach_volume | Status : SUCCESS ===
ok
Delete a Volume unattached to an VM ... === TestName: test_09_delete_detached_volume | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 4 tests in 184.132s

OK

test_network.py

Test for delete account ... === TestName: test_delete_account | Status : SUCCESS ===
ok
Test for Associate/Disassociate public IP address for admin account ... === TestName: test_public_ip_admin_account | Status : SUCCESS ===
ok
Test for Associate/Disassociate public IP address for user account ... === TestName: test_public_ip_user_account | Status : SUCCESS ===
ok
Test for release public IP address ... === TestName: test_releaseIP | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 4 tests in 783.726s

OK

test_routers.py

Test router internal advanced zone ... SKIP: Marvin configuration has no host credentials                            to check router services
Test restart network ... === TestName: test_03_restart_network_cleanup | Status : SUCCESS ===
ok
Test router basic setup ... === TestName: test_05_router_basic | Status : SUCCESS ===
ok
Test router advanced setup ... === TestName: test_06_router_advanced | Status : SUCCESS ===
ok
Test stop router ... === TestName: test_07_stop_router | Status : SUCCESS ===
ok
Test start router ... === TestName: test_08_start_router | Status : SUCCESS ===
ok
Test reboot router ... === TestName: test_09_reboot_router | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 7 tests in 42.958s

OK (SKIP=1)

test_global_settings.py

test update configuration setting at zone level scope ... === TestName: test_UpdateConfigParamWithScope | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 0.127s

OK

test_resource_detail.py

Test volume detail ... === TestName: test_01_updatevolumedetail | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 11.492s

OK
