### PR TITLE
CLOUDSTACK-9121: Adding VmSnapshot validation in testpath_revert_snap.py

### DIFF
--- a/test/integration/testpaths/testpath_revert_snap.py
+++ b/test/integration/testpaths/testpath_revert_snap.py
@@ -150,7 +150,12 @@ class TestUnableToRevertSnapshot(cloudstackTestCase):
         vm_snap = VmSnapshot.create(self.apiclient,
                 vm.id)
 
-        volume_list_validation = validateList(vm_snap)
+	self.assertEqual(
+			vm_snap.state,
+			"Ready",
+			"Check the snapshot of vm is ready!"
+			)
+
 
         #Step 3
         with self.assertRaises(Exception):


### PR DESCRIPTION
In testpath_revert_snap.py, there was no code to check if VM snapshot is created or not hence adding code for snapshot validation.