### PR TITLE
CLOUDSTACK-9602: API: improve resource limits comprehension

### DIFF
--- a/api/src/com/cloud/configuration/Resource.java
+++ b/api/src/com/cloud/configuration/Resource.java
@@ -71,6 +71,15 @@ public interface Resource {
         public int getOrdinal() {
             return ordinal;
         }
+
+        public static ResourceType fromOrdinal(int ordinal) {
+            for (ResourceType r : ResourceType.values()) {
+                if (r.ordinal == ordinal) {
+                    return r;
+                }
+            }
+            return null;
+        }
     }
 
     public static class ResourceOwnerType {

--- a/api/src/com/cloud/user/ResourceLimitService.java
+++ b/api/src/com/cloud/user/ResourceLimitService.java
@@ -64,11 +64,11 @@ public interface ResourceLimitService {
      *            TODO
      * @param domainId
      *            TODO
-     * @param type
+     * @param resourceType
      *            TODO
      * @return a list of limits that match the criteria
      */
-    public List<? extends ResourceLimit> searchForLimits(Long id, Long accountId, Long domainId, Integer type, Long startIndex, Long pageSizeVal);
+    public List<? extends ResourceLimit> searchForLimits(Long id, Long accountId, Long domainId, ResourceType resourceType, Long startIndex, Long pageSizeVal);
 
     /**
      * Finds the resource limit for a specified account and type. If the account has an infinite limit, will check

--- a/api/src/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/org/apache/cloudstack/api/ApiConstants.java
@@ -216,6 +216,7 @@ public class ApiConstants {
     public static final String RECEIVED_BYTES = "receivedbytes";
     public static final String REQUIRES_HVM = "requireshvm";
     public static final String RESOURCE_TYPE = "resourcetype";
+    public static final String RESOURCE_TYPE_NAME = "resourcetypename";
     public static final String RESPONSE = "response";
     public static final String REVERTABLE = "revertable";
     public static final String REGISTERED = "registered";

--- a/api/src/org/apache/cloudstack/api/command/user/resource/ListResourceLimitsCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/resource/ListResourceLimitsCmd.java
@@ -19,6 +19,8 @@ package org.apache.cloudstack.api.command.user.resource;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.cloud.configuration.Resource;
+import com.cloud.exception.InvalidParameterValueException;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseListProjectAndAccountResourcesCmd;
@@ -58,6 +60,21 @@ public class ListResourceLimitsCmd extends BaseListProjectAndAccountResourcesCmd
         + "11 - SecondaryStorage. Total secondary storage space (in GiB) a user can use. ")
     private Integer resourceType;
 
+    @Parameter(name = ApiConstants.RESOURCE_TYPE_NAME, type = CommandType.STRING, description = "Type of resource (wins over resourceType if both are provided). Values are: "
+            + "user_vm - Instance. Number of instances a user can create. "
+            + "public_ip - IP. Number of public IP addresses an account can own. "
+            + "volume - Volume. Number of disk volumes an account can own. "
+            + "snapshot - Snapshot. Number of snapshots an account can own. "
+            + "template - Template. Number of templates an account can register/create. "
+            + "project - Project. Number of projects an account can own. "
+            + "network - Network. Number of networks an account can own. "
+            + "vpc - VPC. Number of VPC an account can own. "
+            + "cpu - CPU. Number of CPU an account can allocate for his resources. "
+            + "memory - Memory. Amount of RAM an account can allocate for his resources. "
+            + "primary_storage - PrimaryStorage. Total primary storage space (in GiB) a user can use. "
+            + "secondary_storage - SecondaryStorage. Total secondary storage space (in GiB) a user can use. ")
+    private String resourceTypeName;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -68,6 +85,10 @@ public class ListResourceLimitsCmd extends BaseListProjectAndAccountResourcesCmd
 
     public Integer getResourceType() {
         return resourceType;
+    }
+
+    public String getResourceTypeName() {
+        return resourceTypeName;
     }
 
     /////////////////////////////////////////////////////
@@ -83,7 +104,7 @@ public class ListResourceLimitsCmd extends BaseListProjectAndAccountResourcesCmd
     public void execute() {
         List<? extends ResourceLimit> result =
                 _resourceLimitService.searchForLimits(id, _accountService.finalyzeAccountId(this.getAccountName(), this.getDomainId(), this.getProjectId(), false), this.getDomainId(),
-                resourceType, this.getStartIndex(), this.getPageSizeVal());
+                        getResourceTypeEnum(), this.getStartIndex(), this.getPageSizeVal());
         ListResponse<ResourceLimitResponse> response = new ListResponse<ResourceLimitResponse>();
         List<ResourceLimitResponse> limitResponses = new ArrayList<ResourceLimitResponse>();
         for (ResourceLimit limit : result) {
@@ -95,5 +116,24 @@ public class ListResourceLimitsCmd extends BaseListProjectAndAccountResourcesCmd
         response.setResponses(limitResponses);
         response.setResponseName(getCommandName());
         this.setResponseObject(response);
+    }
+
+    private Resource.ResourceType getResourceTypeEnum() {
+        // Map resource type
+        Resource.ResourceType resourceTypeResult = null;
+        if (resourceTypeName != null) {
+            try {
+                resourceTypeResult = Resource.ResourceType.valueOf(resourceTypeName);
+            } catch (IllegalArgumentException e) {
+                throw new InvalidParameterValueException("Please specify a valid resource type name.");
+            }
+        } else if (resourceType != null) {
+            resourceTypeResult = Resource.ResourceType.fromOrdinal(resourceType);
+            if (resourceTypeResult == null) {
+                throw new InvalidParameterValueException("Please specify a valid resource type.");
+            }
+        }
+
+        return resourceTypeResult;
     }
 }

--- a/api/src/org/apache/cloudstack/api/response/ResourceCountResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/ResourceCountResponse.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
+import com.cloud.configuration.Resource;
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.cloudstack.api.ApiConstants;
@@ -49,6 +50,10 @@ public class ResourceCountResponse extends BaseResponse implements ControlledEnt
     @Param(description = "resource type. Values include 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11. See the resourceType parameter for more information on these values.")
     private String resourceType;
 
+    @SerializedName(ApiConstants.RESOURCE_TYPE_NAME)
+    @Param(description = "resource type name. Values include user_vm, public_ip, volume, snapshot, template, project, network, vpc, cpu, memory, primary_storage, secondary_storage.")
+    private String resourceTypeName;
+
     @SerializedName("resourcecount")
     @Param(description = "resource count")
     private long resourceCount;
@@ -68,8 +73,9 @@ public class ResourceCountResponse extends BaseResponse implements ControlledEnt
         this.domainName = domainName;
     }
 
-    public void setResourceType(String resourceType) {
-        this.resourceType = resourceType;
+    public void setResourceType(Resource.ResourceType resourceType) {
+        this.resourceType = Integer.valueOf(resourceType.getOrdinal()).toString();
+        this.resourceTypeName = resourceType.getName();
     }
 
     public void setResourceCount(Long resourceCount) {

--- a/api/src/org/apache/cloudstack/api/response/ResourceLimitResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/ResourceLimitResponse.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
+import com.cloud.configuration.Resource;
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.cloudstack.api.ApiConstants;
@@ -43,6 +44,10 @@ public class ResourceLimitResponse extends BaseResponse implements ControlledEnt
     @SerializedName(ApiConstants.RESOURCE_TYPE)
     @Param(description = "resource type. Values include 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11. See the resourceType parameter for more information on these values.")
     private String resourceType;
+
+    @SerializedName(ApiConstants.RESOURCE_TYPE_NAME)
+    @Param(description = "resource type name. Values include user_vm, public_ip, volume, snapshot, template, project, network, vpc, cpu, memory, primary_storage, secondary_storage.")
+    private String resourceTypeName;
 
     @SerializedName("max")
     @Param(description = "the maximum number of the resource. A -1 means the resource currently has no limit.")
@@ -76,8 +81,9 @@ public class ResourceLimitResponse extends BaseResponse implements ControlledEnt
         this.domainName = domainName;
     }
 
-    public void setResourceType(String resourceType) {
-        this.resourceType = resourceType;
+    public void setResourceType(Resource.ResourceType resourceType) {
+        this.resourceType = Integer.valueOf(resourceType.getOrdinal()).toString();
+        this.resourceTypeName = resourceType.getName();
     }
 
     public void setMax(Long max) {

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -411,7 +411,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             populateAccount(resourceLimitResponse, limit.getOwnerId());
             populateDomain(resourceLimitResponse, accountTemp.getDomainId());
         }
-        resourceLimitResponse.setResourceType(Integer.toString(limit.getType().getOrdinal()));
+        resourceLimitResponse.setResourceType(limit.getType());
 
         if ((limit.getType() == ResourceType.primary_storage || limit.getType() == ResourceType.secondary_storage) && limit.getMax() >= 0) {
             resourceLimitResponse.setMax((long)Math.ceil((double)limit.getMax() / ResourceType.bytesToGiB));
@@ -437,7 +437,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             populateDomain(resourceCountResponse, resourceCount.getOwnerId());
         }
 
-        resourceCountResponse.setResourceType(Integer.toString(resourceCount.getType().getOrdinal()));
+        resourceCountResponse.setResourceType(resourceCount.getType());
         resourceCountResponse.setResourceCount(resourceCount.getCount());
         resourceCountResponse.setObjectName("resourcecount");
         return resourceCountResponse;

--- a/server/src/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -477,7 +477,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
     }
 
     @Override
-    public List<ResourceLimitVO> searchForLimits(Long id, Long accountId, Long domainId, Integer type, Long startIndex, Long pageSizeVal) {
+    public List<ResourceLimitVO> searchForLimits(Long id, Long accountId, Long domainId, ResourceType resourceType, Long startIndex, Long pageSizeVal) {
         Account caller = CallContext.current().getCallingAccount();
         List<ResourceLimitVO> limits = new ArrayList<ResourceLimitVO>();
         boolean isAccount = true;
@@ -507,16 +507,6 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
                     _accountMgr.checkAccess(caller, null, true, account);
                     domainId = null;
                 }
-            }
-        }
-
-        // Map resource type
-        ResourceType resourceType = null;
-        if (type != null) {
-            try {
-                resourceType = ResourceType.values()[type];
-            } catch (ArrayIndexOutOfBoundsException e) {
-                throw new InvalidParameterValueException("Please specify a valid resource type.");
             }
         }
 

--- a/server/test/com/cloud/vpc/MockResourceLimitManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockResourceLimitManagerImpl.java
@@ -54,10 +54,10 @@ public class MockResourceLimitManagerImpl extends ManagerBase implements Resourc
     }
 
     /* (non-Javadoc)
-     * @see com.cloud.user.ResourceLimitService#searchForLimits(java.lang.Long, java.lang.Long, java.lang.Long, java.lang.Integer, java.lang.Long, java.lang.Long)
+     * @see com.cloud.user.ResourceLimitService#searchForLimits(java.lang.Long, java.lang.Long, java.lang.Long, com.cloud.user.ResourceLimitService, java.lang.Long, java.lang.Long)
      */
     @Override
-    public List<? extends ResourceLimit> searchForLimits(Long id, Long accountId, Long domainId, Integer type, Long startIndex, Long pageSizeVal) {
+    public List<? extends ResourceLimit> searchForLimits(Long id, Long accountId, Long domainId, ResourceType resourceType, Long startIndex, Long pageSizeVal) {
         // TODO Auto-generated method stub
         return null;
     }


### PR DESCRIPTION
Add resource type name in request and response.

This adds in the response a new attribute `typename` with the String value for the corresponding resource enum.

```
    {
      "capacitytotal": 0,
      "capacityused": 0,
      "percentused": "0",
      "type": 19,
      "typename": "gpu",
      "zoneid": "381d0a95-ed4a-4ad9-b41c-b97073c1a433",
      "zonename": "ch-dk-2"
    }
```
