### PR TITLE
CLOUDSTACK-9230: Remove unnecessary return statement from cloudStack.js

### DIFF
--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -213,8 +213,6 @@
                         domainid: g_domainid
                     }
                 } : false;
-
-                return testAddUser;
             },
 
             // Actual login process, via form


### PR DESCRIPTION
Removed the unnecessary return statement.
The statement is never reached.