### PR TITLE
Cloudstack-9285 exception log addition

### DIFF
--- a/agent/src/com/cloud/agent/Agent.java
+++ b/agent/src/com/cloud/agent/Agent.java
@@ -227,6 +227,7 @@ public class Agent implements HandlerFactory, IAgentControl {
         try {
             _connection.start();
         } catch (final NioConnectionException e) {
+            s_logger.warn("NIO Connection Exception  " + e);
             s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
         }
         while (!_connection.isStartup()) {
@@ -235,6 +236,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             try {
                 _connection.start();
             } catch (final NioConnectionException e) {
+                s_logger.warn("NIO Connection Exception  " + e);
                 s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
             }
         }
@@ -412,6 +414,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             try {
                 _connection.start();
             } catch (final NioConnectionException e) {
+                s_logger.warn("NIO Connection Exception  " + e);
                 s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
             }
             _shell.getBackoffAlgorithm().waitBeforeRetry();


### PR DESCRIPTION
After discussion with @miguelaferreira on the previous PR related to Cloudstack-9285, we decided on adding additional exception logging for this issue.

After adding it, the logs look like this in our lab:

2016-04-07 15:44:03,298 WARN  [cloud.agent.Agent] (Agent-Handler-1:null) (logid:7225632a) NIO Connection Exception com.cloud.utils.exception.NioConnectionException: Connection closed with -1 on reading size.  <<-- new exception logging
2016-04-07 15:44:03,298 INFO  [cloud.agent.Agent] (Agent-Handler-1:null) (logid:7225632a) Attempted to connect to the server, but received an unexpected exception, trying again... << --original logging from previous PR.
