### PR TITLE
CLOUDSTACK-9133: Two volume.delete usage events are getting generated…

### DIFF
--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -3919,13 +3919,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (status) {
             // Mark the account's volumes as destroyed
             List<VolumeVO> volumes = _volsDao.findByInstance(vmId);
-            for (VolumeVO volume : volumes) {
-                if (volume.getVolumeType().equals(Volume.Type.ROOT)) {
-                    UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VOLUME_DELETE, volume.getAccountId(), volume.getDataCenterId(), volume.getId(), volume.getName(),
-                            Volume.class.getName(), volume.getUuid(), volume.isDisplayVolume());
-                }
-            }
-
             if (vmState != State.Error) {
                 // Get serviceOffering for Virtual Machine
                 ServiceOfferingVO offering = _serviceOfferingDao.findByIdIncludingRemoved(vm.getId(), vm.getServiceOfferingId());


### PR DESCRIPTION
It was happening because event triggering  was happening in UserVmManagerImpl.java and VolumeStateListener.java respectively. So i have removed it from UserVmManagerImpl.java.

ACS Link ==>
https://issues.apache.org/jira/browse/CLOUDSTACK-9133