### PR TITLE
CLOUDSTACK-9161: fix the quota marvin test

### DIFF
--- a/framework/quota/src/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -220,7 +220,9 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
             _quotaBalanceDao.saveQuotaBalance(firstBalance);
         } else {
             QuotaBalanceVO lastRealBalanceEntry = _quotaBalanceDao.findLastBalanceEntry(account.getAccountId(), account.getDomainId(), endDate);
-            aggrUsage = aggrUsage.add(lastRealBalanceEntry.getCreditBalance());
+            if (lastRealBalanceEntry != null){
+                aggrUsage = aggrUsage.add(lastRealBalanceEntry.getCreditBalance());
+            }
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Last balance entry  " + lastRealBalanceEntry + " AggrUsage=" + aggrUsage);
             }

--- a/framework/quota/src/org/apache/cloudstack/quota/vo/QuotaBalanceVO.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/vo/QuotaBalanceVO.java
@@ -62,7 +62,7 @@ public class QuotaBalanceVO implements InternalIdentity {
         this.accountId = credit.getAccountId();
         this.domainId = credit.getDomainId();
         this.creditBalance = credit.getCredit();
-        this.updatedOn = credit.getUpdatedOn()  == null ? null : new Date(credit.getUpdatedOn().getTime());
+        this.updatedOn = credit.getUpdatedOn() == null ? null : new Date(credit.getUpdatedOn().getTime());
         this.creditsId = credit.getId();
     }
 
@@ -72,7 +72,7 @@ public class QuotaBalanceVO implements InternalIdentity {
         this.domainId = domainId;
         this.creditBalance = creditBalance;
         this.creditsId = 0L;
-        this.updatedOn = updatedOn  == null ? null : new Date(updatedOn.getTime());
+        this.updatedOn = updatedOn == null ? null : new Date(updatedOn.getTime());
     }
 
     @Override
@@ -108,6 +108,10 @@ public class QuotaBalanceVO implements InternalIdentity {
         this.creditsId = creditsId;
     }
 
+    public boolean isBalanceEntry(){
+        return creditsId==0;
+    }
+
     public BigDecimal getCreditBalance() {
         return creditBalance;
     }
@@ -121,7 +125,7 @@ public class QuotaBalanceVO implements InternalIdentity {
     }
 
     public void setUpdatedOn(Date updatedOn) {
-        this.updatedOn =  updatedOn == null ? null : new Date(updatedOn.getTime());
+        this.updatedOn = updatedOn == null ? null : new Date(updatedOn.getTime());
     }
 
     @Override

--- a/plugins/database/quota/src/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
+++ b/plugins/database/quota/src/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
@@ -186,7 +186,7 @@ public class QuotaResponseBuilderImpl implements QuotaResponseBuilder {
         //check that there is at least one balance entry
         for (Iterator<QuotaBalanceVO> it = quotaBalance.iterator(); it.hasNext();) {
             QuotaBalanceVO entry = it.next();
-            if (entry.getCreditsId() > 0) {
+            if (entry.isBalanceEntry()) {
                 have_balance_entries = true;
                 break;
             }

--- a/test/integration/plugins/test_quota.py
+++ b/test/integration/plugins/test_quota.py
@@ -30,9 +30,29 @@ from nose.plugins.attrib import attr
 #Import System modules
 import time
 
-#ENABLE THE QUOTA PLUGIN AND RESTART THE MANAGEMENT SERVER TO RUN QUOTA TESTS
-
 class TestQuota(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Create Account
+        testClient = super(TestQuota, cls).getClsTestClient()
+        cls.apiclient = testClient.getApiClient()
+        cls.services = testClient.getParsedTestDataConfig()
+
+        # Get Zone, Domain
+        cls.domain = get_domain(cls.apiclient)
+        cls.zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
+
+        # Create Account
+        cls.account = Account.create(
+                            cls.apiclient,
+                            cls.services["account"],
+                            domainid=cls.domain.id
+                            )
+        cls._cleanup = [
+                        cls.account,
+                        ]
+        return
 
     def setUp(self):
         self.apiclient = self.testClient.getApiClient()
@@ -55,6 +75,12 @@ class TestQuota(cloudstackTestCase):
     #Check quotaTariffList API returning 22 items
     @attr(tags=["smoke", "advanced"], required_hardware="false")
     def test_01_quota(self):
+        if not is_config_suitable(
+                apiclient=self.apiclient,
+                name='quota.enable.service',
+                 value='true'):
+             self.skipTest('quota.enable.service should be true. skipping')
+             
         cmd = quotaTariffList.quotaTariffListCmd()
         response = self.apiclient.quotaTariffList(cmd)
 
@@ -75,6 +101,12 @@ class TestQuota(cloudstackTestCase):
     #Check quota tariff on a particualr day
     @attr(tags=["smoke", "advanced"], required_hardware="false")
     def test_02_quota(self):
+        if not is_config_suitable(
+                apiclient=self.apiclient,
+                name='quota.enable.service',
+                 value='true'):
+             self.skipTest('quota.enable.service should be true. skipping')
+             
         cmd = quotaTariffList.quotaTariffListCmd()
         cmd.startdate='2015-07-06'
         response = self.apiclient.quotaTariffList(cmd)
@@ -89,6 +121,12 @@ class TestQuota(cloudstackTestCase):
     #check quota tariff of a particular item
     @attr(tags=["smoke", "advanced"], required_hardware="false")
     def test_03_quota(self):
+        if not is_config_suitable(
+                apiclient=self.apiclient,
+                name='quota.enable.service',
+                 value='true'):
+             self.skipTest('quota.enable.service should be true. skipping')
+             
         cmd = quotaTariffList.quotaTariffListCmd()
         cmd.startdate='2015-07-06'
         cmd.usagetype='10'
@@ -107,6 +145,12 @@ class TestQuota(cloudstackTestCase):
     #check the old tariff it should be same
     @attr(tags=["smoke", "advanced"], required_hardware="false")
     def test_04_quota(self):
+        if not is_config_suitable(
+                apiclient=self.apiclient,
+                name='quota.enable.service',
+                 value='true'):
+             self.skipTest('quota.enable.service should be true. skipping')
+             
         cmd = quotaTariffList.quotaTariffListCmd()
         cmd.startdate='2015-07-06'
         cmd.usagetype='10'
@@ -157,9 +201,15 @@ class TestQuota(cloudstackTestCase):
     #Make credit deposit
     @attr(tags=["smoke", "advanced"], required_hardware="false")
     def test_05_quota(self):
+        if not is_config_suitable(
+                apiclient=self.apiclient,
+                name='quota.enable.service',
+                 value='true'):
+             self.skipTest('quota.enable.service should be true. skipping')
+             
         cmd = quotaCredits.quotaCreditsCmd()
-        cmd.domainid = '1'
-        cmd.account = 'admin'
+        cmd.domainid = self.account.domainid
+        cmd.account = self.account.name
         cmd.value = '10'
         cmd.quota_enforce = '1'
         cmd.min_balance = '9'
@@ -173,32 +223,45 @@ class TestQuota(cloudstackTestCase):
     #Make credit deposit and check today balance
     @attr(tags=["smoke", "advanced"], required_hardware="false")
     def test_06_quota(self):
+        if not is_config_suitable(
+                apiclient=self.apiclient,
+                name='quota.enable.service',
+                 value='true'):
+             self.skipTest('quota.enable.service should be true. skipping')
+             
         cmd = quotaBalance.quotaBalanceCmd()
         today = datetime.date.today()
-        cmd.domainid = '1'
-        cmd.account = 'admin'
+        cmd.domainid = self.account.domainid
+        cmd.account = self.account.name
         cmd.startdate = today
         response = self.apiclient.quotaBalance(cmd)
 
         self.debug("Quota Balance on: %s" % response.startdate)
         self.debug("is: %s" % response.startquota)
 
-        self.assertGreater( response.startquota, 9)
+        self.assertEqual( response.startquota, 10)
         return
 
     #make credit deposit and check start and end date balances
     @attr(tags=["smoke", "advanced"], required_hardware="false")
     def test_07_quota(self):
+        if not is_config_suitable(
+                apiclient=self.apiclient,
+                name='quota.enable.service',
+                 value='true'):
+             self.skipTest('quota.enable.service should be true. skipping')
+             
         cmd = quotaBalance.quotaBalanceCmd()
         today = datetime.date.today()
-        cmd.domainid = '1'
-        cmd.account = 'admin'
+        cmd.domainid = self.account.domainid
+        cmd.account = self.account.name
         cmd.startdate = today - datetime.timedelta(days=2)
-        cmd.enddate = today
+        cmd.enddate = today 
         response = self.apiclient.quotaBalance(cmd)
 
         self.debug("Quota Balance on: %s" % response.startdate)
         self.debug("is: %s" % response.startquota)
 
-        self.assertGreater( response.endquota, 9)
+        self.assertEqual( response.startquota, 0)
+        self.assertEqual( response.endquota, 10)
         return

--- a/tools/marvin/marvin/config/setup.cfg
+++ b/tools/marvin/marvin/config/setup.cfg
@@ -143,6 +143,10 @@
         },
     "globalConfig": [
         {
+            "name": "quota.enable.service",
+            "value": "true"
+        },
+        {
             "name": "network.gc.wait",
             "value": "60"
         },


### PR DESCRIPTION
  1. Create a dummy user, as existing user may already have stale quota
  data
  2. fix the tests to use the dummy user
  3. a boundary condition was revealed and fixed for a new user where
  quota service has never run and created bootstrap entries