### PR TITLE
CLOUDSTACK-9065: fix bug when creating packaging with noredist flag

### DIFF
--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -102,7 +102,7 @@ function packaging() {
     echo ". executing rpmbuild"
     cp "$DISTRO/cloud.spec" "$RPMDIR/SPECS"
 
-    (cd "$RPMDIR"; rpmbuild --define "_topdir ${RPMDIR}" "${DEFVER}" "${DEFREL}" ${DEFPRE+"$DEFPRE"} ${DEFOSSNOSS+$DEFOSSNOSS} ${DEFSIM+"$DEFSIM"} -bb SPECS/cloud.spec)
+    (cd "$RPMDIR"; rpmbuild --define "_topdir ${RPMDIR}" "${DEFVER}" "${DEFREL}" ${DEFPRE+"$DEFPRE"} ${DEFOSSNOSS+"$DEFOSSNOSS"} ${DEFSIM+"$DEFSIM"} -bb SPECS/cloud.spec)
     if [ $? -ne 0 ]; then
         echo "RPM Build Failed "
         exit 3


### PR DESCRIPTION
Fixes this:
```
$ bash -x package.sh -p noredist -d centos63
(...)
+ rpmbuild --define '_topdir /home/david/cloudstack/packaging/../dist/rpmbuild' '-D_ver 4.6.1' '-D_rel SNAPSHOT' '-D_prerelease 1' -D_ossnoss noredist -bb SPECS/cloud.spec
error: Macro %_ossnoss has empty body
error: Macro %_ossnoss has empty body
error: failed to stat /home/david/cloudstack/dist/rpmbuild/noredist: No such file or directory
+ '[' 1 -ne 0 ']'
+ echo 'RPM Build Failed '
RPM Build Failed
+ exit 3
```

It was missing quotes around the rpmbuild argument '-D_ossnoss noredist'.
