### PR TITLE
CLOUDSTACK-9195: Cancelled/failed async jobs not getting cleaned up f…

### DIFF
--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -1006,6 +1006,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                         job.setStatus(JobInfo.Status.FAILED);
                         job.setResultCode(ApiErrorCode.INTERNAL_ERROR.getHttpCode());
                         job.setResult("job cancelled because of management server restart or shutdown");
+                        job.setCompleteMsid(msid);
                         _jobDao.update(job.getId(), job);
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("Purge queue item for cancelled job-" + job.getId());


### PR DESCRIPTION
…rom DB

Setting 'job_complete_msid' field in async_job table when marking job as cancelled during MS restart.
This will ensure that the job is cleaned up as part of GC thread.