### PR TITLE
CLOUDSTACK-9155 make sure logrotate is effective for cloud.log

### DIFF
--- a/systemvm/patches/debian/config/etc/logrotate.d/cloud
+++ b/systemvm/patches/debian/config/etc/logrotate.d/cloud
@@ -22,4 +22,8 @@
         notifempty
         compress
         delaycompress
+        # CLOUDSTACK-9155: We cannot tell the processes that are writing to this
+        # file to use the new inode, so instead we copy the original file, truncate
+        # it and keep the same inode.
+        copytruncate
 }


### PR DESCRIPTION
Many processes on the VRs log to cloud.log. When log rotate kicks in, the file is rotated but the scripts still write to the old inode (cloud.log.1 after rotate). Tis quickly fills up the tiny log partition.

Using 'copytruncate' is a small tradeoff, there is a slight change of missing a log entry, but in the old situation nothing ended up in cloud.log after rotate (except for stuff that was (re)started) so I think this is the best solution until we properly rewrite the script to either use their own script or syslog.

More details: https://issues.apache.org/jira/browse/CLOUDSTACK-9155