### PR TITLE
CLOUDSTACK-7836: Make s2s VPN CIDR list longer

### DIFF
--- a/setup/db/db/schema-481to490.sql
+++ b/setup/db/db/schema-481to490.sql
@@ -21,3 +21,4 @@
 
 ALTER TABLE `event` ADD INDEX `archived` (`archived`);
 ALTER TABLE `event` ADD INDEX `state` (`state`);
+ALTER TABLE `s2s_customer_gateway` MODIFY `guest_cidr_list` VARCHAR(4096);


### PR DESCRIPTION
We found the 200 char limit not sufficient. This should provide more room for longer CIDR lists.

123.123.123.123/24 ==> 18 chars + comma = 19 chars per cidr max

Was: 200/19 = ~10
Now: 4096/19 = ~215