### PR TITLE
CLOUDSTACK-9058 Password server should respond with saved_password if there is no password to issue

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py
@@ -113,6 +113,7 @@ class PasswordRequestHandler(BaseHTTPRequestHandler):
         if requestType == 'send_my_password':
             password = getPassword(clientAddress)
             if not password:
+                self.wfile.write('saved_password')
                 syslog.syslog('serve_password: requested password not found for %s' % clientAddress)
             else:
                 self.wfile.write(password)


### PR DESCRIPTION
Respond with "saved_password" if no password is to be issued.