### PR TITLE
CLOUDSTACK-9386: DS template copies don’t get deleted in VMware ESXi with multiple clusters and zone wide storage

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -5535,17 +5535,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             VmwareHypervisorHost hyperHost = getHyperHost(context, null);
             VolumeTO vol = cmd.getVolume();
 
-            ManagedObjectReference morDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, vol.getPoolUuid());
-            if (morDs == null) {
-                String msg = "Unable to find datastore based on volume mount point " + vol.getMountPoint();
-                s_logger.error(msg);
-                throw new Exception(msg);
-            }
+            VirtualMachineMO vmMo = findVmOnDatacenter(context, hyperHost, vol);
 
-            ManagedObjectReference morCluster = hyperHost.getHyperHostCluster();
-            ClusterMO clusterMo = new ClusterMO(context, morCluster);
-
-            VirtualMachineMO vmMo = clusterMo.findVmOnHyperHost(vol.getPath());
             if (vmMo != null && vmMo.isTemplate()) {
                 if (s_logger.isInfoEnabled()) {
                     s_logger.info("Destroy template volume " + vol.getPath());
@@ -5568,6 +5559,26 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             s_logger.error(msg, e);
             return new Answer(cmd, false, msg);
         }
+    }
+
+    /**
+     * Use data center to look for vm, instead of randomly picking up a cluster<br/>
+     * (in multiple cluster environments vm could not be found if wrong cluster was chosen)
+     * @param context vmware context
+     * @param hyperHost vmware hv host
+     * @param vol volume
+     * @return a virtualmachinemo if could be found on datacenter.
+     * @throws Exception if there is an error while finding vm
+     * @throws CloudRuntimeException if datacenter cannot be found
+     */
+    protected VirtualMachineMO findVmOnDatacenter(VmwareContext context, VmwareHypervisorHost hyperHost, VolumeTO vol) throws Exception {
+        DatacenterMO dcMo = new DatacenterMO(context, hyperHost.getHyperHostDatacenter());
+        if (dcMo.getMor() == null) {
+            String msg = "Unable to find VMware DC";
+            s_logger.error(msg);
+            throw new CloudRuntimeException(msg);
+        }
+        return dcMo.findVm(vol.getPath());
     }
 
     private String getAbsoluteVmdkFile(VirtualDisk disk) {


### PR DESCRIPTION
JIRA TICKET: https://issues.apache.org/jira/browse/CLOUDSTACK-9386

### Introduction
In some production environments with multiple clusters it was noticed that unused templates were consuming too much storage. It was discovered that template cleanup was not deleting marked templates on ESXi.

### Description of the problem
Suppose we have multiple clusters `(c1, c2,...,cN)` on a data center and template `T` from which we deploy vms on `c1.`
Suppose now that we expunge those vms, and there's no other vm instance from template `T,` so this was the actual workflow:

1. CloudStack marks template for cleanup after `storage.cleanup.interval` seconds, by setting `marked_for_gc = 1` on `template_spool_ref` table, for that template.

2. After another `storage.cleanup.interval` seconds a `DestroyCommand` will be sent, to delete template from primary storage

3. On `VmwareResource`, command is processed, and it first picks up a random cluster, say `ci != c1` to look for vm template (using volume's path) and destroy it. But, as template was on `c1` it cannot be found, so it won't be deleted. Entry on `template_spool_ref` is deleted but not the actual template on hypervisor side.

### Proposed solution
We propose a way to attack problem shown in point 3, by not picking up a random cluster to look for vm but using vSphere data center. This way we make sure vm template will be deleted in every case, and not depending on random cluster selection