### PR TITLE
Apply static routes on change to master state

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -42,6 +42,7 @@ from cs.CsMonitor import CsMonitor
 from cs.CsLoadBalancer import CsLoadBalancer
 from cs.CsConfig import CsConfig
 from cs.CsProcess import CsProcess
+from cs.CsStaticRoutes import CsStaticRoutes
 
 
 class CsPassword(CsDataBag):
@@ -72,27 +73,6 @@ class CsPassword(CsDataBag):
                 '-F "token={TOKEN}" >/dev/null 2>/dev/null &'.format(SERVER_IP=server_ip, VM_IP=vm_ip, PASSWORD=password, TOKEN=token)
                 result = CsHelper.execute(update_command)
                 logging.debug("Update password server result ==> %s" % result)
-
-
-class CsStaticRoutes(CsDataBag):
-    
-    def process(self):
-        logging.debug("Processing CsStaticRoutes file ==> %s" % self.dbag)
-        for item in self.dbag:
-            if item == "id":
-                continue
-            self.__update(self.dbag[item])
-
-    def __update(self, route):
-        if route['revoke']:
-            command = "ip route del %s via %s" % (route['network'], route['gateway'])
-            result = CsHelper.execute(command)
-        else:
-            command = "ip route show | grep %s | awk '{print $1, $3}'" % route['network']
-            result = CsHelper.execute(command)
-            if not result:
-                route_command = "ip route add %s via %s" % (route['network'], route['gateway'])
-                result = CsHelper.execute(route_command)
 
 
 class CsAcl(CsDataBag):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -38,6 +38,7 @@ from CsProcess import CsProcess
 from CsApp import CsPasswdSvc
 from CsAddress import CsDevice
 from CsRoute import CsRoute
+from CsStaticRoutes import CsStaticRoutes
 import socket
 from time import sleep
 
@@ -298,9 +299,9 @@ class CsRedundant(object):
                 continue
             dev = ip.get_device()
             logging.info("Will proceed configuring device ==> %s" % dev)
-            cmd2 = "ip link set %s up" % dev
+            cmd = "ip link set %s up" % dev
             if CsDevice(dev, self.config).waitfordevice():
-                CsHelper.execute(cmd2)
+                CsHelper.execute(cmd)
                 logging.info("Bringing public interface %s up" % dev)
 
                 try:
@@ -312,7 +313,10 @@ class CsRedundant(object):
             else:
                 logging.error("Device %s was not ready could not bring it up" % dev)
 
-        # ip route add default via $gw table Table_$dev proto static
+        logging.debug("Configuring static routes")
+        static_routes = CsStaticRoutes("staticroutes", self.config)
+        static_routes.process()
+
         cmd = "%s -C %s" % (self.CONNTRACKD_BIN, self.CONNTRACKD_CONF)
         CsHelper.execute("%s -c" % cmd)
         CsHelper.execute("%s -f" % cmd)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# -- coding: utf-8 --
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from CsDatabag import CsDataBag
+from CsRedundant import *
+
+
+class CsStaticRoutes(CsDataBag):
+
+    def process(self):
+        logging.debug("Processing CsStaticRoutes file ==> %s" % self.dbag)
+        for item in self.dbag:
+            if item == "id":
+                continue
+            self.__update(self.dbag[item])
+
+    def __update(self, route):
+        if route['revoke']:
+            command = "ip route del %s via %s" % (route['network'], route['gateway'])
+            CsHelper.execute(command)
+        else:
+            command = "ip route show | grep %s | awk '{print $1, $3}'" % route['network']
+            result = CsHelper.execute(command)
+            if not result:
+                route_command = "ip route add %s via %s" % (route['network'], route['gateway'])
+                CsHelper.execute(route_command)


### PR DESCRIPTION
Refactored static routes for private gateways so they also get loaded when the router switches to master state. Otherwise they're lost and connections drop after fail over.