### PR TITLE
CLOUDSTACK-9235: Autoscale button is missing in VPC

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -3643,22 +3643,7 @@
                                                             success: function(json) {
                                                                 var networkOffering = json.listnetworkofferingsresponse.networkoffering[0];
                                                                 var services = networkOffering.service;
-                                                                if (services != null) {
-                                                                    for (var i = 0; i < services.length; i++) {
-                                                                        if (services[i].name == 'Lb') {
-                                                                            var providers = services[i].provider;
-                                                                            if (providers != null) {
-                                                                                for (var k = 0; k < providers.length; k++) {
-                                                                                    if (providers[k].name == 'Netscaler') {
-                                                                                        lbProviderIsNetscaler = true;
-                                                                                        break;
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                            break;
-                                                                        }
-                                                                    }
-                                                                }
+                                                                lbProviderIsNetscaler = checkIfNetScalerProviderIsEnabled(services);
                                                             }
                                                         });
                                                         if (lbProviderIsNetscaler == true) { //AutoScale is only supported on Netscaler (but not on any other provider like VirtualRouter)
@@ -3667,8 +3652,16 @@
                                                             return 2; //hide Autoscale button (both header and form)
                                                         }
                                                     } else { //from VPC section
-                                                        //VPC doesn't support autoscale
-                                                        return 2;
+                                                        var lbProviderIsNetscaler;
+                                                        var services = args.context.vpc[0].service;
+
+                                                        lbProviderIsNetscaler = checkIfNetScalerProviderIsEnabled(services);
+
+                                                        if (lbProviderIsNetscaler == true) { //AutoScale is only supported on Netscaler (but not on any other provider like VirtualRouter)
+                                                            return false; //show AutoScale button
+                                                        } else {
+                                                            return 2; //hide Autoscale button (both header and form)
+                                                        }
                                                     }
                                                 }
                                             },
@@ -6524,6 +6517,26 @@
             }
         }
     };
+
+    function checkIfNetScalerProviderIsEnabled(services) {
+        if (services != null) {
+            for (var i = 0; i < services.length; i++) {
+                if (services[i].name == 'Lb') {
+                    var providers = services[i].provider;
+                    if (providers != null) {
+                        for (var k = 0; k < providers.length; k++) {
+                            if (providers[k].name == 'Netscaler') {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+            }
+        }
+
+        return false;
+    }
 
     function getExtaPropertiesForIpObj(ipObj, args) {
         if (!('vpc' in args.context)) { //***** Guest Network section > Guest Network page > IP Address page *****


### PR DESCRIPTION
Autoscale button is missing. This should not be the case since we are able to add NS as the external LB provider in VPC.

Steps:
=====
1. Create a VPC offering with NS as the external LB provider
2. Create a VPC and configure the public tier with the above offering
3. Acquire an IP address and try to configure Load Balancing rule

Result:
======
Autoscale option is not visible at all for the LB.

Expected Result:
=============
Autoscale option should be available and should work exactly like the way it works for a normal isolated network with NS. If we choose NS as service provider for LB, autoscale should also be visible. If VR is chosen, only then we should not display autoscale.

Fix:
===
In case of VPC, it checks the services available.
If LB is there, It checks the provider is Netscaler then it shows the button or hides it.