### PR TITLE
CLOUDSTACK-9065: Packaging RPM, add option for package release version, cleanup and lint

### DIFF
--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -18,26 +18,37 @@
 
 function usage() {
     echo ""
-    echo "usage: ./package.sh [-p|--pack] [-h|--help] [ARGS]"
+    echo "usage: ./package.sh [-h|--help] -d|--distribution <name> [-r|--release <version>] [-p|--pack oss|OSS|noredist|NOREDIST] [-s|--simulator default|DEFAULT|simulator|SIMULATOR]"
     echo ""
-    echo "The commonly used Arguments are:"
-    echo "-p|--pack oss|OSS             To package with only redistributable libraries (default)"
-    echo "-p|--pack noredist|NOREDIST   To package with non-redistributable libraries"
-    echo "-d centos7|centos63|fedora20|fedora21  To build a package for a distribution"
-    echo "-s simulator|SIMULATOR        To build for Simulator"
+    echo "The supported arguments are:"
+    echo "  To package with only redistributable libraries (default)"
+    echo "    -p|--pack oss|OSS"
+    echo "  To package with non-redistributable libraries"
+    echo "    -p|--pack noredist|NOREDIST"
+    echo "  To build a package for a distribution (mandatory)"
+    echo "    -d|--distribution centos7|centos63|fedora20|fedora21"
+    echo "  To set the package release version (optional)"
+    echo "  (default is 1 for normal and prereleases, empty for SNAPSHOT)"
+    echo "    -r|--release version(integer)"
+    echo "  To build for Simulator (optional)"
+    echo "    -s|--simulator default|DEFAULT|simulator|SIMULATOR"
+    echo "  To display this information"
+    echo "    -h|--help"
     echo ""
-    echo "Examples: ./package.sh -p|--pack oss|OSS"
-    echo "          ./package.sh -p|--pack noredist|NOREDIST"
-    echo "          ./package.sh (Default OSS)"
-    exit 1
+    echo "Examples: ./package.sh --pack oss"
+    echo "          ./package.sh --pack noredist"
+    echo "          ./package.sh --pack oss --distribution centos7 --release 42"
+    echo "          ./package.sh --distribution centos7 --release 42"
+    echo "          ./package.sh --distribution centos7"
 }
 
 # packaging
 #   $1 redist flag
 #   $2 simulator flag
 #   $3 distribution name
+#   $4 package release version
 function packaging() {
-    CWD=`pwd`
+    CWD=$(pwd)
     RPMDIR=$CWD/../dist/rpmbuild
     PACK_PROJECT=cloudstack
     if [ -n "$1" ] ; then
@@ -48,116 +59,127 @@ function packaging() {
     fi
 
     DISTRO=$3
-    MVN=`which mvn`
+    MVN=$(which mvn)
     if [ -z "$MVN" ] ; then
-        MVN=`locate bin/mvn | grep -e mvn$ | tail -1`
+        MVN=$(locate bin/mvn | grep -e mvn$ | tail -1)
         if [ -z "$MVN" ] ; then
-            echo "mvn not found\n cannot retrieve version to package\n RPM Build Failed"
+            echo -e "mvn not found\n cannot retrieve version to package\n RPM Build Failed"
             exit 2
         fi
     fi
-    VERSION=`(cd ../; $MVN org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version) | grep --color=none '^[0-9]\.'`
-    if echo $VERSION | grep -q SNAPSHOT ; then
-        REALVER=`echo $VERSION | cut -d '-' -f 1`
-        DEFVER="-D_ver $REALVER"
-        DEFPRE="-D_prerelease 1"
-        DEFREL="-D_rel SNAPSHOT"
+    VERSION=$(cd ../; $MVN org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep --color=none '^[0-9]\.')
+    if echo "$VERSION" | grep -q SNAPSHOT ; then
+        REALVER=$(echo "$VERSION" | cut -d '-' -f 1)
+        if [ -n "$4" ] ; then
+            DEFPRE="-D_prerelease $4"
+            DEFREL="-D_rel SNAPSHOT$4"
+        else
+            DEFPRE="-D_prerelease 1"
+            DEFREL="-D_rel SNAPSHOT"
+        fi
     else
-        REALVER=`echo $VERSION`
-        DEFVER="-D_ver $REALVER"
-        DEFREL="-D_rel 1"
+        REALVER="$VERSION"
+        if [ -n "$4" ] ; then
+            DEFREL="-D_rel $4"
+        else
+            DEFREL="-D_rel 1"
+        fi
     fi
+    DEFVER="-D_ver $REALVER"
 
-    echo Preparing to package Apache CloudStack ${VERSION}
+    echo "Preparing to package Apache CloudStack $VERSION"
 
-    mkdir -p $RPMDIR/SPECS
-    mkdir -p $RPMDIR/BUILD
-    mkdir -p $RPMDIR/RPMS
-    mkdir -p $RPMDIR/SRPMS
-    mkdir -p $RPMDIR/SOURCES/$PACK_PROJECT-$VERSION
+    mkdir -p "$RPMDIR/SPECS"
+    mkdir -p "$RPMDIR/BUILD"
+    mkdir -p "$RPMDIR/RPMS"
+    mkdir -p "$RPMDIR/SRPMS"
+    mkdir -p "$RPMDIR/SOURCES/$PACK_PROJECT-$VERSION"
 
     echo ". preparing source tarball"
-    (cd ../; tar -c --exclude .git --exclude dist  .  | tar -C $RPMDIR/SOURCES/$PACK_PROJECT-$VERSION -x )
-    (cd $RPMDIR/SOURCES/; tar -czf $PACK_PROJECT-$VERSION.tgz $PACK_PROJECT-$VERSION)
+    (cd ../; tar -c --exclude .git --exclude dist . | tar -C "$RPMDIR/SOURCES/$PACK_PROJECT-$VERSION" -x )
+    (cd "$RPMDIR/SOURCES/"; tar -czf "$PACK_PROJECT-$VERSION.tgz" "$PACK_PROJECT-$VERSION")
 
     echo ". executing rpmbuild"
-    cp $DISTRO/cloud.spec $RPMDIR/SPECS
+    cp "$DISTRO/cloud.spec" "$RPMDIR/SPECS"
 
-    (cd $RPMDIR; rpmbuild --define "_topdir $RPMDIR" "${DEFVER}" "${DEFREL}" ${DEFPRE+"${DEFPRE}"} ${DEFOSSNOSS+"$DEFOSSNOSS"} ${DEFSIM+"$DEFSIM"} -bb SPECS/cloud.spec)
-
+    (cd "$RPMDIR"; rpmbuild --define "_topdir ${RPMDIR}" "${DEFVER}" "${DEFREL}" ${DEFPRE+"$DEFPRE"} ${DEFOSSNOSS+$DEFOSSNOSS} ${DEFSIM+"$DEFSIM"} -bb SPECS/cloud.spec)
     if [ $? -ne 0 ]; then
         echo "RPM Build Failed "
-        exit 1
+        exit 3
     else
         echo "RPM Build Done"
     fi
     exit
-
 }
 
-
 TARGETDISTRO=""
-sim=""
-packageval=""
+SIM=""
+PACKAGEVAL=""
+RELEASE=""
 
-    SHORTOPTS="hp:d:"
-    LONGOPTS="help,pack:,simulator:distribution"
-    ARGS=$(getopt -s bash -u -a --options $SHORTOPTS  --longoptions $LONGOPTS --name $0 -- "$@")
-    eval set -- "$ARGS"
-    echo "$ARGS"
-    while [ $# -gt 0 ] ; do
-        case "$1" in
-            -h | --help)
+SHORTOPTS="hp:s:d:r:"
+LONGOPTS="help,pack:simulator:distribution:release:"
+ARGS=$(getopt -s bash -u -a --options "$SHORTOPTS"  --longoptions "$LONGOPTS" --name "$0" -- "$@")
+eval set -- "$ARGS"
+echo "$ARGS"
+while [ $# -gt 0 ] ; do
+    case "$1" in
+        -h | --help)
             usage
             exit 0
             ;;
         -p | --pack)
-            echo "Doing CloudStack Packaging ....."
-            packageval=$2
-            echo "$packageval"
-            if [ "$packageval" == "oss" -o "$packageval" == "OSS" ] ; then
-                packageval=""
-            elif [ "$packageval" == "noredist" -o "$packageval" == "NOREDIST" ] ; then
-                packageval="noredist"
+            echo "Packaging CloudStack..."
+            PACKAGEVAL=$2
+            echo "$PACKAGEVAL"
+            if [ "$PACKAGEVAL" == "oss" -o "$PACKAGEVAL" == "OSS" ] ; then
+                PACKAGEVAL=""
+            elif [ "$PACKAGEVAL" == "noredist" -o "$PACKAGEVAL" == "NOREDIST" ] ; then
+                PACKAGEVAL="noredist"
             else
-                echo "Error: Incorrect value provided in package.sh script, Please see help ./package.sh --help|-h for more details."
+                echo "Error: Unsupported value for --pack"
+                usage
                 exit 1
             fi
             shift
             ;;
         -s | --simulator)
-            sim=$2
-            echo "$sim"
-            if [ "$sim" == "default" -o "$sim" == "DEFAULT" ] ; then
-                sim = "false"
-            elif [ "$sim" == "simulator" -o "$sim" == "SIMULATOR" ] ; then
-                sim="simulator"
+            SIM=$2
+            echo "$SIM"
+            if [ "$SIM" == "default" -o "$SIM" == "DEFAULT" ] ; then
+                SIM="false"
+            elif [ "$SIM" == "simulator" -o "$SIM" == "SIMULATOR" ] ; then
+                SIM="simulator"
             else
-                echo "Error: Incorrect value provided in package.sh script for -o, Please see help ./package.sh --help|-h for more details."
-		exit 1
+                echo "Error: Unsupported value for --simulator"
+                usage
+                exit 1
             fi
             shift
             ;;
         -d | --distribution)
             TARGETDISTRO=$2
+            if [ -z "$TARGETDISTRO" ] ; then
+                echo "Error: Missing target distribution"
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+        -r | --release)
+            RELEASE=$2
             shift
             ;;
         -)
-            echo "Unrecognized option..."
+            echo "Error: Unrecognized option"
             usage
             exit 1
             ;;
         *)
             shift
             ;;
-        esac
-    done
+    esac
+done
 
-    if [ -z "$TARGETDISTRO" ]
-    then
-        echo "Missing target distribution"
-        usage
-        exit 1
-    fi
+packaging "$PACKAGEVAL" "$SIM" "$TARGETDISTRO" "$RELEASE"
 
-    packaging "$packageval" "$sim" "$TARGETDISTRO"


### PR DESCRIPTION
In package.sh
 * lint
 * adjust exit codes (1 for usage, 2 for maven, 3 for rpmbuild)
 * fix variable naming for consistency
 * add option for package release version
 * revise synopsis and usage