### PR TITLE
CLOUDSTACK-9021 - Add right interface when test is executed against HyperV/VMware

### DIFF
--- a/test/integration/smoke/test_ssvm.py
+++ b/test/integration/smoke/test_ssvm.py
@@ -490,7 +490,7 @@ class TestSSVMs(cloudstackTestCase):
                 self.apiclient.connection.user,
                 self.apiclient.connection.passwd,
                 ssvm.privateip,
-                "cat /var/cache/cloud/cmdline | xargs | sed \"s/ /\\n/g\" | grep eth0ip= | sed \"s/\=/ /g\" | awk '{print $2}'",
+                "cat /var/cache/cloud/cmdline | xargs | sed \"s/ /\\n/g\" | grep eth1ip= | sed \"s/\=/ /g\" | awk '{print $2}'",
                 hypervisor=self.hypervisor
             )
         else:
@@ -625,7 +625,7 @@ class TestSSVMs(cloudstackTestCase):
                 self.apiclient.connection.user,
                 self.apiclient.connection.passwd,
                 cpvm.privateip,
-                "cat /var/cache/cloud/cmdline | xargs | sed \"s/ /\\n/g\" | grep eth0ip= | sed \"s/\=/ /g\" | awk '{print $2}'",
+                "cat /var/cache/cloud/cmdline | xargs | sed \"s/ /\\n/g\" | grep eth1ip= | sed \"s/\=/ /g\" | awk '{print $2}'",
                 hypervisor=self.hypervisor
             )
         else:


### PR DESCRIPTION
The test now check the IP taking into account the right interface for VMware/HyperV (eth1).

@karuturi could you please have a look? Unfortunately, I do not have HyperV/VMware test environment.