### PR TITLE
Map LDAP group to Cloudstack account

### DIFF
--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -71,6 +71,7 @@
         <configuration>
           <includes>
             <include>**/*Spec*</include>
+            <include>**/*Test.java</include>
           </includes>
         </configuration>
       </plugin>

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/DistinguishedNameParser.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/DistinguishedNameParser.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cloudstack.ldap;
+
+public class DistinguishedNameParser {
+
+    private static final String KEY_VALUE_SEPARATOR = "=";
+    private static final String NAME_SEPARATOR = ",";
+
+    public static String parseLeafName(final String distinguishedName) {
+        if (distinguishedName.contains(NAME_SEPARATOR)) {
+            final String[] parts = distinguishedName.split(NAME_SEPARATOR);
+            return parseValue(parts[0]);
+        } else {
+            return parseValue(distinguishedName);
+        }
+    }
+
+    private static String parseValue(final String distinguishedName) {
+        if (distinguishedName.contains(KEY_VALUE_SEPARATOR)) {
+            final String[] parts = distinguishedName.split(KEY_VALUE_SEPARATOR);
+            if (parts.length > 1) {
+                return parts[1];
+            }
+        }
+        throw new IllegalArgumentException("Malformed distinguished name: " + distinguishedName);
+    }
+
+}

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
@@ -54,8 +54,8 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
     }
 
     @Override
-    public Pair<Boolean, ActionOnFailedAuthentication> authenticate(final String username, final String password, final Long domainId, final Map<String, Object[]> requestParameters) {
-
+    public Pair<Boolean, ActionOnFailedAuthentication> authenticate(final String username, final String password, final Long domainId,
+                    final Map<String, Object[]> requestParameters) {
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
             s_logger.debug("Username or Password cannot be empty");
             return new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
@@ -66,14 +66,14 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
 
         if (_ldapManager.isLdapEnabled()) {
             final UserAccount user = _userAccountDao.getUserAccount(username, domainId);
-            LdapTrustMapVO ldapTrustMapVO = _ldapManager.getDomainLinkedToLdap(domainId);
-            if(ldapTrustMapVO != null) {
+            final LdapTrustMapVO ldapTrustMapVO = _ldapManager.getDomainLinkedToLdap(domainId);
+            if (ldapTrustMapVO != null) {
                 try {
-                    LdapUser ldapUser = _ldapManager.getUser(username, ldapTrustMapVO.getType().toString(), ldapTrustMapVO.getName());
-                    if(!ldapUser.isDisabled()) {
+                    final LdapUser ldapUser = _ldapManager.getUser(username, ldapTrustMapVO.getType().toString(), ldapTrustMapVO.getName());
+                    if (!ldapUser.isDisabled()) {
                         result = _ldapManager.canAuthenticate(ldapUser.getPrincipal(), password);
-                        if(result) {
-                            if(user == null) {
+                        if (result) {
+                            if (user == null) {
                                 // import user to cloudstack
                                 createCloudStackUserAccount(ldapUser, domainId, ldapTrustMapVO.getAccountType());
                             } else {
@@ -81,24 +81,24 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
                             }
                         }
                     } else {
-                        //disable user in cloudstack
+                        // disable user in cloudstack
                         disableUserInCloudStack(user);
                     }
-                } catch (NoLdapUserMatchingQueryException e) {
+                } catch (final NoLdapUserMatchingQueryException e) {
                     s_logger.debug(e.getMessage());
                 }
 
             } else {
-                //domain is not linked to ldap follow normal authentication
-                if(user != null ) {
+                // domain is not linked to ldap follow normal authentication
+                if (user != null) {
                     try {
-                        LdapUser ldapUser = _ldapManager.getUser(username);
-                        if(!ldapUser.isDisabled()) {
+                        final LdapUser ldapUser = _ldapManager.getUser(username);
+                        if (!ldapUser.isDisabled()) {
                             result = _ldapManager.canAuthenticate(ldapUser.getPrincipal(), password);
                         } else {
-                            s_logger.debug("user with principal "+ ldapUser.getPrincipal() + " is disabled in ldap");
+                            s_logger.debug("user with principal " + ldapUser.getPrincipal() + " is disabled in ldap");
                         }
-                    } catch (NoLdapUserMatchingQueryException e) {
+                    } catch (final NoLdapUserMatchingQueryException e) {
                         s_logger.debug(e.getMessage());
                     }
                 }
@@ -111,19 +111,19 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
         return new Pair<Boolean, ActionOnFailedAuthentication>(result, action);
     }
 
-    private void enableUserInCloudStack(UserAccount user) {
-        if(user != null && (user.getState().equalsIgnoreCase(Account.State.disabled.toString()))) {
+    private void enableUserInCloudStack(final UserAccount user) {
+        if (user != null && user.getState().equalsIgnoreCase(Account.State.disabled.toString())) {
             _accountManager.enableUser(user.getId());
         }
     }
 
-    private void createCloudStackUserAccount(LdapUser user, long domainId, short accountType) {
-        String username = user.getUsername();
-        _accountManager.createUserAccount(username, "", user.getFirstname(), user.getLastname(), user.getEmail(), null, username, accountType, domainId, username, null,
-                                          UUID.randomUUID().toString(), UUID.randomUUID().toString(), User.Source.LDAP);
+    private void createCloudStackUserAccount(final LdapUser user, final long domainId, final short accountType) {
+        final String username = user.getUsername();
+        _accountManager.createUserAccount(username, "", user.getFirstname(), user.getLastname(), user.getEmail(), null, ldapGroupName, accountType, domainId,
+                        username, null, UUID.randomUUID().toString(), UUID.randomUUID().toString(), User.Source.LDAP);
     }
 
-    private void disableUserInCloudStack(UserAccount user) {
+    private void disableUserInCloudStack(final UserAccount user) {
         if (user != null) {
             _accountManager.disableUser(user.getId());
         }

--- a/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/DistinguishedNameParserTest.java
+++ b/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/DistinguishedNameParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cloudstack.ldap;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class DistinguishedNameParserTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseLeafeNameEmptyString() throws Exception {
+        final String distinguishedName = "";
+        DistinguishedNameParser.parseLeafName(distinguishedName);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseLeafeNameSingleMalformedKeyValue() throws Exception {
+        final String distinguishedName = "someMalformedKeyValue";
+        DistinguishedNameParser.parseLeafName(distinguishedName);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseLeafeNameNonSingleMalformedKeyValue() throws Exception {
+        final String distinguishedName = "someMalformedKeyValue,key=value";
+        DistinguishedNameParser.parseLeafName(distinguishedName);
+    }
+
+    @Test
+    public void testParseLeafeNameSingleKeyValue() throws Exception {
+        final String distinguishedName = "key=value";
+        final String value = DistinguishedNameParser.parseLeafName(distinguishedName);
+
+        assertThat(value, equalTo("value"));
+    }
+
+    @Test
+    public void testParseLeafeNameMultipleKeyValue() throws Exception {
+        final String distinguishedName = "key1=leaf,key2=nonleaf";
+        final String value = DistinguishedNameParser.parseLeafName(distinguishedName);
+
+        assertThat(value, equalTo("leaf"));
+    }
+}


### PR DESCRIPTION
The LDAP plugin authenticates Cloudstack users against users in an LDAP group, and when doing so creates a Cloudstack account with the same name as the LDAP user, and a Cloudstack user also with the same name as the LDAP user.
This makes it difficult to manage the users in a given LDAP group because each user will have it's own account and user in Cloudstack, and cannot therefore collaborate in managing cloud resources.

This PR changes the LDAP plugin to use the LDAP group for the Cloudstack account name, and create the users (belonging to the LDAP group) under the same Cloudstack account.