### PR TITLE
Fix deleting template from UI

### DIFF
--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -1451,8 +1451,18 @@
                                                      }
                                                  },
                                                  action: function(args) {
+                                                     var data = {
+                                                         id: args.context.templates[0].id,
+                                                     };
+                                                     if (args.context.zones[0].zoneid.length > 0) {
+                                                         var zoneid_data = {
+                                                            zoneid: args.context.zones[0].zoneid,
+                                                         };
+                                                         data = $.extend({}, data, zoneid_data);
+                                                     }
                                                      $.ajax({
-                                                         url: createURL("deleteTemplate&id=" + args.context.templates[0].id + "&zoneid=" + args.context.zones[0].zoneid),
+                                                         url: createURL("deleteTemplate"),
+                                                         data: data,
                                                          dataType: "json",
                                                          async: true,
                                                          success: function(json) {


### PR DESCRIPTION
It failed because zoneid was zero. Added a check for it and only send it when it makes sense.

With zoneid:
![screen shot 2016-03-29 at 21 40 11](https://cloud.githubusercontent.com/assets/1630096/14121676/b5bb1b0c-f5f8-11e5-88c4-c9fe28b55a21.png)

Without:
![screen shot 2016-03-29 at 21 43 16](https://cloud.githubusercontent.com/assets/1630096/14121681/b90477cc-f5f8-11e5-8501-9ad6f0a350bd.png)

Both result in:
![screen shot 2016-03-29 at 21 43 27](https://cloud.githubusercontent.com/assets/1630096/14121683/bd955bbc-f5f8-11e5-88ea-779569eac69b.png)