### PR TITLE
[4.9] CLOUDSTACK-8958: release dedicated ip range in domain removal

### DIFF
--- a/engine/components-api/src/com/cloud/configuration/ConfigurationManager.java
+++ b/engine/components-api/src/com/cloud/configuration/ConfigurationManager.java
@@ -219,6 +219,20 @@ public interface ConfigurationManager {
 
     void createDefaultSystemNetworks(long zoneId) throws ConcurrentOperationException;
 
+    /**
+     * Release dedicated virtual ip ranges of a domain.
+     *
+     * @param domainId
+     * @return success/failure
+     */
+    boolean releaseDomainSpecificVirtualRanges(long domainId);
+
+    /**
+     * Release dedicated virtual ip ranges of an account.
+     *
+     * @param accountId
+     * @return success/failure
+     */
     boolean releaseAccountSpecificVirtualRanges(long accountId);
 
     /**

--- a/engine/schema/src/com/cloud/domain/DomainVO.java
+++ b/engine/schema/src/com/cloud/domain/DomainVO.java
@@ -103,6 +103,10 @@ public class DomainVO implements Domain {
         return id;
     }
 
+    public void setId(long id) {
+        this.id = id;
+    }
+
     @Override
     public Long getParent() {
         return parent;
@@ -133,6 +137,10 @@ public class DomainVO implements Domain {
     @Override
     public long getAccountId() {
         return accountId;
+    }
+
+    public void setAccountId(long accountId) {
+        this. accountId= accountId;
     }
 
     @Override

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -84,6 +84,7 @@ import org.apache.cloudstack.region.dao.RegionDao;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.commons.collections.CollectionUtils;
 
 import com.cloud.alert.AlertManager;
 import com.cloud.api.ApiDBUtils;
@@ -4930,6 +4931,32 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         sc.addAnd("systemOnly", SearchCriteria.Op.EQ, systemOnly);
 
         return _networkOfferingDao.search(sc, searchFilter);
+    }
+
+     @Override
+     @DB
+     public boolean releaseDomainSpecificVirtualRanges(final long domainId) {
+        final List<DomainVlanMapVO> maps = _domainVlanMapDao.listDomainVlanMapsByDomain(domainId);
+        if (CollectionUtils.isNotEmpty(maps)) {
+            try {
+                Transaction.execute(new TransactionCallbackNoReturn() {
+                    @Override
+                    public void doInTransactionWithoutResult(final TransactionStatus status) {
+                        for (DomainVlanMapVO map : maps) {
+                            if (!releasePublicIpRange(map.getVlanDbId(), _accountMgr.getSystemUser().getId(), _accountMgr.getAccount(Account.ACCOUNT_ID_SYSTEM))) {
+                                throw new CloudRuntimeException("Failed to release domain specific virtual ip ranges for domain id=" + domainId);
+                            }
+                        }
+                    }
+                });
+            } catch (final CloudRuntimeException e) {
+                s_logger.error(e);
+                return false;
+            }
+        } else {
+            s_logger.trace("Domain id=" + domainId + " has no domain specific virtual ip ranges, nothing to release");
+        }
+        return true;
     }
 
     @Override

--- a/server/src/com/cloud/user/DomainManagerImpl.java
+++ b/server/src/com/cloud/user/DomainManagerImpl.java
@@ -35,6 +35,7 @@ import org.apache.cloudstack.framework.messagebus.MessageBus;
 import org.apache.cloudstack.framework.messagebus.PublishScope;
 import org.apache.cloudstack.region.RegionManager;
 
+import com.cloud.configuration.ConfigurationManager;
 import com.cloud.configuration.Resource.ResourceOwnerType;
 import com.cloud.configuration.ResourceLimit;
 import com.cloud.configuration.dao.ResourceCountDao;
@@ -105,6 +106,8 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
     private NetworkOrchestrationService _networkMgr;
     @Inject
     private NetworkDomainDao _networkDomainDao;
+    @Inject
+    private ConfigurationManager _configMgr;
 
     @Inject
     MessageBus _messageBus;
@@ -324,6 +327,14 @@ public class DomainManagerImpl extends ManagerBase implements DomainManager, Dom
                     e.addProxyObject(domain.getUuid(), "domainId");
                     throw e;
                 }
+            }
+
+            if (!_configMgr.releaseDomainSpecificVirtualRanges(domain.getId())) {
+                CloudRuntimeException e = new CloudRuntimeException("Can't delete the domain yet because failed to release domain specific virtual ip ranges");
+                e.addProxyObject(domain.getUuid(), "domainId");
+                throw e;
+            } else {
+                s_logger.debug("Domain specific Virtual IP ranges " + " are successfully released as a part of domain id=" + domain.getId() + " cleanup.");
             }
 
             cleanupDomainOfferings(domain.getId());

--- a/server/test/com/cloud/vpc/MockConfigurationManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockConfigurationManagerImpl.java
@@ -456,7 +456,16 @@ public class MockConfigurationManagerImpl extends ManagerBase implements Configu
     }
 
     /* (non-Javadoc)
-     * @see com.cloud.configuration.ConfigurationManager#deleteAccountSpecificVirtualRanges(long)
+     * @see com.cloud.configuration.ConfigurationManager#releaseDomainSpecificVirtualRanges(long)
+     */
+    @Override
+    public boolean releaseDomainSpecificVirtualRanges(long domainId) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see com.cloud.configuration.ConfigurationManager#releaseAccountSpecificVirtualRanges(long)
      */
     @Override
     public boolean releaseAccountSpecificVirtualRanges(long accountId) {


### PR DESCRIPTION
We are able to assign didacated vlan ip ranges after the merge of CLOUDSTACK-8958.
These ip ranges need to be released automatically when we delete a domain.
