### PR TITLE
CLOUDSTACK-9104: VM naming convention in case vmware is used

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1889,11 +1889,20 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     // Pair<internal CS name, vCenter display name>
     private Pair<String, String> composeVmNames(VirtualMachineTO vmSpec) {
-        String vmInternalCSName = vmSpec.getName();
-        String vmNameOnVcenter = vmSpec.getName();
-        if (_instanceNameFlag && vmSpec.getHostName() != null) {
-            vmNameOnVcenter = vmSpec.getHostName();
+
+        String vmInternalCSName = null;
+        String vmNameOnVcenter  = null;
+        if(vmSpec != null)
+        {
+            vmInternalCSName = vmNameOnVcenter = vmSpec.getName();
+            if (_instanceNameFlag == true) {
+                String[] tokens = vmInternalCSName.split("-");
+                assert (tokens.length >= 3); // vmInternalCSName has format i-x-y-<instance.name>
+                vmNameOnVcenter = String.format("%s-%s-%s-%s", tokens[0], tokens[1], tokens[2], vmSpec.getHostName());
+            }
+
         }
+
         return new Pair<String, String>(vmInternalCSName, vmNameOnVcenter);
     }
 


### PR DESCRIPTION
I have reverted all the changes. Now functionality is same as it was  in earlier version. 
ACS Link ==>
https://issues.apache.org/jira/browse/CLOUDSTACK-9104
