### PR TITLE
[4.9+] WIP: Support Java 8, Maven 3.3, Upgraded dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
   directories:
   - $HOME/.cache
 jdk:
-- oraclejdk7
+- oraclejdk8
 notifications:
   email: false
 env:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,12 +14,12 @@ was tested against a CentOS 6.5 x86_64 setup.
 
 Install tools and dependencies used for development:
 
-    $ yum install git ant ant-devel java-1.6.0-openjdk java-1.6.0-openjdk-devel
-    mysql mysql-server tomcat6 mkisofs gcc python MySQL-python openssh-clients wget
+    $ yum install git java-1.8.0-openjdk java-1.8.0-openjdk-devel
+      mysql mysql-server tomcat6 mkisofs gcc python MySQL-python openssh-clients wget
 
     # yum -y update
-    # yum -y install java-1.7.0-openjdk
-    # yum -y install java-1.7.0-openjdk-devel
+    # yum -y install java-1.8.0-openjdk
+    # yum -y install java-1.8.0-openjdk-devel
     # yum -y install mysql-server
     # yum -y install git
     # yum -y install genisoimage
@@ -63,7 +63,7 @@ Clear old database (if any) and deploy the database schema:
 
 Export the following variable if you need to run and debug the management server:
 
-    $ export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=500m -Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+    $ export MAVEN_OPTS="-Xmx1024m -Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
 
 Start the management server:
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -969,6 +969,7 @@
         </dependency>
       </dependencies>
     </profile>
+    <!--
     <profile>
       <id>f5</id>
       <activation>
@@ -984,6 +985,7 @@
         </dependency>
       </dependencies>
     </profile>
+    -->
     <profile>
       <id>nuagevsp</id>
       <activation>

--- a/engine/api/pom.xml
+++ b/engine/api/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.13</version>
+      <version>2.7.18</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>

--- a/engine/service/pom.xml
+++ b/engine/service/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.13</version>
+      <version>2.7.18</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>

--- a/framework/quota/src/org/apache/cloudstack/quota/QuotaStatementImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/QuotaStatementImpl.java
@@ -59,11 +59,11 @@ public class QuotaStatementImpl extends ManagerBase implements QuotaStatement {
 
     final public static int s_LAST_STATEMENT_SENT_DAYS = 6; //ideally should be less than 7 days
 
-    public enum STATEMENT_PERIODS {
+    public enum QuotaStatementPeriods {
         BIMONTHLY, MONTHLY, QUATERLY, HALFYEARLY, YEARLY
     };
 
-    private STATEMENT_PERIODS _period = STATEMENT_PERIODS.MONTHLY;
+    private QuotaStatementPeriods _period = QuotaStatementPeriods.MONTHLY;
 
     public QuotaStatementImpl() {
         super();
@@ -87,7 +87,7 @@ public class QuotaStatementImpl extends ManagerBase implements QuotaStatement {
         String period_str = configs.get(QuotaConfig.QuotaStatementPeriod.key());
         int period = period_str == null ? 1 : Integer.valueOf(period_str);
 
-        STATEMENT_PERIODS _period = STATEMENT_PERIODS.values()[period];
+        QuotaStatementPeriods _period = QuotaStatementPeriods.values()[period];
         return true;
     }
 
@@ -263,7 +263,7 @@ public class QuotaStatementImpl extends ManagerBase implements QuotaStatement {
         return null;
     }
 
-    public Calendar[] statementTime(final Calendar today, final STATEMENT_PERIODS period) {
+    public Calendar[] statementTime(final Calendar today, final QuotaStatementPeriods period) {
         //check if it is statement time
         int day_of_month = today.get(Calendar.DAY_OF_MONTH);
         int month_of_year = today.get(Calendar.MONTH);

--- a/framework/quota/test/org/apache/cloudstack/quota/QuotaStatementTest.java
+++ b/framework/quota/test/org/apache/cloudstack/quota/QuotaStatementTest.java
@@ -21,7 +21,7 @@ import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.db.TransactionLegacy;
 import junit.framework.TestCase;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.cloudstack.quota.QuotaStatementImpl.STATEMENT_PERIODS;
+import org.apache.cloudstack.quota.QuotaStatementImpl.QuotaStatementPeriods;
 import org.apache.cloudstack.quota.dao.QuotaAccountDao;
 import org.apache.cloudstack.quota.dao.QuotaUsageDao;
 import org.apache.cloudstack.quota.vo.QuotaAccountVO;
@@ -85,12 +85,12 @@ public class QuotaStatementTest extends TestCase {
 
         //BIMONTHLY - first statement of month
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS + 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period == null);
 
         //1 of this month
         date.set(Calendar.DATE, 1);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue(period[0].toString(), period[0].before(period[1]));
@@ -100,12 +100,12 @@ public class QuotaStatementTest extends TestCase {
         //BIMONTHLY - second statement of month
         date = Calendar.getInstance();
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS + 16);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period == null);
 
         //17 of this month
         date.set(Calendar.DATE, 17);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue(period[0].toString(), period[0].before(period[1]));
@@ -128,12 +128,12 @@ public class QuotaStatementTest extends TestCase {
         //MONTHLY
         date = Calendar.getInstance();
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS + 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.MONTHLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.MONTHLY);
         assertTrue(period == null);
 
         //1 of this month
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS - 1);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.MONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.MONTHLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue(period[0].toString(), period[0].before(period[1]));
@@ -157,7 +157,7 @@ public class QuotaStatementTest extends TestCase {
         date = Calendar.getInstance();
         date.set(Calendar.MONTH, Calendar.JANUARY); // 1 Jan
         date.set(Calendar.DATE, 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.QUATERLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.QUATERLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue("period[0].before(period[1])" + period[0].toString(), period[0].before(period[1]));
@@ -182,7 +182,7 @@ public class QuotaStatementTest extends TestCase {
         date = Calendar.getInstance();
         date.set(Calendar.MONTH, Calendar.JANUARY); // 1 Jan
         date.set(Calendar.DATE, 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.HALFYEARLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.HALFYEARLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue("period[0].before(period[1])" + period[0].toString(), period[0].before(period[1]));
@@ -207,7 +207,7 @@ public class QuotaStatementTest extends TestCase {
         date = Calendar.getInstance();
         date.set(Calendar.MONTH, Calendar.JANUARY); // 1 Jan
         date.set(Calendar.DATE, 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.YEARLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.YEARLY);
         assertTrue("period != null", period != null);
         assertTrue(period.length == 2);
         assertTrue("period[0].before(period[1])" + period[0].toString(), period[0].before(period[1]));
@@ -244,7 +244,7 @@ public class QuotaStatementTest extends TestCase {
 
         // call real method on send monthly statement
         quotaStatement.sendStatement();
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.MONTHLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.MONTHLY);
         if (period != null){
             Mockito.verify(alertManager, Mockito.times(1)).sendQuotaAlert(Mockito.any(QuotaAlertManagerImpl.DeferredQuotaEmail.class));
         }

--- a/framework/rest/pom.xml
+++ b/framework/rest/pom.xml
@@ -33,32 +33,32 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.13</version>
+      <version>2.7.18</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>

--- a/plugins/api/rate-limit/pom.xml
+++ b/plugins/api/rate-limit/pom.xml
@@ -33,7 +33,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkMode>always</forkMode>
-          <argLine>-Xmx2048m -XX:MaxPermSize=1024m</argLine>
+          <argLine>-Xmx2048m</argLine>
           <excludes>
             <exclude>org/apache/cloudstack/ratelimit/integration/*</exclude>
           </excludes>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.8.2.0</version>
+      <version>0.9.0.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugins/event-bus/rabbitmq/pom.xml
+++ b/plugins/event-bus/rabbitmq/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
     <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-        <version>3.5.4</version>
+        <version>3.6.0</version>
     </dependency>
     <dependency>
     <groupId>org.apache.cloudstack</groupId>

--- a/plugins/network-elements/globodns/pom.xml
+++ b/plugins/network-elements/globodns/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.globo.globodns</groupId>
       <artifactId>globodns-client</artifactId>
-      <version>0.0.15</version>
+      <version>0.0.20</version>
     </dependency>
   </dependencies>
 </project>

--- a/plugins/network-elements/juniper-contrail/pom.xml
+++ b/plugins/network-elements/juniper-contrail/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <version>1.9.5</version>
+        <version>1.10.19</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -146,6 +146,7 @@
         <module>file-systems/netapp</module>
       </modules>
     </profile>
+    <!--
     <profile>
       <id>f5</id>
       <activation>
@@ -157,6 +158,7 @@
         <module>network-elements/f5</module>
       </modules>
     </profile>
+    -->
     <profile>
       <id>srx</id>
       <activation>

--- a/plugins/storage/volume/cloudbyte/pom.xml
+++ b/plugins/storage/volume/cloudbyte/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
 	<groupId>com.sun.jersey</groupId>
 	<artifactId>jersey-bundle</artifactId>
-	<version>1.18.3</version>
+	<version>1.19</version>
 </dependency>
   </dependencies>
   <build>

--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
-      <version>0.7-groovy-2.0</version>
+      <version>1.0-groovy-2.4</version>
     </dependency>
 
     <!-- Optional dependencies for using Spock -->

--- a/plugins/user-authenticators/saml2/pom.xml
+++ b/plugins/user-authenticators/saml2/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.springframework.security.extensions</groupId>
       <artifactId>spring-security-saml2-core</artifactId>
-      <version>1.0.0.RELEASE</version>
+      <version>1.0.1.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.opensaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   </issueManagement>
 
   <prerequisites>
-    <maven>3.0.4</maven>
+    <maven>3.3.9</maven>
   </prerequisites>
 
   <properties>
@@ -55,7 +55,7 @@
 
     <cs.log4j.version>1.2.17</cs.log4j.version>
     <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
-    <cs.cglib.version>3.1</cs.cglib.version>
+    <cs.cglib.version>3.2.0</cs.cglib.version>
     <cs.dbcp.version>1.4</cs.dbcp.version>
     <cs.pool.version>1.6</cs.pool.version>
     <cs.codec.version>1.10</cs.codec.version>
@@ -65,25 +65,25 @@
     <cs.discovery.version>0.5</cs.discovery.version>
     <cs.ejb.version>3.0</cs.ejb.version>
     <!-- do not forget to also upgrade hamcrest library with junit -->
-    <cs.junit.version>4.11</cs.junit.version>
+    <cs.junit.version>4.12</cs.junit.version>
     <cs.hamcrest.version>1.3</cs.hamcrest.version>
     <cs.bcprov.version>1.46</cs.bcprov.version>
-    <cs.jsch.version>0.1.51</cs.jsch.version>
-    <cs.jpa.version>2.1.0</cs.jpa.version>
+    <cs.jsch.version>0.1.53</cs.jsch.version>
+    <cs.jpa.version>2.1.1</cs.jpa.version>
     <cs.jasypt.version>1.9.2</cs.jasypt.version>
-    <cs.trilead.version>1.0.0-build217</cs.trilead.version>
-    <cs.ehcache.version>2.6.9</cs.ehcache.version>
-    <cs.gson.version>1.7.2</cs.gson.version>
+    <cs.trilead.version>1.0.0-build220</cs.trilead.version>
+    <cs.ehcache.version>2.6.11</cs.ehcache.version>
+    <cs.gson.version>2.5</cs.gson.version>
     <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
-    <cs.guava.version>18.0</cs.guava.version>
+    <cs.guava.version>19.0</cs.guava.version>
     <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
-    <cs.httpclient.version>4.5</cs.httpclient.version>
-    <cs.httpcore.version>4.4</cs.httpcore.version>
+    <cs.httpclient.version>4.5.1</cs.httpclient.version>
+    <cs.httpcore.version>4.4.4</cs.httpcore.version>
     <cs.commons-httpclient.version>3.1</cs.commons-httpclient.version>
     <cs.mysql.version>5.1.34</cs.mysql.version>
-    <cs.xstream.version>1.4.7</cs.xstream.version>
+    <cs.xstream.version>1.4.8</cs.xstream.version>
     <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>
-    <cs.mail.version>1.4.7</cs.mail.version>
+    <cs.mail.version>1.5.0-b01</cs.mail.version>
     <cs.axis.version>1.4</cs.axis.version>
     <cs.axis2.version>1.5.6</cs.axis2.version>
     <cs.rampart.version>1.5.1</cs.rampart.version>
@@ -93,27 +93,27 @@
     <cs.jstl.version>1.2</cs.jstl.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
     <cs.vmware.api.version>5.5</cs.vmware.api.version>
-    <org.springframework.version>3.2.12.RELEASE</org.springframework.version>
-    <cs.mockito.version>1.9.5</cs.mockito.version>
-    <cs.powermock.version>1.5.3</cs.powermock.version>
-    <cs.aws.sdk.version>1.10.34</cs.aws.sdk.version>
+    <org.springframework.version>3.2.16.RELEASE</org.springframework.version>
+    <cs.mockito.version>1.10.19</cs.mockito.version>
+    <cs.powermock.version>1.6.4</cs.powermock.version>
+    <cs.aws.sdk.version>1.10.49</cs.aws.sdk.version>
     <cs.jackson.version>2.6.3</cs.jackson.version>
     <cs.lang.version>2.6</cs.lang.version>
     <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>
-    <cs.commons-validator.version>1.4.0</cs.commons-validator.version>
-    <cs.reflections.version>0.9.9</cs.reflections.version>
-    <cs.java-ipv6.version>0.15</cs.java-ipv6.version>
+    <cs.commons-validator.version>1.5.0</cs.commons-validator.version>
+    <cs.reflections.version>0.9.10</cs.reflections.version>
+    <cs.java-ipv6.version>0.16</cs.java-ipv6.version>
     <cs.replace.properties>build/replace.properties</cs.replace.properties>
     <cs.libvirt-java.version>0.5.1</cs.libvirt-java.version>
     <cs.rados-java.version>0.2.0</cs.rados-java.version>
     <cs.target.dir>target</cs.target.dir>
     <cs.daemon.version>1.0.15</cs.daemon.version>
     <cs.jna.version>4.0.0</cs.jna.version>
-    <cs.checkstyle.version>2.11</cs.checkstyle.version>
-    <cs.mycila.license.version>2.7</cs.mycila.license.version>
-    <cs.findbugs.version>3.0.1</cs.findbugs.version>
-    <cs.javadoc.version>2.10.1</cs.javadoc.version>
+    <cs.checkstyle.version>2.17</cs.checkstyle.version>
+    <cs.mycila.license.version>2.11</cs.mycila.license.version>
+    <cs.findbugs.version>3.0.3</cs.findbugs.version>
+    <cs.javadoc.version>2.10.3</cs.javadoc.version>
     <cs.opensaml.version>2.6.1</cs.opensaml.version>
     <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
@@ -390,17 +390,17 @@
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.snmp4j</artifactId>
-        <version>2.3.1_1</version>
+        <version>2.3.4_1</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjtools</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.8</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjweaver</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.8</version>
       </dependency>
       <dependency>
         <groupId>org.apache.axis</groupId>
@@ -425,12 +425,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   </prerequisites>
 
   <properties>
-    <cs.jdk.version>1.7</cs.jdk.version>
+    <cs.jdk.version>1.8</cs.jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/services/console-proxy-rdp/rdpconsole/pom.xml
+++ b/services/console-proxy-rdp/rdpconsole/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
-      <version>8.0.15</version>
+      <version>8.0.30</version>
     </dependency>
     <!-- Another implementation of SSL protocol. Does not work with broken MS RDP SSL too. -->
     <dependency>

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -57,7 +57,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.0.25.Final</version>
+        <version>4.0.33.Final</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/tools/checkstyle/pom.xml
+++ b/tools/checkstyle/pom.xml
@@ -28,7 +28,7 @@
     
     
     <prerequisites>
-      <maven>3.0.4</maven>
+      <maven>3.3.9</maven>
     </prerequisites>
     
     <build>

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -y update && apt-get install -y \
     genisoimage \
     git \
     maven \
-    openjdk-7-jdk \
+    openjdk-8-jdk \
     python-dev \
     python-setuptools \
     python-pip \

--- a/tools/travis/before_script.sh
+++ b/tools/travis/before_script.sh
@@ -35,7 +35,7 @@ if [ $MOD -ne 0 ]; then
 fi
 
 
-export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=500m -Djava.security.egd=file:/dev/./urandom"
+export MAVEN_OPTS="-Xmx1024m -Djava.security.egd=file:/dev/./urandom"
 echo -e "\nStarting simulator"
 mvn -Dsimulator -pl :cloud-client-ui jetty:run 2>&1 > /tmp/jetty-log &
 

--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -34,7 +34,7 @@ if [ $MOD -ne 0 ]; then
  fi
 fi
 
-export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=500m -Djava.security.egd=file:/dev/./urandom"
+export MAVEN_OPTS="-Xmx1024m -Djava.security.egd=file:/dev/./urandom"
 
 if [ $TEST_SEQUENCE_NUMBER -eq 1 ]; then
    mvn -q -Pimpatient -Dsimulator clean install

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -53,17 +53,17 @@
      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
     <dependency>
       <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>
-      <version>2.4.9</version>
+      <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.3</version>
+      <version>3.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Was learning about JDK8, lambdas, streams etc today. Thought it would be a good idea to get ACS codebase to latest mvn and jdk8. This is a WIP branch pushed on ACS remote so feel free to push changes if you're a committer or send PR.

Major changes:
- Moved to latest JDK8
- Moved to latest Maven 3.3.9 (-T threaded compilations appears faster)
- Upgraded several dependencies to latest minor versions (or major in few cases)

What fails/unsupported or TODOs:
- Unit tests in cloud-server and few other places
- F5 plugin fails, tried to resolve the issue but I was unable to grok it
- Major spring framework version (that would be a lot of work on its own)
- Major servlet version changes
- Fix packaging, init.d/system.d JAVA_HOME paths
- Check ACS agents with JDK/JRE8 (kvm, cpvm, ssvm)
- Check and configure GC related changes wrt JRE7/JRE8 (in any configs, say tomcat configs)
- Check against compatibility guide: http://www.oracle.com/technetwork/java/javase/8-compatibility-guide-2156366.html

What works:
- Compiling in -Dnoredist with -DskipTests to test if ACS codebase (minus unit tests) worked (non-issue once we fix the failing unit tests)
- Deploy db worked
- Running the management server locally with Java8