### PR TITLE
CLOUDSTACK-9196: Fixing null pointer exception when vm meta data is synced on upgraded setup

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2641,7 +2641,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
             if(!found) {
                 VMInstanceVO vm = _vmDao.findVMByInstanceName(name);
-                if(vm.getType() == VirtualMachine.Type.User) {
+                if(vm != null && vm.getType() == VirtualMachine.Type.User) {
                     updateVmMetaData(vm.getId(), platform);
                 }
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9196

NullPointerException can occur if XenServer reports non-existing VM in cloud DB.