### PR TITLE
[4.7] VMware boot order fix

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 
 import javax.naming.ConfigurationException;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.log4j.NDC;
 
@@ -1718,6 +1719,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             //
             // Setup ROOT/DATA disk devices
             //
+            String hddBootOrder = "";
             DiskTO[] sortedDisks = sortVolumesByDeviceId(disks);
             for (DiskTO vol : sortedDisks) {
                 if (vol.getType() == Volume.Type.ISO)
@@ -1726,6 +1728,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 VirtualMachineDiskInfo matchingExistingDisk = getMatchingExistingDisk(diskInfoBuilder, vol, hyperHost, context);
                 controllerKey = getDiskController(matchingExistingDisk, vol, vmSpec, ideControllerKey, scsiControllerKey);
                 String diskController = getDiskController(vmMo, matchingExistingDisk, vol, new Pair<String, String>(rootDiskController, dataDiskController));
+
+                if (matchingExistingDisk != null && matchingExistingDisk.getDiskDeviceBusName() != null) {
+                    if (vol.getType() == Volume.Type.ROOT) {
+                        hddBootOrder = matchingExistingDisk.getDiskDeviceBusName() + "," + hddBootOrder;
+                    } else if (vol.getType() == Volume.Type.DATADISK) {
+                        hddBootOrder = hddBootOrder + matchingExistingDisk.getDiskDeviceBusName() + ",";
+                    }
+                }
 
                 if (DiskControllerType.getType(diskController) == DiskControllerType.osdefault) {
                     diskController = vmMo.getRecommendedDiskController(null);
@@ -1867,6 +1877,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // pass boot arguments through machine.id & perform customized options to VMX
             ArrayList<OptionValue> extraOptions = new ArrayList<OptionValue>();
             configBasicExtraOption(extraOptions, vmSpec);
+            configBasicWithBootOrder(extraOptions, hddBootOrder);
             configNvpExtraOption(extraOptions, vmSpec, nicUuidToDvSwitchUuid);
             configCustomExtraOption(extraOptions, vmSpec);
 
@@ -2075,6 +2086,25 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         newVal.setKey("devices.hotplug");
         newVal.setValue("true");
         extraOptions.add(newVal);
+    }
+
+    protected static void configBasicWithBootOrder(List<OptionValue> extraOptions, String hddBootOrder) {
+        if (StringUtils.isEmpty(hddBootOrder)) {
+            return;
+        }
+
+        hddBootOrder = hddBootOrder.replaceAll(",+$", "");
+        if (!hddBootOrder.isEmpty()) {
+            OptionValue newVal = new OptionValue();
+            newVal.setKey("bios.bootOrder");
+            newVal.setValue("cdrom,hdd,floppy");
+            extraOptions.add(newVal);
+
+            newVal = new OptionValue();
+            newVal.setKey("bios.hddOrder");
+            newVal.setValue(hddBootOrder);
+            extraOptions.add(newVal);
+        }
     }
 
     private static void configNvpExtraOption(List<OptionValue> extraOptions, VirtualMachineTO vmSpec, Map<String, String> nicUuidToDvSwitchUuid) {

--- a/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
+++ b/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -35,6 +36,10 @@ import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.hypervisor.vmware.mo.VirtualMachineMO;
 import com.cloud.hypervisor.vmware.mo.VmwareHypervisorHost;
 import com.cloud.hypervisor.vmware.util.VmwareContext;
+import com.vmware.vim25.OptionValue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class VmwareResourceTest {
 
@@ -88,6 +93,21 @@ public class VmwareResourceTest {
 
         _resource.execute(cmd);
         verify(_resource).execute(cmd);
+    }
+
+    @Test
+    public void testHddBootOrder() {
+        List<OptionValue> options = new ArrayList<>();
+        VmwareResource.configBasicWithBootOrder(options, null);
+        Assert.assertTrue(options.size() == 0);
+        VmwareResource.configBasicWithBootOrder(options, ",");
+        Assert.assertTrue(options.size() == 0);
+        VmwareResource.configBasicWithBootOrder(options, ",,,");
+        Assert.assertTrue(options.size() == 0);
+        VmwareResource.configBasicWithBootOrder(options, "ide0:0,scsi1:0,");
+        Assert.assertTrue(options.size() == 2);
+        Assert.assertEquals(options.get(0).getValue(), "cdrom,hdd,floppy");
+        Assert.assertEquals(options.get(1).getValue(), "ide0:0,scsi1:0");
     }
 
 }


### PR DESCRIPTION
In case of VMware, since root disk needs to be first in the hdd boot order, we
collect list of hdds and create a hdd boot order with the root disk as the first
disk. This fixes a rare edge case where VMs would stop booting due to changed
boot order in hdds.

For sanity, we want cdroms to boot first, then hdds, floppies etc.