### PR TITLE
CLOUDSTACK-9352: Test fails in Widows as the file separator "/" is different from "\"

### DIFF
--- a/utils/src/test/java/com/cloud/utils/SwiftUtilTest.java
+++ b/utils/src/test/java/com/cloud/utils/SwiftUtilTest.java
@@ -19,9 +19,11 @@
 
 package com.cloud.utils;
 
+
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.File;
 import java.net.URL;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -31,7 +33,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
-
 
 public class SwiftUtilTest {
 
@@ -72,7 +73,7 @@ public class SwiftUtilTest {
 
     @Test
     public void testSplitSwiftPath(){
-        String input = "container/object";
+        String input = "container" + File.separator + "object";
         String[] output = SwiftUtil.splitSwiftPath(input);
         String[] expected = {"container", "object"};
 


### PR DESCRIPTION
**Problem:**
File separator in windows ("\") is different from the expected in the test ("/"); thus, the test *com.cloud.utils.SwiftUtilTest.testSplitSwiftPath()* will fail in Windows systems.

The problem is that the input of the test is "*container/object*" but the tested method uses the *File.separator* (that depends from the OS), in windows systems the tested method (*com.cloud.utils.SwiftUtil.splitSwiftPath(String)*) looks for a "\", as the string does not contain "\" it returns an empty string and consequently results in a test failure.

**Solution:**
Create a string `String input = "container" + File.separator + "object";`, with that the test will validate the tested method verifying if the method splits the string around matches of the given regular expression (in this case *File.separator*).

*JIRA link: https://issues.apache.org/jira/browse/CLOUDSTACK-9352*