### PR TITLE
CLOUDSTACK-9127 Missing PV-bootloader-args for "SUSE Linux Enterprise…

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
@@ -236,4 +236,15 @@ public class CitrixHelper {
         }
         return prodVersion;
     }
+
+    public static String getPVbootloaderArgs(String guestOS) {
+        if (guestOS.startsWith("SUSE Linux Enterprise Server")) {
+            if (guestOS.contains("64-bit")) {
+                return "--kernel /boot/vmlinuz-xen --ramdisk /boot/initrd-xen";
+            } else if (guestOS.contains("32-bit")) {
+                return "--kernel /boot/vmlinuz-xenpae --ramdisk /boot/initrd-xenpae";
+            }
+        }
+        return "";
+    }
 }

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1352,6 +1352,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                 }
             } else if (vmSpec.getBootloader() == BootloaderType.PyGrub) {
                 vm.setPVBootloader(conn, "pygrub");
+                vm.setPVBootloaderArgs(conn,CitrixHelper.getPVbootloaderArgs(guestOsTypeName));
             } else {
                 vm.destroy(conn);
                 throw new CloudRuntimeException("Unable to handle boot loader type: " + vmSpec.getBootloader());

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixHelperTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixHelperTest.java
@@ -1,0 +1,34 @@
+package com.cloud.hypervisor.xenserver.resource;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+
+/**
+ * Created by ajna123 on 12/11/2015.
+ */
+public class CitrixHelperTest {
+
+    @Test
+    public void testGetPVbootloaderArgs() throws Exception {
+
+        String os_name_Suse10Sp2_64 = "SUSE Linux Enterprise Server 10 SP2 (64-bit)";
+        String os_name_Suse10Sp2_32 = "SUSE Linux Enterprise Server 10 SP2 (32-bit)";
+        String os_name_Suse11Sp3_64 = "SUSE Linux Enterprise Server 11 SP3 (64-bit)";
+        String os_name_Suse11Sp3_32 = "SUSE Linux Enterprise Server 11 SP3 (32-bit)";
+
+        String os_name_Windows8_64 = "Windows 8 (64-bit)";
+        String os_name_Windows8_32 = "Windows 8 (32-bit)";
+
+        String pvBootLoaderArgs_32 = "--kernel /boot/vmlinuz-xenpae --ramdisk /boot/initrd-xenpae";
+        String pvBootLoaderArgs_64 = "--kernel /boot/vmlinuz-xen --ramdisk /boot/initrd-xen";
+
+        Assert.assertEquals(CitrixHelper.getPVbootloaderArgs(os_name_Suse10Sp2_32), pvBootLoaderArgs_32);
+        Assert.assertEquals(CitrixHelper.getPVbootloaderArgs(os_name_Suse10Sp2_64),pvBootLoaderArgs_64);
+        Assert.assertEquals(CitrixHelper.getPVbootloaderArgs(os_name_Suse11Sp3_32),pvBootLoaderArgs_32);
+        Assert.assertEquals(CitrixHelper.getPVbootloaderArgs(os_name_Suse11Sp3_64),pvBootLoaderArgs_64);
+
+        Assert.assertEquals(CitrixHelper.getPVbootloaderArgs(os_name_Windows8_32),"");
+        Assert.assertEquals(CitrixHelper.getPVbootloaderArgs(os_name_Windows8_64),"");
+    }
+}


### PR DESCRIPTION
… Server 10 SP2 and SP3"

ISSUE
--------
STOP-START of SUSE Linux VMs fail, as PV-bootloader-args are missing during the start command.
DESCRIPTION
----------------------
Repro steps
1. Upload Suse ISO 
2. Create a VM with this ISO, and install it.
3. Detach ISO from the VM. 
4. Reboot the VM, :>>>> This will work fine, as the pv-bootloader-args are not missing during reboot.
5.Stop the VM from CCP(VM will get destroyed in Xencenter)
6. Start the same VM from CCP , it will try to start but will fail.

Before Applying the fix
--------------------------------
Before applying the starting the VM failed with following exception 
com.cloud.utils.exception.CloudRuntimeException: Unable to start VM(i-2-6-VM) on host(7cfd6388-b763-4c09-b3a3-9679db2904a3) due to Task failed! Task record:                 uuid: 21a6799f-9523-7c0e-bb86-1de750a38d74
           nameLabel: Async.VM.start_on
     nameDescription:
   allowedOperations: []
   currentOperations: {}
             created: Wed Dec 09 07:00:29 UTC 2015
            finished: Wed Dec 09 07:00:31 UTC 2015
              status: failure
          residentOn: com.xensource.xenapi.Host@513d238c
            progress: 1.0
                type: <none/>
              result:
           errorInfo: [BOOTLOADER_FAILED, OpaqueRef:0b10b6ac-837d-29af-da9d-6ef1e11a064a, Unable to find partition containing kernel
]
         otherConfig: {}
           subtaskOf: com.xensource.xenapi.Task@aaf13f6f
            subtasks: []

![image](https://cloud.githubusercontent.com/assets/12229259/11678758/bd0fc9aa-9e70-11e5-9687-c77bfecaa4dd.png)


After Applying the fix
--------------------------
After applying the fix I am able to start the vm.
![image](https://cloud.githubusercontent.com/assets/12229259/11678938/6d44f5b0-9e72-11e5-83b0-60a736408b4d.png)
