### PR TITLE
CLOUDSTACK-9236: Load Balancing Health Check button displayed when non-NetScaler offering is used

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -3620,7 +3620,37 @@
                                                     requireValidation: true,
                                                     buttonLabel: 'Configure',
                                                     action: cloudStack.uiCustom.healthCheck()
-
+                                                },
+                                                isHidden: function(args) {
+                                                    if (!('vpc' in args.context)) {  //From Guest Network section
+                                                        var lbProviderIsNetscaler = false;
+                                                        $.ajax({
+                                                            url: createURL('listNetworkOfferings'),
+                                                            data: {
+                                                                id: args.context.networks[0].networkofferingid
+                                                            },
+                                                            async: false,
+                                                            success: function(json) {
+                                                                var networkOffering = json.listnetworkofferingsresponse.networkoffering[0];
+                                                                var services = networkOffering.service;
+                                                                lbProviderIsNetscaler = checkIfNetScalerProviderIsEnabled(services);
+                                                            }
+                                                        });
+                                                        if (lbProviderIsNetscaler == true) { //Health-Check is only supported on Netscaler (but not on any other provider)
+                                                            return false; //Show Health-Check button
+                                                        } else {
+                                                            return 2; //Hide Health-Check button (Both Header and Form)
+                                                        }
+                                                    } else { //From VPC section
+                                                        var lbProviderIsNetscaler;
+                                                        var services = args.context.vpc[0].service;
+                                                        lbProviderIsNetscaler = checkIfNetScalerProviderIsEnabled(services);
+                                                        if (lbProviderIsNetscaler == true) { //Health-Check is only supported on Netscaler (but not on any other provider)
+                                                            return false; //Show Health-Check button
+                                                        } else {
+                                                            return 2; //Hide Health-Check button (both Header and Form)
+                                                        }
+                                                    }
                                                 }
                                             },
 
@@ -6524,6 +6554,26 @@
             }
         }
     };
+
+    function checkIfNetScalerProviderIsEnabled(services) {
+        if (services != null) {
+            for (var i = 0; i < services.length; i++) {
+                if (services[i].name == 'Lb') {
+                    var providers = services[i].provider;
+                    if (providers != null) {
+                        for (var k = 0; k < providers.length; k++) {
+                            if (providers[k].name == 'Netscaler') {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+            }
+        }
+
+        return false;
+    }
 
     function getExtaPropertiesForIpObj(ipObj, args) {
         if (!('vpc' in args.context)) { //***** Guest Network section > Guest Network page > IP Address page *****


### PR DESCRIPTION
Load balancing health check option / button should only be displayed when a NetScaler based networking offering is being used. 

If you try to use the health check option when NetScaler is not being used as the load balancing technology the UI throws an error stating that the health check option is not supported. 

This button / option should be removed from the UI if NetScaler is not included in the network offering as customers will be confused. 

Fix:
===
This button will be shown only when the load balancer is NetScaler.
Otherwise it is hidden.