### PR TITLE
CLOUDSTACK-9388: Remove string conversion in assertion statement

### DIFF
--- a/test/integration/component/test_blocker_bugs.py
+++ b/test/integration/component/test_blocker_bugs.py
@@ -409,7 +409,7 @@ class TestNATRules(cloudstackTestCase):
                         )
         self.assertEqual(
                             firewall_response[0].startport,
-                            str(self.services["firewall_rule"]["startport"]),
+                            self.services["firewall_rule"]["startport"],
                             "Firewall rule is not with specific port"
                         )
 


### PR DESCRIPTION
Remove string convertion in Assertion statement, since the start port parameter in listFirewallAPI response is of type integer

Test Result:
=========
"Checking firewall rules deletion after static NAT disable ... === TestName: test_01_firewall_rules_port_fw | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 1 test in 153.974s

OK
