### PR TITLE
CLOUDSTACK-9343 Removed unused parameters and variable from NetworkHelper hierarchy

### DIFF
--- a/api/src/com/cloud/network/VirtualNetworkApplianceService.java
+++ b/api/src/com/cloud/network/VirtualNetworkApplianceService.java
@@ -63,7 +63,7 @@ public interface VirtualNetworkApplianceService {
 
     VirtualRouter startRouter(long id) throws ResourceUnavailableException, InsufficientCapacityException, ConcurrentOperationException;
 
-    VirtualRouter destroyRouter(long routerId, Account caller, Long callerUserId) throws ResourceUnavailableException, ConcurrentOperationException;
+    VirtualRouter destroyRouter(long routerId, Account caller) throws ResourceUnavailableException, ConcurrentOperationException;
 
     VirtualRouter findRouter(long routerId);
 

--- a/api/src/org/apache/cloudstack/api/command/admin/router/DestroyRouterCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/router/DestroyRouterCmd.java
@@ -16,8 +16,6 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.router;
 
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiCommandJobType;
 import org.apache.cloudstack.api.ApiConstants;
@@ -27,6 +25,7 @@ import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.DomainRouterResponse;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.log4j.Logger;
 
 import com.cloud.event.EventTypes;
 import com.cloud.exception.ConcurrentOperationException;
@@ -100,7 +99,7 @@ public class DestroyRouterCmd extends BaseAsyncCmd {
         CallContext ctx = CallContext.current();
         ctx.setEventDetails("Router Id: " + getId());
 
-        VirtualRouter result = _routerService.destroyRouter(getId(), ctx.getCallingAccount(), ctx.getCallingUserId());
+        VirtualRouter result = _routerService.destroyRouter(getId(), ctx.getCallingAccount());
         if (result != null) {
             DomainRouterResponse response = _responseGenerator.createDomainRouterResponse(result);
             response.setResponseName(getCommandName());

--- a/server/src/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VirtualRouterElement.java
@@ -685,7 +685,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
                 s_logger.warn("Failed to stop virtual router element " + router + ", but would try to process clean up anyway.");
             }
             if (cleanup) {
-                destroyResult = destroyResult && _routerMgr.destroyRouter(router.getId(), context.getAccount(), context.getCaller().getId()) != null;
+                destroyResult = destroyResult && _routerMgr.destroyRouter(router.getId(), context.getAccount()) != null;
                 if (!destroyResult) {
                     s_logger.warn("Failed to clean up virtual router element " + router);
                 }
@@ -707,7 +707,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         // not caller account
         final Account callerAccount = _accountMgr.getAccount(context.getCaller().getAccountId());
         for (final DomainRouterVO router : routers) {
-            result = result && _routerMgr.destroyRouter(router.getId(), callerAccount, context.getCaller().getId()) != null;
+            result = result && _routerMgr.destroyRouter(router.getId(), callerAccount) != null;
         }
         return result;
     }
@@ -888,7 +888,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor {
         final List<DomainRouterVO> routers = _routerDao.listByElementId(elementId);
         boolean result = true;
         for (final DomainRouterVO router : routers) {
-            result = result && _routerMgr.destroyRouter(router.getId(), context.getAccount(), context.getCaller().getId()) != null;
+            result = result && _routerMgr.destroyRouter(router.getId(), context.getAccount()) != null;
         }
         _vrProviderDao.remove(elementId);
 

--- a/server/src/com/cloud/network/element/VpcVirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VpcVirtualRouterElement.java
@@ -170,7 +170,7 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         boolean result = true;
         for (final DomainRouterVO router : routers) {
-            result = result && _routerMgr.destroyRouter(router.getId(), context.getAccount(), context.getCaller().getId()) != null;
+            result = result && _routerMgr.destroyRouter(router.getId(), context.getAccount()) != null;
         }
         return result;
     }

--- a/server/src/com/cloud/network/router/NetworkHelper.java
+++ b/server/src/com/cloud/network/router/NetworkHelper.java
@@ -35,7 +35,6 @@ import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.network.Network;
 import com.cloud.storage.VMTemplateVO;
 import com.cloud.user.Account;
-import com.cloud.user.User;
 import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.VirtualMachineProfile.Param;
@@ -53,8 +52,7 @@ public interface NetworkHelper {
     public abstract NicTO getNicTO(VirtualRouter router, Long networkId,
             String broadcastUri);
 
-    public abstract VirtualRouter destroyRouter(long routerId, Account caller,
-            Long callerUserId) throws ResourceUnavailableException,
+    public abstract VirtualRouter destroyRouter(long routerId, Account caller) throws ResourceUnavailableException,
             ConcurrentOperationException;
 
     /**
@@ -70,8 +68,7 @@ public interface NetworkHelper {
                     throws StorageUnavailableException, InsufficientCapacityException,
                     ConcurrentOperationException, ResourceUnavailableException;
 
-    public abstract DomainRouterVO startVirtualRouter(DomainRouterVO router,
-            User user, Account caller, Map<Param, Object> params)
+    public abstract DomainRouterVO startVirtualRouter(DomainRouterVO router, Map<Param, Object> params)
                     throws StorageUnavailableException, InsufficientCapacityException,
                     ConcurrentOperationException, ResourceUnavailableException;
 

--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -406,8 +406,8 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     BlockingQueue<Long> _vrUpdateQueue = null;
 
     @Override
-    public VirtualRouter destroyRouter(final long routerId, final Account caller, final Long callerUserId) throws ResourceUnavailableException, ConcurrentOperationException {
-        return _nwHelper.destroyRouter(routerId, caller, callerUserId);
+    public VirtualRouter destroyRouter(final long routerId, final Account caller) throws ResourceUnavailableException, ConcurrentOperationException {
+        return _nwHelper.destroyRouter(routerId, caller);
     }
 
     @Override
@@ -2311,15 +2311,13 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
         if (router.getState() == VirtualMachine.State.Running) {
             return router;
         }
-
-        final UserVO user = _userDao.findById(CallContext.current().getCallingUserId());
         final Map<Param, Object> params = new HashMap<Param, Object>();
         if (reprogramNetwork) {
             params.put(Param.ReProgramGuestNetworks, true);
         } else {
             params.put(Param.ReProgramGuestNetworks, false);
         }
-        final VirtualRouter virtualRouter = _nwHelper.startVirtualRouter(router, user, caller, params);
+        final VirtualRouter virtualRouter = _nwHelper.startVirtualRouter(router, params);
         if (virtualRouter == null) {
             throw new CloudRuntimeException("Failed to start router with id " + routerId);
         }

--- a/server/test/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
+++ b/server/test/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
@@ -145,7 +145,7 @@ public class MockVpcVirtualNetworkApplianceManager extends ManagerBase implement
      * @see com.cloud.network.VirtualNetworkApplianceService#destroyRouter(long, com.cloud.user.Account, java.lang.Long)
      */
     @Override
-    public VirtualRouter destroyRouter(final long routerId, final Account caller, final Long callerUserId) throws ResourceUnavailableException, ConcurrentOperationException {
+    public VirtualRouter destroyRouter(final long routerId, final Account caller) throws ResourceUnavailableException, ConcurrentOperationException {
         // TODO Auto-generated method stub
         return null;
     }


### PR DESCRIPTION
This issue was detected during the analysis of this PR https://github.com/apache/cloudstack/pull/1278/files.
- It was removed some unused params User & Account in the com.cloud.network.router.NetworkHelper.startVirtualRouter(DomainRouterVO, User, Account, Map<Param, Object>) and the param Long in the com.cloud.network.router.NetworkHelper.destroyRouter(long, Account, Long)
- Also, it was removed some unused params User & Account from com.cloud.network.router.NetworkHelperImpl.start(DomainRouterVO, User, Account, Map<Param, Object>, DeploymentPlan)
