### PR TITLE
engine/schema: Use semantically correct upgrade path 4.6.2->4.7.0

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -60,6 +60,7 @@ import com.cloud.upgrade.dao.Upgrade452to460;
 import com.cloud.upgrade.dao.Upgrade453to460;
 import com.cloud.upgrade.dao.Upgrade460to461;
 import com.cloud.upgrade.dao.Upgrade461to470;
+import com.cloud.upgrade.dao.Upgrade462to470;
 import com.cloud.upgrade.dao.Upgrade470to471;
 import com.cloud.upgrade.dao.UpgradeSnapshot217to224;
 import com.cloud.upgrade.dao.UpgradeSnapshot223to224;
@@ -249,7 +250,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
 
         _upgradeMap.put("4.6.1", new DbUpgrade[] {new Upgrade461to470(), new Upgrade470to471()});
 
-        _upgradeMap.put("4.6.2", new DbUpgrade[] {new Upgrade461to470(), new Upgrade470to471()});
+        _upgradeMap.put("4.6.2", new DbUpgrade[] {new Upgrade462to470(), new Upgrade470to471()});
 
         _upgradeMap.put("4.7.0", new DbUpgrade[] {new Upgrade470to471()});
 

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade462to470.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade462to470.java
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.cloud.upgrade.dao;
+
+import org.apache.log4j.Logger;
+
+public class Upgrade462to470 extends Upgrade461to470 implements DbUpgrade {
+    final static Logger s_logger = Logger.getLogger(Upgrade462to470.class);
+
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[] {"4.6.2", "4.7.0"};
+    }
+}


### PR DESCRIPTION
Adds an explicit upgrade path class from 4.6.2 to 4.7.0, that extends over
the upgrade path from 4.6.1 to 4.7.0

cc @remibergsma @DaanHoogland -- from #1247 