### PR TITLE
[UI] bug fix: Delete added ACL lists is not available for Domain Admin and normal users

### DIFF
--- a/ui/scripts/vpc.js
+++ b/ui/scripts/vpc.js
@@ -638,7 +638,7 @@
                             args.response.success({
                                 _custom: {
                                     jobId: jobID,
-                                    getUpdateIdtem: function() {
+                                    getUpdatedItem: function() {
                                         $(window).trigger('cloudStack.fullRefresh');
                                     }
                                 },
@@ -1225,12 +1225,19 @@
                                     url: createURL('createNetworkACLList&vpcid=' + args.context.vpc[0].id),
                                     data: data,
                                     success: function(json) {
-                                        var items = json.createnetworkacllistresponse;
                                         args.response.success({
-                                            data: items
+                                            _custom: {
+                                                jobId: json.createnetworkacllistresponse.jobid,
+                                                getUpdatedItem: function(json) {
+                                                    return json.queryasyncjobresultresponse.jobresult.networkacllist;
+                                                }
+                                            }
                                         });
                                     }
                                 });
+                            },
+                            notification: {
+                                poll: pollAsyncJobResult
                             }
                         }
                     },
@@ -1255,7 +1262,10 @@
                                             var jid = json.deletenetworkacllistresponse.jobid;
                                             args.response.success({
                                                 _custom: {
-                                                    jobId: jid
+                                                    jobId: jid,
+                                                    getUpdatedItem: function() {
+                                                        $(window).trigger('cloudStack.fullRefresh');
+                                                    }
                                                 }
                                             });
                                         },
@@ -1292,9 +1302,8 @@
                                             data: items,
                                             actionFilter: function(args) {
                                                 var allowedActions = [];
-                                                if (isAdmin() && items.vpcid) {
+                                                if (items.vpcid != null) {
                                                     allowedActions.push("remove");
-
                                                 }
                                                 return allowedActions;
                                             }


### PR DESCRIPTION
Only the owner or domain admin/admin can access the page (vpc->Network ACL Lists), they are also able to remove the network ACL lists, which is not allowed on UI.