### PR TITLE
CLOUDSTACK-9091: Update testpath for parameter issues

### DIFF
--- a/test/integration/testpaths/testpath_volume_snapshot.py
+++ b/test/integration/testpaths/testpath_volume_snapshot.py
@@ -805,13 +805,13 @@ class TestVolumeSnapshot(cloudstackTestCase):
             event_list_validation_result[2])
         self.debug("Events list contains event SNAPSHOT.CREATE")
 
+	self.testdata["volume"]["zoneid"] = self.zone.id
         volumeFromSnap = Volume.create_from_snapshot(
             self.apiclient,
             data_vol_snap.id,
             self.testdata["volume"],
             account=self.account.name,
             domainid=self.account.domainid,
-            zoneid=self.zone.id
         )
 
         self.assertTrue(
@@ -926,13 +926,13 @@ class TestVolumeSnapshot(cloudstackTestCase):
             "Check resource id in list resources call"
         )
 
+	self.testdata["volume"]["zoneid"] = self.zone.id
         volumeFromSnap_2 = Volume.create_from_snapshot(
             self.apiclient,
             data_vol_snap_2.id,
             self.testdata["volume"],
             account=self.account.name,
             domainid=self.account.domainid,
-            zoneid=self.zone.id
         )
 
         self.vm_2.attach_volume(


### PR DESCRIPTION
In testpath_volume_snapshot testpath creating volume from snapshot function is passing zonid parameter to function in base class but there it doesn't take as separate parameter it takes it from "services" so updating it.