### PR TITLE
CLOUDSTACK-8964: Ovm3HypervisorGuru handle only srcData with HypervisorType is Ovm3

### DIFF
--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
@@ -96,18 +96,16 @@ public class Ovm3HypervisorGuru extends HypervisorGuruBase implements Hypervisor
             DataTO srcData = cpyCommand.getSrcTO();
             DataTO destData = cpyCommand.getDestTO();
 
-            if (srcData.getObjectType() == DataObjectType.SNAPSHOT && destData.getObjectType() == DataObjectType.TEMPLATE) {
+            if (HypervisorType.Ovm3.equals(srcData.getHypervisorType()) && srcData.getObjectType() == DataObjectType.SNAPSHOT && destData.getObjectType() == DataObjectType.TEMPLATE) {
                 LOGGER.debug("Snapshot to Template: " + cmd);
                 DataStoreTO srcStore = srcData.getDataStore();
                 DataStoreTO destStore = destData.getDataStore();
                 if (srcStore instanceof NfsTO && destStore instanceof NfsTO) {
                     HostVO host = hostDao.findById(hostId);
                     EndPoint ep = endPointSelector.selectHypervisorHost(new ZoneScope(host.getDataCenterId()));
-                    host = hostDao.findById(ep.getId());
-                    hostDao.loadDetails(host);
-                    // String snapshotHotFixVersion = host.getDetail(XenserverConfigs.XS620HotFix);
-                    // if (snapshotHotFixVersion != null && snapshotHotFixVersion.equalsIgnoreCase(XenserverConfigs.XSHotFix62ESP1004)) {
-                    return new Pair<Boolean, Long>(Boolean.TRUE,  Long.valueOf(ep.getId()));
+                    if (ep != null) {
+                        return new Pair<Boolean, Long>(Boolean.TRUE,  Long.valueOf(ep.getId()));
+                    }
                 }
             }
         }

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
@@ -87,15 +87,6 @@ public class Ovm3HypervisorGuru extends HypervisorGuruBase implements Hypervisor
      */
     public Pair<Boolean, Long> getCommandHostDelegation(long hostId, Command cmd) {
         LOGGER.debug("getCommandHostDelegation: " + cmd.getClass());
-        performSideEffectsForDelegationOnCommand(hostId, cmd);
-        return new Pair<Boolean, Long>(Boolean.FALSE, Long.valueOf(hostId));
-    }
-
-    /**
-     * @param hostId
-     * @param cmd
-     */
-    void performSideEffectsForDelegationOnCommand(long hostId, Command cmd) {
         if (cmd instanceof StorageSubSystemCommand) {
             StorageSubSystemCommand c = (StorageSubSystemCommand)cmd;
             c.setExecuteInSequence(true);
@@ -117,5 +108,6 @@ public class Ovm3HypervisorGuru extends HypervisorGuruBase implements Hypervisor
                 }
             }
         }
+        return new Pair<Boolean, Long>(Boolean.FALSE, Long.valueOf(hostId));
     }
 }

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorGuru.java
@@ -105,6 +105,9 @@ public class Ovm3HypervisorGuru extends HypervisorGuruBase implements Hypervisor
                     EndPoint ep = endPointSelector.selectHypervisorHost(new ZoneScope(host.getDataCenterId()));
                     host = hostDao.findById(ep.getId());
                     hostDao.loadDetails(host);
+                    // String snapshotHotFixVersion = host.getDetail(XenserverConfigs.XS620HotFix);
+                    // if (snapshotHotFixVersion != null && snapshotHotFixVersion.equalsIgnoreCase(XenserverConfigs.XSHotFix62ESP1004)) {
+                    return new Pair<Boolean, Long>(Boolean.TRUE,  Long.valueOf(ep.getId()));
                 }
             }
         }


### PR DESCRIPTION
This PR can only be applied after PR #1176 

The CopyCommand on Ovm3 should be handled by Ovm3StorageProcessor, not SSVM.
Hence, I revert two commits on Ovm3HypervisorGuru, and add the hypervisorType check so that only the this guru will only handle Ovm3 (not KVM)