### PR TITLE
CLOUDSTACK-9362: Skip VXLANs when rewriting the bridge name for migrations (4.8)

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -26,6 +26,8 @@ def isOldStyleBridge(brName):
     else:
        return False
 def isNewStyleBridge(brName):
+    if brName.startswith('brvx-'):
+        return False
     if re.match(r"br(\w+)-(\d+)", brName) == None:
        return False
     else:


### PR DESCRIPTION
From the [JIRA issue](https://issues.apache.org/jira/browse/CLOUDSTACK-9362):

> https://github.com/apache/cloudstack/commit/bb8f7c652e42caacff5adce1ce60342603677605
> 
> The above commit introduces rewriting of bridge device names when migrating a virtual machine from one host to another. However, it also matches bridges called "brvx-1234" and rewrites them to (in my case) "brem1-1234" - this doesn't match the bridge name on the destination and causes the migration to fail with the error:
> 
> error : virNetDevGetMTU:397 : Cannot get interface MTU on 'brem1-1234': No such device
> 
> I have flagged this as major because it's not possible to migrate VMs using VXLANs for maintenance, which seems important (it's certainly important to me!).

This is a version of #1508 based against 4.8