### PR TITLE
CLOUDSTACK-9186: Root admin cannot see VPC created by Domain admin user

### DIFF
--- a/ui/scripts/vpc.js
+++ b/ui/scripts/vpc.js
@@ -748,7 +748,8 @@
                         $.ajax({
                             url: createURL('listLoadBalancers'),
                             data: {
-                                networkid: args.context.networks[0].id
+                                networkid: args.context.networks[0].id,
+                                listAll: true
                             },
                             success: function(json) {
                                 var items = json.listloadbalancersresponse.loadbalancer;
@@ -1132,7 +1133,8 @@
                             async: false,
                             data: {
                                 associatednetworkid: args.context.networks[0].id,
-                                forloadbalancing: true
+                                forloadbalancing: true,
+                                listall: true
                             },
                             success: function(json) {
                                 var items = json.listpublicipaddressesresponse.publicipaddress;


### PR DESCRIPTION
Issue:
=====
Root admin cannot see LB rules and Public LB IP addresses created by domain-admin in UI therefore root admin cannot manage those.

Reproducible Steps:
================
Log in as a Domain-Admin account and create a VPC with vpc virtual router as public load balancer provider
click on the newly created VPC -> click on the VPC tier -> click internal LB
Add internal LB,
Logoff domain-admin and login as root admin
Navigate the VPC created previously and click internal LB, internal lb is not showing up.
Same steps for Public LB IP addresses except select the correct Network offering while creating a tier.

Expected Behaviour:
================
Root admin should be able to manage VPC created by Domain admin user .

Actual Behaviour:
==============
Root admin cannot see VPC created by Domain admin user and hence not able to manage it.

Fix:
===
Added the parameter listAll=true in case of Internal LB as well as Public LB IP addresses.