### PR TITLE
CLOUDSTACK-8867: Added retry logic to reconnect to host on connection termination to console

### DIFF
--- a/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxy.java
+++ b/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxy.java
@@ -411,6 +411,12 @@ public class ConsoleProxy {
         String clientKey = param.getClientMapKey();
         synchronized (connectionMap) {
             viewer = connectionMap.get(clientKey);
+            if(viewer != null && !(viewer.getClientHostPort() == param.getClientHostPort())) {
+                viewer.closeClient();
+                connectionMap.remove(clientKey);
+                viewer = null;
+            }
+
             if (viewer == null) {
                 viewer = getClient(param);
                 viewer.initClient(param);
@@ -445,6 +451,12 @@ public class ConsoleProxy {
         String clientKey = param.getClientMapKey();
         synchronized (connectionMap) {
             ConsoleProxyClient viewer = connectionMap.get(clientKey);
+            if(viewer != null && !(viewer.getClientHostPort() == param.getClientHostPort())) {
+                viewer.closeClient();
+                connectionMap.remove(clientKey);
+                viewer = null;
+            }
+
             if (viewer == null) {
                 authenticationExternally(param);
                 viewer = getClient(param);


### PR DESCRIPTION
It also improves handling of sessions to hypervisor in console proxy

https://issues.apache.org/jira/browse/CLOUDSTACK-8867

To test:
Try on XenServer setup as  frequent disconnections are more common for XenServer.
Try random key combinations on VM console and see after fix console access denied errors are less frequent.
