### PR TITLE
CLOUDSTACK-9137 Allow domain admin to manage private gw

### DIFF
--- a/client/tomcatconf/commands.properties.in
+++ b/client/tomcatconf/commands.properties.in
@@ -486,9 +486,9 @@ deleteVPCOffering=1
 listVPCOfferings=15
 
 #### Private gateway commands
-createPrivateGateway=1
+createPrivateGateway=7
 listPrivateGateways=15
-deletePrivateGateway=1
+deletePrivateGateway=7
 
 #### Network ACL commands
 createNetworkACL=15


### PR DESCRIPTION
To create a private gateway you need a root admin account. This does not make sense, as you can do a lot more with such a powerful account. Other network related API calls can be made by a domain admin.

This PR allows domain admins to create their own private gateways.