### PR TITLE
Fix for CLOUDSTACK-8937 - XenServer migrations with storage failing i…

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageCommandWrapper.java
@@ -41,6 +41,7 @@ import com.cloud.network.Networks.TrafficType;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
 import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.Pair;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.Host;
 import com.xensource.xenapi.Network;
@@ -60,7 +61,7 @@ public final class XenServer610MigrateWithStorageCommandWrapper extends CommandW
     public Answer execute(final MigrateWithStorageCommand command, final XenServer610Resource xenServer610Resource) {
         final Connection connection = xenServer610Resource.getConnection();
         final VirtualMachineTO vmSpec = command.getVirtualMachine();
-        final Map<VolumeTO, StorageFilerTO> volumeToFiler = command.getVolumeToFiler();
+        final List<Pair<VolumeTO, StorageFilerTO>> volToFiler = command.getVolumeToFilerAsList();
         final String vmName = vmSpec.getName();
         Task task = null;
 
@@ -83,10 +84,8 @@ public final class XenServer610MigrateWithStorageCommandWrapper extends CommandW
             // Create the vif map. The vm stays in the same cluster so we have to pass an empty vif map.
             final Map<VIF, Network> vifMap = new HashMap<VIF, Network>();
             final Map<VDI, SR> vdiMap = new HashMap<VDI, SR>();
-            for (final Map.Entry<VolumeTO, StorageFilerTO> entry : volumeToFiler.entrySet()) {
-                final VolumeTO volume = entry.getKey();
-                final StorageFilerTO sotrageFiler = entry.getValue();
-                vdiMap.put(xenServer610Resource.getVDIbyUuid(connection, volume.getPath()), xenServer610Resource.getStorageRepository(connection, sotrageFiler.getUuid()));
+            for (final Pair<VolumeTO, StorageFilerTO> entry : volToFiler) {
+                vdiMap.put(xenServer610Resource.getVDIbyUuid(connection, entry.first().getPath()), xenServer610Resource.getStorageRepository(connection, entry.second().getUuid()));
             }
 
             // Get the vm to migrate.

--- a/plugins/hypervisors/xenserver/src/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
+++ b/plugins/hypervisors/xenserver/src/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.cloudstack.storage.motion;
 
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -59,6 +60,7 @@ import com.cloud.storage.StoragePool;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.Pair;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.dao.VMInstanceDao;
 
@@ -193,15 +195,14 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
 
         // Initiate migration of a virtual machine with it's volumes.
         try {
-            Map<VolumeTO, StorageFilerTO> volumeToFilerto = new HashMap<VolumeTO, StorageFilerTO>();
+            List<Pair<VolumeTO, StorageFilerTO>> volumeToFilerto = new ArrayList<Pair<VolumeTO, StorageFilerTO>>();
             for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
                 VolumeInfo volume = entry.getKey();
                 VolumeTO volumeTo = new VolumeTO(volume, storagePoolDao.findById(volume.getPoolId()));
                 StorageFilerTO filerTo = new StorageFilerTO((StoragePool)entry.getValue());
-                volumeToFilerto.put(volumeTo, filerTo);
+                volumeToFilerto.add(new Pair<VolumeTO, StorageFilerTO>(volumeTo, filerTo));
             }
-
-            MigrateWithStorageCommand command = new MigrateWithStorageCommand(to, volumeToFilerto);
+            MigrateWithStorageCommand command = new MigrateWithStorageCommand(to, volumeToFilerto,destHost.getGuid());
             MigrateWithStorageAnswer answer = (MigrateWithStorageAnswer)agentMgr.send(destHost.getId(), command);
             if (answer == null) {
                 s_logger.error("Migration with storage of vm " + vm + " failed.");


### PR DESCRIPTION
…n clustered management server environment

This pull request relates to the following Jira bug report:
https://issues.apache.org/jira/browse/CLOUDSTACK-8937

A previous fix was proposed for the 4.5 branch here: https://github.com/apache/cloudstack/pull/925
This was tested within a working environment and everything appeared to work fine. 

@remibergsma Unfortunately I have not been able to test this within a running environment. Everything appears to compile ok and tests pass. I believe you are much further along in the Cloudstack automated testing arena, so I'm not sure if this is something you would be able to test at some point in the future?

If not I will be able to test it when my current workload permits and report back here with my findings. 
