### PR TITLE
CLOUDSTACK-9305: Cloudstack Usage Breaks if DB HA enabled

### DIFF
--- a/packaging/systemd/cloudstack-usage.service
+++ b/packaging/systemd/cloudstack-usage.service
@@ -28,7 +28,7 @@ Environment=JAVA_HEAP_INITIAL=256m
 Environment=JAVA_HEAP_MAX=2048m
 Environment=JAVA_CLASS=com.cloud.usage.UsageServer
 ExecStart=/bin/sh -ec '\
-    export UCP=`ls /usr/share/cloudstack-usage/cloud-usage-*.jar /usr/share/cloudstack-usage/lib/*.jar | tr "\\n" ":"`; \
+    export UCP=`ls /usr/share/cloudstack-usage/cloud-usage-*.jar /usr/share/cloudstack-usage/lib/*.jar /usr/share/cloudstack-mysql-ha/lib/*.jar | tr "\\n" ":"`; \
     export CLASSPATH="$UCP:/etc/cloudstack/usage:/usr/share/java/mysql-connector-java.jar"; \
     ${JAVA_HOME}/bin/java -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
 Restart=always


### PR DESCRIPTION
With DB HA enabled in db.properties, the cloudstack-usage service restarts every 10 seconds.  Making the suggested change has fixed it for me.  Cloudstack 4.8 on Centos7