### PR TITLE
CLOUDSTACK-9208: Assertion Error in VM_POWER_STATE handler- Fixed

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1256,7 +1256,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         final VirtualMachine vm = profile.getVirtualMachine();
         final StopCommand stop = new StopCommand(vm, getExecuteInSequence(vm.getHypervisorType()), checkBeforeCleanup);
         try {
-            final Answer answer = _agentMgr.send(vm.getHostId(), stop);
+            Answer answer = null;
+            if(vm.getHostId() != null) {
+                answer = _agentMgr.send(vm.getHostId(), stop);
+            }
             if (answer != null && answer instanceof StopAnswer) {
                 final StopAnswer stopAns = (StopAnswer)answer;
                 if (vm.getType() == VirtualMachine.Type.User) {


### PR DESCRIPTION
Root Cause: In the case of VM_POWER_STATE handler, if PowerOff or PowerReportMissing state is encountered, handlePowerOffReportWithNoPendingJobsOnVM() is called. If the VM is already in stopped state, so in DB the host ID is set to NULL. But in the above function, the sendStop() is still called on the empty hostID which results in the assertion error.

Fix: Added a condition in the sendStop() itself to check for the host id. 
