### PR TITLE
CLOUDSTACK-9087:adding projectid parameter to create method of class VmSnapshot

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -4511,7 +4511,7 @@ class VmSnapshot:
 
     @classmethod
     def create(cls, apiclient, vmid, snapshotmemory="false",
-               name=None, description=None):
+               name=None, description=None, projectid=None):
         cmd = createVMSnapshot.createVMSnapshotCmd()
         cmd.virtualmachineid = vmid
 
@@ -4521,6 +4521,8 @@ class VmSnapshot:
             cmd.name = name
         if description:
             cmd.description = description
+        if projectid:
+            cmd.projectid = projectid
         return VmSnapshot(apiclient.createVMSnapshot(cmd).__dict__)
 
     @classmethod


### PR DESCRIPTION
Adding projectid parameter to class VmSnapshot of base.py .

currently create method does not support create vm snpashot under a project . modifying create method  for the same 