### PR TITLE
CLOUDSTACK-9200: Fixed failed to delete snapshot if snapshot is stuck in Allocated state without any job associated with it

### DIFF
--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
@@ -245,6 +245,12 @@ public class XenserverSnapshotStrategy extends SnapshotStrategyBase {
             return true;
         }
 
+        if(snapshotVO.getState() == Snapshot.State.Allocated) {
+            s_logger.debug("delete snapshot in Allocated state");
+            snapshotDao.remove(snapshotId);
+            return true;
+        }
+
         if (!Snapshot.State.BackedUp.equals(snapshotVO.getState()) && !Snapshot.State.Error.equals(snapshotVO.getState())) {
             throw new InvalidParameterValueException("Can't delete snapshotshot " + snapshotId + " due to it is in " + snapshotVO.getState() + " Status");
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9200

This issue is hard to reproduce but if occurs then it may lead to account resources cleanup failures.
