### PR TITLE
build_asf.sh: fix debian changelog altering

### DIFF
--- a/tools/build/build_asf.sh
+++ b/tools/build/build_asf.sh
@@ -101,7 +101,6 @@ perl -pi -e "s/-SNAPSHOT//" build/replace.properties
 perl -pi -e "s/-SNAPSHOT//" services/console-proxy/plugin/pom.xml
 perl -pi -e "s/-SNAPSHOT//" tools/marvin/setup.py
 perl -pi -e "s/-SNAPSHOT//" tools/marvin/marvin/deployAndRun.py
-perl -pi -e "s/-SNAPSHOT//" debian/changelog
 perl -pi -e "s/-SNAPSHOT//" services/iam/plugin/pom.xml
 perl -pi -e "s/-SNAPSHOT//" services/iam/pom.xm
 perl -pi -e "s/-SNAPSHOT//" services/iam/server/pom.xml


### PR DESCRIPTION
The script already adds a new entry so we shouldn't replace the
previous one. That is done only in the next version script.

As discussed with @DaanHoogland 