### PR TITLE
CLOUDSTACK-9380: fix NPE in listDomains API for a mistake

### DIFF
--- a/server/src/com/cloud/api/query/dao/DomainJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/DomainJoinDaoImpl.java
@@ -110,7 +110,7 @@ public class DomainJoinDaoImpl extends GenericDaoBase<DomainJoinVO, Long> implem
 
         long volumeLimit = ApiDBUtils.findCorrectResourceLimitForDomain(domain.getVolumeLimit(), fullView, ResourceType.volume, domain.getId());
         String volumeLimitDisplay = (fullView || volumeLimit == -1) ? "Unlimited" : String.valueOf(volumeLimit);
-        long volumeTotal = (domain.getVolumeTotal() == 0) ? 0 : domain.getVolumeTotal();
+        long volumeTotal = (domain.getVolumeTotal() == null) ? 0 : domain.getVolumeTotal();
         String volumeAvail = (fullView || volumeLimit == -1) ? "Unlimited" : String.valueOf(volumeLimit - volumeTotal);
         response.setVolumeLimit(volumeLimitDisplay);
         response.setVolumeTotal(volumeTotal);


### PR DESCRIPTION
The issue happens if volumeTotal is NULL in database.
This is caused by commit 0407fb334f3a79f570217f35636b47076b06d500 for CLOUDSTACK-7847.

