### PR TITLE
CLOUDSTACK-8830 : VM snapshot  creation fails for 12 min

### DIFF
--- a/test/integration/component/test_escalations_snapshots.py
+++ b/test/integration/component/test_escalations_snapshots.py
@@ -31,8 +31,6 @@ from marvin.lib.utils import validateList, cleanup_resources
 from marvin.codes import PASS
 from nose.plugins.attrib import attr
 import time
-
-
 class TestSnapshots(cloudstackTestCase):
 
     @classmethod
@@ -101,7 +99,6 @@ class TestSnapshots(cloudstackTestCase):
             cls.tearDownClass()
             raise Exception("Warning: Exception in setup : %s" % e)
         return
-
     @classmethod
     def tearDownClass(cls):
         try:
@@ -110,21 +107,16 @@ class TestSnapshots(cloudstackTestCase):
             raise Exception("Warning: Exception during cleanup : %s" % e)
 
         return
-
     def setUp(self):
 
         self.apiClient = self.testClient.getApiClient()
         self.cleanup = []
         if self.unsupportedHypervisor:
             self.skipTest("Snapshots are not supported on %s" %self.hypervisor)
-
     def tearDown(self):
         # Clean up, terminate the created resources
         cleanup_resources(self.apiClient, self.cleanup)
         return
-
-   #placeholder
-
     def __verify_values(self, expected_vals, actual_vals):
         """
         @Desc: Function to verify expected and actual values
@@ -155,7 +147,6 @@ class TestSnapshots(cloudstackTestCase):
                                                                                           act_val
                                                                                           ))
         return return_flag
-
     def createInstance(self, service_off, networks=None, api_client=None):
         """Creates an instance in account"""
 
@@ -174,16 +165,12 @@ class TestSnapshots(cloudstackTestCase):
                  networkids=networks,
                  serviceofferingid=service_off.id)
             vms = VirtualMachine.list(api_client, id=vm.id, listall=True)
-            self.assertIsInstance(vms,
-                list,
-                "List VMs should return a valid response")
+            validateList(vms)
             self.assertEqual(vms[0].state, "Running",
                     "Vm state should be running after deployment")
             return vm
         except Exception as e:
             self.fail("Failed to deploy an instance: %s" % e)
-
-
     @attr(tags=["advanced", "basic"], required_hardware="true")
     def test_01_list_volume_snapshots_pagination(self):
         """
@@ -318,7 +305,6 @@ class TestSnapshots(cloudstackTestCase):
                           "Volume snapshot not deleted from page 2"
                           )
         return
-
     @attr(tags=["advanced", "basic"], required_hardware="true")
     def test_02_list_volume_snapshots_byid(self):
         """
@@ -671,12 +657,11 @@ class TestSnapshots(cloudstackTestCase):
                          "Listed VM Snapshot details are not as expected"
                          )
         return
-
     @attr(tags=["advanced", "basic"], required_hardware="true")
     def test_05_check_vm_snapshot_creation_after_Instance_creation(self):
         """
-        @summary: Test  if SS creation is successful in the first
-        10 minutes of VM deployment
+        @summary: Test  if Snapshot creation is successful
+        in the first 10 minutes of VM deployment
 
         Step1: Create a VM with any Service offering
         Step2: Create a VM snapshot
@@ -684,8 +669,8 @@ class TestSnapshots(cloudstackTestCase):
                10 minutes of VM deployment
         """
         if self.hypervisor.lower() not in ['vmware']:
-            raise unittest.SkipTest("This test case is only for vmware. Hence, skipping the test")
-
+            self.skipTest("This test case is only for vmware. Hence, skipping the test")
+            
         api_client = self.testClient.getUserApiClient(
                 UserName=self.account.name,
                 DomainName=self.account.domain)

--- a/test/integration/component/test_escalations_snapshots.py
+++ b/test/integration/component/test_escalations_snapshots.py
@@ -30,6 +30,8 @@ from marvin.lib.common import (get_domain,
 from marvin.lib.utils import validateList, cleanup_resources
 from marvin.codes import PASS
 from nose.plugins.attrib import attr
+import time
+
 
 class TestSnapshots(cloudstackTestCase):
 
@@ -100,6 +102,15 @@ class TestSnapshots(cloudstackTestCase):
             raise Exception("Warning: Exception in setup : %s" % e)
         return
 
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cleanup_resources(cls.api_client, cls._cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+
+        return
+
     def setUp(self):
 
         self.apiClient = self.testClient.getApiClient()
@@ -112,14 +123,7 @@ class TestSnapshots(cloudstackTestCase):
         cleanup_resources(self.apiClient, self.cleanup)
         return
 
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            cleanup_resources(cls.api_client, cls._cleanup)
-        except Exception as e:
-            raise Exception("Warning: Exception during cleanup : %s" % e)
-
-        return
+   #placeholder
 
     def __verify_values(self, expected_vals, actual_vals):
         """
@@ -151,6 +155,34 @@ class TestSnapshots(cloudstackTestCase):
                                                                                           act_val
                                                                                           ))
         return return_flag
+
+    def createInstance(self, service_off, networks=None, api_client=None):
+        """Creates an instance in account"""
+
+        if api_client is None:
+            api_client = self.apiclient
+
+        self.debug("Deploying an instance in account: %s" %
+                       self.account.name)
+        try:
+            vm = VirtualMachine.create(
+                 api_client,
+                 self.services["virtual_machine"],
+                 templateid=self.template.id,
+                 accountid=self.account.name,
+                 domainid=self.account.domainid,
+                 networkids=networks,
+                 serviceofferingid=service_off.id)
+            vms = VirtualMachine.list(api_client, id=vm.id, listall=True)
+            self.assertIsInstance(vms,
+                list,
+                "List VMs should return a valid response")
+            self.assertEqual(vms[0].state, "Running",
+                    "Vm state should be running after deployment")
+            return vm
+        except Exception as e:
+            self.fail("Failed to deploy an instance: %s" % e)
+
 
     @attr(tags=["advanced", "basic"], required_hardware="true")
     def test_01_list_volume_snapshots_pagination(self):
@@ -639,3 +671,47 @@ class TestSnapshots(cloudstackTestCase):
                          "Listed VM Snapshot details are not as expected"
                          )
         return
+
+    @attr(tags=["advanced", "basic"], required_hardware="true")
+    def test_05_check_vm_snapshot_creation_after_Instance_creation(self):
+        """
+        @summary: Test  if SS creation is successful in the first
+        10 minutes of VM deployment
+
+        Step1: Create a VM with any Service offering
+        Step2: Create a VM snapshot
+        Step3: Verify if SS creation is successful within first
+               10 minutes of VM deployment
+        """
+        if self.hypervisor.lower() not in ['vmware']:
+            raise unittest.SkipTest("This test case is only for vmware. Hence, skipping the test")
+
+        api_client = self.testClient.getUserApiClient(
+                UserName=self.account.name,
+                DomainName=self.account.domain)
+
+        vm = self.createInstance(service_off=self.service_offering, api_client=api_client)
+        start_time = time.time()
+
+
+        snapshot_created_1 = VmSnapshot.create(
+                                                 self.userapiclient,
+                                                 vm.id
+                                                 )
+        self.assertIsNotNone(
+                                snapshot_created_1,
+                                "Snapshot creation failed"
+                                 )
+
+        time_elapsed = time.time()-start_time
+
+        self.assertTrue(
+                        time_elapsed < 600,
+                        "Snapshot did not get created in the first 10 minutes after VM creation"
+                        )
+
+
+
+
+
+


### PR DESCRIPTION
VM snapshot fails for 12 min after instance creation
# ISSUE

VM snapshot fails for 12 min after instance creation
# EXPECTED BEHAVIOR

VMSnapshot should be successful from the moment the VM is ready
