### PR TITLE
Dynamically load drivers before creating our DB connections

### DIFF
--- a/build/replace.properties
+++ b/build/replace.properties
@@ -21,6 +21,7 @@ DBROOTPW=
 MSLOG=vmops.log
 APISERVERLOG=api.log
 DBHOST=localhost
+DBDRIVER=jdbc:mysql
 AGENTLOGDIR=logs
 AGENTLOG=logs/agent.log
 MSMNTDIR=/mnt

--- a/client/tomcatconf/db.properties.in
+++ b/client/tomcatconf/db.properties.in
@@ -25,6 +25,7 @@ region.id=1
 db.cloud.username=@DBUSER@
 db.cloud.password=@DBPW@
 db.cloud.host=@DBHOST@
+db.cloud.driver=@DBDRIVER@
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -56,6 +57,7 @@ db.cloud.encrypt.secret=
 db.usage.username=@DBUSER@
 db.usage.password=@DBPW@
 db.usage.host=@DBHOST@
+db.usage.driver=@DBDRIVER@
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -69,6 +71,7 @@ db.usage.url.params=
 db.simulator.username=@DBUSER@
 db.simulator.password=@DBPW@
 db.simulator.host=@DBHOST@
+db.simulator.driver=@DBDRIVER@
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/engine/storage/snapshot/test/resources/db.properties
+++ b/engine/storage/snapshot/test/resources/db.properties
@@ -26,6 +26,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -46,6 +47,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -59,6 +62,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/framework/db/test/db.properties
+++ b/framework/db/test/db.properties
@@ -29,6 +29,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -49,6 +50,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -62,6 +65,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/framework/jobs/test/resources/db.properties
+++ b/framework/jobs/test/resources/db.properties
@@ -22,6 +22,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -42,6 +43,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -55,6 +58,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/packaging/centos63/replace.properties
+++ b/packaging/centos63/replace.properties
@@ -21,6 +21,7 @@ DBROOTPW=
 MSLOG=vmops.log
 APISERVERLOG=api.log
 DBHOST=localhost
+DBDRIVER=jdbc:mysql
 COMPONENTS-SPEC=components-premium.xml
 REMOTEHOST=localhost
 AGENTCLASSPATH=

--- a/packaging/centos7/replace.properties
+++ b/packaging/centos7/replace.properties
@@ -21,6 +21,7 @@ DBROOTPW=
 MSLOG=vmops.log
 APISERVERLOG=api.log
 DBHOST=localhost
+DBDRIVER=jdbc:mysql
 COMPONENTS-SPEC=components-premium.xml
 REMOTEHOST=localhost
 AGENTCLASSPATH=

--- a/packaging/centos7/tomcat7/db.properties
+++ b/packaging/centos7/tomcat7/db.properties
@@ -25,6 +25,7 @@ region.id=1
 db.cloud.username=cloud
 db.cloud.password=ENC(vlzQjmqOV4s5q7n+S1OMbA==)
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -56,6 +57,8 @@ db.cloud.encrypt.secret=ENC(zaGuSF5a4KyWayn2t0yyjDa0HjdToVtZ)
 db.usage.password=ENC(cQEcN5aVucSYK+WUkPjDcw==)
 db.usage.username=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -69,6 +72,8 @@ db.usage.url.params=
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/packaging/debian/replace.properties
+++ b/packaging/debian/replace.properties
@@ -21,6 +21,7 @@ DBROOTPW=
 MSLOG=vmops.log
 APISERVERLOG=api.log
 DBHOST=localhost
+DBDRIVER=jdbc:mysql
 COMPONENTS-SPEC=components-premium.xml
 REMOTEHOST=localhost
 AGENTCLASSPATH=

--- a/packaging/fedora20/replace.properties
+++ b/packaging/fedora20/replace.properties
@@ -21,6 +21,7 @@ DBROOTPW=
 MSLOG=vmops.log
 APISERVERLOG=api.log
 DBHOST=localhost
+DBDRIVER=jdbc:mysql
 COMPONENTS-SPEC=components-premium.xml
 REMOTEHOST=localhost
 AGENTCLASSPATH=

--- a/packaging/fedora21/replace.properties
+++ b/packaging/fedora21/replace.properties
@@ -21,6 +21,7 @@ DBROOTPW=
 MSLOG=vmops.log
 APISERVERLOG=api.log
 DBHOST=localhost
+DBDRIVER=jdbc:mysql
 COMPONENTS-SPEC=components-premium.xml
 REMOTEHOST=localhost
 AGENTCLASSPATH=

--- a/plugins/network-elements/globodns/test/resources/db.properties
+++ b/plugins/network-elements/globodns/test/resources/db.properties
@@ -27,6 +27,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -47,6 +48,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -60,6 +63,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/plugins/network-elements/juniper-contrail/test/resources/db.properties
+++ b/plugins/network-elements/juniper-contrail/test/resources/db.properties
@@ -22,6 +22,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -42,6 +43,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -55,6 +58,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/server/test/resources/db.properties
+++ b/server/test/resources/db.properties
@@ -26,6 +26,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -46,6 +47,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -59,6 +62,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/services/iam/plugin/test/resources/db.properties
+++ b/services/iam/plugin/test/resources/db.properties
@@ -27,6 +27,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -47,6 +48,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -60,6 +63,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/services/iam/server/test/resources/db.properties
+++ b/services/iam/server/test/resources/db.properties
@@ -27,6 +27,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -47,6 +48,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -60,6 +63,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/tools/devcloud-kvm/pom.xml
+++ b/tools/devcloud-kvm/pom.xml
@@ -83,7 +83,7 @@
             </dependencies>
             <configuration>
               <driver>org.gjt.mm.mysql.Driver</driver>
-              <url>jdbc:mysql://${db.cloud.host}:${db.cloud.port}/cloud</url>
+              <url>${db.cloud.driver}://${db.cloud.host}:${db.cloud.port}/cloud</url>
               <username>${db.cloud.username}</username>
               <password>${db.cloud.password}</password>
               <!--all executions are ignored if -Dmaven.test.skip=true -->

--- a/tools/devcloud/pom.xml
+++ b/tools/devcloud/pom.xml
@@ -83,7 +83,7 @@
             </dependencies>
             <configuration>
               <driver>org.gjt.mm.mysql.Driver</driver>
-              <url>jdbc:mysql://${db.cloud.host}:${db.cloud.port}/cloud</url>
+              <url>${db.cloud.driver}://${db.cloud.host}:${db.cloud.port}/cloud</url>
               <username>${db.cloud.username}</username>
               <password>${db.cloud.password}</password>
               <!--all executions are ignored if -Dmaven.test.skip=true -->

--- a/tools/devcloud4/pom.xml
+++ b/tools/devcloud4/pom.xml
@@ -83,7 +83,7 @@
             </dependencies>
             <configuration>
               <driver>org.gjt.mm.mysql.Driver</driver>
-              <url>jdbc:mysql://${db.cloud.host}:${db.cloud.port}/cloud</url>
+              <url>${db.cloud.driver}://${db.cloud.host}:${db.cloud.port}/cloud</url>
               <username>${db.cloud.username}</username>
               <password>${db.cloud.password}</password>
               <!--all executions are ignored if -Dmaven.test.skip=true -->

--- a/usage/conf/db.properties.in
+++ b/usage/conf/db.properties.in
@@ -19,6 +19,7 @@
 db.usage.username=@DBUSER@
 db.usage.password=@DBPW@
 db.usage.host=@DBHOST@
+db.usage.driver=@DBDRIVER@
 db.usage.port=3306
 db.usage.name=cloud_usage
 

--- a/usage/test/resources/db.properties
+++ b/usage/test/resources/db.properties
@@ -26,6 +26,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -46,6 +47,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -59,6 +62,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250

--- a/utils/conf/db.properties
+++ b/utils/conf/db.properties
@@ -29,6 +29,7 @@ db.cloud.username=cloud
 db.cloud.password=cloud
 db.root.password=
 db.cloud.host=localhost
+db.cloud.driver=jdbc:mysql
 db.cloud.port=3306
 db.cloud.name=cloud
 
@@ -49,6 +50,8 @@ db.cloud.url.params=prepStmtCacheSize=517&cachePrepStmts=true&prepStmtCacheSqlLi
 db.usage.username=cloud
 db.usage.password=cloud
 db.usage.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.usage.driver=jdbc:mysql
 db.usage.port=3306
 db.usage.name=cloud_usage
 
@@ -62,6 +65,8 @@ db.usage.autoReconnect=true
 db.simulator.username=cloud
 db.simulator.password=cloud
 db.simulator.host=localhost
+# It's not guaranteed that using a different DB provider than the one from the regular cloud DB will work
+db.simulator.driver=jdbc:mysql
 db.simulator.port=3306
 db.simulator.name=simulator
 db.simulator.maxActive=250


### PR DESCRIPTION
Solution to the mailing thread titled "MySQL : No suitable driver found for jdbc:mysql".
It doesn't harm that we explicitely load the MySQL driver, and for those which would use a commons-dbcp version < 1.4 this would fix it as well. Since JDBC 4.0, the JDBC driver can auto-register itself, but for some weird cases (like ours), it's not working. Therefore we need to explicitly load the JDBC driver.