### PR TITLE
CLOUDSTACK-9222 Prevent cloud.log.1 filling up the disk

### DIFF
--- a/systemvm/patches/debian/config/etc/logrotate.d/cloud
+++ b/systemvm/patches/debian/config/etc/logrotate.d/cloud
@@ -21,7 +21,6 @@
         missingok
         notifempty
         compress
-        delaycompress
         # CLOUDSTACK-9155: We cannot tell the processes that are writing to this
         # file to use the new inode, so instead we copy the original file, truncate
         # it and keep the same inode.


### PR DESCRIPTION
Delay Compress results in more space usage than needed. Since we have copy truncate we don't need it.