### PR TITLE
CLOUDSTACK-9210: Pass secondary IPs to default_network_rules() function

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -818,7 +818,7 @@ def add_network_rules(vm_name, vm_id, vm_ip, signature, seqno, vmMac, rules, vif
       execute("iptables -F " + egress_vmchain)
     except:
       logging.debug("Error flushing iptables rules for " + vmchain + ". Presuming firewall rules deleted, re-initializing." )
-      default_network_rules(vm_name, vm_id, vm_ip, vmMac, vif, brname)
+      default_network_rules(vm_name, vm_id, vm_ip, vmMac, vif, brname, sec_ips)
     egressrule = 0
     for line in lines:
         tokens = line.split(':')


### PR DESCRIPTION
This is a mandatory argument but it was NOT passed which caused the
re-programming of security groups to fail.

Simple fix to just add the argument since the variable is available
there.