### PR TITLE
travis: increase build verbosity

### DIFF
--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -37,9 +37,9 @@ fi
 export MAVEN_OPTS="-Xmx2048m -XX:MaxPermSize=500m -Djava.security.egd=file:/dev/./urandom"
 
 if [ $TEST_SEQUENCE_NUMBER -eq 1 ]; then
-   mvn -Pdeveloper,systemvm -Dsimulator clean install -T4 | egrep "Building|SUCCESS"
+   mvn -Pdeveloper,systemvm -Dsimulator clean install -T4 | egrep "Building|Tests|SUCCESS|FAILURE"
 else
-   mvn -Pdeveloper -Dsimulator clean install -DskipTests=true -T4 | egrep "Building|SUCCESS"
+   mvn -Pdeveloper -Dsimulator clean install -DskipTests=true -T4 | egrep "Building|Tests|SUCCESS|FAILURE"
 fi
 
 # Install mysql-connector-python


### PR DESCRIPTION
Outputs for modules that fail or succeed with unit tests results.

Based on the issue raised in https://github.com/apache/cloudstack/pull/1466 this PR aims at increasing Travis build output so we can know which unit test fail.

/cc @swill @nvazquez -- let me know if we just allow outputting everything will help? I had restricted the output as including all of them would disallow viewing the tabular final integration/marvin tests at the end (only possible by viewing raw output of each travis job).