### PR TITLE
zip the processed json files so we save diskspace

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -20,6 +20,9 @@ import json
 import os
 import time
 import logging
+import gzip
+import shutil
+import uuid
 import cs_ip
 import cs_guestnetwork
 import cs_cmdline
@@ -272,5 +275,10 @@ class QueueFile:
     def __moveFile(self, origPath, path):
         if not os.path.exists(path):
             os.makedirs(path)
-        timestamp = str(int(round(time.time())))
-        os.rename(origPath, path + "/" + self.fileName + "." + timestamp)
+
+        zipped_file_name = path + "/" + self.fileName + "." + str(uuid.uuid4()) + ".gz"
+
+        with open(origPath, 'rb') as f_in, gzip.open(zipped_file_name, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+        os.remove(origPath)


### PR DESCRIPTION
Zip the processed json files and make sure they're unique (timestamp is not unique). Especially in combination with #1400.