### PR TITLE
CLOUDSTACK-9283: add pid to java arguments in cloudstack-usage.service

### DIFF
--- a/packaging/systemd/cloudstack-usage.service
+++ b/packaging/systemd/cloudstack-usage.service
@@ -27,10 +27,11 @@ Environment=JAVA_HOME=/usr/lib/jvm/jre
 Environment=JAVA_HEAP_INITIAL=256m
 Environment=JAVA_HEAP_MAX=2048m
 Environment=JAVA_CLASS=com.cloud.usage.UsageServer
+Environment=JAVA_PID=$$
 ExecStart=/bin/sh -ec '\
     export UCP=`ls /usr/share/cloudstack-usage/cloud-usage-*.jar /usr/share/cloudstack-usage/lib/*.jar | tr "\\n" ":"`; \
     export CLASSPATH="$UCP:/etc/cloudstack/usage:/usr/share/java/mysql-connector-java.jar"; \
-    ${JAVA_HOME}/bin/java -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
+    ${JAVA_HOME}/bin/java -Dpid=${JAVA_PID} -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
 Restart=always
 RestartSec=10s
 


### PR DESCRIPTION
cloudstack-usage fails to start throwing Integer exception during PID retrieval, and the service keeps restarting after 10s (as defined in the systemd service definition).

Adding the pid to the java arguments in the systemd service definition makes it stop looping in centos7
