### PR TITLE
CLOUDSTACK-9264: Make /32 static routes for private gw work

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -85,13 +85,13 @@ class CsStaticRoutes(CsDataBag):
 
     def __update(self, route):
         if route['revoke']:
-            command = "route del -net %s gw %s" % (route['network'], route['gateway'])
+            command = "ip route del %s via %s" % (route['network'], route['gateway'])
             result = CsHelper.execute(command)
         else:
             command = "ip route show | grep %s | awk '{print $1, $3}'" % route['network']
             result = CsHelper.execute(command)
             if not result:
-                route_command = "route add -net %s gw %s" % (route['network'], route['gateway'])
+                route_command = "ip route add %s via %s" % (route['network'], route['gateway'])
                 result = CsHelper.execute(route_command)
 
 


### PR DESCRIPTION
Static routes for private gateways that were /32 failed because the `route` command used had `-net` in it and a `/32` requires `-host` instead. I rewrote it to `ip` commands.