### PR TITLE
CLOUDSTACK-5822: keep user-added sshkeys in authorized_keys

### DIFF
--- a/setup/bindir/cloud-set-guest-sshkey.in
+++ b/setup/bindir/cloud-set-guest-sshkey.in
@@ -81,8 +81,8 @@ if [ ! -e $authorized ]; then
     chmod 600 $authorized
 fi
 
-cat $authorized|grep -v "$publickey"|tee $authorized > /dev/null
-echo "$publickey" >> $authorized
+sed -i "/ cloudstack@apache.org$/d" $authorized
+echo "$publickey cloudstack@apache.org" >> $authorized
 
 which restorecon && restorecon -R -v $sshdir
 


### PR DESCRIPTION
For now, if we add the ssh key inside the vm (not on cloudstack UI), the sshkey will be removed if we reset the sshkey on cloudstack UI.

After this commit, the sshkey (added by cloudstack) will end with cloudstack@apache.org.
We will only control the sshkeys with cloudstack@apache.org.

This will be used for multiple sshkey support for vm in the future.
