### PR TITLE
Debian/Ubuntu packaging issues

### DIFF
--- a/python/lib/cloudutils/serviceConfigServer.py
+++ b/python/lib/cloudutils/serviceConfigServer.py
@@ -121,7 +121,8 @@ class cloudManagementConfig(serviceCfgBase):
         #distro like sl 6.1 needs this folder, or tomcat6 failed to start
         checkHostName()
         bash("mkdir /var/log/cloudstack-management/")
-        bash("chown cloud:cloud -R /var/lib/cloudstack")
+        bash("chown cloud:cloud -R /var/lib/cloudstack/")
+        bash("chmod +x -R /usr/share/cloudstack-management/webapps/client/WEB-INF/classes/scripts/")
         #set max process per account is unlimited
         if os.path.exists("/etc/security/limits.conf"):
             cfo = configFileOps("/etc/security/limits.conf")

--- a/python/lib/cloudutils/serviceConfigServer.py
+++ b/python/lib/cloudutils/serviceConfigServer.py
@@ -121,6 +121,7 @@ class cloudManagementConfig(serviceCfgBase):
         #distro like sl 6.1 needs this folder, or tomcat6 failed to start
         checkHostName()
         bash("mkdir /var/log/cloudstack-management/")
+        bash("chown cloud:cloud -R /var/lib/cloudstack")
         #set max process per account is unlimited
         if os.path.exists("/etc/security/limits.conf"):
             cfo = configFileOps("/etc/security/limits.conf")


### PR DESCRIPTION
See individual issues. I've installed the management server with and without the fix. See difference bellow.

Before:
```
root@acs46:~# ls -la /var/lib/cloudstack
total 16
drwxr-xr-x  4 root root  4096 Nov 23 00:20 .
drwxr-xr-x 46 root root  4096 Nov 23 00:21 ..
drwxrwx---  2 root cloud 4096 Nov 17 01:15 management
drwxr-xr-x  2 root root  4096 Nov 17 01:15 mnt
```
```
root@acs46:~# ls -la /usr/share/cloudstack-management/webapps/client/WEB-INF/classes/scripts/storage/secondary/
total 152
drwxr-xr-x 2 root root  4096 Nov 23 00:20 .
drwxr-xr-x 4 root root  4096 Nov 23 00:20 ..
-rw-r--r-- 1 root root 10092 Nov 17 01:15 cloud-install-sys-tmplt
-rw-r--r-- 1 root root 10591 Nov 17 01:15 cloud-install-sys-tmplt.py
-rw-r--r-- 1 root root 11254 Nov 23 00:20 cloud-install-sys-tmplt.pyc
-rw-r--r-- 1 root root  2362 Nov 17 01:15 create_privatetemplate_from_snapshot_xen.sh
-rw-r--r-- 1 root root  5446 Nov 17 01:15 createtmplt.sh
-rw-r--r-- 1 root root  5388 Nov 17 01:15 createvolume.sh
-rw-r--r-- 1 root root  2532 Nov 17 01:15 installIso.sh
-rw-r--r-- 1 root root  1622 Nov 17 01:15 listvmtmplt.sh
-rw-r--r-- 1 root root  1621 Nov 17 01:15 listvolume.sh
-rw-r--r-- 1 root root 75712 Nov 17 01:15 swift
```

After:
```
root@acs46:~# ls -la /var/lib/cloudstack
total 16
drwxr-xr-x  4 cloud cloud 4096 Nov 23 00:51 .
drwxr-xr-x 46 root  root  4096 Nov 23 00:53 ..
drwxrwx---  2 cloud cloud 4096 Nov 23 00:33 management
drwxr-xr-x  2 cloud cloud 4096 Nov 23 00:33 mnt
```
```
root@acs46:~# ls -la /usr/share/cloudstack-management/webapps/client/WEB-INF/classes/scripts/storage/secondary/
total 152
drwxr-xr-x 2 root root  4096 Nov 23 00:53 .
drwxr-xr-x 4 root root  4096 Nov 23 00:53 ..
-rwxr-xr-x 1 root root 10092 Nov 23 00:33 cloud-install-sys-tmplt
-rwxr-xr-x 1 root root 10591 Nov 23 00:33 cloud-install-sys-tmplt.py
-rwxr-xr-x 1 root root 11254 Nov 23 00:53 cloud-install-sys-tmplt.pyc
-rwxr-xr-x 1 root root  2362 Nov 23 00:33 create_privatetemplate_from_snapshot_xen.sh
-rwxr-xr-x 1 root root  5446 Nov 23 00:33 createtmplt.sh
-rwxr-xr-x 1 root root  5388 Nov 23 00:33 createvolume.sh
-rwxr-xr-x 1 root root  2532 Nov 23 00:33 installIso.sh
-rwxr-xr-x 1 root root  1622 Nov 23 00:33 listvmtmplt.sh
-rwxr-xr-x 1 root root  1621 Nov 23 00:33 listvolume.sh
-rwxr-xr-x 1 root root 75712 Nov 23 00:33 swift
```