### PR TITLE
CLOUDSTACK-9103 : Missing OS Mappings for VMware 6.0

### DIFF
--- a/setup/db/db/schema-461to470.sql
+++ b/setup/db/db/schema-461to470.sql
@@ -247,3 +247,6 @@ CREATE VIEW `cloud`.`domain_router_view` AS
             and async_job.instance_type = 'DomainRouter'
             and async_job.job_status = 0;
 
+INSERT IGNORE INTO `cloud`.`hypervisor_capabilities` values (25,UUID(),'VMware','6.0',128,0,13,32,1,1);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '5.5', 'rhel7_64Guest', 245, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) SELECT UUID(),'VMware', '6.0', guest_os_name, guest_os_id, utc_timestamp(), 0  FROM `cloud`.`guest_os_hypervisor` WHERE hypervisor_type='VMware' AND hypervisor_version='5.5' AND (guest_os_id NOT IN (1,2,3,4,62,63,64,65,156,157,221,222) AND guest_os_id NOT BETWEEN 121 AND 130);


### PR DESCRIPTION
Added suitable db entries in tables hypervisor_capabilities and guest_os_hypervisor to support VMware 6.0 by copying from 5.5 and excluding few depricated guest os.And also added entries for guest os RHEL 7 for vmware 5.5 and 6.0.