### PR TITLE
Fixes regarding VOLUME_DELETE events resulting from account deletion.

### DIFF
--- a/engine/components-api/src/com/cloud/event/UsageEventUtils.java
+++ b/engine/components-api/src/com/cloud/event/UsageEventUtils.java
@@ -177,7 +177,7 @@ public class UsageEventUtils {
             return; // no provider is configured to provide events bus, so just return
         }
 
-        Account account = s_accountDao.findById(accountId);
+        Account account = s_accountDao.findByIdIncludingRemoved(accountId);
         DataCenterVO dc = s_dcDao.findById(zoneId);
 
         // if account has been deleted, this might be called during cleanup of resources and results in null pointer

--- a/server/src/com/cloud/storage/listener/VolumeStateListener.java
+++ b/server/src/com/cloud/storage/listener/VolumeStateListener.java
@@ -115,6 +115,7 @@ public class VolumeStateListener implements StateListener<State, Event, Volume> 
         eventDescription.put("id", vo.getUuid());
         eventDescription.put("old-state", oldState.name());
         eventDescription.put("new-state", newState.name());
+        eventDescription.put("status", status);
 
         String eventDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(new Date());
         eventDescription.put("eventDateTime", eventDate);


### PR DESCRIPTION
New version of #924, but on the right branch with the commits squashed.

Original pull request:
Fixes regarding usage event emission.

UsageEventUtils was previously not checking deleted accounts, which meant that if an account was deleted that had some resources running on it, those resources would get destroyed without emitting any events.

Furthermore, the VOLUME_DELETE event of ROOT volumes is the responsibility of the UserVmManager, which gets circumvented when expunging resources following the account deletion. Added a check to the AccountManager which catches the ROOT volumes that need to be deleted and emits events for them.

To test this: Create a new user. As that user, create and destroy an instance. This should cause the VM_CREATE, VM_START, VM_STOP, VM_DESTROY, VOLUME_CREATE, and VOLUME_DELETE events to be emitted. 
Create a new instance as the same user. Log in as admin, and delete the user. The same set of events should be emitted, and there should be no duplicate DELETE events for the ROOT volume of the previous instance.