### PR TITLE
CLOUDSTACK-9046 - Fix upgrade path from 4.4 and 4.5 to 4.6

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
@@ -171,31 +171,39 @@ public class Upgrade452to460 implements DbUpgrade {
         return new File[] { new File(script) };
     }
 
+    @SuppressWarnings("serial")
     private void updateSystemVmTemplates(final Connection conn) {
         s_logger.debug("Updating System Vm template IDs");
-        //Get all hypervisors in use
+        // Get all hypervisors in use
         final Set<Hypervisor.HypervisorType> hypervisorsListInUse = new HashSet<Hypervisor.HypervisorType>();
-        try (PreparedStatement pstmt = conn.prepareStatement("select distinct(hypervisor_type) from `cloud`.`cluster` where removed is null");
-                ResultSet rs = pstmt.executeQuery()
-                ) {
-            while(rs.next()){
+        try (PreparedStatement pstmt = conn.prepareStatement("select distinct(hypervisor_type) from `cloud`.`cluster` where removed is null"); ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
                 switch (Hypervisor.HypervisorType.getType(rs.getString(1))) {
-                case XenServer: hypervisorsListInUse.add(Hypervisor.HypervisorType.XenServer);
-                break;
-                case KVM:       hypervisorsListInUse.add(Hypervisor.HypervisorType.KVM);
-                break;
-                case VMware:    hypervisorsListInUse.add(Hypervisor.HypervisorType.VMware);
-                break;
-                case Hyperv:    hypervisorsListInUse.add(Hypervisor.HypervisorType.Hyperv);
-                break;
-                case LXC:       hypervisorsListInUse.add(Hypervisor.HypervisorType.LXC);
-                break;
-                default:  // no action on cases Any, BareMetal, None, Ovm, Parralels, Simulator and VirtualBox:
+                case XenServer:
+                    hypervisorsListInUse.add(Hypervisor.HypervisorType.XenServer);
+                    break;
+                case KVM:
+                    hypervisorsListInUse.add(Hypervisor.HypervisorType.KVM);
+                    break;
+                case VMware:
+                    hypervisorsListInUse.add(Hypervisor.HypervisorType.VMware);
+                    break;
+                case Hyperv:
+                    hypervisorsListInUse.add(Hypervisor.HypervisorType.Hyperv);
+                    break;
+                case LXC:
+                    hypervisorsListInUse.add(Hypervisor.HypervisorType.LXC);
+                    break;
+                case Ovm3:
+                    hypervisorsListInUse.add(Hypervisor.HypervisorType.Ovm3);
+                    break;
+                default: // no action on cases Any, BareMetal, None, Ovm,
+                    // Parralels, Simulator and VirtualBox:
                     break;
                 }
             }
         } catch (final SQLException e) {
-            s_logger.error("updateSystemVmTemplates:Exception while getting hypervisor types from clusters: "+e.getMessage());
+            s_logger.error("updateSystemVmTemplates:Exception while getting hypervisor types from clusters: " + e.getMessage());
             throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting hypervisor types from clusters", e);
         }
 
@@ -206,108 +214,127 @@ public class Upgrade452to460 implements DbUpgrade {
                 put(Hypervisor.HypervisorType.KVM, "systemvm-kvm-4.6");
                 put(Hypervisor.HypervisorType.LXC, "systemvm-lxc-4.6");
                 put(Hypervisor.HypervisorType.Hyperv, "systemvm-hyperv-4.6");
+                put(Hypervisor.HypervisorType.Ovm3, "systemvm-ovm3-4.6");
             }
         };
 
         final Map<Hypervisor.HypervisorType, String> routerTemplateConfigurationNames = new HashMap<Hypervisor.HypervisorType, String>() {
             {
-                put(Hypervisor.HypervisorType.XenServer, "router.template.xen");
+                put(Hypervisor.HypervisorType.XenServer, "router.template.xenserver");
                 put(Hypervisor.HypervisorType.VMware, "router.template.vmware");
                 put(Hypervisor.HypervisorType.KVM, "router.template.kvm");
                 put(Hypervisor.HypervisorType.LXC, "router.template.lxc");
                 put(Hypervisor.HypervisorType.Hyperv, "router.template.hyperv");
+                put(Hypervisor.HypervisorType.Ovm3, "router.template.ovm3");
             }
         };
 
         final Map<Hypervisor.HypervisorType, String> newTemplateUrl = new HashMap<Hypervisor.HypervisorType, String>() {
             {
-                put(Hypervisor.HypervisorType.XenServer, "http://download.cloud.com/templates/4.6/systemvm64template-4.6-xen.vhd.bz2");
-                put(Hypervisor.HypervisorType.VMware, "http://download.cloud.com/templates/4.6/systemvm64template-4.6-vmware.ova");
-                put(Hypervisor.HypervisorType.KVM, "http://download.cloud.com/templates/4.6/systemvm64template-4.6-kvm.qcow2.bz2");
-                put(Hypervisor.HypervisorType.LXC, "http://download.cloud.com/templates/4.6/systemvm64template-4.6-kvm.qcow2.bz2");
-                put(Hypervisor.HypervisorType.Hyperv, "http://download.cloud.com/templates/4.6/systemvm64template-4.6-hyperv.vhd.zip");
+                put(Hypervisor.HypervisorType.XenServer, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-xen.vhd.bz2");
+                put(Hypervisor.HypervisorType.VMware, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-vmware.ova");
+                put(Hypervisor.HypervisorType.KVM, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-kvm.qcow2.bz2");
+                put(Hypervisor.HypervisorType.LXC, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-kvm.qcow2.bz2");
+                put(Hypervisor.HypervisorType.Hyperv, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-hyperv.vhd.zip");
+                put(Hypervisor.HypervisorType.Ovm3, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-ovm.raw.bz2");
             }
         };
 
         final Map<Hypervisor.HypervisorType, String> newTemplateChecksum = new HashMap<Hypervisor.HypervisorType, String>() {
             {
-                put(Hypervisor.HypervisorType.XenServer, "2b15ab4401c2d655264732d3fc600241");
-                put(Hypervisor.HypervisorType.VMware, "3106a79a4ce66cd7f6a7c50e93f2db57");
-                put(Hypervisor.HypervisorType.KVM, "aa9f501fecd3de1daeb9e2f357f6f002");
-                put(Hypervisor.HypervisorType.LXC, "aa9f501fecd3de1daeb9e2f357f6f002");
-                put(Hypervisor.HypervisorType.Hyperv, "70bd30ea02ee9ed67d2c6b85c179cee9");
+                put(Hypervisor.HypervisorType.XenServer, "8886f554a499ec5405b6f203d9d36460");
+                put(Hypervisor.HypervisorType.VMware, "4b415224fe00b258f66cad9fce9f73fc");
+                put(Hypervisor.HypervisorType.KVM, "c059b0d051e0cd6fbe9d5d4fc40c7e5d");
+                put(Hypervisor.HypervisorType.LXC, "c059b0d051e0cd6fbe9d5d4fc40c7e5d");
+                put(Hypervisor.HypervisorType.Hyperv, "53e24bddfa56ea3139ed37af4b519013");
+                put(Hypervisor.HypervisorType.Ovm3, "c8577d27b2daafb2d9a4ed307ce2f00f");
             }
         };
 
         for (final Map.Entry<Hypervisor.HypervisorType, String> hypervisorAndTemplateName : NewTemplateNameList.entrySet()) {
             s_logger.debug("Updating " + hypervisorAndTemplateName.getKey() + " System Vms");
-            try  (PreparedStatement pstmt = conn.prepareStatement("select id from `cloud`.`vm_template` where name = ? and removed is null order by id desc limit 1")) {
-                //Get 4.6.0 system Vm template Id for corresponding hypervisor
+            try (PreparedStatement pstmt = conn.prepareStatement("select id from `cloud`.`vm_template` where name = ? and removed is null order by id desc limit 1")) {
+                // Get 4.6.0 system Vm template Id for corresponding hypervisor
                 long templateId = -1;
                 pstmt.setString(1, hypervisorAndTemplateName.getValue());
                 try (ResultSet rs = pstmt.executeQuery()) {
-                    if(rs.next()){
+                    if (rs.next()) {
                         templateId = rs.getLong(1);
                     }
-                } catch (final SQLException e)
-                {
-                    s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: "+e.getMessage());
+                } catch (final SQLException e) {
+                    s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
                     throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
                 }
 
                 // change template type to SYSTEM
                 if (templateId != -1) {
-                    try(PreparedStatement templ_type_pstmt = conn.prepareStatement("update `cloud`.`vm_template` set type='SYSTEM' where id = ?");)
-                    {
+                    try (PreparedStatement templ_type_pstmt = conn.prepareStatement("update `cloud`.`vm_template` set type='SYSTEM' where id = ?");) {
                         templ_type_pstmt.setLong(1, templateId);
                         templ_type_pstmt.executeUpdate();
-                    }
-                    catch (final SQLException e)
-                    {
-                        s_logger.error("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system': "+e.getMessage());
+                    } catch (final SQLException e) {
+                        s_logger.error("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system': " + e.getMessage());
                         throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system'", e);
                     }
                     // update template ID of system Vms
-                    try(PreparedStatement update_templ_id_pstmt = conn.prepareStatement("update `cloud`.`vm_instance` set vm_template_id = ? where type <> 'User' and hypervisor_type = ?");)
-                    {
+                    try (PreparedStatement update_templ_id_pstmt = conn
+                            .prepareStatement("update `cloud`.`vm_instance` set vm_template_id = ? where type <> 'User' and hypervisor_type = ?");) {
                         update_templ_id_pstmt.setLong(1, templateId);
                         update_templ_id_pstmt.setString(2, hypervisorAndTemplateName.getKey().toString());
                         update_templ_id_pstmt.executeUpdate();
-                    }catch (final Exception e)
-                    {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to " + templateId + ": "+e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to " + templateId, e);
+                    } catch (final Exception e) {
+                        s_logger.error("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to " + templateId
+                                + ": " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to "
+                                + templateId, e);
                     }
-                    // Change value of global configuration parameter router.template.* for the corresponding hypervisor
-                    try(PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
+
+                    // Change value of global configuration parameter
+                    // router.template.* for the corresponding hypervisor
+                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
                         update_pstmt.setString(1, hypervisorAndTemplateName.getValue());
                         update_pstmt.setString(2, routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()));
                         update_pstmt.executeUpdate();
-                    }catch (final SQLException e)
-                    {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting " + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to " + hypervisorAndTemplateName.getValue() + ": "+e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting " + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to " + hypervisorAndTemplateName.getValue(), e);
+                    } catch (final SQLException e) {
+                        s_logger.error("updateSystemVmTemplates:Exception while setting " + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to "
+                                + hypervisorAndTemplateName.getValue() + ": " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting "
+                                + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to " + hypervisorAndTemplateName.getValue(), e);
+                    }
+
+                    // Change value of global configuration parameter
+                    // minreq.sysvmtemplate.version for the ACS version
+                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
+                        update_pstmt.setString(1, getUpgradedVersion());
+                        update_pstmt.setString(2, "minreq.sysvmtemplate.version");
+                        update_pstmt.executeUpdate();
+                    } catch (final SQLException e) {
+                        s_logger.error("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.6.0: " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.6.0", e);
                     }
                 } else {
-                    if (hypervisorsListInUse.contains(hypervisorAndTemplateName.getKey())){
-                        throw new CloudRuntimeException("4.6.0 " + hypervisorAndTemplateName.getKey() + " SystemVm template not found. Cannot upgrade system Vms");
+                    if (hypervisorsListInUse.contains(hypervisorAndTemplateName.getKey())) {
+                        throw new CloudRuntimeException(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. Cannot upgrade system Vms");
                     } else {
-                        s_logger.warn("4.6.0 " + hypervisorAndTemplateName.getKey() + " SystemVm template not found. " + hypervisorAndTemplateName.getKey() + " hypervisor is not used, so not failing upgrade");
-                        // Update the latest template URLs for corresponding hypervisor
-                        try(PreparedStatement update_templ_url_pstmt = conn.prepareStatement("UPDATE `cloud`.`vm_template` SET url = ? , checksum = ? WHERE hypervisor_type = ? AND type = 'SYSTEM' AND removed is null order by id desc limit 1");) {
+                        s_logger.warn(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. " + hypervisorAndTemplateName.getKey()
+                                + " hypervisor is not used, so not failing upgrade");
+                        // Update the latest template URLs for corresponding
+                        // hypervisor
+                        try (PreparedStatement update_templ_url_pstmt = conn
+                                .prepareStatement("UPDATE `cloud`.`vm_template` SET url = ? , checksum = ? WHERE hypervisor_type = ? AND type = 'SYSTEM' AND removed is null order by id desc limit 1");) {
                             update_templ_url_pstmt.setString(1, newTemplateUrl.get(hypervisorAndTemplateName.getKey()));
                             update_templ_url_pstmt.setString(2, newTemplateChecksum.get(hypervisorAndTemplateName.getKey()));
                             update_templ_url_pstmt.setString(3, hypervisorAndTemplateName.getKey().toString());
                             update_templ_url_pstmt.executeUpdate();
-                        }catch (final SQLException e)
-                        {
-                            s_logger.error("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type " + hypervisorAndTemplateName.getKey().toString() + ": "+e.getMessage());
-                            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type " + hypervisorAndTemplateName.getKey().toString(), e);
+                        } catch (final SQLException e) {
+                            s_logger.error("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
+                                    + hypervisorAndTemplateName.getKey().toString() + ": " + e.getMessage());
+                            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
+                                    + hypervisorAndTemplateName.getKey().toString(), e);
                         }
                     }
                 }
             } catch (final SQLException e) {
-                s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: "+e.getMessage());
+                s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
                 throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
             }
         }

--- a/setup/db/db/schema-452to460.sql
+++ b/setup/db/db/schema-452to460.sql
@@ -377,7 +377,7 @@ INSERT IGNORE INTO `cloud`.`hypervisor_capabilities`(hypervisor_type, hypervisor
 UPDATE  `cloud`.`volumes` v,  `cloud`.`storage_pool` s,  `cloud`.`cluster` c  set v.format='RAW' where v.pool_id=s.id and s.cluster_id=c.id and c.hypervisor_type='Ovm3';
 UPDATE configuration SET value='KVM,XenServer,VMware,BareMetal,Ovm,Ovm3,LXC' WHERE name='hypervisor.list';
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text, format, guest_os_id,featured, cross_zones, hypervisor_type, state)
-VALUES (12, UUID(), 'routing-12', 'SystemVM Template (Ovm3)', 0, now(), 'SYSTEM', 0, 64, 1, 'http://download.cloud.com/templates/4.6/systemvm64template.ovm.raw.bz2', '4425688804dbcf0abc9e9e56c53070d7', 0, 'SystemVM Template (Ovm3)', 'RAW', 183, 0, 1, 'Ovm3', 'Active' );
+VALUES (12, UUID(), 'routing-12', 'SystemVM Template (Ovm3)', 0, now(), 'SYSTEM', 0, 64, 1, 'http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-ovm.raw.bz2', 'c8577d27b2daafb2d9a4ed307ce2f00f', 0, 'SystemVM Template (Ovm3)', 'RAW', 183, 0, 1, 'Ovm3', 'Active' );
 
 INSERT IGNORE INTO `cloud`.`configuration` (`category`, `instance`, `component`, `name`, `value`, `default_value`, `description`) VALUES ('Advanced', 'DEFAULT', 'ManagementServer', 'ovm3.heartbeat.timeout' , '180', '120', 'Timeout value to send to the checkheartbeat script for guarding the self fencing functionality on ovm3');
 INSERT IGNORE INTO `cloud`.`configuration` (`category`, `instance`, `component`, `name`, `value`, `default_value`, `description`) VALUES ('Advanced', 'DEFAULT', 'ManagementServer', 'ovm3.heartbeat.interval' , '10', '1', 'Interval value the checkheartbeat script uses before triggering the timeout for ovm3');


### PR DESCRIPTION
This PR fixes the upgrade path from 4.4.x/4.5.x to 4.6.0. We introduced the logic to update the database with the correct information about the SystemVMs.

We tested this PR with by doing an upgrade from 4.4.4 to 4.6.0 and it works as expected.
