### PR TITLE
CLOUDSTACK-6485 prevent ip asignment of private gw iface

### DIFF
--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1668,7 +1668,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                         // A more permanent solution would be to define a type of 'gatewaynetwork'
                         // so that handling code is not mixed between the two
                         final NetworkVO gatewaynet = _ntwkDao.findById(privateNtwk.getId());
-                        gatewaynet.setVpcId(vpcId);
+                        gatewaynet.setVpcId(null);
                         _ntwkDao.persist(gatewaynet);
                     }
 


### PR DESCRIPTION
Prevent ipaddress asignment of gateway to gateway-interface on vpc router by setting vpcid to null in network. This was fixed in 4.4 by 1f209ff226a24979cf3a43ce0c02e05c84dd4dc2, reimplemented for 4.7