### PR TITLE
Reducing expunge delay and interval on default dev cfgs

### DIFF
--- a/setup/dev/advanced.cfg
+++ b/setup/dev/advanced.cfg
@@ -186,7 +186,7 @@
         },
         {
             "name": "expunge.delay",
-            "value": "60"
+            "value": "5"
         },
         {
             "name": "vm.allocation.algorithm",
@@ -194,7 +194,7 @@
         },
         {
             "name": "expunge.interval",
-            "value": "60"
+            "value": "5"
         },
         {
             "name": "expunge.workers",

--- a/setup/dev/advancedsg.cfg
+++ b/setup/dev/advancedsg.cfg
@@ -146,7 +146,7 @@
         }, 
         {
             "name": "expunge.delay", 
-            "value": "60"
+            "value": "5"
         }, 
         {
             "name": "vm.allocation.algorithm", 
@@ -154,7 +154,7 @@
         }, 
         {
             "name": "expunge.interval", 
-            "value": "60"
+            "value": "5"
         }, 
         {
             "name": "expunge.workers", 

--- a/setup/dev/basic.cfg
+++ b/setup/dev/basic.cfg
@@ -147,7 +147,7 @@
         },
         {
             "name": "expunge.delay",
-            "value": "60"
+            "value": "5"
         },
         {
             "name": "vm.allocation.algorithm",
@@ -155,7 +155,7 @@
         },
         {
             "name": "expunge.interval",
-            "value": "60"
+            "value": "5"
         },
         {
             "name": "expunge.workers",


### PR DESCRIPTION
Significantly reduces the time it takes to execute the integration tests