### PR TITLE
CLOUDSTACK-9025: Fixed can't create usable template from snapshot in Xenserver and Vmware

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/XenServerGuru.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/XenServerGuru.java
@@ -185,7 +185,8 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
             DataTO srcData = cpyCommand.getSrcTO();
             DataTO destData = cpyCommand.getDestTO();
 
-            if (srcData.getObjectType() == DataObjectType.SNAPSHOT && destData.getObjectType() == DataObjectType.TEMPLATE) {
+            if (srcData.getHypervisorType() == HypervisorType.XenServer && srcData.getObjectType() == DataObjectType.SNAPSHOT &&
+                    destData.getObjectType() == DataObjectType.TEMPLATE) {
                 DataStoreTO srcStore = srcData.getDataStore();
                 DataStoreTO destStore = destData.getDataStore();
                 if (srcStore instanceof NfsTO && destStore instanceof NfsTO) {
@@ -193,9 +194,13 @@ public class XenServerGuru extends HypervisorGuruBase implements HypervisorGuru,
                     EndPoint ep = endPointSelector.selectHypervisorHost(new ZoneScope(host.getDataCenterId()));
                     host = hostDao.findById(ep.getId());
                     hostDao.loadDetails(host);
+                    String hypervisorVersion = host.getHypervisorVersion();
                     String snapshotHotFixVersion = host.getDetail(XenserverConfigs.XS620HotFix);
-                    if (snapshotHotFixVersion != null && snapshotHotFixVersion.equalsIgnoreCase(XenserverConfigs.XSHotFix62ESP1004)) {
-                        return new Pair<Boolean, Long>(Boolean.TRUE, new Long(ep.getId()));
+                    if (hypervisorVersion != null && !hypervisorVersion.equalsIgnoreCase("6.1.0")) {
+                        if (!(hypervisorVersion.equalsIgnoreCase("6.2.0") &&
+                                !(snapshotHotFixVersion != null && snapshotHotFixVersion.equalsIgnoreCase(XenserverConfigs.XSHotFix62ESP1004)))) {
+                            return new Pair<Boolean, Long>(Boolean.TRUE, new Long(ep.getId()));
+                        }
                     }
                 }
             }

--- a/server/src/com/cloud/hypervisor/HypervisorGuruManagerImpl.java
+++ b/server/src/com/cloud/hypervisor/HypervisorGuruManagerImpl.java
@@ -28,7 +28,6 @@ import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.api.Command;
-import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.utils.Pair;
@@ -75,9 +74,7 @@ public class HypervisorGuruManagerImpl extends ManagerBase implements Hypervisor
 
     @Override
     public long getGuruProcessedCommandTargetHost(long hostId, Command cmd) {
-        HostVO host = _hostDao.findById(hostId);
-        HypervisorGuru guru = getGuru(host.getHypervisorType());
-        if (guru != null) {
+        for (HypervisorGuru guru : _hvGuruList) {
             Pair<Boolean, Long> result = guru.getCommandHostDelegation(hostId, cmd);
             if (result.first()) {
                 return result.second();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9025

Fix also reverts below commit as below solution making assumption about hypervisor which are not applicable in case of XenServer and VmWare

Revert "CLOUDSTACK-8964: Can't create template or volume from snapshot"

This reverts commit ccf5d75cfbe769b34c021ab3653ed318cae25933.

Testing:

Able to deploy VM successfully from template created from linked clone snapshot on XenServer.