### PR TITLE
Add missing license header to ActionEventUtilsTest.

### DIFF
--- a/server/test/com/cloud/event/ActionEventUtilsTest.java
+++ b/server/test/com/cloud/event/ActionEventUtilsTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.event;
 
 import java.lang.reflect.Field;


### PR DESCRIPTION
The test class was merged without the license header. This commit fixes that problem.

Also note that the license header exists on the master branch only as a result of commit 8a5fc16. The commit seems to be on the master branch and the 4.7 branch only. So there may be some conflicts when forward merging.