### PR TITLE
CLOUDSTACK-9130: Make RebootCommand similar to start/stop/migrate age…

### DIFF
--- a/core/src/com/cloud/agent/api/RebootCommand.java
+++ b/core/src/com/cloud/agent/api/RebootCommand.java
@@ -19,29 +19,25 @@
 
 package com.cloud.agent.api;
 
-import com.cloud.vm.VirtualMachine;
-
 public class RebootCommand extends Command {
     String vmName;
+    protected boolean executeInSequence = false;
 
     protected RebootCommand() {
     }
 
-    public RebootCommand(VirtualMachine vm) {
-        vmName = vm.getInstanceName();
-    }
-
-    public RebootCommand(String vmName) {
+    public RebootCommand(String vmName, boolean executeInSequence) {
         this.vmName = vmName;
+        this.executeInSequence = executeInSequence;
     }
 
     public String getVmName() {
-        return vmName;
+        return this.vmName;
     }
 
     @Override
     public boolean executeInSequence() {
-        return true;
+        return this.executeInSequence;
     }
 
 }

--- a/core/src/com/cloud/agent/api/RebootRouterCommand.java
+++ b/core/src/com/cloud/agent/api/RebootRouterCommand.java
@@ -27,7 +27,7 @@ public class RebootRouterCommand extends RebootCommand {
     }
 
     public RebootRouterCommand(String vmName, String privateIp) {
-        super(vmName);
+        super(vmName, true);
         this.privateIp = privateIp;
     }
 

--- a/core/src/com/cloud/agent/api/StopCommand.java
+++ b/core/src/com/cloud/agent/api/StopCommand.java
@@ -26,7 +26,6 @@ public class StopCommand extends RebootCommand {
     private boolean isProxy = false;
     private String urlPort = null;
     private String publicConsoleProxyIpAddress = null;
-    boolean executeInSequence = false;
     private GPUDeviceTO gpuDevice;
     boolean checkBeforeCleanup = false;
 
@@ -34,33 +33,30 @@ public class StopCommand extends RebootCommand {
     }
 
     public StopCommand(VirtualMachine vm, boolean isProxy, String urlPort, String publicConsoleProxyIpAddress, boolean executeInSequence, boolean checkBeforeCleanup) {
-        super(vm);
+        super(vm.getInstanceName(), executeInSequence);
         this.isProxy = isProxy;
         this.urlPort = urlPort;
         this.publicConsoleProxyIpAddress = publicConsoleProxyIpAddress;
-        this.executeInSequence = executeInSequence;
         this.checkBeforeCleanup = checkBeforeCleanup;
     }
 
     public StopCommand(VirtualMachine vm, boolean executeInSequence, boolean checkBeforeCleanup) {
-        super(vm);
-        this.executeInSequence = executeInSequence;
+        super(vm.getInstanceName(), executeInSequence);
         this.checkBeforeCleanup = checkBeforeCleanup;
     }
 
     public StopCommand(String vmName, boolean executeInSequence, boolean checkBeforeCleanup) {
-        super(vmName);
-        this.executeInSequence = executeInSequence;
+        super(vmName, executeInSequence);
         this.checkBeforeCleanup = checkBeforeCleanup;
     }
 
     @Override
     public boolean executeInSequence() {
-        //VR stop doesn't go through queue
-        if (vmName != null && vmName.startsWith("r-")) {
+        // VR stop doesn't go through queue
+        if (this.vmName != null && this.vmName.startsWith("r-")) {
             return false;
         }
-        return executeInSequence;
+        return this.executeInSequence;
     }
 
     public boolean isProxy() {

--- a/engine/api/src/com/cloud/vm/VirtualMachineManager.java
+++ b/engine/api/src/com/cloud/vm/VirtualMachineManager.java
@@ -49,11 +49,10 @@ import com.cloud.utils.fsm.NoTransitionException;
 public interface VirtualMachineManager extends Manager {
 
     static final ConfigKey<Boolean> ExecuteInSequence = new ConfigKey<Boolean>("Advanced", Boolean.class, "execute.in.sequence.hypervisor.commands", "false",
-            "If set to true, StartCommand, StopCommand, CopyCommand, MigrateCommand will be synchronized on the agent side."
-                    + " If set to false, these commands become asynchronous. Default value is false.", false);
+            "If set to true, start, stop, reboot, copy and migrate commands will be serialized on the agent side. If set to false the commands are executed in parallel. Default value is false.", false);
 
     static final ConfigKey<String> VmConfigDriveLabel = new ConfigKey<String>("Hidden", String.class, "vm.configdrive.label", "config",
-            "The default lable name for the config drive", false);
+            "The default label name for the config drive", false);
 
     public interface Topics {
         public static final String VM_POWER_STATE = "vm.powerstate";
@@ -199,4 +198,6 @@ public interface VirtualMachineManager extends Manager {
         ConcurrentOperationException, ResourceUnavailableException;
 
     void migrateForScale(String vmUuid, long srcHostId, DeployDestination dest, Long newSvcOfferingId) throws ResourceUnavailableException, ConcurrentOperationException;
+
+    boolean getExecuteInSequence(HypervisorType hypervisorType);
 }

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1240,11 +1240,11 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         }
     }
 
-
-    protected boolean getExecuteInSequence(final HypervisorType hypervisorType) {
-        if (HypervisorType.KVM == hypervisorType || HypervisorType.LXC == hypervisorType || HypervisorType.XenServer == hypervisorType) {
+    @Override
+    public boolean getExecuteInSequence(final HypervisorType hypervisorType) {
+        if (HypervisorType.KVM == hypervisorType || HypervisorType.XenServer == hypervisorType || HypervisorType.Hyperv == hypervisorType || HypervisorType.LXC == hypervisorType) {
             return false;
-        } else if(HypervisorType.VMware == hypervisorType) {
+        } else if (HypervisorType.VMware == hypervisorType) {
             final Boolean fullClone = HypervisorGuru.VmwareFullClone.value();
             return fullClone;
         } else {
@@ -2584,7 +2584,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         try {
 
             final Commands cmds = new Commands(Command.OnError.Stop);
-            cmds.addCommand(new RebootCommand(vm.getInstanceName()));
+            cmds.addCommand(new RebootCommand(vm.getInstanceName(), getExecuteInSequence(vm.getHypervisorType())));
             _agentMgr.send(host.getId(), cmds);
 
             final Answer rebootAnswer = cmds.getAnswer(RebootAnswer.class);

--- a/engine/orchestration/test/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/test/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -17,6 +17,7 @@
 
 package com.cloud.vm;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.isA;
@@ -504,5 +505,13 @@ public class VirtualMachineManagerImplTest {
         boolean actual = _vmMgr.sendStop(guru, profile, false, false);
 
         Assert.assertFalse(actual);
+    }
+
+    @Test
+    public void testExeceuteInSequence() {
+        assertTrue(_vmMgr.getExecuteInSequence(HypervisorType.XenServer) == false);
+        assertTrue(_vmMgr.getExecuteInSequence(HypervisorType.KVM) == false);
+        assertTrue(_vmMgr.getExecuteInSequence(HypervisorType.VMware) == HypervisorGuru.VmwareFullClone.value());
+        assertTrue(_vmMgr.getExecuteInSequence(HypervisorType.Ovm3) == VirtualMachineManager.ExecuteInSequence.value());
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRebootRouterCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRebootRouterCommandWrapper.java
@@ -34,7 +34,7 @@ public final class LibvirtRebootRouterCommandWrapper extends CommandWrapper<Rebo
     public Answer execute(final RebootRouterCommand command, final LibvirtComputingResource libvirtComputingResource) {
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
 
-        final RebootCommand rebootCommand = new RebootCommand(command.getVmName());
+        final RebootCommand rebootCommand = new RebootCommand(command.getVmName(), true);
         final Answer answer = wrapper.execute(rebootCommand, libvirtComputingResource);
 
         final VirtualRoutingResource virtualRouterResource = libvirtComputingResource.getVirtRouterResource();

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -748,7 +748,7 @@ public class LibvirtComputingResourceTest {
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
 
         final String vmName = "Test";
-        final RebootCommand command = new RebootCommand(vmName);
+        final RebootCommand command = new RebootCommand(vmName, true);
 
         when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
         try {
@@ -777,7 +777,7 @@ public class LibvirtComputingResourceTest {
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
 
         final String vmName = "Test";
-        final RebootCommand command = new RebootCommand(vmName);
+        final RebootCommand command = new RebootCommand(vmName, true);
 
         when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
         try {
@@ -806,7 +806,7 @@ public class LibvirtComputingResourceTest {
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
 
         final String vmName = "Test";
-        final RebootCommand command = new RebootCommand(vmName);
+        final RebootCommand command = new RebootCommand(vmName, true);
 
         when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
         try {
@@ -837,7 +837,7 @@ public class LibvirtComputingResourceTest {
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
 
         final String vmName = "Test";
-        final RebootCommand command = new RebootCommand(vmName);
+        final RebootCommand command = new RebootCommand(vmName, true);
 
         when(libvirtComputingResource.getLibvirtUtilitiesHelper()).thenReturn(libvirtUtilitiesHelper);
         try {

--- a/plugins/hypervisors/ovm3/src/test/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorResourceTest.java
+++ b/plugins/hypervisors/ovm3/src/test/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorResourceTest.java
@@ -172,7 +172,7 @@ public class Ovm3HypervisorResourceTest {
         con.removeMethodResponse("list_vms");
         con.addResult(xen.getMultipleVmsListXML());
         con.addResult(xen.getMultipleVmsListXML());
-        RebootCommand cmd = new RebootCommand(name);
+        RebootCommand cmd = new RebootCommand(name, true);
         Answer ra = hypervisor.executeRequest(cmd);
         return ra.getResult();
     }

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRebootRouterCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRebootRouterCommandWrapper.java
@@ -36,7 +36,7 @@ public final class CitrixRebootRouterCommandWrapper extends CommandWrapper<Reboo
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
 
-        final RebootCommand rebootCommand = new RebootCommand(command.getVmName());
+        final RebootCommand rebootCommand = new RebootCommand(command.getVmName(), true);
         final Answer answer = wrapper.execute(rebootCommand, citrixResourceBase);
 
         if (answer.getResult()) {

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixRequestWrapperTest.java
@@ -298,7 +298,7 @@ public class CitrixRequestWrapperTest {
 
     @Test
     public void testRebootCommand() {
-        final RebootCommand rebootCommand = new RebootCommand("Test");
+        final RebootCommand rebootCommand = new RebootCommand("Test", true);
 
         final CitrixRequestWrapper wrapper = CitrixRequestWrapper.getInstance();
         assertNotNull(wrapper);

--- a/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -1127,7 +1127,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
         }
 
         if (proxy.getState() == State.Running && proxy.getHostId() != null) {
-            final RebootCommand cmd = new RebootCommand(proxy.getInstanceName());
+            final RebootCommand cmd = new RebootCommand(proxy.getInstanceName(), _itMgr.getExecuteInSequence(proxy.getHypervisorType()));
             final Answer answer = _agentMgr.easySend(proxy.getHostId(), cmd);
 
             if (answer != null && answer.getResult()) {

--- a/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -983,7 +983,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         }
 
         if (secStorageVm.getState() == State.Running && secStorageVm.getHostId() != null) {
-            final RebootCommand cmd = new RebootCommand(secStorageVm.getInstanceName());
+            final RebootCommand cmd = new RebootCommand(secStorageVm.getInstanceName(), _itMgr.getExecuteInSequence(secStorageVm.getHypervisorType()));
             final Answer answer = _agentMgr.easySend(secStorageVm.getHostId(), cmd);
 
             if (answer != null && answer.getResult()) {


### PR DESCRIPTION
…nt commands w.r.t. "execute in sequence" flag

RebootCommand now behaves in the same way as start/stop/migrate agent commands w.r.t. to sequential/parallel execution.