### PR TITLE
Removed unnecessary code from getGuestOsType in CitrixResourceBase

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
-import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -164,7 +163,6 @@ import com.xensource.xenapi.XenAPIObject;
  * before you do any changes in this code here.
  *
  */
-@Local(value = ServerResource.class)
 public abstract class CitrixResourceBase implements ServerResource, HypervisorResource, VirtualRouterDeployer {
 
     public enum SRType {
@@ -1232,7 +1230,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
     }
 
     public VM createVmFromTemplate(final Connection conn, final VirtualMachineTO vmSpec, final Host host) throws XenAPIException, XmlRpcException {
-        final String guestOsTypeName = getGuestOsType(vmSpec.getOs(), vmSpec.getPlatformEmulator(), vmSpec.getBootloader() == BootloaderType.CD);
+        final String guestOsTypeName = getGuestOsType(vmSpec.getPlatformEmulator());
         final Set<VM> templates = VM.getByNameLabel(conn, guestOsTypeName);
         if (templates == null || templates.isEmpty()) {
             throw new CloudRuntimeException("Cannot find template " + guestOsTypeName + " on XenServer host");
@@ -1337,7 +1335,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                         final TemplateObjectTO iso = (TemplateObjectTO) disk.getData();
                         final String osType = iso.getGuestOsType();
                         if (osType != null) {
-                            final String isoGuestOsName = getGuestOsType(osType, vmSpec.getPlatformEmulator(), vmSpec.getBootloader() == BootloaderType.CD);
+                            final String isoGuestOsName = getGuestOsType(vmSpec.getPlatformEmulator());
                             if (!isoGuestOsName.equals(guestOsTypeName)) {
                                 vmSpec.setBootloader(BootloaderType.PyGrub);
                             }
@@ -2019,8 +2017,8 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         return null;
     }
 
-    protected String getGuestOsType(final String stdType, String platformEmulator, final boolean bootFromCD) {
-        if (platformEmulator == null) {
+    protected String getGuestOsType(String platformEmulator) {
+        if (org.apache.commons.lang.StringUtils.isBlank(platformEmulator)) {
             s_logger.debug("no guest OS type, start it as HVM guest");
             platformEmulator = "Other install media";
         }

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XcpOssResource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XcpOssResource.java
@@ -17,16 +17,12 @@
 
 package com.cloud.hypervisor.xenserver.resource;
 
-import javax.ejb.Local;
-
 import org.apache.xmlrpc.XmlRpcException;
 
-import com.cloud.resource.ServerResource;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.Types.XenAPIException;
 import com.xensource.xenapi.VM;
 
-@Local(value = ServerResource.class)
 public class XcpOssResource extends CitrixResourceBase {
 
     private static final long mem_32m = 33554432L;
@@ -34,18 +30,6 @@ public class XcpOssResource extends CitrixResourceBase {
     @Override
     protected String getPatchFilePath() {
         return "scripts/vm/hypervisor/xenserver/xcposs/patch";
-    }
-
-    @Override
-    protected String getGuestOsType(final String stdType,
-            final String platformEmulator, final boolean bootFromCD) {
-        if (stdType.equalsIgnoreCase("Debian GNU/Linux 6(64-bit)")) {
-            return "Debian Squeeze 6.0 (64-bit)";
-        } else if (stdType.equalsIgnoreCase("CentOS 5.6 (64-bit)")) {
-            return "CentOS 5 (64-bit)";
-        } else {
-            return super.getGuestOsType(stdType, platformEmulator, bootFromCD);
-        }
     }
 
     @Override

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixResourceBaseTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixResourceBaseTest.java
@@ -49,4 +49,35 @@ public abstract class CitrixResourceBaseTest {
         String receivedPath = files.get(0).getAbsolutePath();
         Assert.assertEquals(receivedPath, pathExpected);
     }
+
+    public void testGetGuestOsTypeNull(CitrixResourceBase citrixResourceBase) {
+        String platformEmulator = null;
+
+        String expected = "Other install media";
+        String guestOsType = citrixResourceBase.getGuestOsType(platformEmulator);
+        Assert.assertEquals(expected, guestOsType);
+    }
+
+    public void testGetGuestOsTypeEmpty(CitrixResourceBase citrixResourceBase) {
+        String platformEmulator = "";
+
+        String expected = "Other install media";
+        String guestOsType = citrixResourceBase.getGuestOsType(platformEmulator);
+        Assert.assertEquals(expected, guestOsType);
+    }
+
+    public void testGetGuestOsTypeBlank(CitrixResourceBase citrixResourceBase) {
+        String platformEmulator = "    ";
+
+        String expected = "Other install media";
+        String guestOsType = citrixResourceBase.getGuestOsType(platformEmulator);
+        Assert.assertEquals(expected, guestOsType);
+    }
+
+    public void testGetGuestOsTypeOther(CitrixResourceBase citrixResourceBase) {
+        String platformEmulator = "My Own Linux Distribution Y.M (64-bit)";
+
+        String guestOsType = citrixResourceBase.getGuestOsType(platformEmulator);
+        Assert.assertEquals(platformEmulator, guestOsType);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixResourceBaseTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/CitrixResourceBaseTest.java
@@ -19,14 +19,22 @@ import java.io.File;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
 import com.cloud.utils.script.Script;
 
-public abstract class CitrixResourceBaseTest {
+public class CitrixResourceBaseTest {
 
-    public void testGetPathFilesExeption(CitrixResourceBase citrixResourceBase) {
+    protected CitrixResourceBase citrixResourceBase = new CitrixResourceBase() {
+        @Override
+        protected String getPatchFilePath() {
+            return null;
+        }
+    };
+
+    public void testGetPathFilesExeption() {
         String patch = citrixResourceBase.getPatchFilePath();
 
         PowerMockito.mockStatic(Script.class);
@@ -36,7 +44,7 @@ public abstract class CitrixResourceBaseTest {
 
     }
 
-    public void testGetPathFilesListReturned(CitrixResourceBase citrixResourceBase) {
+    public void testGetPathFilesListReturned() {
         String patch = citrixResourceBase.getPatchFilePath();
 
         PowerMockito.mockStatic(Script.class);
@@ -50,7 +58,8 @@ public abstract class CitrixResourceBaseTest {
         Assert.assertEquals(receivedPath, pathExpected);
     }
 
-    public void testGetGuestOsTypeNull(CitrixResourceBase citrixResourceBase) {
+    @Test
+    public void testGetGuestOsTypeNull() {
         String platformEmulator = null;
 
         String expected = "Other install media";
@@ -58,7 +67,8 @@ public abstract class CitrixResourceBaseTest {
         Assert.assertEquals(expected, guestOsType);
     }
 
-    public void testGetGuestOsTypeEmpty(CitrixResourceBase citrixResourceBase) {
+    @Test
+    public void testGetGuestOsTypeEmpty() {
         String platformEmulator = "";
 
         String expected = "Other install media";
@@ -66,7 +76,8 @@ public abstract class CitrixResourceBaseTest {
         Assert.assertEquals(expected, guestOsType);
     }
 
-    public void testGetGuestOsTypeBlank(CitrixResourceBase citrixResourceBase) {
+    @Test
+    public void testGetGuestOsTypeBlank() {
         String platformEmulator = "    ";
 
         String expected = "Other install media";
@@ -74,7 +85,8 @@ public abstract class CitrixResourceBaseTest {
         Assert.assertEquals(expected, guestOsType);
     }
 
-    public void testGetGuestOsTypeOther(CitrixResourceBase citrixResourceBase) {
+    @Test
+    public void testGetGuestOsTypeOther() {
         String platformEmulator = "My Own Linux Distribution Y.M (64-bit)";
 
         String guestOsType = citrixResourceBase.getGuestOsType(platformEmulator);

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpOssResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpOssResourceTest.java
@@ -47,4 +47,21 @@ public class XcpOssResourceTest extends CitrixResourceBaseTest{
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xcpOssResource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xcpOssResource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xcpOssResource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xcpOssResource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xcpOssResource);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpOssResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpOssResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -26,11 +27,14 @@ import com.cloud.utils.script.Script;
 @RunWith(PowerMockRunner.class)
 public class XcpOssResourceTest extends CitrixResourceBaseTest{
 
-    private XcpOssResource xcpOssResource = new XcpOssResource();
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new XcpOssResource();
+    }
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xcpOssResource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xcposs/patch";
 
         Assert.assertEquals(patch, patchFilePath);
@@ -39,29 +43,12 @@ public class XcpOssResourceTest extends CitrixResourceBaseTest{
     @Test(expected = CloudRuntimeException.class)
     @PrepareForTest(Script.class )
     public void testGetFiles(){
-        testGetPathFilesExeption(xcpOssResource);
+        testGetPathFilesExeption();
     }
 
     @Test
     @PrepareForTest(Script.class )
     public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xcpOssResource);
-    }
-
-    @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xcpOssResource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xcpOssResource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xcpOssResource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xcpOssResource);
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpServerResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpServerResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -27,11 +28,14 @@ import com.cloud.utils.script.Script;
 @RunWith(PowerMockRunner.class)
 public class XcpServerResourceTest extends CitrixResourceBaseTest{
 
-    private XcpServerResource xcpServerResource = new XcpServerResource();
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new XcpServerResource();
+    }
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xcpServerResource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xcpserver/patch";
 
         Assert.assertEquals(patch, patchFilePath);
@@ -40,29 +44,12 @@ public class XcpServerResourceTest extends CitrixResourceBaseTest{
     @Test(expected = CloudRuntimeException.class)
     @PrepareForTest(Script.class )
     public void testGetFilesExeption(){
-        testGetPathFilesExeption(xcpServerResource);
+        testGetPathFilesExeption();
     }
 
     @Test
     @PrepareForTest(Script.class )
     public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xcpServerResource);
-    }
-
-    @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xcpServerResource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xcpServerResource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xcpServerResource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xcpServerResource);
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpServerResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XcpServerResourceTest.java
@@ -48,4 +48,21 @@ public class XcpServerResourceTest extends CitrixResourceBaseTest{
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xcpServerResource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xcpServerResource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xcpServerResource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xcpServerResource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xcpServerResource);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56FP1ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56FP1ResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -23,43 +24,32 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
+
 @RunWith(PowerMockRunner.class)
 public class XenServer56FP1ResourceTest extends CitrixResourceBaseTest{
 
-    private XenServer56FP1Resource xenServer56FP1Resource = new XenServer56FP1Resource();
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new XenServer56FP1Resource();
+    }
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer56FP1Resource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver56fp1/patch";
 
         Assert.assertEquals(patch, patchFilePath);
     }
+
     @Test(expected = CloudRuntimeException.class)
     @PrepareForTest(Script.class )
     public void testGetFiles(){
-        testGetPathFilesExeption(xenServer56FP1Resource);
-    }
-    @Test
-    @PrepareForTest(Script.class )
-    public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xenServer56FP1Resource);
+        testGetPathFilesExeption();
     }
 
     @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xenServer56FP1Resource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xenServer56FP1Resource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xenServer56FP1Resource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xenServer56FP1Resource);
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56FP1ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56FP1ResourceTest.java
@@ -45,4 +45,21 @@ public class XenServer56FP1ResourceTest extends CitrixResourceBaseTest{
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xenServer56FP1Resource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xenServer56FP1Resource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xenServer56FP1Resource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xenServer56FP1Resource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xenServer56FP1Resource);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56ResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -26,11 +27,14 @@ import com.cloud.utils.script.Script;
 @RunWith(PowerMockRunner.class)
 public class XenServer56ResourceTest extends CitrixResourceBaseTest {
 
-    private XenServer56Resource xenServer56Resource = new XenServer56Resource();
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new XenServer56Resource();
+    }
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer56Resource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver56/patch";
 
         Assert.assertEquals(patch, patchFilePath);
@@ -39,28 +43,12 @@ public class XenServer56ResourceTest extends CitrixResourceBaseTest {
     @Test(expected = CloudRuntimeException.class)
     @PrepareForTest(Script.class )
     public void testGetFiles(){
-        testGetPathFilesExeption(xenServer56Resource);
-    }
-    @Test
-    @PrepareForTest(Script.class )
-    public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xenServer56Resource);
+        testGetPathFilesExeption();
     }
 
     @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xenServer56Resource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xenServer56Resource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xenServer56Resource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xenServer56Resource);
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56ResourceTest.java
@@ -46,4 +46,21 @@ public class XenServer56ResourceTest extends CitrixResourceBaseTest {
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xenServer56Resource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xenServer56Resource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xenServer56Resource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xenServer56Resource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xenServer56Resource);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56SP2ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56SP2ResourceTest.java
@@ -45,4 +45,21 @@ public class XenServer56SP2ResourceTest extends CitrixResourceBaseTest{
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xenServer56SP2Resource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xenServer56SP2Resource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xenServer56SP2Resource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xenServer56SP2Resource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xenServer56SP2Resource);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56SP2ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer56SP2ResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -26,40 +27,28 @@ import com.cloud.utils.script.Script;
 @RunWith(PowerMockRunner.class)
 public class XenServer56SP2ResourceTest extends CitrixResourceBaseTest{
 
-    private XenServer56SP2Resource xenServer56SP2Resource = new XenServer56SP2Resource();
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new XenServer56SP2Resource();
+    }
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer56SP2Resource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver56fp1/patch";
 
         Assert.assertEquals(patch, patchFilePath);
     }
+
     @Test(expected = CloudRuntimeException.class)
     @PrepareForTest(Script.class )
     public void testGetFiles(){
-        testGetPathFilesExeption(xenServer56SP2Resource);
-    }
-    @Test
-    @PrepareForTest(Script.class )
-    public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xenServer56SP2Resource);
+        testGetPathFilesExeption();
     }
 
     @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xenServer56SP2Resource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xenServer56SP2Resource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xenServer56SP2Resource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xenServer56SP2Resource);
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer600ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer600ResourceTest.java
@@ -45,4 +45,21 @@ public class XenServer600ResourceTest extends CitrixResourceBaseTest{
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xenServer600Resource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xenServer600Resource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xenServer600Resource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xenServer600Resource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xenServer600Resource);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer600ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer600ResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -26,40 +27,29 @@ import com.cloud.utils.script.Script;
 @RunWith(PowerMockRunner.class)
 public class XenServer600ResourceTest extends CitrixResourceBaseTest{
 
-    private XenServer600Resource xenServer600Resource = new XenServer600Resource();
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new XenServer600Resource();
+    }
+
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer600Resource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver60/patch";
 
         Assert.assertEquals(patch, patchFilePath);
     }
+
     @Test(expected = CloudRuntimeException.class)
     @PrepareForTest(Script.class )
     public void testGetFiles(){
-        testGetPathFilesExeption(xenServer600Resource);
-    }
-    @Test
-    @PrepareForTest(Script.class )
-    public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xenServer600Resource);
+        testGetPathFilesExeption();
     }
 
     @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xenServer600Resource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xenServer600Resource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xenServer600Resource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xenServer600Resource);
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer625ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer625ResourceTest.java
@@ -45,4 +45,21 @@ public class XenServer625ResourceTest extends CitrixResourceBaseTest{
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xenServer625Resource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xenServer625Resource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xenServer625Resource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xenServer625Resource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xenServer625Resource);
+    }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer625ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer625ResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -23,43 +24,32 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
-@RunWith(PowerMockRunner.class)
-public class XenServer625ResourceTest extends CitrixResourceBaseTest{
 
-    private Xenserver625Resource xenServer625Resource = new Xenserver625Resource();
+@RunWith(PowerMockRunner.class)
+public class XenServer625ResourceTest extends CitrixResourceBaseTest {
+
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new Xenserver625Resource();
+    }
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer625Resource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver62/patch";
 
         Assert.assertEquals(patch, patchFilePath);
     }
+
     @Test(expected = CloudRuntimeException.class)
-    @PrepareForTest(Script.class )
-    public void testGetFiles(){
-        testGetPathFilesExeption(xenServer625Resource);
-    }
-    @Test
-    @PrepareForTest(Script.class )
-    public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xenServer625Resource);
+    @PrepareForTest(Script.class)
+    public void testGetFiles() {
+        testGetPathFilesExeption();
     }
 
     @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xenServer625Resource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xenServer625Resource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xenServer625Resource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xenServer625Resource);
+    @PrepareForTest(Script.class)
+    public void testGetFilesListReturned() {
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer650ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer650ResourceTest.java
@@ -16,6 +16,7 @@
 package com.cloud.hypervisor.xenserver.resource;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -26,11 +27,14 @@ import com.cloud.utils.script.Script;
 @RunWith(PowerMockRunner.class)
 public class XenServer650ResourceTest extends CitrixResourceBaseTest{
 
-    private XenServer650Resource xenServer650Resource = new XenServer650Resource();
+    @Before
+    public void beforeTest() {
+        super.citrixResourceBase = new XenServer650Resource();
+    }
 
     @Test
     public void testPatchFilePath() {
-        String patchFilePath = xenServer650Resource.getPatchFilePath();
+        String patchFilePath = citrixResourceBase.getPatchFilePath();
         String patch = "scripts/vm/hypervisor/xenserver/xenserver65/patch";
 
         Assert.assertEquals(patch, patchFilePath);
@@ -39,28 +43,12 @@ public class XenServer650ResourceTest extends CitrixResourceBaseTest{
     @Test(expected = CloudRuntimeException.class)
     @PrepareForTest(Script.class )
     public void testGetFiles(){
-        testGetPathFilesExeption(xenServer650Resource);
-    }
-    @Test
-    @PrepareForTest(Script.class )
-    public void testGetFilesListReturned(){
-        testGetPathFilesListReturned(xenServer650Resource);
+        testGetPathFilesExeption();
     }
 
     @Test
-    public void testGetOsTypeNull() {
-        testGetGuestOsTypeNull(xenServer650Resource);
-    }
-    @Test
-    public void testGetOsTypeEmpty() {
-        testGetGuestOsTypeEmpty(xenServer650Resource);
-    }
-    @Test
-    public void testGetOsTypeBlank() {
-        testGetGuestOsTypeBlank(xenServer650Resource);
-    }
-    @Test
-    public void testGetOsTypeOther() {
-        testGetGuestOsTypeOther(xenServer650Resource);
+    @PrepareForTest(Script.class )
+    public void testGetFilesListReturned(){
+        testGetPathFilesListReturned();
     }
 }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer650ResourceTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/XenServer650ResourceTest.java
@@ -46,4 +46,21 @@ public class XenServer650ResourceTest extends CitrixResourceBaseTest{
     public void testGetFilesListReturned(){
         testGetPathFilesListReturned(xenServer650Resource);
     }
+
+    @Test
+    public void testGetOsTypeNull() {
+        testGetGuestOsTypeNull(xenServer650Resource);
+    }
+    @Test
+    public void testGetOsTypeEmpty() {
+        testGetGuestOsTypeEmpty(xenServer650Resource);
+    }
+    @Test
+    public void testGetOsTypeBlank() {
+        testGetGuestOsTypeBlank(xenServer650Resource);
+    }
+    @Test
+    public void testGetOsTypeOther() {
+        testGetGuestOsTypeOther(xenServer650Resource);
+    }
 }


### PR DESCRIPTION
Considering that all mapping of Guest OS Names to their respective hypervisor compatible types is made thorugh accessing a database, we've decided to remove a bit of code in the XcpOssResource class which was doing that same thing for 2 different OS's (both of which ARE in the database). That has led us to a bunch of unused parameters in the getGuestOsType method from its superclass, which we've also decided to remove. Test cases were added for four different possibilities for the platformEmulator String: one for a null String, one for a blank String, one for an empy String and one for a random case with a valid String.