### PR TITLE
CLOUDSTACK-9104: VM naming convention in case vmware is used

### DIFF
--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -3383,12 +3383,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     hostName = generateHostName(uuidName);
                 }
             }
-            // If global config vm.instancename.flag is set to true, then CS will set guest VM's name as it appears on the hypervisor, to its hostname.
-            // In case of VMware since VM name must be unique within a DC, check if VM with the same hostname already exists in the zone.
-            VMInstanceVO vmByHostName = _vmInstanceDao.findVMByHostNameInZone(hostName, zone.getId());
-            if (vmByHostName != null && vmByHostName.getState() != VirtualMachine.State.Expunging) {
-                 throw new InvalidParameterValueException("There already exists a VM by the name: " + hostName + ".");
-            }
         } else {
             if (hostName == null) {
                 //Generate name using uuid and instance.name global config


### PR DESCRIPTION
I have reverted all the changes. Now functionality is same as it was in earlier version. 
ACS  Bug Link is as follow ==>
https://issues.apache.org/jira/browse/CLOUDSTACK-9104
