### PR TITLE
CLOUDSTACK-9202 Bump ssh timeout for VR commands

### DIFF
--- a/utils/src/main/java/com/cloud/utils/ssh/SSHCmdHelper.java
+++ b/utils/src/main/java/com/cloud/utils/ssh/SSHCmdHelper.java
@@ -29,6 +29,8 @@ import com.trilead.ssh2.Session;
 
 public class SSHCmdHelper {
     private static final Logger s_logger = Logger.getLogger(SSHCmdHelper.class);
+    private static final int DEFAULT_CONNECT_TIMEOUT = 180000;
+    private static final int DEFAULT_KEX_TIMEOUT = 60000;
 
     public static com.trilead.ssh2.Connection acquireAuthorizedConnection(String ip, String username, String password) {
         return acquireAuthorizedConnection(ip, 22, username, password);
@@ -37,7 +39,7 @@ public class SSHCmdHelper {
     public static com.trilead.ssh2.Connection acquireAuthorizedConnection(String ip, int port, String username, String password) {
         com.trilead.ssh2.Connection sshConnection = new com.trilead.ssh2.Connection(ip, port);
         try {
-            sshConnection.connect(null, 60000, 60000);
+            sshConnection.connect(null, DEFAULT_CONNECT_TIMEOUT, DEFAULT_KEX_TIMEOUT);
             if (!sshConnection.authenticateWithPassword(username, password)) {
                 String[] methods = sshConnection.getRemainingAuthMethods(username);
                 StringBuffer mStr = new StringBuffer();

--- a/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
+++ b/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
@@ -29,14 +29,14 @@ import com.trilead.ssh2.ChannelCondition;
 import com.cloud.utils.Pair;
 
 public class SshHelper {
-    private static final int DEFAULT_CONNECT_TIMEOUT = 60000;
+    private static final int DEFAULT_CONNECT_TIMEOUT = 180000;
     private static final int DEFAULT_KEX_TIMEOUT = 60000;
 
     private static final Logger s_logger = Logger.getLogger(SshHelper.class);
 
     public static Pair<Boolean, String> sshExecute(String host, int port, String user, File pemKeyFile, String password, String command) throws Exception {
 
-        return sshExecute(host, port, user, pemKeyFile, password, command, 60000, 60000, 120000);
+        return sshExecute(host, port, user, pemKeyFile, password, command, DEFAULT_CONNECT_TIMEOUT, DEFAULT_KEX_TIMEOUT, 120000);
     }
 
     public static void scpTo(String host, int port, String user, File pemKeyFile, String password, String remoteTargetDirectory, String localFile, String fileMode)


### PR DESCRIPTION
It seems the VR needs more time for some of its commands. Until we figured out the root cause, this allows the VRs to start again.

Error seen:
```
2015-12-28 14:35:18,201 ERROR [c.c.n.r.VirtualNetworkApplianceManagerImpl] (Work-Job-Executor-1:ctx-34ff7f80 job-39723/job-39726 ctx-d63de41b) Timed out in waiting SSH execution result
2015-12-28 14:35:18,201 WARN [c.c.n.r.VirtualNetworkApplianceManagerImpl] (Work-Job-Executor-1:ctx-34ff7f80 job-39723/job-39726 ctx-d63de41b) Command: com.cloud.agent.api.Command failed while starting virtua
l router
2015-12-28 14:35:18,201 INFO [c.c.v.VirtualMachineManagerImpl] (Work-Job-Executor-1:ctx-34ff7f80 job-39723/job-39726 ctx-d63de41b) The guru did not like the answers so stopping VM[DomainRouter|r-1534-VM]
.Answer":{"result":true,"wait":0}},{"com.cloud.agent.api.Answer":{"result":false,"details":"Timed out in waiting SSH execution result","wait":0}}] }
```
