### PR TITLE
CLOUDSTACK-9118 - As a Developer I want the checkrouter.sh script to report the right information about RVR routers state

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
@@ -21,15 +21,17 @@ INTERFACE=eth1
 ROUTER_TYPE=$(cat /etc/cloudstack/cmdline.json | grep type | awk '{print $2;}' | sed -e 's/[,\"]//g')
 if [ $ROUTER_TYPE = "router" ]
 then
-    INTERFACE=eth2
+	ROUTER_STATE=$(ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
+	STATUS=$ROUTER_STATE
+else
+	ROUTER_STATE=$(ip addr | grep $INTERFACE | grep state | awk '{print $9;}')
+	if [ $ROUTER_STATE = "UP" ]
+	then
+	    STATUS=MASTER
+	elif [ $ROUTER_STATE = "DOWN" ]
+	then
+	    STATUS=BACKUP
+	fi
 fi
 
-ETH1_STATE=$(ip addr | grep $INTERFACE | grep state | awk '{print $9;}')
-if [ $ETH1_STATE = "UP" ]
-then
-    STATUS=MASTER
-elif [ $ETH1_STATE = "DOWN" ]
-then
-    STATUS=BACKUP
-fi
 echo "Status: ${STATUS}"

--- a/systemvm/patches/debian/config/opt/cloud/templates/checkrouter.sh.templ
+++ b/systemvm/patches/debian/config/opt/cloud/templates/checkrouter.sh.templ
@@ -21,15 +21,17 @@ INTERFACE=eth1
 ROUTER_TYPE=$(cat /etc/cloudstack/cmdline.json | grep type | awk '{print $2;}' | sed -e 's/[,\"]//g')
 if [ $ROUTER_TYPE = "router" ]
 then
-    INTERFACE=eth2
+	ROUTER_STATE=$(ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
+	STATUS=$ROUTER_STATE
+else
+	ROUTER_STATE=$(ip addr | grep $INTERFACE | grep state | awk '{print $9;}')
+	if [ $ROUTER_STATE = "UP" ]
+	then
+	    STATUS=MASTER
+	elif [ $ROUTER_STATE = "DOWN" ]
+	then
+	    STATUS=BACKUP
+	fi
 fi
 
-ETH1_STATE=$(ip addr | grep $INTERFACE | grep state | awk '{print $9;}')
-if [ $ETH1_STATE = "UP" ]
-then
-    STATUS=MASTER
-elif [ $ETH1_STATE = "DOWN" ]
-then
-    STATUS=BACKUP
-fi
 echo "Status: ${STATUS}"


### PR DESCRIPTION
This PR fixes the RVR routers state information retrieved by the Management Server via the ```checkrouter.sh``` script.

In order to cover the changes, a new test has been added to the component/test_routers_network_ops.py test suite: test_03_RVR_Network_check_router_state