### PR TITLE
CLOUDSTACK-9026: Modifying testpath for adding missing parameter

### DIFF
--- a/test/integration/testpaths/testpath_storage_migration.py
+++ b/test/integration/testpaths/testpath_storage_migration.py
@@ -248,6 +248,13 @@ class TestStorageMigration(cloudstackTestCase):
                 DomainName=cls.account.domain
             )
             # Create Service offering
+            cls.service_offering = ServiceOffering.create(
+                cls.apiclient,
+                cls.testdata["service_offering"]
+            )
+
+            cls._cleanup.append(cls.service_offering)
+
             cls.service_offering_zone1 = ServiceOffering.create(
                 cls.apiclient,
                 cls.testdata["service_offering"],


### PR DESCRIPTION
Adding service_offering creation in testpath_storage_migration.py testpath which is missing right now 