### PR TITLE
systemvm: preserve file permissions, set default umask

### DIFF
--- a/packaging/centos63/cloud-management.rc
+++ b/packaging/centos63/cloud-management.rc
@@ -87,6 +87,7 @@ handle_pid_file() {
 }
 
 start() {
+    umask 0022
     readpath=$(readlink -f $0)
     source `dirname $readpath`/tomcat.sh
 }

--- a/packaging/centos7/cloud-management.service
+++ b/packaging/centos7/cloud-management.service
@@ -24,6 +24,7 @@ Description=CloudStack Management Server
 After=syslog.target network.target
 
 [Service]
+UMask=0022
 Type=simple
 EnvironmentFile=/etc/tomcat/tomcat.conf
 Environment="NAME=cloudstack-management"

--- a/scripts/vm/systemvm/injectkeys.sh
+++ b/scripts/vm/systemvm/injectkeys.sh
@@ -27,7 +27,7 @@ set -e
 TMP=/tmp
 MOUNTPATH=${HOME}/systemvm_mnt
 TMPDIR=${TMP}/cloud/systemvm
-
+umask 022
 
 clean_up() {
   $SUDO umount $MOUNTPATH
@@ -43,20 +43,21 @@ inject_into_iso() {
   $SUDO mount -o loop $isofile $MOUNTPATH 
   [ $? -ne 0 ] && echo "$(basename $0): Failed to mount original iso $isofile" && clean_up && return 1
   diff -q $MOUNTPATH/authorized_keys $newpubkey &> /dev/null && clean_up && return 0
-  $SUDO cp -b $isofile $backup
+  $SUDO cp -bp $isofile $backup
   [ $? -ne 0 ] && echo "$(basename $0): Failed to backup original iso $isofile" && clean_up && return 1
   rm -rf $TMPDIR
   mkdir -p $TMPDIR
   [ ! -d $TMPDIR  ] && echo "$(basename $0): Could not find/create temporary dir $TMPDIR" && clean_up && return 1
-  $SUDO cp -fr $MOUNTPATH/* $TMPDIR/
+  $SUDO cp -frp $MOUNTPATH/* $TMPDIR/
   [ $? -ne 0 ] && echo "$(basename $0): Failed to copy from original iso $isofile" && clean_up && return 1
   $SUDO cp $newpubkey $TMPDIR/authorized_keys
+  $SUDO chmod 644 $TMPDIR/authorized_keys
   [ $? -ne 0 ] && echo "$(basename $0): Failed to copy key $newpubkey from original iso to new iso " && clean_up && return 1
   mkisofs -quiet -r -o $tmpiso $TMPDIR
   [ $? -ne 0 ] && echo "$(basename $0): Failed to create new iso $tmpiso from $TMPDIR" && clean_up && return 1
   $SUDO umount $MOUNTPATH
   [ $? -ne 0 ] && echo "$(basename $0): Failed to unmount old iso from $MOUNTPATH" && return 1
-  $SUDO cp -f $tmpiso $isofile
+  $SUDO cp -fp $tmpiso $isofile
   [ $? -ne 0 ] && echo "$(basename $0): Failed to overwrite old iso $isofile with $tmpiso" && return 1
   rm -rf $TMPDIR
 }


### PR DESCRIPTION
- In injectkeys.sh which is used to inject new public keys everytime cloudstack
  starts; while copying files preserve the mode/ownership. This ensures the
  scripts have same mode bits as originally configured in the iso file
- The default umask of 0022 is set in Ubuntu and other packages. Set the same
  in case of CentOS startup scripts

cc @abhinandanprateek @wido @remibergsma @jburwell @DaanHoogland 