### PR TITLE
CLOUDSTACK-9113: skip vm with inconsistent state when getVmStats/getVmDiskStats

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVmDiskStatsCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVmDiskStatsCommandWrapper.java
@@ -48,12 +48,16 @@ public final class LibvirtGetVmDiskStatsCommandWrapper extends CommandWrapper<Ge
             final HashMap<String, List<VmDiskStatsEntry>> vmDiskStatsNameMap = new HashMap<String, List<VmDiskStatsEntry>>();
             final Connect conn = libvirtUtilitiesHelper.getConnection();
             for (final String vmName : vmNames) {
-                final List<VmDiskStatsEntry> statEntry = libvirtComputingResource.getVmDiskStat(conn, vmName);
-                if (statEntry == null) {
-                    continue;
-                }
+                try {
+                    final List<VmDiskStatsEntry> statEntry = libvirtComputingResource.getVmDiskStat(conn, vmName);
+                    if (statEntry == null) {
+                        continue;
+                    }
 
-                vmDiskStatsNameMap.put(vmName, statEntry);
+                    vmDiskStatsNameMap.put(vmName, statEntry);
+                } catch (LibvirtException e) {
+                    s_logger.warn("Can't get vm disk stats: " + e.toString() + ", continue");
+                }
             }
             return new GetVmDiskStatsAnswer(command, "", command.getHostName(), vmDiskStatsNameMap);
         } catch (final LibvirtException e) {

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVmStatsCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetVmStatsCommandWrapper.java
@@ -49,12 +49,16 @@ public final class LibvirtGetVmStatsCommandWrapper extends CommandWrapper<GetVmS
                 final LibvirtUtilitiesHelper libvirtUtilitiesHelper = libvirtComputingResource.getLibvirtUtilitiesHelper();
 
                 final Connect conn = libvirtUtilitiesHelper.getConnectionByVmName(vmName);
-                final VmStatsEntry statEntry = libvirtComputingResource.getVmStat(conn, vmName);
-                if (statEntry == null) {
-                    continue;
-                }
+                try {
+                    final VmStatsEntry statEntry = libvirtComputingResource.getVmStat(conn, vmName);
+                    if (statEntry == null) {
+                        continue;
+                    }
 
-                vmStatsNameMap.put(vmName, statEntry);
+                    vmStatsNameMap.put(vmName, statEntry);
+                } catch (LibvirtException e) {
+                    s_logger.warn("Can't get vm stats: " + e.toString() + ", continue");
+                }
             }
             return new GetVmStatsAnswer(command, vmStatsNameMap);
         } catch (final LibvirtException e) {


### PR DESCRIPTION
on KVM, if there is a vm has inconsistent state between hypervisor and db, the getVmStat will terminate and return nothing, all vm stats will not be updated.
we should skip the vm which has inconsistent state, and continue on others.