### PR TITLE
CLOUDSTACK-9050 Virtual router should only match IP address when choosing which interface to NAT

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/firewall_nat.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/firewall_nat.sh
@@ -45,7 +45,7 @@ ip_to_dev() {
   local ip=$1
 
   for dev in $DEV_LIST; do
-    ip addr show dev $dev | grep inet | grep $ip &>> /dev/null
+    ip addr show dev $dev | grep inet | grep -w $ip &>> /dev/null
     [ $? -eq 0 ] && echo $dev && return 0
   done
   return 1


### PR DESCRIPTION
Changed grep to match IP address only. Solves issue where virtual router was NATing IP addresses to the wrong interface if the IP address was a substring of the broadcast address on another interface.