### PR TITLE
Fix cloud-cli references after PR 1228

### DIFF
--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -103,7 +103,6 @@ Obsoletes: cloud-core < 4.1.0
 Obsoletes: cloud-deps < 4.1.0
 Obsoletes: cloud-python < 4.1.0
 Obsoletes: cloud-setup < 4.1.0
-Obsoletes: cloud-cli < 4.1.0
 Obsoletes: cloud-daemonize < 4.1.0
 Group:   System Environment/Libraries
 %description common
@@ -339,10 +338,6 @@ install -D usage/target/transformed/log4j-cloud_usage.xml ${RPM_BUILD_ROOT}%{_sy
 cp usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
 install -D packaging/centos63/cloud-usage.rc ${RPM_BUILD_ROOT}/%{_sysconfdir}/init.d/%{name}-usage
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
-
-# CLI
-cp -r cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
-install cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
 
 # MYSQL HA
 if [ "x%{_ossnoss}" == "xnoredist" ] ; then

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -312,10 +312,6 @@ cp usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
 install -D packaging/systemd/cloudstack-usage.service ${RPM_BUILD_ROOT}%{_unitdir}/%{name}-usage.service
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
 
-# CLI
-cp -r cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
-install cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
-
 # MYSQL HA
 if [ "x%{_ossnoss}" == "xnoredist" ] ; then
   mkdir -p ${RPM_BUILD_ROOT}%{_datadir}/%{name}-mysql-ha/lib

--- a/packaging/fedora20/cloud.spec
+++ b/packaging/fedora20/cloud.spec
@@ -103,7 +103,6 @@ Obsoletes: cloud-core < 4.1.0
 Obsoletes: cloud-deps < 4.1.0
 Obsoletes: cloud-python < 4.1.0
 Obsoletes: cloud-setup < 4.1.0
-Obsoletes: cloud-cli < 4.1.0
 Obsoletes: cloud-daemonize < 4.1.0
 Group:   System Environment/Libraries
 %description common
@@ -338,10 +337,6 @@ install -D usage/target/transformed/log4j-cloud_usage.xml ${RPM_BUILD_ROOT}%{_sy
 cp usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
 install -D packaging/centos63/cloud-usage.rc ${RPM_BUILD_ROOT}/%{_sysconfdir}/init.d/%{name}-usage
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
-
-# CLI
-cp -r cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
-install cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
 
 # MYSQL HA
 if [ "x%{_ossnoss}" == "xnoredist" ] ; then

--- a/packaging/fedora21/cloud.spec
+++ b/packaging/fedora21/cloud.spec
@@ -103,7 +103,6 @@ Obsoletes: cloud-core < 4.1.0
 Obsoletes: cloud-deps < 4.1.0
 Obsoletes: cloud-python < 4.1.0
 Obsoletes: cloud-setup < 4.1.0
-Obsoletes: cloud-cli < 4.1.0
 Obsoletes: cloud-daemonize < 4.1.0
 Group:   System Environment/Libraries
 %description common
@@ -338,10 +337,6 @@ install -D usage/target/transformed/log4j-cloud_usage.xml ${RPM_BUILD_ROOT}%{_sy
 cp usage/target/dependencies/* ${RPM_BUILD_ROOT}%{_datadir}/%{name}-usage/lib/
 install -D packaging/centos63/cloud-usage.rc ${RPM_BUILD_ROOT}/%{_sysconfdir}/init.d/%{name}-usage
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/usage/
-
-# CLI
-cp -r cloud-cli/cloudtool ${RPM_BUILD_ROOT}%{python_sitearch}/
-install cloud-cli/cloudapis/cloud.py ${RPM_BUILD_ROOT}%{python_sitearch}/cloudapis.py
 
 # MYSQL HA
 if [ "x%{_ossnoss}" == "xnoredist" ] ; then


### PR DESCRIPTION
After merging PR #1228, building RPM packages results in problems:

```
+ cp -r cloud-cli/cloudtool /data/git/cs2/cloudstack/dist/rpmbuild/BUILDROOT/cloudstack-4.8.0-SNAPSHOT.el7.centos.x86_64/usr/lib64/python2.7/site-packages/
cp: cannot stat ‘cloud-cli/cloudtool’: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.n1gFxV (%install)

RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.n1gFxV (%install)
RPM Build Failed 
Sun Jan 17 20:14:45 GMT 2016
```