### PR TITLE
CLOUDSTACK-9184: [VMware] vmware.ports.per.dvportgroup global setting is not useful from vCenter 5.0 onwards

### DIFF
--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -1135,14 +1135,6 @@ public enum Config {
             "false",
             "Enable/Disable Nexus/Vmware dvSwitch in VMware environment",
             null),
-    VmwarePortsPerDVPortGroup(
-            "Network",
-            ManagementServer.class,
-            Integer.class,
-            "vmware.ports.per.dvportgroup",
-            "256",
-            "Default number of ports per Vmware dvPortGroup in VMware environment",
-            null),
     VmwareCreateFullClone(
             "Advanced",
             ManagementServer.class,

--- a/setup/db/db/schema-4930to41000-cleanup.sql
+++ b/setup/db/db/schema-4930to41000-cleanup.sql
@@ -21,4 +21,6 @@
 
 DELETE FROM `cloud`.`configuration` WHERE name='consoleproxy.loadscan.interval';
 
+DELETE FROM `cloud`.`configuration` WHERE `name`='vmware.ports.per.dvportgroup';
+
 DELETE FROM `cloud`.`host_details` where name = 'vmName' and  value in (select name from `cloud`.`vm_instance`  where state = 'Expunging' and hypervisor_type ='BareMetal');


### PR DESCRIPTION
Modify the default value of this setting, which is currently 256, by decreasing it to 8 because even a dvportgroup with autoexpand feature enabled there exists an initial number of ports as starting point, which can be again configured through this configuration setting. But keeping this value 256 doesn't make sense when auto expand feature is available. Keeping the starting number of dvports per dvportgroup to reasonably minimum would ensure optimal distribution across dvportgroups in dvSwitch.

The vSphere Auto Expand feature (introduced in vSphere 5.0) will take care of dynamically increasing/decreasing the dvPorts when running out of distributed ports . But in case of vSphere 4.1/4.0 (If used), as this feature is not there, the new default value (=> 8) have an impact in the existing deployments. Action item for vSphere 4.1/4.0: Admin should modify the global configuration setting "vmware.ports.per.dvportgroup" from 8 to any number based on their environment because the proposal default value of 8 would be very less without auto expand feature in general. The current default value of 256 may not need immediate modification after deployment, but 8 would be very less which means admin need to update immediately after upgrade.
