### PR TITLE
CLOUDSTACK-9192: UpdateVpnCustomerGateway is failing

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -6219,7 +6219,7 @@
                                         url: createURL('updateVpnCustomerGateway'),
                                         data: data,
                                         success: function(json) {
-                                            var jobId = json.updatecustomergatewayresponse.jobid;
+                                            var jobId = json.updatevpncustomergatewayresponse.jobid;
                                             args.response.success({
                                                 _custom: {
                                                     jobId: jobId,
@@ -6231,6 +6231,9 @@
                                                     }
                                                 }
                                             });
+                                        },
+                                        error: function(json) {
+                                            args.response.error(parseXMLHttpResponse(json));
                                         }
                                     });
                                 },


### PR DESCRIPTION
Reproducible Steps:
================
1.Create a customer gateway for a VPC.
2.Edit it using UI(API call is UpdateVpnCustomerGateway).
3.When we try to update the customer vpn gateway with connection state is not in "Error", we see the API error but that won't be reflected to the user in UI.

Actual Behaviour:
==============
The API throws error. But UI doesn't show it to user.

Expected Behaviour:
================
The UI should show the error to user.

Fix:
===
TypeError: json.updatecustomergatewayresponse is undefined
The response name was wrong so corrected it.
It should be json.updatevpncustomergatewayresponse.
Added the error function.