### PR TITLE
systemvm: preserve file permissions, set default umask

### DIFF
--- a/packaging/centos63/cloud-management.rc
+++ b/packaging/centos63/cloud-management.rc
@@ -87,6 +87,7 @@ handle_pid_file() {
 }
 
 start() {
+    umask 0022
     readpath=$(readlink -f $0)
     source `dirname $readpath`/tomcat.sh
 }

--- a/packaging/centos7/cloud-management.service
+++ b/packaging/centos7/cloud-management.service
@@ -24,6 +24,7 @@ Description=CloudStack Management Server
 After=syslog.target network.target
 
 [Service]
+UMask=0022
 Type=simple
 EnvironmentFile=/etc/tomcat/tomcat.conf
 Environment="NAME=cloudstack-management"

--- a/scripts/vm/systemvm/injectkeys.sh
+++ b/scripts/vm/systemvm/injectkeys.sh
@@ -27,7 +27,7 @@ set -e
 TMP=/tmp
 MOUNTPATH=${HOME}/systemvm_mnt
 TMPDIR=${TMP}/cloud/systemvm
-
+umask 022
 
 clean_up() {
   $SUDO umount $MOUNTPATH


### PR DESCRIPTION
- In injectkeys.sh which is used to inject new public keys everytime cloudstack
  starts; while copying files preserve the mode/ownership. This ensures the
  scripts have same mode bits as originally configured in the iso file
- The default umask of 0022 is set in Ubuntu and other packages. Set the same
  in case of CentOS startup scripts

cc @abhinandanprateek @wido @remibergsma @DaanHoogland @jburwell 