### PR TITLE
Followup fix for #1162: Add support for not (re)starting server after cloud-setup-management.

### DIFF
--- a/python/lib/cloudutils/serviceConfigServer.py
+++ b/python/lib/cloudutils/serviceConfigServer.py
@@ -138,9 +138,8 @@ class cloudManagementConfig(serviceCfgBase):
         except:
             pass
 
-        self.syscfg.svo.stopService("cloudstack-management")
-
         if self.syscfg.env.noStart == False:
+            self.syscfg.svo.stopService("cloudstack-management")
             if self.syscfg.svo.enableService("cloudstack-management"):
                 return True
             else:


### PR DESCRIPTION
This is a follow-up fix for pull request #1162, which added a `--no-start` option to cloudstack-setup-management. It is necessary for further script execution under systemd, otherwise the service aborts.