### PR TITLE
[blocker/critical] CLOUDSTACK-9025 : [Xenserver] Sending template creation from snapshot command to Hypervisor

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/XenServerGuru.java
@@ -193,9 +193,13 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
                     EndPoint ep = endPointSelector.selectHypervisorHost(new ZoneScope(host.getDataCenterId()));
                     host = hostDao.findById(ep.getId());
                     hostDao.loadDetails(host);
+                    String hypervisorVersion = host.getHypervisorVersion();
                     String snapshotHotFixVersion = host.getDetail(XenserverConfigs.XS620HotFix);
-                    if (snapshotHotFixVersion != null && snapshotHotFixVersion.equalsIgnoreCase(XenserverConfigs.XSHotFix62ESP1004)) {
-                        return new Pair<Boolean, Long>(Boolean.TRUE, new Long(ep.getId()));
+                    if(hypervisorVersion != null && !hypervisorVersion.equalsIgnoreCase("6.1.0") ) {
+                        if (!(hypervisorVersion.equalsIgnoreCase("6.2.0") &&
+                                !(snapshotHotFixVersion != null && snapshotHotFixVersion.equalsIgnoreCase(XenserverConfigs.XSHotFix62ESP1004)))) {
+                            return new Pair<Boolean, Long>(Boolean.TRUE, new Long(ep.getId()));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9025

In this fix we are sending command to hypervisor only if hypervisor version is not 6.1.0 and 6.2.0 without XSHotFix62ESP1004. I am not sure whether we support Xenserver 6.1.0 and 6.2.0 without XSHotFix62ESP1004. This conditional check is there to make sure users are able to upgrade in transition period. If that's not the case we can remove condition all together and can send command to hypervisor.

To test this issue we need different versions of XenServer. Versions which we are mentioning in condition in that case it should go to SSVM and in other cases it should go to Hypervsior. SSVM can't handle linked snapshots in case of XenServer. 