### PR TITLE
Fixing an issue in Marvin around creating a template from a snapshot

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -1201,8 +1201,8 @@ class Template:
             random_gen()
         ]) if random_name else services["name"]
 
-	if services["ispublic"]:
-	    cmd.ispublic = services["ispublic"]
+        if "ispublic" in services:
+            cmd.ispublic = services["ispublic"]
 
         if "ostypeid" in services:
             cmd.ostypeid = services["ostypeid"]


### PR DESCRIPTION
This fixes the following ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-9354

The problem was that Marvin was requiring you to pass in the "ispublic" parameter when creating a template from a snapshot.

As the ticket notes, this issue was introduced by the following commit: https://git-wip-us.apache.org/repos/asf?p=cloudstack.git;a=commit;h=bbe0fc4be9527d51820b067a602886003991db4d

The solution I've provided is simply to check if the "ispublic" property is in the dictionary before referencing it.