### PR TITLE
CLOUDSTACK-9333: Exclude clusters from OVF operations

### DIFF
--- a/engine/components-api/src/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/com/cloud/capacity/CapacityManager.java
@@ -53,6 +53,16 @@ public interface CapacityManager {
             "0.85",
             "Percentage (as a value between 0 and 1) of allocated storage utilization above which allocators will disable using the pool for low allocated storage available.",
             true, ConfigKey.Scope.Zone);
+    static final ConfigKey<Boolean> StorageOperationsExcludeCluster =
+            new ConfigKey<Boolean>(
+                    Boolean.class,
+                    "cluster.storage.operations.exclude",
+                    "Advanced",
+                    "false",
+                    "Exclude cluster from storage operations",
+                    true,
+                    ConfigKey.Scope.Cluster,
+                    null);
 
     public boolean releaseVmCapacity(VirtualMachine vm, boolean moveFromReserved, boolean moveToReservered, Long hostId);
 

--- a/server/src/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/com/cloud/capacity/CapacityManagerImpl.java
@@ -1082,6 +1082,6 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {CpuOverprovisioningFactor, MemOverprovisioningFactor, StorageCapacityDisableThreshold, StorageOverprovisioningFactor,
-            StorageAllocatedCapacityDisableThreshold};
+            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster};
     }
 }

--- a/setup/db/db/schema-481to490.sql
+++ b/setup/db/db/schema-481to490.sql
@@ -410,3 +410,6 @@ VIEW `user_vm_view` AS
             AND (`custom_speed`.`name` = 'CpuSpeed'))))
         LEFT JOIN `user_vm_details` `custom_ram_size` ON (((`custom_ram_size`.`vm_id` = `vm_instance`.`id`)
             AND (`custom_ram_size`.`name` = 'memory'))));
+
+-- Add cluster.storage.operations.exclude property
+INSERT INTO `cloud`.`configuration` (`category`, `instance`, `component`, `name`, `description`, `default_value`, `updated`, `scope`, `is_dynamic`) VALUES ('Advanced', 'DEFAULT', 'CapacityManager', 'cluster.storage.operations.exclude', 'Exclude cluster from storage operations', 'false', now(), 'Cluster', '1');


### PR DESCRIPTION
JIRA TICKET: https://issues.apache.org/jira/browse/CLOUDSTACK-9333 

## Introduction
In some environments there is a need to exclude certain VMware clusters from performing OVF operations. This operations are part of: 
* create template
* create volume snaphsot
* copy template, volume, images from primary storage to secondary storage
* migrate volume 
* participate when a template gets cached over to primary storage.

In ESX/ESXi, OVF operations are low priority and bound to a single CPU and most likely get throttled to certain IOPS and network limits. 
If the hypervisor chosen for OVF operations is weak or overloaded this results in significantly longer execution of such OVF command and therefore degraded performance of underlying CloudStack API call.

### Proposed solution
It is proposed to add a way to exclude hosts from selected clusters for OVF operations.
To exclude a cluster, would be necessary to insert a record in <code>cluster_details</code> specifying property **vmware.exclude_from_ovf** in this way: (supposing we want to exclude cluster X)

| cluster_id | name| value |
|:-------------:|:-------------:|:-------------:|
|X|vmware.exclude_from_ovf|true|
