### PR TITLE
CLOUDSTACK-9143 Setup routes for RFC 1918 ip space

### DIFF
--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -1165,12 +1165,28 @@ setup_storage_network() {
 	log_it "Successfully setup storage network with STORAGE_IP:$STORAGE_IP, STORAGE_NETMASK:$STORAGE_NETMASK, STORAGE_CIDR:$STORAGE_CIDR"
 }
 
+setup_system_rfc1918_internal() {
+  echo "$public_ip" | grep -E "^((127\.)|(10\.)|(172\.1[6-9]\.)|(172\.2[0-9]\.)|(172\.3[0-1]\.)|(192\.168\.))"
+  if [ "$?" == "0" ]; then
+     log_it "Not setting up route of RFC1918 space to $LOCAL_GW befause $public_ip is RFC1918."
+  else
+     log_it "Setting up route of RFC1918 space to $LOCAL_GW"
+     # Setup general route for RFC 1918 space, as otherwise it will be sent to
+     # the public gateway and not work
+     # More specific routes that may be set have preference over this generic route.
+     ip route add 10.0.0.0/8 via $LOCAL_GW
+     ip route add 172.16.0.0/12 via $LOCAL_GW
+     ip route add 192.168.0.0/16 via $LOCAL_GW
+  fi
+}
+
 setup_secstorage() {
   log_it "Setting up secondary storage system vm"
   sysctl vm.min_free_kbytes=8192
   local hyp=$1
   setup_common eth0 eth1 eth2
   setup_storage_network
+  setup_system_rfc1918_internal
   sed -i  /gateway/d /etc/hosts
   public_ip=$ETH2_IP
   [ "$ETH2_IP" == "0.0.0.0" ] && public_ip=$ETH1_IP
@@ -1229,6 +1245,7 @@ setup_console_proxy() {
   log_it "Setting up console proxy system vm"
   local hyp=$1
   setup_common eth0 eth1 eth2
+  setup_system_rfc1918_internal
   public_ip=$ETH2_IP
   [ "$ETH2_IP" == "0.0.0.0" ] && public_ip=$ETH1_IP
   sed -i  /gateway/d /etc/hosts


### PR DESCRIPTION
Setup general route for RFC 1918 space, as otherwise it will be sent to the public gateway and likely to be dropped (internet providers do not route ip space that is meant for internal use). More specific routes that may be set have preference over this generic routes so this works even with private ranges used for public ip space (as shown below).

When using an internal DNS server some hosts may resolve to an RFC 1918 ip address. The SSVM has a default gw to public so if it has no route for this ip address space, it will not work. This PR makes generic RFC 1918 (so all internal ip adresses like 10.0.0.10 etc) to the local management gateway. This makes them reachable. Without this fix, it is sent upstream and it is dropped there.

Should there be a more generic route (smaller prefix), this has preference over the generic routes.

Example in my dev environment:

```
root@v-1-VM:~# route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         192.168.23.1    0.0.0.0         UG    0      0        0 eth2
10.0.0.0        192.168.22.1    255.0.0.0       UG    0      0        0 eth1
169.254.0.0     0.0.0.0         255.255.0.0     U     0      0        0 eth0
172.16.0.0      192.168.22.1    255.240.0.0     UG    0      0        0 eth1
192.168.0.0     192.168.22.1    255.255.0.0     UG    0      0        0 eth1
192.168.22.0    0.0.0.0         255.255.255.0   U     0      0        0 eth1
192.168.23.0    0.0.0.0         255.255.255.0   U     0      0        0 eth2
```

Route `192.168.0.0/16` goes via `eth1` but `192.168.23.0/24` is more specific and has preference and goes via `eth2`. It works:

```
root@v-1-VM:~# ping 8.8.8.8
PING 8.8.8.8 (8.8.8.8): 48 data bytes
56 bytes from 8.8.8.8: icmp_seq=0 ttl=49 time=7.179 ms
^C--- 8.8.8.8 ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max/stddev = 7.179/7.179/7.179/0.000 ms
```

This solves a lot of the 'internal resolving' issues we face.

When the public ip address is RFC1918 itself, we do not set the routes.