### PR TITLE
CLOUDSTACK-9099: SecretKey is returned from the APIs - Fixed

### DIFF
--- a/api/src/com/cloud/user/AccountService.java
+++ b/api/src/com/cloud/user/AccountService.java
@@ -16,17 +16,20 @@
 // under the License.
 package com.cloud.user;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
+import org.apache.cloudstack.api.command.admin.user.GetUserKeysCmd;
 import org.apache.cloudstack.api.command.admin.user.RegisterCmd;
 
 import com.cloud.domain.Domain;
 import com.cloud.exception.PermissionDeniedException;
 import com.cloud.offering.DiskOffering;
 import com.cloud.offering.ServiceOffering;
+
 
 public interface AccountService {
 
@@ -124,6 +127,8 @@ public interface AccountService {
 
     void checkAccess(Account account, DiskOffering dof) throws PermissionDeniedException;
 
+    void checkAccess(User user, ControlledEntity entity);
+
     void checkAccess(Account account, AccessType accessType, boolean sameOwner, String apiName,
             ControlledEntity... entities) throws PermissionDeniedException;
 
@@ -136,4 +141,5 @@ public interface AccountService {
      */
     UserAccount getUserAccountById(Long userId);
 
+    public List<String> getKeys(GetUserKeysCmd cmd);
 }

--- a/api/src/org/apache/cloudstack/api/command/admin/user/GetUserKeysCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/user/GetUserKeysCmd.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.admin.user;
+
+
+import com.cloud.user.Account;
+import com.cloud.user.User;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.response.RegisterResponse;
+import org.apache.cloudstack.api.response.UserResponse;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+@APICommand(name = "getUserKeys",
+            description = "This command allows the user to query the seceret and API keys for the account",
+            responseObject = RegisterResponse.class,
+            requestHasSensitiveInfo = false,
+            responseHasSensitiveInfo = true)
+
+public class GetUserKeysCmd extends BaseCmd{
+
+    @Parameter(name= ApiConstants.ID, type = CommandType.UUID, entityType = UserResponse.class, required = true, description = "ID of the user whose keys are required")
+    private Long id;
+
+    public static final Logger s_logger = Logger.getLogger(RegisterCmd.class.getName());
+    public static final String s_name = "getuserkeysresponse";
+
+    public Long getID(){
+        return id;
+    }
+
+    public String getCommandName(){
+        return s_name;
+    }
+
+    public long getEntityOwnerId(){
+        User user = _entityMgr.findById(User.class, getID());
+        if(user != null){
+            return user.getAccountId();
+        }
+        else return Account.ACCOUNT_ID_SYSTEM;
+    }
+    public void execute(){
+        List<String> keys = _accountService.getKeys(this);
+        RegisterResponse response = new RegisterResponse();
+        if(keys != null){
+            response.setApiKey(keys.get(0));
+            response.setSecretKey(keys.get(1));
+        }
+
+        response.setObjectName("listkeys");
+        response.setResponseName(getCommandName());
+        this.setResponseObject(response);
+    }
+}

--- a/api/src/org/apache/cloudstack/api/response/UserResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/UserResponse.java
@@ -81,6 +81,7 @@ public class UserResponse extends BaseResponse {
     @Param(description = "the api key of the user", isSensitive = true)
     private String apiKey;
 
+    @Deprecated
     @SerializedName("secretkey")
     @Param(description = "the secret key of the user", isSensitive = true)
     private String secretKey;
@@ -209,7 +210,6 @@ public class UserResponse extends BaseResponse {
     public String getSecretKey() {
         return secretKey;
     }
-
     public void setSecretKey(String secretKey) {
         this.secretKey = secretKey;
     }

--- a/client/tomcatconf/commands.properties.in
+++ b/client/tomcatconf/commands.properties.in
@@ -332,6 +332,7 @@ updateVolume=1
 ####                                 the userId...every request to the developer API should be
 ####                                 checked against the key
 registerUserKeys=15
+getUserKeys=15
 
 ### async-query command
 queryAsyncJobResult=15

--- a/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
@@ -198,6 +198,7 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
             "This parameter allows developers to enable a check to see if a transaction wraps commands that are sent to the resource.  This is not to be enabled on production systems.",
             true);
 
+
     @Override
     public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
 

--- a/plugins/network-elements/juniper-contrail/test/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
+++ b/plugins/network-elements/juniper-contrail/test/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
@@ -24,6 +24,8 @@ import java.net.InetAddress;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import org.apache.cloudstack.api.command.admin.user.GetUserKeysCmd;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.ControlledEntity;
@@ -431,5 +433,25 @@ public class MockAccountManager extends ManagerBase implements AccountManager {
     @Override
     public void checkAccess(Account account, DiskOffering dof) throws PermissionDeniedException {
         // TODO Auto-generated method stub
+    }
+
+    @Override
+    public List<String> getKeys(GetUserKeysCmd cmd){
+        return null;
+    }
+
+    @Override
+    public void checkAccess(User user, ControlledEntity entity)
+            throws PermissionDeniedException {
+
+    }
+    @Override
+    public String getConfigComponentName() {
+        return null;
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return null;
     }
 }

--- a/server/src/com/cloud/api/ApiDBUtils.java
+++ b/server/src/com/cloud/api/ApiDBUtils.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import com.cloud.user.AccountManager;
 import org.apache.cloudstack.affinity.AffinityGroup;
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
 import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
@@ -427,6 +428,7 @@ public class ApiDBUtils {
     static ResourceMetaDataService s_resourceDetailsService;
     static HostGpuGroupsDao s_hostGpuGroupsDao;
     static VGPUTypesDao s_vgpuTypesDao;
+    static AccountManager s_accountManager;
 
     @Inject
     private ManagementServer ms;
@@ -555,6 +557,8 @@ public class ApiDBUtils {
     private HighAvailabilityManager haMgr;
     @Inject
     private VpcManager vpcMgr;
+    @Inject
+    private AccountManager accountManager;
     @Inject
     private TaggedResourceService taggedResourceService;
     @Inject
@@ -772,6 +776,7 @@ public class ApiDBUtils {
         s_resourceDetailsService = resourceDetailsService;
         s_hostGpuGroupsDao = hostGpuGroupsDao;
         s_vgpuTypesDao = vgpuTypesDao;
+        s_accountManager = accountManager;
     }
 
     // ///////////////////////////////////////////////////////////
@@ -1695,6 +1700,9 @@ public class ApiDBUtils {
 
     public static UserResponse newUserResponse(UserAccountJoinVO usr, Long domainId) {
         UserResponse response = s_userAccountJoinDao.newUserResponse(usr);
+        if(!s_accountManager.UseSecretKeyInResponse.value()){
+            response.setSecretKey(" ");
+        }
         if (domainId != null && usr.getDomainId() != domainId)
             response.setIsCallerChildDomain(true);
         else

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -211,6 +211,7 @@ import org.apache.cloudstack.api.command.admin.user.DeleteUserCmd;
 import org.apache.cloudstack.api.command.admin.user.DisableUserCmd;
 import org.apache.cloudstack.api.command.admin.user.EnableUserCmd;
 import org.apache.cloudstack.api.command.admin.user.GetUserCmd;
+import org.apache.cloudstack.api.command.admin.user.GetUserKeysCmd;
 import org.apache.cloudstack.api.command.admin.user.ListUsersCmd;
 import org.apache.cloudstack.api.command.admin.user.LockUserCmd;
 import org.apache.cloudstack.api.command.admin.user.RegisterCmd;
@@ -3021,6 +3022,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(UpdateLBHealthCheckPolicyCmd.class);
         cmdList.add(GetUploadParamsForTemplateCmd.class);
         cmdList.add(GetUploadParamsForVolumeCmd.class);
+        cmdList.add(GetUserKeysCmd.class);
         return cmdList;
     }
 

--- a/server/src/com/cloud/user/AccountManager.java
+++ b/server/src/com/cloud/user/AccountManager.java
@@ -33,12 +33,14 @@ import com.cloud.utils.Pair;
 import com.cloud.utils.Ternary;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 
 /**
  * AccountManager includes logic that deals with accounts, domains, and users.
  *
  */
-public interface AccountManager extends AccountService {
+public interface AccountManager extends AccountService, Configurable{
     /**
      * Disables an account by accountId
      * @param accountId
@@ -198,4 +200,11 @@ public interface AccountManager extends AccountService {
     public static final String MESSAGE_ADD_ACCOUNT_EVENT = "Message.AddAccount.Event";
 
     public static final String MESSAGE_REMOVE_ACCOUNT_EVENT = "Message.RemoveAccount.Event";
+    public static final ConfigKey<Boolean> UseSecretKeyInResponse = new ConfigKey<Boolean>(
+            "Advanced",
+            Boolean.class,
+            "use.secret.key.in.response",
+            "true",
+            "This parameter allows the users to enable or disable secret as a part of response for various APIs. By default it is allowed and value is set to true.",
+            true);
 }

--- a/server/src/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/com/cloud/user/AccountManagerImpl.java
@@ -16,52 +16,6 @@
 // under the License.
 package com.cloud.user;
 
-import java.net.InetAddress;
-import java.net.URLEncoder;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
-import javax.crypto.KeyGenerator;
-import javax.crypto.Mac;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-
-import org.apache.cloudstack.acl.ControlledEntity;
-import org.apache.cloudstack.acl.QuerySelector;
-import org.apache.cloudstack.acl.RoleType;
-import org.apache.cloudstack.acl.SecurityChecker;
-import org.apache.cloudstack.acl.SecurityChecker.AccessType;
-import org.apache.cloudstack.affinity.AffinityGroup;
-import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
-import org.apache.cloudstack.api.command.admin.account.UpdateAccountCmd;
-import org.apache.cloudstack.api.command.admin.user.DeleteUserCmd;
-import org.apache.cloudstack.api.command.admin.user.RegisterCmd;
-import org.apache.cloudstack.api.command.admin.user.UpdateUserCmd;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.cloudstack.framework.messagebus.MessageBus;
-import org.apache.cloudstack.framework.messagebus.PublishScope;
-import org.apache.cloudstack.managed.context.ManagedContextRunnable;
-import org.apache.cloudstack.region.gslb.GlobalLoadBalancerRuleDao;
-import org.apache.cloudstack.utils.baremetal.BaremetalUtils;
-
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.vo.ControlledViewEntity;
 import com.cloud.configuration.Config;
@@ -167,6 +121,53 @@ import com.cloud.vm.snapshot.VMSnapshot;
 import com.cloud.vm.snapshot.VMSnapshotManager;
 import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
+import org.apache.cloudstack.acl.ControlledEntity;
+import org.apache.cloudstack.acl.QuerySelector;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.acl.SecurityChecker;
+import org.apache.cloudstack.acl.SecurityChecker.AccessType;
+import org.apache.cloudstack.affinity.AffinityGroup;
+import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
+import org.apache.cloudstack.api.command.admin.account.UpdateAccountCmd;
+import org.apache.cloudstack.api.command.admin.user.DeleteUserCmd;
+import org.apache.cloudstack.api.command.admin.user.GetUserKeysCmd;
+import org.apache.cloudstack.api.command.admin.user.RegisterCmd;
+import org.apache.cloudstack.api.command.admin.user.UpdateUserCmd;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.framework.messagebus.PublishScope;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.cloudstack.region.gslb.GlobalLoadBalancerRuleDao;
+import org.apache.cloudstack.utils.baremetal.BaremetalUtils;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+import java.net.InetAddress;
+import java.net.URLEncoder;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
 
 public class AccountManagerImpl extends ManagerBase implements AccountManager, Manager {
     public static final Logger s_logger = Logger.getLogger(AccountManagerImpl.class);
@@ -1353,10 +1354,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         boolean success = Transaction.execute(new TransactionCallback<Boolean>() {
             @Override
             public Boolean doInTransaction(TransactionStatus status) {
-        boolean success = doSetUserStatus(userId, State.enabled);
+                boolean success = doSetUserStatus(userId, State.enabled);
 
-        // make sure the account is enabled too
-        success = success && enableAccount(user.getAccountId());
+                // make sure the account is enabled too
+                success = success && enableAccount(user.getAccountId());
 
                 return success;
             }
@@ -2228,6 +2229,24 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     }
 
     @Override
+    public List<String> getKeys(GetUserKeysCmd cmd){
+        final long userId = cmd.getID();
+
+        User user = getActiveUser(userId);
+        if(user==null){
+            throw new InvalidParameterValueException("Unable to find user by id");
+        }
+        final ControlledEntity account = getAccount(getUserAccountById(userId).getAccountId()); //Extracting the Account from the userID of the requested user.
+        checkAccess(CallContext.current().getCallingUser(), account);
+
+        List<String> keys = new ArrayList<String>();
+        keys.add(user.getApiKey());
+        keys.add(user.getSecretKey());
+
+        return keys;
+    }
+
+    @Override
     @DB
     @ActionEvent(eventType = EventTypes.EVENT_REGISTER_FOR_SECRET_API_KEY, eventDescription = "register for the developer API keys")
     public String[] createApiKeyAndSecretKey(RegisterCmd cmd) {
@@ -2635,4 +2654,29 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         assert false : "How can all of the security checkers pass on checking this caller?";
         throw new PermissionDeniedException("There's no way to confirm " + account + " has access to " + dof);
     }
+
+    @Override
+    public void checkAccess(User user, ControlledEntity entity)
+        throws PermissionDeniedException {
+        for(SecurityChecker checker : _securityCheckers){
+            if(checker.checkAccess(user,entity)){
+                if(s_logger.isDebugEnabled()){
+                    s_logger.debug("Access granted to " + user + "to " + entity + "by " + checker.getName());
+                }
+                return;
+            }
+        }
+        throw new PermissionDeniedException("There's no way to confirm " + user + " has access to " + entity);
+    }
+    @Override
+    public String getConfigComponentName() {
+        return AccountManager.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[]{UseSecretKeyInResponse};
+    }
 }
+
+

--- a/server/test/com/cloud/user/MockAccountManagerImpl.java
+++ b/server/test/com/cloud/user/MockAccountManagerImpl.java
@@ -22,6 +22,8 @@ import java.net.InetAddress;
 
 import javax.naming.ConfigurationException;
 
+import org.apache.cloudstack.api.command.admin.user.GetUserKeysCmd;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.acl.ControlledEntity;
@@ -401,5 +403,24 @@ public class MockAccountManagerImpl extends ManagerBase implements Manager, Acco
         return null;
     }
 
+    @Override
+    public List<String> getKeys(GetUserKeysCmd cmd) {
+        return null;
+    }
+
+    @Override
+    public void checkAccess(User user, ControlledEntity entity)
+        throws PermissionDeniedException {
+
+    }
+    @Override
+    public String getConfigComponentName() {
+        return null;
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return null;
+    }
 
 }

--- a/ui/scripts/accounts.js
+++ b/ui/scripts/accounts.js
@@ -1637,20 +1637,33 @@
                                 }],
 
                                 dataProvider: function(args) {
-                                    if (isAdmin() || isDomainAdmin()) {
-                                        $.ajax({
-                                            url: createURL('listUsers'),
+                                if (isAdmin() || isDomainAdmin()) {
+                                    $.ajax({
+                                        url: createURL('listUsers'),
                                             data: {
                                                 id: args.context.users[0].id
                                             },
                                             success: function(json) {
-                                                args.response.success({
-                                                    actionFilter: userActionfilter,
-                                                    data: json.listusersresponse.user[0]
-                                                });
-                                            }
-                                        });
-                                    } else { //normal user doesn't have access listUsers API until Bug 14127 is fixed.
+                                                var items = json.listusersresponse.user[0];
+                                                    $.ajax({
+                                                        url: createURL('getUserKeys'),//change
+                                                        data: {
+                                                            id: args.context.users[0].id//change
+                                                        },
+                                                        success: function(json) {
+                                                            $.extend(items, {
+                                                                secretkey: json.getuserkeysresponse.listkeys.secretkey//change
+                                                            });
+                                                        args.response.success({
+                                                            actionFilter: userActionfilter,
+                                                                data: items
+                                                        });
+                                                        }
+                                                    });
+                                                }
+                                            });
+                                        }
+                                    else { //normal user doesn't have access listUsers API until Bug 14127 is fixed.
                                         args.response.success({
                                             actionFilter: userActionfilter,
                                             data: args.context.users[0]


### PR DESCRIPTION
The current implementation of User and account management API (in general) return the secret key as a user or account response. 
Fix: Added a new API to explicitly return the secretKey and removed it from the user and account response.
