### PR TITLE
Removed unused code from com.cloud.api.ApiServer

### DIFF
--- a/api/src/org/apache/cloudstack/api/ApiServerService.java
+++ b/api/src/org/apache/cloudstack/api/ApiServerService.java
@@ -16,10 +16,12 @@
 // under the License.
 package org.apache.cloudstack.api;
 
-import com.cloud.exception.CloudAuthenticationException;
-import javax.servlet.http.HttpSession;
-import java.util.Map;
 import java.net.InetAddress;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import com.cloud.exception.CloudAuthenticationException;
 
 public interface ApiServerService {
     public boolean verifyRequest(Map<String, Object[]> requestParameters, Long userId) throws ServerApiException;
@@ -27,7 +29,7 @@ public interface ApiServerService {
     public Long fetchDomainId(String domainUUID);
 
     public ResponseObject loginUser(HttpSession session, String username, String password, Long domainId, String domainPath, InetAddress loginIpAddress,
-                                    Map<String, Object[]> requestParameters) throws CloudAuthenticationException;
+            Map<String, Object[]> requestParameters) throws CloudAuthenticationException;
 
     public void logoutUser(long userId);
 
@@ -40,4 +42,8 @@ public interface ApiServerService {
     public String handleRequest(Map params, String responseType, StringBuilder auditTrailSb) throws ServerApiException;
 
     public Class<?> getCmdClass(String cmdName);
+
+    public String getJSONContentType();
+
+    public boolean isSecureSessionCookieEnabled();
 }

--- a/server/test/com/cloud/api/ApiServletTest.java
+++ b/server/test/com/cloud/api/ApiServletTest.java
@@ -89,7 +89,7 @@ public class ApiServletTest {
     @SuppressWarnings("unchecked")
     @Before
     public void setup() throws SecurityException, NoSuchFieldException,
-            IllegalArgumentException, IllegalAccessException, IOException, UnknownHostException {
+    IllegalArgumentException, IllegalAccessException, IOException, UnknownHostException {
         servlet = new ApiServlet();
         responseWriter = new StringWriter();
         Mockito.when(response.getWriter()).thenReturn(
@@ -98,8 +98,7 @@ public class ApiServletTest {
         Mockito.when(accountService.getSystemUser()).thenReturn(user);
         Mockito.when(accountService.getSystemAccount()).thenReturn(account);
 
-        Field accountMgrField = ApiServlet.class
-                .getDeclaredField("_accountMgr");
+        Field accountMgrField = ApiServlet.class.getDeclaredField("accountMgr");
         accountMgrField.setAccessible(true);
         accountMgrField.set(servlet, accountService);
 
@@ -107,11 +106,11 @@ public class ApiServletTest {
         Mockito.when(authenticator.authenticate(Mockito.anyString(), Mockito.anyMap(), Mockito.isA(HttpSession.class),
                 Mockito.same(InetAddress.getByName("127.0.0.1")), Mockito.anyString(), Mockito.isA(StringBuilder.class), Mockito.isA(HttpServletRequest.class), Mockito.isA(HttpServletResponse.class))).thenReturn("{\"loginresponse\":{}");
 
-        Field authManagerField = ApiServlet.class.getDeclaredField("_authManager");
+        Field authManagerField = ApiServlet.class.getDeclaredField("authManager");
         authManagerField.setAccessible(true);
         authManagerField.set(servlet, authManager);
 
-        Field apiServerField = ApiServlet.class.getDeclaredField("_apiServer");
+        Field apiServerField = ApiServlet.class.getDeclaredField("apiServer");
         apiServerField.setAccessible(true);
         apiServerField.set(servlet, apiServer);
     }
@@ -176,7 +175,7 @@ public class ApiServletTest {
         Mockito.when(request.getMethod()).thenReturn("GET");
         Mockito.when(
                 apiServer.verifyRequest(Mockito.anyMap(), Mockito.anyLong()))
-                .thenReturn(false);
+        .thenReturn(false);
         servlet.processRequestInContext(request, response);
         Mockito.verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         Mockito.verify(apiServer, Mockito.never()).handleRequest(
@@ -190,7 +189,7 @@ public class ApiServletTest {
         Mockito.when(request.getMethod()).thenReturn("GET");
         Mockito.when(
                 apiServer.verifyRequest(Mockito.anyMap(), Mockito.anyLong()))
-                .thenReturn(true);
+        .thenReturn(true);
         servlet.processRequestInContext(request, response);
         Mockito.verify(response).setStatus(HttpServletResponse.SC_OK);
         Mockito.verify(apiServer, Mockito.times(1)).handleRequest(


### PR DESCRIPTION
**Removed “\_” from variables names**: private variables with “\_” at the beginning is common in C++ but not in Java.
 
**Removed unused code from ApiServer:**
- com.cloud.api.ApiServer.getPluggableServices(): unused method;
- com.cloud.api.ApiServer.getApiAccessCheckers(): unused method;

**Methods and variables access level reviewed:**
- com.cloud.api.ApiServer.handleAsyncJobPublishEvent(String, String ,Object): this method was private but the annotation @MessageHandler requests public methods, as can be seen in org.apache.cloudstack.framework.messagebus.MessageDispatcher.buildHandlerMethodCache(Class\<?\>), which searches methods with the @MessageHandler annotation and changes
it to be accessible (“setAccessible(true)”). Thus, there is no reason for handleAsyncJobPublishEvent be a private method and lead some other dev to wrong conclusions about the use of the method; 
- Global variables and methods called just by this class (ApiServer) were changed to private.
 
**Changed variables and methods from static to non-static (if possible):** as some variables/methods are used just by one object of this class, instantiated by Spring, they were changed to non-static.
 
With that, calls from com.cloud.api.ApiServlet.ApiServlet() that used static methods from ApiServer, were changed from ApiServer.\<staticMethodName\> to \_apiServer.\<methodName\> that refers to the org.apache.cloudstack.api.ApiServerService interface. Thus, methods com.cloud.api.ApiServer.getJSONContentType() and com.cloud.api.ApiServer.isSecureSessionCookieEnabled() had to be added in the interface (org.apache.cloudstack.api.ApiServerService, interface implemented by class ApiServer).