### PR TITLE
CLOUDSTACK-9237: Create LB Healthcheck issues - button alignment and error message goes outside the window

### DIFF
--- a/server/src/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -596,7 +596,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
          */
         if (!validateHealthCheck(cmd)) {
             throw new InvalidParameterValueException(
-                "Failed to create HealthCheck policy: Validation Failed (HealthCheck Policy is not supported by LB Provider for the LB rule id :)" + cmd.getLbRuleId());
+                "Failed to create HealthCheck policy: Validation Failed (HealthCheck Policy is not supported by LB Provider for the LB rule id :" + cmd.getLbRuleId() + ")");
         }
 
         /* Validation : check for the multiple hc policies to the rule id */

--- a/ui/scripts/ui-custom/healthCheck.js
+++ b/ui/scripts/ui-custom/healthCheck.js
@@ -35,9 +35,9 @@
             var topFieldForm, bottomFieldForm, $topFieldForm, $bottomFieldForm;
             var topfields = forms.topFields;
 
-            var $healthCheckDesc = $('<div>' + 'label.health.check.message.desc' + '</div>').addClass('health-check-description');
-            var $healthCheckConfigTitle = $('<div><br><br>' + 'label.health.check.configurations.options' + '</div>').addClass('health-check-config-title');
-            var $healthCheckAdvancedTitle = $('<div><br><br>' + 'label.health.check.advanced.options' + '</div>').addClass('health-check-advanced-title');
+            var $healthCheckDesc = $('<div>' + _l('label.health.check.message.desc') + '</div>').addClass('health-check-description');
+            var $healthCheckConfigTitle = $('<div><br><br>' + _l('label.health.check.configurations.options') + '</div>').addClass('health-check-config-title');
+            var $healthCheckAdvancedTitle = $('<div><br><br>' + _l('label.health.check.advanced.options') + '</div>').addClass('health-check-advanced-title');
 
             var $healthCheckDialog = $('<div>').addClass('health-check');
             $healthCheckDialog.append($healthCheckDesc);
@@ -200,7 +200,7 @@
                             error: function(json) {
 
                                 cloudStack.dialog.notice({
-                                    message: _s(json.responseText)
+                                    message: parseXMLHttpResponse(json)
                                 }); //Error message in the API needs to be improved
                                 $healthCheckDialog.dialog('close');
                                 $('.overlay').remove();
@@ -361,8 +361,8 @@
             }
 
             $healthCheckDialog.dialog({
-                title: 'label.health.check.wizard',
-                width: 600,
+                title: _l('label.health.check.wizard'),
+                width: 630,
                 height: 600,
                 draggable: true,
                 closeonEscape: false,


### PR DESCRIPTION
Browser - Chrome Version 47.0.2526.106 m

Steps to Repro:
============
Open up - Network-Guest Networks -> IP Addresses-> IP<Static NAT> -> Load Balancing
- click on the "Configure" button below the healthcheck, 
- opens a "label.heath.check.wizard"

Issues:
======
(1) Please see the snapshot attached
- leave the default values as is and click on the "Create" 
- opens a "Status" dialog with an error message

(2) Message on the dialog goes outside the window

Fix:
===
Increased the size of width of dialog box.
Json response parsing was missing. Added it.

Snapshot for Error Message Issue:
===========================
![error_message_details](https://cloud.githubusercontent.com/assets/12583725/12320920/52dbd3d0-bad1-11e5-9ce1-0fbdd2203b60.png)

Snapshot of the fix:
===============
<img width="627" alt="fixed_ss1_nitin" src="https://cloud.githubusercontent.com/assets/12583725/12320935/76613368-bad1-11e5-8540-cbd565edff9f.png">

Snapshot for out of window issue:
==========================
![label_health_check_window](https://cloud.githubusercontent.com/assets/12583725/12320952/8f3d3062-bad1-11e5-9b85-4743d286921e.png)

Snapshot of the fix:
===============
<img width="695" alt="fixed_ss2_nitin" src="https://cloud.githubusercontent.com/assets/12583725/12320970/a3f7e2ae-bad1-11e5-8a9c-d2811aa6effc.png">
