### PR TITLE
CLOUDSTACK-9092: L10n fix in "Add LDAP Account page"

### DIFF
--- a/client/WEB-INF/classes/resources/messages.properties
+++ b/client/WEB-INF/classes/resources/messages.properties
@@ -2214,3 +2214,4 @@ message.removed.ssh.key.pair=Removed a SSH Key Pair
 message.please.select.ssh.key.pair.use.with.this.vm=Please select a ssh key pair you want this VM to use:
 message.configure.firewall.rules.allow.traffic=Configure the rules to allow Traffic
 message.configure.firewall.rules.block.traffic=Configure the rules to block Traffic
+message.ldap.group.import=All The users from the given group name will be imported

--- a/ui/dictionary2.jsp
+++ b/ui/dictionary2.jsp
@@ -1122,6 +1122,7 @@ under the License.
 'label.ssh.key.pairs': '<fmt:message key="label.ssh.key.pairs" />',
 'message.desc.create.ssh.key.pair': '<fmt:message key="message.desc.create.ssh.key.pair" />',
 'message.removed.ssh.key.pair': '<fmt:message key="message.removed.ssh.key.pair" />',
-'message.please.select.ssh.key.pair.use.with.this.vm': '<fmt:message key="message.please.select.ssh.key.pair.use.with.this.vm" />'
+'message.please.select.ssh.key.pair.use.with.this.vm': '<fmt:message key="message.please.select.ssh.key.pair.use.with.this.vm" />',
+'message.ldap.group.import': '<fmt:message key="message.ldap.group.import" />'
 });
 </script>

--- a/ui/scripts/ui-custom/accountsWizard.js
+++ b/ui/scripts/ui-custom/accountsWizard.js
@@ -114,7 +114,7 @@
                     var $table = $wizard.find('.ldap-account-choice tbody');
                     $("#label_ldap_group_name").live("keypress", function(event) {
                         if ($table.find("#tr-groupname-message").length === 0) {
-                            $("<tr id='tr-groupname-message'>").appendTo($table).append("<td colspan=\"4\">All The users from the given group name will be imported</td>");
+                            $("<tr id='tr-groupname-message'>").appendTo($table).append("<td colspan=\"4\">"+_l('message.ldap.group.import')+"</td>");
                         }
                         $table.find("tr").hide();
                         $table.find("#tr-groupname-message").show();
@@ -323,7 +323,7 @@
                 }
 
                 return $wizard.dialog({
-                    title: ldapStatus ? _l('Add LDAP Account') : _l('label.add.account'),
+                    title: ldapStatus ? _l('label.add.LDAP.account') : _l('label.add.account'),
                     width: ldapStatus ? 800 : 330,
                     height: ldapStatus ? 500 : 500,
                     closeOnEscape: false,


### PR DESCRIPTION
fixed two strings on the "Add LDAP Account page"

After the change: (with a test string in messages_ja_JP.properties file)
![screen shot 2015-11-30 at 11 07 42 am](https://cloud.githubusercontent.com/assets/186833/11464468/213f0f4e-9755-11e5-85b3-1cc6a89895c1.png)
