### PR TITLE
CLOUDSTACK-9229: Autoscale policy creation failing in VPC due to zone id missing in createAutoScaleVmProfile

### DIFF
--- a/ui/scripts/autoscaler.js
+++ b/ui/scripts/autoscaler.js
@@ -1116,7 +1116,7 @@
                     var apiCmd, apiCmdRes;
                     if (!('multiRules' in args.context)) { //from a new LB
                         var data = {
-                            zoneid: args.context.networks[0].zoneid, //get zoneid from args.context.networks[0] instead of args.context.ipAddresses[0] because args.context.ipAddresses is null when adding AutoScale rule from Add Load Balancer tab in Network page
+                            zoneid: args.context.networks[0].zoneid ? args.context.networks[0].zoneid : args.context.ipAddresses[0].zoneid, //get zoneid from args.context.networks[0]. If it is not null then get it from args.context.ipAddresses[0] because args.context.ipAddresses is null when adding AutoScale rule from Add Load Balancer tab in Network page
                             serviceofferingid: args.data.serviceOfferingId,
                             templateid: args.data.templateNames,
                             destroyvmgraceperiod: args.data.destroyVMgracePeriod,

--- a/ui/scripts/ui-custom/autoscaler.js
+++ b/ui/scripts/ui-custom/autoscaler.js
@@ -333,7 +333,7 @@
 
             var $loading = $('<div>').addClass('loading-overlay').appendTo($autoscalerDialog);
             $autoscalerDialog.dialog({
-                title: 'label.autoscale.configuration.wizard',
+                title: _l('label.autoscale.configuration.wizard'),
                 width: 825,
                 height: 600,
                 draggable: true,


### PR DESCRIPTION
Autoscale policy creation is failing on VPC while creating autoscalevmprofile since zoneid parameter is missing.

Steps to Reproduce:
================
1. Create VPC Network offering with NS as service provider for LB
2. Create VPC using offering which has NetScaler as LB provider
3. Add a tier using the network offering created in Step1
4. Launch a VM
5. Acquire a public IP
6. Create an auto scale policy with all required parameters on an LB rule

Result:
======
Fails during autoscalevmprofile creation with the following error:

GET  command=createAutoScaleVmProfile&response=json&serviceofferingid=05ac866f-604c-43e2-a48b-47e83ef7c4f1&templateid=3cdd83c4-ad27-11e5-9eaf-42407779c24b&destroyvmgraceperiod=30&counterparam%5B0%5D.name=snmpcommunity&counterparam%5B0%5D.value=public&counterparam%5B1%5D.name=snmpport&counterparam%5B1%5D.value=161&_=1451458073663
DEBUG [o.a.c.a.BaseCmd] (catalina-exec-10:ctx-58bcf6cf ctx-f5123e30) (logid:ae6742c8) Ignoring paremeter fordisplay as the caller is not authorized to pass it in
INFO  [c.c.a.ApiServer] (catalina-exec-10:ctx-58bcf6cf ctx-f5123e30) (logid:ae6742c8) Unable to execute API command autoscalevmprofile due to missing parameter zoneid

Expected Result:
=============
Autoscale policy creation should be successful and the "min" number of VMs specified in the policy should be deployed.

Following should be the params for autoscalevmprofile creation:
command=createAutoScaleVmProfile&response=json&zoneid=0b43fff3-c069-417b-ac0c-e4dc46b407ea&serviceofferingid=0
5ac866f-604c-43e2-a48b-47e83ef7c4f1&templateid=3cdd83c4-ad27-11e5-9eaf-42407779c24b&destroyvmgraceperiod=30&counterparam%5B0%5D
.name=snmpcommunity&counterparam%5B0%5D.value=public&counterparam%5B1%5D.name=snmpport&counterparam%5B1%5D.value=161

Fix:
===
Added a conditon to check whether the zoneid in networks is undefined,
If that is undefined, it gets the zoneid from ipaddresses argument.
Fixed a localization issue.