### PR TITLE
[4.6/master] CLOUDSTACK-9019: Add storage network offering in ssvm only if storage…

### DIFF
--- a/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -92,6 +92,7 @@ import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.rules.RulesManager;
+import com.cloud.network.StorageNetworkManager;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.offerings.dao.NetworkOfferingDao;
@@ -179,6 +180,8 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
     @Inject
     protected SecondaryStorageVmDao _secStorageVmDao;
+    @Inject
+    protected StorageNetworkManager _sNwMgr;
     @Inject
     private DataCenterDao _dcDao;
     @Inject
@@ -551,9 +554,12 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             defaultNetwork = defaultNetworks.get(0);
         }
 
-        List<? extends NetworkOffering> offerings =
-            _networkModel.getSystemAccountNetworkOfferings(NetworkOffering.SystemControlNetwork, NetworkOffering.SystemManagementNetwork,
-                NetworkOffering.SystemStorageNetwork);
+        List<? extends NetworkOffering> offerings = null;
+        if (_sNwMgr.isStorageIpRangeAvailable(dataCenterId)) {
+            offerings = _networkModel.getSystemAccountNetworkOfferings(NetworkOffering.SystemControlNetwork, NetworkOffering.SystemManagementNetwork, NetworkOffering.SystemStorageNetwork);
+        } else {
+            offerings = _networkModel.getSystemAccountNetworkOfferings(NetworkOffering.SystemControlNetwork, NetworkOffering.SystemManagementNetwork);
+        }
         LinkedHashMap<Network, List<? extends NicProfile>> networks = new LinkedHashMap<Network, List<? extends NicProfile>>(offerings.size() + 1);
         NicProfile defaultNic = new NicProfile();
         defaultNic.setDefaultNic(true);


### PR DESCRIPTION
… network is defined

During creation of SSVM, checks and adds NetworkOffering.SystemStorageNetwork to
offerings only if storage network exists for the target datacenter.

(Manually tested)