### PR TITLE
trailing commas in javascripts removed

### DIFF
--- a/ui/plugins/plugins.js
+++ b/ui/plugins/plugins.js
@@ -16,7 +16,7 @@
 // under the License.
 (function($, cloudStack) {
   cloudStack.plugins = [
-    'quota',
-    //'testPlugin'
+    //'testPlugin',
+    'quota'
   ];
 }(jQuery, cloudStack));

--- a/ui/plugins/quota/quota.js
+++ b/ui/plugins/quota/quota.js
@@ -79,9 +79,9 @@
                               indicator: {
                                   'enabled': 'on',
                                   'disabled': 'off',
-                                  'locked': 'off',
+                                  'locked': 'off'
                               }
-                          },
+                          }
                       },
                       dataProvider: function(args) {
                           var data = {
@@ -171,7 +171,7 @@
                                             label: 'label.quota.enforcequota',
                                             isBoolean: true,
                                             isChecked: false
-                                        },
+                                        }
                                     }
 
                                 },
@@ -196,7 +196,7 @@
                                     });
                                     $(window).trigger('cloudStack.fullRefresh');
                                  }
-                            },
+                            }
                           },
                           tabs: {
                              details: {
@@ -207,10 +207,10 @@
                                         }
                                     }, {
                                         startdate: {
-                                            label: 'label.quota.date',
+                                            label: 'label.quota.date'
                                         },
                                         startquota: {
-                                            label: 'label.quota.value',
+                                            label: 'label.quota.value'
                                         }
                                     }],
                                     dataProvider: function(args) {
@@ -235,8 +235,7 @@
                                             }
                                         });
                                     }
-                                },
-
+                                }
                           }
                       }
                   }
@@ -277,9 +276,9 @@
                               indicator: {
                                   'enabled': 'on',
                                   'disabled': 'off',
-                                  'locked': 'off',
+                                  'locked': 'off'
                               }
-                          },
+                          }
                       },
                       dataProvider: function(args) {
                           var data = {
@@ -369,7 +368,7 @@
                                             label: 'label.quota.enforcequota',
                                             isBoolean: true,
                                             isChecked: false
-                                        },
+                                        }
                                     }
 
                                 },
@@ -394,7 +393,7 @@
                                     });
                                     $(window).trigger('cloudStack.fullRefresh');
                                  }
-                            },
+                            }
                           },
                           tabs: {
                              details: {
@@ -405,10 +404,10 @@
                                         }
                                     }, {
                                         startdate: {
-                                            label: 'label.quota.date',
+                                            label: 'label.quota.date'
                                         },
                                         startquota: {
-                                            label: 'label.quota.value',
+                                            label: 'label.quota.value'
                                         }
                                     }],
                                     dataProvider: function(args) {
@@ -433,7 +432,7 @@
                                             }
                                         });
                                     }
-                                },
+                                }
                            }
                       }
                   }
@@ -668,7 +667,7 @@
                               action: function(args) {
                                   if (isAdmin()) {
                                        var data = {
-                                            usagetype: args.data.jsonObj.usageType,
+                                            usagetype: args.data.jsonObj.usageType
                                        };
                                       var tariffVal = args.data.tariffValue.split(' ');
                                       if (tariffVal.length==2){
@@ -697,7 +696,7 @@
                                                           validation: {
                                                               required: true
                                                           }
-                                                      },
+                                                      }
                                                   }
                                               },
                                               after: function(argsLocal) {
@@ -769,7 +768,7 @@
                                   input.datepicker({
                                       defaultDate: new Date(),
                                       changeMonth: true,
-                                      dateFormat: "yy-mm-dd",
+                                      dateFormat: "yy-mm-dd"
                                   });
                                   input.parent().attr('title', _l('label.quota.effectivedate'));
                               },
@@ -800,7 +799,7 @@
                               label: 'label.usage.unit'
                           },
                           tariffValue: {
-                              label: 'label.quota.tariff.value',
+                              label: 'label.quota.tariff.value'
                           },
                           description: {
                               label: 'label.quota.description',
@@ -832,7 +831,7 @@
                                   input.datepicker({
                                       defaultDate: new Date(),
                                       changeMonth: true,
-                                      dateFormat: "yy-mm-dd",
+                                      dateFormat: "yy-mm-dd"
                                   });
                                   input.parent().attr('title', _l('label.quota.effectivedate'));
                               },
@@ -854,7 +853,7 @@
                       disableInfiniteScrolling: true,
                       fields: {
                           templatetype: {
-                              label: 'label.quota.email.template',
+                              label: 'label.quota.email.template'
                           },
                           templatesubject: {
                               label: 'label.quota.email.subject',
@@ -867,7 +866,7 @@
                           last_updated: {
                               label: 'label.quota.email.lastupdated',
                               truncate: true
-                          },
+                          }
                       },
                       dataProvider: function(args) {
                           var data = {};
@@ -941,8 +940,8 @@
                                           textArea: true
                                       },
                                       last_updated: {
-                                          label: 'label.quota.email.lastupdated',
-                                      },
+                                          label: 'label.quota.email.lastupdated'
+                                      }
                                   }],
 
                                   dataProvider: function(args) {

--- a/ui/scripts/accounts.js
+++ b/ui/scripts/accounts.js
@@ -1337,7 +1337,7 @@
                                             $.ajax({
                                                 url: createURL('listSamlAuthorization'),
                                                 data: {
-                                                    userid: context.users[0].id,
+                                                    userid: context.users[0].id
                                                 },
                                                 success: function(json) {
                                                     var authorization = json.listsamlauthorizationsresponse.samlauthorization[0];
@@ -1881,7 +1881,7 @@
                                     if (!args.context.projects) {
                                         $.extend(data, {
                                             domainid: args.context.sshkeypairs[0].domainid,
-                                            account: args.context.sshkeypairs[0].account,
+                                            account: args.context.sshkeypairs[0].account
                                         });
                                     }
                                     $.ajax({

--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -181,7 +181,7 @@
                         }
                     },
                     error: function(xhr) { // ignore any errors, fallback to the default
-                    },
+                    }
                 });
 
 

--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -310,7 +310,7 @@
                             return 'label.metrics';
                         }
                     }
-                },
+                }
             },
 
             dataProvider: function(args) {

--- a/ui/scripts/metrics.js
+++ b/ui/scripts/metrics.js
@@ -23,7 +23,7 @@
                 name: {
                     label: 'metrics'
                 }
-            },
+            }
         }
     };
 
@@ -546,7 +546,7 @@
                         'Error': 'off',
                         'Connecting': 'transition',
                         'Rebalancing': 'transition',
-                        'Alert': 'warning',
+                        'Alert': 'warning'
                     },
                     compact: true
                 },
@@ -558,7 +558,7 @@
                     collapsible: true,
                     columns: {
                         cores: {
-                            label: 'label.metrics.num.cpu.cores',
+                            label: 'label.metrics.num.cpu.cores'
                         },
                         cputotal: {
                             label: 'label.metrics.cpu.total'
@@ -768,7 +768,7 @@
                         'Stopping': 'transition',
                         'Starting': 'transition',
                         'Migrating': 'transition',
-                        'Shutdowned': 'warning',
+                        'Shutdowned': 'warning'
                     },
                     compact: true
                 },
@@ -783,13 +783,13 @@
                     collapsible: true,
                     columns: {
                         cores: {
-                            label: 'label.metrics.num.cpu.cores',
+                            label: 'label.metrics.num.cpu.cores'
                         },
                         cputotal: {
                             label: 'label.metrics.cpu.total'
                         },
                         cpuused: {
-                            label: 'label.metrics.cpu.used.avg',
+                            label: 'label.metrics.cpu.used.avg'
                         }
                     }
                 },
@@ -912,7 +912,7 @@
                         'Expunging': 'off',
                         'Migrating': 'warning',
                         'UploadOp': 'transition',
-                        'Snapshotting': 'warning',
+                        'Snapshotting': 'warning'
                     },
                     compact: true
                 },
@@ -927,7 +927,7 @@
                 },
                 storagepool: {
                     label: 'label.metrics.storagepool'
-                },
+                }
             },
             dataProvider: function(args) {
                 var data = {listAll: true};
@@ -990,7 +990,7 @@
                                 'ErrorInMaintenance': 'off',
                                 'PrepareForMaintenance': 'transition',
                                 'CancelMaintenance': 'warning',
-                                'Maintenance': 'warning',
+                                'Maintenance': 'warning'
                             },
                             compact: true
                         },
@@ -999,7 +999,7 @@
                         },
                         type: {
                             label: 'label.metrics.disk.storagetype'
-                        },
+                        }
                     }
                 },
                 disk: {

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -870,7 +870,7 @@
                                                     var data = {
                                                         id: args.context.multiRule[0].id,
                                                         zoneid: args.context.multiRule[0].zoneid,
-                                                        domainid: args.data.domainid,
+                                                        domainid: args.data.domainid
                                                     };
                                                     if (args.data.account) {
                                                         $.extend(data, {
@@ -7869,7 +7869,7 @@
                                             return 'label.metrics';
                                         }
                                     }
-                                },
+                                }
                             },
 
                             detailView: {


### PR DESCRIPTION
According to SonarQube this is a bug on internet explorer. It is the only 'blocker' level issue in cloudstack. @abhinandanprateek (@agneya2001) @bhaisaab @miguelaferreira should we enforce this or, as alternative, have it disabled in SonarQube?