### PR TITLE
Fix Instance creation with swift as Secondary Storage [CLOUDSTACK-9061]

### DIFF
--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -354,9 +354,17 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         try {
             String downloadPath = determineStorageTemplatePath(storagePath, destPath);
             final File downloadDirectory = _storage.getFile(downloadPath);
-            if (!downloadDirectory.mkdirs()) {
-                return new CopyCmdAnswer("Failed to create download directory " + downloadPath);
+
+            if (downloadDirectory.exists()) {
+                s_logger.debug("Directory " + downloadPath + " already exists");
+            } else {
+                if (!downloadDirectory.mkdirs()) {
+                    final String errMsg = "Unable to create directory " + downloadPath + " to copy from Swift to cache.";
+                    s_logger.error(errMsg);
+                    return new CopyCmdAnswer(errMsg);
+                }
             }
+
             File destFile = SwiftUtil.getObject(swiftTO, downloadDirectory, srcData.getPath());
             return postProcessing(destFile, downloadPath, destPath, srcData, destData);
         } catch (Exception e) {


### PR DESCRIPTION
Swift is currently broken when used as Secondary storage. This fix does the right thing when creating directories on the NFS staging server. We should think of a better solution as this should have been common code path between S3 and Swift. We should also make the "Object Storage as Secondary Storage" interface generic so that we can add other object stores too. 

-Syed