### PR TITLE
CLOUDSTACK-9280: System VM volumes can be expunged if no SSVM exists.

### DIFF
--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreManager.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreManager.java
@@ -25,6 +25,8 @@ import com.cloud.storage.DataStoreRole;
 public interface DataStoreManager {
     DataStore getDataStore(long storeId, DataStoreRole role);
 
+    DataStore getDataStoreForExpunge(long storeId, DataStoreRole role);
+
     DataStore getPrimaryDataStore(long storeId);
 
     DataStore getPrimaryDataStore(String storeUuid);

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/VolumeDataFactory.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/VolumeDataFactory.java
@@ -31,5 +31,7 @@ public interface VolumeDataFactory {
 
     VolumeInfo getVolume(long volumeId);
 
+    VolumeInfo getVolumeForExpunge(long volumeId);
+
     List<VolumeInfo> listVolumeOnCache(long volumeId);
 }

--- a/engine/storage/image/src/org/apache/cloudstack/storage/image/manager/ImageStoreProviderManagerImpl.java
+++ b/engine/storage/image/src/org/apache/cloudstack/storage/image/manager/ImageStoreProviderManagerImpl.java
@@ -67,6 +67,16 @@ public class ImageStoreProviderManagerImpl implements ImageStoreProviderManager 
 
     @Override
     public ImageStoreEntity getImageStore(long dataStoreId) {
+        return getImageStore(dataStoreId, false);
+    }
+
+    @Override
+    public ImageStoreEntity getImageStoreForExpunge(long dataStoreId) {
+        return getImageStore(dataStoreId, true);
+    }
+
+    protected ImageStoreEntity getImageStore(long dataStoreId, boolean forExpunge) {
+        //The forExpunge parameter is currently ignored.
         ImageStoreVO dataStore = dataStoreDao.findById(dataStoreId);
         String providerName = dataStore.getProviderName();
         ImageStoreProvider provider = (ImageStoreProvider)providerManager.getDataStoreProvider(providerName);

--- a/engine/storage/src/org/apache/cloudstack/storage/DummyEndpoint.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/DummyEndpoint.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cloudstack.storage;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
+import org.apache.cloudstack.framework.async.AsyncCompletionCallback;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.Command;
+import com.cloud.utils.component.ComponentContext;
+import com.cloud.utils.net.NetUtils;
+
+public class DummyEndpoint implements EndPoint {
+    private static final Logger s_logger = Logger.getLogger(DummyEndpoint.class);
+
+    private ScheduledExecutorService executor;
+
+    public static EndPoint getEndpoint() {
+        return ComponentContext.inject(DummyEndpoint.class);
+    }
+
+    public void configure() {
+        executor = Executors.newScheduledThreadPool(10);
+    }
+
+    @Override
+    public long getId() {
+        return 0;
+    }
+
+    @Override
+    public Answer sendMessage(Command cmd) {
+        s_logger.info("Handling " + cmd + " with dummy endpoint. We will pretend that the operation succeeded.");
+        return new Answer(cmd, true, "Success");
+    }
+
+    private class CmdRunner extends ManagedContextRunnable {
+        final Command cmd;
+        final AsyncCompletionCallback<Answer> callback;
+
+        public CmdRunner(Command cmd, AsyncCompletionCallback<Answer> callback) {
+            this.cmd = cmd;
+            this.callback = callback;
+        }
+
+        @Override
+        protected void runInContext() {
+            Answer answer = sendMessage(cmd);
+            callback.complete(answer);
+        }
+    }
+
+    @Override
+    public void sendMessageAsync(Command cmd, AsyncCompletionCallback<Answer> callback) {
+        executor.schedule(new CmdRunner(cmd, callback), 10, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public String getHostAddr() {
+        return "127.0.0.0";
+    }
+
+    @Override
+    public String getPublicAddr() {
+        String hostIp = NetUtils.getDefaultHostIp();
+        if (hostIp != null)
+            return hostIp;
+        else
+            return "127.0.0.0";
+    }
+}

--- a/engine/storage/src/org/apache/cloudstack/storage/datastore/DataStoreManagerImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/datastore/DataStoreManagerImpl.java
@@ -43,13 +43,28 @@ public class DataStoreManagerImpl implements DataStoreManager {
 
     @Override
     public DataStore getDataStore(long storeId, DataStoreRole role) {
+        return getDataStore(storeId, role, false);
+    }
+
+    @Override
+    public DataStore getDataStoreForExpunge(long storeId, DataStoreRole role) {
+        return getDataStore(storeId, role, true);
+    }
+
+    protected DataStore getDataStore(long storeId, DataStoreRole role, boolean forExpunge) {
         try {
             if (role == DataStoreRole.Primary) {
-                return primaryStoreMgr.getPrimaryDataStore(storeId);
-            } else if (role == DataStoreRole.Image) {
-                return imageDataStoreMgr.getImageStore(storeId);
-            } else if (role == DataStoreRole.ImageCache) {
-                return imageDataStoreMgr.getImageStore(storeId);
+                if (forExpunge) {
+                    return primaryStoreMgr.getPrimaryDataStoreForExpunge(storeId);
+                } else {
+                    return primaryStoreMgr.getPrimaryDataStore(storeId);
+                }
+            } else if (role == DataStoreRole.Image || role == DataStoreRole.ImageCache) {
+                if (forExpunge) {
+                    return imageDataStoreMgr.getImageStoreForExpunge(storeId);
+                } else {
+                    return imageDataStoreMgr.getImageStore(storeId);
+                }
             }
         } catch (CloudRuntimeException e) {
             throw e;

--- a/engine/storage/src/org/apache/cloudstack/storage/datastore/PrimaryDataStoreProviderManager.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/datastore/PrimaryDataStoreProviderManager.java
@@ -25,6 +25,8 @@ import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreDriver
 public interface PrimaryDataStoreProviderManager {
     public PrimaryDataStore getPrimaryDataStore(long dataStoreId);
 
+    public PrimaryDataStore getPrimaryDataStoreForExpunge(long dataStoreId);
+
     public PrimaryDataStore getPrimaryDataStore(String uuid);
 
     boolean registerDriver(String providerName, PrimaryDataStoreDriver driver);

--- a/engine/storage/src/org/apache/cloudstack/storage/image/datastore/ImageStoreProviderManager.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/datastore/ImageStoreProviderManager.java
@@ -28,6 +28,8 @@ import org.apache.cloudstack.storage.image.ImageStoreDriver;
 public interface ImageStoreProviderManager {
     ImageStoreEntity getImageStore(long dataStoreId);
 
+    ImageStoreEntity getImageStoreForExpunge(long dataStoreId);
+
     ImageStoreEntity getImageStore(String uuid);
 
     List<DataStore> listImageStores();

--- a/engine/storage/test/org/apache/cloudstack/storage/endpoint/DefaultEndPointSelectorTest.java
+++ b/engine/storage/test/org/apache/cloudstack/storage/endpoint/DefaultEndPointSelectorTest.java
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.storage.endpoint;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
+import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
+import org.apache.cloudstack.engine.subsystem.api.storage.StorageAction;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.storage.DummyEndpoint;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cloud.host.dao.HostDao;
+import com.cloud.utils.component.ComponentContext;
+import com.cloud.vm.SecondaryStorageVm;
+import com.cloud.vm.SecondaryStorageVmVO;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachine.State;
+import com.cloud.vm.VirtualMachine.Type;
+import com.cloud.vm.dao.SecondaryStorageVmDao;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ComponentContext.class)
+public class DefaultEndPointSelectorTest {
+    @Mock
+    HostDao _hostDao;
+
+    @Mock
+    SecondaryStorageVmDao _ssvmDao;
+
+    @InjectMocks
+    @Spy
+    DefaultEndPointSelector selector = new DefaultEndPointSelector();
+
+    //Special mocked endpoints that the tests can use to identify what was returned from the method.
+    private EndPoint selectMethodEndpoint = mock(EndPoint.class);
+    private DummyEndpoint dummyEndpoint = mock(DummyEndpoint.class);
+
+    /**
+     * The single common method that sets up the mocks to cover all possible scenarios we want to
+     * test. The VM type and volume state are passed in, while a potential list of existing SSVMs
+     * are also passed in. As its final action, the method calls {@link DefaultEndPointSelector#select(DataObject, StorageAction)}
+     * in order to test the method's operation and returns the endpoint found.
+     *
+     * @param vmType - State of the VM attached to the volume
+     * @param volumeState - State of the volume
+     * @param ssvmVOs - A list of SSVMs to return from the DAO
+     * @return The selected endpoint.
+     */
+    private EndPoint mockEndpointSelection(Type vmType, State volumeState, SecondaryStorageVmVO ... ssvmVOs) {
+        VolumeInfo volume = mock(VolumeInfo.class);
+        VirtualMachine vm = mock(VirtualMachine.class);
+        Long zoneId = 1l;
+
+        when(vm.getType()).thenReturn(vmType);
+        when(vm.getState()).thenReturn(volumeState);
+        when(volume.getAttachedVM()).thenReturn(vm);
+        when(volume.getDataCenterId()).thenReturn(zoneId);
+
+        List<SecondaryStorageVmVO> ssvmList = new ArrayList<>();
+        if (ssvmVOs != null) {
+            for (SecondaryStorageVmVO ssvm : ssvmVOs) {
+                ssvmList.add(ssvm);
+            }
+        }
+
+        when(_ssvmDao.listByZoneId(eq(SecondaryStorageVm.Role.templateProcessor), eq(zoneId)))
+            .thenReturn(ssvmList);
+
+        PowerMockito.mockStatic(ComponentContext.class);
+        when(ComponentContext.inject(DummyEndpoint.class)).thenReturn(dummyEndpoint);
+
+        doReturn(selectMethodEndpoint).when(selector).select(any(DataObject.class));
+
+        return selector.select(volume, StorageAction.DELETEVOLUME);
+    }
+
+    private EndPoint executeTestSelectionWithExpunging(Type vmType, Object expectedEndPoint, SecondaryStorageVmVO ... ssvmVOs) {
+        EndPoint ep = mockEndpointSelection(vmType, State.Expunging, ssvmVOs);
+        Assert.assertNotNull(ep);
+        Assert.assertEquals(expectedEndPoint, ep);
+        return ep;
+    }
+
+    /**
+     * Dummy endpoint should be selected if an SSVM volume is expunging
+     * and no SSVMs are available.
+     */
+    @Test
+    public void testSelectionWithExpungingSsvm() {
+        EndPoint ep = executeTestSelectionWithExpunging(Type.SecondaryStorageVm, dummyEndpoint);
+        Assert.assertTrue(ep instanceof DummyEndpoint);
+    }
+
+    /**
+     * Dummy endpoint should be selected if a console proxy volume is expunging
+     * and no SSVMs are available.
+     */
+    @Test
+    public void testSelectionWithExpungingConsoleProxy() {
+        EndPoint ep = executeTestSelectionWithExpunging(Type.ConsoleProxy, dummyEndpoint);
+        Assert.assertTrue(ep instanceof DummyEndpoint);
+    }
+
+    /**
+     * The endpoint returned by {@link DefaultEndPointSelector#select(DataObject)} should be
+     * returned if we pass in an expunging User VM.
+     */
+    @Test
+    public void testSelectionWithExpungingUserVM() {
+        EndPoint ep = executeTestSelectionWithExpunging(Type.User, selectMethodEndpoint);
+    }
+
+    /**
+     * The endpoint returned by {@link DefaultEndPointSelector#select(DataObject)} should be
+     * returned if we pass in an expunging system VM while an SSVM exists in the zone.
+     */
+    @Test
+    public void testSelectionWithExpungingSsvmWithSsvmExisting() {
+        SecondaryStorageVmVO ssvmVO = mock(SecondaryStorageVmVO.class);
+        executeTestSelectionWithExpunging(Type.SecondaryStorageVm, selectMethodEndpoint, ssvmVO);
+    }
+
+    /**
+     * The endpoint returned by {@link DefaultEndPointSelector#select(DataObject)} should be
+     * returned if we pass in an expunging system VM while an SSVM exists in the zone.
+     */
+    @Test
+    public void testSelectionWithExpungingConsoleProxyWithSsvmExisting() {
+        SecondaryStorageVmVO ssvmVO = mock(SecondaryStorageVmVO.class);
+        executeTestSelectionWithExpunging(Type.ConsoleProxy, selectMethodEndpoint, ssvmVO);
+    }
+
+}

--- a/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeObject.java
+++ b/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeObject.java
@@ -92,7 +92,7 @@ public class VolumeObject implements VolumeInfo {
     public String getAttachedVmName() {
         Long vmId = volumeVO.getInstanceId();
         if (vmId != null) {
-            VMInstanceVO vm = vmInstanceDao.findById(vmId);
+            VMInstanceVO vm = vmInstanceDao.findByIdIncludingRemoved(vmId);
 
             if (vm == null) {
                 return null;
@@ -106,7 +106,7 @@ public class VolumeObject implements VolumeInfo {
     public VirtualMachine getAttachedVM() {
         Long vmId = volumeVO.getInstanceId();
         if (vmId != null) {
-            VMInstanceVO vm = vmInstanceDao.findById(vmId);
+            VMInstanceVO vm = vmInstanceDao.findByIdIncludingRemoved(vmId);
             return vm;
         }
         return null;

--- a/engine/storage/volume/test/org/apache/cloudstack/storage/volume/VolumeDataFactoryImplTest.java
+++ b/engine/storage/volume/test/org/apache/cloudstack/storage/volume/VolumeDataFactoryImplTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cloudstack.storage.volume;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
+
+import java.util.Map;
+
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreProvider;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreProviderManager;
+import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreDriver;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.storage.datastore.DataStoreManagerImpl;
+import org.apache.cloudstack.storage.datastore.PrimaryDataStoreImpl;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreVO;
+import org.apache.cloudstack.storage.datastore.manager.PrimaryDataStoreProviderManagerImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cloud.storage.StorageManager;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.VolumeDao;
+import com.cloud.utils.component.ComponentContext;
+import com.cloud.utils.exception.CloudRuntimeException;
+import org.mockito.internal.util.reflection.Whitebox;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ComponentContext.class, PrimaryDataStoreImpl.class })
+public class VolumeDataFactoryImplTest {
+    //PrimaryDataStoreProviderManager mocks
+    @Mock
+    PrimaryDataStoreDao _dsDao;
+
+    @Mock
+    DataStoreProviderManager _providerMgr;
+
+    @Mock
+    StorageManager _storageMgr;
+
+    @InjectMocks
+    @Spy
+    PrimaryDataStoreProviderManagerImpl primaryStoreMgr = new PrimaryDataStoreProviderManagerImpl();
+
+    //DataStoreManager mocks
+    @Mock
+    VolumeDataStoreDao _volumeDataStoreDao;
+
+    @Mock
+    VolumeDao _volDao;
+
+    @InjectMocks
+    @Spy
+    DataStoreManagerImpl _dsManagerImpl = new DataStoreManagerImpl();
+
+    //The final mock
+    @InjectMocks
+    VolumeDataFactoryImpl _volumeDataFactory;
+
+    /**
+     * Set up the mocks. The variable parameters are used to set up different scenarios for testing,
+     * such as what happens when a pool cannot be found. For example, the volume reports a different pool ID
+     * than the one specified, that means the code will not be able to find a pool.
+     * @param volumePoolId - The pool ID reported by the volume.
+     * @param poolId - The ID of the pool that actually exists in the scenario.
+     */
+    public void setupMocks(Long volumePoolId, Long poolId) {
+        //Common data stuff
+        String providerName = "TestProviderName";
+
+        //PrimaryDataStoreProviderManagerImpl mocks
+        StoragePoolVO pool = mock(StoragePoolVO.class);
+        when(pool.getId()).thenReturn(poolId);
+        when(pool.getStorageProviderName()).thenReturn(providerName);
+        when(_dsDao.findById(eq(poolId))).thenReturn(pool);
+
+        DataStoreProvider provider = mock(DataStoreProvider.class);
+        when(provider.getName()).thenReturn(providerName);
+        when(_providerMgr.getDataStoreProvider(eq(providerName))).thenReturn(provider);
+
+        @SuppressWarnings("unchecked")
+        Map<String, PrimaryDataStoreDriver> driverMaps = mock(Map.class);
+        PrimaryDataStoreDriver driver = mock(PrimaryDataStoreDriver.class);
+        when(driverMaps.get(providerName)).thenReturn(driver);
+        Whitebox.setInternalState(primaryStoreMgr, "driverMaps", driverMaps);
+
+        PowerMockito.mockStatic(PrimaryDataStoreImpl.class);
+        PrimaryDataStoreImpl dsImpl = mock(PrimaryDataStoreImpl.class);
+        when(PrimaryDataStoreImpl.createDataStore(any(StoragePoolVO.class), any(PrimaryDataStoreDriver.class), eq(provider)))
+            .thenReturn(dsImpl);
+
+        //DataStoreManager mocks
+        VolumeDataStoreVO volDataStore = mock(VolumeDataStoreVO.class);
+        when(volDataStore.getDataStoreId()).thenReturn(1l);
+
+        VolumeVO vol = mock(VolumeVO.class);
+        when(vol.getId()).thenReturn(1l);
+        when(vol.getPoolId()).thenReturn(volumePoolId);
+        when(_volDao.findByIdIncludingRemoved(anyLong())).thenReturn(vol);
+
+        PowerMockito.mockStatic(ComponentContext.class);
+        VolumeObject volObj = spy(new VolumeObject());
+        when(ComponentContext.inject(VolumeObject.class)).thenReturn(volObj);
+
+        when(_volumeDataStoreDao.findByVolume(anyLong())).thenReturn(volDataStore);
+    }
+
+    /**
+     * Verify that a volume is returned from getVolumeForExpunge and that it has a
+     * data store attached to it, since the pool reports ID 1, and pool ID 1 exists.
+     */
+    @Test
+    public void testGetVolumeForExpungeWithStoragePool() {
+        setupMocks(1l, 1l);
+        VolumeInfo volInfo = _volumeDataFactory.getVolumeForExpunge(1);
+        Assert.assertNotNull(volInfo);
+        Assert.assertNotNull(volInfo.getDataStore());
+    }
+
+    /**
+     * Verify that a volume is returned from getVolumeForExpunge and that it does
+     * not have a data store attached to it, since the pool ID is 2 and the volume reports ID 1.
+     */
+    @Test
+    public void testGetVolumeForExpungeWithoutStoragePool() {
+        setupMocks(1l, 2l);
+        VolumeInfo volInfo = _volumeDataFactory.getVolumeForExpunge(1);
+        Assert.assertNotNull(volInfo);
+        Assert.assertNull(volInfo.getDataStore());
+    }
+
+    /**
+     * Verify that an exception is thrown when the pool doesn't exist and the regular
+     * getVolume method is called.
+     */
+    @Test(expected = CloudRuntimeException.class)
+    public void testGetVolumeWithoutStoragePool() {
+        setupMocks(1l, 2l);
+        _volumeDataFactory.getVolume(1l);
+    }
+
+    /**
+     * Verify that a volume is returned from regular getVolume call when the storage pool
+     * exists.
+     */
+    @Test
+    public void testGetVolumeWithStoragePool() {
+        setupMocks(1l, 1l);
+        VolumeInfo volInfo = _volumeDataFactory.getVolume(1l);
+        Assert.assertNotNull(volInfo);
+        Assert.assertNotNull(volInfo.getDataStore());
+    }
+}

--- a/server/src/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/com/cloud/storage/StorageManagerImpl.java
@@ -1125,7 +1125,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                         }
 
                         try {
-                            volService.expungeVolumeAsync(volFactory.getVolume(vol.getId()));
+                            volService.expungeVolumeAsync(volFactory.getVolumeForExpunge(vol.getId()));
                         } catch (Exception e) {
                             s_logger.warn("Unable to destroy volume " + vol.getUuid(), e);
                         }


### PR DESCRIPTION
This commit adds a special SSVM endpoint which simply returns true for
all operations sent to it, without actually doing anything. This
allows for destroyed volumes of system VMs to be expunged when there
are no hosts (and thus no system VMs) remaining to handle the volume
destruction.
