### PR TITLE
CLOUDSTACK-9181 Prevent syntax error in checkrouter.sh

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
@@ -17,14 +17,13 @@
 # under the License.
 
 STATUS=UNKNOWN
-INTERFACE=eth1
 ROUTER_TYPE=$(cat /etc/cloudstack/cmdline.json | grep type | awk '{print $2;}' | sed -e 's/[,\"]//g')
 if [ "$ROUTER_TYPE" = "router" ]
 then
 	ROUTER_STATE=$(ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
 	STATUS=$ROUTER_STATE
 else
-	ROUTER_STATE=$(ip addr | grep $INTERFACE | grep state | awk '{print $9;}')
+	ROUTER_STATE=$(ip addr | grep eth1 | grep state | awk '{print $9;}')
 	if [ "$ROUTER_STATE" = "UP" ]
 	then
 	    STATUS=MASTER

--- a/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/checkrouter.sh
@@ -19,16 +19,16 @@
 STATUS=UNKNOWN
 INTERFACE=eth1
 ROUTER_TYPE=$(cat /etc/cloudstack/cmdline.json | grep type | awk '{print $2;}' | sed -e 's/[,\"]//g')
-if [ $ROUTER_TYPE = "router" ]
+if [ "$ROUTER_TYPE" = "router" ]
 then
 	ROUTER_STATE=$(ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
 	STATUS=$ROUTER_STATE
 else
 	ROUTER_STATE=$(ip addr | grep $INTERFACE | grep state | awk '{print $9;}')
-	if [ $ROUTER_STATE = "UP" ]
+	if [ "$ROUTER_STATE" = "UP" ]
 	then
 	    STATUS=MASTER
-	elif [ $ROUTER_STATE = "DOWN" ]
+	elif [ "$ROUTER_STATE" = "DOWN" ]
 	then
 	    STATUS=BACKUP
 	fi


### PR DESCRIPTION
Added quotes to prevent syntax errors in weird situations.

Error seen in mgt server:
```
2015-12-15 14:30:32,371 DEBUG [c.c.a.m.AgentManagerImpl] (RedundantRouterStatusMonitor-7:ctx-0dd8ef3e) Details from executing class com.cloud.agent.api.CheckRouterCommand: Status: UNKNOWN
/opt/cloud/bin/checkrouter.sh: line 28: [: =: unary operator expected
/opt/cloud/bin/checkrouter.sh: line 31: [: =: unary operator expected
```
Cause:
```
root@r-1191-VM:/opt/cloud/bin# ./checkrouter.sh
./checkrouter.sh: line 28: [: =: unary operator expected
./checkrouter.sh: line 31: [: =: unary operator expected
Status: UNKNOWN
```

Somehow a nic was missing.

After fix the script can handle this:

```
root@r-1191-VM:/opt/cloud/bin# ./checkrouter.sh
Status: UNKNOWN
```

The other states are also reported fine:
```
root@r-1191-VM:/opt/cloud/bin# ./checkrouter.sh
Status: MASTER
```

```
root@r-1192-VM:/opt/cloud/bin# ./checkrouter.sh
Status: BACKUP
```

While at it, I also removed the INTERFACES variable/constant as it was only used once and hardcoded the second time. Now both are hardcoded and easier to read.

This is the same as PR #1249 except it is against `4.7`.