### PR TITLE
CLOUDSTACK-9256 add unique key for static routes in json

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
@@ -20,7 +20,7 @@ from pprint import pprint
 
 def merge(dbag, staticroutes):
     for route in staticroutes['routes']:
-        key = route['ip_address']
+        key = route['network']
         revoke = route['revoke']
         if revoke:
             try:


### PR DESCRIPTION
Static routes that are being set do not show up in the static_routes.json file. The reason for this is that the index that is used, is the gateway address, which is not unique. Hence stuff is overwritten and lost.

Ping @borisroman @wilderrodrigues @DaanHoogland 