### PR TITLE
CLOUDSTACK-9138 - Adds multiple providers back to VPC implementation

### DIFF
--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -412,10 +412,6 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 final Network.Service service = Network.Service.getService(serviceEntry.getKey());
                 if (svcProviderMap.containsKey(service)) {
                     final Set<Provider> providers = new HashSet<Provider>();
-                    // don't allow to specify more than 1 provider per service
-                    if (serviceEntry.getValue() != null && serviceEntry.getValue().size() > 1) {
-                        throw new InvalidParameterValueException("In the current release only one provider can be " + "specified for the service");
-                    }
                     for (final String prvNameStr : serviceEntry.getValue()) {
                         // check if provider is supported
                         final Network.Provider provider = Network.Provider.getProvider(prvNameStr);


### PR DESCRIPTION
   - It is need and already allowed/used in the current implementation. For example, the Default [redundant] VPC offerings use two LB providers. If we cannot create offerings with 2 LB providers, the whole internal loadbalancer implementation won't work.