### PR TITLE
[4.5] rate-limit: increase JVM memory and enable fork mode for unit tests

### DIFF
--- a/plugins/api/rate-limit/pom.xml
+++ b/plugins/api/rate-limit/pom.xml
@@ -32,7 +32,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-Xmx1024m</argLine>
+          <forkMode>always</forkMode>
+          <argLine>-Xmx2048m -XX:MaxPermSize=1024m</argLine>
           <excludes>
             <exclude>org/apache/cloudstack/ratelimit/integration/*</exclude>
           </excludes>


### PR DESCRIPTION
Enables forkmode for surefire plugin and increases memory opts for JVM
for rate-limit tests. This tries to fix intermittent Jenkins failures
which look like:

multipleClientsCanAccessWithoutBlocking(org.apache.cloudstack.ratelimit.ApiRateLimitTest):
unable to create new native thread