### PR TITLE
Disable NioTest

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -208,6 +208,7 @@
           <excludes>
             <exclude>com/cloud/utils/testcase/*TestCase*</exclude>
             <exclude>com/cloud/utils/db/*Test*</exclude>
+            <exclude>com/cloud/utils/testcase/NioTest.java</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Historically NioTest has caused issue in CI environment and several developer machines due to network requirements which could be disabled by firewall or security enforcers such as selinux. This disables the test once again using a historic commit 881a6e1
Signed-off-by: Rohit Yadav <rohit.yada

To build and just run this test: mvn clean install -pl utils -Dtest=NioTest