### PR TITLE
Honour GS use_ext_dns and redundant VR VIP

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
@@ -68,8 +68,11 @@ class CsConfig(object):
 
     def get_dns(self):
         dns = []
-        # Check what happens with use_ext_dns
-        dns.append(self.address().get_guest_ip())
+        if not self.cl.get_use_ext_dns():
+            if not self.is_vpc() and self.cl.is_redundant():
+                dns.append(self.cl.get_guest_gw())
+            else:
+                dns.append(self.address().get_guest_ip())
         names = ["dns1", "dns2"]
         for name in names:
             if name in self.cmdline().idata():

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
@@ -148,3 +148,9 @@ class CsCmdLine(CsDataBag):
         if "gateway" in self.idata():
             return self.idata()['gateway']
         return False
+
+    def get_use_ext_dns(self):
+        if "useextdns" in self.idata():
+            return self.idata()['useextdns']
+        return False
+


### PR DESCRIPTION
This patch addresses two issues:

- On redundant VR setups, the primary resolver being handed out to instances is the guest_ip (primary IP for the VR). This might lead to problems upon failover, at least while the DHCP lease doesn't update (because the primary resolver will be checked first until times out, however it'll be gone upon failover).

- If Global Setting use_ext_dns is true, we don't want the VR to be the primary resolver at all.