### PR TITLE
agent: Enable IPv6 connectivity for KVM Agent to Management Server

### DIFF
--- a/agent/src/com/cloud/agent/AgentShell.java
+++ b/agent/src/com/cloud/agent/AgentShell.java
@@ -409,12 +409,7 @@ public class AgentShell implements IAgentShell, Daemon {
             /* By default we only search for log4j.xml */
             LogUtils.initLog4j("log4j-cloud.xml");
 
-            /*
-                By default we disable IPv6 for now to maintain backwards
-                compatibility. At a later point in time we can change this
-                behavior to prefer IPv6 over IPv4.
-            */
-            boolean ipv6disabled = true;
+            boolean ipv6disabled = false;
             String ipv6 = getProperty(null, "ipv6disabled");
             if (ipv6 != null) {
                 ipv6disabled = Boolean.parseBoolean(ipv6);


### PR DESCRIPTION
IPv4 is still preferred, so if the hostname of the Management Server
returns a A and AAAA-record the Agent will still connect to the
server over IPv4.

This situation will however allow to use a hostname which only has
a AAAA-record. In that case the Agent will connect to the Management
Server over IPv6.