### PR TITLE
Bump ssh retries to prevent false positives of test_loadbalance

### DIFF
--- a/test/integration/smoke/test_loadbalance.py
+++ b/test/integration/smoke/test_loadbalance.py
@@ -134,7 +134,7 @@ class TestLoadBalance(cloudstackTestCase):
                 self.services['lbrule']["publicport"],
                 self.vm_1.username,
                 self.vm_1.password,
-                retries=5
+                retries=10
             )
             unameCmd.append(ssh_1.execute("uname")[0])
             self.debug(unameCmd)


### PR DESCRIPTION
No more false positives after this change.

```
[root@cs1 integration]# cat /tmp//MarvinLogs/test_loadbalance_TR5RJD/results.txt
Test to create Load balancing rule with source NAT ... === TestName: test_01_create_lb_rule_src_nat | Status : SUCCESS ===
ok
Test to create Load balancing rule with non source NAT ... === TestName: test_02_create_lb_rule_non_nat | Status : SUCCESS ===
ok
Test for assign & removing load balancing rule ... === TestName: test_assign_and_removal_lb | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 3 tests in 930.418s

OK
```