### PR TITLE
CLOUDSTACK-9158: Removed SLF4J, it's abundant due to log4j

### DIFF
--- a/agent/src/com/cloud/agent/Agent.java
+++ b/agent/src/com/cloud/agent/Agent.java
@@ -37,7 +37,7 @@ import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.managed.context.ManagedContextTimerTask;
 import org.apache.log4j.Logger;
-import org.slf4j.MDC;
+import org.apache.log4j.MDC;
 
 import com.cloud.agent.api.AgentControlAnswer;
 import com.cloud.agent.api.AgentControlCommand;

--- a/api/src/org/apache/cloudstack/context/LogContext.java
+++ b/api/src/org/apache/cloudstack/context/LogContext.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.log4j.Logger;
-import org.slf4j.MDC;
+import org.apache.log4j.MDC;
 
 import org.apache.cloudstack.managed.threadlocal.ManagedThreadLocal;
 

--- a/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
@@ -45,7 +45,7 @@ import org.apache.cloudstack.framework.jobs.AsyncJobExecutionContext;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.log4j.Logger;
-import org.slf4j.MDC;
+import org.apache.log4j.MDC;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.Listener;
@@ -390,8 +390,8 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
                 cmd.setContextParam("job", "job-" + job.getId());
             }
         }
-        if (MDC.get("logcontextid") != null && !MDC.get("logcontextid").isEmpty()) {
-            cmd.setContextParam("logid", MDC.get("logcontextid"));
+        if (MDC.get("logcontextid") != null && MDC.get("logcontextid") != null) {
+            cmd.setContextParam("logid", MDC.get("logcontextid").toString());
         }
     }
 

--- a/engine/orchestration/src/com/cloud/agent/manager/DirectAgentAttache.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/DirectAgentAttache.java
@@ -24,9 +24,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.log4j.Logger;
+import org.apache.log4j.MDC;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
-import org.slf4j.MDC;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;

--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import org.apache.log4j.Logger;
+import org.apache.log4j.MDC;
 import org.apache.log4j.NDC;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.context.CallContext;
@@ -54,7 +55,6 @@ import org.apache.cloudstack.jobs.JobInfo;
 import org.apache.cloudstack.jobs.JobInfo.Status;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
-import org.slf4j.MDC;
 
 import com.cloud.cluster.ClusterManagerListener;
 import com.cloud.cluster.ManagementServerHost;

--- a/framework/managed-context/pom.xml
+++ b/framework/managed-context/pom.xml
@@ -27,10 +27,4 @@
     <version>4.7.0-SNAPSHOT</version>
     <relativePath>../../maven-standard/pom.xml</relativePath>
   </parent>
-  <dependencies>
-      <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-      </dependency>
-  </dependencies>
 </project>

--- a/framework/managed-context/src/main/java/org/apache/cloudstack/managed/context/ManagedContextRunnable.java
+++ b/framework/managed-context/src/main/java/org/apache/cloudstack/managed/context/ManagedContextRunnable.java
@@ -18,8 +18,7 @@
  */
 package org.apache.cloudstack.managed.context;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.managed.context.impl.DefaultManagedContext;
 
@@ -27,7 +26,7 @@ public abstract class ManagedContextRunnable implements Runnable {
 
     private static final int SLEEP_COUNT = 120;
 
-    private static final Logger log = LoggerFactory.getLogger(ManagedContextRunnable.class);
+    private static final Logger log = Logger.getLogger(ManagedContextRunnable.class);
     private static final ManagedContext DEFAULT_MANAGED_CONTEXT = new DefaultManagedContext();
     private static ManagedContext context;
     private static boolean managedContext = false;

--- a/framework/managed-context/src/main/java/org/apache/cloudstack/managed/context/impl/DefaultManagedContext.java
+++ b/framework/managed-context/src/main/java/org/apache/cloudstack/managed/context/impl/DefaultManagedContext.java
@@ -23,8 +23,7 @@ import java.util.Stack;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.managed.context.ManagedContext;
 import org.apache.cloudstack.managed.context.ManagedContextListener;
@@ -33,7 +32,7 @@ import org.apache.cloudstack.managed.threadlocal.ManagedThreadLocal;
 
 public class DefaultManagedContext implements ManagedContext {
 
-    private static final Logger log = LoggerFactory.getLogger(DefaultManagedContext.class);
+    private static final Logger log = Logger.getLogger(DefaultManagedContext.class);
 
     List<ManagedContextListener<?>> listeners = new CopyOnWriteArrayList<ManagedContextListener<?>>();
 
@@ -88,7 +87,7 @@ public class DefaultManagedContext implements ManagedContext {
                     if (firstError == null) {
                         firstError = t;
                     }
-                    log.error("Failed onEnterContext for listener [{}]", listener, t);
+                    log.error("Failed onEnterContext for listener [" + listener + "]", t);
                 }
 
                 /* Stack data structure is used because in between onEnter and onLeave
@@ -114,7 +113,7 @@ public class DefaultManagedContext implements ManagedContext {
                         invocation.listener.onLeaveContext(invocation.data, reentry);
                     } catch (Throwable t) {
                         lastError = t;
-                        log.error("Failed onLeaveContext for listener [{}]", invocation.listener, t);
+                        log.error("Failed onLeaveContext for listener [" + invocation.listener + "]", t);
                     }
                 }
 

--- a/framework/managed-context/src/main/java/org/apache/cloudstack/managed/threadlocal/ManagedThreadLocal.java
+++ b/framework/managed-context/src/main/java/org/apache/cloudstack/managed/threadlocal/ManagedThreadLocal.java
@@ -21,8 +21,7 @@ package org.apache.cloudstack.managed.threadlocal;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.managed.context.ManagedContextUtils;
 
@@ -36,7 +35,7 @@ public class ManagedThreadLocal<T> extends ThreadLocal<T> {
     };
 
     private static boolean s_validateContext = false;
-    private static final Logger log = LoggerFactory.getLogger(ManagedThreadLocal.class);
+    private static final Logger log = Logger.getLogger(ManagedThreadLocal.class);
 
     @SuppressWarnings("unchecked")
     @Override

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/CloudStackExtendedLifeCycle.java
@@ -29,8 +29,7 @@ import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.naming.ConfigurationException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 import com.cloud.utils.component.ComponentLifecycle;
 import com.cloud.utils.component.SystemIntegrityChecker;
@@ -40,7 +39,7 @@ import com.cloud.utils.mgmt.ManagementBean;
 
 public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
 
-    private static final Logger log = LoggerFactory.getLogger(CloudStackExtendedLifeCycle.class);
+    private static final Logger log = Logger.getLogger(CloudStackExtendedLifeCycle.class);
 
     Map<Integer, Set<ComponentLifecycle>> sorted = new TreeMap<Integer, Set<ComponentLifecycle>>();
 
@@ -60,7 +59,7 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
 
     protected void checkIntegrity() {
         for (SystemIntegrityChecker checker : getBeans(SystemIntegrityChecker.class)) {
-            log.info("Running system integrity checker {}", checker);
+            log.info("Running system integrity checker " + checker);
 
             checker.check();
         }
@@ -114,7 +113,7 @@ public class CloudStackExtendedLifeCycle extends AbstractBeanCollector {
                 try {
                     lifecycle.configure(lifecycle.getName(), lifecycle.getConfigParams());
                 } catch (ConfigurationException e) {
-                    log.error("Failed to configure {}", lifecycle.getName(), e);
+                    log.error("Failed to configure " + lifecycle.getName(), e);
                     throw new CloudRuntimeException(e);
                 }
             }

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/DumpRegistry.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/DumpRegistry.java
@@ -22,8 +22,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 import com.cloud.utils.component.ComponentLifecycleBase;
 import com.cloud.utils.component.Named;
@@ -31,7 +30,7 @@ import com.cloud.utils.component.Registry;
 
 public class DumpRegistry extends ComponentLifecycleBase {
 
-    private static final Logger log = LoggerFactory.getLogger(DumpRegistry.class);
+    private static final Logger log = Logger.getLogger(DumpRegistry.class);
 
     List<Registry<?>> registries;
 
@@ -56,7 +55,7 @@ public class DumpRegistry extends ComponentLifecycleBase {
                 buffer.append(getName(o));
             }
 
-            log.info("Registry [{}] contains [{}]", registry.getName(), buffer);
+            log.info("Registry [" + registry.getName() + "] contains [" + buffer + "]");
         }
 
         return super.start();

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/ExtensionRegistry.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/ExtensionRegistry.java
@@ -27,9 +27,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.annotation.PostConstruct;
 
+import org.apache.log4j.Logger;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanNameAware;
 
 import org.apache.cloudstack.framework.config.ConfigKey;
@@ -39,7 +38,7 @@ import com.cloud.utils.component.Registry;
 
 public class ExtensionRegistry implements Registry<Object>, Configurable, BeanNameAware {
 
-    private static final Logger log = LoggerFactory.getLogger(ExtensionRegistry.class);
+    private static final Logger log = Logger.getLogger(ExtensionRegistry.class);
 
     String name;
     String beanName;
@@ -112,7 +111,7 @@ public class ExtensionRegistry implements Registry<Object>, Configurable, BeanNa
             registered.add(item);
         }
 
-        log.debug("Registering extension [{}] in [{}]", name, this.name);
+        log.debug("Registering extension [" + name + "] in [" + this.name + "]");
 
         return true;
     }

--- a/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/RegistryLifecycle.java
+++ b/framework/spring/lifecycle/src/main/java/org/apache/cloudstack/spring/lifecycle/registry/RegistryLifecycle.java
@@ -23,8 +23,7 @@ import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
@@ -36,7 +35,7 @@ import com.cloud.utils.component.Registry;
 
 public class RegistryLifecycle implements BeanPostProcessor, SmartLifecycle, ApplicationContextAware {
 
-    private static final Logger log = LoggerFactory.getLogger(RegistryLifecycle.class);
+    private static final Logger log = Logger.getLogger(RegistryLifecycle.class);
 
     public static final String EXTENSION_EXCLUDE = "extensions.exclude";
     public static final String EXTENSION_INCLUDE_PREFIX = "extensions.include.";
@@ -71,7 +70,7 @@ public class RegistryLifecycle implements BeanPostProcessor, SmartLifecycle, App
 
         boolean result = excludes.contains(name);
         if (result) {
-            log.info("Excluding extension [{}] based on configuration", name);
+            log.info("Excluding extension [" + name + "] based on configuration");
         }
 
         return result;
@@ -110,7 +109,7 @@ public class RegistryLifecycle implements BeanPostProcessor, SmartLifecycle, App
         while (iter.hasNext()) {
             Object next = iter.next();
             if (registry.register(next)) {
-                log.debug("Registered {}", next);
+                log.debug("Registered " + next);
             } else {
                 iter.remove();
             }

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/factory/CloudStackSpringContext.java
@@ -24,8 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.Resource;
@@ -37,7 +36,7 @@ import org.apache.cloudstack.spring.module.model.ModuleDefinitionSet;
 
 public class CloudStackSpringContext {
 
-    private static final Logger log = LoggerFactory.getLogger(CloudStackSpringContext.class);
+    private static final Logger log = Logger.getLogger(CloudStackSpringContext.class);
 
     public static final String CLOUDSTACK_CONTEXT_SERVLET_KEY = CloudStackSpringContext.class.getSimpleName();
     public static final String CLOUDSTACK_CONTEXT = "META-INF/cloudstack";
@@ -130,7 +129,7 @@ public class CloudStackSpringContext {
                 String urlString = r.getURL().toExternalForm();
                 urlList.add(urlString);
             } catch (IOException e) {
-                log.error("Failed to create URL for {}", r.getDescription(), e);
+                log.error("Failed to create URL for " + r.getDescription(), e);
             }
         }
 

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/model/impl/DefaultModuleDefinitionSet.java
@@ -33,8 +33,7 @@ import java.util.Set;
 import java.util.Stack;
 
 import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -49,7 +48,7 @@ import org.apache.cloudstack.spring.module.model.ModuleDefinitionSet;
 
 public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
 
-    private static final Logger log = LoggerFactory.getLogger(DefaultModuleDefinitionSet.class);
+    private static final Logger log = Logger.getLogger(DefaultModuleDefinitionSet.class);
 
     public static final String DEFAULT_CONFIG_RESOURCES = "DefaultConfigResources";
     public static final String DEFAULT_CONFIG_PROPERTIES = "DefaultConfigProperties";
@@ -101,7 +100,7 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
                     ApplicationContext context = getApplicationContext(def.getName());
                     try {
                         Runnable runnable = context.getBean("moduleStartup", Runnable.class);
-                        log.info("Starting module [{}]", def.getName());
+                        log.info("Starting module [" + def.getName() + "]");
                         runnable.run();
                     } catch (BeansException e) {
                         // Ignore
@@ -139,11 +138,11 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
         long start = System.currentTimeMillis();
         if (log.isInfoEnabled()) {
             for (Resource resource : resources) {
-                log.info("Loading module context [{}] from {}", def.getName(), resource);
+                log.info("Loading module context [" + def.getName() + "] from " + resource);
             }
         }
         context.refresh();
-        log.info("Loaded module context [{}] in {} ms", def.getName(), (System.currentTimeMillis() - start));
+        log.info("Loaded module context [" + def.getName() + "] in " + (System.currentTimeMillis() - start) + " ms");
 
         contexts.put(def.getName(), context);
 
@@ -238,7 +237,7 @@ public class DefaultModuleDefinitionSet implements ModuleDefinitionSet {
             return;
 
         if (!shouldLoad(def)) {
-            log.info("Excluding context [{}] based on configuration", def.getName());
+            log.info("Excluding context [" + def.getName() + "] based on configuration");
             return;
         }
 

--- a/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/web/CloudStackContextLoaderListener.java
+++ b/framework/spring/module/src/main/java/org/apache/cloudstack/spring/module/web/CloudStackContextLoaderListener.java
@@ -23,8 +23,7 @@ import java.io.IOException;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.context.ContextLoaderListener;
@@ -36,7 +35,7 @@ public class CloudStackContextLoaderListener extends ContextLoaderListener {
     public static final String WEB_PARENT_MODULE = "parentModule";
     public static final String WEB_PARENT_MODULE_DEFAULT = "web";
 
-    private static final Logger log = LoggerFactory.getLogger(CloudStackContextLoaderListener.class);
+    private static final Logger log = Logger.getLogger(CloudStackContextLoaderListener.class);
 
     CloudStackSpringContext cloudStackContext;
     String configuredParentName;

--- a/plugins/alert-handlers/snmp-alerts/pom.xml
+++ b/plugins/alert-handlers/snmp-alerts/pom.xml
@@ -34,10 +34,6 @@
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.snmp4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/plugins/alert-handlers/syslog-alerts/pom.xml
+++ b/plugins/alert-handlers/syslog-alerts/pom.xml
@@ -28,12 +28,4 @@
   <modelVersion>4.0.0</modelVersion>
   <name>Apache CloudStack Plugin - Syslog Alerts</name>
   <artifactId>cloud-plugin-syslog-alerts</artifactId>
-
-  <dependencies>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-  </dependencies>
-
 </project>

--- a/plugins/hypervisors/ovm3/pom.xml
+++ b/plugins/hypervisors/ovm3/pom.xml
@@ -47,11 +47,6 @@
 	<artifactId>commons-lang3</artifactId>
 	<version>${cs.commons-lang3.version}</version>
     </dependency>
-    <dependency>
-	<groupId>log4j</groupId>
-	<artifactId>log4j</artifactId>
-	<version>${cs.log4j.version}</version>
-    </dependency>
   </dependencies>
    <build>
     <sourceDirectory>${basedir}/src/main/java</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -422,16 +422,6 @@
         <artifactId>wsdl4j</artifactId>
         <version>1.6.3</version>
       </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.7</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -487,6 +477,11 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>${cs.log4j.version}</version>
     </dependency>
   </dependencies>
 

--- a/scripts/installer/windows/client.wxs
+++ b/scripts/installer/windows/client.wxs
@@ -1758,12 +1758,6 @@
                         <Component Id="cmp13F40EF7ACA81350C4F8E813736A2CAE" Guid="{F9B9AE15-A292-41A1-830F-5515977D2100}">
                             <File Id="fil34FB2D991F3071B2EF73946CB0431D34" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\lib\servlet-api-2.5-20081211.jar" />
                         </Component>
-                        <Component Id="cmp8CBA9E0D91DF8138E2BF1EEFE71BC07D" Guid="{FA12FAE1-F600-450E-A3D8-F455EA4BAF5D}">
-                            <File Id="fil168484CFF129899A7D518AFE187E4127" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\lib\slf4j-api-1.7.5.jar" />
-                        </Component>
-                        <Component Id="cmpD51A9DB18A9C78D3F72950E5F2EAB25D" Guid="{BAFB763B-69F2-42BB-A152-C59064D2CD5B}">
-                            <File Id="fil16A4FB967AF2762742B451B2B67CC207" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\lib\slf4j-log4j12-1.7.5.jar" />
-                        </Component>
                         <Component Id="cmpF1031D7436E22BE80D98DE4EB55C7BE3" Guid="{77B3F71F-111B-45AC-A7FB-FEFA507F7D7C}">
                             <File Id="fil532C144DF3AF862A6374F54E37FFBB6B" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\lib\spock-core-0.7-groovy-2.0.jar" />
                         </Component>

--- a/services/console-proxy/server/pom.xml
+++ b/services/console-proxy/server/pom.xml
@@ -28,10 +28,6 @@
   </parent>
   <dependencies>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -31,10 +31,6 @@
   </properties>
     <dependencies>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -32,10 +32,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${cs.junit.version}</version>

--- a/tools/whisker/LICENSE
+++ b/tools/whisker/LICENSE
@@ -1798,10 +1798,6 @@ Within the deps/awsapi-lib directory
             LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
             OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
             WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-                        
-        from QOS.ch  http://www.qos.ch/ 
-            slf4j-api-1.5.11.jar  from https://github.com/qos-ch/slf4j
-            slf4j-jdk14-1.5.11.jar  from https://github.com/qos-ch/slf4j
 
     licensed under the Mozilla Public License, Version 1.1 http://www.mozilla.org/MPL/1.1/  (as follows)
  

--- a/tools/whisker/descriptor-for-packaging.xml
+++ b/tools/whisker/descriptor-for-packaging.xml
@@ -2862,15 +2862,6 @@ Copyright (c) 2004-2008 The Apache Software Foundation
                 <resource name='antlr-2.7.6.jar' source='http://repo1.maven.org/maven2/antlr/antlr/2.7.6/antlr-2.7.6-sources.jar' />
             </by-organisation>
         </with-license>
-        <with-license id='MIT'>
-            <copyright-notice>
-Copyright (c) 2004-2011 QOS.ch
-            </copyright-notice>
-            <by-organisation id='qos.ch'>
-                <resource name='slf4j-api-1.5.11.jar' source='https://github.com/qos-ch/slf4j' />
-                <resource name='slf4j-jdk14-1.5.11.jar' source='https://github.com/qos-ch/slf4j' />
-            </by-organisation>
-        </with-license>
         <with-license id="ApacheLicenseVersion2">
             <copyright-notice>
 Copyright (c) 2004-2012 The Apache Software Foundation

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -50,16 +50,6 @@
       <version>${cs.mysql.version}</version>
       <scope>provided</scope>
     </dependency>
-     <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.7</version>
-      </dependency>
     <dependency>
       <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -44,18 +44,6 @@
       <artifactId>aspectjweaver</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
     </dependency>


### PR DESCRIPTION
In the entire project we use log4j, so why also use slf4j? I've removed slf4j and all references to it from the codebase.

Also I've let the top-level pom depend on log4j so not every project has to define it for itself.

Ping @remibergsma @DaanHoogland @miguelaferreira @wilderrodrigues @wido 

Builds ok, running integration tests now!
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 6:33.329s
[INFO] Finished at: Sun Dec 13 16:53:55 CET 2015
[INFO] Final Memory: 104M/813M
[INFO] ------------------------------------------------------------------------
```