### PR TITLE
Add support for not (re)starting server after cloud-setup-management.

### DIFF
--- a/client/bindir/cloud-setup-management.in
+++ b/client/bindir/cloud-setup-management.in
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,18 +26,21 @@ from optparse import OptionParser
 if __name__ == '__main__':
     initLoging("@MSLOGDIR@/setupManagement.log")
     glbEnv = globalEnv()
-    
+
     parser = OptionParser()
     parser.add_option("--https", action="store_true", dest="https", help="Enable HTTPs connection of management server")
     parser.add_option("--tomcat7", action="store_true", dest="tomcat7", help="Use Tomcat7 configuration files in Management Server")
+    parser.add_option("--no-start", action="store_true", dest="nostart", help="Do not start management server after successful configuration")
     (options, args) = parser.parse_args()
     if options.https:
         glbEnv.svrMode = "HttpsServer"
     if options.tomcat7:
         glbEnv.svrConf = "Tomcat7"
+    if options.nostart:
+        glbEnv.noStart = True
 
     glbEnv.mode = "Server"
-    
+
     print "Starting to configure CloudStack Management Server:"
     try:
         syscfg = sysConfigFactory.getSysConfigFactory(glbEnv)

--- a/python/lib/cloudutils/globalEnv.py
+++ b/python/lib/cloudutils/globalEnv.py
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,6 +20,8 @@ class globalEnv:
         self.mode = None
         #server mode: normal/mycloud
         self.svrMode = None
+        #noStart: do not start mgmt server after configuration?
+        self.noStart = False
         #myCloud/Agent/Console
         self.agentMode = None
         #Tomcat6/Tomcat7

--- a/python/lib/cloudutils/serviceConfigServer.py
+++ b/python/lib/cloudutils/serviceConfigServer.py
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,7 +25,7 @@ class cloudManagementConfig(serviceCfgBase):
     def __init__(self, syscfg):
         super(cloudManagementConfig, self).__init__(syscfg)
         self.serviceName = "CloudStack Management Server"
-    
+
     def config(self):
         def checkHostName():
            ret = bash("hostname --fqdn")
@@ -46,7 +46,7 @@ class cloudManagementConfig(serviceCfgBase):
                 dbPass = None
             dbName = cfo.getEntry("db.cloud.name")
             db = Database(dbUser, dbPass, dbHost, dbPort, dbName)
-            
+
             try:
                 db.testConnection()
             except CloudRuntimeException, e:
@@ -56,27 +56,27 @@ class cloudManagementConfig(serviceCfgBase):
 
             try:
                 statement = """ UPDATE configuration SET value='%s' WHERE name='%s'"""
-                
+
                 db.execute(statement%('true','use.local.storage'))
                 db.execute(statement%('20','max.template.iso.size'))
-                
+
                 statement = """ UPDATE vm_template SET url='%s',checksum='%s' WHERE id='%s' """
                 db.execute(statement%('https://rightscale-cloudstack.s3.amazonaws.com/kvm/RightImage_CentOS_5.4_x64_v5.6.28.qcow2.bz2', '90fcd2fa4d3177e31ff296cecb9933b7', '4'))
-                
+
                 statement="""UPDATE disk_offering set use_local_storage=1"""
                 db.execute(statement)
             except:
                 raise e
-            
+
             #add DNAT 443 to 8250
             if not bash("iptables-save |grep PREROUTING | grep 8250").isSuccess():
                 bash("iptables -A PREROUTING -t nat -p tcp --dport 443 -j REDIRECT --to-port 8250 ")
-             
+
             #generate keystore
             keyPath = "/var/cloudstack/management/web.keystore"
             if not os.path.exists(keyPath):
                 cmd = bash("keytool -genkey -keystore %s -storepass \"cloud.com\" -keypass \"cloud.com\" -validity 3650 -dname cn=\"Cloudstack User\",ou=\"mycloud.cloud.com\",o=\"mycloud.cloud.com\",c=\"Unknown\""%keyPath)
-               
+
                 if not cmd.isSuccess():
                     raise CloudInternalException(cmd.getErrMsg())
             if not self.syscfg.env.svrConf == "Tomcat7":
@@ -127,7 +127,7 @@ class cloudManagementConfig(serviceCfgBase):
             cfo.add_lines("cloud soft nproc -1\n")
             cfo.add_lines("cloud hard nproc -1\n")
             cfo.save()
-        
+
         try:
             if self.syscfg.env.svrConf == "Tomcat7":
                 self.syscfg.svo.disableService("tomcat")
@@ -135,9 +135,14 @@ class cloudManagementConfig(serviceCfgBase):
                 self.syscfg.svo.disableService("tomcat6")
         except:
             pass
-            
+
         self.syscfg.svo.stopService("cloudstack-management")
-        if self.syscfg.svo.enableService("cloudstack-management"):
-            return True
+
+        if self.syscfg.env.noStart == False:
+            if self.syscfg.svo.enableService("cloudstack-management"):
+                return True
+            else:
+                raise CloudRuntimeException("Failed to configure %s, please see the /var/log/cloudstack/management/setupManagement.log for detail"%self.serviceName)
         else:
-            raise CloudRuntimeException("Failed to configure %s, please see the /var/log/cloudstack/management/setupManagement.log for detail"%self.serviceName)
+            print "Configured successfully, but not starting management server."
+            return True


### PR DESCRIPTION
This adds an option to the cloud-setup-management script to not start the management server after a successful configuration of it. 

The primary motivation for this is to avoid circular dependency issues on systems that use systemd. When calling cloud-setup-management from a unit with a Before= directive on a service depending on
cloudstack-management, the process will deadlock because /usr/bin/service will delegate to systemd, which is waiting for the Before service to start.

Executing the cloud-setup-management script with this new `--no-start` option will simply leave the management server stopped after a successful configuration. systemd can then be bypassed with `export _SYSTEMCTL_SKIP_REDIRECT=1` and using the init.d script.