### PR TITLE
4.9 mvn version safeupgradeonly

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -429,9 +429,8 @@
         </configuration>
       </plugin>
       <plugin>
-         <groupId>org.mortbay.jetty</groupId>
-         <artifactId>maven-jetty-plugin</artifactId>
-         <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
          <dependencies>
           <!-- specify the dependent jdbc driver here -->
           <dependency>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -431,6 +431,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
+        <version>${cs.jetty.version}</version>
          <dependencies>
           <!-- specify the dependent jdbc driver here -->
           <dependency>

--- a/engine/api/pom.xml
+++ b/engine/api/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.13</version>
+      <version>2.7.18</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>

--- a/engine/service/pom.xml
+++ b/engine/service/pom.xml
@@ -61,17 +61,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.18</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-server</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -84,9 +73,9 @@
     <finalName>engine</finalName>
     <plugins>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>8.1.7.v20120910</version>
+        <version>${cs.jetty.version}</version>
         <configuration>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <webApp>

--- a/engine/service/pom.xml
+++ b/engine/service/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.13</version>
+      <version>2.7.18</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>

--- a/framework/quota/src/org/apache/cloudstack/quota/QuotaStatementImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/QuotaStatementImpl.java
@@ -59,11 +59,11 @@ public class QuotaStatementImpl extends ManagerBase implements QuotaStatement {
 
     final public static int s_LAST_STATEMENT_SENT_DAYS = 6; //ideally should be less than 7 days
 
-    public enum STATEMENT_PERIODS {
+    public enum QuotaStatementPeriods {
         BIMONTHLY, MONTHLY, QUATERLY, HALFYEARLY, YEARLY
     };
 
-    private STATEMENT_PERIODS _period = STATEMENT_PERIODS.MONTHLY;
+    private QuotaStatementPeriods _period = QuotaStatementPeriods.MONTHLY;
 
     public QuotaStatementImpl() {
         super();
@@ -87,7 +87,7 @@ public class QuotaStatementImpl extends ManagerBase implements QuotaStatement {
         String period_str = configs.get(QuotaConfig.QuotaStatementPeriod.key());
         int period = period_str == null ? 1 : Integer.parseInt(period_str);
 
-        STATEMENT_PERIODS _period = STATEMENT_PERIODS.values()[period];
+        QuotaStatementPeriods _period = QuotaStatementPeriods.values()[period];
         return true;
     }
 
@@ -265,7 +265,7 @@ public class QuotaStatementImpl extends ManagerBase implements QuotaStatement {
         return null;
     }
 
-    public Calendar[] statementTime(final Calendar today, final STATEMENT_PERIODS period) {
+    public Calendar[] statementTime(final Calendar today, final QuotaStatementPeriods period) {
         //check if it is statement time
         int day_of_month = today.get(Calendar.DAY_OF_MONTH);
         int month_of_year = today.get(Calendar.MONTH);

--- a/framework/quota/test/org/apache/cloudstack/quota/QuotaStatementTest.java
+++ b/framework/quota/test/org/apache/cloudstack/quota/QuotaStatementTest.java
@@ -21,7 +21,7 @@ import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.db.TransactionLegacy;
 import junit.framework.TestCase;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.cloudstack.quota.QuotaStatementImpl.STATEMENT_PERIODS;
+import org.apache.cloudstack.quota.QuotaStatementImpl.QuotaStatementPeriods;
 import org.apache.cloudstack.quota.dao.QuotaAccountDao;
 import org.apache.cloudstack.quota.dao.QuotaUsageDao;
 import org.apache.cloudstack.quota.vo.QuotaAccountVO;
@@ -85,12 +85,12 @@ public class QuotaStatementTest extends TestCase {
 
         //BIMONTHLY - first statement of month
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS + 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period == null);
 
         //1 of this month
         date.set(Calendar.DATE, 1);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue(period[0].toString(), period[0].before(period[1]));
@@ -100,12 +100,12 @@ public class QuotaStatementTest extends TestCase {
         //BIMONTHLY - second statement of month
         date = Calendar.getInstance();
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS + 16);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period == null);
 
         //17 of this month
         date.set(Calendar.DATE, 17);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.BIMONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.BIMONTHLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue(period[0].toString(), period[0].before(period[1]));
@@ -128,12 +128,12 @@ public class QuotaStatementTest extends TestCase {
         //MONTHLY
         date = Calendar.getInstance();
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS + 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.MONTHLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.MONTHLY);
         assertTrue(period == null);
 
         //1 of this month
         date.set(Calendar.DATE, QuotaStatementImpl.s_LAST_STATEMENT_SENT_DAYS - 1);
-        period = quotaStatement.statementTime(date, STATEMENT_PERIODS.MONTHLY);
+        period = quotaStatement.statementTime(date, QuotaStatementPeriods.MONTHLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue(period[0].toString(), period[0].before(period[1]));
@@ -157,7 +157,7 @@ public class QuotaStatementTest extends TestCase {
         date = Calendar.getInstance();
         date.set(Calendar.MONTH, Calendar.JANUARY); // 1 Jan
         date.set(Calendar.DATE, 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.QUATERLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.QUATERLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue("period[0].before(period[1])" + period[0].toString(), period[0].before(period[1]));
@@ -182,7 +182,7 @@ public class QuotaStatementTest extends TestCase {
         date = Calendar.getInstance();
         date.set(Calendar.MONTH, Calendar.JANUARY); // 1 Jan
         date.set(Calendar.DATE, 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.HALFYEARLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.HALFYEARLY);
         assertTrue(period != null);
         assertTrue(period.length == 2);
         assertTrue("period[0].before(period[1])" + period[0].toString(), period[0].before(period[1]));
@@ -207,7 +207,7 @@ public class QuotaStatementTest extends TestCase {
         date = Calendar.getInstance();
         date.set(Calendar.MONTH, Calendar.JANUARY); // 1 Jan
         date.set(Calendar.DATE, 1);
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.YEARLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.YEARLY);
         assertTrue("period != null", period != null);
         assertTrue(period.length == 2);
         assertTrue("period[0].before(period[1])" + period[0].toString(), period[0].before(period[1]));
@@ -244,7 +244,7 @@ public class QuotaStatementTest extends TestCase {
 
         // call real method on send monthly statement
         quotaStatement.sendStatement();
-        Calendar period[] = quotaStatement.statementTime(date, STATEMENT_PERIODS.MONTHLY);
+        Calendar period[] = quotaStatement.statementTime(date, QuotaStatementPeriods.MONTHLY);
         if (period != null){
             Mockito.verify(alertManager, Mockito.times(1)).sendQuotaAlert(Mockito.any(QuotaAlertManagerImpl.DeferredQuotaEmail.class));
         }

--- a/framework/rest/pom.xml
+++ b/framework/rest/pom.xml
@@ -33,32 +33,32 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.7.1</version>
+      <version>${cs.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.7.1</version>
+      <version>${cs.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.7.1</version>
+      <version>${cs.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.7.1</version>
+      <version>${cs.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.7.1</version>
+      <version>${cs.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.18</version>
+      <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+      <version>${cs.cxf.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>

--- a/framework/rest/pom.xml
+++ b/framework/rest/pom.xml
@@ -33,32 +33,32 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.6.3</version>
+      <version>2.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-bundle-jaxrs</artifactId>
-      <version>2.7.13</version>
+      <version>2.7.18</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.8.2.0</version>
+      <version>0.9.0.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.9.0.0</version>
+      <version>0.9.0.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugins/event-bus/rabbitmq/pom.xml
+++ b/plugins/event-bus/rabbitmq/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
     <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-        <version>3.5.4</version>
+        <version>3.6.0</version>
     </dependency>
     <dependency>
     <groupId>org.apache.cloudstack</groupId>

--- a/plugins/event-bus/rabbitmq/pom.xml
+++ b/plugins/event-bus/rabbitmq/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
     <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
     </dependency>
     <dependency>
     <groupId>org.apache.cloudstack</groupId>

--- a/plugins/hypervisors/hyperv/pom.xml
+++ b/plugins/hypervisors/hyperv/pom.xml
@@ -42,11 +42,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
-      <version>6.1.26</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-utils</artifactId>
       <version>${project.version}</version>

--- a/plugins/network-elements/globodns/pom.xml
+++ b/plugins/network-elements/globodns/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.globo.globodns</groupId>
       <artifactId>globodns-client</artifactId>
-      <version>0.0.15</version>
+      <version>0.0.20</version>
     </dependency>
   </dependencies>
 </project>

--- a/plugins/network-elements/juniper-contrail/pom.xml
+++ b/plugins/network-elements/juniper-contrail/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <version>1.9.5</version>
+        <version>1.10.19</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugins/network-elements/netscaler/pom.xml
+++ b/plugins/network-elements/netscaler/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
         <groupId>com.citrix.netscaler.nitro</groupId>
         <artifactId>nitro</artifactId>
-        <version>10.1</version>
+        <version>${cs.nitro.version}</version>
     </dependency>
     <dependency>
       <groupId>com.citrix.netscaler.nitro</groupId>
       <artifactId>sdx_nitro</artifactId>
-      <version>10.1</version>
+      <version>${cs.nitro.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/plugins/storage/volume/cloudbyte/pom.xml
+++ b/plugins/storage/volume/cloudbyte/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
 	<groupId>com.sun.jersey</groupId>
 	<artifactId>jersey-bundle</artifactId>
-	<version>1.18.3</version>
+	<version>1.19</version>
 </dependency>
   </dependencies>
   <build>

--- a/plugins/storage/volume/cloudbyte/pom.xml
+++ b/plugins/storage/volume/cloudbyte/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
 	<groupId>com.sun.jersey</groupId>
 	<artifactId>jersey-bundle</artifactId>
-	<version>1.19</version>
+	<version>1.19.1</version>
 </dependency>
   </dependencies>
   <build>

--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
-      <version>0.7-groovy-2.0</version>
+      <version>1.0-groovy-2.4</version>
     </dependency>
 
     <!-- Optional dependencies for using Spock -->

--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -97,12 +97,14 @@
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
       <version>1.0-groovy-2.4</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- Optional dependencies for using Spock -->
     <dependency> <!-- enables mocking of classes (in addition to interfaces) -->
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      </dependency>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/plugins/user-authenticators/saml2/pom.xml
+++ b/plugins/user-authenticators/saml2/pom.xml
@@ -28,11 +28,6 @@
   </parent>
   <dependencies>
     <dependency>
-      <groupId>org.springframework.security.extensions</groupId>
-      <artifactId>spring-security-saml2-core</artifactId>
-      <version>1.0.1.RELEASE</version>
-    </dependency>
-    <dependency>
       <groupId>org.opensaml</groupId>
       <artifactId>opensaml</artifactId>
       <version>${cs.opensaml.version}</version>

--- a/plugins/user-authenticators/saml2/pom.xml
+++ b/plugins/user-authenticators/saml2/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.springframework.security.extensions</groupId>
       <artifactId>spring-security-saml2-core</artifactId>
-      <version>1.0.0.RELEASE</version>
+      <version>1.0.1.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.opensaml</groupId>

--- a/plugins/user-authenticators/saml2/pom.xml
+++ b/plugins/user-authenticators/saml2/pom.xml
@@ -47,5 +47,11 @@
       <artifactId>cloud-framework-config</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+      <version>2.11.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,6 @@
     <url>https://issues.apache.org/jira/browse/CLOUDSTACK</url>
   </issueManagement>
 
-  <prerequisites>
-    <maven>3.0.4</maven>
-  </prerequisites>
-
   <properties>
     <cs.jdk.version>1.7</cs.jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -55,7 +51,7 @@
 
     <cs.log4j.version>1.2.17</cs.log4j.version>
     <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
-    <cs.cglib.version>3.1</cs.cglib.version>
+    <cs.cglib.version>3.2.0</cs.cglib.version>
     <cs.dbcp.version>1.4</cs.dbcp.version>
     <cs.pool.version>1.6</cs.pool.version>
     <cs.codec.version>1.10</cs.codec.version>
@@ -65,25 +61,25 @@
     <cs.discovery.version>0.5</cs.discovery.version>
     <cs.ejb.version>3.0</cs.ejb.version>
     <!-- do not forget to also upgrade hamcrest library with junit -->
-    <cs.junit.version>4.11</cs.junit.version>
+    <cs.junit.version>4.12</cs.junit.version>
     <cs.hamcrest.version>1.3</cs.hamcrest.version>
     <cs.bcprov.version>1.46</cs.bcprov.version>
-    <cs.jsch.version>0.1.51</cs.jsch.version>
-    <cs.jpa.version>2.1.0</cs.jpa.version>
+    <cs.jsch.version>0.1.53</cs.jsch.version>
+    <cs.jpa.version>2.1.1</cs.jpa.version>
     <cs.jasypt.version>1.9.2</cs.jasypt.version>
-    <cs.trilead.version>1.0.0-build217</cs.trilead.version>
-    <cs.ehcache.version>2.6.9</cs.ehcache.version>
+    <cs.trilead.version>1.0.0-build220</cs.trilead.version>
+    <cs.ehcache.version>2.6.11</cs.ehcache.version>
     <cs.gson.version>1.7.2</cs.gson.version>
     <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
-    <cs.guava.version>18.0</cs.guava.version>
+    <cs.guava.version>19.0</cs.guava.version>
     <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
-    <cs.httpclient.version>4.5</cs.httpclient.version>
-    <cs.httpcore.version>4.4</cs.httpcore.version>
+    <cs.httpclient.version>4.5.1</cs.httpclient.version>
+    <cs.httpcore.version>4.4.4</cs.httpcore.version>
     <cs.commons-httpclient.version>3.1</cs.commons-httpclient.version>
     <cs.mysql.version>5.1.34</cs.mysql.version>
-    <cs.xstream.version>1.4.7</cs.xstream.version>
+    <cs.xstream.version>1.4.8</cs.xstream.version>
     <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>
-    <cs.mail.version>1.4.7</cs.mail.version>
+    <cs.mail.version>1.5.0-b01</cs.mail.version>
     <cs.axis.version>1.4</cs.axis.version>
     <cs.axis2.version>1.5.6</cs.axis2.version>
     <cs.rampart.version>1.5.1</cs.rampart.version>
@@ -93,27 +89,27 @@
     <cs.jstl.version>1.2</cs.jstl.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
     <cs.vmware.api.version>5.5</cs.vmware.api.version>
-    <org.springframework.version>3.2.12.RELEASE</org.springframework.version>
-    <cs.mockito.version>1.9.5</cs.mockito.version>
-    <cs.powermock.version>1.5.3</cs.powermock.version>
-    <cs.aws.sdk.version>1.10.34</cs.aws.sdk.version>
+    <org.springframework.version>3.2.16.RELEASE</org.springframework.version>
+    <cs.mockito.version>1.10.19</cs.mockito.version>
+    <cs.powermock.version>1.6.4</cs.powermock.version>
+    <cs.aws.sdk.version>1.10.50</cs.aws.sdk.version>
     <cs.jackson.version>2.6.3</cs.jackson.version>
     <cs.lang.version>2.6</cs.lang.version>
     <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>
-    <cs.commons-validator.version>1.4.0</cs.commons-validator.version>
-    <cs.reflections.version>0.9.9</cs.reflections.version>
-    <cs.java-ipv6.version>0.15</cs.java-ipv6.version>
+    <cs.commons-validator.version>1.5.0</cs.commons-validator.version>
+    <cs.reflections.version>0.9.10</cs.reflections.version>
+    <cs.java-ipv6.version>0.16</cs.java-ipv6.version>
     <cs.replace.properties>build/replace.properties</cs.replace.properties>
     <cs.libvirt-java.version>0.5.1</cs.libvirt-java.version>
     <cs.rados-java.version>0.2.0</cs.rados-java.version>
     <cs.target.dir>target</cs.target.dir>
     <cs.daemon.version>1.0.15</cs.daemon.version>
     <cs.jna.version>4.0.0</cs.jna.version>
-    <cs.checkstyle.version>2.11</cs.checkstyle.version>
-    <cs.mycila.license.version>2.7</cs.mycila.license.version>
-    <cs.findbugs.version>3.0.1</cs.findbugs.version>
-    <cs.javadoc.version>2.10.1</cs.javadoc.version>
+    <cs.checkstyle.version>2.17</cs.checkstyle.version>
+    <cs.mycila.license.version>2.11</cs.mycila.license.version>
+    <cs.findbugs.version>3.0.3</cs.findbugs.version>
+    <cs.javadoc.version>2.10.3</cs.javadoc.version>
     <cs.opensaml.version>2.6.1</cs.opensaml.version>
     <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
@@ -390,17 +386,17 @@
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.snmp4j</artifactId>
-        <version>2.3.1_1</version>
+        <version>2.3.4_1</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjtools</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.8</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjweaver</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.8</version>
       </dependency>
       <dependency>
         <groupId>org.apache.axis</groupId>
@@ -425,12 +421,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <!-- do not forget to also upgrade hamcrest library with junit -->
     <cs.junit.version>4.12</cs.junit.version>
     <cs.hamcrest.version>1.3</cs.hamcrest.version>
-    <cs.bcprov.version>1.46</cs.bcprov.version>
+    <cs.bcprov.version>1.54</cs.bcprov.version>
     <cs.jsch.version>0.1.53</cs.jsch.version>
     <cs.jpa.version>2.1.1</cs.jpa.version>
     <cs.jasypt.version>1.9.2</cs.jasypt.version>
@@ -86,17 +86,19 @@
     <cs.axiom.version>1.2.8</cs.axiom.version>
     <cs.neethi.version>2.0.4</cs.neethi.version>
     <cs.servlet.version>2.5</cs.servlet.version>
-    <cs.jstl.version>1.2</cs.jstl.version>
+    <cs.jstl.version>1.2.1</cs.jstl.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
     <cs.vmware.api.version>5.5</cs.vmware.api.version>
     <org.springframework.version>3.2.16.RELEASE</org.springframework.version>
     <cs.mockito.version>1.10.19</cs.mockito.version>
     <cs.powermock.version>1.6.4</cs.powermock.version>
     <cs.aws.sdk.version>1.10.50</cs.aws.sdk.version>
-    <cs.jackson.version>2.6.3</cs.jackson.version>
+    <cs.jackson.version>2.7.1</cs.jackson.version>
     <cs.lang.version>2.6</cs.lang.version>
     <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
     <cs.commons-io.version>2.4</cs.commons-io.version>
+    <cs.commons-fileupload.version>1.3.1</cs.commons-fileupload.version>
+    <cs.commons-collections.version>3.2.2</cs.commons-collections.version>
     <cs.commons-validator.version>1.5.0</cs.commons-validator.version>
     <cs.reflections.version>0.9.10</cs.reflections.version>
     <cs.java-ipv6.version>0.16</cs.java-ipv6.version>
@@ -110,9 +112,18 @@
     <cs.mycila.license.version>2.11</cs.mycila.license.version>
     <cs.findbugs.version>3.0.3</cs.findbugs.version>
     <cs.javadoc.version>2.10.3</cs.javadoc.version>
-    <cs.opensaml.version>2.6.1</cs.opensaml.version>
+    <cs.opensaml.version>2.6.4</cs.opensaml.version>
     <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
+    <cs.batik.version>1.8</cs.batik.version>
+    <cs.servicemix.version>2.3.4_1</cs.servicemix.version>
+    <cs.jetty.version>9.3.7.v20160115</cs.jetty.version>
+    <cs.cxf.version>3.1.4</cs.cxf.version>
+    <cs.spring-security-saml2-core.version>1.0.1.RELEASE</cs.spring-security-saml2-core.version>
+    <cs.spring-security-core.version>4.0.3.RELEASE</cs.spring-security-core.version>
+    <cs.groovy.version>2.4.3</cs.groovy.version>
+    <cs.apache-jsp.version>9.3.7.v20160115</cs.apache-jsp.version>
+    <cs.nitro.version>10.1</cs.nitro.version>
   </properties>
 
   <distributionManagement>
@@ -205,6 +216,51 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>apache-jsp</artifactId>
+        <version>${cs.apache-jsp.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <version>${cs.groovy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-core</artifactId>
+        <version>${cs.spring-security-core.version}</version>
+      </dependency>
+      <dependency>
+	    <groupId>org.springframework.security.extensions</groupId>
+	    <artifactId>spring-security-saml2-core</artifactId>
+	    <version>${cs.spring-security-saml2-core.version}</version>
+	  </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <version>${cs.bcprov.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-css</artifactId>
+        <version>${cs.batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-ext</artifactId>
+        <version>${cs.batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-util</artifactId>
+        <version>${cs.batik.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>${cs.commons-collections.version}</version>
+      </dependency>
+      <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
         <version>${cs.mysql.version}</version>
@@ -242,24 +298,24 @@
         <version>${cs.ehcache.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-pool</groupId>
-        <artifactId>commons-pool</artifactId>
-        <version>${cs.pool.version}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${cs.codec.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>${cs.commons-fileupload.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-pool</groupId>
+        <artifactId>commons-pool</artifactId>
+        <version>${cs.pool.version}</version>
+      </dependency>
+      <dependency>
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
         <version>${cs.commons-validator.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk16</artifactId>
-        <version>${cs.bcprov.version}</version>
       </dependency>
       <dependency>
         <groupId>com.jcraft</groupId>
@@ -386,7 +442,7 @@
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.snmp4j</artifactId>
-        <version>2.3.4_1</version>
+        <version>${cs.servicemix.version}</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <cs.log4j.version>1.2.17</cs.log4j.version>
     <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
-    <cs.cglib.version>3.2.0</cs.cglib.version>
+    <cs.cglib.version>3.2.1</cs.cglib.version>
     <cs.dbcp.version>1.4</cs.dbcp.version>
     <cs.pool.version>1.6</cs.pool.version>
     <cs.codec.version>1.10</cs.codec.version>
@@ -63,7 +63,7 @@
     <!-- do not forget to also upgrade hamcrest library with junit -->
     <cs.junit.version>4.12</cs.junit.version>
     <cs.hamcrest.version>1.3</cs.hamcrest.version>
-    <cs.bcprov.version>1.54</cs.bcprov.version>
+    <cs.bcprov.version>1.46</cs.bcprov.version>
     <cs.jsch.version>0.1.53</cs.jsch.version>
     <cs.jpa.version>2.1.1</cs.jpa.version>
     <cs.jasypt.version>1.9.2</cs.jasypt.version>
@@ -73,11 +73,11 @@
     <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
     <cs.guava.version>19.0</cs.guava.version>
     <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
-    <cs.httpclient.version>4.5.1</cs.httpclient.version>
+    <cs.httpclient.version>4.5.2</cs.httpclient.version>
     <cs.httpcore.version>4.4.4</cs.httpcore.version>
     <cs.commons-httpclient.version>3.1</cs.commons-httpclient.version>
     <cs.mysql.version>5.1.34</cs.mysql.version>
-    <cs.xstream.version>1.4.8</cs.xstream.version>
+    <cs.xstream.version>1.4.9</cs.xstream.version>
     <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>
     <cs.mail.version>1.5.0-b01</cs.mail.version>
     <cs.axis.version>1.4</cs.axis.version>
@@ -88,11 +88,11 @@
     <cs.servlet.version>2.5</cs.servlet.version>
     <cs.jstl.version>1.2.1</cs.jstl.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
-    <cs.vmware.api.version>5.5</cs.vmware.api.version>
+    <cs.vmware.api.version>6.0</cs.vmware.api.version>
     <org.springframework.version>3.2.16.RELEASE</org.springframework.version>
     <cs.mockito.version>1.10.19</cs.mockito.version>
     <cs.powermock.version>1.6.4</cs.powermock.version>
-    <cs.aws.sdk.version>1.10.50</cs.aws.sdk.version>
+    <cs.aws.sdk.version>1.10.64</cs.aws.sdk.version>
     <cs.jackson.version>2.7.1</cs.jackson.version>
     <cs.lang.version>2.6</cs.lang.version>
     <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
@@ -117,12 +117,10 @@
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
     <cs.batik.version>1.8</cs.batik.version>
     <cs.servicemix.version>2.3.4_1</cs.servicemix.version>
-    <cs.jetty.version>9.3.7.v20160115</cs.jetty.version>
+    <cs.jetty.version>9.2.15.v20160210</cs.jetty.version>
     <cs.cxf.version>3.1.4</cs.cxf.version>
-    <cs.spring-security-saml2-core.version>1.0.1.RELEASE</cs.spring-security-saml2-core.version>
-    <cs.spring-security-core.version>4.0.3.RELEASE</cs.spring-security-core.version>
-    <cs.groovy.version>2.4.3</cs.groovy.version>
-    <cs.apache-jsp.version>9.3.7.v20160115</cs.apache-jsp.version>
+    <cs.groovy.version>2.4.6</cs.groovy.version>
+    <cs.apache-jsp.version>9.2.15.v20160210</cs.apache-jsp.version>
     <cs.nitro.version>10.1</cs.nitro.version>
   </properties>
 
@@ -225,16 +223,6 @@
         <artifactId>groovy-all</artifactId>
         <version>${cs.groovy.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-core</artifactId>
-        <version>${cs.spring-security-core.version}</version>
-      </dependency>
-      <dependency>
-	    <groupId>org.springframework.security.extensions</groupId>
-	    <artifactId>spring-security-saml2-core</artifactId>
-	    <version>${cs.spring-security-saml2-core.version}</version>
-	  </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
@@ -377,7 +365,7 @@
       <dependency>
         <groupId>org.owasp.esapi</groupId>
         <artifactId>esapi</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
@@ -447,12 +435,12 @@
       <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjtools</artifactId>
-        <version>1.8.8</version>
+        <version>1.8.9</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjweaver</artifactId>
-        <version>1.8.8</version>
+        <version>1.8.9</version>
       </dependency>
       <dependency>
         <groupId>org.apache.axis</groupId>
@@ -477,12 +465,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.14</version>
+        <version>1.7.21</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.14</version>
+        <version>1.7.21</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -70,8 +70,9 @@
       <artifactId>mail</artifactId>
     </dependency>
     <dependency>
-      <groupId>jstl</groupId>
-      <artifactId>jstl</artifactId>
+      <groupId>javax.servlet.jsp.jstl</groupId>
+      <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+      <version>${cs.jstl.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/services/console-proxy-rdp/rdpconsole/pom.xml
+++ b/services/console-proxy-rdp/rdpconsole/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
-      <version>8.0.15</version>
+      <version>8.0.30</version>
     </dependency>
     <!-- Another implementation of SSL protocol. Does not work with broken MS RDP SSL too. -->
     <dependency>

--- a/services/console-proxy-rdp/rdpconsole/pom.xml
+++ b/services/console-proxy-rdp/rdpconsole/pom.xml
@@ -77,6 +77,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk16</artifactId>
+      <version>1.46</version>
     </dependency>
   </dependencies>
 </project>

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -57,7 +57,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.0.25.Final</version>
+        <version>4.0.33.Final</version>
         <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/tools/checkstyle/pom.xml
+++ b/tools/checkstyle/pom.xml
@@ -25,12 +25,7 @@
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>checkstyle</artifactId>
     <version>4.9.0-SNAPSHOT</version>
-    
-    
-    <prerequisites>
-      <maven>3.0.4</maven>
-    </prerequisites>
-    
+
     <build>
       <plugins>
         <plugin>

--- a/tools/whisker/LICENSE
+++ b/tools/whisker/LICENSE
@@ -2896,7 +2896,7 @@ Within the target/jar directory
             cloud-axis.jar  from http://axis.apache.org/axis/
             cloud-cglib.jar  from http://cglib.sourceforge.net/
             cloud-commons-codec-1.5.jar  from http://commons.apache.org/codec/
-            cloud-commons-collections-3.2.1.jar  from http://commons.apache.org/collections/
+            cloud-commons-collections-3.2.2.jar  from http://commons.apache.org/collections/
             cloud-commons-configuration-1.8.jar  from http://commons.apache.org/configuration/
             cloud-commons-dbcp-1.4.jar  from http://commons.apache.org/dbcp/
             cloud-commons-httpclient-3.1.jar  from http://hc.apache.org/httpclient-3.x/

--- a/tools/whisker/descriptor-for-packaging.xml
+++ b/tools/whisker/descriptor-for-packaging.xml
@@ -2673,7 +2673,7 @@ Copyright (C) 2008      Tóth István &lt;stoty@tvnet.hu&gt;
               2009-2011 Bryan Kearney &lt;bkearney@redhat.com&gt;
             </copyright-notice>
             <by-organisation id='libvirt.org'>
-                <resource name='libvirt-java-0.4.9' />
+                <resource name='libvirt-java-0.5.1' />
             </by-organisation>
         </with-license>
         <with-license id="ApacheLicenseVersion2">
@@ -2683,7 +2683,7 @@ Copyright (c) 2012 The Apache Software Foundation
             <by-organisation id="apache.org.2">
                 <resource name="cloud-axis.jar" source="http://axis.apache.org/axis/" notice='axis2.notice'/>
                 <resource name="cloud-commons-codec-1.5.jar" source="http://commons.apache.org/codec/" notice="codec" />
-                <resource name="cloud-commons-collections-3.2.1.jar" source="http://commons.apache.org/collections/"/>
+                <resource name="cloud-commons-collections-3.2.2.jar" source="http://commons.apache.org/collections/"/>
                 <resource name="cloud-commons-configuration-1.8.jar" source="http://commons.apache.org/configuration/"/>
                 <resource name="cloud-commons-dbcp-1.4.jar" source="http://commons.apache.org/dbcp/" />
                 <resource name="cloud-commons-httpclient-3.1.jar" source="http://hc.apache.org/httpclient-3.x/" />

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -53,17 +53,17 @@
      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.7</version>
+        <version>1.7.14</version>
       </dependency>
     <dependency>
       <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>
-      <version>2.4.9</version>
+      <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -53,17 +53,17 @@
      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.14</version>
+        <version>1.7.21</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.14</version>
+        <version>1.7.21</version>
       </dependency>
     <dependency>
       <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>
-      <version>2.5.1</version>
+      <version>2.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.3</version>
+      <version>3.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk16</artifactId>
+      <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>


### PR DESCRIPTION
Upgrades maven dependencies versions that can be safely upgraded without breaking console-proxy/crypto usage.

Bisected changes from: https://github.com/apache/cloudstack/pull/1397

cc @swill @DaanHoogland 
