### PR TITLE
CLOUDSTACK-9151 - As a Developer I want the VRID to be set within the limits of KeepaliveD

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -137,8 +137,6 @@ class CsRedundant(object):
             " router_id ", "    router_id %s" % self.cl.get_name())
         keepalived_conf.search(
             " interface ", "    interface %s" % guest.get_device())
-        keepalived_conf.search(
-            " virtual_router_id ", "    virtual_router_id %s" % self.cl.get_router_id())
         keepalived_conf.greplace("[RROUTER_BIN_PATH]", self.CS_ROUTER_DIR)
         keepalived_conf.section("authentication {", "}", [
                                 "        auth_type AH \n", "        auth_pass %s\n" % self.cl.get_router_password()])


### PR DESCRIPTION
This PR fixes a blocker issue! 

   - Just like with RVRs, use the VRID 51 instead of making it dependent on the VPCID
   - Reason: arbitary unique number 0..255 used to differentiate multiple instances of vrrpd running on the same NIC (and hence same socket). virtual_router_id 51