### PR TITLE
Removed unused methods from EventBus interface.

### DIFF
--- a/framework/events/src/org/apache/cloudstack/framework/events/EventBus.java
+++ b/framework/events/src/org/apache/cloudstack/framework/events/EventBus.java
@@ -19,8 +19,6 @@
 
 package org.apache.cloudstack.framework.events;
 
-import java.util.UUID;
-
 /**
  * Interface to publish and subscribe to CloudStack events
  *
@@ -33,21 +31,4 @@ public interface EventBus {
      * @param event event that needs to be published on the event bus
      */
     void publish(Event event) throws EventBusException;
-
-    /**
-     * subscribe to events that matches specified event topics
-     *
-     * @param topic defines category and type of the events being subscribed to
-     * @param subscriber subscriber that intends to receive event notification
-     * @return UUID returns the subscription ID
-     */
-    UUID subscribe(EventTopic topic, EventSubscriber subscriber) throws EventBusException;
-
-    /**
-     * unsubscribe to events of a category and a type
-     *
-     * @param subscriber subscriber that intends to unsubscribe from the event notification
-     */
-    void unsubscribe(UUID subscriberId, EventSubscriber subscriber) throws EventBusException;
-
 }

--- a/plugins/event-bus/inmemory/src/org/apache/cloudstack/mom/inmemory/InMemoryEventBus.java
+++ b/plugins/event-bus/inmemory/src/org/apache/cloudstack/mom/inmemory/InMemoryEventBus.java
@@ -58,34 +58,6 @@ public class InMemoryEventBus extends ManagerBase implements EventBus {
     }
 
     @Override
-    public UUID subscribe(EventTopic topic, EventSubscriber subscriber) throws EventBusException {
-        if (subscriber == null || topic == null) {
-            throw new EventBusException("Invalid EventSubscriber/EventTopic object passed.");
-        }
-        UUID subscriberId = UUID.randomUUID();
-
-        subscribers.put(subscriberId, new Pair<EventTopic, EventSubscriber>(topic, subscriber));
-        return subscriberId;
-    }
-
-    @Override
-    public void unsubscribe(UUID subscriberId, EventSubscriber subscriber) throws EventBusException {
-        if (subscriberId == null) {
-            throw new EventBusException("Cannot unregister a null subscriberId.");
-        }
-
-        if (subscribers.isEmpty()) {
-            throw new EventBusException("There are no registered subscribers to unregister.");
-        }
-
-        if (!subscribers.containsKey(subscriberId)) {
-            throw new EventBusException("No subscriber found with subscriber id " + subscriberId);
-        } else {
-            subscribers.remove(subscriberId);
-        }
-    }
-
-    @Override
     public void publish(Event event) throws EventBusException {
         if (subscribers == null || subscribers.isEmpty()) {
             return; // no subscriber to publish to, so just return

--- a/plugins/event-bus/inmemory/test/org/apache/cloudstack/mom/inmemory/InMemoryEventBusTest.java
+++ b/plugins/event-bus/inmemory/test/org/apache/cloudstack/mom/inmemory/InMemoryEventBusTest.java
@@ -19,21 +19,14 @@
 
 package org.apache.cloudstack.mom.inmemory;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.UUID;
-
 import org.apache.cloudstack.framework.events.Event;
-import org.apache.cloudstack.framework.events.EventBusException;
 import org.apache.cloudstack.framework.events.EventSubscriber;
-import org.apache.cloudstack.framework.events.EventTopic;
 import org.junit.Test;
-
-import com.cloud.utils.UuidUtils;
 
 public class InMemoryEventBusTest {
 
@@ -46,107 +39,6 @@ public class InMemoryEventBusTest {
 
         assertTrue(success);
         assertTrue(name.equals(bus.getName()));
-    }
-
-    @Test
-    public void testSubscribe() throws Exception {
-        EventTopic topic = mock(EventTopic.class);
-        EventSubscriber subscriber = mock(EventSubscriber.class);
-
-        InMemoryEventBus bus = new InMemoryEventBus();
-
-        UUID uuid = bus.subscribe(topic, subscriber);
-        assertNotNull(uuid);
-
-        String uuidStr = uuid.toString();
-        assertTrue(UuidUtils.validateUUID(uuidStr));
-        assertTrue(bus.totalSubscribers() == 1);
-
-        bus.unsubscribe(uuid, subscriber);
-        assertTrue(bus.totalSubscribers() == 0);
-    }
-
-    @Test(expected = EventBusException.class)
-    public void testSubscribeFailTopic() throws Exception {
-        EventSubscriber subscriber = mock(EventSubscriber.class);
-
-        InMemoryEventBus bus = new InMemoryEventBus();
-
-        bus.subscribe(null, subscriber);
-    }
-
-    @Test(expected = EventBusException.class)
-    public void testSubscribeFailSubscriber() throws Exception {
-        EventTopic topic = mock(EventTopic.class);
-
-        InMemoryEventBus bus = new InMemoryEventBus();
-
-        bus.subscribe(topic, null);
-    }
-
-    @Test
-    public void testUnsubscribe() throws Exception {
-        EventTopic topic = mock(EventTopic.class);
-        EventSubscriber subscriber = mock(EventSubscriber.class);
-
-        InMemoryEventBus bus = new InMemoryEventBus();
-
-        UUID uuid = bus.subscribe(topic, subscriber);
-        assertNotNull(uuid);
-
-        String uuidStr = uuid.toString();
-
-        assertTrue(UuidUtils.validateUUID(uuidStr));
-        assertTrue(bus.totalSubscribers() == 1);
-        //
-        bus.unsubscribe(uuid, subscriber);
-        assertTrue(bus.totalSubscribers() == 0);
-    }
-
-    @Test(expected = EventBusException.class)
-    public void testUnsubscribeFailEmpty() throws Exception {
-        UUID uuid = UUID.randomUUID();
-
-        InMemoryEventBus bus = new InMemoryEventBus();
-        bus.unsubscribe(uuid, null);
-    }
-
-    @Test(expected = EventBusException.class)
-    public void testUnsubscribeFailNull() throws Exception {
-        InMemoryEventBus bus = new InMemoryEventBus();
-        bus.unsubscribe(null, null);
-    }
-
-    @Test(expected = EventBusException.class)
-    public void testUnsubscribeFailWrongUUID() throws Exception {
-        EventSubscriber subscriber = mock(EventSubscriber.class);
-        InMemoryEventBus bus = new InMemoryEventBus();
-        UUID uuid = UUID.randomUUID();
-
-        bus.unsubscribe(uuid, subscriber);
-    }
-
-    @Test
-    public void testPublish() throws Exception {
-        EventTopic topic = mock(EventTopic.class);
-        EventSubscriber subscriber = mock(EventSubscriber.class);
-        Event event = mock(Event.class);
-
-        InMemoryEventBus bus = new InMemoryEventBus();
-
-        UUID uuid = bus.subscribe(topic, subscriber);
-        assertNotNull(uuid);
-
-        String uuidStr = uuid.toString();
-        assertTrue(UuidUtils.validateUUID(uuidStr));
-        assertTrue(bus.totalSubscribers() == 1);
-
-        bus.publish(event);
-
-        verify(subscriber, times(1)).onEvent(event);
-
-        bus.unsubscribe(uuid, subscriber);
-        assertTrue(bus.totalSubscribers() == 0);
     }
 
     @Test

--- a/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
+++ b/plugins/event-bus/kafka/src/org/apache/cloudstack/mom/kafka/KafkaEventBus.java
@@ -20,28 +20,21 @@
 package org.apache.cloudstack.mom.kafka;
 
 import java.io.FileInputStream;
-
 import java.util.Map;
-import java.util.UUID;
 import java.util.Properties;
 
 import javax.naming.ConfigurationException;
 
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.framework.events.Event;
 import org.apache.cloudstack.framework.events.EventBus;
 import org.apache.cloudstack.framework.events.EventBusException;
-import org.apache.cloudstack.framework.events.EventSubscriber;
-import org.apache.cloudstack.framework.events.EventTopic;
-
-import com.cloud.utils.component.ManagerBase;
-
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.log4j.Logger;
 
 import com.cloud.utils.PropertiesUtil;
+import com.cloud.utils.component.ManagerBase;
 
 public class KafkaEventBus extends ManagerBase implements EventBus {
 
@@ -85,17 +78,6 @@ public class KafkaEventBus extends ManagerBase implements EventBus {
     @Override
     public void setName(String name) {
         _name = name;
-    }
-
-    @Override
-    public UUID subscribe(EventTopic topic, EventSubscriber subscriber) throws EventBusException {
-        /* NOOP */
-        return UUID.randomUUID();
-    }
-
-    @Override
-    public void unsubscribe(UUID subscriberId, EventSubscriber subscriber) throws EventBusException {
-        /* NOOP */
     }
 
     @Override

--- a/plugins/event-bus/rabbitmq/src/org/apache/cloudstack/mom/rabbitmq/RabbitMQEventBus.java
+++ b/plugins/event-bus/rabbitmq/src/org/apache/cloudstack/mom/rabbitmq/RabbitMQEventBus.java
@@ -20,17 +20,23 @@
 package org.apache.cloudstack.mom.rabbitmq;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.naming.ConfigurationException;
 
+import org.apache.cloudstack.framework.events.Event;
+import org.apache.cloudstack.framework.events.EventBus;
+import org.apache.cloudstack.framework.events.EventBusException;
+import org.apache.cloudstack.framework.events.EventSubscriber;
+import org.apache.cloudstack.framework.events.EventTopic;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
 import org.apache.log4j.Logger;
 
+import com.cloud.utils.Ternary;
+import com.cloud.utils.component.ManagerBase;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
@@ -41,16 +47,6 @@ import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.MessageProperties;
 import com.rabbitmq.client.ShutdownListener;
 import com.rabbitmq.client.ShutdownSignalException;
-
-import org.apache.cloudstack.framework.events.Event;
-import org.apache.cloudstack.framework.events.EventBus;
-import org.apache.cloudstack.framework.events.EventBusException;
-import org.apache.cloudstack.framework.events.EventSubscriber;
-import org.apache.cloudstack.framework.events.EventTopic;
-import org.apache.cloudstack.managed.context.ManagedContextRunnable;
-
-import com.cloud.utils.Ternary;
-import com.cloud.utils.component.ManagerBase;
 
 public class RabbitMQEventBus extends ManagerBase implements EventBus {
 
@@ -169,92 +165,6 @@ public class RabbitMQEventBus extends ManagerBase implements EventBus {
 
     public static void setRetryInterval(Integer retryInterval) {
         RabbitMQEventBus.retryInterval = retryInterval;
-    }
-
-    /** Call to subscribe to interested set of events
-     *
-     * @param topic defines category and type of the events being subscribed to
-     * @param subscriber subscriber that intends to receive event notification
-     * @return UUID that represents the subscription with event bus
-     * @throws EventBusException
-     */
-    @Override
-    public UUID subscribe(EventTopic topic, EventSubscriber subscriber) throws EventBusException {
-
-        if (subscriber == null || topic == null) {
-            throw new EventBusException("Invalid EventSubscriber/EventTopic object passed.");
-        }
-
-        // create a UUID, that will be used for managing subscriptions and also used as queue name
-        // for on the queue used for the subscriber on the AMQP broker
-        UUID queueId = UUID.randomUUID();
-        String queueName = queueId.toString();
-
-        try {
-            String bindingKey = createBindingKey(topic);
-
-            // store the subscriber details before creating channel
-            s_subscribers.put(queueName, new Ternary(bindingKey, null, subscriber));
-
-            // create a channel dedicated for this subscription
-            Connection connection = getConnection();
-            Channel channel = createChannel(connection);
-
-            // create a queue and bind it to the exchange with binding key formed from event topic
-            createExchange(channel, amqpExchangeName);
-            channel.queueDeclare(queueName, false, false, false, null);
-            channel.queueBind(queueName, amqpExchangeName, bindingKey);
-
-            // register a callback handler to receive the events that a subscriber subscribed to
-            channel.basicConsume(queueName, s_autoAck, queueName, new DefaultConsumer(channel) {
-                @Override
-                public void handleDelivery(String queueName, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
-                    Ternary<String, Channel, EventSubscriber> queueDetails = s_subscribers.get(queueName);
-                    if (queueDetails != null) {
-                        EventSubscriber subscriber = queueDetails.third();
-                        String routingKey = envelope.getRoutingKey();
-                        String eventSource = getEventSourceFromRoutingKey(routingKey);
-                        String eventCategory = getEventCategoryFromRoutingKey(routingKey);
-                        String eventType = getEventTypeFromRoutingKey(routingKey);
-                        String resourceType = getResourceTypeFromRoutingKey(routingKey);
-                        String resourceUUID = getResourceUUIDFromRoutingKey(routingKey);
-                        Event event = new Event(eventSource, eventCategory, eventType, resourceType, resourceUUID);
-                        event.setDescription(new String(body));
-
-                        // deliver the event to call back object provided by subscriber
-                        subscriber.onEvent(event);
-                    }
-                }
-            });
-
-            // update the channel details for the subscription
-            Ternary<String, Channel, EventSubscriber> queueDetails = s_subscribers.get(queueName);
-            queueDetails.second(channel);
-            s_subscribers.put(queueName, queueDetails);
-
-        } catch (AlreadyClosedException closedException) {
-            s_logger.warn("Connection to AMQP service is lost. Subscription:" + queueName + " will be active after reconnection");
-        } catch (ConnectException connectException) {
-            s_logger.warn("Connection to AMQP service is lost. Subscription:" + queueName + " will be active after reconnection");
-        } catch (Exception e) {
-            throw new EventBusException("Failed to subscribe to event due to " + e.getMessage());
-        }
-
-        return queueId;
-    }
-
-    @Override
-    public void unsubscribe(UUID subscriberId, EventSubscriber subscriber) throws EventBusException {
-        try {
-            String classname = subscriber.getClass().getName();
-            String queueName = UUID.nameUUIDFromBytes(classname.getBytes()).toString();
-            Ternary<String, Channel, EventSubscriber> queueDetails = s_subscribers.get(queueName);
-            Channel channel = queueDetails.second();
-            channel.basicCancel(queueName);
-            s_subscribers.remove(queueName, queueDetails);
-        } catch (Exception e) {
-            throw new EventBusException("Failed to unsubscribe from event bus due to " + e.getMessage());
-        }
     }
 
     // publish event on to the exchange created on AMQP server


### PR DESCRIPTION
We removed the following methods from "org.apache.cloudstack.framework.events.EventBus" and it respective implementations.
. org.apache.cloudstack.framework.events.EventBus.subscribe(EventTopic, EventSubscriber)
. org.apache.cloudstack.framework.events.EventBus.unsubscribe(UUID, EventSubscriber)

the following files are affected by this PR:
org.apache.cloudstack.mom.inmemory.InMemoryEventBus, org.apache.cloudstack.mom.kafka.KafkaEventBus and org.apache.cloudstack.mom.rabbitmq.RabbitMQEventBus 

Those methods are not used in cloudstack, they are used only in some test cases and these tests cases were removed too.