### PR TITLE
Show actual diff in commits after merge with git-pr / git-fwd-merge

### DIFF
--- a/tools/git/git-fwd-merge
+++ b/tools/git/git-fwd-merge
@@ -52,5 +52,10 @@ fi
 # Clean up
 rm -fr ${tmpMessageFile}
 
+apache_remote=$(git remote -v | grep -E "git-wip-us\.apache\.org" | head -n 1 | cut -f1)
+echo "INFO: Actual diff in commits is: (running git log --pretty=oneline --abbrev-commit ${apache_remote}/${currentBranch}..${currentBranch})"
+echo
+git log --pretty=oneline --abbrev-commit ${apache_remote}/${currentBranch}..${currentBranch}
+
 # What's next
 echo "We're done! Please double check using 'git log -p' and 'git push' when you're sure."

--- a/tools/git/git-pr
+++ b/tools/git/git-pr
@@ -179,6 +179,7 @@ elif [ "${prMergeableState}" != "clean" ] && [ ${force} -eq 1 ]; then
 fi
 
 github_remote=$(git remote -v | grep -E "apache/${repoName}(.git)?" | head -n 1 | cut -f1)
+apache_remote=$(git remote -v | grep -E "git-wip-us\.apache\.org" | head -n 1 | cut -f1)
 if [ ${#github_remote} -eq 0 ]; then
   echo "ERROR: We couldn't find a git remote pointing to 'apache/${repoName}.git' to merge the PR from."
   echo "INFO: Currently, your configured remotes are:"
@@ -230,6 +231,8 @@ fi
 echo "INFO: ***********************************************************************************"
 echo "INFO: Merged successfully! Please double check using 'git log -p' and 'git push' when you're sure."
 echo "INFO: About commits: there should be ${prCommits} from the PR plus 1 merge commit."
+echo "INFO: Actual diff in commits is: (running git log --pretty=oneline --abbrev-commit ${apache_remote}/${currentBranch}..${currentBranch})"
 echo
+git log --pretty=oneline --abbrev-commit ${apache_remote}/${currentBranch}..${currentBranch}
 
 clean_up_and_exit 0


### PR DESCRIPTION
This shows the diff in commits after using `git-pr` and `git-fwd-merge` tools, like this:

```
44e8c92 Merge pull request #1226 from borisroman/CLOUDSTACK-9148
0554610 Removed .pydevproject from plugin kvm hypervisor.
```

That helps in quickly seeing what change is applied and whether it makes sense. It doesn't touch the actual code base. I'm using this patch for some time already.