### PR TITLE
CLOUDSTACK-9037 patterns can be more elaborate then prefixes.

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1170,17 +1170,17 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         return "";
     }
 
-    String [] _ifNamePrefixes = {
-            "eth",
-            "bond",
-            "vlan",
-            "vx",
-            "em",
-            "ens",
-            "eno",
-            "enp",
-            "team",
-            "enx",
+    String [] _ifNamePatterns = {
+            "^eth",
+            "^bond",
+            "^vlan",
+            "^vx",
+            "^em",
+            "^ens",
+            "^eno",
+            "^enp",
+            "^team",
+            "^enx",
             "^p\\d+p\\d+"
     };
     /**
@@ -1188,9 +1188,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
      * @return
      */
     boolean isInterface(final String fname) {
-        final StringBuffer commonPattern = new StringBuffer();
-        for (final String ifNamePrefix : _ifNamePrefixes) {
-            commonPattern.append("|(").append(ifNamePrefix).append(".*)");
+        StringBuffer commonPattern = new StringBuffer();
+        for (final String ifNamePattern : _ifNamePatterns) {
+            commonPattern.append("|(").append(ifNamePattern).append(".*)");
         }
         if(fname.matches(commonPattern.toString())) {
             return true;

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -5005,10 +5005,11 @@ public class LibvirtComputingResourceTest {
         LibvirtComputingResource lvcr = new LibvirtComputingResource();
         assertFalse(lvcr.isInterface("bla"));
         assertTrue(lvcr.isInterface("p99p00"));
-        for  (String ifNamePrefix : lvcr._ifNamePrefixes) {
+        for  (String ifNamePattern : lvcr._ifNamePatterns) {
             // excluding regexps as "\\\\d+" won't replace with String.replaceAll(String,String);
-            if (!ifNamePrefix.contains("\\")) {
-                assertTrue(lvcr.isInterface(ifNamePrefix + "0"));
+            if (!ifNamePattern.contains("\\")) {
+                String ifName = ifNamePattern.replaceFirst("\\^", "") + "0";
+                assertTrue("The pattern '" + ifNamePattern + "' is expected to be valid for interface " + ifName,lvcr.isInterface(ifName));
             }
         }
     }


### PR DESCRIPTION
little fix to make sure for instance "eth" is not regarded as interface when it is part of "methamfetamine"