### PR TITLE
Changed Void Methods to void

### DIFF
--- a/engine/storage/image/src/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -589,7 +589,7 @@ public class TemplateServiceImpl implements TemplateService {
         return null;
     }
 
-    protected Void createTemplateCallback(AsyncCallbackDispatcher<TemplateServiceImpl, CreateCmdResult> callback, TemplateOpContext<TemplateApiResult> context) {
+    protected void createTemplateCallback(AsyncCallbackDispatcher<TemplateServiceImpl, CreateCmdResult> callback, TemplateOpContext<TemplateApiResult> context) {
         TemplateObject template = context.getTemplate();
         AsyncCompletionCallback<TemplateApiResult> parentCallback = context.getParentCallback();
         TemplateApiResult result = new TemplateApiResult(template);
@@ -600,9 +600,7 @@ public class TemplateServiceImpl implements TemplateService {
             if (parentCallback != null) {
                 parentCallback.complete(result);
             }
-            return null;
         }
-
         try {
             template.processEvent(ObjectInDataStoreStateMachine.Event.OperationSuccessed);
         } catch (Exception e) {
@@ -610,13 +608,10 @@ public class TemplateServiceImpl implements TemplateService {
             if (parentCallback != null) {
                 parentCallback.complete(result);
             }
-            return null;
         }
-
         if (parentCallback != null) {
             parentCallback.complete(result);
         }
-        return null;
     }
 
     @Override
@@ -634,7 +629,7 @@ public class TemplateServiceImpl implements TemplateService {
         return future;
     }
 
-    public Void deleteTemplateCallback(AsyncCallbackDispatcher<TemplateServiceImpl, CommandResult> callback, TemplateOpContext<TemplateApiResult> context) {
+    public void deleteTemplateCallback(AsyncCallbackDispatcher<TemplateServiceImpl, CommandResult> callback, TemplateOpContext<TemplateApiResult> context) {
         CommandResult result = callback.getResult();
         TemplateObject vo = context.getTemplate();
         if (result.isSuccess()) {
@@ -646,7 +641,6 @@ public class TemplateServiceImpl implements TemplateService {
         apiResult.setResult(result.getResult());
         apiResult.setSuccess(result.isSuccess());
         context.future.complete(apiResult);
-        return null;
     }
 
     private AsyncCallFuture<TemplateApiResult> copyAsync(DataObject source, TemplateInfo template, DataStore store) {
@@ -687,7 +681,7 @@ public class TemplateServiceImpl implements TemplateService {
         return future;
     }
 
-    protected Void syncTemplateCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, CopyCommandResult> callback, TemplateOpContext<TemplateApiResult> context) {
+    protected void syncTemplateCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, CopyCommandResult> callback, TemplateOpContext<TemplateApiResult> context) {
         TemplateInfo destTemplate = context.getTemplate();
         CopyCommandResult result = callback.getResult();
         AsyncCallFuture<TemplateApiResult> future = context.getFuture();
@@ -706,8 +700,6 @@ public class TemplateServiceImpl implements TemplateService {
             res.setResult(e.toString());
             future.complete(res);
         }
-
-        return null;
     }
 
     // This routine is used to push templates currently on cache store, but not in region store to region store.
@@ -847,7 +839,7 @@ public class TemplateServiceImpl implements TemplateService {
         return copyAsync(srcTemplate, srcTemplate, (DataStore)pool);
     }
 
-    protected Void copyTemplateCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, CopyCommandResult> callback, TemplateOpContext<TemplateApiResult> context) {
+    protected void copyTemplateCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, CopyCommandResult> callback, TemplateOpContext<TemplateApiResult> context) {
         TemplateInfo destTemplate = context.getTemplate();
         CopyCommandResult result = callback.getResult();
         AsyncCallFuture<TemplateApiResult> future = context.getFuture();
@@ -865,11 +857,9 @@ public class TemplateServiceImpl implements TemplateService {
             res.setResult(e.toString());
             future.complete(res);
         }
-
-        return null;
     }
 
-    protected Void copyTemplateCrossZoneCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, CreateCmdResult> callback, TemplateOpContext<TemplateApiResult> context) {
+    protected void copyTemplateCrossZoneCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, CreateCmdResult> callback, TemplateOpContext<TemplateApiResult> context) {
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Performing copy template cross zone callback after completion");
         }
@@ -890,8 +880,6 @@ public class TemplateServiceImpl implements TemplateService {
             res.setResult(e.toString());
             future.complete(res);
         }
-
-        return null;
     }
 
     @Override

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotServiceImpl.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotServiceImpl.java
@@ -122,7 +122,7 @@ public class SnapshotServiceImpl implements SnapshotService {
 
     }
 
-    protected Void createSnapshotAsyncCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CreateCmdResult> callback, CreateSnapshotContext<CreateCmdResult> context) {
+    protected void createSnapshotAsyncCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CreateCmdResult> callback, CreateSnapshotContext<CreateCmdResult> context) {
         CreateCmdResult result = callback.getResult();
         SnapshotObject snapshot = (SnapshotObject)context.snapshot;
         AsyncCallFuture<SnapshotResult> future = context.future;
@@ -138,9 +138,7 @@ public class SnapshotServiceImpl implements SnapshotService {
 
             snapResult.setResult(result.getResult());
             future.complete(snapResult);
-            return null;
         }
-
         try {
             snapshot.processEvent(Event.OperationSuccessed, result.getAnswer());
             snapshot.processEvent(Snapshot.Event.OperationSucceeded);
@@ -153,9 +151,7 @@ public class SnapshotServiceImpl implements SnapshotService {
                 s_logger.debug("Failed to change snapshot state: " + e1.toString());
             }
         }
-
         future.complete(snapResult);
-        return null;
     }
 
     @Override
@@ -296,7 +292,7 @@ public class SnapshotServiceImpl implements SnapshotService {
 
     }
 
-    protected Void copySnapshotAsyncCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CopyCommandResult> callback, CopySnapshotContext<CommandResult> context) {
+    protected void copySnapshotAsyncCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CopyCommandResult> callback, CopySnapshotContext<CommandResult> context) {
         CopyCommandResult result = callback.getResult();
         SnapshotInfo destSnapshot = context.destSnapshot;
         SnapshotObject srcSnapshot = (SnapshotObject)context.srcSnapshot;
@@ -316,9 +312,7 @@ public class SnapshotServiceImpl implements SnapshotService {
             }
             snapResult.setResult(result.getResult());
             future.complete(snapResult);
-            return null;
         }
-
         try {
             CopyCmdAnswer copyCmdAnswer = (CopyCmdAnswer)result.getAnswer();
             destSnapshot.processEvent(Event.OperationSuccessed, copyCmdAnswer);
@@ -330,11 +324,9 @@ public class SnapshotServiceImpl implements SnapshotService {
             snapResult.setResult(e.toString());
             future.complete(snapResult);
         }
-        return null;
     }
 
-    protected Void deleteSnapshotCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CommandResult> callback, DeleteSnapshotContext<CommandResult> context) {
-
+    protected void deleteSnapshotCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CommandResult> callback, DeleteSnapshotContext<CommandResult> context) {
         CommandResult result = callback.getResult();
         AsyncCallFuture<SnapshotResult> future = context.future;
         SnapshotInfo snapshot = context.snapshot;
@@ -354,11 +346,9 @@ public class SnapshotServiceImpl implements SnapshotService {
             res.setResult(e.toString());
         }
         future.complete(res);
-        return null;
     }
 
-    protected Void revertSnapshotCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CommandResult> callback, RevertSnapshotContext<CommandResult> context) {
-
+    protected void revertSnapshotCallback(AsyncCallbackDispatcher<SnapshotServiceImpl, CommandResult> callback, RevertSnapshotContext<CommandResult> context) {
         CommandResult result = callback.getResult();
         AsyncCallFuture<SnapshotResult> future = context.future;
         SnapshotResult res = null;
@@ -375,7 +365,6 @@ public class SnapshotServiceImpl implements SnapshotService {
             res.setResult(e.toString());
         }
         future.complete(res);
-        return null;
     }
 
     @Override
@@ -523,12 +512,11 @@ public class SnapshotServiceImpl implements SnapshotService {
         return future;
     }
 
-    protected Void syncSnapshotCallBack(AsyncCallbackDispatcher<SnapshotServiceImpl, CopyCommandResult> callback,
+    protected void syncSnapshotCallBack(AsyncCallbackDispatcher<SnapshotServiceImpl, CopyCommandResult> callback,
             CopySnapshotContext<CommandResult> context) {
         CopyCommandResult result = callback.getResult();
         SnapshotInfo destSnapshot = context.destSnapshot;
         SnapshotResult res = new SnapshotResult(destSnapshot, null);
-
         AsyncCallFuture<SnapshotResult> future = context.future;
         try {
             if (result.isFailed()) {
@@ -544,7 +532,5 @@ public class SnapshotServiceImpl implements SnapshotService {
             res.setResult(e.toString());
             future.complete(res);
         }
-
-        return null;
     }
 }

--- a/engine/storage/src/org/apache/cloudstack/storage/datastore/DataObjectManagerImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/datastore/DataObjectManagerImpl.java
@@ -166,16 +166,14 @@ public class DataObjectManagerImpl implements DataObjectManager {
         return;
     }
 
-    protected Void createAsynCallback(AsyncCallbackDispatcher<DataObjectManagerImpl, CreateCmdResult> callback, CreateContext<CreateCmdResult> context) {
+    protected void createAsynCallback(AsyncCallbackDispatcher<DataObjectManagerImpl, CreateCmdResult> callback, CreateContext<CreateCmdResult> context) {
         CreateCmdResult result = callback.getResult();
         DataObject objInStrore = context.objInStrore;
         CreateCmdResult upResult = new CreateCmdResult(null, null);
         if (result.isFailed()) {
             upResult.setResult(result.getResult());
             context.getParentCallback().complete(upResult);
-            return null;
         }
-
         try {
             objectInDataStoreMgr.update(objInStrore, ObjectInDataStoreStateMachine.Event.OperationSuccessed);
         } catch (NoTransitionException e) {
@@ -184,24 +182,18 @@ public class DataObjectManagerImpl implements DataObjectManager {
             } catch (Exception e1) {
                 s_logger.debug("failed to change state", e1);
             }
-
             upResult.setResult(e.toString());
             context.getParentCallback().complete(upResult);
-            return null;
         } catch (ConcurrentOperationException e) {
             try {
                 objectInDataStoreMgr.update(objInStrore, ObjectInDataStoreStateMachine.Event.OperationFailed);
             } catch (Exception e1) {
                 s_logger.debug("failed to change state", e1);
             }
-
             upResult.setResult(e.toString());
             context.getParentCallback().complete(upResult);
-            return null;
         }
-
         context.getParentCallback().complete(result);
-        return null;
     }
 
     class CopyContext<T> extends AsyncRpcContext<T> {
@@ -248,10 +240,9 @@ public class DataObjectManagerImpl implements DataObjectManager {
         motionSrv.copyAsync(srcData, destData, caller);
     }
 
-    protected Void copyCallback(AsyncCallbackDispatcher<DataObjectManagerImpl, CopyCommandResult> callback, CopyContext<CreateCmdResult> context) {
+    protected void copyCallback(AsyncCallbackDispatcher<DataObjectManagerImpl, CopyCommandResult> callback, CopyContext<CreateCmdResult> context) {
         CopyCommandResult result = callback.getResult();
         DataObject destObj = context.destObj;
-
         if (result.isFailed()) {
             try {
                 objectInDataStoreMgr.update(destObj, Event.OperationFailed);
@@ -264,7 +255,6 @@ public class DataObjectManagerImpl implements DataObjectManager {
             res.setResult(result.getResult());
             context.getParentCallback().complete(res);
         }
-
         try {
             objectInDataStoreMgr.update(destObj, ObjectInDataStoreStateMachine.Event.OperationSuccessed);
         } catch (NoTransitionException e) {
@@ -290,7 +280,6 @@ public class DataObjectManagerImpl implements DataObjectManager {
         }
         CreateCmdResult res = new CreateCmdResult(result.getPath(), null);
         context.getParentCallback().complete(res);
-        return null;
     }
 
     class DeleteContext<T> extends AsyncRpcContext<T> {
@@ -325,9 +314,8 @@ public class DataObjectManagerImpl implements DataObjectManager {
         return;
     }
 
-    protected Void deleteAsynCallback(AsyncCallbackDispatcher<DataObjectManagerImpl, CommandResult> callback, DeleteContext<CommandResult> context) {
+    protected void deleteAsynCallback(AsyncCallbackDispatcher<DataObjectManagerImpl, CommandResult> callback, DeleteContext<CommandResult> context) {
         DataObject destObj = context.obj;
-
         CommandResult res = callback.getResult();
         if (res.isFailed()) {
             try {
@@ -337,7 +325,6 @@ public class DataObjectManagerImpl implements DataObjectManager {
             } catch (ConcurrentOperationException e) {
                 s_logger.debug("delete failed", e);
             }
-
         } else {
             try {
                 objectInDataStoreMgr.update(destObj, Event.OperationSuccessed);
@@ -347,9 +334,7 @@ public class DataObjectManagerImpl implements DataObjectManager {
                 s_logger.debug("delete failed", e);
             }
         }
-
         context.getParentCallback().complete(res);
-        return null;
     }
 
     @Override

--- a/engine/storage/src/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/BaseImageStoreDriverImpl.java
@@ -141,7 +141,7 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
         }
     }
 
-    protected Void createTemplateAsyncCallback(AsyncCallbackDispatcher<? extends BaseImageStoreDriverImpl, DownloadAnswer> callback,
+    protected void createTemplateAsyncCallback(AsyncCallbackDispatcher<? extends BaseImageStoreDriverImpl, DownloadAnswer> callback,
         CreateContext<CreateCmdResult> context) {
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Performing image store createTemplate async callback");
@@ -156,7 +156,6 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Template is already in DOWNLOADED state, ignore further incoming DownloadAnswer");
                 }
-                return null;
             }
             TemplateDataStoreVO updateBuilder = _templateStoreDao.createForUpdate();
             updateBuilder.setDownloadPercent(answer.getDownloadPct());
@@ -196,11 +195,9 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
             CreateCmdResult result = new CreateCmdResult(null, null);
             caller.complete(result);
         }
-        return null;
     }
 
-    protected Void
-        createVolumeAsyncCallback(AsyncCallbackDispatcher<? extends BaseImageStoreDriverImpl, DownloadAnswer> callback, CreateContext<CreateCmdResult> context) {
+    protected void createVolumeAsyncCallback(AsyncCallbackDispatcher<? extends BaseImageStoreDriverImpl, DownloadAnswer> callback, CreateContext<CreateCmdResult> context) {
         DownloadAnswer answer = callback.getResult();
         DataObject obj = context.data;
         DataStore store = obj.getDataStore();
@@ -211,7 +208,6 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Volume is already in DOWNLOADED state, ignore further incoming DownloadAnswer");
                 }
-                return null;
             }
             VolumeDataStoreVO updateBuilder = _volumeStoreDao.createForUpdate();
             updateBuilder.setDownloadPercent(answer.getDownloadPct());
@@ -246,7 +242,6 @@ public abstract class BaseImageStoreDriverImpl implements ImageStoreDriver {
             CreateCmdResult result = new CreateCmdResult(null, null);
             caller.complete(result);
         }
-        return null;
     }
 
     @Override

--- a/plugins/hypervisors/vmware/test/org/apache/cloudstack/storage/motion/VmwareStorageMotionStrategyTest.java
+++ b/plugins/hypervisors/vmware/test/org/apache/cloudstack/storage/motion/VmwareStorageMotionStrategyTest.java
@@ -226,9 +226,8 @@ public class VmwareStorageMotionStrategyTest {
         }
     }
 
-    protected Void mockCallBack(AsyncCallbackDispatcher<VmwareStorageMotionStrategyTest, CopyCommandResult> callback, MockContext<CommandResult> context) {
+    protected void mockCallBack(AsyncCallbackDispatcher<VmwareStorageMotionStrategyTest, CopyCommandResult> callback, MockContext<CommandResult> context) {
         result = callback.getResult();
-        return null;
     }
 
     @Configuration

--- a/plugins/storage/volume/sample/src/org/apache/cloudstack/storage/datastore/driver/SamplePrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/sample/src/org/apache/cloudstack/storage/datastore/driver/SamplePrimaryDataStoreDriverImpl.java
@@ -20,8 +20,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.engine.subsystem.api.storage.ChapInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.CreateCmdResult;
@@ -38,6 +36,7 @@ import org.apache.cloudstack.framework.async.AsyncRpcContext;
 import org.apache.cloudstack.storage.command.CommandResult;
 import org.apache.cloudstack.storage.command.CreateObjectCommand;
 import org.apache.cloudstack.storage.datastore.DataObjectManager;
+import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.to.DataStoreTO;
@@ -111,7 +110,7 @@ public class SamplePrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver 
         }
     }
 
-    public Void createAsyncCallback(AsyncCallbackDispatcher<SamplePrimaryDataStoreDriverImpl, Answer> callback, CreateVolumeContext<CreateCmdResult> context) {
+    public void createAsyncCallback(AsyncCallbackDispatcher<SamplePrimaryDataStoreDriverImpl, Answer> callback, CreateVolumeContext<CreateCmdResult> context) {
         /*
          * CreateCmdResult result = null; CreateObjectAnswer volAnswer =
          * (CreateObjectAnswer) callback.getResult(); if (volAnswer.getResult())
@@ -121,7 +120,6 @@ public class SamplePrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver 
          *
          * context.getParentCallback().complete(result);
          */
-        return null;
     }
 
     @Override
@@ -138,14 +136,13 @@ public class SamplePrimaryDataStoreDriverImpl implements PrimaryDataStoreDriver 
          */
     }
 
-    public Void deleteCallback(AsyncCallbackDispatcher<SamplePrimaryDataStoreDriverImpl, Answer> callback, AsyncRpcContext<CommandResult> context) {
+    public void deleteCallback(AsyncCallbackDispatcher<SamplePrimaryDataStoreDriverImpl, Answer> callback, AsyncRpcContext<CommandResult> context) {
         CommandResult result = new CommandResult();
         Answer answer = callback.getResult();
         if (!answer.getResult()) {
             result.setResult(answer.getDetails());
         }
         context.getParentCallback().complete(result);
-        return null;
     }
 
     /*

--- a/server/src/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/com/cloud/template/HypervisorTemplateAdapter.java
@@ -309,7 +309,7 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
         }
     }
 
-    protected Void createTemplateAsyncCallBack(AsyncCallbackDispatcher<HypervisorTemplateAdapter, TemplateApiResult> callback,
+    protected void createTemplateAsyncCallBack(AsyncCallbackDispatcher<HypervisorTemplateAdapter, TemplateApiResult> callback,
         CreateTemplateContext<TemplateApiResult> context) {
         TemplateApiResult result = callback.getResult();
         TemplateInfo template = context.template;
@@ -352,8 +352,6 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
                 _resourceLimitMgr.incrementResourceCount(accountId, ResourceType.secondary_storage, template.getSize());
             }
         }
-
-        return null;
     }
 
     @Override


### PR DESCRIPTION
I have changed many "Void" methods to "void" since they have to return
null at the end and it has the same effect of "void" methods.
The method _HandleVolumeCreateAsyncCallback_ cannot be void, so I let it as Void.
