### PR TITLE
Log asynchronous responses in the api log

### DIFF
--- a/server/src/com/cloud/api/ApiServer.java
+++ b/server/src/com/cloud/api/ApiServer.java
@@ -686,14 +686,21 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 s_logger.warn(errorMsg);
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, errorMsg);
             }
-
+            final String response;
             if (objectId != null) {
                 final String objUuid = (objectUuid == null) ? objectId.toString() : objectUuid;
-                return getBaseAsyncCreateResponse(jobId, (BaseAsyncCreateCmd)asyncCmd, objUuid);
+                response = getBaseAsyncCreateResponse(jobId, (BaseAsyncCreateCmd)asyncCmd, objUuid);
             } else {
                 SerializationContext.current().setUuidTranslation(true);
-                return getBaseAsyncResponse(jobId, asyncCmd);
+                response = getBaseAsyncResponse(jobId, asyncCmd);
             }
+            // Always log response for async for now, I don't think any sensitive data will be in here.
+            // It might be nice to send this through scrubbing similar to how
+            // ApiResponseSerializer.toSerializedStringWithSecureLogs works. For now, this gets jobid's
+            // in the api logs.
+            log.append(response);
+            return response;
+
         } else {
             dispatcher.dispatch(cmdObj, params, false);
 


### PR DESCRIPTION
Currently API responses for synchronous calls are logged, but asynchronous call responses are not.  This pull request makes a minor modification that logs the response including the JobId of all asynchronous requests.

As an example, here is what a stopVirtualMachine request looked like in the logs:

    2016-04-27 10:43:11,084 INFO  [a.c.c.a.ApiServer] (catalina-exec-3:ctx-37d9f693 ctx-d2368de3) (logid:3a0fad97) (userId=2 accountId=2 sessionId=AF8B1F726ACB5C3A637B8B300AA218A7) 10.103.0.207 -- GET command=stopVirtualMachine&id=f63b6fcc-e0b0-480f-8f7a-cba329634ba1&forced=false&response=json&_=1461771791036 200 

After this modification, here is what the logs look like:

    2016-04-27 13:37:11,338 INFO  [a.c.c.a.ApiServer] (catalina-exec-6:ctx-915b5c84 ctx-a03152fa) (logid:66249df0) (userId=2 accountId=2 sessionId=9EF127EED5CA6E74797DFE487D980FAF) 10.103.0.207 -- GET command=stopVirtualMachine&id=f63b6fcc-e0b0-480f-8f7a-cba329634ba1&forced=false&response=json&_=1461782231194 200 {"stopvirtualmachineresponse":{"jobid":"5b9f4a9b-eabe-4fa4-849d-3d004bb65634"}}