### PR TITLE
CLOUDSTACK-9221 Allow admin to see user VMs on port forwarding page

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -3526,6 +3526,8 @@
                                                     if ('vpc' in args.context) {
                                                         var data = {
                                                             //listAll: true,  //do not pass listAll to listNetworks under VPC
+                                                            domainid: args.context.vpc[0].domainid,
+                                                            account: args.context.vpc[0].account,
                                                             supportedservices: 'Lb'
                                                         };
                                                         if (args.context.ipAddresses[0].associatednetworkid == null) {
@@ -4158,6 +4160,8 @@
                                                     if ('vpc' in args.context) {
                                                         var data = {
                                                             //listAll: true,  //do not pass listAll to listNetworks under VPC
+                                                            domainid: args.context.vpc[0].domainid,
+                                                            account: args.context.vpc[0].account,
                                                             supportedservices: 'PortForwarding'
                                                         };
                                                         if (args.context.ipAddresses[0].associatednetworkid == null) {


### PR DESCRIPTION
On commit a902443708ee10acb9f68fff74af346a6a9fb370 the 'listAll=true' is removed. On some places the domainid and accountid are added but not on these. I added them now.

It's either doing this, or readding listAll is true. I've seeing other folks doing that so let's see what performs best.