### PR TITLE
[4.7.0/master] DB Paths fixes: 4.5.3->4.7.0, 4.6.2->4.7.0

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -60,6 +60,7 @@ import com.cloud.upgrade.dao.Upgrade452to460;
 import com.cloud.upgrade.dao.Upgrade453to460;
 import com.cloud.upgrade.dao.Upgrade460to461;
 import com.cloud.upgrade.dao.Upgrade461to470;
+import com.cloud.upgrade.dao.Upgrade462to470;
 import com.cloud.upgrade.dao.UpgradeSnapshot217to224;
 import com.cloud.upgrade.dao.UpgradeSnapshot223to224;
 import com.cloud.upgrade.dao.VersionDao;
@@ -242,13 +243,13 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
 
         _upgradeMap.put("4.5.2", new DbUpgrade[] {new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470()});
 
-        _upgradeMap.put("4.5.3", new DbUpgrade[] {new Upgrade453to460()});
+        _upgradeMap.put("4.5.3", new DbUpgrade[] {new Upgrade453to460(), new Upgrade460to461(), new Upgrade461to470()});
 
         _upgradeMap.put("4.6.0", new DbUpgrade[] {new Upgrade460to461(), new Upgrade461to470()});
 
         _upgradeMap.put("4.6.1", new DbUpgrade[] {new Upgrade461to470()});
 
-        _upgradeMap.put("4.6.2", new DbUpgrade[] {new Upgrade461to470()});
+        _upgradeMap.put("4.6.2", new DbUpgrade[] {new Upgrade462to470()});
 
         //CP Upgrades
         _upgradeMap.put("3.0.3", new DbUpgrade[] {new Upgrade303to304(), new Upgrade304to305(), new Upgrade305to306(), new Upgrade306to307(), new Upgrade307to410(),

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade462to470.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade462to470.java
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.cloud.upgrade.dao;
+
+import org.apache.log4j.Logger;
+
+public class Upgrade462to470 extends Upgrade461to470 implements DbUpgrade {
+    final static Logger s_logger = Logger.getLogger(Upgrade462to470.class);
+
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[] {"4.6.2", "4.7.0"};
+    }
+}


### PR DESCRIPTION
- Adds missing upgrade path objects from 4.5.3 to 4.7.0
- Adds an explicit upgrade path class from 4.6.2 to 4.7.0, that extends over
  the upgrade path from 4.6.1 to 4.7.0

Notes:
- The getUpgradableVersionRange() is not used to validate from/to versions which is why upgrading from 4.6.2 to 4.7.0 works without any errors when using the Upgrade461to470 for 4.6.2 version.