### PR TITLE
DAO: Hit the cache for entity flagged as removed too

### DIFF
--- a/framework/db/src/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/com/cloud/utils/db/GenericDaoBase.java
@@ -942,12 +942,18 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     @DB()
     @SuppressWarnings("unchecked")
     public T findById(final ID id) {
+        T result = null;
         if (_cache != null) {
             final Element element = _cache.get(id);
-            return element == null ? lockRow(id, null) : (T)element.getObjectValue();
+            if (element == null) {
+                result = lockRow(id, null);
+            } else {
+                result = (T)element.getObjectValue();
+            }
         } else {
-            return lockRow(id, null);
+            result = lockRow(id, null);
         }
+        return result;
     }
 
     @Override
@@ -968,13 +974,19 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
 
     @Override
     @DB()
-    public T findByIdIncludingRemoved(ID id) {
+    public T findByIdIncludingRemoved(final ID id) {
+        T result = null;
         if (_cache != null) {
             final Element element = _cache.get(id);
-            return element == null ? findById(id, true, null) : (T)element.getObjectValue();
+            if (element == null) {
+                result = findById(id, true, null);
+            } else {
+                result = (T)element.getObjectValue();
+            }
         } else {
-            return findById(id, true, null);
+            result = findById(id, true, null);
         }
+        return result;
     }
 
     @Override

--- a/framework/db/src/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/com/cloud/utils/db/GenericDaoBase.java
@@ -969,7 +969,12 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     @Override
     @DB()
     public T findByIdIncludingRemoved(ID id) {
-        return findById(id, true, null);
+        if (_cache != null) {
+            final Element element = _cache.get(id);
+            return element == null ? findById(id, true, null) : (T)element.getObjectValue();
+        } else {
+            return findById(id, true, null);
+        }
     }
 
     @Override


### PR DESCRIPTION
I came along this part of the code and I don't see any reason why the cache should not be used when fetching with the "removed" ones. It will help decrease the number of DB queries.

*It can be merged in many CS versions*