### PR TITLE
CLOUDSTACK-4374 - As a Developer I want to have HA enabled for routers that are part or a redundant network or VPC

### DIFF
--- a/server/src/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/com/cloud/network/router/NetworkHelperImpl.java
@@ -472,14 +472,7 @@ public class NetworkHelperImpl implements NetworkHelper {
                     continue;
                 }
 
-                boolean offerHA = routerOffering.getOfferHA();
-                /*
-                 * We don't provide HA to redundant router VMs, admin should own
-                 * it all, and redundant router themselves are HA
-                 */
-                if (routerDeploymentDefinition.isRedundant()) {
-                    offerHA = false;
-                }
+                final boolean offerHA = routerOffering.getOfferHA();
 
                 // routerDeploymentDefinition.getVpc().getId() ==> do not use
                 // VPC because it is not a VPC offering.
@@ -487,7 +480,7 @@ public class NetworkHelperImpl implements NetworkHelper {
 
                 long userId = CallContext.current().getCallingUserId();
                 if (CallContext.current().getCallingAccount().getId() != owner.getId()) {
-                    List<UserVO> userVOs = _userDao.listByAccount(owner.getAccountId());
+                    final List<UserVO> userVOs = _userDao.listByAccount(owner.getAccountId());
                     if (!userVOs.isEmpty()) {
                         userId =  userVOs.get(0).getId();
                     }


### PR DESCRIPTION
This PR fixes the issue we were facing with crashed redundant routers not being picked up by the HA monitor due to an IF statement in the code.

* Redundant Routers are not the same as Haigh Available. Having a router HA is actually saying that the given router will be controlled by the High Availability monitor. Hence fix any problem we might face.