### PR TITLE
CLOUDSTACK-9239 throw exception on deprecated command

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/account/LockAccountCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/account/LockAccountCmd.java
@@ -16,7 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.account;
 
-import org.apache.log4j.Logger;
+import java.util.logging.Logger;
 
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
@@ -26,9 +26,14 @@ import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
 
 import com.cloud.user.Account;
+import com.cloud.utils.exception.CloudRuntimeException;
 
-@APICommand(name = "lockAccount", description = "Locks an account", responseObject = AccountResponse.class, entityType = {Account.class},
-        requestHasSensitiveInfo = false, responseHasSensitiveInfo = true)
+@APICommand(name = "lockAccount",
+            description = "This deprecated function used to locks an account. Look for the API DisableAccount instead",
+            responseObject = AccountResponse.class,
+            entityType = {Account.class},
+            requestHasSensitiveInfo = false,
+            responseHasSensitiveInfo = true)
 public class LockAccountCmd extends BaseCmd {
     public static final Logger s_logger = Logger.getLogger(LockAccountCmd.class.getName());
 
@@ -71,7 +76,7 @@ public class LockAccountCmd extends BaseCmd {
 
     @Override
     public long getEntityOwnerId() {
-        Account account = _accountService.getActiveAccountByName(getAccountName(), getDomainId());
+        final Account account = _accountService.getActiveAccountByName(getAccountName(), getDomainId());
         if (account != null) {
             return account.getAccountId();
         }
@@ -81,14 +86,6 @@ public class LockAccountCmd extends BaseCmd {
 
     @Override
     public void execute() {
-//        Account result = null;
-        //result = _accountService.lockAccount(this);
-//        if (result != null){
-//            AccountResponse response = _responseGenerator.createAccountResponse(result);
-//            response.setResponseName(getCommandName());
-//            this.setResponseObject(response);
-//        } else {
-//            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to lock account");
-//        }
+        throw new CloudRuntimeException("LockAccount does not lock accounts. Its implementation is disabled. Use DisableAccount instead");
     }
 }


### PR DESCRIPTION
an API call to LockAccount fails silently with a 200 return and no contents. client are responsible to check and will find that no locking has actually occured. This way they may be lured to a sense of false security.
Throwing an exption makes the failure explicit.
cloudmonkey lock account name=<name> domainid=<id>
now errors out with an http result of 530