### PR TITLE
Marvin: Replace a timer.sleep(30) with pulling logic

### DIFF
--- a/tools/marvin/marvin/codes.py
+++ b/tools/marvin/marvin/codes.py
@@ -116,6 +116,31 @@ Network states
 ALLOCATED = "Allocated"
 
 '''
+Host states
+'''
+HOST_CREATING = "Creating"
+HOST_CONNECTING = "Connecting"
+HOST_UP = "Up"
+HOST_DOWN = "Down"
+HOST_DISCONNECTED = "Disconnected"
+HOST_ALERT = "Alert"
+HOST_REMOVED = "Removed"
+HOST_ERROR = "Error"
+HOST_REBALANCING = "Rebalancing"
+HOST_UNKNOWN = "Unknown"
+
+'''
+Host resource states
+'''
+HOST_RS_CREATING = "Creating"
+HOST_RS_ENABLED = "Enabled"
+HOST_RS_DISABLED = "Disabled"
+HOST_RS_PREPARE_FOR_MAINTENANCE = "PrepareForMaintenance"
+HOST_RS_ERROR_IN_MAINTENANCE = "ErrorInMaintenance"
+HOST_RS_MAINTENANCE = "Maintenance"
+HOST_RS_ERROR = "Error"
+
+'''
 Storage Tags
 '''
 ZONETAG1 = "zwps1"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9374

From the ticket:

In the base.py file, there is a Host class with a delete instance method.

This method first attempts to transition the host into the maintenance resource state.

The first step in this process is to transition the host into the prepare-for-maintenance resource state.

A while later, the host can be transitioned completely into the maintenance resource state.

In an attempt to wait for this transition to occur, the delete method has a timer.sleep(30) call.

The hope is that the host will have transitioned from the prepare-for-maintenance resource state to the maintenance resource state within 30 seconds, but this does not always happen.

We should correct this problem by putting in logic to query the management server for the resource state of the host. If it's in the expected state, move on; else, sleep for a bit and try again (up to a certain limit).