### PR TITLE
CLOUDSTACK-9254: Make longer names display pretty in UI

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -2489,7 +2489,7 @@ div.detail-group.actions td {
   padding: 1px 0 0;
   /*+placement:shift -174px -57px;*/
   position: relative;
-  left: -174px;
+  left: -239px;
   top: -57px;
 }
 
@@ -2555,7 +2555,7 @@ div.detail-group.actions td {
   margin: 0;
   position: absolute;
   top: -47px;
-  left: 1090px;
+  left: 1025px;
   cursor: default !important;
   display: inline-block;
   float: left;
@@ -2568,8 +2568,8 @@ div.detail-group.actions td {
   padding: 9px 18px 7px 12px;
   border-right: none;
   /*[empty]border-top:;*/
-  min-width: 75px;
-  max-width: 120px;
+  min-width: 110px;
+  max-width: 220px;
   text-align: center;
   height: 12px;
   overflow: hidden;
@@ -4310,7 +4310,7 @@ textarea {
 #user-options {
   background: #FFFFFF;
   z-index: 10000;
-  width: 104px;
+  width: 150px;
   position: absolute;
   padding: 15px;
   top: 30px;

--- a/ui/scripts/ui/core.js
+++ b/ui/scripts/ui/core.js
@@ -225,7 +225,7 @@
                 .append(
                     $('<div>').addClass('name').text(
                         args.context && args.context.users ?
-                        cloudStack.concat(userLabel, 14) : 'Invalid User'
+                        cloudStack.concat(userLabel, 21) : 'Invalid User'
                     )
             )
                 .append(


### PR DESCRIPTION
The arrow always fell off when I log in ;-)

Before change it looked like this:
<img width="1521" alt="screenshot_23_01_16_21_10" src="https://cloud.githubusercontent.com/assets/1630096/12533043/f4e4baa8-c223-11e5-83ed-7e77bbce3a6c.png">

Now also longer names display nicely:
<img width="1549" alt="screen shot 2016-01-23 at 22 19 41" src="https://cloud.githubusercontent.com/assets/1630096/12533051/19474d20-c224-11e5-85c4-8d5ba1b7e938.png">

Ping @borisroman 
