### PR TITLE
CLOUDSTACK-9199: Fixed deployVirtualMachine API does not throw an error when cpunumber is specified for static compute offering

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -553,6 +553,14 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd {
                 throw new InvalidParameterValueException("Unable to find service offering: " + serviceOfferingId);
             }
 
+            if(!serviceOffering.isDynamic()) {
+                for(String detail: getDetails().keySet()) {
+                    if(detail.equalsIgnoreCase("cpuNumber") || detail.equalsIgnoreCase("cpuSpeed") || detail.equalsIgnoreCase("memory")) {
+                        throw new InvalidParameterValueException("cpuNumber or cpuSpeed or memory should not be specified for static service offering");
+                    }
+                }
+            }
+
             VirtualMachineTemplate template = _entityMgr.findById(VirtualMachineTemplate.class, templateId);
             // Make sure a valid template ID was specified
             if (template == null) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9199

To test:
-------------
Deploy VM by providing cpuNumber, cpuSpeed or memory for static/ non dynamic service offering
Deployment should fail.

API example:
------------------
http://10.220.135.6/client/api?command=deployVirtualMachine&name=olotwo&response=&zoneid=ab6e4154-62a3-42a8-9627-3cbdc66bcbb6&templateid=3aaaace6-91b4-11e5-b6fc-e26c2aa1d1d0&hypervisor=XenServer&serviceofferingid=39643075-4b45-489d-afac-88f09d536bdd&details[0].cpuNumber=1&details[0].cpuSpeed=1000&details[0].memory=1000&securitygroupids=60844698-91b4-11e5-b6fc-e26c2aa1d1d0&_=1448277187743

