### PR TITLE
CLOUDSTACK-9162: Unable to add VPN user via API with Required Paramet…

### DIFF
--- a/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -377,6 +377,10 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
     public VpnUser addVpnUser(final long vpnOwnerId, final String username, final String password) {
         final Account caller = CallContext.current().getCallingAccount();
 
+        if(caller.getId() == Account.ACCOUNT_ID_SYSTEM){
+            throw new InvalidParameterValueException("Not logged in and no account and domain specified. Can't create VPN users on System Account.");
+        }
+
         if (!username.matches("^[a-zA-Z0-9][a-zA-Z0-9@._-]{2,63}$")) {
             throw new InvalidParameterValueException("Username has to be begin with an alphabet have 3-64 characters including alphabets, numbers and the set '@.-_'");
         }


### PR DESCRIPTION
…ers - Fixed

RCA:
When we do not provide account parameter which is an optional field , API picks up the account from which we are logged in. So this works fine with cloudmonkey and ACS UI. But if we fire API directly from the browser(Make sure no cookies are stored and you are not logged in), by default system account is picked and the VPN users addition fails. This behaviour is expected, but no exception is thrown. So users think that VPN user is created.

Fix: Added an exception when VPN users are added in the system account. 
