### PR TITLE
[4.9] CLOUDSTACK-9136: remove ssh keypairs along with removing account

### DIFF
--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -3600,7 +3600,17 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final Long domainId = cmd.getDomainId();
         final Long projectId = cmd.getProjectId();
 
-        final Account owner = _accountMgr.finalizeOwner(caller, accountName, domainId, projectId);
+        Account owner = null;
+        try {
+            owner = _accountMgr.finalizeOwner(caller, accountName, domainId, projectId);
+        } catch (InvalidParameterValueException ex) {
+            if (caller.getType() == Account.ACCOUNT_TYPE_ADMIN && accountName != null && domainId != null) {
+                owner = _accountDao.findAccountIncludingRemoved(accountName, domainId);
+            }
+            if (owner == null) {
+                throw ex;
+            }
+        }
 
         final SSHKeyPairVO s = _sshKeyPairDao.findByName(owner.getAccountId(), owner.getDomainId(), cmd.getName());
         if (s == null) {

--- a/server/src/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/com/cloud/user/AccountManagerImpl.java
@@ -133,6 +133,7 @@ import com.cloud.template.TemplateManager;
 import com.cloud.template.VirtualMachineTemplate;
 import com.cloud.user.Account.State;
 import com.cloud.user.dao.AccountDao;
+import com.cloud.user.dao.SSHKeyPairDao;
 import com.cloud.user.dao.UserAccountDao;
 import com.cloud.user.dao.UserDao;
 import com.cloud.utils.ConstantTimeComparator;
@@ -262,6 +263,8 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     private DedicatedResourceDao _dedicatedDao;
     @Inject
     private GlobalLoadBalancerRuleDao _gslbRuleDao;
+    @Inject
+    private SSHKeyPairDao _sshKeyPairDao;
 
     List<QuerySelector> _querySelectors;
 
@@ -923,6 +926,12 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             // Delete resource count and resource limits entries set for this account (if there are any).
             _resourceCountDao.removeEntriesByOwner(accountId, ResourceOwnerType.Account);
             _resourceLimitDao.removeEntriesByOwner(accountId, ResourceOwnerType.Account);
+
+            // Delete ssh keypairs
+            List<SSHKeyPairVO> sshkeypairs = _sshKeyPairDao.listKeyPairs(accountId, account.getDomainId());
+            for (SSHKeyPairVO keypair: sshkeypairs) {
+                _sshKeyPairDao.remove(keypair.getId());
+            }
             return true;
         } catch (Exception ex) {
             s_logger.warn("Failed to cleanup account " + account + " due to ", ex);

--- a/server/test/com/cloud/user/AccountManagerImplTest.java
+++ b/server/test/com/cloud/user/AccountManagerImplTest.java
@@ -20,6 +20,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
 import com.cloud.server.auth.UserAuthenticator;
 import com.cloud.utils.Pair;
 
@@ -99,6 +101,13 @@ public class AccountManagerImplTest extends AccountManagetImplTestBase {
                         Mockito.any(Domain.class)))
         .thenReturn(true);
         Mockito.when(_vmSnapshotDao.listByAccountId(Mockito.anyLong())).thenReturn(new ArrayList<VMSnapshotVO>());
+
+        List<SSHKeyPairVO> sshkeyList = new ArrayList<SSHKeyPairVO>();
+        SSHKeyPairVO sshkey = new SSHKeyPairVO();
+        sshkey.setId(1l);
+        sshkeyList.add(sshkey);
+        Mockito.when(_sshKeyPairDao.listKeyPairs(Mockito.anyLong(), Mockito.anyLong())).thenReturn(sshkeyList);
+        Mockito.when(_sshKeyPairDao.remove(Mockito.anyLong())).thenReturn(true);
 
         Assert.assertTrue(accountManager.deleteUserAccount(42));
         // assert that this was a clean delete

--- a/server/test/com/cloud/user/AccountManagetImplTestBase.java
+++ b/server/test/com/cloud/user/AccountManagetImplTestBase.java
@@ -69,6 +69,7 @@ import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.snapshot.SnapshotManager;
 import com.cloud.template.TemplateManager;
 import com.cloud.user.dao.AccountDao;
+import com.cloud.user.dao.SSHKeyPairDao;
 import com.cloud.user.dao.UserAccountDao;
 import com.cloud.user.dao.UserDao;
 import com.cloud.vm.VirtualMachineManager;
@@ -189,7 +190,8 @@ public class AccountManagetImplTestBase {
     ServiceOfferingDao _offeringDao;
     @Mock
     OrchestrationService _orchSrvc;
-
+    @Mock
+    SSHKeyPairDao _sshKeyPairDao;
 
     AccountManagerImpl accountManager;
 


### PR DESCRIPTION
We also allow ROOT Admin to remove remained ssh keypairs of removed account
