### PR TITLE
CLOUDSTACK-9373: Class methods over-shawdowing instance methods

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -2587,13 +2587,6 @@ class Host:
         apiclient.deleteHost(cmd)
         return
 
-    def enableMaintenance(self, apiclient):
-        """enables maintenance mode Host"""
-
-        cmd = prepareHostForMaintenance.prepareHostForMaintenanceCmd()
-        cmd.id = self.id
-        return apiclient.prepareHostForMaintenance(cmd)
-
     @classmethod
     def enableMaintenance(cls, apiclient, id):
         """enables maintenance mode Host"""
@@ -2601,13 +2594,6 @@ class Host:
         cmd = prepareHostForMaintenance.prepareHostForMaintenanceCmd()
         cmd.id = id
         return apiclient.prepareHostForMaintenance(cmd)
-
-    def cancelMaintenance(self, apiclient):
-        """Cancels maintenance mode Host"""
-
-        cmd = cancelHostMaintenance.cancelHostMaintenanceCmd()
-        cmd.id = self.id
-        return apiclient.cancelHostMaintenance(cmd)
 
     @classmethod
     def cancelMaintenance(cls, apiclient, id):
@@ -2757,13 +2743,6 @@ class StoragePool:
         cmd.id = self.id
         apiclient.deleteStoragePool(cmd)
         return
-
-    def enableMaintenance(self, apiclient):
-        """enables maintenance mode Storage pool"""
-
-        cmd = enableStorageMaintenance.enableStorageMaintenanceCmd()
-        cmd.id = self.id
-        return apiclient.enableStorageMaintenance(cmd)
 
     @classmethod
     def enableMaintenance(cls, apiclient, id):


### PR DESCRIPTION
We have some methods in base.py that are named the same.

Per my findings below, Python methods in a class should not be named the same even if one is a class method and the other is an instance method.

The solution discussed on dev@ is to remove the instance versions (reason listed in e-mail text, which is listed in JIRA ticket).

https://issues.apache.org/jira/browse/CLOUDSTACK-9373