### PR TITLE
CLOUDSTACK-9100: ISO.CREATE/TEMPLATE.CREATE event missing for usage_e…

### DIFF
--- a/engine/storage/image/src/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -27,6 +27,12 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.cloud.configuration.Resource;
+import com.cloud.event.EventTypes;
+import com.cloud.event.UsageEventUtils;
+import org.apache.cloudstack.engine.subsystem.api.storage.Scope;
+import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.framework.messagebus.PublishScope;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
@@ -136,6 +142,8 @@ public class TemplateServiceImpl implements TemplateService {
     ConfigurationDao _configDao;
     @Inject
     StorageCacheManager _cacheMgr;
+    @Inject
+    MessageBus _messageBus;
     @Inject
     ImageStoreDetailsUtil imageStoreDetailsUtil;
 
@@ -355,6 +363,16 @@ public class TemplateServiceImpl implements TemplateService {
                                         toBeDownloaded.add(tmplt);
                                     }
                                 } else {
+                                    if(tmpltStore.getDownloadState() != Status.DOWNLOADED) {
+                                        String etype = EventTypes.EVENT_TEMPLATE_CREATE;
+                                        if (tmplt.getFormat() == ImageFormat.ISO) {
+                                            etype = EventTypes.EVENT_ISO_CREATE;
+                                        }
+
+                                        UsageEventUtils.publishUsageEvent(etype, tmplt.getAccountId(), zoneId, tmplt.getId(), tmplt.getName(), null, null,
+                                                tmpltInfo.getPhysicalSize(), tmpltInfo.getSize(), VirtualMachineTemplate.class.getName(), tmplt.getUuid());
+                                    }
+
                                     tmpltStore.setDownloadPercent(100);
                                     tmpltStore.setDownloadState(Status.DOWNLOADED);
                                     tmpltStore.setState(ObjectInDataStoreStateMachine.State.Ready);
@@ -405,6 +423,14 @@ public class TemplateServiceImpl implements TemplateService {
                                 tmlpt.setSize(tmpltInfo.getSize());
                                 _templateDao.update(tmplt.getId(), tmlpt);
                                 associateTemplateToZone(tmplt.getId(), zoneId);
+
+                                String etype = EventTypes.EVENT_TEMPLATE_CREATE;
+                                if (tmplt.getFormat() == ImageFormat.ISO) {
+                                    etype = EventTypes.EVENT_ISO_CREATE;
+                                }
+
+                                UsageEventUtils.publishUsageEvent(etype, tmplt.getAccountId(), zoneId, tmplt.getId(), tmplt.getName(), null, null,
+                                        tmpltInfo.getPhysicalSize(), tmpltInfo.getSize(), VirtualMachineTemplate.class.getName(), tmplt.getUuid());
                             }
                         } else if (tmplt.getState() == VirtualMachineTemplate.State.NotUploaded || tmplt.getState() == VirtualMachineTemplate.State.UploadInProgress) {
                             s_logger.info("Template Sync did not find " + uniqueName + " on image store " + storeId + " uploaded using SSVM, marking it as failed");
@@ -474,8 +500,12 @@ public class TemplateServiceImpl implements TemplateService {
                             if (availHypers.contains(tmplt.getHypervisorType())) {
                                 s_logger.info("Downloading template " + tmplt.getUniqueName() + " to image store " + store.getName());
                                 associateTemplateToZone(tmplt.getId(), zoneId);
-                                TemplateInfo tmpl = _templateFactory.getTemplate(tmplt.getId(), DataStoreRole.Image);
-                                createTemplateAsync(tmpl, store, null);
+                                TemplateInfo tmpl = _templateFactory.getTemplate(tmplt.getId(), store);
+                                TemplateOpContext<TemplateApiResult> context = new TemplateOpContext<>(null,(TemplateObject)tmpl, null);
+                                AsyncCallbackDispatcher<TemplateServiceImpl, TemplateApiResult> caller = AsyncCallbackDispatcher.create(this);
+                                caller.setCallback(caller.getTarget().createTemplateAsyncCallBack(null, null));
+                                caller.setContext(context);
+                                createTemplateAsync(tmpl, store, caller);
                             } else {
                                 s_logger.info("Skip downloading template " + tmplt.getUniqueName() + " since current data center does not have hypervisor " +
                                         tmplt.getHypervisorType().toString());
@@ -564,6 +594,47 @@ public class TemplateServiceImpl implements TemplateService {
                 }
             }
         }
+    }
+
+    protected Void createTemplateAsyncCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, TemplateApiResult> callback,
+                                               TemplateOpContext<TemplateApiResult> context) {
+        TemplateInfo template = context.template;
+        TemplateApiResult result = callback.getResult();
+        if (result.isSuccess()) {
+            VMTemplateVO tmplt = _templateDao.findById(template.getId());
+            // need to grant permission for public templates
+            if (tmplt.isPublicTemplate()) {
+                _messageBus.publish(null, TemplateManager.MESSAGE_REGISTER_PUBLIC_TEMPLATE_EVENT, PublishScope.LOCAL, tmplt.getId());
+            }
+            long accountId = tmplt.getAccountId();
+            if (template.getSize() != null) {
+                // publish usage event
+                String etype = EventTypes.EVENT_TEMPLATE_CREATE;
+                if (tmplt.getFormat() == ImageFormat.ISO) {
+                    etype = EventTypes.EVENT_ISO_CREATE;
+                }
+                // get physical size from template_store_ref table
+                long physicalSize = 0;
+                DataStore ds = template.getDataStore();
+                TemplateDataStoreVO tmpltStore = _vmTemplateStoreDao.findByStoreTemplate(ds.getId(), template.getId());
+                if (tmpltStore != null) {
+                    physicalSize = tmpltStore.getPhysicalSize();
+                } else {
+                    s_logger.warn("No entry found in template_store_ref for template id: " + template.getId() + " and image store id: " + ds.getId() +
+                            " at the end of registering template!");
+                }
+                Scope dsScope = ds.getScope();
+                if (dsScope.getScopeId() != null) {
+                    UsageEventUtils.publishUsageEvent(etype, template.getAccountId(), dsScope.getScopeId(), template.getId(), template.getName(), null, null,
+                            physicalSize, template.getSize(), VirtualMachineTemplate.class.getName(), template.getUuid());
+                } else {
+                    s_logger.warn("Zone scope image store " + ds.getId() + " has a null scope id");
+                }
+                _resourceLimitMgr.incrementResourceCount(accountId, Resource.ResourceType.secondary_storage, template.getSize());
+            }
+        }
+
+        return null;
     }
 
     private Map<String, TemplateProp> listTemplate(DataStore ssStore) {


### PR DESCRIPTION
…vent by template sync thread

If there is a Management server restart while template is in downloading or installing state. Template Sync does not push event into usage_event table. 

I have verified the fix manually. Here is a snapshot.
![image](https://cloud.githubusercontent.com/assets/12229259/11559714/0989748c-99e1-11e5-88e0-48b4dbec0224.png)

 I have registered 4 templates. template id 207 and 208(ISO.CREATE event is missing) before applying the fix. and template id 209 and 210 after applying the fix.

Repro Steps (3 cases)
==========
Case - 1 (private template)
-------------
1. register a private template/iso.
2. restart management server when template is in downloading state.
3. After management server restart, template_store_ref entry is removed if  download was not yet completed.
4. on next management server restart, if download would have completed, template_store_ref entry will get populated, but TEMPLATE.CREATE event is missing in usage_event.

Case - 2 (Public template)
--------------------------------
1.  register public template.
2. restart management server when in downloading state.
3. after restart template download reinitiates.
4. template goes to ready state, but there is no usage event.

case -3 (public/private template)
--------------------------------- 
1. register a template 
2. restart management server when template is in installing state.
3. after restart template goes to ready, but there is no usage event.

