### PR TITLE
CLOUDSTACK-9076: Changed ownership of directory /var/lib/cloudstack to cloud.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -69,6 +69,7 @@ override_dh_auto_install:
 	cp -r client/target/cloud-client-ui-$(VERSION)/* $(DESTDIR)/usr/share/$(PACKAGE)-management/webapps/client/
 	cp server/target/conf/* $(DESTDIR)/$(SYSCONFDIR)/$(PACKAGE)/server/
 	cp client/target/conf/* $(DESTDIR)/$(SYSCONFDIR)/$(PACKAGE)/management/
+	chown cloud:cloud -R /var/lib/$(PACKAGE)
 
 	# nast hack for a couple of configuration files
 	mv $(DESTDIR)/$(SYSCONFDIR)/$(PACKAGE)/server/cloudstack-limits.conf $(DESTDIR)/$(SYSCONFDIR)/security/limits.d/


### PR DESCRIPTION
Now the management server can create directories inside this folder.

It's a packaging issue. Testing can be manually done by verifying the owner of the /var/lib/cloudstack directory.

Bug fix for 4.6.1, can be Fast-Forward merged to master (4.7).