### PR TITLE
[4.6] CLOUDSTACK-9083: Add disk serial to kvm virt xml

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2140,6 +2140,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             if (data instanceof VolumeObjectTO) {
                 final VolumeObjectTO volumeObjectTO = (VolumeObjectTO)data;
+                disk.setSerial(diskUuidToSerial(volumeObjectTO.getUuid()));
                 if (volumeObjectTO.getBytesReadRate() != null && volumeObjectTO.getBytesReadRate() > 0) {
                     disk.setBytesReadRate(volumeObjectTO.getBytesReadRate());
                 }
@@ -2417,6 +2418,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         } else {
             return new StartupCommand[] {cmd};
         }
+    }
+
+    public String diskUuidToSerial(String uuid) {
+        String uuidWithoutHyphen = uuid.replace("-","");
+        return uuidWithoutHyphen.substring(0, Math.min(uuidWithoutHyphen.length(), 20));
     }
 
     private String getIqn() {

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -419,7 +419,7 @@ public class LibvirtVMDef {
 
     public static class DiskDef {
         public enum DeviceType {
-            FLOPPY("floppy"), DISK("disk"), CDROM("cdrom");
+            FLOPPY("floppy"), DISK("disk"), CDROM("cdrom"), LUN("lun");
             String _type;
 
             DeviceType(String type) {
@@ -524,6 +524,7 @@ public class LibvirtVMDef {
         private Long _iopsReadRate;
         private Long _iopsWriteRate;
         private DiskCacheMode _diskCacheMode;
+        private String _serial;
         private boolean qemuDriver = true;
 
         public void setDeviceType(DeviceType deviceType) {
@@ -708,6 +709,10 @@ public class LibvirtVMDef {
             this.qemuDriver = qemuDriver;
         }
 
+        public void setSerial(String serial) {
+            this._serial = serial;
+        }
+
         @Override
         public String toString() {
             StringBuilder diskBuilder = new StringBuilder();
@@ -760,6 +765,10 @@ public class LibvirtVMDef {
                 diskBuilder.append(" bus='" + _bus + "'");
             }
             diskBuilder.append("/>\n");
+
+            if (_serial != null && !_serial.isEmpty() && _deviceType != DeviceType.LUN) {
+                diskBuilder.append("<serial>" + _serial + "</serial>");
+            }
 
             if ((_deviceType != DeviceType.CDROM) &&
                     (s_libvirtVersion >= 9008) &&

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -390,6 +390,14 @@ public class LibvirtComputingResourceTest {
     }
 
     @Test
+    public void diskUuidToSerialTest() {
+        String uuid = "38400000-8cf0-11bd-b24e-10b96e4ef00d";
+        String expected = "384000008cf011bdb24e";
+        LibvirtComputingResource lcr = new LibvirtComputingResource();
+        Assert.assertEquals(expected, lcr.diskUuidToSerial(uuid));
+    }
+
+    @Test
     public void testUUID() {
         String uuid = "1";
         final LibvirtComputingResource lcr = new LibvirtComputingResource();


### PR DESCRIPTION
Adds disk serial ids based on volume uuids to the virt xml. This may be useful
for appliances/software that needs some serial ids on the VM disks. This does not
impact existing/running VMs, the vm virt xmls will be updates for running VMs
the next time they are stopped/started.

For testing, disk serial (of debian based systemvm) in the virt xml matched that
in /sys/devices/pci0000:00:0000:00:07.0/virtio4/block/vda/serial.

We currently don't support scsi-blcok devices for which serial is not supported,
for this we've added a DeviceType (LUN) which may be used in future and a check
to not add the serial to the xml if disk type is LUN.
Refer: https://libvirt.org/formatdomain.html#elementsDisks