### PR TITLE
CLOUDSTACK-9378: Fix for #1497

### DIFF
--- a/test/integration/smoke/test_list_ids_parameter.py
+++ b/test/integration/smoke/test_list_ids_parameter.py
@@ -194,10 +194,7 @@ class TestListIdsParams(cloudstackTestCase):
         cls._cleanup = [
                         cls.disk_offering,
                         cls.account,
-                        cls.service_offering,
-                        cls.snapshot_1,
-                        cls.snapshot_2,
-                        cls.snapshot_3
+                        cls.service_offering
                         ]
 
     @classmethod

--- a/test/integration/smoke/test_list_ids_parameter.py
+++ b/test/integration/smoke/test_list_ids_parameter.py
@@ -192,8 +192,11 @@ class TestListIdsParams(cloudstackTestCase):
                                          )
         
         cls._cleanup = [
-                        cls.disk_offering,
+                        cls.snapshot_1,
+                        cls.snapshot_2,
+                        cls.snapshot_3,
                         cls.account,
+                        cls.disk_offering,
                         cls.service_offering
                         ]
 


### PR DESCRIPTION
JIRA TICKET: https://issues.apache.org/jira/browse/CLOUDSTACK-9378

After #1497 was merged, test_list_ids_parameter.py failed on Travis. It was noticed that snapshots could be removed from cleaup