### PR TITLE
[4.7] FIX Site2SiteVPN on redundant VPC

### DIFF
--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -907,6 +907,9 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             if (conns == null || conns.isEmpty()) {
                 continue;
             }
+            if (router.getIsRedundantRouter() && router.getRedundantState() != RedundantState.MASTER){
+                continue;
+            }
             if (router.getState() != VirtualMachine.State.Running) {
                 for (final Site2SiteVpnConnectionVO conn : conns) {
                     if (conn.getState() != Site2SiteVpnConnection.State.Error) {

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -538,9 +538,9 @@ class CsSite2SiteVpn(CsDataBag):
             file.commit()
             logging.info("Configured vpn %s %s", leftpeer, rightpeer)
             CsHelper.execute("ipsec auto --rereadall")
-            CsHelper.execute("ipsec --add vpn-%s" % rightpeer)
+            CsHelper.execute("ipsec auto --add vpn-%s" % rightpeer)
             if not obj['passive']:
-                CsHelper.execute("ipsec --up vpn-%s" % rightpeer)
+                CsHelper.execute("ipsec auto --up vpn-%s" % rightpeer)
         os.chmod(vpnsecretsfile, 0o400)
 
     def convert_sec_to_h(self, val):

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -462,16 +462,20 @@ class CsSite2SiteVpn(CsDataBag):
             if m:
                 self.confips.append(m.group(1))
 
-        for public_ip in self.dbag:
-            if public_ip == "id":
+        for vpn in self.dbag:
+            if vpn == "id":
                 continue
-            dev = CsHelper.get_device(public_ip)
+
+            local_ip = self.dbag[vpn]['local_public_ip']
+            dev = CsHelper.get_device(local_ip)
+
             if dev == "":
-                logging.error("Request for ipsec to %s not possible because ip is not configured", public_ip)
+                logging.error("Request for ipsec to %s not possible because ip is not configured", local_ip)
                 continue
+
             CsHelper.start_if_stopped("ipsec")
-            self.configure_iptables(dev, self.dbag[public_ip])
-            self.configure_ipsec(self.dbag[public_ip])
+            self.configure_iptables(dev, self.dbag[vpn])
+            self.configure_ipsec(self.dbag[vpn])
 
         # Delete vpns that are no longer in the configuration
         for ip in self.confips:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_site2sitevpn.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_site2sitevpn.py
@@ -19,7 +19,7 @@ from pprint import pprint
 
 
 def merge(dbag, vpn):
-    key = vpn['local_public_ip']
+    key = vpn['peer_gateway_ip']
     op = vpn['create']
     if key in dbag.keys() and not op:
         del(dbag[key])

--- a/test/integration/smoke/test_vpc_vpn.py
+++ b/test/integration/smoke/test_vpc_vpn.py
@@ -19,7 +19,8 @@
 # Import Local Modules
 from marvin.codes import PASS, FAILED
 from marvin.cloudstackTestCase import cloudstackTestCase
-from marvin.lib.utils import (cleanup_resources,
+from marvin.lib.utils import (validateList,
+                              cleanup_resources,
                               get_process_status)
 
 from marvin.lib.base import (Domain,
@@ -259,7 +260,6 @@ class Services:
         }
 
 
-
 class TestVpcRemoteAccessVpn(cloudstackTestCase):
 
     @classmethod
@@ -286,8 +286,10 @@ class TestVpcRemoteAccessVpn(cloudstackTestCase):
 
         cls.hypervisor = testClient.getHypervisorInfo()
 
-        cls.logger.debug("Downloading Template: %s from: %s" %(cls.services["template"][cls.hypervisor.lower()], cls.services["template"][cls.hypervisor.lower()]["url"]))
-        cls.template = Template.register(cls.apiclient, cls.services["template"][cls.hypervisor.lower()], cls.zone.id, hypervisor=cls.hypervisor.lower(), account=cls.account.name, domainid=cls.domain.id)
+        cls.logger.debug("Downloading Template: %s from: %s" % (cls.services["template"][
+                         cls.hypervisor.lower()], cls.services["template"][cls.hypervisor.lower()]["url"]))
+        cls.template = Template.register(cls.apiclient, cls.services["template"][cls.hypervisor.lower(
+        )], cls.zone.id, hypervisor=cls.hypervisor.lower(), account=cls.account.name, domainid=cls.domain.id)
         cls.template.download(cls.apiclient)
 
         if cls.template == FAILED:
@@ -463,8 +465,10 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
 
         cls.hypervisor = testClient.getHypervisorInfo()
 
-        cls.logger.debug("Downloading Template: %s from: %s" %(cls.services["template"][cls.hypervisor.lower()], cls.services["template"][cls.hypervisor.lower()]["url"]))
-        cls.template = Template.register(cls.apiclient, cls.services["template"][cls.hypervisor.lower()], cls.zone.id, hypervisor=cls.hypervisor.lower(), account=cls.account.name, domainid=cls.domain.id)
+        cls.logger.debug("Downloading Template: %s from: %s" % (cls.services["template"][
+                         cls.hypervisor.lower()], cls.services["template"][cls.hypervisor.lower()]["url"]))
+        cls.template = Template.register(cls.apiclient, cls.services["template"][cls.hypervisor.lower(
+        )], cls.zone.id, hypervisor=cls.hypervisor.lower(), account=cls.account.name, domainid=cls.domain.id)
         cls.template.download(cls.apiclient)
 
         if cls.template == FAILED:
@@ -530,11 +534,11 @@ class TestVpcSite2SiteVpn(cloudstackTestCase):
             self.apiclient,
             id=vpc_offering.id
         )
-        self.assertEqual(
-            isinstance(vpc_offs, list),
-            True,
-            "List VPC offerings should return a valid list"
-        )
+        offering_list = validateList(vpc_offs)
+        self.assertEqual(offering_list[0],
+                         PASS,
+                         "List VPC offerings should return a valid list"
+                         )
         self.assertEqual(
             vpc_offering.name,
             vpc_offs[0].name,
@@ -824,8 +828,10 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
 
         cls.hypervisor = testClient.getHypervisorInfo()
 
-        cls.logger.debug("Downloading Template: %s from: %s" %(cls.services["template"][cls.hypervisor.lower()], cls.services["template"][cls.hypervisor.lower()]["url"]))
-        cls.template = Template.register(cls.apiclient, cls.services["template"][cls.hypervisor.lower()], cls.zone.id, hypervisor=cls.hypervisor.lower(), account=cls.account.name, domainid=cls.domain.id)
+        cls.logger.debug("Downloading Template: %s from: %s" % (cls.services["template"][
+                         cls.hypervisor.lower()], cls.services["template"][cls.hypervisor.lower()]["url"]))
+        cls.template = Template.register(cls.apiclient, cls.services["template"][cls.hypervisor.lower(
+        )], cls.zone.id, hypervisor=cls.hypervisor.lower(), account=cls.account.name, domainid=cls.domain.id)
         cls.template.download(cls.apiclient)
 
         if cls.template == FAILED:
@@ -845,11 +851,11 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
             self.apiclient,
             id=vpc_offering.id
         )
-        self.assertEqual(
-            isinstance(vpc_offs, list),
-            True,
-            "List VPC offerings should return a valid list"
-        )
+        offering_list = validateList(vpc_offs)
+        self.assertEqual(offering_list[0],
+                         PASS,
+                         "List VPC offerings should return a valid list"
+                         )
         self.assertEqual(
             vpc_offering.name,
             vpc_offs[0].name,
@@ -875,7 +881,6 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
             self.cleanup.append(vpc_off)
 
         return vpc_off
-
 
     def _get_ssh_client(self, virtual_machine, services, retries):
         """ Setup ssh client connection and return connection
@@ -923,7 +928,6 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
         vm.public_port = int(public_port)
         return nat_rule
 
-
     @attr(tags=["advanced"], required_hardware="true")
     def test_01_redundant_vpc_site2site_vpn(self):
         """Test Site 2 Site VPN Across redundant VPCs"""
@@ -936,8 +940,10 @@ class TestRVPCSite2SiteVpn(cloudstackTestCase):
             networkOffering) > 0, "No VPC based network offering")
 
         # Create and enable redundant VPC offering
-        redundant_vpc_offering = self._create_vpc_offering('redundant_vpc_offering')
-        self.assert_(redundant_vpc_offering is not None, "Failed to create redundant VPC Offering")
+        redundant_vpc_offering = self._create_vpc_offering(
+            'redundant_vpc_offering')
+        self.assert_(redundant_vpc_offering is not None,
+                     "Failed to create redundant VPC Offering")
 
         redundant_vpc_offering.update(self.apiclient, state='Enabled')
 


### PR DESCRIPTION
This PR:
- fixes the inability to setup more than one Site2Site VPN connection from a VPC
- fixes starting of Site2Site VPN on redundant VPC
- fixes Site2Site VPN state checking on redundant VPC
- improves the vpc_vpn test to allow multple hypervisors
- adds an integration test for Site2Site VPN on redundant VPC

Tested it on 4.7 single Xen server zone:

command:
```
nosetests --with-marvin --marvin-config=/data/shared/marvin/mct-zone1-xen1.cfg -a tags=advanced,required_hardware=true /tmp/test_vpc_vpn.py
```

results:
```
Test Site 2 Site VPN Across redundant VPCs ... === TestName: test_01_redundant_vpc_site2site_vpn | Status : SUCCESS ===
ok
Test Remote Access VPN in VPC ... === TestName: test_01_vpc_remote_access_vpn | Status : SUCCESS ===
ok
Test Site 2 Site VPN Across VPCs ... === TestName: test_01_vpc_site2site_vpn | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 3 tests in 1490.076s

OK
``` 

also performed numerous manual inspections of state of VPN connections and connectivity between VPC's