### PR TITLE
CLOUDSTACK-9319: Use timeout when applying config to virtual router

### DIFF
--- a/core/src/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
+++ b/core/src/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
@@ -152,11 +152,10 @@ public class VirtualRoutingResource {
         }
     }
 
-    private ExecutionResult applyConfigToVR(String routerAccessIp, ConfigItem c) {
-        return applyConfigToVR(routerAccessIp, c, VRScripts.DEFAULT_EXECUTEINVR_TIMEOUT);
-    }
-
     private ExecutionResult applyConfigToVR(String routerAccessIp, ConfigItem c, int timeout) {
+        if (timeout < VRScripts.DEFAULT_EXECUTEINVR_TIMEOUT) {
+            timeout = VRScripts.DEFAULT_EXECUTEINVR_TIMEOUT;
+        }
         if (c instanceof FileConfigItem) {
             FileConfigItem configItem = (FileConfigItem)c;
             return _vrDeployer.createFileInVR(routerAccessIp, configItem.getFilePath(), configItem.getFileName(), configItem.getFileContents());
@@ -180,7 +179,7 @@ public class VirtualRoutingResource {
         boolean finalResult = false;
         for (ConfigItem configItem : cfg) {
             long startTimestamp = System.currentTimeMillis();
-            ExecutionResult result = applyConfigToVR(cmd.getRouterAccessIp(), configItem);
+            ExecutionResult result = applyConfigToVR(cmd.getRouterAccessIp(), configItem, VRScripts.DEFAULT_EXECUTEINVR_TIMEOUT);
             if (s_logger.isDebugEnabled()) {
                 long elapsed = System.currentTimeMillis() - startTimestamp;
                 s_logger.debug("Processing " + configItem + " took " + elapsed + "ms");
@@ -375,9 +374,6 @@ public class VirtualRoutingResource {
                 ScriptConfigItem scriptConfigItem = new ScriptConfigItem(VRScripts.VR_CFG, "-c " + VRScripts.CONFIG_CACHE_LOCATION + cfgFileName);
                 // 120s is the minimal timeout
                 int timeout = answerCounts * _eachTimeout;
-                if (timeout < 120) {
-                    timeout = 120;
-                }
 
                 ExecutionResult result = applyConfigToVR(cmd.getRouterAccessIp(), fileConfigItem, timeout);
                 if (!result.isSuccess()) {

--- a/core/src/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
+++ b/core/src/com/cloud/agent/resource/virtualnetwork/VirtualRoutingResource.java
@@ -379,7 +379,7 @@ public class VirtualRoutingResource {
                     timeout = 120;
                 }
 
-                ExecutionResult result = applyConfigToVR(cmd.getRouterAccessIp(), fileConfigItem);
+                ExecutionResult result = applyConfigToVR(cmd.getRouterAccessIp(), fileConfigItem, timeout);
                 if (!result.isSuccess()) {
                     return new Answer(cmd, false, result.getDetails());
                 }


### PR DESCRIPTION
From the [JIRA issue](https://issues.apache.org/jira/browse/CLOUDSTACK-9319):

> The timeout parameter is not passed down to `applyConfigToVR` inside `VirtualRoutingResource` in all cases.
> 
> This timeout is worked out as 3 seconds per command or 120 seconds (whichever is larger), but because it's not passed to the first invocation, the default (120 seconds, DEFAULT_EXECUTEINVR_TIMEOUT) is used.
> 
> In a recent upgrade of our Virtual Routers, the timeout was being hit and increasing `router.aggregation.command.each.timeout` had no effect. I built a custom 4.8 agent with the timeout increased to allow the upgrade to continue.
