### PR TITLE
Fixes regarding VOLUME_DELETE events resulting from account deletion.

### DIFF
--- a/engine/components-api/src/com/cloud/event/UsageEventUtils.java
+++ b/engine/components-api/src/com/cloud/event/UsageEventUtils.java
@@ -177,7 +177,7 @@ public class UsageEventUtils {
             return; // no provider is configured to provide events bus, so just return
         }
 
-        Account account = s_accountDao.findById(accountId);
+        Account account = s_accountDao.findByIdIncludingRemoved(accountId);
         DataCenterVO dc = s_dcDao.findById(zoneId);
 
         // if account has been deleted, this might be called during cleanup of resources and results in null pointer

--- a/server/src/com/cloud/storage/listener/VolumeStateListener.java
+++ b/server/src/com/cloud/storage/listener/VolumeStateListener.java
@@ -115,6 +115,7 @@ public class VolumeStateListener implements StateListener<State, Event, Volume> 
         eventDescription.put("id", vo.getUuid());
         eventDescription.put("old-state", oldState.name());
         eventDescription.put("new-state", newState.name());
+        eventDescription.put("status", status);
 
         String eventDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(new Date());
         eventDescription.put("eventDateTime", eventDate);

--- a/server/src/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/com/cloud/user/AccountManagerImpl.java
@@ -84,6 +84,7 @@ import com.cloud.event.ActionEvent;
 import com.cloud.event.ActionEventUtils;
 import com.cloud.event.ActionEvents;
 import com.cloud.event.EventTypes;
+import com.cloud.event.UsageEventUtils;
 import com.cloud.exception.AgentUnavailableException;
 import com.cloud.exception.CloudAuthenticationException;
 import com.cloud.exception.ConcurrentOperationException;
@@ -160,6 +161,7 @@ import com.cloud.vm.ReservationContextImpl;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.dao.InstanceGroupDao;
 import com.cloud.vm.dao.UserVmDao;
@@ -762,6 +764,17 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 if (!_vmMgr.expunge(vm, callerUserId, caller)) {
                     s_logger.error("Unable to expunge vm: " + vm.getId());
                     accountCleanupNeeded = true;
+                }
+                else if (!vm.getState().equals(VirtualMachine.State.Destroyed)) {
+                    // We have to emit the event here because the state listener is ignoring root volume deletions,
+                    // assuming that the UserVMManager is responsible for emitting the usage event for them when
+                    // the vm delete command is processed
+                    List<VolumeVO> volumes = _volumeDao.findByInstanceAndType(vm.getId(), Volume.Type.ROOT);
+                    for (VolumeVO volume : volumes) {
+                            UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VOLUME_DELETE, volume.getAccountId(), volume.getDataCenterId(), volume.getId(), volume.getName(),
+                                    Volume.class.getName(), volume.getUuid(), volume.isDisplayVolume());
+                    }
+
                 }
             }
 

--- a/server/test/com/cloud/user/AccountManagerImplTest.java
+++ b/server/test/com/cloud/user/AccountManagerImplTest.java
@@ -17,23 +17,21 @@
 package com.cloud.user;
 
 import java.lang.reflect.Field;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Arrays;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
 import com.cloud.server.auth.UserAuthenticator;
 import com.cloud.utils.Pair;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker;
@@ -44,10 +42,14 @@ import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationSe
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
 import org.apache.cloudstack.region.gslb.GlobalLoadBalancerRuleDao;
-
-import com.cloud.vm.snapshot.VMSnapshotManager;
-import com.cloud.vm.snapshot.VMSnapshotVO;
-import com.cloud.vm.snapshot.dao.VMSnapshotDao;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import com.cloud.configuration.ConfigurationManager;
 import com.cloud.configuration.dao.ResourceCountDao;
@@ -58,6 +60,8 @@ import com.cloud.dc.dao.DedicatedResourceDao;
 import com.cloud.domain.Domain;
 import com.cloud.domain.DomainVO;
 import com.cloud.domain.dao.DomainDao;
+import com.cloud.event.UsageEventUtils;
+import com.cloud.event.UsageEventVO;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.network.as.AutoScaleManager;
@@ -74,7 +78,9 @@ import com.cloud.network.vpn.Site2SiteVpnManager;
 import com.cloud.projects.ProjectManager;
 import com.cloud.projects.dao.ProjectAccountDao;
 import com.cloud.projects.dao.ProjectDao;
+import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeApiService;
+import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.storage.dao.VolumeDao;
@@ -87,12 +93,16 @@ import com.cloud.user.dao.UserDao;
 import com.cloud.vm.UserVmManager;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.InstanceGroupDao;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 import org.springframework.test.util.ReflectionTestUtils;
+import com.cloud.vm.snapshot.VMSnapshotManager;
+import com.cloud.vm.snapshot.VMSnapshotVO;
+import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AccountManagerImplTest {
@@ -193,6 +203,9 @@ public class AccountManagerImplTest {
     VMSnapshotDao _vmSnapshotDao;
 
     @Mock
+    MockUsageEventDao _usageEventDao;
+
+    @Mock
     User callingUser;
     @Mock
     Account callingAccount;
@@ -204,6 +217,11 @@ public class AccountManagerImplTest {
 
     @Mock
     private UserAuthenticator userAuthenticator;
+
+    //Maintain a list of old fields in the usage utils class... This
+    //is because of weirdness of how it uses static fields and an init
+    //method.
+    private Map<String, Object> oldFields = new HashMap<>();
 
     @Before
     public void setup() throws NoSuchFieldException, SecurityException,
@@ -353,6 +371,133 @@ public class AccountManagerImplTest {
         Mockito.verify(userAuthenticator, Mockito.times(1)).authenticate("test", "fail", 1L, null);
         Mockito.verify(userAuthenticator, Mockito.never()).authenticate("test", null, 1L, null);
         Mockito.verify(userAuthenticator, Mockito.never()).authenticate("test", "", 1L, null);
+    }
 
+    public UsageEventUtils setupUsageUtils() {
+        _usageEventDao = new MockUsageEventDao();
+        UsageEventUtils utils = new UsageEventUtils();
+
+        Map<String, String> usageUtilsFields = new HashMap<String, String>();
+        usageUtilsFields.put("usageEventDao", "_usageEventDao");
+        usageUtilsFields.put("accountDao", "_accountDao");
+        usageUtilsFields.put("dcDao", "_dcDao");
+        usageUtilsFields.put("configDao", "_configDao");
+
+        for (String fieldName : usageUtilsFields.keySet()) {
+            try {
+                Field f = UsageEventUtils.class.getDeclaredField(fieldName);
+                f.setAccessible(true);
+                //Remember the old fields for cleanup later (see cleanupUsageUtils)
+                Field staticField = UsageEventUtils.class.getDeclaredField("s_" + fieldName);
+                staticField.setAccessible(true);
+                oldFields.put(f.getName(), staticField.get(null));
+                f.set(utils,
+                        this.getClass()
+                                .getDeclaredField(
+                                        usageUtilsFields.get(fieldName))
+                                .get(this));
+            } catch (IllegalArgumentException | IllegalAccessException
+                    | NoSuchFieldException | SecurityException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+
+        }
+        try {
+            Method method = UsageEventUtils.class.getDeclaredMethod("init");
+            method.setAccessible(true);
+            method.invoke(utils);
+        } catch (SecurityException | NoSuchMethodException
+                | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+        return utils;
+    }
+
+    public void cleanupUsageUtils() {
+        UsageEventUtils utils = new UsageEventUtils();
+
+        for (String fieldName : oldFields.keySet()) {
+            try {
+                Field f = UsageEventUtils.class.getDeclaredField(fieldName);
+                f.setAccessible(true);
+                f.set(utils, oldFields.get(fieldName));
+            } catch (IllegalArgumentException | IllegalAccessException
+                    | NoSuchFieldException | SecurityException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+
+        }
+        try {
+            Method method = UsageEventUtils.class.getDeclaredMethod("init");
+            method.setAccessible(true);
+            method.invoke(utils);
+        } catch (SecurityException | NoSuchMethodException
+                | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+    public List<UsageEventVO> deleteUserAccountRootVolumeUsageEvents(boolean vmDestroyedPrior) {
+        AccountVO account = new AccountVO();
+        account.setId(42l);
+        DomainVO domain = new DomainVO();
+        UserVmVO vm = Mockito.mock(UserVmVO.class);
+        VolumeVO vol = Mockito.mock(VolumeVO.class);
+        Mockito.when(_accountDao.findById(42l)).thenReturn(account);
+        Mockito.when(
+                securityChecker.checkAccess(Mockito.any(Account.class),
+                        Mockito.any(ControlledEntity.class), Mockito.any(AccessType.class),
+                        Mockito.anyString()))
+                .thenReturn(true);
+        Mockito.when(_accountDao.remove(42l)).thenReturn(true);
+        Mockito.when(_userVmDao.listByAccountId(42l)).thenReturn(
+                Arrays.asList(vm));
+        Mockito.when(_userVmDao.findByUuid(Mockito.any(String.class))).thenReturn(vm);
+        Mockito.when(
+                _vmMgr.expunge(Mockito.any(UserVmVO.class), Mockito.anyLong(),
+                        Mockito.any(Account.class))).thenReturn(true);
+        Mockito.when(vm.getState()).thenReturn(
+                vmDestroyedPrior
+                        ? VirtualMachine.State.Destroyed
+                        : VirtualMachine.State.Running);
+        Mockito.when(
+                _volumeDao.findByInstanceAndType(Mockito.any(Long.class),
+                        Mockito.eq(Volume.Type.ROOT))).thenReturn(
+                Arrays.asList(vol));
+        Mockito.when(vol.getAccountId()).thenReturn((long) 1);
+        Mockito.when(vol.getDataCenterId()).thenReturn((long) 1);
+        Mockito.when(vol.getId()).thenReturn((long) 1);
+        Mockito.when(vol.getName()).thenReturn("root volume");
+        Mockito.when(vol.getUuid()).thenReturn("vol-111111");
+        Mockito.when(vol.isDisplayVolume()).thenReturn(true);
+
+        Mockito.when(_domainMgr.getDomain(Mockito.anyLong()))
+                .thenReturn(domain);
+
+        accountManager.deleteUserAccount(42);
+        return _usageEventDao.listAll();
+    }
+
+    @Test
+    public void destroyedVMRootVolumeUsageEvent() {
+        UsageEventUtils utils = setupUsageUtils();
+        List<UsageEventVO> emittedEvents = deleteUserAccountRootVolumeUsageEvents(true);
+        Assert.assertEquals(0, emittedEvents.size());
+        cleanupUsageUtils();
+    }
+
+    @Test
+    public void runningVMRootVolumeUsageEvent() {
+        UsageEventUtils utils = setupUsageUtils();
+        List<UsageEventVO> emittedEvents = deleteUserAccountRootVolumeUsageEvents(false);
+        Assert.assertEquals(1, emittedEvents.size());
+        cleanupUsageUtils();
     }
 }

--- a/server/test/com/cloud/user/MockUsageEventDao.java
+++ b/server/test/com/cloud/user/MockUsageEventDao.java
@@ -1,0 +1,340 @@
+package com.cloud.user;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import javax.naming.ConfigurationException;
+
+import com.cloud.event.UsageEventVO;
+import com.cloud.event.dao.UsageEventDao;
+import com.cloud.utils.Pair;
+import com.cloud.utils.db.Attribute;
+import com.cloud.utils.db.Filter;
+import com.cloud.utils.db.GenericSearchBuilder;
+import com.cloud.utils.db.SearchBuilder;
+import com.cloud.utils.db.SearchCriteria;
+
+public class MockUsageEventDao implements UsageEventDao{
+
+    List<UsageEventVO> persistedItems;
+
+    public MockUsageEventDao() {
+        persistedItems = new ArrayList<UsageEventVO>();
+    }
+
+    @Override
+    public UsageEventVO findById(Long id) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO findByIdIncludingRemoved(Long id) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO findById(Long id, boolean fresh) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO findByUuid(String uuid) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO findByUuidIncludingRemoved(String uuid) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO createForUpdate() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public SearchBuilder<UsageEventVO> createSearchBuilder() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <K> GenericSearchBuilder<UsageEventVO, K> createSearchBuilder(
+            Class<K> clazz) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO createForUpdate(Long id) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public SearchCriteria<UsageEventVO> createSearchCriteria() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> lockRows(SearchCriteria<UsageEventVO> sc,
+            Filter filter, boolean exclusive) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO lockOneRandomRow(SearchCriteria<UsageEventVO> sc,
+            boolean exclusive) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO lockRow(Long id, Boolean exclusive) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO acquireInLockTable(Long id) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO acquireInLockTable(Long id, int seconds) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean releaseFromLockTable(Long id) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean update(Long id, UsageEventVO entity) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public int update(UsageEventVO entity, SearchCriteria<UsageEventVO> sc) {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public List<UsageEventVO> listAll() {
+
+        return persistedItems;
+    }
+
+    @Override
+    public List<UsageEventVO> listAll(Filter filter) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> search(SearchCriteria<UsageEventVO> sc,
+            Filter filter) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> search(SearchCriteria<UsageEventVO> sc,
+            Filter filter, boolean enableQueryCache) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> searchIncludingRemoved(
+            SearchCriteria<UsageEventVO> sc, Filter filter, Boolean lock,
+            boolean cache) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> searchIncludingRemoved(
+            SearchCriteria<UsageEventVO> sc, Filter filter, Boolean lock,
+            boolean cache, boolean enableQueryCache) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <M> List<M> customSearchIncludingRemoved(SearchCriteria<M> sc,
+            Filter filter) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> listAllIncludingRemoved() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> listAllIncludingRemoved(Filter filter) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO persist(UsageEventVO entity) {
+        persistedItems.add(entity);
+        return entity;
+    }
+
+    @Override
+    public boolean remove(Long id) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public int remove(SearchCriteria<UsageEventVO> sc) {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public boolean expunge(Long id) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public int expunge(SearchCriteria<UsageEventVO> sc) {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public void expunge() {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public <K> K getNextInSequence(Class<K> clazz, String name) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean configure(String name, Map<String, Object> params)
+            throws ConfigurationException {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public <M> List<M> customSearch(SearchCriteria<M> sc, Filter filter) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean lockInLockTable(String id) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean lockInLockTable(String id, int seconds) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean unlockFromLockTable(String id) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public <K> K getRandomlyIncreasingNextInSequence(Class<K> clazz, String name) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public UsageEventVO findOneBy(SearchCriteria<UsageEventVO> sc) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Class<UsageEventVO> getEntityBeanType() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Pair<List<UsageEventVO>, Integer> searchAndCount(
+            SearchCriteria<UsageEventVO> sc, Filter filter) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public Map<String, Attribute> getAllAttributes() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> listLatestEvents(Date endDate) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> getLatestEvent() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> getRecentEvents(Date endDate) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<UsageEventVO> listDirectIpEvents(Date startDate, Date endDate,
+            long zoneId) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void saveDetails(long eventId, Map<String, String> details) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public Pair<List<UsageEventVO>, Integer> searchAndDistinctCount(SearchCriteria<UsageEventVO> sc, Filter filter) {
+        //TODO Auto-generated method stub
+        return null;
+    }
+
+}


### PR DESCRIPTION
New version of #924, but on the right branch with the commits squashed.

**Original pull request:**
Fixes regarding usage event emission.

UsageEventUtils was previously not checking deleted accounts, which meant that if an account was deleted that had some resources running on it, those resources would get destroyed without emitting any events.

Furthermore, the VOLUME_DELETE event of ROOT volumes is the responsibility of the UserVmManager, which gets circumvented when expunging resources following the account deletion. Added a check to the AccountManager which catches the ROOT volumes that need to be deleted and emits events for them.

To test this: Create a new user. As that user, create and destroy an instance. This should cause the VM_CREATE, VM_START, VM_STOP, VM_DESTROY, VOLUME_CREATE, and VOLUME_DELETE events to be emitted. 
Create a new instance as the same user. Log in as admin, and delete the user. The same set of events should be emitted, and there should be no duplicate DELETE events for the ROOT volume of the previous instance.