### PR TITLE
CLOUDSTACK-9134: set device_id as the first device_id not in use instead of nic count

### DIFF
--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -3150,7 +3150,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
         //1) allocate nic (if needed) Always allocate if it is a user vm
         if (nic == null || (vmProfile.getType() == VirtualMachine.Type.User)) {
-            int deviceId = _nicDao.countNics(vm.getId());
+            int deviceId = _nicDao.getFreeDeviceId(vm.getId());
 
             nic = allocateNic(requested, network, false, deviceId, vmProfile).first();
 

--- a/engine/schema/src/com/cloud/vm/dao/NicDao.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicDao.java
@@ -55,7 +55,7 @@ public interface NicDao extends GenericDao<NicVO, Long> {
 
     String getIpAddress(long networkId, long instanceId);
 
-    int countNics(long instanceId);
+    int getFreeDeviceId(long instanceId);
 
     NicVO findByNetworkIdInstanceIdAndBroadcastUri(long networkId, long instanceId, String broadcastUri);
 


### PR DESCRIPTION

when we restart vpc tiers, the old nics will be removed, and create a new nic.
however, the device_id was set to the nic count, which may be already used.
this commit get the first device_id not in use as the device_id of new nic.

This issue also happen when we add multiple networks to a vm and remove them.