### PR TITLE
CLOUDSTACK-9285 -  Agent throws an exception on reconnect and fails

### DIFF
--- a/agent/src/com/cloud/agent/Agent.java
+++ b/agent/src/com/cloud/agent/Agent.java
@@ -412,7 +412,8 @@ public class Agent implements HandlerFactory, IAgentControl {
             try {
                 _connection.start();
             } catch (final NioConnectionException e) {
-                throw new CloudRuntimeException("Unable to start the connection!", e);
+		s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
+
             }
             _shell.getBackoffAlgorithm().waitBeforeRetry();
         } while (!_connection.isStartup());

--- a/agent/src/com/cloud/agent/Agent.java
+++ b/agent/src/com/cloud/agent/Agent.java
@@ -412,7 +412,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             try {
                 _connection.start();
             } catch (final NioConnectionException e) {
-		s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
+               s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
 
             }
             _shell.getBackoffAlgorithm().waitBeforeRetry();


### PR DESCRIPTION
Agent throws an exception that can never be recovered from when the agent attempts to reconnect and is sent a RST. This case occurs when a load balancer (haproxy) is proxying the traffic and there is no management server active to serve the request on the backend.

Original issue logs from agent.log:

2016-03-03 17:15:36,527 INFO  [utils.nio.NioClient] (Agent-Handler-2:null) (logid:) NioClient connection closed
2016-03-03 17:15:36,527 INFO  [cloud.agent.Agent] (Agent-Handler-2:null) (logid:) Reconnecting...
2016-03-03 17:15:36,527 INFO  [utils.nio.NioClient] (Agent-Handler-2:null) (logid:) Connecting to 10.103.0.154:8250
2016-03-03 17:15:36,540 ERROR [utils.nio.NioConnection] (Agent-Handler-2:null) (logid:) Unable to initialize the threads.
java.io.IOException: Connection closed with -1 on reading size.
        at com.cloud.utils.nio.Link.doHandshake(Link.java:513)
        at com.cloud.utils.nio.NioClient.init(NioClient.java:80)
        at com.cloud.utils.nio.NioConnection.start(NioConnection.java:88)
        at com.cloud.agent.Agent.reconnect(Agent.java:413)
        at com.cloud.agent.Agent$ServerHandler.doTask(Agent.java:868)
        at com.cloud.utils.nio.Task.call(Task.java:83)
        at com.cloud.utils.nio.Task.call(Task.java:29)
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
2016-03-03 17:15:36,545 INFO  [utils.exception.CSExceptionErrorCode] (Agent-Handler-2:null) (logid:) Could not find exception: com.cloud.utils.exception.NioConnectionException in error code list for exceptions
<agent thread is dead>

After the patch is applied:


2016-03-03 17:50:05,190 INFO  [utils.nio.NioClient] (Agent-Handler-3:null) (logid:) NioClient connection closed
2016-03-03 17:50:05,190 INFO  [cloud.agent.Agent] (Agent-Handler-3:null) (logid:) Reconnecting...
2016-03-03 17:50:05,190 INFO  [utils.nio.NioClient] (Agent-Handler-3:null) (logid:) Connecting to 10.103.0.154:8250
2016-03-03 17:50:05,206 ERROR [utils.nio.NioConnection] (Agent-Handler-3:null) (logid:) Unable to initialize the threads.
java.io.IOException: Connection closed with -1 on reading size.
        at com.cloud.utils.nio.Link.doHandshake(Link.java:513)
        at com.cloud.utils.nio.NioClient.init(NioClient.java:80)
        at com.cloud.utils.nio.NioConnection.start(NioConnection.java:88)
        at com.cloud.agent.Agent.reconnect(Agent.java:413)
        at com.cloud.agent.Agent$ServerHandler.doTask(Agent.java:869)
        at com.cloud.utils.nio.Task.call(Task.java:83)
        at com.cloud.utils.nio.Task.call(Task.java:29)
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
2016-03-03 17:50:05,210 INFO  [utils.exception.CSExceptionErrorCode] (Agent-Handler-3:null) (logid:) Could not find exception: com.cloud.utils.exception.NioConnectionException in error code list for exceptions
2016-03-03 17:50:05,211 INFO  [cloud.agent.Agent] (Agent-Handler-3:null) (logid:) Attempted to connect to the server, but received an unexpected exception, trying again...
2016-03-03 17:50:10,211 INFO  [cloud.agent.Agent] (Agent-Handler-3:null) (logid:) Reconnecting...
2016-03-03 17:50:10,211 INFO  [utils.nio.NioClient] (Agent-Handler-3:null) (logid:) Connecting to 10.103.0.154:8250

This has been tested on 4.7.1 and master.
