### PR TITLE
CLOUDSTACK-9068: Listing Port Forwarding Rules take too much time to load

### DIFF
--- a/ui/scripts/ui/widgets/multiEdit.js
+++ b/ui/scripts/ui/widgets/multiEdit.js
@@ -278,9 +278,6 @@
                     $td.addClass('blank');
                 }
 
-                // Align width to main header
-                //_medit.refreshItemWidths($multi);
-
                 if (data._hideFields &&
                     $.inArray(fieldName, data._hideFields) > -1) {
                     $td.addClass('disabled');

--- a/ui/scripts/ui/widgets/multiEdit.js
+++ b/ui/scripts/ui/widgets/multiEdit.js
@@ -279,7 +279,7 @@
                 }
 
                 // Align width to main header
-                _medit.refreshItemWidths($multi);
+                //_medit.refreshItemWidths($multi);
 
                 if (data._hideFields &&
                     $.inArray(fieldName, data._hideFields) > -1) {


### PR DESCRIPTION
For setting the width of each data item for each row of Port Forwarding rules, it was processing all rules.

Basically for each data item, it was searching in all rules, which is un-necessary.
If there are N-Rules, It was processing N-times.

Now, it only processes one time by taking all N-rules at a time.
The previous solution was of O(NxN). Now its changed to O(N).