### PR TITLE
Set default networkDomain to empty instead of username

### DIFF
--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/api/command/LinkDomainToLdapCmd.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/api/command/LinkDomainToLdapCmd.java
@@ -82,7 +82,7 @@ public class LinkDomainToLdapCmd extends BaseCmd {
                     if (account == null) {
                         try {
                             UserAccount userAccount = _accountService.createUserAccount(admin, "", ldapUser.getFirstname(), ldapUser.getLastname(), ldapUser.getEmail(), null,
-                                    admin, Account.ACCOUNT_TYPE_DOMAIN_ADMIN, domainId, admin, null, UUID.randomUUID().toString(), UUID.randomUUID().toString(), User.Source.LDAP);
+                                    admin, Account.ACCOUNT_TYPE_DOMAIN_ADMIN, domainId, null, null, UUID.randomUUID().toString(), UUID.randomUUID().toString(), User.Source.LDAP);
                             response.setAdminId(String.valueOf(userAccount.getAccountId()));
                             s_logger.info("created an account with name " + admin + " in the given domain " + domainId);
                         } catch (Exception e) {

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
@@ -119,7 +119,7 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
 
     private void createCloudStackUserAccount(LdapUser user, long domainId, short accountType) {
         String username = user.getUsername();
-        _accountManager.createUserAccount(username, "", user.getFirstname(), user.getLastname(), user.getEmail(), null, username, accountType, domainId, username, null,
+        _accountManager.createUserAccount(username, "", user.getFirstname(), user.getLastname(), user.getEmail(), null, username, accountType, domainId, null, null,
                                           UUID.randomUUID().toString(), UUID.randomUUID().toString(), User.Source.LDAP);
     }
 


### PR DESCRIPTION
The 10th field of `createUserAccount` is `networkDomain` (See `AccountService.java`) and it is set to a var named `admin`, which is the user name.
So, the first user that is created in a domain that links to LDAP, creates the account within the domain, and sets the `networkDomain` field to the username. All next users are created in the same account.

Then we have the situation that in domain SBP we have a user `rbergsma` that logs in first, gets an account created and then (unless you override) all VMs started in the SBP domain will have network domain `rbergsma`. That is highly confusing and not what is should be.

The `linkDomainToLdap` api call has no `networkDomain` field, so I propose to make this field empty (set it to null). It's a sting and null / empty is allowed.

One can also specify the networkDomain when creating a VPC and also there it is allowed to be null.

When te networkDomain is needed (and is not set in the domain and not in the VPC) it is constructed by using `guest.domain.suffix` so there always is a networkDomain to be used.

It makes more sense to manually set it on a domain level, or specify it on the VPC and in the final case end up with something that is clearly generated (like cs342cloud.local) rather than the username of someone else.