### PR TITLE
CLOUDSTACK-9112: Deploy VM failing frequently due to capacity calculation not synchron…

### DIFF
--- a/engine/schema/src/com/cloud/host/dao/HostDao.java
+++ b/engine/schema/src/com/cloud/host/dao/HostDao.java
@@ -98,5 +98,7 @@ public interface HostDao extends GenericDao<HostVO, Long>, StateDao<Status, Stat
 
     HostVO findByPublicIp(String publicIp);
 
+    List<Long> listClustersByHostTag(String hostTagOnOffering);
+
     List<HostVO> listByType(Type type);
 }

--- a/server/src/com/cloud/deploy/FirstFitPlanner.java
+++ b/server/src/com/cloud/deploy/FirstFitPlanner.java
@@ -393,6 +393,10 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
             }
 
             removeClustersCrossingThreshold(prioritizedClusterIds, avoid, vmProfile, plan);
+            String hostTagOnOffering = offering.getHostTag();
+            if (hostTagOnOffering != null) {
+                removeClustersWithoutMatchingTag(prioritizedClusterIds, hostTagOnOffering);
+            }
 
         } else {
             if (s_logger.isDebugEnabled()) {
@@ -517,6 +521,18 @@ public class FirstFitPlanner extends AdapterBase implements DeploymentClusterPla
         }
 
         return result;
+
+    }
+
+    private void removeClustersWithoutMatchingTag(List<Long> clusterListForVmAllocation, String hostTagOnOffering) {
+
+        List<Long> matchingClusters = hostDao.listClustersByHostTag(hostTagOnOffering);
+
+        clusterListForVmAllocation.retainAll(matchingClusters);
+
+        if (s_logger.isDebugEnabled()) {
+            s_logger.debug("The clusterId list for the given offering tag: " + clusterListForVmAllocation);
+        }
 
     }
 


### PR DESCRIPTION
CLOUDSTACK-9112: deployVM thread is holding the global lock on network longer and cause delays and some improvements in the planner

There are some VM deployment failures happening when multiple VMs are deployed at a time, failures mainly due to NetworkModel code that iterates over all the vlans in the pod. This causes each deployVM thread to hold the global lock on Network longer and cause delays. This delay in turn causes more threads to choose same host and fail since capacity is not available on that host.

Following are some changes required to be done to reduce delays during VM deployments which in turn causes some vm deployment failures when multiple VMs are launched at a time.
-  In Planner, remove the clusters that do not contain a host with matching service offering tag. This will save some iterations over clusters that dont have matching tagged host
-  In NetworkModel, do not query the vlans for the pod within the loop. Also optimized the logic to query the ip/ipv6
-  In DeploymentPlanningManagerImpl, do not process the affinity group if the plan has hostId provided.
