### PR TITLE
CLOUDSTACK-9269: Missing field for Switch type for Management and Storage traffic types

### DIFF
--- a/ui/scripts/ui-custom/zoneWizard.js
+++ b/ui/scripts/ui-custom/zoneWizard.js
@@ -310,69 +310,67 @@
                 };
 
                 if(zoneType == 'Advanced') {
-                    if($trafficType.hasClass('guest') || $trafficType.hasClass('public')) {
-                        if(trafficData.vSwitchType == null) {
-                             var useDvs = false;
+                    if(trafficData.vSwitchType == null) {
+                         var useDvs = false;
+                         $.ajax({
+                             url: createURL('listConfigurations'),
+                             data: {
+                                 name: 'vmware.use.dvswitch'
+                             },
+                             async: false,
+                             success: function(json) {
+                                 if (json.listconfigurationsresponse.configuration[0].value == 'true') {
+                                     useDvs = true;
+                                 }
+                             }
+                         });
+                         if (useDvs == true) {
+                             var useNexusDvs = false;
                              $.ajax({
                                  url: createURL('listConfigurations'),
                                  data: {
-                                     name: 'vmware.use.dvswitch'
+                                     name: 'vmware.use.nexus.vswitch'
                                  },
                                  async: false,
                                  success: function(json) {
                                      if (json.listconfigurationsresponse.configuration[0].value == 'true') {
-                                         useDvs = true;
+                                         useNexusDvs = true;
                                      }
                                  }
                              });
-                             if (useDvs == true) {
-                                 var useNexusDvs = false;
-                                 $.ajax({
-                                     url: createURL('listConfigurations'),
-                                     data: {
-                                         name: 'vmware.use.nexus.vswitch'
-                                     },
-                                     async: false,
-                                     success: function(json) {
-                                         if (json.listconfigurationsresponse.configuration[0].value == 'true') {
-                                             useNexusDvs = true;
-                                         }
-                                     }
-                                 });
-                                 if (useNexusDvs == true) {
-                                     trafficData.vSwitchType = 'nexusdvs';
-                                     fields.vSwitchName.defaultValue = 'epp0';
-                                 } else {
-                                     trafficData.vSwitchType = 'vmwaredvs';
-                                     fields.vSwitchName.defaultValue = 'dvSwitch0';
-                                 }
-                             } else { //useDvs == false
-                                 trafficData.vSwitchType = 'vmwaresvs';
-                                 fields.vSwitchName.defaultValue = 'vSwitch0';
+                             if (useNexusDvs == true) {
+                                 trafficData.vSwitchType = 'nexusdvs';
+                                 fields.vSwitchName.defaultValue = 'epp0';
+                             } else {
+                                 trafficData.vSwitchType = 'vmwaredvs';
+                                 fields.vSwitchName.defaultValue = 'dvSwitch0';
                              }
-                        }
-
-                        $.extend(fields, {
-                            vSwitchType: {
-                                    label: 'label.vSwitch.type',
-                                select: function (args) {
-                                    args.response.success({
-                                        data: [{
-                                            id: 'nexusdvs',
-                                            description: 'Cisco Nexus 1000v Distributed Virtual Switch'
-                                        }, {
-                                            id: 'vmwaresvs',
-                                            description: 'VMware vNetwork Standard Virtual Switch'
-                                        }, {
-                                            id: 'vmwaredvs',
-                                            description: 'VMware vNetwork Distributed Virtual Switch'
-                                        }]
-                                    });
-                                },
-                                defaultValue: trafficData.vSwitchType
-                            }
-                        });
+                         } else { //useDvs == false
+                             trafficData.vSwitchType = 'vmwaresvs';
+                             fields.vSwitchName.defaultValue = 'vSwitch0';
+                         }
                     }
+
+                    $.extend(fields, {
+                        vSwitchType: {
+                                label: 'label.vSwitch.type',
+                            select: function (args) {
+                                args.response.success({
+                                    data: [{
+                                        id: 'nexusdvs',
+                                        description: 'Cisco Nexus 1000v Distributed Virtual Switch'
+                                    }, {
+                                        id: 'vmwaresvs',
+                                        description: 'VMware vNetwork Standard Virtual Switch'
+                                    }, {
+                                        id: 'vmwaredvs',
+                                        description: 'VMware vNetwork Distributed Virtual Switch'
+                                    }]
+                                });
+                            },
+                            defaultValue: trafficData.vSwitchType
+                        }
+                    });
                 }
             } else {
                 fields = {


### PR DESCRIPTION
# Repro Steps:

Create an Advanced zone(VMware).
Configure physical network.
Edit traffic type (Management or Storage)
Observe the switch type dropdown list is missing.

If we choose Guest or Public the dropdown is visible. See the below snapshots.
# Expected Result:

The list should be shown in case of Management and storage.
# Actual Result:

The list is missing in case of management and storage.
# Fix:

Showing vswitchtype for all traffic types in case of VMware.
# Traffic Type - Guest:

![public-nitin](https://cloud.githubusercontent.com/assets/12583725/12759158/aec4d38e-ca05-11e5-911f-d8aa8cb995b7.jpg)
# Traffic Type - Management (Issue):

![management-nitin](https://cloud.githubusercontent.com/assets/12583725/12759171/bff00e08-ca05-11e5-8051-c24f0952a321.jpg)
