### PR TITLE
Removed unused variables from "NetworkStateListener" class

### DIFF
--- a/engine/components-api/src/com/cloud/network/NetworkStateListener.java
+++ b/engine/components-api/src/com/cloud/network/NetworkStateListener.java
@@ -24,38 +24,29 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import com.cloud.utils.fsm.StateMachine2;
-import org.apache.log4j.Logger;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.events.EventBus;
 import org.apache.cloudstack.framework.events.EventBusException;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import com.cloud.event.EventCategory;
-import com.cloud.event.dao.UsageEventDao;
 import com.cloud.network.Network.Event;
 import com.cloud.network.Network.State;
-import com.cloud.network.dao.NetworkDao;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.fsm.StateListener;
+import com.cloud.utils.fsm.StateMachine2;
 
 public class NetworkStateListener implements StateListener<State, Event, Network> {
 
     @Inject
-    protected UsageEventDao _usageEventDao;
-    @Inject
-    protected NetworkDao _networkDao;
-    @Inject
-    protected ConfigurationDao _configDao;
+    private ConfigurationDao _configDao;
 
-    protected static EventBus s_eventBus = null;
+    private static EventBus s_eventBus = null;
 
     private static final Logger s_logger = Logger.getLogger(NetworkStateListener.class);
 
-    public NetworkStateListener(UsageEventDao usageEventDao, NetworkDao networkDao, ConfigurationDao configDao) {
-        _usageEventDao = usageEventDao;
-        _networkDao = networkDao;
+    public NetworkStateListener(ConfigurationDao configDao) {
         _configDao = configDao;
     }
 

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -575,7 +575,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
         _agentMgr.registerForHostEvents(this, true, false, true);
 
-        Network.State.getStateMachine().registerListener(new NetworkStateListener(_usageEventDao, _networksDao, _configDao));
+        Network.State.getStateMachine().registerListener(new NetworkStateListener(_configDao));
 
         s_logger.info("Network Manager is configured.");
 

--- a/server/src/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/com/cloud/network/IpAddressManagerImpl.java
@@ -401,7 +401,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         AssignIpAddressFromPodVlanSearch.join("vlan", podVlanSearch, podVlanSearch.entity().getId(), AssignIpAddressFromPodVlanSearch.entity().getVlanId(), JoinType.INNER);
         AssignIpAddressFromPodVlanSearch.done();
 
-        Network.State.getStateMachine().registerListener(new NetworkStateListener(_usageEventDao, _networksDao, _configDao));
+        Network.State.getStateMachine().registerListener(new NetworkStateListener(_configDao));
 
         s_logger.info("Network Manager is configured.");
 


### PR DESCRIPTION
We removed the following variables from "com.cloud.network.NetworkStateListener"
. UsageEventDao _usageEventDao
. NetworkDao _networkDao

We changed the EventBus s_eventBus variable to private, the constructor not to use those variables and applied this change in classes “com.cloud.network.IpAddressManagerImpl” and “org.apache.cloudstack.engine.orchestration.NetworkOrchestrator”