### PR TITLE
Improve ordering of fields of VPC router detail tab

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -5838,35 +5838,14 @@
                                         label: 'label.name'
                                     }
                                 }, {
-                                    id: {
-                                        label: 'label.id'
-                                    },
-                                    zonename: {
-                                        label: 'label.zone'
-                                    },
-                                    dns1: {
-                                        label: 'label.dns'
-                                    },
-                                    gateway: {
-                                        label: 'label.gateway'
-                                    },
-                                    publicip: {
-                                        label: 'label.public.ip'
-                                    },
-                                    guestipaddress: {
-                                        label: 'label.guest.ip'
-                                    },
-                                    linklocalip: {
-                                        label: 'label.linklocal.ip'
+                                    state: {
+                                        label: 'label.state'
                                     },
                                     hostname: {
                                         label: 'label.host'
                                     },
-                                    state: {
-                                        label: 'label.state'
-                                    },
-                                    serviceofferingname: {
-                                        label: 'label.service.offering'
+                                    linklocalip: {
+                                        label: 'label.linklocal.ip'
                                     },
                                     isredundantrouter: {
                                         label: 'label.redundant.router',
@@ -5877,6 +5856,30 @@
                                             return "No";
                                         }
                                     },
+                                    redundantstate: {
+                                        label: 'label.redundant.state'
+                                    },
+                                    id: {
+                                        label: 'label.id'
+                                    },
+                                    serviceofferingname: {
+                                        label: 'label.service.offering'
+                                    },
+                                    zonename: {
+                                        label: 'label.zone'
+                                    },
+                                    gateway: {
+                                        label: 'label.gateway'
+                                    },
+                                    publicip: {
+                                        label: 'label.public.ip'
+                                    },
+                                    guestipaddress: {
+                                        label: 'label.guest.ip'
+                                    },
+                                    dns1: {
+                                        label: 'label.dns'
+                                    },
                                     account: {
                                         label: 'label.account'
                                     },
@@ -5884,6 +5887,7 @@
                                         label: 'label.domain'
                                     }
                                 }],
+
                                 dataProvider: function(args) {
                                     $.ajax({
                                         url: createURL("listRouters&listAll=true&vpcid=" + args.context.vpc[0].id),


### PR DESCRIPTION
The field we use most are now on the top:
- name
- state
- hypervisor
- link local ip
- redundant state

The other fields are nice, but not needed most of the time.

Result:
![screen shot 2016-02-21 at 20 11 49](https://cloud.githubusercontent.com/assets/1630096/13204809/37ce63c0-d8d9-11e5-8861-35c1c1a406cf.png)

Before:
![vpc_router_details_before](https://cloud.githubusercontent.com/assets/1630096/13204811/41510f10-d8d9-11e5-850f-549a3333b063.png)
