### PR TITLE
Restore iptables at once using iptables-restore instead of calling iptables numerous times

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -217,7 +217,23 @@ class CsAcl(CsDataBag):
 
         def process(self, direction, rule_list, base):
             count = base
-            for i in rule_list:
+            rule_list_splitted = []
+            for rule in rule_list:
+                if ',' in rule['cidr']:
+                    cidrs = rule['cidr'].split(',')
+                    for cidr in cidrs:
+                        new_rule = {
+                            'cidr': cidr,
+                            'last_port': rule['last_port'],
+                            'type': rule['type'],
+                            'first_port': rule['first_port'],
+                            'allowed': rule['allowed']
+                        }
+                        rule_list_splitted.append(new_rule)
+                else:
+                    rule_list_splitted.append(rule)
+
+            for i in rule_list_splitted:
                 r = self.AclRule(direction, self, i, self.config, count)
                 r.create()
                 count += 1

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -988,7 +988,7 @@ def main(argv):
         lb.process()
 
         logging.debug("Configuring iptables rules")
-        nf = CsNetfilters()
+        nf = CsNetfilters(False)
         nf.compare(config.get_fw())
 
         logging.debug("Configuring iptables rules done ...saving rules")

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -520,6 +520,8 @@ class CsSite2SiteVpn(CsDataBag):
         file.addeq(" pfs=%s" % CsHelper.bool_to_yn(obj['dpd']))
         file.addeq(" keyingtries=2")
         file.addeq(" auto=start")
+        if not obj.has_key('encap'):
+            obj['encap']="false"
         file.addeq(" forceencaps=%s" % CsHelper.bool_to_yn(obj['encap']))
         if obj['dpd']:
             file.addeq("  dpddelay=30")

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -536,8 +536,6 @@ class CsSite2SiteVpn(CsDataBag):
         file.addeq(" pfs=%s" % CsHelper.bool_to_yn(obj['dpd']))
         file.addeq(" keyingtries=2")
         file.addeq(" auto=start")
-        if not obj.has_key('encap'):
-            obj['encap']="false"
         file.addeq(" forceencaps=%s" % CsHelper.bool_to_yn(obj['encap']))
         if obj['dpd']:
             file.addeq("  dpddelay=30")

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -15,9 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from CsDatabag import CsDataBag, CsCmdLine
+from CsDatabag import CsDataBag
 from CsApp import CsApache, CsDnsmasq, CsPasswdSvc
-import CsHelper
 import logging
 from netaddr import IPAddress, IPNetwork
 import CsHelper
@@ -198,7 +197,7 @@ class CsInterface:
         return self.get_attr("add")
 
     def to_str(self):
-        pprint(self.address)
+        print(self.address)
 
 
 class CsDevice:
@@ -384,8 +383,6 @@ class CsIP:
                             "-A FIREWALL_%s " % self.address['public_ip'] +
                             "-m state --state RELATED,ESTABLISHED -j ACCEPT"])
             self.fw.append(["mangle", "",
-                            "-A FIREWALL_%s DROP" % self.address['public_ip']])
-            self.fw.append(["mangle", "",
                             "-A VPN_%s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.address['public_ip']])
             self.fw.append(["mangle", "",
                             "-A VPN_%s -j RETURN" % self.address['public_ip']])
@@ -402,8 +399,7 @@ class CsIP:
 
         self.fw.append(["filter", "", "-A INPUT -d 224.0.0.18/32 -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -d 225.0.0.50/32 -j ACCEPT"])
-        self.fw.append(["filter", "", "-A INPUT -i %s -m state --state RELATED,ESTABLISHED -j ACCEPT" %
-                        self.dev])
+        self.fw.append(["filter", "", "-A INPUT -i %s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.dev])
         self.fw.append(["filter", "", "-A INPUT -p icmp -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -i lo -j ACCEPT"])
 
@@ -446,6 +442,13 @@ class CsIP:
         self.fw.append(["mangle", "front", "-A PREROUTING " +
                         "-m state --state RELATED,ESTABLISHED " +
                         "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])
+
+        self.fw.append(["", "front", "-A FORWARD -j NETWORK_STATS"])
+        self.fw.append(["", "front", "-A INPUT -j NETWORK_STATS"])
+        self.fw.append(["", "front", "-A OUTPUT -j NETWORK_STATS"])
+
+        self.fw.append(["filter", "", "-A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT"])
+
         if self.get_type() in ["guest"]:
             self.fw.append(["filter", "", "-A FORWARD -d %s -o %s -j ACL_INBOUND_%s" %
                             (self.address['network'], self.dev, self.dev)])
@@ -484,10 +487,6 @@ class CsIP:
                             ])
 
         if self.get_type() in ["public"]:
-            self.fw.append(["", "front",
-                            "-A FORWARD -o %s -d %s -j ACL_INBOUND_%s" % (
-                                self.dev, self.address['network'], self.dev)
-                            ])
             self.fw.append(
                 ["mangle", "", "-A FORWARD -j VPN_STATS_%s" % self.dev])
             self.fw.append(
@@ -495,11 +494,7 @@ class CsIP:
             self.fw.append(
                 ["mangle", "", "-A VPN_STATS_%s -i %s -m mark --mark 0x524/0xffffffff" % (self.dev, self.dev)])
             self.fw.append(
-                ["", "front", "-A FORWARD -j NETWORK_STATS_%s" % self.dev])
-
-        self.fw.append(["", "front", "-A FORWARD -j NETWORK_STATS"])
-        self.fw.append(["", "front", "-A INPUT -j NETWORK_STATS"])
-        self.fw.append(["", "front", "-A OUTPUT -j NETWORK_STATS"])
+                ["", "front", "-A FORWARD -j NETWORK_STATS_eth1"])
 
         self.fw.append(["", "", "-A NETWORK_STATS -i eth0 -o eth2 -p tcp"])
         self.fw.append(["", "", "-A NETWORK_STATS -i eth2 -o eth0 -p tcp"])
@@ -508,9 +503,11 @@ class CsIP:
 
         self.fw.append(["filter", "", "-A INPUT -d 224.0.0.18/32 -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -d 225.0.0.50/32 -j ACCEPT"])
-
+        self.fw.append(["filter", "", "-A INPUT -i %s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.dev])
+        self.fw.append(["filter", "", "-A INPUT -i lo -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -p icmp -j ACCEPT"])
         self.fw.append(["filter", "", "-A INPUT -i eth0 -p tcp -m tcp --dport 3922 -m state --state NEW,ESTABLISHED -j ACCEPT"])
+        self.fw.append(["filter", "", "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT"])
 
         self.fw.append(["filter", "", "-P INPUT DROP"])
         self.fw.append(["filter", "", "-P FORWARD DROP"])

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -54,7 +54,7 @@ class CsDhcp(CsDataBag):
         self.cloud.commit()
 
         # We restart DNSMASQ every time the configure.py is called in order to avoid lease problems.
-        CsHelper.service("dnsmasq", "restart")
+        CsHelper.execute2("service dnsmasq restart")
 
     def configure_server(self):
         # self.conf.addeq("dhcp-hostsfile=%s" % DHCP_HOSTS)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -71,14 +71,16 @@ class CsLoadBalancer(CsDataBag):
             port = path[1]
             firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
 
-        for rules in remove_rules:
-            path = rules.split(':')
-            ip = path[0]
-            port = path[1]
-            firewall.append(["filter", "", "-D INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
-
         for rules in stat_rules:
             path = rules.split(':')
             ip = path[0]
             port = path[1]
             firewall.append(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+
+        for rules in remove_rules:
+            path = rules.split(':')
+            ip = path[0]
+            port = path[1]
+            if ["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)] in firewall:
+                firewall.remove(["filter", "", "-A INPUT -p tcp -m tcp -d %s --dport %s -m state --state NEW -j ACCEPT" % (ip, port)])
+

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
@@ -172,6 +172,7 @@ class CsNetfilters(object):
     def apply_rules(self):
         s = []
         for r in self.iptablerules:
+            r.replace('  ', ' ')  # Remove duplicate spaces
             if r not in s:
                 s.append(r)
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_iptables_save.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_iptables_save.py
@@ -1,0 +1,267 @@
+#!/usr/bin/python
+#
+# -*- coding: utf-8 -*-
+#
+"""
+iptables_converter.py:
+    convert iptables commands within a script
+    into a correspondig iptables-save script
+
+    default filename to read is rules, to read some other
+        file, append: -s filename
+
+    output is written to stdout for maximum flexibilty
+
+Author:     Johannes Hubertz <johannes@hubertz.de>
+Date:       2015-03-17
+version:    0.9.8
+License:    GNU General Public License version 3 or later
+
+Have Fun!
+"""
+
+try:
+    from collections import UserDict
+except ImportError:
+    from UserDict import UserDict
+from optparse import OptionParser
+import re
+import sys
+
+
+class ConverterError():
+    """on accidential case of error show given reason"""
+
+    def __init__(self, message):
+        """message to stdout to compatible testings 2.7 and 3.4"""
+        print (message)
+        sys.exit(1)
+
+
+class Chains(UserDict):
+    """this is for one type of tables"""
+
+    def __init__(self, name, tables):
+        """init Chains object"""
+        UserDict.__init__(self)
+        self.name = name
+        self.tables = tables
+        self.predef = tables
+        self.reset()  # name, tables)
+
+    def put_into_fgr(self, content):
+        """fill this line into this tabular"""
+        self.length += 1
+        cha = "filter"
+        # act = ""
+        liste = content.split()
+        action = liste[0]
+        if "-t" in action:
+            liste.pop(0)  # remove 1st: -t
+            fname = liste.pop(0)
+            legals = ["filter", "nat", "raw", "mangle"]
+            if fname not in legals:
+                msg = "Valid is one of %s, got: %s" % (legals, fname)
+                raise ValueError(msg)
+            action = liste[0]
+            content = ""                       # rebuild content from here
+            for elem in liste:
+                content = content + elem + " "
+            if len(liste) > 1:
+                chain_name = liste[1]
+        if "-F" in action:
+            self.reset()
+            return
+        if "-P" in action:
+            liste.pop(0)
+            cha = liste.pop(0)
+            new = liste.pop(0)
+            if new not in ["ACCEPT", "DROP", "REJECT"]:
+                msg = "Illegal policy: % s" % (new)
+                raise ValueError(msg)
+            self.poli[cha] = new
+            return
+        if "-X" in action:
+            predef = ['INPUT', 'FORWARD', 'OUTPUT',
+                      'PREROUTING', 'POSTROUTING']
+            rem_chain_name = liste.pop(1)
+            if rem_chain_name in predef:
+                msg = "Cannot remove predefined chain"
+                raise ValueError(msg)
+            if rem_chain_name in self.data:
+                self.data[rem_chain_name] = []        # empty list
+                self.poli[rem_chain_name] = "-"       # empty policy, no need
+                self.data.pop(rem_chain_name)
+            return
+        if "-N" in action:
+            new_chain_name = liste.pop(1)
+            existing = self.data.keys()
+            if new_chain_name in existing:
+                msg = "Chain %s already exists" % (new_chain_name)
+                raise ValueError(msg)
+            self.data[new_chain_name] = []        # empty list
+            self.poli[new_chain_name] = "-"       # empty policy, no need
+            return
+        if "-I" in action:  # or "-A" in action:
+            chain_name = liste[1]
+            existing = self.data.keys()
+            if chain_name not in existing:
+                msg = "invalid chain name: %s" % (chain_name)
+                raise ValueError(msg)
+            kette = self.data[chain_name]
+            if len(kette) > 0:
+                kette.insert(0, content)
+            else:
+                msg = "Empty chain %s allows append only!" % (chain_name)
+                raise ValueError(msg)
+            self.data[chain_name] = kette
+            return
+        if "-A" in action:  # or "-I" in action:
+            chain_name = liste[1]
+            existing = self.data.keys()
+            if chain_name not in existing:
+                msg = "invalid chain name: %s" % (chain_name)
+                raise ValueError(msg)
+            kette = self.data[chain_name]
+            kette.append(content)
+            self.data[chain_name] = kette
+            return
+        msg = "Unknown filter command in input:", content
+        raise ValueError(msg)
+
+    def reset(self):  # name, tables):
+        """
+        name is one of filter, nat, raw, mangle,
+        tables is a list of tables in that table-class
+        """
+        self.poli = {}               # empty dict
+        self.length = 0
+        self.policy = "-"
+        for tabular in self.tables:
+            self.data[tabular] = []
+            self.poli[tabular] = "ACCEPT"
+
+
+class Tables(UserDict):
+    """
+    some chaingroups in tables are predef: filter, nat, mangle, raw
+    """
+
+    def __init__(self, fname="reference-one"):
+        """init Tables Object is easy going"""
+        UserDict.__init__(self)
+        self.reset(fname)
+
+    def reset(self, fname):
+        """all predefined Chains aka lists are setup as new here"""
+        filter = Chains("filter", ["INPUT", "FORWARD", "OUTPUT"])
+
+        mang = ["PREROUTING", "INPUT", "FORWARD", "OUTPUT", "POSTROUTING", ]
+        mangle = Chains("mangle", mang)
+
+        # kernel 2.6.32 has no INPUT in NAT!
+        nat = Chains("nat", ["PREROUTING", "OUTPUT", "POSTROUTING"])
+
+        raw = Chains("raw", ["PREROUTING", "OUTPUT", ])
+
+        self.data["filter"] = filter
+        self.data["mangle"] = mangle
+        self.data["nat"] = nat
+        self.data["raw"] = raw
+        if len(fname) > 0:
+            self.linecounter = self.read_file(fname)
+
+    def table_printout(self):
+        """printout nonempty tabulars in fixed sequence"""
+        for key in ["raw", "nat", "mangle", "filter"]:
+            len = self.data[key].length
+            if len > -1:
+                print("*%s" % (self.data[key].name))
+                for chain in self.data[key].keys():
+                    poli = self.data[key].poli[chain]
+                    print(":%s %s [0:0]" % (chain, poli))
+                for chain in self.data[key].values():
+                    for elem in chain:
+                        print(elem)
+                print("COMMIT")
+
+    def put_into_tables(self, line):
+        """put line into matching Chains-object"""
+        liste = line.split()
+        liste.pop(0)                        # we always know, it's iptables
+        rest = ""
+        for elem in liste:                  # remove redirects and the like
+            if ">" not in elem:
+                rest = rest + elem + " "    # string again with single blanks
+        action = liste.pop(0)               # action is one of {N,F,A,I, etc.}
+        fam = "filter"
+        if "-t nat" in line:                # nat filter group
+            fam = "nat"
+        elif "-t mangle" in line:           # mangle filter group
+            fam = "mangle"
+        elif "-t raw" in line:              # raw filter group
+            fam = "raw"
+        fam_dict = self.data[fam]           # select the group dictionary
+        fam_dict.put_into_fgr(rest)         # do action thers
+
+    def read_file(self, fname):
+        """read file into Tables-object"""
+        self.linecounter = 0
+        self.tblctr = 0
+        try:
+            fil0 = open(fname, 'r')
+            for zeile in fil0:
+                line = str(zeile.strip())
+                self.linecounter += 1
+                if line.startswith('#'):
+                    continue
+                for element in ['\$', '\(', '\)', ]:
+                    if re.search(element, line):
+                        m1 = "Line %d:\n%s\nplain files only, " % \
+                             (self.linecounter, line)
+                        if element in ['\(', '\)', ]:
+                            m2 = "unable to convert shell functions, abort"
+                        else:
+                            m2 = "unable to resolve shell variables, abort"
+                        msg = m1 + m2
+                        raise ConverterError(msg)
+                for muster in ["^/sbin/iptables ", "^iptables "]:
+                    if re.search(muster, line):
+                        self.tblctr += 1
+                        self.put_into_tables(line)
+            fil0.close()
+        except ValueError as err:
+            print (fname + ": "), err
+            sys.exit(1)
+        except IOError as err:
+            print(fname + ": "), err.strerror
+            sys.exit(1)
+        if not fname == "reference-one":
+            print("# generated from: %s" % (fname))
+
+
+def main():
+    """
+    main parses options, filnames and the like
+    one option (-s) may be given: input-filename
+    if none given, it defaults to: rules
+    """
+    usage = "usage:  %prog --help | -h \n\n\t%prog: version 0.9.8"
+    usage = usage + "\tHave Fun!"
+    parser = OptionParser(usage)
+    parser.disable_interspersed_args()
+    parser.add_option("-s", "", dest="sourcefile",
+                      help="file with iptables commands, default: rules\n")
+    (options, args) = parser.parse_args()
+    hlp = "\n\tplease use \"--help\" as argument, abort!\n"
+    if options.sourcefile is None:
+        options.sourcefile = "rules"
+    sourcefile = options.sourcefile
+
+    chains = Tables(sourcefile)
+    chains.table_printout()
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)


### PR DESCRIPTION
This makes handling the firewall rules about 50-60 times faster because it is generated in memory and then loaded once. It's work by @borisroman see PR #1400. Reopened it here because I think this is a great improvement. 