### PR TITLE
CLOUDSTACK-9204 Do not error when staticroute is already gone

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
@@ -23,7 +23,10 @@ def merge(dbag, staticroutes):
         key = route['ip_address']
         revoke = route['revoke']
         if revoke:
-            del dbag[key]
+            try:
+                del dbag[key]
+            except KeyError:
+                pass
         else:
             dbag[key] = route
 


### PR DESCRIPTION
When deleting a static route fails because it isn't there any more (KeyError), it should succeed instead.

Error seen:
```
[INFO] Processing JSON file static_routes.json.1451560145
Traceback (most recent call last):
File "/opt/cloud/bin/update_config.py", line 140, in <module>
process_file()
File "/opt/cloud/bin/update_config.py", line 52, in process_file
qf.load(None)
File "/opt/cloud/bin/merge.py", line 258, in load
proc = updateDataBag(self)
File "/opt/cloud/bin/merge.py", line 91, in _init_
self.process()
File "/opt/cloud/bin/merge.py", line 131, in process
dbag = self.process_staticroutes(self.db.getDataBag())
File "/opt/cloud/bin/merge.py", line 179, in process_staticroutes
return cs_staticroutes.merge(dbag, self.qFile.data)
File "/opt/cloud/bin/cs_staticroutes.py", line 26, in merge
del dbag[key]
KeyError: u'192.168.0.3'
```