### PR TITLE
CLOUDSTACK-9106 - As a Developer I want the Redundant VPC private gateway feature fixed

### DIFF
--- a/plugins/network-elements/ovs/src/com/cloud/network/element/OvsElement.java
+++ b/plugins/network-elements/ovs/src/com/cloud/network/element/OvsElement.java
@@ -210,7 +210,7 @@ StaticNatServiceProvider, IpDeployer {
             return false;
         }
 
-        HostVO host = _hostDao.findById(vm.getVirtualMachine().getHostId());
+        final HostVO host = _hostDao.findById(vm.getVirtualMachine().getHostId());
         _ovsTunnelMgr.checkAndRemoveHostFromTunnelNetwork(network, host);
         return true;
     }
@@ -262,10 +262,10 @@ StaticNatServiceProvider, IpDeployer {
     }
 
     private static Map<Service, Map<Capability, String>> setCapabilities() {
-        Map<Service, Map<Capability, String>> capabilities = new HashMap<Service, Map<Capability, String>>();
+        final Map<Service, Map<Capability, String>> capabilities = new HashMap<Service, Map<Capability, String>>();
 
         // L2 Support : SDN provisioning
-        Map<Capability, String> connectivityCapabilities = new HashMap<Capability, String>();
+        final Map<Capability, String> connectivityCapabilities = new HashMap<Capability, String>();
         connectivityCapabilities.put(Capability.DistributedRouter, null);
         connectivityCapabilities.put(Capability.StretchedL2Subnet, null);
         connectivityCapabilities.put(Capability.RegionLevelVpc, null);
@@ -280,7 +280,7 @@ StaticNatServiceProvider, IpDeployer {
 
         // L3 support : Load Balancer
         // Set capabilities for LB service
-        Map<Capability, String> lbCapabilities = new HashMap<Capability, String>();
+        final Map<Capability, String> lbCapabilities = new HashMap<Capability, String>();
         lbCapabilities.put(Capability.SupportedLBAlgorithms, "roundrobin,leastconn,source");
         lbCapabilities.put(Capability.SupportedLBIsolation, "dedicated");
         lbCapabilities.put(Capability.SupportedProtocols, "tcp, udp");
@@ -294,7 +294,7 @@ StaticNatServiceProvider, IpDeployer {
 
     public static String getHAProxyStickinessCapability() {
         LbStickinessMethod method;
-        List<LbStickinessMethod> methodList = new ArrayList<LbStickinessMethod>(1);
+        final List<LbStickinessMethod> methodList = new ArrayList<LbStickinessMethod>(1);
 
         method = new LbStickinessMethod(StickinessMethodType.LBCookieBased, "This is loadbalancer cookie based stickiness method.");
         method.addParam("cookie-name", false, "Cookie name passed in http header by the LB to the client.", false);
@@ -385,14 +385,14 @@ StaticNatServiceProvider, IpDeployer {
                 " example: expire=30m 20s 50h 4d. Default value:3h", false);
         methodList.add(method);
 
-        Gson gson = new Gson();
-        String capability = gson.toJson(methodList);
+        final Gson gson = new Gson();
+        final String capability = gson.toJson(methodList);
         return capability;
     }
 
     @Override
     public List<Class<?>> getCommands() {
-        List<Class<?>> cmdList = new ArrayList<Class<?>>();
+        final List<Class<?>> cmdList = new ArrayList<Class<?>>();
         return cmdList;
     }
 
@@ -432,15 +432,16 @@ StaticNatServiceProvider, IpDeployer {
             final List<? extends PublicIpAddress> ipAddress, final Set<Service> services)
                     throws ResourceUnavailableException {
         boolean canHandle = true;
-        for (Service service : services) {
+        for (final Service service : services) {
             // check if Ovs can handle services except SourceNat & Firewall
             if (!canHandle(network, service) && service != Service.SourceNat && service != Service.Firewall) {
                 canHandle = false;
                 break;
             }
         }
+        boolean result = false;
         if (canHandle) {
-            List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
+            final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                     network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
                 s_logger.debug("Virtual router element doesn't need to associate ip addresses on the backend; virtual "
@@ -449,13 +450,14 @@ StaticNatServiceProvider, IpDeployer {
                 return true;
             }
 
-            DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
-            NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
+            final DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
+            final NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
 
-            return networkTopology.associatePublicIP(network, ipAddress, routers);
-        } else {
-            return false;
+            for (final DomainRouterVO domainRouterVO : routers) {
+                result =  networkTopology.associatePublicIP(network, ipAddress, domainRouterVO);
+            }
         }
+        return result;
     }
 
     @Override
@@ -464,7 +466,7 @@ StaticNatServiceProvider, IpDeployer {
         if (!canHandle(network, Service.StaticNat)) {
             return false;
         }
-        List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
+        final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                 network.getId(), Role.VIRTUAL_ROUTER);
         if (routers == null || routers.isEmpty()) {
             s_logger.debug("Ovs element doesn't need to apply static nat on the backend; virtual "
@@ -472,19 +474,23 @@ StaticNatServiceProvider, IpDeployer {
             return true;
         }
 
-        DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
-        NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
-
-        return networkTopology.applyStaticNats(network, rules, routers);
+        final DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
+        final NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
+        boolean result = false;
+        for (final DomainRouterVO domainRouterVO : routers) {
+            result = networkTopology.applyStaticNats(network, rules, domainRouterVO);
+        }
+        return result;
     }
 
     @Override
     public boolean applyPFRules(final Network network, final List<PortForwardingRule> rules)
             throws ResourceUnavailableException {
+        boolean result = false;
         if (!canHandle(network, Service.PortForwarding)) {
-            return false;
+            return result;
         }
-        List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
+        final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                 network.getId(), Role.VIRTUAL_ROUTER);
         if (routers == null || routers.isEmpty()) {
             s_logger.debug("Ovs element doesn't need to apply firewall rules on the backend; virtual "
@@ -492,50 +498,54 @@ StaticNatServiceProvider, IpDeployer {
             return true;
         }
 
-        DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
-        NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
-
-        return networkTopology.applyFirewallRules(network, rules, routers);
+        final DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
+        final NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
+        for (final DomainRouterVO domainRouterVO : routers) {
+            result = networkTopology.applyFirewallRules(network, rules, domainRouterVO);
+        }
+        return result;
     }
 
     @Override
     public boolean applyLBRules(final Network network, final List<LoadBalancingRule> rules)
             throws ResourceUnavailableException {
+        boolean result = false;
         if (canHandle(network, Service.Lb)) {
             if (!canHandleLbRules(rules)) {
-                return false;
+                return result;
             }
 
-            List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
+            final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                     network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
                 s_logger.debug("Virtual router elemnt doesn't need to apply firewall rules on the backend; virtual "
                         + "router doesn't exist in the network "
                         + network.getId());
-                return true;
+                result = true;
+                return result;
             }
 
-            DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
-            NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
+            final DataCenterVO dcVO = _dcDao.findById(network.getDataCenterId());
+            final NetworkTopology networkTopology = _networkTopologyContext.retrieveNetworkTopology(dcVO);
 
-            if (!networkTopology.applyLoadBalancingRules(network, rules, routers)) {
-                throw new CloudRuntimeException(
-                        "Failed to apply load balancing rules in network "
-                                + network.getId());
-            } else {
-                return true;
+            for (final DomainRouterVO domainRouterVO : routers) {
+                result = networkTopology.applyLoadBalancingRules(network, rules, domainRouterVO);
+                if (!result) {
+                    throw new CloudRuntimeException(
+                            "Failed to apply load balancing rules in network "
+                                    + network.getId());
+                }
             }
-        } else {
-            return false;
         }
+        return result;
     }
 
     @Override
     public boolean validateLBRule(final Network network, final LoadBalancingRule rule) {
-        List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
+        final List<LoadBalancingRule> rules = new ArrayList<LoadBalancingRule>();
         rules.add(rule);
         if (canHandle(network, Service.Lb) && canHandleLbRules(rules)) {
-            List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
+            final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(
                     network.getId(), Role.VIRTUAL_ROUTER);
             if (routers == null || routers.isEmpty()) {
                 return true;
@@ -553,11 +563,11 @@ StaticNatServiceProvider, IpDeployer {
     }
 
     private boolean canHandleLbRules(final List<LoadBalancingRule> rules) {
-        Map<Capability, String> lbCaps = getCapabilities().get(Service.Lb);
+        final Map<Capability, String> lbCaps = getCapabilities().get(Service.Lb);
         if (!lbCaps.isEmpty()) {
-            String schemeCaps = lbCaps.get(Capability.LbSchemes);
+            final String schemeCaps = lbCaps.get(Capability.LbSchemes);
             if (schemeCaps != null) {
-                for (LoadBalancingRule rule : rules) {
+                for (final LoadBalancingRule rule : rules) {
                     if (!schemeCaps.contains(rule.getScheme().toString())) {
                         s_logger.debug("Scheme " + rules.get(0).getScheme()
                                 + " is not supported by the provider "
@@ -571,10 +581,10 @@ StaticNatServiceProvider, IpDeployer {
     }
 
     public static boolean validateHAProxyLBRule(final LoadBalancingRule rule) {
-        String timeEndChar = "dhms";
+        final String timeEndChar = "dhms";
 
-        for (LbStickinessPolicy stickinessPolicy : rule.getStickinessPolicies()) {
-            List<Pair<String, String>> paramsList = stickinessPolicy
+        for (final LbStickinessPolicy stickinessPolicy : rule.getStickinessPolicies()) {
+            final List<Pair<String, String>> paramsList = stickinessPolicy
                     .getParams();
 
             if (StickinessMethodType.LBCookieBased.getName().equalsIgnoreCase(
@@ -586,9 +596,9 @@ StaticNatServiceProvider, IpDeployer {
                 String expire = "30m"; // optional
 
                 /* overwrite default values with the stick parameters */
-                for (Pair<String, String> paramKV : paramsList) {
-                    String key = paramKV.first();
-                    String value = paramKV.second();
+                for (final Pair<String, String> paramKV : paramsList) {
+                    final String key = paramKV.first();
+                    final String value = paramKV.second();
                     if ("tablesize".equalsIgnoreCase(key)) {
                         tablesize = value;
                     }
@@ -596,14 +606,14 @@ StaticNatServiceProvider, IpDeployer {
                         expire = value;
                     }
                 }
-                if ((expire != null)
+                if (expire != null
                         && !containsOnlyNumbers(expire, timeEndChar)) {
                     throw new InvalidParameterValueException(
                             "Failed LB in validation rule id: " + rule.getId()
                             + " Cause: expire is not in timeformat: "
                             + expire);
                 }
-                if ((tablesize != null)
+                if (tablesize != null
                         && !containsOnlyNumbers(tablesize, "kmg")) {
                     throw new InvalidParameterValueException(
                             "Failed LB in validation rule id: "
@@ -617,9 +627,9 @@ StaticNatServiceProvider, IpDeployer {
                 String length = null; // optional
                 String holdTime = null; // optional
 
-                for (Pair<String, String> paramKV : paramsList) {
-                    String key = paramKV.first();
-                    String value = paramKV.second();
+                for (final Pair<String, String> paramKV : paramsList) {
+                    final String key = paramKV.first();
+                    final String value = paramKV.second();
                     if ("length".equalsIgnoreCase(key)) {
                         length = value;
                     }
@@ -628,15 +638,15 @@ StaticNatServiceProvider, IpDeployer {
                     }
                 }
 
-                if ((length != null) && (!containsOnlyNumbers(length, null))) {
+                if (length != null && !containsOnlyNumbers(length, null)) {
                     throw new InvalidParameterValueException(
                             "Failed LB in validation rule id: " + rule.getId()
                             + " Cause: length is not a number: "
                             + length);
                 }
-                if ((holdTime != null)
-                        && (!containsOnlyNumbers(holdTime, timeEndChar) && !containsOnlyNumbers(
-                                holdTime, null))) {
+                if (holdTime != null
+                        && !containsOnlyNumbers(holdTime, timeEndChar) && !containsOnlyNumbers(
+                                holdTime, null)) {
                     throw new InvalidParameterValueException(
                             "Failed LB in validation rule id: " + rule.getId()
                             + " Cause: holdtime is not in timeformat: "
@@ -665,8 +675,8 @@ StaticNatServiceProvider, IpDeployer {
                 return false; // atleast one numeric and one char. example:
             }
             // 3h
-            char strEnd = str.toCharArray()[str.length() - 1];
-            for (char c : endChar.toCharArray()) {
+            final char strEnd = str.toCharArray()[str.length() - 1];
+            for (final char c : endChar.toCharArray()) {
                 if (strEnd == c) {
                     number = str.substring(0, str.length() - 1);
                     matchedEndChar = true;
@@ -679,7 +689,7 @@ StaticNatServiceProvider, IpDeployer {
         }
         try {
             Integer.parseInt(number);
-        } catch (NumberFormatException e) {
+        } catch (final NumberFormatException e) {
             return false;
         }
         return true;

--- a/server/src/com/cloud/network/router/NicProfileHelper.java
+++ b/server/src/com/cloud/network/router/NicProfileHelper.java
@@ -24,8 +24,7 @@ import com.cloud.vm.NicProfile;
 
 public interface NicProfileHelper {
 
-    public abstract NicProfile createPrivateNicProfileForGateway(
-            VpcGateway privateGateway);
+    public abstract NicProfile createPrivateNicProfileForGateway(final VpcGateway privateGateway, final VirtualRouter router);
 
     public abstract NicProfile createGuestNicProfileForVpcRouter(final RouterDeploymentDefinition vpcRouterDeploymentDefinition,
             Network guestNetwork);

--- a/server/src/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/server/src/com/cloud/network/router/NicProfileHelperImpl.java
@@ -31,6 +31,7 @@ import com.cloud.network.Networks.AddressFormat;
 import com.cloud.network.Networks.BroadcastDomainType;
 import com.cloud.network.vpc.PrivateIpAddress;
 import com.cloud.network.vpc.PrivateIpVO;
+import com.cloud.network.vpc.Vpc;
 import com.cloud.network.vpc.VpcGateway;
 import com.cloud.network.vpc.VpcManager;
 import com.cloud.network.vpc.dao.PrivateIpDao;
@@ -38,7 +39,6 @@ import com.cloud.utils.db.DB;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.Nic;
 import com.cloud.vm.NicProfile;
-import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
@@ -61,19 +61,25 @@ public class NicProfileHelperImpl implements NicProfileHelper {
 
     @Override
     @DB
-    public NicProfile createPrivateNicProfileForGateway(final VpcGateway privateGateway) {
+    public NicProfile createPrivateNicProfileForGateway(final VpcGateway privateGateway, final VirtualRouter router) {
         final Network privateNetwork = _networkModel.getNetwork(privateGateway.getNetworkId());
-        final PrivateIpVO ipVO = _privateIpDao.allocateIpAddress(privateNetwork.getDataCenterId(), privateNetwork.getId(), privateGateway.getIp4Address());
+        PrivateIpVO ipVO = _privateIpDao.allocateIpAddress(privateNetwork.getDataCenterId(), privateNetwork.getId(), privateGateway.getIp4Address());
+
+        final Long vpcId = privateGateway.getVpcId();
+        final Vpc activeVpc = _vpcMgr.getActiveVpc(vpcId);
+        if (activeVpc.isRedundant() && ipVO == null) {
+            ipVO = _privateIpDao.findByIpAndVpcId(vpcId, privateGateway.getIp4Address());
+        }
+
         final Nic privateNic = _nicDao.findByIp4AddressAndNetworkId(ipVO.getIpAddress(), privateNetwork.getId());
 
         NicProfile privateNicProfile = new NicProfile();
 
         if (privateNic != null) {
-            final VirtualMachine vm = _vmDao.findById(privateNic.getInstanceId());
             privateNicProfile =
                     new NicProfile(privateNic, privateNetwork, privateNic.getBroadcastUri(), privateNic.getIsolationUri(), _networkModel.getNetworkRate(
-                            privateNetwork.getId(), vm.getId()), _networkModel.isSecurityGroupSupportedInNetwork(privateNetwork), _networkModel.getNetworkTag(
-                                    vm.getHypervisorType(), privateNetwork));
+                            privateNetwork.getId(), router.getId()), _networkModel.isSecurityGroupSupportedInNetwork(privateNetwork), _networkModel.getNetworkTag(
+                                    router.getHypervisorType(), privateNetwork));
         } else {
             final String netmask = NetUtils.getCidrNetmask(privateNetwork.getCidr());
             final PrivateIpAddress ip =

--- a/server/src/com/cloud/network/router/VpcNetworkHelperImpl.java
+++ b/server/src/com/cloud/network/router/VpcNetworkHelperImpl.java
@@ -93,7 +93,7 @@ public class VpcNetworkHelperImpl extends NetworkHelperImpl {
         final List<PrivateGateway> privateGateways = vpcMgr.getVpcPrivateGateways(vpcId);
         if (privateGateways != null && !privateGateways.isEmpty()) {
             for (final PrivateGateway privateGateway : privateGateways) {
-                final NicProfile privateNic = nicProfileHelper.createPrivateNicProfileForGateway(privateGateway);
+                final NicProfile privateNic = nicProfileHelper.createPrivateNicProfileForGateway(privateGateway, router);
                 final Network privateNetwork = _networkModel.getNetwork(privateGateway.getNetworkId());
                 networks.put(privateNetwork, new ArrayList<NicProfile>(Arrays.asList(privateNic)));
             }

--- a/server/src/com/cloud/server/StatsCollector.java
+++ b/server/src/com/cloud/server/StatsCollector.java
@@ -125,11 +125,11 @@ import com.cloud.vm.dao.VMInstanceDao;
 @Component
 public class StatsCollector extends ManagerBase implements ComponentMethodInterceptable {
 
-    public static enum externalStatsProtocol {
+    public static enum ExternalStatsProtocol {
         NONE("none"), GRAPHITE("graphite");
         String _type;
 
-        externalStatsProtocol(String type) {
+        ExternalStatsProtocol(String type) {
             _type = type;
         }
 
@@ -218,7 +218,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     String externalStatsHost = null;
     int externalStatsPort = -1;
     boolean externalStatsEnabled = false;
-    externalStatsProtocol externalStatsType = externalStatsProtocol.NONE;
+    ExternalStatsProtocol externalStatsType = ExternalStatsProtocol.NONE;
 
     private ScheduledExecutorService _diskStatsUpdateExecutor;
     private int _usageAggregationRange = 1440;
@@ -266,7 +266,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                 String scheme = uri.getScheme();
 
                 try {
-                    externalStatsType = externalStatsProtocol.valueOf(scheme.toUpperCase());
+                    externalStatsType = ExternalStatsProtocol.valueOf(scheme.toUpperCase());
                 } catch (IllegalArgumentException e) {
                     s_logger.info(scheme + " is not a valid protocol for external statistics. No statistics will be send.");
                 }
@@ -492,7 +492,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                              * Currently only Graphite is supported
                              */
                             if (!metrics.isEmpty()) {
-                                if (externalStatsType != null && externalStatsType == externalStatsProtocol.GRAPHITE) {
+                                if (externalStatsType != null && externalStatsType == ExternalStatsProtocol.GRAPHITE) {
 
                                     if (externalStatsPort == -1) {
                                         externalStatsPort = 2003;

--- a/server/src/org/apache/cloudstack/network/topology/AdvancedNetworkTopology.java
+++ b/server/src/org/apache/cloudstack/network/topology/AdvancedNetworkTopology.java
@@ -141,7 +141,7 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
     }
 
     @Override
-    public boolean applyUserData(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final List<DomainRouterVO> routers)
+    public boolean applyUserData(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final DomainRouterVO router)
             throws ResourceUnavailableException {
 
         s_logger.debug("APPLYING VPC USERDATA RULES");
@@ -153,12 +153,12 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
 
         final UserdataPwdRules pwdRules = new UserdataPwdRules(network, nic, profile, dest);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(pwdRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(pwdRules));
     }
 
     @Override
     public boolean applyDhcpEntry(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest,
-            final List<DomainRouterVO> routers) throws ResourceUnavailableException {
+            final DomainRouterVO router) throws ResourceUnavailableException {
 
         s_logger.debug("APPLYING VPC DHCP ENTRY RULES");
 
@@ -169,11 +169,11 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
 
         final DhcpEntryRules dhcpRules = new DhcpEntryRules(network, nic, profile, dest);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(dhcpRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(dhcpRules));
     }
 
     @Override
-    public boolean associatePublicIP(final Network network, final List<? extends PublicIpAddress> ipAddresses, final List<? extends VirtualRouter> routers)
+    public boolean associatePublicIP(final Network network, final List<? extends PublicIpAddress> ipAddresses, final VirtualRouter router)
             throws ResourceUnavailableException {
 
         if (ipAddresses == null || ipAddresses.isEmpty()) {
@@ -182,7 +182,7 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
         }
 
         if (network.getVpcId() == null) {
-            return super.associatePublicIP(network, ipAddresses, routers);
+            return super.associatePublicIP(network, ipAddresses, router);
         }
 
         s_logger.debug("APPLYING VPC IP RULES");
@@ -193,12 +193,10 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
         final Long podId = null;
 
         final NicPlugInOutRules nicPlugInOutRules = new NicPlugInOutRules(network, ipAddresses);
-        for (final VirtualRouter router : routers) {
-            nicPlugInOutRules.accept(_advancedVisitor, router);
-        }
+        nicPlugInOutRules.accept(_advancedVisitor, router);
 
         final VpcIpAssociationRules ipAssociationRules = new VpcIpAssociationRules(network, ipAddresses);
-        final boolean result = applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(ipAssociationRules));
+        final boolean result = applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(ipAssociationRules));
 
         if (result) {
             _advancedVisitor.visit(nicPlugInOutRules);
@@ -208,7 +206,7 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
     }
 
     @Override
-    public boolean applyNetworkACLs(final Network network, final List<? extends NetworkACLItem> rules, final List<? extends VirtualRouter> routers, final boolean isPrivateGateway)
+    public boolean applyNetworkACLs(final Network network, final List<? extends NetworkACLItem> rules, final VirtualRouter router, final boolean isPrivateGateway)
             throws ResourceUnavailableException {
 
         if (rules == null || rules.isEmpty()) {
@@ -225,6 +223,6 @@ public class AdvancedNetworkTopology extends BasicNetworkTopology {
 
         final NetworkAclsRules aclsRules = new NetworkAclsRules(network, rules, isPrivateGateway);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(aclsRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(aclsRules));
     }
 }

--- a/server/src/org/apache/cloudstack/network/topology/BasicNetworkTopology.java
+++ b/server/src/org/apache/cloudstack/network/topology/BasicNetworkTopology.java
@@ -110,7 +110,7 @@ public class BasicNetworkTopology implements NetworkTopology {
     }
 
     @Override
-    public boolean applyNetworkACLs(final Network network, final List<? extends NetworkACLItem> rules, final List<? extends VirtualRouter> routers, final boolean isPrivateGateway)
+    public boolean applyNetworkACLs(final Network network, final List<? extends NetworkACLItem> rules, final VirtualRouter router, final boolean isPrivateGateway)
             throws ResourceUnavailableException {
         throw new CloudRuntimeException("applyNetworkACLs not implemented in Basic Network Topology.");
     }
@@ -140,7 +140,7 @@ public class BasicNetworkTopology implements NetworkTopology {
 
     @Override
     public boolean applyDhcpEntry(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest,
-            final List<DomainRouterVO> routers) throws ResourceUnavailableException {
+            final DomainRouterVO router) throws ResourceUnavailableException {
 
         s_logger.debug("APPLYING DHCP ENTRY RULES");
 
@@ -160,11 +160,11 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final DhcpEntryRules dhcpRules = new DhcpEntryRules(network, nic, profile, dest);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(dhcpRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(dhcpRules));
     }
 
     @Override
-    public boolean applyUserData(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final List<DomainRouterVO> routers)
+    public boolean applyUserData(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final DomainRouterVO router)
             throws ResourceUnavailableException {
 
         s_logger.debug("APPLYING USERDATA RULES");
@@ -182,11 +182,11 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final UserdataPwdRules pwdRules = new UserdataPwdRules(network, nic, profile, dest);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(pwdRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(pwdRules));
     }
 
     @Override
-    public boolean applyLoadBalancingRules(final Network network, final List<LoadBalancingRule> rules, final List<? extends VirtualRouter> routers)
+    public boolean applyLoadBalancingRules(final Network network, final List<LoadBalancingRule> rules, final VirtualRouter router)
             throws ResourceUnavailableException {
 
         if (rules == null || rules.isEmpty()) {
@@ -203,11 +203,11 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final LoadBalancingRules loadBalancingRules = new LoadBalancingRules(network, rules);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(loadBalancingRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(loadBalancingRules));
     }
 
     @Override
-    public boolean applyFirewallRules(final Network network, final List<? extends FirewallRule> rules, final List<? extends VirtualRouter> routers)
+    public boolean applyFirewallRules(final Network network, final List<? extends FirewallRule> rules, final VirtualRouter router)
             throws ResourceUnavailableException {
         if (rules == null || rules.isEmpty()) {
             s_logger.debug("No firewall rules to be applied for network " + network.getId());
@@ -223,11 +223,11 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final FirewallRules firewallRules = new FirewallRules(network, rules);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(firewallRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(firewallRules));
     }
 
     @Override
-    public boolean applyStaticNats(final Network network, final List<? extends StaticNat> rules, final List<? extends VirtualRouter> routers) throws ResourceUnavailableException {
+    public boolean applyStaticNats(final Network network, final List<? extends StaticNat> rules, final VirtualRouter router) throws ResourceUnavailableException {
         if (rules == null || rules.isEmpty()) {
             s_logger.debug("No static nat rules to be applied for network " + network.getId());
             return true;
@@ -242,11 +242,11 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final StaticNatRules natRules = new StaticNatRules(network, rules);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(natRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(natRules));
     }
 
     @Override
-    public boolean associatePublicIP(final Network network, final List<? extends PublicIpAddress> ipAddress, final List<? extends VirtualRouter> routers)
+    public boolean associatePublicIP(final Network network, final List<? extends PublicIpAddress> ipAddress, final VirtualRouter router)
             throws ResourceUnavailableException {
         if (ipAddress == null || ipAddress.isEmpty()) {
             s_logger.debug("No ip association rules to be applied for network " + network.getId());
@@ -262,7 +262,7 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final IpAssociationRules ipAddresses = new IpAssociationRules(network, ipAddress);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(ipAddresses));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(ipAddresses));
     }
 
     @Override
@@ -304,7 +304,7 @@ public class BasicNetworkTopology implements NetworkTopology {
     }
 
     @Override
-    public boolean savePasswordToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final List<? extends VirtualRouter> routers)
+    public boolean savePasswordToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final VirtualRouter router)
             throws ResourceUnavailableException {
 
         s_logger.debug("SAVE PASSWORD TO ROUTE RULES");
@@ -316,11 +316,11 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final PasswordToRouterRules routerRules = new PasswordToRouterRules(network, nic, profile);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(routerRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(routerRules));
     }
 
     @Override
-    public boolean saveSSHPublicKeyToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final List<? extends VirtualRouter> routers,
+    public boolean saveSSHPublicKeyToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final VirtualRouter router,
             final String sshPublicKey) throws ResourceUnavailableException {
         s_logger.debug("SAVE SSH PUB KEY TO ROUTE RULES");
 
@@ -331,11 +331,11 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final SshKeyToRouterRules keyToRouterRules = new SshKeyToRouterRules(network, nic, profile, sshPublicKey);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(keyToRouterRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(keyToRouterRules));
     }
 
     @Override
-    public boolean saveUserDataToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final List<? extends VirtualRouter> routers)
+    public boolean saveUserDataToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final VirtualRouter router)
             throws ResourceUnavailableException {
         s_logger.debug("SAVE USERDATA TO ROUTE RULES");
 
@@ -346,14 +346,14 @@ public class BasicNetworkTopology implements NetworkTopology {
 
         final UserdataToRouterRules userdataToRouterRules = new UserdataToRouterRules(network, nic, profile);
 
-        return applyRules(network, routers, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(userdataToRouterRules));
+        return applyRules(network, router, typeString, isPodLevelException, podId, failWhenDisconnect, new RuleApplierWrapper<RuleApplier>(userdataToRouterRules));
     }
 
     @Override
-    public boolean applyRules(final Network network, final List<? extends VirtualRouter> routers, final String typeString, final boolean isPodLevelException, final Long podId,
+    public boolean applyRules(final Network network, final VirtualRouter router, final String typeString, final boolean isPodLevelException, final Long podId,
             final boolean failWhenDisconnect, final RuleApplierWrapper<RuleApplier> ruleApplierWrapper) throws ResourceUnavailableException {
 
-        if (routers == null || routers.isEmpty()) {
+        if (router == null) {
             s_logger.warn("Unable to apply " + typeString + ", virtual router doesn't exist in the network " + network.getId());
             throw new ResourceUnavailableException("Unable to apply " + typeString, DataCenter.class, network.getDataCenterId());
         }
@@ -370,45 +370,43 @@ public class BasicNetworkTopology implements NetworkTopology {
         final List<VirtualRouter> disconnectedRouters = new ArrayList<VirtualRouter>();
         boolean result = true;
         final String msg = "Unable to apply " + typeString + " on disconnected router ";
-        for (final VirtualRouter router : routers) {
-            if (router.getState() == State.Running) {
-                s_logger.debug("Applying " + typeString + " in network " + network);
+        if (router.getState() == State.Running) {
+            s_logger.debug("Applying " + typeString + " in network " + network);
 
-                if (router.isStopPending()) {
-                    if (_hostDao.findById(router.getHostId()).getState() == Status.Up) {
-                        throw new ResourceUnavailableException("Unable to process due to the stop pending router " + router.getInstanceName()
-                                + " haven't been stopped after it's host coming back!", DataCenter.class, router.getDataCenterId());
-                    }
-                    s_logger.debug("Router " + router.getInstanceName() + " is stop pending, so not sending apply " + typeString + " commands to the backend");
-                    continue;
+            if (router.isStopPending()) {
+                if (_hostDao.findById(router.getHostId()).getState() == Status.Up) {
+                    throw new ResourceUnavailableException("Unable to process due to the stop pending router " + router.getInstanceName()
+                            + " haven't been stopped after it's host coming back!", DataCenter.class, router.getDataCenterId());
                 }
-
-                try {
-                    result = ruleApplier.accept(getVisitor(), router);
-                    connectedRouters.add(router);
-                } catch (final AgentUnavailableException e) {
-                    s_logger.warn(msg + router.getInstanceName(), e);
-                    disconnectedRouters.add(router);
-                }
-
-                // If rules fail to apply on one domR and not due to
-                // disconnection, no need to proceed with the rest
-                if (!result) {
-                    if (isZoneBasic && isPodLevelException) {
-                        throw new ResourceUnavailableException("Unable to apply " + typeString + " on router ", Pod.class, podId);
-                    }
-                    throw new ResourceUnavailableException("Unable to apply " + typeString + " on router ", DataCenter.class, router.getDataCenterId());
-                }
-
-            } else if (router.getState() == State.Stopped || router.getState() == State.Stopping) {
-                s_logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending apply " + typeString + " commands to the backend");
-            } else {
-                s_logger.warn("Unable to apply " + typeString + ", virtual router is not in the right state " + router.getState());
-                if (isZoneBasic && isPodLevelException) {
-                    throw new ResourceUnavailableException("Unable to apply " + typeString + ", virtual router is not in the right state", Pod.class, podId);
-                }
-                throw new ResourceUnavailableException("Unable to apply " + typeString + ", virtual router is not in the right state", DataCenter.class, router.getDataCenterId());
+                s_logger.debug("Router " + router.getInstanceName() + " is stop pending, so not sending apply " + typeString + " commands to the backend");
+                return false;
             }
+
+            try {
+                result = ruleApplier.accept(getVisitor(), router);
+                connectedRouters.add(router);
+            } catch (final AgentUnavailableException e) {
+                s_logger.warn(msg + router.getInstanceName(), e);
+                disconnectedRouters.add(router);
+            }
+
+            // If rules fail to apply on one domR and not due to
+            // disconnection, no need to proceed with the rest
+            if (!result) {
+                if (isZoneBasic && isPodLevelException) {
+                    throw new ResourceUnavailableException("Unable to apply " + typeString + " on router ", Pod.class, podId);
+                }
+                throw new ResourceUnavailableException("Unable to apply " + typeString + " on router ", DataCenter.class, router.getDataCenterId());
+            }
+
+        } else if (router.getState() == State.Stopped || router.getState() == State.Stopping) {
+            s_logger.debug("Router " + router.getInstanceName() + " is in " + router.getState() + ", so not sending apply " + typeString + " commands to the backend");
+        } else {
+            s_logger.warn("Unable to apply " + typeString + ", virtual router is not in the right state " + router.getState());
+            if (isZoneBasic && isPodLevelException) {
+                throw new ResourceUnavailableException("Unable to apply " + typeString + ", virtual router is not in the right state", Pod.class, podId);
+            }
+            throw new ResourceUnavailableException("Unable to apply " + typeString + ", virtual router is not in the right state", DataCenter.class, router.getDataCenterId());
         }
 
         if (!connectedRouters.isEmpty()) {
@@ -425,10 +423,8 @@ public class BasicNetworkTopology implements NetworkTopology {
                 }
             }
         } else if (!disconnectedRouters.isEmpty()) {
-            for (final VirtualRouter router : disconnectedRouters) {
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug(msg + router.getInstanceName() + "(" + router.getId() + ")");
-                }
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(msg + router.getInstanceName() + "(" + router.getId() + ")");
             }
             if (isZoneBasic && isPodLevelException) {
                 throw new ResourceUnavailableException(msg, Pod.class, podId);

--- a/server/src/org/apache/cloudstack/network/topology/NetworkTopology.java
+++ b/server/src/org/apache/cloudstack/network/topology/NetworkTopology.java
@@ -50,7 +50,7 @@ public interface NetworkTopology {
     boolean configDhcpForSubnet(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final List<DomainRouterVO> routers)
             throws ResourceUnavailableException;
 
-    boolean applyNetworkACLs(final Network network, final List<? extends NetworkACLItem> rules, final List<? extends VirtualRouter> routers, final boolean isPrivateGateway)
+    boolean applyNetworkACLs(final Network network, final List<? extends NetworkACLItem> rules, final VirtualRouter router, final boolean isPrivateGateway)
             throws ResourceUnavailableException;
 
     boolean applyStaticRoutes(final List<StaticRouteProfile> staticRoutes, final List<DomainRouterVO> routers) throws ResourceUnavailableException;
@@ -61,30 +61,30 @@ public interface NetworkTopology {
 
     // ====== USED FOR GUEST NETWORK AND VCP ====== //
 
-    boolean applyDhcpEntry(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final List<DomainRouterVO> routers)
+    boolean applyDhcpEntry(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final DomainRouterVO router)
             throws ResourceUnavailableException;
 
-    boolean applyUserData(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final List<DomainRouterVO> routers)
+    boolean applyUserData(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final DeployDestination dest, final DomainRouterVO router)
             throws ResourceUnavailableException;
 
-    boolean applyLoadBalancingRules(Network network, List<LoadBalancingRule> rules, List<? extends VirtualRouter> routers) throws ResourceUnavailableException;
+    boolean applyLoadBalancingRules(Network network, List<LoadBalancingRule> rules, VirtualRouter router) throws ResourceUnavailableException;
 
-    boolean applyFirewallRules(final Network network, final List<? extends FirewallRule> rules, final List<? extends VirtualRouter> routers) throws ResourceUnavailableException;
+    boolean applyFirewallRules(final Network network, final List<? extends FirewallRule> rules, final VirtualRouter router) throws ResourceUnavailableException;
 
-    boolean applyStaticNats(final Network network, final List<? extends StaticNat> rules, final List<? extends VirtualRouter> routers) throws ResourceUnavailableException;
+    boolean applyStaticNats(final Network network, final List<? extends StaticNat> rules, final VirtualRouter router) throws ResourceUnavailableException;
 
-    boolean associatePublicIP(final Network network, final List<? extends PublicIpAddress> ipAddress, final List<? extends VirtualRouter> routers) throws ResourceUnavailableException;
+    boolean associatePublicIP(final Network network, final List<? extends PublicIpAddress> ipAddress, final VirtualRouter router) throws ResourceUnavailableException;
 
     String[] applyVpnUsers(final Network network, final List<? extends VpnUser> users, final List<DomainRouterVO> routers) throws ResourceUnavailableException;
 
-    boolean savePasswordToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final List<? extends VirtualRouter> routers) throws ResourceUnavailableException;
+    boolean savePasswordToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final VirtualRouter router) throws ResourceUnavailableException;
 
-    boolean saveSSHPublicKeyToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final List<? extends VirtualRouter> routers,
+    boolean saveSSHPublicKeyToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final VirtualRouter router,
             final String sshPublicKey) throws ResourceUnavailableException;
 
-    boolean saveUserDataToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final List<? extends VirtualRouter> routers)
+    boolean saveUserDataToRouter(final Network network, final NicProfile nic, final VirtualMachineProfile profile, final VirtualRouter router)
             throws ResourceUnavailableException;
 
-    boolean applyRules(final Network network, final List<? extends VirtualRouter> routers, final String typeString, final boolean isPodLevelException, final Long podId,
+    boolean applyRules(final Network network, final VirtualRouter router, final String typeString, final boolean isPodLevelException, final Long podId,
             final boolean failWhenDisconnect, RuleApplierWrapper<RuleApplier> ruleApplier) throws ResourceUnavailableException;
 }

--- a/server/src/org/apache/cloudstack/network/topology/NetworkTopologyContext.java
+++ b/server/src/org/apache/cloudstack/network/topology/NetworkTopologyContext.java
@@ -49,4 +49,20 @@ public class NetworkTopologyContext {
         }
         return _flyweight.get(dc.getNetworkType());
     }
+
+    /**
+     * Method used for tests purpose only. Please do not use it to set the AdvanceNetworkTopology and it is managed by Spring.
+     * @param advancedNetworkTopology
+     */
+    public void setAdvancedNetworkTopology(final AdvancedNetworkTopology advancedNetworkTopology) {
+        _advancedNetworkTopology = advancedNetworkTopology;
+    }
+
+    /**
+     *  Method used for tests purpose only. Please do not use it to set the BasicNetworkTopology and it is managed by Spring.
+     * @param basicNetworkTopology
+     */
+    public void setBasicNetworkTopology(final BasicNetworkTopology basicNetworkTopology) {
+        _basicNetworkTopology = basicNetworkTopology;
+    }
 }

--- a/server/test/com/cloud/network/element/VpcVirtualRouterElementTest.java
+++ b/server/test/com/cloud/network/element/VpcVirtualRouterElementTest.java
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.network.element;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.cloudstack.network.topology.AdvancedNetworkTopology;
+import org.apache.cloudstack.network.topology.BasicNetworkTopology;
+import org.apache.cloudstack.network.topology.NetworkTopologyContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.network.RemoteAccessVpn;
+import com.cloud.network.VpnUser;
+import com.cloud.network.router.VpcVirtualNetworkApplianceManagerImpl;
+import com.cloud.network.vpc.Vpc;
+import com.cloud.utils.db.EntityManager;
+import com.cloud.vm.DomainRouterVO;
+import com.cloud.vm.dao.DomainRouterDao;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VpcVirtualRouterElementTest {
+    @Mock
+    DataCenterDao _dcDao;
+    @Mock private DomainRouterDao _routerDao;
+
+    @Mock
+    EntityManager _entityMgr;
+
+    @Mock
+    NetworkTopologyContext networkTopologyContext;
+
+    @InjectMocks
+    VpcVirtualNetworkApplianceManagerImpl _vpcRouterMgr;
+
+    @InjectMocks
+    VpcVirtualRouterElement vpcVirtualRouterElement;
+
+
+    @Test
+    public void testApplyVpnUsers() {
+        vpcVirtualRouterElement._vpcRouterMgr = _vpcRouterMgr;
+
+        final AdvancedNetworkTopology advancedNetworkTopology = Mockito.mock(AdvancedNetworkTopology.class);
+        final BasicNetworkTopology basicNetworkTopology = Mockito.mock(BasicNetworkTopology.class);
+
+        networkTopologyContext.setAdvancedNetworkTopology(advancedNetworkTopology);
+        networkTopologyContext.setBasicNetworkTopology(basicNetworkTopology);
+        networkTopologyContext.init();
+
+        final Vpc vpc = Mockito.mock(Vpc.class);
+        final DataCenterVO dataCenterVO = Mockito.mock(DataCenterVO.class);
+        final RemoteAccessVpn remoteAccessVpn = Mockito.mock(RemoteAccessVpn.class);
+        final DomainRouterVO domainRouterVO1 = Mockito.mock(DomainRouterVO.class);
+        final DomainRouterVO domainRouterVO2 = Mockito.mock(DomainRouterVO.class);
+        final VpnUser vpnUser1 = Mockito.mock(VpnUser.class);
+        final VpnUser vpnUser2 = Mockito.mock(VpnUser.class);
+
+        final List<VpnUser> users = new ArrayList<VpnUser>();
+        users.add(vpnUser1);
+        users.add(vpnUser2);
+
+        final List<DomainRouterVO> routers = new ArrayList<DomainRouterVO>();
+        routers.add(domainRouterVO1);
+        routers.add(domainRouterVO2);
+
+        final Long vpcId = new Long(1l);
+        final Long zoneId = new Long(1l);
+
+        when(remoteAccessVpn.getVpcId()).thenReturn(vpcId);
+        when(_vpcRouterMgr.getVpcRouters(vpcId)).thenReturn(routers);
+        when(_entityMgr.findById(Vpc.class, vpcId)).thenReturn(vpc);
+        when(vpc.getZoneId()).thenReturn(zoneId);
+        when(_dcDao.findById(zoneId)).thenReturn(dataCenterVO);
+        when(networkTopologyContext.retrieveNetworkTopology(dataCenterVO)).thenReturn(advancedNetworkTopology);
+
+        try {
+            when(advancedNetworkTopology.applyVpnUsers(remoteAccessVpn, users, domainRouterVO1)).thenReturn(new String[]{"user1", "user2"});
+            when(advancedNetworkTopology.applyVpnUsers(remoteAccessVpn, users, domainRouterVO2)).thenReturn(new String[]{"user3", "user4"});
+        } catch (final ResourceUnavailableException e) {
+            fail(e.getMessage());
+        }
+
+        try {
+            final String [] results = vpcVirtualRouterElement.applyVpnUsers(remoteAccessVpn, users);
+
+            assertNotNull(results);
+            assertEquals(results[0], "user1");
+            assertEquals(results[1], "user2");
+            assertEquals(results[2], "user3");
+            assertEquals(results[3], "user4");
+        } catch (final ResourceUnavailableException e) {
+            fail(e.getMessage());
+        }
+
+        verify(remoteAccessVpn, times(1)).getVpcId();
+        verify(vpc, times(1)).getZoneId();
+        verify(_dcDao, times(1)).findById(zoneId);
+        verify(networkTopologyContext, times(1)).retrieveNetworkTopology(dataCenterVO);
+    }
+
+    @Test
+    public void testApplyVpnUsersException1() {
+        vpcVirtualRouterElement._vpcRouterMgr = _vpcRouterMgr;
+
+        final AdvancedNetworkTopology advancedNetworkTopology = Mockito.mock(AdvancedNetworkTopology.class);
+        final BasicNetworkTopology basicNetworkTopology = Mockito.mock(BasicNetworkTopology.class);
+
+        networkTopologyContext.setAdvancedNetworkTopology(advancedNetworkTopology);
+        networkTopologyContext.setBasicNetworkTopology(basicNetworkTopology);
+        networkTopologyContext.init();
+
+        final RemoteAccessVpn remoteAccessVpn = Mockito.mock(RemoteAccessVpn.class);
+        final List<VpnUser> users = new ArrayList<VpnUser>();
+
+        when(remoteAccessVpn.getVpcId()).thenReturn(null);
+
+        try {
+            final String [] results = vpcVirtualRouterElement.applyVpnUsers(remoteAccessVpn, users);
+            assertNull(results);
+        } catch (final ResourceUnavailableException e) {
+            fail(e.getMessage());
+        }
+
+        verify(remoteAccessVpn, times(1)).getVpcId();
+    }
+
+    @Test
+    public void testApplyVpnUsersException2() {
+        vpcVirtualRouterElement._vpcRouterMgr = _vpcRouterMgr;
+
+        final AdvancedNetworkTopology advancedNetworkTopology = Mockito.mock(AdvancedNetworkTopology.class);
+        final BasicNetworkTopology basicNetworkTopology = Mockito.mock(BasicNetworkTopology.class);
+
+        networkTopologyContext.setAdvancedNetworkTopology(advancedNetworkTopology);
+        networkTopologyContext.setBasicNetworkTopology(basicNetworkTopology);
+        networkTopologyContext.init();
+
+        final RemoteAccessVpn remoteAccessVpn = Mockito.mock(RemoteAccessVpn.class);
+
+        final List<VpnUser> users = new ArrayList<VpnUser>();
+
+        final Long vpcId = new Long(1l);
+
+        when(remoteAccessVpn.getVpcId()).thenReturn(vpcId);
+        when(_vpcRouterMgr.getVpcRouters(vpcId)).thenReturn(null);
+
+        try {
+            final String [] results = vpcVirtualRouterElement.applyVpnUsers(remoteAccessVpn, users);
+
+            assertNull(results);
+        } catch (final ResourceUnavailableException e) {
+            fail(e.getMessage());
+        }
+
+        verify(remoteAccessVpn, times(1)).getVpcId();
+    }
+}

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -28,7 +28,7 @@ from CsRoute import CsRoute
 from CsRule import CsRule
 
 VRRP_TYPES = ['guest']
-
+PUBLIC_INTERFACE = ['eth1']
 
 class CsAddress(CsDataBag):
 
@@ -314,9 +314,10 @@ class CsIP:
         for i in CsHelper.execute(cmd):
             if " DOWN " in i:
                 cmd2 = "ip link set %s up" % self.getDevice()
-                # If redundant do not bring up public interfaces
-                # master.py and keepalived will deal with them
-                if self.cl.is_redundant() and not self.is_public():
+                # If redundant only bring up public interfaces that are not eth1.
+                # Reason: private gateways are public interfaces.
+                # master.py and keepalived will deal with eth1 public interface.
+                if self.cl.is_redundant() and (not self.is_public() or self.getDevice() not in PUBLIC_INTERFACE):
                     CsHelper.execute(cmd2)
                 # if not redundant bring everything up
                 if not self.cl.is_redundant():

--- a/test/integration/smoke/test_privategw_acl.py
+++ b/test/integration/smoke/test_privategw_acl.py
@@ -242,7 +242,6 @@ class TestPrivateGwACL(cloudstackTestCase):
 
     @attr(tags=["advanced"], required_hardware="true")
     def test_02_vpc_privategw_static_routes(self):
-
         self.logger.debug("Creating a VPC offering..")
         vpc_off = VpcOffering.create(
             self.apiclient,
@@ -255,8 +254,6 @@ class TestPrivateGwACL(cloudstackTestCase):
 
     @attr(tags=["advanced"], required_hardware="true")
     def test_03_rvpc_privategw_static_routes(self):
-        self.skipTest("Redundant VPC Routers have to be fixed. Private Gateway not working yet.")
-
         self.logger.debug("Creating a Redundant VPC offering..")
         vpc_off = VpcOffering.create(
             self.apiclient,
@@ -268,7 +265,6 @@ class TestPrivateGwACL(cloudstackTestCase):
         self.performVPCTests(vpc_off)
 
     def performVPCTests(self, vpc_off):
-
         self.logger.debug("Creating VPCs with  offering ID %s" % vpc_off.id)
         vpc_1 = self.createVPC(vpc_off, cidr = '10.0.1.0/24')
         vpc_2 = self.createVPC(vpc_off, cidr = '10.0.2.0/24')


### PR DESCRIPTION
This PR contains the same fixes from PR #1179, which was created against the master branch.

In addition, the points mentioned by @DaanHoogland were handled in this new PR:

* Made the code more consistent
  - result = result && methodCall(), instead of throwing exceptions in some places or not checking 2 consecutive returns - in case of rVPC.
* Added an unit test to cover changes in the VpcRouterElementImpl.applyVpnUsers() method. The method returns an array of String, so I had to make sure it would contain the users from 2 consecutive calls. There are 2 tests to cover negative scenarios.