### PR TITLE
CLOUDSTACK-9164: Prevent firefox's quick search from opening in VM console

### DIFF
--- a/systemvm/js/ajaxviewer.js
+++ b/systemvm/js/ajaxviewer.js
@@ -649,6 +649,7 @@ AjaxViewer.prototype = {
 		this.sendingEventInProgress = false;
 		ajaxViewer.installMouseHook();
 		ajaxViewer.installKeyboardHook();
+		ajaxViewer.panel.parent().focus();
 
 		$(window).bind("resize", function() {
 			ajaxViewer.onWindowResize();
@@ -1259,6 +1260,7 @@ AjaxViewer.prototype = {
 		case 38 :		// UP
 		case 39 :		// RIGHT
 		case 40 :		// DOWN
+		case 47 :		// FORWARD SLASH // Added to stop Firefox's quick search from opening
 			return false;
 		}
 		


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9164

To test:
In Firefox open any VM conosle, and try typing "/". 
It should be typed in VM console and quick search of firefox should not open.