### PR TITLE
CLOUDSTACK-9066: Update testpath to delete account after deleting VM's of that account 

### DIFF
--- a/test/integration/testpaths/testpath_snapshot_hadrning.py
+++ b/test/integration/testpaths/testpath_snapshot_hadrning.py
@@ -262,7 +262,6 @@ class TestSnapshotsHardning(cloudstackTestCase):
                 cls.testdata["account"],
                 domainid=cls.domain.id
             )
-            cls._cleanup.append(cls.account)
 
             # Create user api client of the account
             cls.userapiclient = testClient.getUserApiClient(
@@ -327,6 +326,8 @@ class TestSnapshotsHardning(cloudstackTestCase):
                 mode=cls.zone.networktype
             )
             cls._cleanup.append(cls.vm_ha)
+
+            cls._cleanup.append(cls.account)
             cls.root_volume_ha = list_volumes(
                 cls.userapiclient,
                 virtualmachineid=cls.vm_ha.id,


### PR DESCRIPTION
In testpath_snapshot_hardning.py testpath account was getting cleared prior to VM's of that account hence while cleaning up the account the VM's in that account also gets deleted hence while clearing VM's it gives exception as "No VM found".