### PR TITLE
CLOUDSTACK-9266: Make deleting static routes in private gw work

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
@@ -21,13 +21,5 @@ from pprint import pprint
 def merge(dbag, staticroutes):
     for route in staticroutes['routes']:
         key = route['network']
-        revoke = route['revoke']
-        if revoke:
-            try:
-                del dbag[key]
-            except KeyError:
-                pass
-        else:
-            dbag[key] = route
-
+        dbag[key] = route
     return dbag


### PR DESCRIPTION
The to-be-deleted static routes were removed from the json file, instead of putting them there with revoke=true. The script that parses the json now doesn't find it and thus does not delete it.

Example after adding/removing some:
```
root@r-3-VM:/var/cache/cloud# cat /etc/cloudstack/staticroutes.json 
{
    "1.2.3.0/24": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "1.2.3.0/24", 
        "revoke": true
    }, 
    "1.2.3.4/32": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "1.2.3.4/32", 
        "revoke": true
    }, 
    "1.2.33.3/32": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "1.2.33.3/32", 
        "revoke": true
    }, 
    "1.22.2.2/32": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "1.22.2.2/32", 
        "revoke": true
    }, 
    "10.1.2.1/32": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "10.1.2.1/32", 
        "revoke": true
    }, 
    "10.1.200.0/25": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "10.1.200.0/25", 
        "revoke": true
    }, 
    "10.11.12.13/32": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "10.11.12.13/32", 
        "revoke": true
    }, 
    "172.16.1.3/32": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "172.16.1.3/32", 
        "revoke": true
    }, 
    "172.16.15.14/32": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "172.16.15.14/32", 
        "revoke": false
    }, 
    "172.16.17.0/25": {
        "gateway": "172.16.0.1", 
        "ip_address": "172.16.0.2", 
        "network": "172.16.17.0/25", 
        "revoke": false
    }, 
    "id": "staticroutes"
}
```

This results in:
```
root@r-3-VM:/var/cache/cloud# ip route show
default via 192.168.23.1 dev eth1 
169.254.0.0/16 dev eth0  proto kernel  scope link  src 169.254.1.67 
172.16.0.0/24 dev eth2  proto kernel  scope link  src 172.16.0.2 
172.16.15.14 via 172.16.0.1 dev eth2 
172.16.17.0/25 via 172.16.0.1 dev eth2 
192.168.23.0/24 dev eth1  proto kernel  scope link  src 192.168.23.4 
```

Two static routes left, the rest deleted:
```
172.16.15.14 via 172.16.0.1 dev eth2 
172.16.17.0/25 via 172.16.0.1 dev eth2 
```

That also matches the UI:

<img width="1327" alt="screen shot 2016-01-30 at 06 34 06" src="https://cloud.githubusercontent.com/assets/1630096/12693933/83e67d80-c71b-11e5-9241-9f478522b7a4.png">

