### PR TITLE
CLOUDSTACK-9270: UI alignment gone bad in multiple places - VM Instance, Network, Egress rules

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -530,6 +530,7 @@ div.list-view table tbody td span {
   display: block;
   float: left;
   max-width: 89%;
+  word-break: break-all;
   word-wrap: break-word;
   text-indent: 0;
   margin-left: 12px;
@@ -8291,6 +8292,16 @@ div.container div.panel div#details-tab-addloadBalancer.detail-group div.loadBal
   background: transparent;
   color: #808B95;
   font-weight: bold;
+}
+
+.multi-edit-add-list div.form-container {
+  width: auto !important;
+  height: auto;
+  text-align: center;
+}
+
+.multi-edit-add-list div.form-container div.name label {
+  display: inline;
 }
 
 .multi-edit .data .data-body {


### PR DESCRIPTION
Steps to Repro:
============
Please see the snapshots attached. 

Fix:
===
Now it breaks into two lines once the word goes out of the box.
Fixed the advanced search field issue.

Network Section:
=============
![network-section-nitin](https://cloud.githubusercontent.com/assets/12583725/12762032/66f27d32-ca13-11e5-8d0a-9c8f99a12a99.png)

Adding VM to LB Rule:
==================
![adding-vm-to-lb-rule-nitin](https://cloud.githubusercontent.com/assets/12583725/12762050/76083cd0-ca13-11e5-873d-0037bc13a444.png)

Affinity Group Section:
==================
![affinity-group-section-nitin](https://cloud.githubusercontent.com/assets/12583725/12762066/881c2a1c-ca13-11e5-8905-f72676151130.png)

Fixed Affinity Group Section:
======================
![fix-affinity-group-section-nitin](https://cloud.githubusercontent.com/assets/12583725/12762083/990a673a-ca13-11e5-9d63-f895f9a1875c.png)
