### PR TITLE
CLOUDSTACK-9165 unable to use reserved IP range in a network for exte…

### DIFF
--- a/api/src/com/cloud/network/NetworkModel.java
+++ b/api/src/com/cloud/network/NetworkModel.java
@@ -287,4 +287,6 @@ public interface NetworkModel {
     List<String[]> generateVmData(String userData, String serviceOffering, String zoneName,
                                   String vmName, long vmId, String publicKey, String password, Boolean isWindows);
 
+    String getValidNetworkCidr(Network guestNetwork);
+
 }

--- a/server/src/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/com/cloud/network/NetworkModelImpl.java
@@ -2377,4 +2377,10 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {MACIdentifier};
     }
+
+    @Override
+    public String getValidNetworkCidr(Network guestNetwork) {
+        String networkCidr = guestNetwork.getNetworkCidr();
+        return networkCidr == null ? guestNetwork.getCidr() : networkCidr;
+    }
 }

--- a/server/src/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/GuestNetworkGuru.java
@@ -376,7 +376,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                 }
 
                 nic.setIPv4Address(guestIp);
-                nic.setIPv4Netmask(NetUtils.cidr2Netmask(network.getCidr()));
+                nic.setIPv4Netmask(NetUtils.cidr2Netmask(_networkModel.getValidNetworkCidr(network)));
 
                 nic.setIPv4Dns1(dc.getDns1());
                 nic.setIPv4Dns2(dc.getDns2());

--- a/server/src/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/com/cloud/network/router/NetworkHelperImpl.java
@@ -743,7 +743,7 @@ public class NetworkHelperImpl implements NetworkHelper {
                 gatewayNic.setBroadcastType(guestNetwork.getBroadcastDomainType());
                 gatewayNic.setIsolationUri(guestNetwork.getBroadcastUri());
                 gatewayNic.setMode(guestNetwork.getMode());
-                final String gatewayCidr = guestNetwork.getCidr();
+                final String gatewayCidr = _networkModel.getValidNetworkCidr(guestNetwork);
                 gatewayNic.setIPv4Netmask(NetUtils.getCidrNetmask(gatewayCidr));
             } else {
                 gatewayNic.setDefaultNic(true);

--- a/server/src/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/server/src/com/cloud/network/router/NicProfileHelperImpl.java
@@ -127,7 +127,7 @@ public class NicProfileHelperImpl implements NicProfileHelper {
         guestNic.setBroadcastType(guestNetwork.getBroadcastDomainType());
         guestNic.setIsolationUri(guestNetwork.getBroadcastUri());
         guestNic.setMode(guestNetwork.getMode());
-        final String gatewayCidr = guestNetwork.getCidr();
+        final String gatewayCidr = _networkModel.getValidNetworkCidr(guestNetwork);
         guestNic.setIPv4Netmask(NetUtils.getCidrNetmask(gatewayCidr));
 
         return guestNic;

--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1535,7 +1535,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                 }
             }
         } else if (dc.getNetworkType() == NetworkType.Advanced) {
-            final String cidr = guestNetwork.getCidr();
+            final String cidr = _networkModel.getValidNetworkCidr(guestNetwork);
             if (cidr != null) {
                 cidrSize = NetUtils.getCidrSize(NetUtils.getCidrNetmask(cidr));
                 dhcpRange = NetUtils.getDhcpRange(cidr);

--- a/server/test/com/cloud/network/MockNetworkModelImpl.java
+++ b/server/test/com/cloud/network/MockNetworkModelImpl.java
@@ -901,4 +901,9 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
         return null;
     }
 
+    @Override
+    public String getValidNetworkCidr(Network guestNetwork) {
+        return null;
+    }
+
 }

--- a/server/test/com/cloud/vpc/MockNetworkModelImpl.java
+++ b/server/test/com/cloud/vpc/MockNetworkModelImpl.java
@@ -916,4 +916,9 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
         return null;
     }
 
+    @Override
+    public String getValidNetworkCidr(Network guestNetwork) {
+        return null;
+    }
+
 }


### PR DESCRIPTION
…rnal VMs
## Repro Steps
1.  Create an isolated network with CIDR 192.168.200.0/24. 
2.  Edit the CIDR to 192.168.200.0/25. 
3.     Perform Network restart with cleanup.
4.  Network Restart with Cleanup, it was successful. 
5.  Add external VM to the network with IP 192.168.200.150/24 to the network. 
6.  After restart Netmask1 displayed CIDR 192.168.200.150/25 and Network CIDR as 192.168.200.150/24.
7.  Create an instance from cloudstack.  
8.  Ping the VM from external VM.
## Before Applying the fix

External Vm was unable to communicate with the cloudstack managed VM. 
![image](https://cloud.githubusercontent.com/assets/12229259/11832815/b642ff08-a3e2-11e5-8716-71ed5bfca742.png)

![image](https://cloud.githubusercontent.com/assets/12229259/11832892/6547de6a-a3e3-11e5-97f0-c1e86753123a.png)

![image](https://cloud.githubusercontent.com/assets/12229259/11833167/fe714df4-a3e5-11e5-8e18-a820e8c97b78.png)

![image](https://cloud.githubusercontent.com/assets/12229259/11833031/c71e23dc-a3e4-11e5-892a-69f877701885.png)
## After applying the fix

![image](https://cloud.githubusercontent.com/assets/12229259/11833583/0e151502-a3ea-11e5-86c8-4eceece59cc1.png)

![image](https://cloud.githubusercontent.com/assets/12229259/11833648/f56d7278-a3ea-11e5-94e1-89577f27686a.png)

![image](https://cloud.githubusercontent.com/assets/12229259/11833601/6689a4dc-a3ea-11e5-805f-cb0c51d35111.png)

![image](https://cloud.githubusercontent.com/assets/12229259/11833618/8fc85906-a3ea-11e5-8452-16cb393b847c.png)
