### PR TITLE
[4.6] Cannot list vlanipranges by keyword

### DIFF
--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1597,9 +1597,9 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final SearchCriteria<VlanVO> sc = sb.create();
         if (keyword != null) {
             final SearchCriteria<VlanVO> ssc = _vlanDao.createSearchCriteria();
-            ssc.addOr("vlanId", SearchCriteria.Op.LIKE, "%" + keyword + "%");
+            ssc.addOr("vlanTag", SearchCriteria.Op.LIKE, "%" + keyword + "%");
             ssc.addOr("ipRange", SearchCriteria.Op.LIKE, "%" + keyword + "%");
-            sc.addAnd("vlanId", SearchCriteria.Op.SC, ssc);
+            sc.addAnd("vlanTag", SearchCriteria.Op.SC, ssc);
         } else {
             if (id != null) {
                 sc.setParameters("id", id);


### PR DESCRIPTION
Before change:

cloudmonkey> list vlanipranges  keyword=118
: Caught: com.mysql.jdbc.JDBC4PreparedStatement@18f36b6e: SELECT vlan.id, vlan.vlan_id, vlan.vlan_gateway, vlan.vlan_netmask, vlan.ip6_gateway, vlan.ip6_cidr, vlan.data_center_id, vlan.description, vlan.ip6_range, vlan.network_id, vlan.physical_network_id, vlan.vlan_type, vlan.uuid, vlan.removed, vlan.created FROM vlan WHERE  ( OR vlan.description LIKE ** NOT SPECIFIED ** )  AND vlan.removed IS NULL  ORDER BY vlan.id ASC  LIMIT 0, 500

After change:

cloudmonkey> list vlanipranges  keyword='118'
count = 1
vlaniprange:
id = 0d80fd9c-cd6b-4f99-96c6-261420e75f58
account = system
domain = ROOT
domainid = 2044762d-c4a5-11e3-8379-005056ac4490
......