### PR TITLE
CLOUDSTACK-9040: Use Tomcat6 for Debian packages.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Description: A common package which contains files which are shared by several C
 
 Package: cloudstack-management
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, cloudstack-common (= ${source:Version}), tomcat8 | tomcat7 | tomcat6, sudo, jsvc, python-mysqldb, libmysql-java, augeas-tools, mysql-client, adduser
+Depends: ${misc:Depends}, ${python:Depends}, cloudstack-common (= ${source:Version}), tomcat6, sudo, jsvc, python-mysqldb, libmysql-java, augeas-tools, mysql-client, adduser
 Conflicts: cloud-server, cloud-client, cloud-client-ui
 Description: CloudStack server library
  The CloudStack management server


### PR DESCRIPTION
Use Tomcat6 for Debian packages.

How to test:
Package debian packages and install them. Will depend specifically on tomcat6 for now.

Error log before:
```
DEBUG:root:execute:uname -r
DEBUG:root:execute:uname -m
DEBUG:root:execute:hostname -f
DEBUG:root:execute:iptables-save|grep INPUT|grep -w 8080
DEBUG:root:Failed to execute:
DEBUG:root:execute:ufw allow 8080/tcp
DEBUG:root:execute:iptables-save|grep INPUT|grep -w 8250
DEBUG:root:Failed to execute:
DEBUG:root:execute:ufw allow 8250/tcp
DEBUG:root:execute:iptables-save|grep INPUT|grep -w 9090
DEBUG:root:Failed to execute:
DEBUG:root:execute:ufw allow 9090/tcp
DEBUG:root:execute:rm -f /etc/cloudstack/management/server.xml
DEBUG:root:execute:rm -f /etc/cloudstack/management/tomcat6.conf
DEBUG:root:execute:ln -s /etc/cloudstack/management/server-nonssl.xml /etc/cloudstack/management/server.xml
DEBUG:root:execute:ln -s /etc/cloudstack/management/tomcat6-nonssl.conf /etc/cloudstack/management/tomcat6.conf
DEBUG:root:execute:touch /var/run/cloudstack-management.pid
DEBUG:root:execute:chown cloud.cloud /var/run/cloudstack-management.pid
DEBUG:root:execute:hostname --fqdn
DEBUG:root:execute:mkdir /var/log/cloudstack-management/
DEBUG:root:Failed to execute:mkdir: cannot create directory '/var/log/cloudstack-management/': File exists
DEBUG:root:execute:sudo /usr/sbin/service tomcat6 status
DEBUG:root:Failed to execute:tomcat6: unrecognized service
DEBUG:root:execute:sudo /usr/sbin/service tomcat6 stop
DEBUG:root:Failed to execute:tomcat6: unrecognized service
DEBUG:root:execute:sudo update-rc.d -f tomcat6 remove
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management status
DEBUG:root:Failed to execute: * cloudstack-management is not installed
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management stop
DEBUG:root:Failed to execute: * cloudstack-management is not installed
DEBUG:root:execute:sudo update-rc.d -f cloudstack-management remove
DEBUG:root:execute:sudo update-rc.d -f cloudstack-management defaults
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management status
DEBUG:root:Failed to execute: * cloudstack-management is not installed
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management start
DEBUG:root:Failed to execute: * cloudstack-management is not installed
DEBUG:root:None
```

After:
```
root@cs1:~# cloudstack-setup-management
Starting to configure CloudStack Management Server:
Configure Firewall ...        [OK]
Configure CloudStack Management Server ...[OK]
CloudStack Management Server setup is Done!
```

Error log after:
```
DEBUG:root:execute:uname -r
DEBUG:root:execute:uname -m
DEBUG:root:execute:hostname -f
DEBUG:root:execute:iptables-save|grep INPUT|grep -w 8080
DEBUG:root:Failed to execute:
DEBUG:root:execute:ufw allow 8080/tcp
DEBUG:root:execute:iptables-save|grep INPUT|grep -w 8250
DEBUG:root:Failed to execute:
DEBUG:root:execute:ufw allow 8250/tcp
DEBUG:root:execute:iptables-save|grep INPUT|grep -w 9090
DEBUG:root:Failed to execute:
DEBUG:root:execute:ufw allow 9090/tcp
DEBUG:root:execute:rm -f /etc/cloudstack/management/server.xml
DEBUG:root:execute:rm -f /etc/cloudstack/management/tomcat6.conf
DEBUG:root:execute:ln -s /etc/cloudstack/management/server-nonssl.xml /etc/cloudstack/management/server.xml
DEBUG:root:execute:ln -s /etc/cloudstack/management/tomcat6-nonssl.conf /etc/cloudstack/management/tomcat6.conf
DEBUG:root:execute:touch /var/run/cloudstack-management.pid
DEBUG:root:execute:chown cloud.cloud /var/run/cloudstack-management.pid
DEBUG:root:execute:hostname --fqdn
DEBUG:root:execute:mkdir /var/log/cloudstack-management/
DEBUG:root:execute:sudo /usr/sbin/service tomcat6 status
DEBUG:root:execute:sudo /usr/sbin/service tomcat6 stop
DEBUG:root:execute:sudo update-rc.d -f tomcat6 remove
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management status
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management stop
DEBUG:root:execute:sudo update-rc.d -f cloudstack-management remove
DEBUG:root:execute:sudo update-rc.d -f cloudstack-management defaults
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management status
DEBUG:root:execute:sudo /usr/sbin/service cloudstack-management start
```