### PR TITLE
CLOUDSTACK-9379: Support nested virtualization at VM level on VMware Hypervisor

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -2208,7 +2208,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         return new Pair<String, String>(vmInternalCSName, vmNameOnVcenter);
     }
 
-    private static void configNestedHVSupport(VirtualMachineMO vmMo, VirtualMachineTO vmSpec, VirtualMachineConfigSpec vmConfigSpec) throws Exception {
+    protected void configNestedHVSupport(VirtualMachineMO vmMo, VirtualMachineTO vmSpec, VirtualMachineConfigSpec vmConfigSpec) throws Exception {
 
         VmwareContext context = vmMo.getContext();
         if ("true".equals(vmSpec.getDetails().get(VmDetailConstants.NESTED_VIRTUALIZATION_FLAG))) {

--- a/plugins/hypervisors/vmware/test/com/cloud/hypervisor/guru/VMwareGuruTest.java
+++ b/plugins/hypervisors/vmware/test/com/cloud/hypervisor/guru/VMwareGuruTest.java
@@ -1,0 +1,157 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.hypervisor.guru;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.inOrder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.vm.VmDetailConstants;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ConfigKey.class, VMwareGuru.class})
+@ContextConfiguration(loader = AnnotationConfigContextLoader.class)
+public class VMwareGuruTest {
+
+    @Mock(name="VmwareEnableNestedVirtualization")
+    private ConfigKey<Boolean> vmwareNestedVirtualizationConfig;
+
+    @Mock(name="VmwareEnableNestedVirtualizationPerVM")
+    private ConfigKey<Boolean> vmwareNestedVirtualizationPerVmConfig;
+
+    @Spy
+    @InjectMocks
+    private VMwareGuru _guru = new VMwareGuru();
+
+    @Mock
+    VirtualMachineTO vmTO;
+
+    private Map<String,String> vmDetails = new HashMap<String, String>();
+
+    @Before
+    public void testSetUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    private void setConfigValues(Boolean globalNV, Boolean globalNVPVM, String localNV){
+        when(vmwareNestedVirtualizationConfig.value()).thenReturn(globalNV);
+        when(vmwareNestedVirtualizationPerVmConfig.value()).thenReturn(globalNVPVM);
+        if (localNV != null) {
+            vmDetails.put(VmDetailConstants.NESTED_VIRTUALIZATION_FLAG, localNV);
+        }
+    }
+
+    private void executeAndVerifyTest(Boolean globalNV, Boolean globalNVPVM, String localNV, Boolean expectedResult){
+        Boolean result = _guru.shouldEnableNestedVirtualization(globalNV, globalNVPVM, localNV);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void testConfigureNestedVirtualization(){
+        setConfigValues(true, true, null);
+        _guru.configureNestedVirtualization(vmDetails, vmTO);
+
+        InOrder inOrder = inOrder(_guru, vmTO);
+        inOrder.verify(_guru).shouldEnableNestedVirtualization(true, true, null);
+        inOrder.verify(vmTO).setDetails(vmDetails);
+
+        assertTrue(vmDetails.containsKey(VmDetailConstants.NESTED_VIRTUALIZATION_FLAG));
+        assertEquals(Boolean.toString(true), vmDetails.get(VmDetailConstants.NESTED_VIRTUALIZATION_FLAG));
+
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVTrueGlobalNVPVMTrueLocalNVNull(){
+        executeAndVerifyTest(true, true, null, true);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVTrueGlobalNVPVMTrueLocalNVTrue(){
+        executeAndVerifyTest(true, true, "true", true);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVTrueGlobalNVPVMTrueLocalNVFalse(){
+        executeAndVerifyTest(true, true, "false", false);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVTrueGlobalNVPVMFalseLocalNVNull(){
+        executeAndVerifyTest(true, false, null, true);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVTrueGlobalNVPVMFalseLocalNVTrue(){
+        executeAndVerifyTest(true, false, "true", true);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVTrueGlobalNVPVMFalseLocalNVNFalse(){
+        executeAndVerifyTest(true, false, "false", true);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVFalseGlobalNVPVMTrueLocalNVNull(){
+        executeAndVerifyTest(false, true, null, false);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVFalseGlobalNVPVMTrueLocalNVTrue(){
+        executeAndVerifyTest(false, true, "true", true);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVFalseGlobalNVPVMTrueLocalNVFalse(){
+        executeAndVerifyTest(false, true, "false", false);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVFalseGlobalNVPVMFalseLocalNVNull(){
+        executeAndVerifyTest(false, false, null, false);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVFalseGlobalNVPVMFalseLocalNVTrue(){
+        executeAndVerifyTest(false, false, "true", false);
+    }
+
+    @Test
+    public void testEnableNestedVirtualizationCaseGlobalNVFalseGlobalNVPVMFalseLocalNVFalse(){
+        executeAndVerifyTest(false, false, "false", false);
+    }
+
+}

--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -1220,14 +1220,6 @@ public enum Config {
             "Specify whether or not to recycle hung worker VMs",
             null),
     VmwareHungWorkerTimeout("Advanced", ManagementServer.class, Long.class, "vmware.hung.wokervm.timeout", "7200", "Worker VM timeout in seconds", null),
-    VmwareEnableNestedVirtualization(
-            "Advanced",
-            ManagementServer.class,
-            Boolean.class,
-            "vmware.nested.virtualization",
-            "false",
-            "When set to true this will enable nested virtualization when this is supported by the hypervisor",
-            null),
     VmwareVcenterSessionTimeout("Advanced", ManagementServer.class, Long.class, "vmware.vcenter.session.timeout", "1200", "VMware client timeout in seconds", null),
 
     // Midonet

--- a/test/integration/smoke/test_nested_virtualization.py
+++ b/test/integration/smoke/test_nested_virtualization.py
@@ -1,0 +1,152 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+""" Tests for Nested Virtualization
+"""
+#Import Local Modules
+from marvin.codes import FAILED
+from marvin.cloudstackTestCase import cloudstackTestCase
+from marvin.lib.utils import (cleanup_resources,
+                              get_hypervisor_type,
+                              get_process_status)
+from marvin.lib.base import (Account,
+                             ServiceOffering,
+                             NetworkOffering,
+                             Configurations,
+                             VirtualMachine,
+                             Network)
+from marvin.lib.common import (get_zone,
+                               get_domain,
+                               get_template)
+from nose.plugins.attrib import attr
+from marvin.sshClient import SshClient
+import logging
+
+class TestNestedVirtualization(cloudstackTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        testClient = super(TestNestedVirtualization, cls).getClsTestClient()
+        cls.apiclient = testClient.getApiClient()
+        cls.services = testClient.getParsedTestDataConfig()
+        
+        cls.logger = logging.getLogger('TestNestedVirtualization')
+        cls.stream_handler = logging.StreamHandler()
+        cls.logger.setLevel(logging.DEBUG)
+        cls.logger.addHandler(cls.stream_handler)
+
+        cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+        cls.services["isolated_network"]["zoneid"] = cls.zone.id
+        cls.domain = get_domain(cls.apiclient)
+        cls.service_offering = ServiceOffering.create(
+            cls.apiclient,
+            cls.services["service_offerings"]["tiny"]
+        )
+        cls.account = Account.create(cls.apiclient, services=cls.services["account"])
+        cls.template = get_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        cls.hypervisor = get_hypervisor_type(cls.apiclient)
+        
+        cls.isolated_network_offering = NetworkOffering.create(
+                                                cls.apiclient,
+                                                cls.services["isolated_network_offering"])
+        # Enable Isolated Network offering
+        cls.isolated_network_offering.update(cls.apiclient, state='Enabled')
+        
+        if cls.template == FAILED:
+            assert False, "get_template() failed to return template with description %s" % cls.services["ostype"]
+            
+        cls.services["small"]["zoneid"] = cls.zone.id
+        cls.services["small"]["template"] = cls.template.id
+
+        cls.cleanup = [cls.account]
+
+    @attr(tags=["advanced"], required_hardware="true")
+    def test_nested_virtualization_vmware(self):
+        """Test nested virtualization on Vmware hypervisor"""
+        if self.hypervisor.lower() not in ["vmware"]:
+             self.skipTest("Skipping test because suitable hypervisor/host not present")
+             
+        # 1) Update nested virtualization configurations, if needed
+        configs = Configurations.list(self.apiclient, name="vmware.nested.virtualization")
+        rollback_nv = False
+        rollback_nv_per_vm = False
+        for conf in configs:
+            if (conf.name == "vmware.nested.virtualization" and conf.value == "false"):
+                config_update = Configurations.update(self.apiclient, "vmware.nested.virtualization", "true")
+                self.logger.debug("Updated global setting vmware.nested.virtualization to true")
+                rollback_nv = True
+            elif (conf.name == "vmware.nested.virtualization.perVM" and conf.value == "false"):
+                config_update = Configurations.update(self.apiclient, "vmware.nested.virtualization.perVM", "true")
+                self.logger.debug("Updated global setting vmware.nested.virtualization.perVM to true")
+                rollback_nv_per_vm = True
+                
+        # 2) Deploy a vm
+        virtual_machine = VirtualMachine.create(
+            self.apiclient,
+            self.services["small"],
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            serviceofferingid=self.service_offering.id,
+            mode=self.services['mode']
+        )
+        self.assert_(virtual_machine is not None, "VM failed to deploy")
+        self.assert_(virtual_machine.state == 'Running', "VM is not running")
+        self.logger.debug("Deployed vm: %s" % virtual_machine.id)
+        
+        isolated_network = Network.create(
+            self.apiclient,
+            self.services["isolated_network"],
+            self.account.name,
+            self.account.domainid,
+            networkofferingid=self.isolated_network_offering.id)
+
+        virtual_machine.add_nic(self.apiclient, isolated_network.id)
+        
+        # 3) SSH into vm
+        ssh_client = virtual_machine.get_ssh_client()
+
+        if ssh_client:
+            # run ping test
+            result = ssh_client.execute("cat /proc/cpuinfo | grep flags")
+            self.logger.debug(result)
+        else:
+            self.fail("Failed to setup ssh connection to %s" % virtual_machine.public_ip)
+            
+        # 4) Revert configurations, if needed
+        if rollback_nv:
+            config_update = Configurations.update(self.apiclient, "vmware.nested.virtualization", "false")
+            self.logger.debug("Reverted global setting vmware.nested.virtualization back to false")
+        if rollback_nv_per_vm:
+            config_update = Configurations.update(self.apiclient, "vmware.nested.virtualization", "false")
+            self.logger.debug("Reverted global setting vmware.nested.virtualization.perVM back to false")
+            
+        #5) Check for CPU flags: vmx for Intel and svm for AMD indicates nested virtualization is enabled
+        self.assert_(result is not None, "Empty result for CPU flags")
+        res = str(result)
+        self.assertTrue('vmx' in res or 'svm' in res)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cleanup_resources(cls.apiclient, cls.cleanup)
+        except Exception, e:
+            raise Exception("Cleanup failed with %s" % e)
+    


### PR DESCRIPTION
## Introduction

[JIRA TICKET](https://issues.apache.org/jira/browse/CLOUDSTACK-9379)

It is desired to support nested virtualization at VM level for VMware hypervisor. Current behaviour supports enabling/desabling global nested virtualization by modifying global config `'vmware.nested.virtualization'`. It is wished to improve this feature, having control at VM level instead of a global control only.
## Proposal

A new global configuration is added, to enable/disable VM nested virtualization control: `'vmware.nested.virtualization.perVM'`. Default value=false
## Behaviour

After a vm deployment or start command, vm params include `'nestedVirtualizationFlag'` key and its value is:
- true -> nested virtualization enabled
- false -> nested virtualization disabled

**We will determinate nested virtualization enabled/disabled by examining this 3 values:**
- **(1)** global configuration `'vmware.nested.virtualization'` value
- **(2)** global configuration `'vmware.nested.virtualization.perVM'` value
- **(3)** `'nestedVirtualizationFlag'` value in `user_vm_details` if present, `null` if not.

Using this 3 values, there are different use cases:
- **(1)** = TRUE, **(2)** = TRUE, **(3)** is null -> _ENABLED_
- **(1)** = TRUE, **(2)** = TRUE, **(3)** = TRUE -> _ENABLED_
- **(1)** = TRUE, **(2)** = TRUE, **(3)** = FALSE -> _DISABLED_
- **(1)** = TRUE, **(2)** = FALSE, **(3)** indifferent  -> _ENABLED_
- **(1)** = FALSE, **(2)** = TRUE, **(3)** is null -> _DISABLED_
- **(1)** = FALSE, **(2)** = TRUE, **(3)** = TRUE -> _ENABLED_
- **(1)** = FALSE, **(2)** = TRUE, **(3)** = FALSE -> _DISABLED_
- **(1)** = FALSE, **(2)** = FALSE, **(3)** indifferent -> _DISABLED_
