### PR TITLE
CLOUDSTACK-9245 - Cannot delete non-attached ACL that contains items

### DIFF
--- a/api/src/com/cloud/network/vpc/NetworkACLService.java
+++ b/api/src/com/cloud/network/vpc/NetworkACLService.java
@@ -96,9 +96,8 @@ public interface NetworkACLService {
     Pair<List<? extends NetworkACLItem>, Integer> listNetworkACLItems(ListNetworkACLsCmd cmd);
 
     /**
-     * Revoked ACL Item with specified Id
+     * Revoke ACL Item with specified Id
      * @param ruleId
-     * @param apply
      * @return
      */
     boolean revokeNetworkACLItem(long ruleId);
@@ -121,7 +120,7 @@ public interface NetworkACLService {
      * @throws ResourceUnavailableException
      */
     NetworkACLItem updateNetworkACLItem(Long id, String protocol, List<String> sourceCidrList, NetworkACLItem.TrafficType trafficType, String action, Integer number,
-        Integer sourcePortStart, Integer sourcePortEnd, Integer icmpCode, Integer icmpType, String newUUID, Boolean forDisplay) throws ResourceUnavailableException;
+            Integer sourcePortStart, Integer sourcePortEnd, Integer icmpCode, Integer icmpType, String newUUID, Boolean forDisplay) throws ResourceUnavailableException;
 
     /**
      * Associates ACL with specified Network

--- a/server/src/com/cloud/network/vpc/NetworkACLManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/NetworkACLManagerImpl.java
@@ -86,8 +86,8 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     MessageBus _messageBus;
 
     @Override
-    public NetworkACL createNetworkACL(String name, String description, long vpcId, Boolean forDisplay) {
-        NetworkACLVO acl = new NetworkACLVO(name, description, vpcId);
+    public NetworkACL createNetworkACL(final String name, final String description, final long vpcId, final Boolean forDisplay) {
+        final NetworkACLVO acl = new NetworkACLVO(name, description, vpcId);
         if (forDisplay != null) {
             acl.setDisplay(forDisplay);
         }
@@ -95,23 +95,23 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public boolean applyNetworkACL(long aclId) throws ResourceUnavailableException {
+    public boolean applyNetworkACL(final long aclId) throws ResourceUnavailableException {
         boolean handled = true;
         boolean aclApplyStatus = true;
 
-        List<NetworkACLItemVO> rules = _networkACLItemDao.listByACL(aclId);
+        final List<NetworkACLItemVO> rules = _networkACLItemDao.listByACL(aclId);
         //Find all networks using this ACL and apply the ACL
-        List<NetworkVO> networks = _networkDao.listByAclId(aclId);
-        for (NetworkVO network : networks) {
+        final List<NetworkVO> networks = _networkDao.listByAclId(aclId);
+        for (final NetworkVO network : networks) {
             if (!applyACLItemsToNetwork(network.getId(), rules)) {
                 handled = false;
                 break;
             }
         }
 
-        List<VpcGatewayVO> vpcGateways = _vpcGatewayDao.listByAclIdAndType(aclId, VpcGateway.Type.Private);
-        for (VpcGatewayVO vpcGateway : vpcGateways) {
-            PrivateGateway privateGateway = _vpcSvc.getVpcPrivateGateway(vpcGateway.getId());
+        final List<VpcGatewayVO> vpcGateways = _vpcGatewayDao.listByAclIdAndType(aclId, VpcGateway.Type.Private);
+        for (final VpcGatewayVO vpcGateway : vpcGateways) {
+            final PrivateGateway privateGateway = _vpcSvc.getVpcPrivateGateway(vpcGateway.getId());
 
             if (!applyACLToPrivateGw(privateGateway)) {
                 aclApplyStatus = false;
@@ -121,11 +121,11 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         }
 
         if (handled && aclApplyStatus) {
-            for (NetworkACLItem rule : rules) {
+            for (final NetworkACLItem rule : rules) {
                 if (rule.getState() == NetworkACLItem.State.Revoke) {
                     removeRule(rule);
                 } else if (rule.getState() == NetworkACLItem.State.Add) {
-                    NetworkACLItemVO ruleVO = _networkACLItemDao.findById(rule.getId());
+                    final NetworkACLItemVO ruleVO = _networkACLItemDao.findById(rule.getId());
                     ruleVO.setState(NetworkACLItem.State.Active);
                     _networkACLItemDao.update(ruleVO.getId(), ruleVO);
                 }
@@ -135,23 +135,18 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public NetworkACL getNetworkACL(long id) {
+    public NetworkACL getNetworkACL(final long id) {
         return _networkACLDao.findById(id);
     }
 
     @Override
-    public boolean deleteNetworkACL(NetworkACL acl) {
-        List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(acl.getId());
-        if (aclItems.size() > 0) {
-            throw new CloudRuntimeException("ACL is not empty. Cannot delete network ACL: " + acl.getUuid());
-        }
-
-        List<NetworkVO> networks = _networkDao.listByAclId(acl.getId());
+    public boolean deleteNetworkACL(final NetworkACL acl) {
+        final List<NetworkVO> networks = _networkDao.listByAclId(acl.getId());
         if (networks != null && networks.size() > 0) {
             throw new CloudRuntimeException("ACL is still associated with " + networks.size() + " tier(s). Cannot delete network ACL: " + acl.getUuid());
         }
 
-        List<VpcGatewayVO> pvtGateways = _vpcGatewayDao.listByAclIdAndType(acl.getId(), VpcGateway.Type.Private);
+        final List<VpcGatewayVO> pvtGateways = _vpcGatewayDao.listByAclIdAndType(acl.getId(), VpcGateway.Type.Private);
 
         if (pvtGateways != null && pvtGateways.size() > 0) {
             throw new CloudRuntimeException("ACL is still associated with " + pvtGateways.size() + " private gateway(s). Cannot delete network ACL: " + acl.getUuid());
@@ -161,9 +156,9 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public boolean replaceNetworkACLForPrivateGw(NetworkACL acl, PrivateGateway gateway) throws ResourceUnavailableException {
-        VpcGatewayVO vpcGatewayVo = _vpcGatewayDao.findById(gateway.getId());
-        List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(acl.getId());
+    public boolean replaceNetworkACLForPrivateGw(final NetworkACL acl, final PrivateGateway gateway) throws ResourceUnavailableException {
+        final VpcGatewayVO vpcGatewayVo = _vpcGatewayDao.findById(gateway.getId());
+        final List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(acl.getId());
         if (aclItems == null || aclItems.isEmpty()) {
             //Revoke ACL Items of the existing ACL if the new network acl is empty
             //Other wise existing rules will not be removed on the router elelment
@@ -182,9 +177,9 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public boolean replaceNetworkACL(NetworkACL acl, NetworkVO network) throws ResourceUnavailableException {
+    public boolean replaceNetworkACL(final NetworkACL acl, final NetworkVO network) throws ResourceUnavailableException {
 
-        NetworkOffering guestNtwkOff = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
+        final NetworkOffering guestNtwkOff = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
 
         if (guestNtwkOff == null) {
             throw new InvalidParameterValueException("Can't find network offering associated with network: " + network.getUuid());
@@ -198,7 +193,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         if (network.getNetworkACLId() != null) {
             //Revoke ACL Items of the existing ACL if the new ACL is empty
             //Existing rules won't be removed otherwise
-            List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(acl.getId());
+            final List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(acl.getId());
             if (aclItems == null || aclItems.isEmpty()) {
                 s_logger.debug("New network ACL is empty. Revoke existing rules before applying ACL");
                 if (!revokeACLItemsForNetwork(network.getId())) {
@@ -212,7 +207,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         if (_networkDao.update(network.getId(), network)) {
             s_logger.debug("Updated network: " + network.getId() + " with Network ACL Id: " + acl.getId() + ", Applying ACL items");
             //Apply ACL to network
-            Boolean result = applyACLToNetwork(network.getId());
+            final Boolean result = applyACLToNetwork(network.getId());
             if (result) {
                 // public message on message bus, so that network elements implementing distributed routing capability
                 // can act on the event
@@ -234,16 +229,16 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         }
 
         final Integer numberFinal = number;
-        NetworkACLItemVO newRule = Transaction.execute(new TransactionCallback<NetworkACLItemVO>() {
+        final NetworkACLItemVO newRule = Transaction.execute(new TransactionCallback<NetworkACLItemVO>() {
             @Override
-            public NetworkACLItemVO doInTransaction(TransactionStatus status) {
+            public NetworkACLItemVO doInTransaction(final TransactionStatus status) {
                 NetworkACLItem.Action ruleAction = NetworkACLItem.Action.Allow;
                 if ("deny".equalsIgnoreCase(action)) {
                     ruleAction = NetworkACLItem.Action.Deny;
                 }
 
                 NetworkACLItemVO newRule =
-                    new NetworkACLItemVO(portStart, portEnd, protocol.toLowerCase(), aclId, sourceCidrList, icmpCode, icmpType, trafficType, ruleAction, numberFinal);
+                        new NetworkACLItemVO(portStart, portEnd, protocol.toLowerCase(), aclId, sourceCidrList, icmpCode, icmpType, trafficType, ruleAction, numberFinal);
 
                 if (forDisplay != null) {
                     newRule.setDisplay(forDisplay);
@@ -264,14 +259,14 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public NetworkACLItem getNetworkACLItem(long ruleId) {
+    public NetworkACLItem getNetworkACLItem(final long ruleId) {
         return _networkACLItemDao.findById(ruleId);
     }
 
     @Override
-    public boolean revokeNetworkACLItem(long ruleId) {
+    public boolean revokeNetworkACLItem(final long ruleId) {
 
-        NetworkACLItemVO rule = _networkACLItemDao.findById(ruleId);
+        final NetworkACLItemVO rule = _networkACLItemDao.findById(ruleId);
 
         revokeRule(rule);
 
@@ -280,7 +275,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         try {
             applyNetworkACL(rule.getAclId());
             success = true;
-        } catch (ResourceUnavailableException e) {
+        } catch (final ResourceUnavailableException e) {
             return false;
         }
 
@@ -288,7 +283,7 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @DB
-    private void revokeRule(NetworkACLItemVO rule) {
+    private void revokeRule(final NetworkACLItemVO rule) {
         if (rule.getState() == State.Staged) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Found a rule that is still in stage state so just removing it: " + rule);
@@ -301,12 +296,12 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public boolean revokeACLItemsForNetwork(long networkId) throws ResourceUnavailableException {
-        Network network = _networkDao.findById(networkId);
+    public boolean revokeACLItemsForNetwork(final long networkId) throws ResourceUnavailableException {
+        final Network network = _networkDao.findById(networkId);
         if (network.getNetworkACLId() == null) {
             return true;
         }
-        List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(network.getNetworkACLId());
+        final List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(network.getNetworkACLId());
         if (aclItems.isEmpty()) {
             s_logger.debug("Found no network ACL Items for network id=" + networkId);
             return true;
@@ -316,14 +311,14 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
             s_logger.debug("Releasing " + aclItems.size() + " Network ACL Items for network id=" + networkId);
         }
 
-        for (NetworkACLItemVO aclItem : aclItems) {
+        for (final NetworkACLItemVO aclItem : aclItems) {
             // Mark all Network ACLs rules as Revoke, but don't update in DB
             if (aclItem.getState() == State.Add || aclItem.getState() == State.Active) {
                 aclItem.setState(State.Revoke);
             }
         }
 
-        boolean success = applyACLItemsToNetwork(network.getId(), aclItems);
+        final boolean success = applyACLItemsToNetwork(network.getId(), aclItems);
 
         if (s_logger.isDebugEnabled() && success) {
             s_logger.debug("Successfully released Network ACLs for network id=" + networkId + " and # of rules now = " + aclItems.size());
@@ -333,9 +328,9 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public boolean revokeACLItemsForPrivateGw(PrivateGateway gateway) throws ResourceUnavailableException {
+    public boolean revokeACLItemsForPrivateGw(final PrivateGateway gateway) throws ResourceUnavailableException {
 
-        List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(gateway.getNetworkACLId());
+        final List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(gateway.getNetworkACLId());
         if (aclItems.isEmpty()) {
             s_logger.debug("Found no network ACL Items for private gateway  id=" + gateway.getId());
             return true;
@@ -345,14 +340,14 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
             s_logger.debug("Releasing " + aclItems.size() + " Network ACL Items for private gateway  id=" + gateway.getId());
         }
 
-        for (NetworkACLItemVO aclItem : aclItems) {
+        for (final NetworkACLItemVO aclItem : aclItems) {
             // Mark all Network ACLs rules as Revoke, but don't update in DB
             if (aclItem.getState() == State.Add || aclItem.getState() == State.Active) {
                 aclItem.setState(State.Revoke);
             }
         }
 
-        boolean success = applyACLToPrivateGw(gateway, aclItems);
+        final boolean success = applyACLToPrivateGw(gateway, aclItems);
 
         if (s_logger.isDebugEnabled() && success) {
             s_logger.debug("Successfully released Network ACLs for private gateway id=" + gateway.getId() + " and # of rules now = " + aclItems.size());
@@ -362,27 +357,27 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Override
-    public List<NetworkACLItemVO> listNetworkACLItems(long guestNtwkId) {
-        Network network = _networkMgr.getNetwork(guestNtwkId);
+    public List<NetworkACLItemVO> listNetworkACLItems(final long guestNtwkId) {
+        final Network network = _networkMgr.getNetwork(guestNtwkId);
         if (network.getNetworkACLId() == null) {
             return null;
         }
         return _networkACLItemDao.listByACL(network.getNetworkACLId());
     }
 
-    private void removeRule(NetworkACLItem rule) {
+    private void removeRule(final NetworkACLItem rule) {
         //remove the rule
         _networkACLItemDao.remove(rule.getId());
     }
 
     @Override
-    public boolean applyACLToPrivateGw(PrivateGateway gateway) throws ResourceUnavailableException {
-        VpcGatewayVO vpcGatewayVO = _vpcGatewayDao.findById(gateway.getId());
-        List<? extends NetworkACLItem> rules = _networkACLItemDao.listByACL(vpcGatewayVO.getNetworkACLId());
+    public boolean applyACLToPrivateGw(final PrivateGateway gateway) throws ResourceUnavailableException {
+        final VpcGatewayVO vpcGatewayVO = _vpcGatewayDao.findById(gateway.getId());
+        final List<? extends NetworkACLItem> rules = _networkACLItemDao.listByACL(vpcGatewayVO.getNetworkACLId());
         return applyACLToPrivateGw(gateway, rules);
     }
 
-    private boolean applyACLToPrivateGw(PrivateGateway gateway, List<? extends NetworkACLItem> rules) throws ResourceUnavailableException {
+    private boolean applyACLToPrivateGw(final PrivateGateway gateway, final List<? extends NetworkACLItem> rules) throws ResourceUnavailableException {
         List<VpcProvider> vpcElements = null;
         vpcElements = new ArrayList<VpcProvider>();
         vpcElements.add((VpcProvider)_ntwkModel.getElementImplementingProvider(Network.Provider.VPCVirtualRouter.getName()));
@@ -392,29 +387,29 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         }
 
         try{
-            for (VpcProvider provider : vpcElements) {
+            for (final VpcProvider provider : vpcElements) {
                 return provider.applyACLItemsToPrivateGw(gateway, rules);
             }
-        } catch(Exception ex) {
+        } catch(final Exception ex) {
             s_logger.debug("Failed to apply acl to private gateway " + gateway);
         }
         return false;
     }
 
     @Override
-    public boolean applyACLToNetwork(long networkId) throws ResourceUnavailableException {
-        Network network = _networkDao.findById(networkId);
+    public boolean applyACLToNetwork(final long networkId) throws ResourceUnavailableException {
+        final Network network = _networkDao.findById(networkId);
         if (network.getNetworkACLId() == null) {
             return true;
         }
-        List<NetworkACLItemVO> rules = _networkACLItemDao.listByACL(network.getNetworkACLId());
+        final List<NetworkACLItemVO> rules = _networkACLItemDao.listByACL(network.getNetworkACLId());
         return applyACLItemsToNetwork(networkId, rules);
     }
 
     @Override
-    public NetworkACLItem updateNetworkACLItem(Long id, String protocol, List<String> sourceCidrList, NetworkACLItem.TrafficType trafficType, String action,
-        Integer number, Integer sourcePortStart, Integer sourcePortEnd, Integer icmpCode, Integer icmpType, String customId, Boolean forDisplay) throws ResourceUnavailableException {
-        NetworkACLItemVO aclItem = _networkACLItemDao.findById(id);
+    public NetworkACLItem updateNetworkACLItem(final Long id, final String protocol, final List<String> sourceCidrList, final NetworkACLItem.TrafficType trafficType, final String action,
+            final Integer number, final Integer sourcePortStart, final Integer sourcePortEnd, final Integer icmpCode, final Integer icmpType, final String customId, final Boolean forDisplay) throws ResourceUnavailableException {
+        final NetworkACLItemVO aclItem = _networkACLItemDao.findById(id);
         aclItem.setState(State.Add);
 
         if (protocol != null) {
@@ -475,13 +470,13 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
         return null;
     }
 
-    public boolean applyACLItemsToNetwork(long networkId, List<NetworkACLItemVO> rules) throws ResourceUnavailableException {
-        Network network = _networkDao.findById(networkId);
+    public boolean applyACLItemsToNetwork(final long networkId, final List<NetworkACLItemVO> rules) throws ResourceUnavailableException {
+        final Network network = _networkDao.findById(networkId);
         boolean handled = false;
         boolean foundProvider = false;
-        for (NetworkACLServiceProvider element : _networkAclElements) {
-            Network.Provider provider = element.getProvider();
-            boolean isAclProvider = _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.NetworkACL, provider);
+        for (final NetworkACLServiceProvider element : _networkAclElements) {
+            final Network.Provider provider = element.getProvider();
+            final boolean isAclProvider = _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.NetworkACL, provider);
             if (!isAclProvider) {
                 continue;
             }
@@ -506,8 +501,8 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
     }
 
     @Inject
-    public void setNetworkAclElements(List<NetworkACLServiceProvider> networkAclElements) {
-        this._networkAclElements = networkAclElements;
+    public void setNetworkAclElements(final List<NetworkACLServiceProvider> networkAclElements) {
+        _networkAclElements = networkAclElements;
     }
 
 }

--- a/server/src/com/cloud/network/vpc/NetworkACLManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/NetworkACLManagerImpl.java
@@ -141,18 +141,24 @@ public class NetworkACLManagerImpl extends ManagerBase implements NetworkACLMana
 
     @Override
     public boolean deleteNetworkACL(final NetworkACL acl) {
-        final List<NetworkVO> networks = _networkDao.listByAclId(acl.getId());
+        final long aclId = acl.getId();
+        final List<NetworkVO> networks = _networkDao.listByAclId(aclId);
         if (networks != null && networks.size() > 0) {
             throw new CloudRuntimeException("ACL is still associated with " + networks.size() + " tier(s). Cannot delete network ACL: " + acl.getUuid());
         }
 
-        final List<VpcGatewayVO> pvtGateways = _vpcGatewayDao.listByAclIdAndType(acl.getId(), VpcGateway.Type.Private);
+        final List<VpcGatewayVO> pvtGateways = _vpcGatewayDao.listByAclIdAndType(aclId, VpcGateway.Type.Private);
 
         if (pvtGateways != null && pvtGateways.size() > 0) {
             throw new CloudRuntimeException("ACL is still associated with " + pvtGateways.size() + " private gateway(s). Cannot delete network ACL: " + acl.getUuid());
         }
 
-        return _networkACLDao.remove(acl.getId());
+        final List<NetworkACLItemVO> aclItems = _networkACLItemDao.listByACL(aclId);
+        for (final NetworkACLItemVO networkACLItem : aclItems) {
+            revokeNetworkACLItem(networkACLItem.getId());
+        }
+
+        return _networkACLDao.remove(aclId);
     }
 
     @Override

--- a/server/src/com/cloud/network/vpc/NetworkACLServiceImpl.java
+++ b/server/src/com/cloud/network/vpc/NetworkACLServiceImpl.java
@@ -627,7 +627,6 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
     }
 
     @Override
-    @ActionEvent(eventType = EventTypes.EVENT_NETWORK_ACL_ITEM_UPDATE, eventDescription = "Updating Network ACL Item", async = true)
     public NetworkACLItem updateNetworkACLItem(final Long id, final String protocol, final List<String> sourceCidrList, final NetworkACLItem.TrafficType trafficType, final String action,
             final Integer number, final Integer sourcePortStart, final Integer sourcePortEnd, final Integer icmpCode, final Integer icmpType, final String newUUID, final Boolean forDisplay) throws ResourceUnavailableException {
         final NetworkACLItemVO aclItem = _networkACLItemDao.findById(id);

--- a/server/src/com/cloud/network/vpc/NetworkACLServiceImpl.java
+++ b/server/src/com/cloud/network/vpc/NetworkACLServiceImpl.java
@@ -22,16 +22,15 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.command.user.network.CreateNetworkACLCmd;
 import org.apache.cloudstack.api.command.user.network.ListNetworkACLListsCmd;
 import org.apache.cloudstack.api.command.user.network.ListNetworkACLsCmd;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.event.ActionEvent;
 import com.cloud.event.EventTypes;
@@ -95,9 +94,9 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
     VpcService _vpcSvc;
 
     @Override
-    public NetworkACL createNetworkACL(String name, String description, long vpcId, Boolean forDisplay) {
-        Account caller = CallContext.current().getCallingAccount();
-        Vpc vpc = _entityMgr.findById(Vpc.class, vpcId);
+    public NetworkACL createNetworkACL(final String name, final String description, final long vpcId, final Boolean forDisplay) {
+        final Account caller = CallContext.current().getCallingAccount();
+        final Vpc vpc = _entityMgr.findById(Vpc.class, vpcId);
         if (vpc == null) {
             throw new InvalidParameterValueException("Unable to find VPC");
         }
@@ -107,37 +106,37 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_ACL_CREATE, eventDescription = "creating network acl list", async = true)
-    public NetworkACL getNetworkACL(long id) {
+    public NetworkACL getNetworkACL(final long id) {
         return _networkAclMgr.getNetworkACL(id);
     }
 
     @Override
-    public Pair<List<? extends NetworkACL>, Integer> listNetworkACLs(ListNetworkACLListsCmd cmd) {
-        Long id = cmd.getId();
-        String name = cmd.getName();
-        Long networkId = cmd.getNetworkId();
-        Long vpcId = cmd.getVpcId();
-        String keyword = cmd.getKeyword();
-        Boolean display = cmd.getDisplay();
+    public Pair<List<? extends NetworkACL>, Integer> listNetworkACLs(final ListNetworkACLListsCmd cmd) {
+        final Long id = cmd.getId();
+        final String name = cmd.getName();
+        final Long networkId = cmd.getNetworkId();
+        final Long vpcId = cmd.getVpcId();
+        final String keyword = cmd.getKeyword();
+        final Boolean display = cmd.getDisplay();
 
-        SearchBuilder<NetworkACLVO> sb = _networkACLDao.createSearchBuilder();
+        final SearchBuilder<NetworkACLVO> sb = _networkACLDao.createSearchBuilder();
         sb.and("id", sb.entity().getId(), Op.EQ);
         sb.and("name", sb.entity().getName(), Op.EQ);
         sb.and("vpcId", sb.entity().getVpcId(), Op.IN);
         sb.and("display", sb.entity().isDisplay(), Op.EQ);
 
-        Account caller = CallContext.current().getCallingAccount();
+        final Account caller = CallContext.current().getCallingAccount();
 
         if (networkId != null) {
-            SearchBuilder<NetworkVO> network = _networkDao.createSearchBuilder();
+            final SearchBuilder<NetworkVO> network = _networkDao.createSearchBuilder();
             network.and("networkId", network.entity().getId(), Op.EQ);
             sb.join("networkJoin", network, sb.entity().getId(), network.entity().getNetworkACLId(), JoinBuilder.JoinType.INNER);
         }
 
-        SearchCriteria<NetworkACLVO> sc = sb.create();
+        final SearchCriteria<NetworkACLVO> sc = sb.create();
 
         if (keyword != null) {
-            SearchCriteria<NetworkACLVO> ssc = _networkACLDao.createSearchCriteria();
+            final SearchCriteria<NetworkACLVO> ssc = _networkACLDao.createSearchCriteria();
             ssc.addOr("name", SearchCriteria.Op.LIKE, "%" + keyword + "%");
             ssc.addOr("description", SearchCriteria.Op.LIKE, "%" + keyword + "%");
             sc.addAnd("name", SearchCriteria.Op.SC, ssc);
@@ -156,7 +155,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         }
 
         if (vpcId != null) {
-            Vpc vpc = _entityMgr.findById(Vpc.class, vpcId);
+            final Vpc vpc = _entityMgr.findById(Vpc.class, vpcId);
             if (vpc == null) {
                 throw new InvalidParameterValueException("Unable to find VPC");
             }
@@ -168,26 +167,26 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
             // VpcId is not specified. Find permitted VPCs for the caller
             // and list ACLs belonging to the permitted VPCs
-            List<Long> permittedAccounts = new ArrayList<Long>();
+            final List<Long> permittedAccounts = new ArrayList<Long>();
             Long domainId = cmd.getDomainId();
             boolean isRecursive = cmd.isRecursive();
-            String accountName = cmd.getAccountName();
-            Long projectId = cmd.getProjectId();
-            boolean listAll = cmd.listAll();
-            Ternary<Long, Boolean, ListProjectResourcesCriteria> domainIdRecursiveListProject = new Ternary<Long, Boolean,
+            final String accountName = cmd.getAccountName();
+            final Long projectId = cmd.getProjectId();
+            final boolean listAll = cmd.listAll();
+            final Ternary<Long, Boolean, ListProjectResourcesCriteria> domainIdRecursiveListProject = new Ternary<Long, Boolean,
                     ListProjectResourcesCriteria>(domainId, isRecursive, null);
             _accountMgr.buildACLSearchParameters(caller, id, accountName, projectId, permittedAccounts, domainIdRecursiveListProject,
                     listAll, false);
             domainId = domainIdRecursiveListProject.first();
             isRecursive = domainIdRecursiveListProject.second();
-            ListProjectResourcesCriteria listProjectResourcesCriteria = domainIdRecursiveListProject.third();
-            SearchBuilder<VpcVO> sbVpc = _vpcDao.createSearchBuilder();
+            final ListProjectResourcesCriteria listProjectResourcesCriteria = domainIdRecursiveListProject.third();
+            final SearchBuilder<VpcVO> sbVpc = _vpcDao.createSearchBuilder();
             _accountMgr.buildACLSearchBuilder(sbVpc, domainId, isRecursive, permittedAccounts, listProjectResourcesCriteria);
-            SearchCriteria<VpcVO> scVpc = sbVpc.create();
+            final SearchCriteria<VpcVO> scVpc = sbVpc.create();
             _accountMgr.buildACLSearchCriteria(scVpc, domainId, isRecursive, permittedAccounts, listProjectResourcesCriteria);
-            List<VpcVO> vpcs = _vpcDao.search(scVpc, null);
-            List<Long> vpcIds = new ArrayList<Long>();
-            for (VpcVO vpc : vpcs) {
+            final List<VpcVO> vpcs = _vpcDao.search(scVpc, null);
+            final List<Long> vpcIds = new ArrayList<Long>();
+            for (final VpcVO vpc : vpcs) {
                 vpcIds.add(vpc.getId());
             }
             //Add vpc_id 0 to list default ACLs
@@ -199,16 +198,16 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
             sc.setJoinParameters("networkJoin", "networkId", networkId);
         }
 
-        Filter filter = new Filter(NetworkACLVO.class, "id", false, null, null);
-        Pair<List<NetworkACLVO>, Integer> acls =  _networkACLDao.searchAndCount(sc, filter);
+        final Filter filter = new Filter(NetworkACLVO.class, "id", false, null, null);
+        final Pair<List<NetworkACLVO>, Integer> acls =  _networkACLDao.searchAndCount(sc, filter);
         return new Pair<List<? extends NetworkACL>, Integer>(acls.first(), acls.second());
     }
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_ACL_DELETE, eventDescription = "Deleting Network ACL List", async = true)
-    public boolean deleteNetworkACL(long id) {
-        Account caller = CallContext.current().getCallingAccount();
-        NetworkACL acl = _networkACLDao.findById(id);
+    public boolean deleteNetworkACL(final long id) {
+        final Account caller = CallContext.current().getCallingAccount();
+        final NetworkACL acl = _networkACLDao.findById(id);
         if (acl == null) {
             throw new InvalidParameterValueException("Unable to find specified ACL");
         }
@@ -218,7 +217,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
             throw new InvalidParameterValueException("Default ACL cannot be removed");
         }
 
-        Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
+        final Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
         if (vpc == null) {
             throw new InvalidParameterValueException("Unable to find specified VPC associated with the ACL");
         }
@@ -227,19 +226,19 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
     }
 
     @Override
-    public boolean replaceNetworkACLonPrivateGw(long aclId, long privateGatewayId) throws ResourceUnavailableException {
-        Account caller = CallContext.current().getCallingAccount();
-        VpcGateway gateway = _vpcGatewayDao.findById(privateGatewayId);
+    public boolean replaceNetworkACLonPrivateGw(final long aclId, final long privateGatewayId) throws ResourceUnavailableException {
+        final Account caller = CallContext.current().getCallingAccount();
+        final VpcGateway gateway = _vpcGatewayDao.findById(privateGatewayId);
         if (gateway == null) {
             throw new InvalidParameterValueException("Unable to find specified private gateway");
         }
 
-        VpcGatewayVO vo = _vpcGatewayDao.findById(privateGatewayId);
+        final VpcGatewayVO vo = _vpcGatewayDao.findById(privateGatewayId);
         if (vo.getState() != VpcGateway.State.Ready) {
             throw new InvalidParameterValueException("Gateway is not in Ready state");
         }
 
-        NetworkACL acl = _networkACLDao.findById(aclId);
+        final NetworkACL acl = _networkACLDao.findById(aclId);
         if (acl == null) {
             throw new InvalidParameterValueException("Unable to find specified NetworkACL");
         }
@@ -249,7 +248,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         }
 
         if (aclId != NetworkACL.DEFAULT_DENY && aclId != NetworkACL.DEFAULT_ALLOW) {
-            Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
+            final Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
             if (vpc == null) {
                 throw new InvalidParameterValueException("Unable to find Vpc associated with the NetworkACL");
             }
@@ -259,7 +258,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
             }
         }
 
-        PrivateGateway privateGateway = _vpcSvc.getVpcPrivateGateway(gateway.getId());
+        final PrivateGateway privateGateway = _vpcSvc.getVpcPrivateGateway(gateway.getId());
         _accountMgr.checkAccess(caller, null, true, privateGateway);
 
         return  _networkAclMgr.replaceNetworkACLForPrivateGw(acl, privateGateway);
@@ -267,15 +266,15 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
     }
 
     @Override
-    public boolean replaceNetworkACL(long aclId, long networkId) throws ResourceUnavailableException {
-        Account caller = CallContext.current().getCallingAccount();
+    public boolean replaceNetworkACL(final long aclId, final long networkId) throws ResourceUnavailableException {
+        final Account caller = CallContext.current().getCallingAccount();
 
-        NetworkVO network = _networkDao.findById(networkId);
+        final NetworkVO network = _networkDao.findById(networkId);
         if (network == null) {
             throw new InvalidParameterValueException("Unable to find specified Network");
         }
 
-        NetworkACL acl = _networkACLDao.findById(aclId);
+        final NetworkACL acl = _networkACLDao.findById(aclId);
         if (acl == null) {
             throw new InvalidParameterValueException("Unable to find specified NetworkACL");
         }
@@ -291,7 +290,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         if (aclId != NetworkACL.DEFAULT_DENY && aclId != NetworkACL.DEFAULT_ALLOW) {
             //ACL is not default DENY/ALLOW
             // ACL should be associated with a VPC
-            Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
+            final Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
             if (vpc == null) {
                 throw new InvalidParameterValueException("Unable to find Vpc associated with the NetworkACL");
             }
@@ -306,15 +305,15 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
     }
 
     @Override
-    public NetworkACLItem createNetworkACLItem(CreateNetworkACLCmd aclItemCmd) {
-        Account caller = CallContext.current().getCallingAccount();
+    public NetworkACLItem createNetworkACLItem(final CreateNetworkACLCmd aclItemCmd) {
+        final Account caller = CallContext.current().getCallingAccount();
         Long aclId = aclItemCmd.getACLId();
         if (aclId == null) {
             //ACL id is not specified. Get the ACL details from network
             if (aclItemCmd.getNetworkId() == null) {
                 throw new InvalidParameterValueException("Cannot create Network ACL Item. ACL Id or network Id is required");
             }
-            Network network = _networkMgr.getNetwork(aclItemCmd.getNetworkId());
+            final Network network = _networkMgr.getNetwork(aclItemCmd.getNetworkId());
             if (network.getVpcId() == null) {
                 throw new InvalidParameterValueException("Network: " + network.getUuid() + " does not belong to VPC");
             }
@@ -329,15 +328,15 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
                     throw new InvalidParameterValueException("Network Offering does not support NetworkACL service");
                 }
 
-                Vpc vpc = _entityMgr.findById(Vpc.class, network.getVpcId());
+                final Vpc vpc = _entityMgr.findById(Vpc.class, network.getVpcId());
                 if (vpc == null) {
                     throw new InvalidParameterValueException("Unable to find Vpc associated with the Network");
                 }
 
                 //Create new ACL
-                String aclName = "VPC_" + vpc.getName() + "_Tier_" + network.getName() + "_ACL_" + network.getUuid();
-                String description = "ACL for " + aclName;
-                NetworkACL acl = _networkAclMgr.createNetworkACL(aclName, description, network.getVpcId(), aclItemCmd.getDisplay());
+                final String aclName = "VPC_" + vpc.getName() + "_Tier_" + network.getName() + "_ACL_" + network.getUuid();
+                final String description = "ACL for " + aclName;
+                final NetworkACL acl = _networkAclMgr.createNetworkACL(aclName, description, network.getVpcId(), aclItemCmd.getDisplay());
                 if (acl == null) {
                     throw new CloudRuntimeException("Error while create ACL before adding ACL Item for network " + network.getId());
                 }
@@ -349,22 +348,22 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
                         throw new CloudRuntimeException("Unable to apply auto created ACL to network " + network.getId());
                     }
                     s_logger.debug("Created ACL is applied to network " + network.getId());
-                } catch (ResourceUnavailableException e) {
+                } catch (final ResourceUnavailableException e) {
                     throw new CloudRuntimeException("Unable to apply auto created ACL to network " + network.getId(), e);
                 }
             }
         }
 
-        NetworkACL acl = _networkAclMgr.getNetworkACL(aclId);
+        final NetworkACL acl = _networkAclMgr.getNetworkACL(aclId);
         if (acl == null) {
             throw new InvalidParameterValueException("Unable to find specified ACL");
         }
 
-        if ((aclId == NetworkACL.DEFAULT_DENY) || (aclId == NetworkACL.DEFAULT_ALLOW)) {
+        if (aclId == NetworkACL.DEFAULT_DENY || aclId == NetworkACL.DEFAULT_ALLOW) {
             throw new InvalidParameterValueException("Default ACL cannot be modified");
         }
 
-        Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
+        final Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
         if (vpc == null) {
             throw new InvalidParameterValueException("Unable to find Vpc associated with the NetworkACL");
         }
@@ -378,15 +377,15 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         }
 
         validateNetworkACLItem(aclItemCmd.getSourcePortStart(), aclItemCmd.getSourcePortEnd(), aclItemCmd.getSourceCidrList(), aclItemCmd.getProtocol(),
-            aclItemCmd.getIcmpCode(), aclItemCmd.getIcmpType(), aclItemCmd.getAction(), aclItemCmd.getNumber());
+                aclItemCmd.getIcmpCode(), aclItemCmd.getIcmpType(), aclItemCmd.getAction(), aclItemCmd.getNumber());
 
         return _networkAclMgr.createNetworkACLItem(aclItemCmd.getSourcePortStart(), aclItemCmd.getSourcePortEnd(), aclItemCmd.getProtocol(),
-            aclItemCmd.getSourceCidrList(), aclItemCmd.getIcmpCode(), aclItemCmd.getIcmpType(), aclItemCmd.getTrafficType(), aclId, aclItemCmd.getAction(),
-            aclItemCmd.getNumber(), aclItemCmd.getDisplay());
+                aclItemCmd.getSourceCidrList(), aclItemCmd.getIcmpCode(), aclItemCmd.getIcmpType(), aclItemCmd.getTrafficType(), aclId, aclItemCmd.getAction(),
+                aclItemCmd.getNumber(), aclItemCmd.getDisplay());
     }
 
-    private void validateNetworkACLItem(Integer portStart, Integer portEnd, List<String> sourceCidrList, String protocol, Integer icmpCode, Integer icmpType,
-        String action, Integer number) {
+    private void validateNetworkACLItem(final Integer portStart, final Integer portEnd, final List<String> sourceCidrList, final String protocol, final Integer icmpCode, final Integer icmpType,
+            final String action, final Integer number) {
 
         if (portStart != null && !NetUtils.isValidPort(portStart)) {
             throw new InvalidParameterValueException("publicPort is an invalid value: " + portStart);
@@ -401,11 +400,12 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         }
 
         // start port and end port must be null for protocol = 'all'
-        if ((portStart != null || portEnd != null) && protocol != null && protocol.equalsIgnoreCase("all"))
+        if ((portStart != null || portEnd != null) && protocol != null && protocol.equalsIgnoreCase("all")) {
             throw new InvalidParameterValueException("start port and end port must be null if protocol = 'all'");
+        }
 
         if (sourceCidrList != null) {
-            for (String cidr : sourceCidrList) {
+            for (final String cidr : sourceCidrList) {
                 if (!NetUtils.isValidCIDR(cidr)) {
                     throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Source cidrs formatting error " + cidr);
                 }
@@ -416,14 +416,14 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         if (protocol != null) {
             //Check if protocol is a number
             if (StringUtils.isNumeric(protocol)) {
-                int protoNumber = Integer.parseInt(protocol);
+                final int protoNumber = Integer.parseInt(protocol);
                 if (protoNumber < 0 || protoNumber > 255) {
                     throw new InvalidParameterValueException("Invalid protocol number: " + protoNumber);
                 }
             } else {
                 //Protocol is not number
                 //Check for valid protocol strings
-                String supportedProtocols = "tcp,udp,icmp,all";
+                final String supportedProtocols = "tcp,udp,icmp,all";
                 if (!supportedProtocols.contains(protocol.toLowerCase())) {
                     throw new InvalidParameterValueException("Invalid protocol: " + protocol);
                 }
@@ -447,7 +447,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
             if (icmpCode != null) {
                 if (icmpCode.longValue() != -1 && !NetUtils.validateIcmpCode(icmpCode.longValue())) {
                     throw new InvalidParameterValueException("Invalid icmp code; should belong to [0-15] range and can"
-                        + " be defined when icmpType belongs to [0-40] range");
+                            + " be defined when icmpType belongs to [0-40] range");
                 }
             }
         }
@@ -466,29 +466,29 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
     }
 
     @Override
-    public NetworkACLItem getNetworkACLItem(long ruleId) {
+    public NetworkACLItem getNetworkACLItem(final long ruleId) {
         return _networkAclMgr.getNetworkACLItem(ruleId);
     }
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_ACL_ITEM_CREATE, eventDescription = "Applying Network ACL Item", async = true)
-    public boolean applyNetworkACL(long aclId) throws ResourceUnavailableException {
+    public boolean applyNetworkACL(final long aclId) throws ResourceUnavailableException {
         return _networkAclMgr.applyNetworkACL(aclId);
     }
 
     @Override
-    public Pair<List<? extends NetworkACLItem>, Integer> listNetworkACLItems(ListNetworkACLsCmd cmd) {
-        Long networkId = cmd.getNetworkId();
-        Long id = cmd.getId();
+    public Pair<List<? extends NetworkACLItem>, Integer> listNetworkACLItems(final ListNetworkACLsCmd cmd) {
+        final Long networkId = cmd.getNetworkId();
+        final Long id = cmd.getId();
         Long aclId = cmd.getAclId();
-        String trafficType = cmd.getTrafficType();
-        String protocol = cmd.getProtocol();
-        String action = cmd.getAction();
-        Map<String, String> tags = cmd.getTags();
-        Account caller = CallContext.current().getCallingAccount();
+        final String trafficType = cmd.getTrafficType();
+        final String protocol = cmd.getProtocol();
+        final String action = cmd.getAction();
+        final Map<String, String> tags = cmd.getTags();
+        final Account caller = CallContext.current().getCallingAccount();
 
-        Filter filter = new Filter(NetworkACLItemVO.class, "id", false, cmd.getStartIndex(), cmd.getPageSizeVal());
-        SearchBuilder<NetworkACLItemVO> sb = _networkACLItemDao.createSearchBuilder();
+        final Filter filter = new Filter(NetworkACLItemVO.class, "id", false, cmd.getStartIndex(), cmd.getPageSizeVal());
+        final SearchBuilder<NetworkACLItemVO> sb = _networkACLItemDao.createSearchBuilder();
 
         sb.and("id", sb.entity().getId(), Op.EQ);
         sb.and("aclId", sb.entity().getAclId(), Op.EQ);
@@ -497,7 +497,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         sb.and("action", sb.entity().getAction(), Op.EQ);
 
         if (tags != null && !tags.isEmpty()) {
-            SearchBuilder<ResourceTagVO> tagSearch = _resourceTagDao.createSearchBuilder();
+            final SearchBuilder<ResourceTagVO> tagSearch = _resourceTagDao.createSearchBuilder();
             for (int count = 0; count < tags.size(); count++) {
                 tagSearch.or().op("key" + String.valueOf(count), tagSearch.entity().getKey(), Op.EQ);
                 tagSearch.and("value" + String.valueOf(count), tagSearch.entity().getValue(), Op.EQ);
@@ -510,19 +510,19 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
         if (aclId == null) {
             //Join with network_acl table when aclId is not specified to list acl_items within permitted VPCs
-            SearchBuilder<NetworkACLVO> vpcSearch = _networkACLDao.createSearchBuilder();
+            final SearchBuilder<NetworkACLVO> vpcSearch = _networkACLDao.createSearchBuilder();
             vpcSearch.and("vpcId", vpcSearch.entity().getVpcId(), Op.IN);
             sb.join("vpcSearch", vpcSearch, sb.entity().getAclId(), vpcSearch.entity().getId(), JoinBuilder.JoinType.INNER);
         }
 
-        SearchCriteria<NetworkACLItemVO> sc = sb.create();
+        final SearchCriteria<NetworkACLItemVO> sc = sb.create();
 
         if (id != null) {
             sc.setParameters("id", id);
         }
 
         if (networkId != null) {
-            Network network = _networkDao.findById(networkId);
+            final Network network = _networkDao.findById(networkId);
             aclId = network.getNetworkACLId();
             if( aclId == null){
                 // No aclId associated with the network.
@@ -537,9 +537,9 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
         if (aclId != null) {
             // Get VPC and check access
-            NetworkACL acl = _networkACLDao.findById(aclId);
+            final NetworkACL acl = _networkACLDao.findById(aclId);
             if (acl.getVpcId() != 0) {
-                Vpc vpc = _vpcDao.findById(acl.getVpcId());
+                final Vpc vpc = _vpcDao.findById(acl.getVpcId());
                 if (vpc == null) {
                     throw new InvalidParameterValueException("Unable to find VPC associated with acl");
                 }
@@ -552,26 +552,26 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
             // aclId is not specified
             // List permitted VPCs and filter aclItems
-            List<Long> permittedAccounts = new ArrayList<Long>();
+            final List<Long> permittedAccounts = new ArrayList<Long>();
             Long domainId = cmd.getDomainId();
             boolean isRecursive = cmd.isRecursive();
-            String accountName = cmd.getAccountName();
-            Long projectId = cmd.getProjectId();
-            boolean listAll = cmd.listAll();
-            Ternary<Long, Boolean, ListProjectResourcesCriteria> domainIdRecursiveListProject = new Ternary<Long, Boolean,
+            final String accountName = cmd.getAccountName();
+            final Long projectId = cmd.getProjectId();
+            final boolean listAll = cmd.listAll();
+            final Ternary<Long, Boolean, ListProjectResourcesCriteria> domainIdRecursiveListProject = new Ternary<Long, Boolean,
                     ListProjectResourcesCriteria>(domainId, isRecursive, null);
             _accountMgr.buildACLSearchParameters(caller, id, accountName, projectId, permittedAccounts, domainIdRecursiveListProject,
                     listAll, false);
             domainId = domainIdRecursiveListProject.first();
             isRecursive = domainIdRecursiveListProject.second();
-            ListProjectResourcesCriteria listProjectResourcesCriteria = domainIdRecursiveListProject.third();
-            SearchBuilder<VpcVO> sbVpc = _vpcDao.createSearchBuilder();
+            final ListProjectResourcesCriteria listProjectResourcesCriteria = domainIdRecursiveListProject.third();
+            final SearchBuilder<VpcVO> sbVpc = _vpcDao.createSearchBuilder();
             _accountMgr.buildACLSearchBuilder(sbVpc, domainId, isRecursive, permittedAccounts, listProjectResourcesCriteria);
-            SearchCriteria<VpcVO> scVpc = sbVpc.create();
+            final SearchCriteria<VpcVO> scVpc = sbVpc.create();
             _accountMgr.buildACLSearchCriteria(scVpc, domainId, isRecursive, permittedAccounts, listProjectResourcesCriteria);
-            List<VpcVO> vpcs = _vpcDao.search(scVpc, null);
-            List<Long> vpcIds = new ArrayList<Long>();
-            for (VpcVO vpc : vpcs) {
+            final List<VpcVO> vpcs = _vpcDao.search(scVpc, null);
+            final List<Long> vpcIds = new ArrayList<Long>();
+            for (final VpcVO vpc : vpcs) {
                 vpcIds.add(vpc.getId());
             }
             //Add vpc_id 0 to list acl_items in default ACL
@@ -590,16 +590,16 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         if (tags != null && !tags.isEmpty()) {
             int count = 0;
             sc.setJoinParameters("tagSearch", "resourceType", ResourceObjectType.NetworkACL.toString());
-            for (String key : tags.keySet()) {
+            for (final String key : tags.keySet()) {
                 sc.setJoinParameters("tagSearch", "key" + String.valueOf(count), key);
                 sc.setJoinParameters("tagSearch", "value" + String.valueOf(count), tags.get(key));
                 count++;
             }
         }
 
-        Pair<List<NetworkACLItemVO>, Integer> result = _networkACLItemDao.searchAndCount(sc, filter);
-        List<NetworkACLItemVO> aclItemVOs = result.first();
-        for (NetworkACLItemVO item: aclItemVOs) {
+        final Pair<List<NetworkACLItemVO>, Integer> result = _networkACLItemDao.searchAndCount(sc, filter);
+        final List<NetworkACLItemVO> aclItemVOs = result.first();
+        for (final NetworkACLItemVO item: aclItemVOs) {
             _networkACLItemDao.loadCidrs(item);
         }
         return new Pair<List<? extends NetworkACLItem>, Integer>(aclItemVOs, result.second());
@@ -607,18 +607,18 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_ACL_ITEM_DELETE, eventDescription = "Deleting Network ACL Item", async = true)
-    public boolean revokeNetworkACLItem(long ruleId) {
-        NetworkACLItemVO aclItem = _networkACLItemDao.findById(ruleId);
+    public boolean revokeNetworkACLItem(final long ruleId) {
+        final NetworkACLItemVO aclItem = _networkACLItemDao.findById(ruleId);
         if(aclItem != null){
-            NetworkACL acl = _networkAclMgr.getNetworkACL(aclItem.getAclId());
+            final NetworkACL acl = _networkAclMgr.getNetworkACL(aclItem.getAclId());
 
-            Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
+            final Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
 
-            if((aclItem.getAclId() == NetworkACL.DEFAULT_ALLOW) || (aclItem.getAclId() == NetworkACL.DEFAULT_DENY)){
+            if(aclItem.getAclId() == NetworkACL.DEFAULT_ALLOW || aclItem.getAclId() == NetworkACL.DEFAULT_DENY){
                 throw new InvalidParameterValueException("ACL Items in default ACL cannot be deleted");
             }
 
-            Account caller = CallContext.current().getCallingAccount();
+            final Account caller = CallContext.current().getCallingAccount();
 
             _accountMgr.checkAccess(caller, null, true, vpc);
 
@@ -628,9 +628,9 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_ACL_ITEM_UPDATE, eventDescription = "Updating Network ACL Item", async = true)
-    public NetworkACLItem updateNetworkACLItem(Long id, String protocol, List<String> sourceCidrList, NetworkACLItem.TrafficType trafficType, String action,
-        Integer number, Integer sourcePortStart, Integer sourcePortEnd, Integer icmpCode, Integer icmpType, String newUUID, Boolean forDisplay) throws ResourceUnavailableException {
-        NetworkACLItemVO aclItem = _networkACLItemDao.findById(id);
+    public NetworkACLItem updateNetworkACLItem(final Long id, final String protocol, final List<String> sourceCidrList, final NetworkACLItem.TrafficType trafficType, final String action,
+            final Integer number, final Integer sourcePortStart, final Integer sourcePortEnd, final Integer icmpCode, final Integer icmpType, final String newUUID, final Boolean forDisplay) throws ResourceUnavailableException {
+        final NetworkACLItemVO aclItem = _networkACLItemDao.findById(id);
         if (aclItem == null) {
             throw new InvalidParameterValueException("Unable to find ACL Item cannot be found");
         }
@@ -639,34 +639,34 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
             throw new InvalidParameterValueException("Default ACL Items cannot be updated");
         }
 
-        NetworkACL acl = _networkAclMgr.getNetworkACL(aclItem.getAclId());
+        final NetworkACL acl = _networkAclMgr.getNetworkACL(aclItem.getAclId());
 
-        Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
+        final Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
 
-        Account caller = CallContext.current().getCallingAccount();
+        final Account caller = CallContext.current().getCallingAccount();
 
         _accountMgr.checkAccess(caller, null, true, vpc);
 
         if (number != null) {
             //Check if ACL Item with specified number already exists
-            NetworkACLItemVO aclNumber = _networkACLItemDao.findByAclAndNumber(acl.getId(), number);
-            if ((aclNumber != null) && (aclNumber.getId() != id)) {
+            final NetworkACLItemVO aclNumber = _networkACLItemDao.findByAclAndNumber(acl.getId(), number);
+            if (aclNumber != null && aclNumber.getId() != id) {
                 throw new InvalidParameterValueException("ACL item with number " + number + " already exists in ACL: " + acl.getUuid());
             }
         }
 
-        validateNetworkACLItem((sourcePortStart == null) ? aclItem.getSourcePortStart() : sourcePortStart, (sourcePortEnd == null) ? aclItem.getSourcePortEnd()
-            : sourcePortEnd, sourceCidrList, protocol, icmpCode, (icmpType == null) ? aclItem.getIcmpType() : icmpType, action, number);
+        validateNetworkACLItem(sourcePortStart == null ? aclItem.getSourcePortStart() : sourcePortStart, sourcePortEnd == null ? aclItem.getSourcePortEnd()
+                : sourcePortEnd, sourceCidrList, protocol, icmpCode, icmpType == null ? aclItem.getIcmpType() : icmpType, action, number);
 
         return _networkAclMgr.updateNetworkACLItem(id, protocol, sourceCidrList, trafficType, action, number, sourcePortStart, sourcePortEnd, icmpCode, icmpType, newUUID, forDisplay);
     }
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_NETWORK_ACL_UPDATE, eventDescription = "updating network acl", async = true)
-    public NetworkACL updateNetworkACL(Long id, String customId, Boolean forDisplay) {
-        NetworkACLVO acl = _networkACLDao.findById(id);
-        Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
-        Account caller = CallContext.current().getCallingAccount();
+    public NetworkACL updateNetworkACL(final Long id, final String customId, final Boolean forDisplay) {
+        final NetworkACLVO acl = _networkACLDao.findById(id);
+        final Vpc vpc = _entityMgr.findById(Vpc.class, acl.getVpcId());
+        final Account caller = CallContext.current().getCallingAccount();
         _accountMgr.checkAccess(caller, null, true, vpc);
 
         if (customId != null) {

--- a/server/test/com/cloud/vpc/NetworkACLManagerTest.java
+++ b/server/test/com/cloud/vpc/NetworkACLManagerTest.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
-import com.cloud.user.User;
 import junit.framework.TestCase;
 
 import org.apache.cloudstack.context.CallContext;
@@ -53,6 +52,7 @@ import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.element.NetworkACLServiceProvider;
 import com.cloud.network.vpc.NetworkACLItem;
+import com.cloud.network.vpc.NetworkACLItem.State;
 import com.cloud.network.vpc.NetworkACLItemDao;
 import com.cloud.network.vpc.NetworkACLItemVO;
 import com.cloud.network.vpc.NetworkACLManager;
@@ -69,10 +69,10 @@ import com.cloud.tags.dao.ResourceTagDao;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
 import com.cloud.user.AccountVO;
+import com.cloud.user.User;
 import com.cloud.user.UserVO;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.EntityManager;
-import com.cloud.utils.exception.CloudRuntimeException;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class)
@@ -110,8 +110,8 @@ public class NetworkACLManagerTest extends TestCase {
     @Before
     public void setUp() {
         ComponentContext.initComponentsLifeCycle();
-        Account account = new AccountVO("testaccount", 1, "testdomain", (short)0, UUID.randomUUID().toString());
-        UserVO user = new UserVO(1, "testuser", "password", "firstname", "lastName", "email", "timezone", UUID.randomUUID().toString(), User.Source.UNKNOWN);
+        final Account account = new AccountVO("testaccount", 1, "testdomain", (short)0, UUID.randomUUID().toString());
+        final UserVO user = new UserVO(1, "testuser", "password", "firstname", "lastName", "email", "timezone", UUID.randomUUID().toString(), User.Source.UNKNOWN);
 
         CallContext.register(user, account);
         acl = Mockito.mock(NetworkACLVO.class);
@@ -133,10 +133,10 @@ public class NetworkACLManagerTest extends TestCase {
     @Test
     @SuppressWarnings("unchecked")
     public void testApplyACL() throws Exception {
-        NetworkVO network = Mockito.mock(NetworkVO.class);
+        final NetworkVO network = Mockito.mock(NetworkVO.class);
         Mockito.when(_networkDao.findById(Matchers.anyLong())).thenReturn(network);
         Mockito.when(_networkModel.isProviderSupportServiceInNetwork(Matchers.anyLong(), Matchers.any(Network.Service.class), Matchers.any(Network.Provider.class)))
-            .thenReturn(true);
+        .thenReturn(true);
         Mockito.when(_networkAclElements.get(0).applyNetworkACLs(Matchers.any(Network.class), Matchers.anyList())).thenReturn(true);
         assertTrue(_aclMgr.applyACLToNetwork(1L));
     }
@@ -149,21 +149,21 @@ public class NetworkACLManagerTest extends TestCase {
     }
 
     @SuppressWarnings("unchecked")
-    public void driveTestApplyNetworkACL(boolean result, boolean applyNetworkACLs, boolean applyACLToPrivateGw) throws Exception {
+    public void driveTestApplyNetworkACL(final boolean result, final boolean applyNetworkACLs, final boolean applyACLToPrivateGw) throws Exception {
         // In order to test ONLY our scope method, we mock the others
-        NetworkACLManager aclManager = Mockito.spy(_aclMgr);
+        final NetworkACLManager aclManager = Mockito.spy(_aclMgr);
 
         // Prepare
         // Reset mocked objects to reuse
         Mockito.reset(_networkACLItemDao);
 
         // Make sure it is handled
-        long aclId = 1L;
-        NetworkVO network = Mockito.mock(NetworkVO.class);
-        List<NetworkVO> networks = new ArrayList<NetworkVO>();
+        final long aclId = 1L;
+        final NetworkVO network = Mockito.mock(NetworkVO.class);
+        final List<NetworkVO> networks = new ArrayList<NetworkVO>();
         networks.add(network);
         Mockito.when(_networkDao.listByAclId(Matchers.anyLong()))
-            .thenReturn(networks);
+        .thenReturn(networks);
         Mockito.when(_networkDao.findById(Matchers.anyLong())).thenReturn(network);
         Mockito.when(_networkModel.isProviderSupportServiceInNetwork(Matchers.anyLong(),
                 Matchers.any(Network.Service.class), Matchers.any(Network.Provider.class)))
@@ -172,21 +172,21 @@ public class NetworkACLManagerTest extends TestCase {
                 Matchers.anyList())).thenReturn(applyNetworkACLs);
 
         // Make sure it applies ACL to private gateway
-        List<VpcGatewayVO> vpcGateways = new ArrayList<VpcGatewayVO>();
-        VpcGatewayVO vpcGateway = Mockito.mock(VpcGatewayVO.class);
-        PrivateGateway privateGateway = Mockito.mock(PrivateGateway.class);
+        final List<VpcGatewayVO> vpcGateways = new ArrayList<VpcGatewayVO>();
+        final VpcGatewayVO vpcGateway = Mockito.mock(VpcGatewayVO.class);
+        final PrivateGateway privateGateway = Mockito.mock(PrivateGateway.class);
         Mockito.when(_vpcSvc.getVpcPrivateGateway(Mockito.anyLong())).thenReturn(privateGateway);
         vpcGateways.add(vpcGateway);
         Mockito.when(_vpcGatewayDao.listByAclIdAndType(aclId, VpcGateway.Type.Private))
-            .thenReturn(vpcGateways);
+        .thenReturn(vpcGateways);
 
         // Create 4 rules to test all 4 scenarios: only revoke should
         // be deleted, only add should update
-        List<NetworkACLItemVO> rules = new ArrayList<NetworkACLItemVO>();
-        NetworkACLItemVO ruleActive = Mockito.mock(NetworkACLItemVO.class);
-        NetworkACLItemVO ruleStaged = Mockito.mock(NetworkACLItemVO.class);
-        NetworkACLItemVO rule2Revoke = Mockito.mock(NetworkACLItemVO.class);
-        NetworkACLItemVO rule2Add = Mockito.mock(NetworkACLItemVO.class);
+        final List<NetworkACLItemVO> rules = new ArrayList<NetworkACLItemVO>();
+        final NetworkACLItemVO ruleActive = Mockito.mock(NetworkACLItemVO.class);
+        final NetworkACLItemVO ruleStaged = Mockito.mock(NetworkACLItemVO.class);
+        final NetworkACLItemVO rule2Revoke = Mockito.mock(NetworkACLItemVO.class);
+        final NetworkACLItemVO rule2Add = Mockito.mock(NetworkACLItemVO.class);
         Mockito.when(ruleActive.getState()).thenReturn(NetworkACLItem.State.Active);
         Mockito.when(ruleStaged.getState()).thenReturn(NetworkACLItem.State.Staged);
         Mockito.when(rule2Add.getState()).thenReturn(NetworkACLItem.State.Add);
@@ -196,15 +196,15 @@ public class NetworkACLManagerTest extends TestCase {
         rules.add(rule2Add);
         rules.add(rule2Revoke);
 
-        long revokeId = 8;
+        final long revokeId = 8;
         Mockito.when(rule2Revoke.getId()).thenReturn(revokeId);
 
-        long addId = 9;
+        final long addId = 9;
         Mockito.when(rule2Add.getId()).thenReturn(addId);
         Mockito.when(_networkACLItemDao.findById(addId)).thenReturn(rule2Add);
 
         Mockito.when(_networkACLItemDao.listByACL(aclId))
-            .thenReturn(rules);
+        .thenReturn(rules);
         // Mock methods to avoid
         Mockito.doReturn(applyACLToPrivateGw).when(aclManager).applyACLToPrivateGw(privateGateway);
 
@@ -212,7 +212,7 @@ public class NetworkACLManagerTest extends TestCase {
         assertEquals("Result was not congruent with applyNetworkACLs and applyACLToPrivateGw", result, aclManager.applyNetworkACL(aclId));
 
         // Assert if conditions met, network ACL was applied
-        int timesProcessingDone = (applyNetworkACLs && applyACLToPrivateGw) ? 1 : 0;
+        final int timesProcessingDone = applyNetworkACLs && applyACLToPrivateGw ? 1 : 0;
         Mockito.verify(_networkACLItemDao, Mockito.times(timesProcessingDone)).remove(revokeId);
         Mockito.verify(rule2Add, Mockito.times(timesProcessingDone)).setState(NetworkACLItem.State.Active);
         Mockito.verify(_networkACLItemDao, Mockito.times(timesProcessingDone)).update(addId, rule2Add);
@@ -232,17 +232,27 @@ public class NetworkACLManagerTest extends TestCase {
         assertNotNull(_aclMgr.updateNetworkACLItem(1L, "UDP", null, NetworkACLItem.TrafficType.Ingress, "Deny", 10, 22, 32, null, null, null, true));
     }
 
-    @Test(expected = CloudRuntimeException.class)
+    @Test
     public void deleteNonEmptyACL() throws Exception {
-        List<NetworkACLItemVO> aclItems = new ArrayList<NetworkACLItemVO>();
+        final List<NetworkACLItemVO> aclItems = new ArrayList<NetworkACLItemVO>();
         aclItems.add(aclItem);
         Mockito.when(_networkACLItemDao.listByACL(Matchers.anyLong())).thenReturn(aclItems);
-        _aclMgr.deleteNetworkACL(acl);
+        Mockito.when(acl.getId()).thenReturn(3l);
+        Mockito.when(_networkACLItemDao.findById(Matchers.anyLong())).thenReturn(aclItem);
+        Mockito.when(aclItem.getState()).thenReturn(State.Add);
+        Mockito.when(aclItem.getId()).thenReturn(3l);
+        Mockito.when(_networkACLDao.remove(Matchers.anyLong())).thenReturn(true);
+
+        final boolean result = _aclMgr.deleteNetworkACL(acl);
+
+        Mockito.verify(aclItem, Mockito.times(4)).getState();
+
+        assertTrue("Operation should be successfull!", result);
     }
 
     @Configuration
     @ComponentScan(basePackageClasses = {NetworkACLManagerImpl.class}, includeFilters = {@ComponentScan.Filter(value = NetworkACLTestConfiguration.Library.class,
-                                                                                                               type = FilterType.CUSTOM)}, useDefaultFilters = false)
+    type = FilterType.CUSTOM)}, useDefaultFilters = false)
     public static class NetworkACLTestConfiguration extends SpringUtils.CloudStackTestConfiguration {
 
         @Bean
@@ -317,9 +327,9 @@ public class NetworkACLManagerTest extends TestCase {
 
         public static class Library implements TypeFilter {
             @Override
-            public boolean match(MetadataReader mdr, MetadataReaderFactory arg1) throws IOException {
+            public boolean match(final MetadataReader mdr, final MetadataReaderFactory arg1) throws IOException {
                 mdr.getClassMetadata().getClassName();
-                ComponentScan cs = NetworkACLTestConfiguration.class.getAnnotation(ComponentScan.class);
+                final ComponentScan cs = NetworkACLTestConfiguration.class.getAnnotation(ComponentScan.class);
                 return SpringUtils.includedInBasePackageClasses(mdr.getClassMetadata().getClassName(), cs);
             }
         }


### PR DESCRIPTION
This PR fixes the issue when trying to delete ACL lists which contain item. 

It seemed it was not thought of when the ACS project started, when most user were relying on the UI to execute those tasks. Nowadays, with automation all over the place and ACL lists containing hundreds of items, it's very hard to have to delete them 1 by 1 either via the UI. Writing scripts to do so might be a solution, but it would be much simpler to just delete non-attached ACLs with all its items in one go.

Also, destroying a VPC that contains ACL lists was "succeeding", but after that the ACL list/items were messing up:

```
list networkacls aclid=920d74b6-4d15-454f-b3a6-61e7a6ffd1a4
Error 431: Unable to find VPC associated with acl
{
  "cserrorcode": 4350,
  "errorcode": 431,
  "errortext": "Unable to find VPC associated with acl",
  "uuidList": []
}
```

So, it also cleans up ACLs when destroying VPCs