### PR TITLE
CLOUDSTACK-9086: ACS allows to create isolated networks with invalide…

### DIFF
--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -1197,6 +1197,13 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
             }
 
             if (gateway != null && netmask != null) {
+                if(NetUtils.isNetworkorBroadcastIP(gateway,netmask)) {
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug("The gateway IP provided is " + gateway + " and netmask is " + netmask + ". The IP is either broadcast or network IP.");
+                    }
+                    throw new InvalidParameterValueException("Invalid gateway IP provided. Either the IP is broadcast or network IP.");
+                }
+
                 if (!NetUtils.isValidIp(gateway)) {
                     throw new InvalidParameterValueException("Invalid gateway");
                 }

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -1570,5 +1570,13 @@ public class NetUtils {
         }
         return false;
     }
+    public static boolean isNetworkorBroadcastIP(String ip, String netmask){
+        String cidr = getCidrFromGatewayAndNetmask(ip,netmask);
+        final SubnetUtils subnetUtils = new SubnetUtils(cidr);
+        subnetUtils.setInclusiveHostCount(false);
+        final boolean isInRange = subnetUtils.getInfo().isInRange(ip);
+        return !isInRange;
+    }
+
 
 }

--- a/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -508,4 +508,22 @@ public class NetUtilsTest {
     public void testIsNetworksOverlapWithEmptyValues() {
         assertEquals(false, NetUtils.isNetworksOverlap("", null));
     }
+    @Test
+    public void testisNetworkorBroadCastIP(){
+         //Checking the True conditions
+        assertTrue(NetUtils.isNetworkorBroadcastIP("192.168.0.0","255.255.255.0"));
+        assertTrue(NetUtils.isNetworkorBroadcastIP("192.168.0.255","255.255.255.0"));
+        assertTrue(NetUtils.isNetworkorBroadcastIP("192.168.0.127","255.255.255.128"));
+        assertTrue(NetUtils.isNetworkorBroadcastIP("192.168.0.63","255.255.255.192"));
+
+        //Checking the False conditions
+        assertFalse(NetUtils.isNetworkorBroadcastIP("192.168.0.1","255.255.255.0"));
+        assertFalse(NetUtils.isNetworkorBroadcastIP("192.168.0.127","255.255.255.0"));
+        assertFalse(NetUtils.isNetworkorBroadcastIP("192.168.0.126","255.255.255.128"));
+        assertFalse(NetUtils.isNetworkorBroadcastIP("192.168.0.62","255.255.255.192"));
+
+        assertTrue(NetUtils.isNetworkorBroadcastIP("192.168.0.63","255.255.255.192"));
+        assertFalse(NetUtils.isNetworkorBroadcastIP("192.168.0.63","255.255.255.128"));
+    }
+
 }


### PR DESCRIPTION
… gateway IP address - Fixed and Test cases added

Problem: There was no check for the network and broadcast IP addresses in the case where we provide the gateway and netmask while creating the isolated network. As a result the provided IP gets assigned to the eth0 interface of the VR.

Note: This is in continuation of PR #1125 which I closed. 