### PR TITLE
[4.5] vmware: improve support for disk controllers

### DIFF
--- a/core/src/org/apache/cloudstack/storage/command/AttachAnswer.java
+++ b/core/src/org/apache/cloudstack/storage/command/AttachAnswer.java
@@ -22,8 +22,11 @@ package org.apache.cloudstack.storage.command;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.to.DiskTO;
 
+import java.util.Map;
+
 public class AttachAnswer extends Answer {
     private DiskTO disk;
+    private Map<String, String> diskDetails;
 
     public AttachAnswer() {
         super(null);
@@ -32,6 +35,12 @@ public class AttachAnswer extends Answer {
     public AttachAnswer(DiskTO disk) {
         super(null);
         setDisk(disk);
+    }
+
+    public AttachAnswer(DiskTO disk, Map<String, String> diskDetails) {
+        super(null);
+        setDisk(disk);
+        setDiskDetails(diskDetails);
     }
 
     public AttachAnswer(String errMsg) {
@@ -44,5 +53,13 @@ public class AttachAnswer extends Answer {
 
     public void setDisk(DiskTO disk) {
         this.disk = disk;
+    }
+
+    public Map<String, String> getDiskDetails() {
+        return diskDetails;
+    }
+
+    public void setDiskDetails(Map<String, String> diskDetails) {
+        this.diskDetails = diskDetails;
     }
 }

--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -407,6 +407,10 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
             VolumeVO volumeVo = volDao.findById(volume.getId());
             Long oldPoolId = volume.getPoolId();
             volumeVo.setPath(((MigrateVolumeAnswer)answer).getVolumePath());
+            String chainInfo = ((MigrateVolumeAnswer) answer).getVolumeChainInfo();
+            if (chainInfo != null) {
+                volumeVo.setChainInfo(chainInfo);
+            }
             volumeVo.setPodId(destPool.getPodId());
             volumeVo.setPoolId(destPool.getId());
             volumeVo.setLastPoolId(oldPoolId);

--- a/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -1345,24 +1345,18 @@ public class VmwareStorageProcessor implements StorageProcessor {
             AttachAnswer answer = new AttachAnswer(disk);
 
             if (isAttach) {
-                String dataDiskController = controllerInfo.get(VmDetailConstants.DATA_DISK_CONTROLLER);
-                String rootDiskController = controllerInfo.get(VmDetailConstants.ROOK_DISK_CONTROLLER);
-                DiskControllerType rootDiskControllerType = DiskControllerType.getType(rootDiskController);
-
-                if (dataDiskController == null) {
-                    dataDiskController = getLegacyVmDataDiskController();
-                } else if ((rootDiskControllerType == DiskControllerType.lsilogic) ||
-                           (rootDiskControllerType == DiskControllerType.lsisas1068) ||
-                           (rootDiskControllerType == DiskControllerType.pvscsi) ||
-                           (rootDiskControllerType == DiskControllerType.buslogic)) {
-                    //TODO: Support mix of SCSI controller types for single VM. If root disk is already over
-                    //a SCSI controller then use the same for data volume as well. This limitation will go once mix
-                    //of SCSI controller types for single VM.
-                    dataDiskController = rootDiskController;
-                } else if (DiskControllerType.getType(dataDiskController) == DiskControllerType.osdefault) {
-                    dataDiskController = vmMo.getRecommendedDiskController(null);
+                Map<String, String> diskDetails = new HashMap<String, String>();
+                String diskController = null;
+                if (controllerInfo != null) {
+                    diskController = controllerInfo.get(VmDetailConstants.DATA_DISK_CONTROLLER);
                 }
-                vmMo.attachDisk(new String[] {datastoreVolumePath}, morDs, dataDiskController);
+                if (diskController == null) {
+                    diskController = getLegacyVmDataDiskController();
+                }
+                if (DiskControllerType.getType(diskController) == DiskControllerType.osdefault) {
+                    diskController = vmMo.getRecommendedDiskController(null);
+                }
+                vmMo.attachDisk(new String[] {datastoreVolumePath}, morDs, diskController);
             } else {
                 vmMo.removeAllSnapshots();
                 vmMo.detachDisk(datastoreVolumePath, false);

--- a/plugins/hypervisors/vmware/src/org/apache/cloudstack/storage/motion/VmwareStorageMotionStrategy.java
+++ b/plugins/hypervisors/vmware/src/org/apache/cloudstack/storage/motion/VmwareStorageMotionStrategy.java
@@ -207,6 +207,9 @@ public class VmwareStorageMotionStrategy implements DataMotionStrategy {
                     VolumeVO volumeVO = volDao.findById(volume.getId());
                     Long oldPoolId = volumeVO.getPoolId();
                     volumeVO.setPath(volumeTo.getPath());
+                    if (volumeTo.getChainInfo() != null) {
+                        volumeVO.setChainInfo(volumeTo.getChainInfo());
+                    }
                     volumeVO.setLastPoolId(oldPoolId);
                     volumeVO.setFolder(pool.getPath());
                     volumeVO.setPodId(pool.getPodId());

--- a/server/src/com/cloud/vm/UserVmManager.java
+++ b/server/src/com/cloud/vm/UserVmManager.java
@@ -111,4 +111,6 @@ public interface UserVmManager extends UserVmService {
     public void removeCustomOfferingDetails(long vmId);
 
     void generateUsageEvent(VirtualMachine vm, boolean isDisplay, String eventType);
+
+    void persistDeviceBusInfo(UserVmVO paramUserVmVO, String paramString);
 }

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -5028,6 +5028,15 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
     }
 
+    public void persistDeviceBusInfo(UserVmVO vm, String rootDiskController) {
+        String existingVmRootDiskController = vm.getDetail(VmDetailConstants.ROOK_DISK_CONTROLLER);
+        if (((existingVmRootDiskController == null) || (existingVmRootDiskController.isEmpty())) && (rootDiskController != null) && (!rootDiskController.isEmpty())) {
+            vm.setDetail(VmDetailConstants.ROOK_DISK_CONTROLLER, rootDiskController);
+            _vmDao.saveDetails(vm);
+            s_logger.debug("Persisted device bus information rootDiskController=" + rootDiskController + " for vm: " + vm.getDisplayName());
+        }
+    }
+
     @Override
     public String getConfigComponentName() {
         return UserVmManager.class.getSimpleName();

--- a/utils/src/org/apache/cloudstack/utils/volume/VirtualMachineVolumeChainInfo.java
+++ b/utils/src/org/apache/cloudstack/utils/volume/VirtualMachineVolumeChainInfo.java
@@ -17,34 +17,32 @@
 // under the License.
 //
 
-package com.cloud.agent.api.storage;
+package org.apache.cloudstack.utils.volume;
 
-import com.cloud.agent.api.Answer;
-import com.cloud.agent.api.Command;
+public class VirtualMachineVolumeChainInfo {
+    String diskDeviceBusName;
+    String[] diskChain;
 
-public class MigrateVolumeAnswer extends Answer {
-    private String volumePath;
-    private String volumeChain;
-
-    public MigrateVolumeAnswer(Command command, boolean success, String details, String volumePath) {
-        super(command, success, details);
-        this.volumePath = volumePath;
+    public String getDiskDeviceBusName() {
+        return this.diskDeviceBusName;
     }
 
-    public MigrateVolumeAnswer(Command command) {
-        super(command);
-        this.volumePath = null;
+    public void setDiskDeviceBusName(String diskDeviceBusName) {
+        this.diskDeviceBusName = diskDeviceBusName;
     }
 
-    public String getVolumePath() {
-        return volumePath;
+    public String[] getDiskChain() {
+        return this.diskChain;
     }
 
-    public String getVolumeChainInfo() {
-        return volumeChain;
+    public void setDiskChain(String[] diskChain) {
+        this.diskChain = diskChain;
     }
 
-    public void setVolumeChainInfo(String volumeChain) {
-        this.volumeChain = volumeChain;
+    public String getControllerFromDeviceBusName() {
+        if ((this.diskDeviceBusName == null) || (this.diskDeviceBusName.isEmpty()) || (!this.diskDeviceBusName.contains(":"))) {
+            return null;
+        }
+        return this.diskDeviceBusName.substring(0, this.diskDeviceBusName.indexOf(":") - 1);
     }
 }

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/GuestOsDescriptorType.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/GuestOsDescriptorType.java
@@ -1,4 +1,3 @@
-//
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -15,36 +14,25 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
+package com.cloud.hypervisor.vmware.mo;
 
-package com.cloud.agent.api.storage;
+public enum GuestOsDescriptorType
+{
+  windows9Guest,
+  windows9_64Guest,
+  windows9Server64Guest,
+  rhel7Guest,
+  rhel7_64Guest;
 
-import com.cloud.agent.api.Answer;
-import com.cloud.agent.api.Command;
-
-public class MigrateVolumeAnswer extends Answer {
-    private String volumePath;
-    private String volumeChain;
-
-    public MigrateVolumeAnswer(Command command, boolean success, String details, String volumePath) {
-        super(command, success, details);
-        this.volumePath = volumePath;
+  public static GuestOsDescriptorType fromValue(String value) {
+    if (value == null) {
+      return null;
     }
-
-    public MigrateVolumeAnswer(Command command) {
-        super(command);
-        this.volumePath = null;
+    GuestOsDescriptorType guestOsType = null;
+    try {
+      guestOsType = valueOf(value);
+    } catch (IllegalArgumentException e) {
     }
-
-    public String getVolumePath() {
-        return volumePath;
-    }
-
-    public String getVolumeChainInfo() {
-        return volumeChain;
-    }
-
-    public void setVolumeChainInfo(String volumeChain) {
-        this.volumeChain = volumeChain;
-    }
+    return guestOsType;
+  }
 }

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -2112,8 +2112,12 @@ public class VirtualMachineMO extends BaseMO {
         List<VirtualDevice> devices = (List<VirtualDevice>)_context.getVimClient().
                 getDynamicProperty(_mor, "config.hardware.device");
 
+        String deviceList = "";
         if (devices != null && devices.size() > 0) {
             for (VirtualDevice device : devices) {
+                if (device != null) {
+                    deviceList += String.format(" Device %s: info:%s controller key:%s;", device.getKey(), device.getDeviceInfo(), device.getControllerKey());
+                }
                 if ((DiskControllerType.getType(diskController) == DiskControllerType.lsilogic || DiskControllerType.getType(diskController) == DiskControllerType.scsi)
                         && device instanceof VirtualLsiLogicController) {
                     return ((VirtualLsiLogicController)device).getKey();
@@ -2131,7 +2135,8 @@ public class VirtualMachineMO extends BaseMO {
         }
 
         assert (false);
-        throw new Exception(diskController + " Controller Not Found");
+        throw new Exception("Scsi disk controller of type " + diskController + " not found among configured devices:" + deviceList +
+                ". Unable to find and return scsi disk controller key.");
     }
 
     public int getScsiDiskControllerKeyNoException(String diskController) throws Exception {


### PR DESCRIPTION
- Improve disk chain usage while attaching, migrating disks
- Gets root disk controller based diskDeviceBusName from volume's chain info
- Enforce a boot order based on the disk information CloudStack has