### PR TITLE
CLOUDSTACK-8300: Set indexes on event table

### DIFF
--- a/setup/db/db/schema-481to490.sql
+++ b/setup/db/db/schema-481to490.sql
@@ -18,3 +18,6 @@
 --;
 -- Schema upgrade from 4.8.1 to 4.9.0;
 --;
+
+ALTER TABLE `event` ADD INDEX `archived` (`archived`);
+ALTER TABLE `event` ADD INDEX `state` (`state`);


### PR DESCRIPTION
When there are many events in the cloud.event table, the UI throws an SQL exception and the management server spikes at 100% CPU for minutes. That causes other API calls to fail with 530 errors.

It seems an index on the 'archived' field is missing (since it is used in the WHERE clause).

We have 1.4M events in the table:
`select count(*) from event;`
1497838

This PR adds the index to the `archived` field and the `state` field.
