### PR TITLE
CLOUDSTACK-8845: set isRevertable of snapshot to false if the volume is removed

### DIFF
--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/StorageSystemSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/StorageSystemSnapshotStrategy.java
@@ -442,6 +442,12 @@ public class StorageSystemSnapshotStrategy extends SnapshotStrategyBase {
     public StrategyPriority canHandle(Snapshot snapshot, SnapshotOperation op) {
         long volumeId = snapshot.getVolumeId();
         VolumeVO volumeVO = _volumeDao.findById(volumeId);
+        if (SnapshotOperation.REVERT.equals(op)) {
+            if (volumeVO != null && ImageFormat.QCOW2.equals(volumeVO.getFormat()))
+                return StrategyPriority.DEFAULT;
+            else
+                return StrategyPriority.CANT_HANDLE;
+        }
 
         long storagePoolId;
 
@@ -457,13 +463,6 @@ public class StorageSystemSnapshotStrategy extends SnapshotStrategyBase {
         }
         else {
             storagePoolId = volumeVO.getPoolId();
-        }
-
-        if (SnapshotOperation.REVERT.equals(op)) {
-            if (volumeVO != null && ImageFormat.QCOW2.equals(volumeVO.getFormat()))
-                return StrategyPriority.DEFAULT;
-            else
-                return StrategyPriority.CANT_HANDLE;
         }
 
         DataStore dataStore = _dataStoreMgr.getDataStore(storagePoolId, DataStoreRole.Primary);


### PR DESCRIPTION
Some users encounter an exception when listSnapshots.
We should set the isRevertable of snapshot to false if the original volume is removed, without checking if the snapshot is stored in primary store (the exception was thowned during the checking).