### PR TITLE
CLOUDSTACK-8818: Use MySQL native connector with Python

### DIFF
--- a/client/bindir/cloud-update-xenserver-licenses.in
+++ b/client/bindir/cloud-update-xenserver-licenses.in
@@ -24,7 +24,7 @@ import glob
 from random import choice
 import string
 from optparse import OptionParser
-import MySQLdb
+import mysql.connector
 import paramiko
 from threading import Thread
 
@@ -59,7 +59,7 @@ parser.add_option("-a", "--all", action="store_true", dest="all", default=False,
 def e(msg): parser.error(msg)
 
 def getknownhosts(host,username,password):
-	conn = MySQLdb.connect(host=host,user=username,passwd=password)
+	conn = mysql.connector.connect(host=host, user=username, password=password)
 	cur = conn.cursor()
 	cur.execute("SELECT h.private_ip_address,d.value FROM cloud.host h inner join cloud.host_details d on (h.id = d.host_id) where d.name = 'username' and setup = 1")
 	usernames = dict(cur.fetchall())

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libs
 Priority: extra
 Maintainer: Wido den Hollander <wido@widodh.nl>
 Build-Depends: debhelper (>= 9), openjdk-8-jdk | openjdk-7-jdk, genisoimage,
- python-mysqldb, maven (>= 3) | maven3, python (>= 2.7)
+ python-mysql.connector, maven (>= 3) | maven3, python (>= 2.7)
 Standards-Version: 3.8.1
 Homepage: http://www.cloudstack.org/
 
@@ -15,7 +15,7 @@ Description: A common package which contains files which are shared by several C
 
 Package: cloudstack-management
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, cloudstack-common (= ${source:Version}), tomcat6, sudo, jsvc, python-mysqldb, libmysql-java, augeas-tools, mysql-client, adduser, bzip2
+Depends: ${misc:Depends}, ${python:Depends}, cloudstack-common (= ${source:Version}), tomcat6, sudo, jsvc, python-mysql.connector, libmysql-java, augeas-tools, mysql-client, adduser, bzip2
 Conflicts: cloud-server, cloud-client, cloud-client-ui
 Description: CloudStack server library
  The CloudStack management server

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -50,7 +50,7 @@ BuildRequires: jpackage-utils
 BuildRequires: gcc
 BuildRequires: glibc-devel
 BuildRequires: /usr/bin/mkisofs
-BuildRequires: MySQL-python
+BuildRequires: mysql-connector-python
 #BuildRequires: maven => 3.0.0
 
 %description
@@ -79,7 +79,7 @@ Requires: /sbin/service
 Requires: /sbin/chkconfig
 Requires: /usr/bin/ssh-keygen
 Requires: mkisofs
-Requires: MySQL-python
+Requires: mysql-connector-python
 Requires: python-paramiko
 Requires: ipmitool
 Requires: %{name}-common = %{_ver}

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -50,7 +50,7 @@ BuildRequires: jpackage-utils
 BuildRequires: gcc
 BuildRequires: glibc-devel
 BuildRequires: /usr/bin/mkisofs
-BuildRequires: MySQL-python
+BuildRequires: mysql-connector-python
 BuildRequires: maven => 3.0.0
 
 %description
@@ -79,7 +79,7 @@ Requires: /sbin/service
 Requires: /sbin/chkconfig
 Requires: /usr/bin/ssh-keygen
 Requires: mkisofs
-Requires: MySQL-python
+Requires: mysql-connector-python
 Requires: ipmitool
 Requires: %{name}-common = %{_ver}
 Requires: iptables-services

--- a/packaging/fedora20/cloud.spec
+++ b/packaging/fedora20/cloud.spec
@@ -50,7 +50,7 @@ BuildRequires: jpackage-utils
 BuildRequires: gcc
 BuildRequires: glibc-devel
 BuildRequires: /usr/bin/mkisofs
-BuildRequires: MySQL-python
+BuildRequires: mysql-connector-python
 #BuildRequires: maven => 3.0.0
 
 %description
@@ -79,7 +79,7 @@ Requires: /sbin/service
 Requires: /sbin/chkconfig
 Requires: /usr/bin/ssh-keygen
 Requires: mkisofs
-Requires: MySQL-python
+Requires: mysql-connector-python
 Requires: python-paramiko
 Requires: ipmitool
 Requires: %{name}-common = %{_ver}

--- a/packaging/fedora21/cloud.spec
+++ b/packaging/fedora21/cloud.spec
@@ -50,7 +50,7 @@ BuildRequires: jpackage-utils
 BuildRequires: gcc
 BuildRequires: glibc-devel
 BuildRequires: /usr/bin/mkisofs
-BuildRequires: MySQL-python
+BuildRequires: mysql-connector-python
 #BuildRequires: maven => 3.0.0
 
 %description
@@ -79,7 +79,7 @@ Requires: /sbin/service
 Requires: /sbin/chkconfig
 Requires: /usr/bin/ssh-keygen
 Requires: mkisofs
-Requires: MySQL-python
+Requires: mysql-connector-python
 Requires: python-paramiko
 Requires: ipmitool
 Requires: %{name}-common = %{_ver}

--- a/python/lib/cloudutils/db.py
+++ b/python/lib/cloudutils/db.py
@@ -5,21 +5,21 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import MySQLdb
 import os
 from utilities import bash
 from cloudException import CloudRuntimeException
-import sys
-class Database:
+import mysql.connector
+
+class Database(object):
     """Database connection"""
     def __init__(self, username, password=None, host='localhost', port='3306', db="cloud"):
         self.host = host
@@ -28,15 +28,16 @@ class Database:
         self.port = port
         self.db = db
 
+    def connect(self):
+        return mysql.connector.connect(host=self.host,
+                                       user=self.username,
+                                       password=self.password,
+                                       database=self.db)
+
     def execute(self, statement):
         txn = None
         try:
-            if self.password is not None:
-                txn = MySQLdb.Connect(host=self.host, user=self.username,
-                                 passwd=self.password, db=self.db)
-            else:
-                txn = MySQLdb.Connect(host=self.host, user=self.username,
-                                 db=self.db)
+            txn = self.connect()
             cursor = txn.cursor()
             cursor.execute(statement)
             cursor.close()
@@ -47,35 +48,33 @@ class Database:
                 except:
                     pass
         except:
+            raise CloudRuntimeException("Failed to execute: %s " % statement)
+        finally:
             if txn is not None:
                 try:
                     txn.close()
                 except:
                     pass
-            raise CloudRuntimeException("Failed to execute:%s"%statement)
-        
+
     def testConnection(self):
         try:
-            if self.password is not None:
-                db = MySQLdb.Connect(host=self.host, user=self.username,
-                                 passwd=self.password, db=self.db)
-            else:
-                db = MySQLdb.Connect(host=self.host, user=self.username,
-                                  db=self.db)
+            conn = self.connect()
+            conn.ping()
+            conn.close()
             return True
         except:
             raise CloudRuntimeException("Failed to Connect to DB")
-        
+
     def executeFromFile(self, file):
         if not os.path.exists(file):
             return False
-        
+
         cmdLine = "mysql --host=" + self.host + " --port=" + str(self.port) + " --user=" + self.username
         if self.password is not None:
             cmdLine += " --password=" + self.password
-        
+
         cmdLine += " < " + file
-        
+
         try:
             bash(cmdLine)
         except:

--- a/setup/bindir/cloud-migrate-databases.in
+++ b/setup/bindir/cloud-migrate-databases.in
@@ -20,7 +20,7 @@
 
 import os,logging,sys
 from optparse import OptionParser
-import MySQLdb
+import mysql.connector
 import subprocess
 import glob
 
@@ -72,10 +72,10 @@ class CloudContext(cloud_utils.MigrationContext):
 		self.database = database
 		self.configdir = configdir
 		self.resourcedir = resourcedir
-		self.conn = MySQLdb.connect(host=self.host,
+		self.conn = mysql.connector.connect(host=self.host,
 			user=self.username,
-			passwd=self.password,
-			db=self.database,
+			password=self.password,
+			database=self.database,
 			port=self.port)
 		self.conn.autocommit(False)
 		self.db = self.conn.cursor()


### PR DESCRIPTION
MySQLdb has been deprecated and is also not supported in Python 3.

mysql.connector is a connector written in Python which talks the
native MySQL protocol without any external code.

https://dev.mysql.com/doc/connector-python/en/