### PR TITLE
QUOTA: Ensuring that the dates displayed are as per user expectations

### DIFF
--- a/plugins/database/quota/src/org/apache/cloudstack/api/command/QuotaBalanceCmd.java
+++ b/plugins/database/quota/src/org/apache/cloudstack/api/command/QuotaBalanceCmd.java
@@ -83,7 +83,12 @@ public class QuotaBalanceCmd extends BaseCmd {
     }
 
     public Date getEndDate() {
-        return endDate == null ? null : _responseBuilder.startOfNextDay(endDate == null ? null : new Date(endDate.getTime()));
+        if (endDate == null){
+            return null;
+        }
+        else{
+            return _responseBuilder.startOfNextDay(new Date(endDate.getTime()));
+        }
     }
 
     public void setEndDate(Date endDate) {
@@ -113,10 +118,10 @@ public class QuotaBalanceCmd extends BaseCmd {
         List<QuotaBalanceVO> quotaUsage = _responseBuilder.getQuotaBalance(this);
 
         QuotaBalanceResponse response;
-        if (getEndDate() == null) {
+        if (endDate == null) {
             response = _responseBuilder.createQuotaLastBalanceResponse(quotaUsage, getStartDate());
         } else {
-            response = _responseBuilder.createQuotaBalanceResponse(quotaUsage, getStartDate(), endDate == null ? null : new Date(endDate.getTime()));
+            response = _responseBuilder.createQuotaBalanceResponse(quotaUsage, getStartDate(), new Date(endDate.getTime()));
         }
         response.setResponseName(getCommandName());
         setResponseObject(response);

--- a/plugins/database/quota/src/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
+++ b/plugins/database/quota/src/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
@@ -233,9 +233,9 @@ public class QuotaResponseBuilderImpl implements QuotaResponseBuilder {
             // order is desc last item is the start item
             QuotaBalanceVO startItem = quotaBalance.get(quotaBalance.size() - 1);
             QuotaBalanceVO endItem = quotaBalance.get(0);
-            resp.setStartDate(startItem.getUpdatedOn());
+            resp.setStartDate(startDate);
             resp.setStartQuota(startItem.getCreditBalance());
-            resp.setEndDate(endItem.getUpdatedOn());
+            resp.setEndDate(endDate);
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("createQuotaBalanceResponse: Start Entry=" + startItem);
                 s_logger.debug("createQuotaBalanceResponse: End Entry=" + endItem);
@@ -479,7 +479,7 @@ public class QuotaResponseBuilderImpl implements QuotaResponseBuilder {
             lastCredits = lastCredits.add(entry.getCreditBalance());
         }
         resp.setStartQuota(lastCredits);
-        resp.setStartDate(_quotaService.computeAdjustedTime(startDate));
+        resp.setStartDate(startDate);
         resp.setCurrency(QuotaConfig.QuotaCurrencySymbol.value());
         resp.setObjectName("balance");
         return resp;

--- a/plugins/database/quota/src/org/apache/cloudstack/quota/QuotaServiceImpl.java
+++ b/plugins/database/quota/src/org/apache/cloudstack/quota/QuotaServiceImpl.java
@@ -138,8 +138,8 @@ public class QuotaServiceImpl extends ManagerBase implements QuotaService, Confi
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] { QuotaPluginEnabled, QuotaEnableEnforcement, QuotaCurrencySymbol, QuotaStatementPeriod, QuotaSmtpHost, QuotaSmtpPort, QuotaSmtpTimeout, QuotaSmtpUser, QuotaSmtpPassword,
-                QuotaSmtpAuthType, QuotaSmtpSender };
+        return new ConfigKey<?>[] {QuotaPluginEnabled, QuotaEnableEnforcement, QuotaCurrencySymbol, QuotaStatementPeriod, QuotaSmtpHost, QuotaSmtpPort, QuotaSmtpTimeout,
+                QuotaSmtpUser, QuotaSmtpPassword, QuotaSmtpAuthType, QuotaSmtpSender};
     }
 
     @Override
@@ -193,8 +193,8 @@ public class QuotaServiceImpl extends ManagerBase implements QuotaService, Confi
             } else if (startDate.before(endDate)) {
                 Date adjustedEndDate = computeAdjustedTime(endDate);
                 if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("getQuotaBalance2: Getting quota balance records for account: " + accountId + ", domainId: " + domainId + ", between " + adjustedStartDate + " and "
-                            + adjustedEndDate);
+                    s_logger.debug("getQuotaBalance2: Getting quota balance records for account: " + accountId + ", domainId: " + domainId + ", between " + adjustedStartDate
+                            + " and " + adjustedEndDate);
                 }
                 List<QuotaBalanceVO> qbrecords = _quotaBalanceDao.findQuotaBalance(accountId, domainId, adjustedStartDate, adjustedEndDate);
                 if (s_logger.isDebugEnabled()) {
@@ -243,7 +243,7 @@ public class QuotaServiceImpl extends ManagerBase implements QuotaService, Confi
         Date adjustedEndDate = computeAdjustedTime(endDate);
         Date adjustedStartDate = computeAdjustedTime(startDate);
         if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Getting quota records for account: " + accountId + ", domainId: " + domainId + ", between " + startDate + " and " + endDate);
+            s_logger.debug("Getting quota records for account: " + accountId + ", domainId: " + domainId + ", between " + adjustedStartDate + " and " + adjustedEndDate);
         }
         return _quotaUsageDao.findQuotaUsage(accountId, domainId, usageType, adjustedStartDate, adjustedEndDate);
     }


### PR DESCRIPTION
    When querying db we use start of next day to query quota usage for
    today, but while displaying it to user we still need to show it as
    todays date