### PR TITLE
CLOUDSTACK-9094: Multiple threads are being used to collect the stats…

### DIFF
--- a/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -685,6 +685,16 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     }
 
     @Override
+    public boolean start() {
+        return true;
+    }
+
+    @Override
+    public boolean stop() {
+        return true;
+    }
+
+    @Override
     public boolean startRemoteAccessVpn(final RemoteAccessVpn vpn, final VirtualRouter router) throws ResourceUnavailableException {
         if (router.getState() != State.Running) {
             s_logger.warn("Unable to apply remote access VPN configuration, virtual router is not in the right state " + router.getState());


### PR DESCRIPTION
CLOUDSTACK-9094: Multiple threads are being used to collect the stats from the same VR

Same thread is being intialised by two managers, VirtualNetworkApplianceManager and VpcVirtualNetworkApplianceManager