### PR TITLE
CLOUDSTACK-9240 remove 40GB filesize limit from SSVM scripts

### DIFF
--- a/scripts/storage/secondary/createtmplt.sh
+++ b/scripts/storage/secondary/createtmplt.sh
@@ -27,7 +27,6 @@ usage() {
 
 
 #set -x
-ulimit -f 41943040 #40GiB in blocks
 ulimit -c 0
 
 rollback_if_needed() {

--- a/scripts/storage/secondary/createvolume.sh
+++ b/scripts/storage/secondary/createvolume.sh
@@ -27,7 +27,6 @@ usage() {
 
 
 #set -x
-ulimit -f 41943040 #40GiB in blocks
 ulimit -c 0
 
 rollback_if_needed() {


### PR DESCRIPTION
Both createvolume.sh and createtmplt.sh have a 40GB hardcoded limit for the size of the template that gets created. I could not find any justification of that. I am just removing them as they caused us a huge headache when we tried to create bigger templates and they failed without any good error.

This closes #1223 (This PR was against master, made a new one against 4.7)

Thanks Syed <syed1.mushtaq@gmail.com>