### PR TITLE
Check the existence of 'forceencap' parameter before use

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -531,6 +531,8 @@ class CsSite2SiteVpn(CsDataBag):
         file.addeq(" pfs=%s" % CsHelper.bool_to_yn(obj['dpd']))
         file.addeq(" keyingtries=2")
         file.addeq(" auto=start")
+        if 'encap' not in obj:
+            obj['encap']=False
         file.addeq(" forceencaps=%s" % CsHelper.bool_to_yn(obj['encap']))
         if obj['dpd']:
             file.addeq("  dpddelay=30")


### PR DESCRIPTION
Check the existence of 'forceencap' parameter before use.

Error seen:

```
Traceback (most recent call last):
  File "/opt/cloud/bin/update_config.py", line 140, in <module>
    process_file()
  File "/opt/cloud/bin/update_config.py", line 54, in process_file
    finish_config()
  File "/opt/cloud/bin/update_config.py", line 44, in finish_config
    returncode = configure.main(sys.argv)
  File "/opt/cloud/bin/configure.py", line 1003, in main
    vpns.process()
  File "/opt/cloud/bin/configure.py", line 488, in process
    self.configure_ipsec(self.dbag[vpn])
  File "/opt/cloud/bin/configure.py", line 544, in configure_ipsec
    file.addeq(" forceencaps=%s" % CsHelper.bool_to_yn(obj['encap']))
KeyError: 'encap'
```
