### PR TITLE
CLOUDSTACK-9041: Modifying template creation from snapshot function 

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -1201,6 +1201,9 @@ class Template:
             random_gen()
         ]) if random_name else services["name"]
 
+	if services["ispublic"]:
+	    cmd.ispublic = services["ispublic"]
+
         if "ostypeid" in services:
             cmd.ostypeid = services["ostypeid"]
         elif "ostype" in services:


### PR DESCRIPTION
In create_from_snapshot function of Template class there is no parameter to accept if the template is public hence default it is creating private templates 
Hence adding this parameter.