### PR TITLE
CLOUDSTACK-9272: No option in UI to add GSLB with service type "HTTP"

### DIFF
--- a/ui/scripts/regions.js
+++ b/ui/scripts/regions.js
@@ -334,6 +334,9 @@
                                             }, {
                                                 id: 'udp',
                                                 description: 'udp'
+                                            }, {
+                                                id: 'http',
+                                                description: 'http'
                                             }];
                                             args.response.success({
                                                 data: array1


### PR DESCRIPTION
Steps to Repro:
============
Go to Regions -> Local -> View GSLB -> Add GSLB
Click on the service type dropdown
Observe http is missing. Please see the attached snapshot.

Expected Behaviour:
================
As it supports http also, So http should be in the list.

Actual Behaviour:
==============
http is missing from the list.

Fix:
===
It supports http also. Added http to the list.

Snapshot:
========
<img width="531" alt="gslb-http-missing-nitin" src="https://cloud.githubusercontent.com/assets/12583725/12772818/21513dc0-ca5b-11e5-822e-e2dd2426da65.png">
