### PR TITLE
CLOUDSTACK-9268: Display VM in Load balancing rule in UI

### DIFF
--- a/ui/scripts/ui/widgets/multiEdit.js
+++ b/ui/scripts/ui/widgets/multiEdit.js
@@ -104,7 +104,7 @@
                         $(data).each(function() {
                             var item = this;
                             var $itemRow = _medit.multiItem.itemRow(item, options.itemActions, multiRule, $tbody);
-
+                            $itemRow.data('json-obj', item);
                             $itemRow.appendTo($tbody);
                             newItemRows.push($itemRow);
 


### PR DESCRIPTION
Steps of Repro:
=============
1:Create VMs 
2:Make LoadBalancing rule in GUI 
　Name:WWW 
　PrivatePort:80 
　PublicPort:80 
　Add VMs:some VMs

Expected Result:
==============
The VMs which has been already assigned is should not be listed when you add the VM to an existing rule.

Actual Result:
===========
The VMs which has been already assigned is still being listed when you add the VM to an existing rule.

Fix:
===
Added jsonObj to newly created row in multiedit.js to stop listing the same VM again.