### PR TITLE
CLOUDSTACK-9377: Fix metrics pagesize issue

### DIFF
--- a/ui/scripts/metrics.js
+++ b/ui/scripts/metrics.js
@@ -153,7 +153,7 @@
 
                                 $.ajax({
                                     url: createURL('listClusters'),
-                                    data: {zoneid: zone.id},
+                                    data: {zoneid: zone.id, pagesize: -1},
                                     success: function(json) {
                                         if (json && json.listclustersresponse && json.listclustersresponse.cluster && json.listclustersresponse.count) {
                                             items[idx].clusters += parseInt(json.listclustersresponse.count);
@@ -163,7 +163,7 @@
                                                 }
                                                 $.ajax({
                                                     url: createURL('listHosts'),
-                                                    data: {clusterid: cluster.id, type: 'routing'},
+                                                    data: {clusterid: cluster.id, type: 'routing', pagesize: -1},
                                                     success: function(json) {
                                                         if (json && json.listhostsresponse && json.listhostsresponse.host && json.listhostsresponse.count) {
                                                             items[idx].hosts += parseInt(json.listhostsresponse.count);
@@ -415,7 +415,7 @@
 
                                 $.ajax({
                                     url: createURL('listHosts'),
-                                    data: {clusterid: cluster.id, type: 'routing'},
+                                    data: {clusterid: cluster.id, type: 'routing', pagesize: -1},
                                     success: function(json) {
                                         if (json && json.listhostsresponse && json.listhostsresponse.host && json.listhostsresponse.count) {
                                             items[idx].hosts += parseInt(json.listhostsresponse.count);


### PR DESCRIPTION
Fixes listing of clusters and host to list all clusters/hosts by passing
pagesize=-1.

/cc @koushik-das @swill @DaanHoogland -- fixes the issue raised on dev@ ML by Rashmi