### PR TITLE
speedup iptables by prefetching the variables

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -775,41 +775,46 @@ class CsForwardingRules(CsDataBag):
             self.forward_vr(rule)
 
     def forward_vr(self, rule):
+        #prefetch iptables variables
+        public_fwinterface = self.getDeviceByIp(rule['public_ip'])
+        internal_fwinterface = self.getDeviceByIp(rule['internal_ip'])
+        public_fwports = self.portsToString(rule['public_ports'], ':')
+        internal_fwports = self.portsToString(rule['internal_ports'], '-')
         fw1 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -j DNAT --to-destination %s:%s" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['public_ip']),
+                public_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
                 rule['internal_ip'],
-                self.portsToString(rule['internal_ports'], '-')
+                internal_fwports
               )
         fw2 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -j DNAT --to-destination %s:%s" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['internal_ip']),
+                internal_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
                 rule['internal_ip'],
-                self.portsToString(rule['internal_ports'], '-')
+                internal_fwports
               )
         fw3 = "-A OUTPUT -d %s/32 -p %s -m %s --dport %s -j DNAT --to-destination %s:%s" % \
               (
                 rule['public_ip'],
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
                 rule['internal_ip'],
-                self.portsToString(rule['internal_ports'], '-')
+                internal_fwports
               )
         fw4 = "-j SNAT --to-source %s -A POSTROUTING -s %s -d %s/32 -o %s -p %s -m %s --dport %s" % \
               (
                 self.getGuestIp(),
                 self.getNetworkByIp(rule['internal_ip']),
                 rule['internal_ip'],
-                self.getDeviceByIp(rule['internal_ip']),
+                internal_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
                 self.portsToString(rule['internal_ports'], ':')
@@ -817,24 +822,24 @@ class CsForwardingRules(CsDataBag):
         fw5 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -j MARK --set-xmark %s/0xffffffff" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['public_ip']),
+                public_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
-                hex(int(self.getDeviceByIp(rule['public_ip'])[3:]))
+                public_fwports,
+                hex(int(public_fwinterface[3:]))
               )
         fw6 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['public_ip']),
+                public_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
               )
         fw7 = "-A FORWARD -i %s -o %s -p %s -m %s --dport %s -m state --state NEW,ESTABLISHED -j ACCEPT" % \
               (
-                self.getDeviceByIp(rule['public_ip']),
-                self.getDeviceByIp(rule['internal_ip']),
+                public_fwinterface,
+                internal_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
                 self.portsToString(rule['internal_ports'], ':')


### PR DESCRIPTION
-- This PR is replacing speedup iptables setup #1449 
-- Squashing commits and cleanup

PR against 4.7 as discussed with Remi Bergsma. This will speed up the iptables creation on the virtual router.

Testing showed the following:
with current code:
root@kvm704:~# time /usr/share/cloudstack-common/scripts/network/domr/router_proxy.sh vr_cfg.sh 169.254.1.176 -c /var/cache/cloud/VR-12f28879-de7e-44d2-8dbe-b93a04bd3ba4.cfg
real 2m56.401s
user 0m0.012s
sys 0m0.012s

modified version:
root@kvm704:~# time /usr/share/cloudstack-common/scripts/network/domr/router_proxy.sh vr_cfg.sh 169.254.1.176 -c /var/cache/cloud/VR-12f28879-de7e-44d2-8dbe-b93a04bd3ba4.cfg
real 1m35.762s
user 0m0.020s
sys 0m0.004s
