### PR TITLE
Factor in inaccurancy of System.nanoTime in class Profiler

### DIFF
--- a/utils/src/test/java/com/cloud/utils/TestProfiler.java
+++ b/utils/src/test/java/com/cloud/utils/TestProfiler.java
@@ -28,9 +28,12 @@ import com.cloud.utils.testcase.Log4jEnabledTestCase;
 public class TestProfiler extends Log4jEnabledTestCase {
     protected final static Logger s_logger = Logger.getLogger(TestProfiler.class);
 
-    private static final long ONE_SECOND = 1000l;
     private static final long MILLIS_FACTOR = 1000l;
     private static final int MARGIN = 100;
+    // Profiler uses System.nanoTime which is not reliable on the millisecond
+    // A sleep of 1000 milliseconds CAN be measured as 999 milliseconds
+    // Therefore make the second larger, by 10% of the margin
+    private static final long ONE_SECOND = 1000l + (MARGIN / 10);
     private static final double EXPONENT = 3d;
 
     @Test


### PR DESCRIPTION
The time diff measurement by the class Profiler, is done by System.nanoTime().
System.nanoTime() is not 100% accurate (lots of info on this on the web). The inaccurance seems to vary/depend with different dependencies (multi-core/OS/kernels).

Problem:
In my case the code which measures `Thread.sleep(ONE_SECOND);` ~~takes~~ measures 999 milliseconds, which breaks the test expecting the sleep of 1000 milliseconds to ~~take~~ measure at least 1000 milliseconds.

Solution:
A `MARGIN` (of 100 milliseconds) is already present to factor in some time for overhead/surrounding code which adds time. Another margin could be added to factor in the possible time measurement error.
To limit additional lines of code, the constant `ONE_SECOND`, which is used by the testcase (sleep), is increased from 1000 milliseconds to `1000l + (MARGIN / 10)` (effectively 1010 milliseconds).

Thereby the inaccurancy on my system of ~1% ("faster") is caught as the `sleep(1010)` is measured as '1009' milliseconds.




