### PR TITLE
[4.6.1] CLOUDSTACK-9015 - Redundant VPC Virtual Router's state is BACKUP & BACKUP or MASTER & MASTER

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -906,9 +906,6 @@ def main(argv):
     fwd = CsForwardingRules("forwardingrules", config)
     fwd.process()
 
-    red = CsRedundant(config)
-    red.set()
-
     logging.debug("Configuring s2s vpn")
     vpns = CsSite2SiteVpn("site2sitevpn", config)
     vpns.process()
@@ -938,6 +935,9 @@ def main(argv):
     logging.debug("Configuring iptables rules .....")
     nf = CsNetfilters()
     nf.compare(config.get_fw())
+    
+    red = CsRedundant(config)
+    red.set()
 
     logging.debug("Configuring iptables rules done ...saving rules")
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -228,10 +228,10 @@ class CsDevice:
                 continue
             self.devlist.append(vals[0])
 
-    def waitfordevice(self):
+    def waitfordevice(self, timeout=15):
         """ Wait up to 15 seconds for a device to become available """
         count = 0
-        while count < 15:
+        while count < timeout:
             if self.dev in self.devlist:
                 return True
             time.sleep(1)
@@ -497,6 +497,9 @@ class CsIP:
         self.fw.append(["", "", "-A NETWORK_STATS -i eth2 -o eth0 -p tcp"])
         self.fw.append(["", "", "-A NETWORK_STATS ! -i eth0 -o eth2 -p tcp"])
         self.fw.append(["", "", "-A NETWORK_STATS -i eth2 ! -o eth0 -p tcp"])
+
+        self.fw.append(["filter", "", "-A INPUT -d 224.0.0.18/32 -j ACCEPT"])
+        self.fw.append(["filter", "", "-A INPUT -d 225.0.0.50/32 -j ACCEPT"])
 
         self.fw.append(["filter", "", "-A INPUT -p icmp -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -i eth0 -p tcp -m tcp --dport 3922 -m state --state NEW,ESTABLISHED -j ACCEPT"])

--- a/systemvm/patches/debian/config/opt/cloud/bin/master.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/master.py
@@ -42,7 +42,7 @@ logging.basicConfig(filename=config.get_logger(),
                     format=config.get_format())
 config.cmdline()
 cl = CsCmdLine("cmdline", config)
-#Update the configuration to set state as backup and let keepalived decide who is the real Master
+#Update the configuration to set state as backup and let keepalived decide who the real Master is!
 cl.set_master_state(False)
 cl.save()
 

--- a/systemvm/patches/debian/config/opt/cloud/templates/keepalived.conf.templ
+++ b/systemvm/patches/debian/config/opt/cloud/templates/keepalived.conf.templ
@@ -26,7 +26,7 @@ vrrp_script heartbeat {
 
 vrrp_instance inside_network {
     state EQUAL
-    interface eth0
+    interface eth2
     virtual_router_id 51
     nopreempt
 
@@ -37,7 +37,7 @@ vrrp_instance inside_network {
     }
 
     virtual_ipaddress {
-        [ROUTER_IP] brd [BOARDCAST] dev eth0
+        [ROUTER_IP] brd [BOARDCAST] dev eth2
     }
 
     track_script {


### PR DESCRIPTION
This PR fixes the problems we were facing with the Redundant VPC Routers. The following changes have been applied:

* Add test to cover the rVPC routers stop/start/reboot scenario
  - Stop/reboot master router should make the backup router become master
  - Start the stopped router should make it become the backup router
* Make sure the Backup router can talk to the Master router after a stop/start/reboot
  - Stop KeepaliveD/ConntrackD if the eth2 (guest) interface is not configured and UP
  - Only setup the redundancy after all the router configuration is done
  - Open the FW for the VRRP communitation
     - 224.0.0.18 and 225.0.0.50
  - Set keepalived.conf.templ by default to use interface eth2 (guest)
    - It will be reconfigured anyway, but having eth2 there is more clear