### PR TITLE
CLOUDSTACK-9238: Increase URL fields to 2048 charachters from 255

### DIFF
--- a/setup/db/db/schema-471to480.sql
+++ b/setup/db/db/schema-471to480.sql
@@ -20,3 +20,10 @@
 --;
 
 ALTER TABLE `cloud`.`nicira_nvp_router_map` DROP INDEX `logicalrouter_uuid` ;
+
+ALTER TABLE `cloud`.`volume_host_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`object_datastore_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`image_store` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`template_store_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`volume_store_ref` MODIFY COLUMN `url` varchar(2048);
+ALTER TABLE `cloud`.`volume_store_ref` MODIFY COLUMN `download_url` varchar(2048);


### PR DESCRIPTION
255 characters is to small for various URLs like S3 pre-signed URLs.

This causes one or more characters to be chopped of the end of the URL
and this renders them useless.

Internally in the code all URLs are passed as Strings and they are not
sized limited. This was purely in the database.

Other URL fields in the database were already 2048 characters.

This limit was introduced in the 4.1 to 4.2 upgrade when Object storage
like S3 and Swift was introduced in CloudStack for Secondary Storage.