### PR TITLE
Remove unused "umount" method in NfsSecondaryStorageResource 

### DIFF
--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -3041,29 +3041,6 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         return dir;
     }
 
-    protected void umount(String localRootPath, URI uri) {
-        ensureLocalRootPathExists(localRootPath, uri);
-
-        if (!mountExists(localRootPath, uri)) {
-            return;
-        }
-
-        Script command = new Script(!_inSystemVM, "mount", _timeout, s_logger);
-        command.add(localRootPath);
-        String result = command.execute();
-        if (result != null) {
-            // Fedora Core 12 errors out with any -o option executed from java
-            String errMsg = "Unable to umount " + localRootPath + " due to " + result;
-            s_logger.error(errMsg);
-            File file = new File(localRootPath);
-            if (file.exists()) {
-                file.delete();
-            }
-            throw new CloudRuntimeException(errMsg);
-        }
-        s_logger.debug("Successfully umounted " + localRootPath);
-    }
-
     protected void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
         s_logger.debug("mount " + uri.toString() + " on " + localRootPath + ((nfsVersion != null) ? " nfsVersion=" + nfsVersion : ""));
         ensureLocalRootPathExists(localRootPath, uri);


### PR DESCRIPTION
Im in process of rewriting the unit test for this class' mount method. Before I can do that, the class needed some refactoring, not just because it was fuzzy but because it was impossible to use mocks the way it was coded. Most of this PR is about transforming big chunks of code into documented methods with two exceptions:

1) I inverted the logic when checking for existing mounts within the same root location. Previously one would first create a directory if it didn't exist and then test if there was already mount there. Now it is first testing if there is a mount, if not, it creates the needed directory. (line 2376)

2) A bug was found in the unmount method. The unmount wasn't issuing the command "umount" to unmount a resource but instead was trying the "mount" command again, resulting in mounted resources never being unmounted. (line 2347)

**[UPDATE] Instead of refactoring the `umount` method, I noticed that it was not being used. Therefore, instead of fixing it, I decided to remove it.**
