### PR TITLE
CLOUDSTACK-9139 make zwps default when defined on zone level

### DIFF
--- a/tools/marvin/marvin/deployDataCenter.py
+++ b/tools/marvin/marvin/deployDataCenter.py
@@ -243,8 +243,8 @@ class DeployDataCenters(object):
 
                 primarycmd.tags = primary.tags
                 primarycmd.url = primary.url
-                if primary.scope == 'zone':
-                    primarycmd.scope = primary.scope
+                if primary.scope == 'zone' or clusterId is None:
+                    primarycmd.scope = 'zone'
                     primarycmd.hypervisor = primary.hypervisor
                 else:
                     primarycmd.podid = podId


### PR DESCRIPTION
When a marvin definition contains a primary storage definition at zone level it will default to zone scope. A test run is underway.
using marvin config:
```
{
    "zones": [
        {
            "name": "MCCT-SHARED-1",
            "guestcidraddress": "10.1.1.0/24",
            "dns1": "8.8.8.8",
            "physical_networks": [
                {
                    "broadcastdomainrange": "Zone",
                    "vlan": "100-200",
                    "name": "mcct-pnet",
                    "traffictypes": [
                        {
                            "typ": "Guest"
                        },
                        {
                            "typ": "Management"
                        },
                        {
                            "typ": "Public"
                        }
                    ],
                    "providers": [
                        {
                            "broadcastdomainrange": "ZONE",
                            "name": "VirtualRouter"
                        },
                        {
                            "broadcastdomainrange": "ZONE",
                            "name": "VpcVirtualRouter"
                        },
                        {
                            "broadcastdomainrange": "ZONE",
                            "name": "InternalLbVm"
                        }
                    ],
                    "isolationmethods": [
                             "VLAN"
                    ]
                }
            ],
            "ipranges": [
                {
                    "startip": "192.168.23.2",
                    "endip": "192.168.23.20",
                    "netmask": "255.255.255.0",
                    "vlan": "50",
                    "gateway": "192.168.23.1"
                }
            ],
            "networktype": "Advanced",
            "pods": [
                {
                    "endip": "192.168.22.150",
                    "name": "MCCT-POD",
                    "startip": "192.168.22.130",
                    "netmask": "255.255.255.0",
                    "clusters": [
                    ],
                    "clusters": [
                        {
                            "clustername": "MCCT-KVM-1",
                            "hypervisor": "KVM",
                            "hosts": [
                                {
                                    "username": "root",
                                    "url": "http://kvm1",
                                    "password": "password"
                                },
                                {
                                    "username": "root",
                                    "url": "http://kvm2",
                                    "password": "password"
                                }
                            ],
                            "clustertype": "CloudManaged"
                        }
                    ],
                    "gateway": "192.168.22.1"
                }
            ],
            "internaldns1": "8.8.4.4",
            "secondaryStorages": [
                {
                    "url": "nfs://192.168.22.1:/data/storage/secondary/MCCT-SHARED-1",
                    "provider" : "NFS"
                }
            ],
            "primaryStorages": [
                {
                    "url": "nfs://192.168.22.1:/data/storage/primary/MCCT-KVM-1",
                    "name": "MCCT-KVM-1-primary",
                    "hypervisor": "kvm"
                }
            ]
        }
    ],
    "dbSvr": {
        "dbSvr": "localhost",
        "passwd": "cloud",
        "db": "cloud",
        "port": 3306,
        "user": "cloud"
    },
    "logger":
        {
            "LogFolderPath": "/tmp/"
        },
    "globalConfig": [
        {
            "name": "network.gc.wait",
            "value": "60"
        },
        {
            "name": "storage.cleanup.interval",
            "value": "300"
        },
        {
            "name": "vm.op.wait.interval",
            "value": "5"
        },
        {
            "name": "default.page.size",
            "value": "10000"
        },
        {
            "name": "network.gc.interval",
            "value": "60"
        },
        {
            "name": "workers",
            "value": "10"
        },
        {
            "name": "account.cleanup.interval",
            "value": "600"
        },
        {
            "name": "guest.domain.suffix",
            "value": "cloud"
        },
        {
            "name": "expunge.delay",
            "value": "60"
        },
        {
            "name": "vm.allocation.algorithm",
            "value": "firstfitleastconsumed"
        },
        {
            "name": "expunge.interval",
            "value": "60"
        },
        {
            "name": "expunge.workers",
            "value": "3"
        },
        {
            "name": "check.pod.cidrs",
            "value": "true"
        },
        {
            "name": "secstorage.allowed.internal.sites",
            "value": "192.168.22.0/24"
        },
        {
            "name": "direct.agent.load.size",
            "value": "1000"
        }
    ],
    "mgtSvr": [
        {
            "mgtSvrIp": "localhost",
            "passwd": "password",
            "user": "root",
            "port": 8096,
            "hypervisor": "KVM",
            "useHttps": "False",
            "certCAPath":  "NA",
            "certPath":  "NA"
        }
    ]
}
```
deploys succesful:
```
Deploy data center..

==== Log Folder Path: /tmp//MarvinLogs//DeployDataCenter__Dec_11_2015_16_27_55_AM5LVR. All logs will be available here ====

==== Deploy DC Started ====

=== Data Center Settings are dumped to /tmp//MarvinLogs//DeployDataCenter__Dec_11_2015_16_27_55_AM5LVR/dc_entries.obj===

====Deploy DC Successful=====
Fri Dec 11 16:32:02 GMT 2015
```

![screen shot 2015-12-11 at 17 37 12](https://cloud.githubusercontent.com/assets/2486961/11749410/e7d99db4-a02d-11e5-9a5b-e5d554a45945.png)
