### PR TITLE
NicProfileHelperImpl NullpointerException when ipVO is null

### DIFF
--- a/server/src/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/server/src/com/cloud/network/router/NicProfileHelperImpl.java
@@ -63,6 +63,7 @@ public class NicProfileHelperImpl implements NicProfileHelper {
     @DB
     public NicProfile createPrivateNicProfileForGateway(final VpcGateway privateGateway, final VirtualRouter router) {
         final Network privateNetwork = _networkModel.getNetwork(privateGateway.getNetworkId());
+
         PrivateIpVO ipVO = _privateIpDao.allocateIpAddress(privateNetwork.getDataCenterId(), privateNetwork.getId(), privateGateway.getIp4Address());
 
         final Long vpcId = privateGateway.getVpcId();
@@ -71,7 +72,11 @@ public class NicProfileHelperImpl implements NicProfileHelper {
             ipVO = _privateIpDao.findByIpAndVpcId(vpcId, privateGateway.getIp4Address());
         }
 
-        final Nic privateNic = _nicDao.findByIp4AddressAndNetworkId(ipVO.getIpAddress(), privateNetwork.getId());
+        Nic privateNic = null;
+
+        if (ipVO != null) {
+            privateNic = _nicDao.findByIp4AddressAndNetworkId(ipVO.getIpAddress(), privateNetwork.getId());
+        }
 
         NicProfile privateNicProfile = new NicProfile();
 


### PR DESCRIPTION
When a VPC has a private gateway, and one would like to restart the VPC with **cleanup** it would fail.

This PR adds a NullPointer check and verifies it with an integration test.

```
test_01_vpc_privategw_acl (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_01_vpc_privategw_acl | Status : SUCCESS ===
ok
test_02_vpc_privategw_static_routes (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_02_vpc_privategw_static_routes | Status : SUCCESS ===
ok
test_03_vpc_privategw_restart_vpc_cleanup (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_03_vpc_privategw_restart_vpc_cleanup | Status : SUCCESS ===
ok
test_04_rvpc_privategw_static_routes (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_04_rvpc_privategw_static_routes | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 4 tests in 2945.055s

OK
```

