### PR TITLE
CLOUDSTACK-4572: findHostsForMigration API does not return correct host list

### DIFF
--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1222,7 +1222,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             plan = new DataCenterDeployment(srcHost.getDataCenterId(), srcHost.getPodId(), srcHost.getClusterId(), null, null, null);
         }
 
-        final Pair<List<? extends Host>, Integer> otherHosts = new Pair<List<? extends Host>, Integer>(allHosts, new Integer(allHosts.size()));
+        //'otherHosts' must use the current value of allHosts as allHosts may get modified later in the allocator
+        List<HostVO> allHostsCpy = new ArrayList<HostVO>(allHosts);
+        final Pair<List<? extends Host>, Integer> otherHosts = new Pair<List <? extends Host>, Integer>(allHostsCpy,
+                new Integer(allHostsCpy.size()));
         List<Host> suitableHosts = new ArrayList<Host>();
         final ExcludeList excludes = new ExcludeList();
         excludes.addHost(srcHostId);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-4572

Fix is missing in recent releases.

The api should return the list of suitable/unsuitable hosts
Added fix that creates a deep copy of the the variable allHosts and prevents faulty host list return.