### PR TITLE
CLOUDSTACK-9389:[automation]updating test_routers_network_ops.py to resolve some test case failures

### DIFF
--- a/test/integration/smoke/test_routers_network_ops.py
+++ b/test/integration/smoke/test_routers_network_ops.py
@@ -270,7 +270,7 @@ class TestRedundantIsolateNetworks(cloudstackTestCase):
         # Test SSH after closing port 22
         expected = 1
         ssh_command = "ping -c 3 8.8.8.8"
-        check_string = "3 packets received"
+        check_string = "3" + " " + self.services["verify_ping_success"]
         result = check_router_command(virtual_machine, nat_rule.ipaddress, ssh_command, check_string, self)
 
         self.assertEqual(
@@ -434,7 +434,7 @@ class TestRedundantIsolateNetworks(cloudstackTestCase):
 
         expected = 0
         ssh_command = "ping -c 3 8.8.8.8"
-        check_string = "3 packets received"
+        check_string = "3" + " " + self.services["verify_ping_success"]
         result = check_router_command(virtual_machine, nat_rule.ipaddress, ssh_command, check_string, self)
 
         self.assertEqual(
@@ -601,7 +601,7 @@ class TestRedundantIsolateNetworks(cloudstackTestCase):
                             self.apiclient.connection.user,
                             self.apiclient.connection.passwd,
                             router.linklocalip,
-                            "sh /opt/cloud/bin/checkrouter.sh ",
+                            "bash /opt/cloud/bin/checkrouter.sh ",
                             hypervisor=hypervisor
                         ))
                 else:
@@ -614,7 +614,7 @@ class TestRedundantIsolateNetworks(cloudstackTestCase):
                             host.user,
                             host.passwd,
                             router.linklocalip,
-                            "sh /opt/cloud/bin/checkrouter.sh "
+                            "bash /opt/cloud/bin/checkrouter.sh "
                         ))
 
                     except KeyError:
@@ -822,7 +822,7 @@ class TestIsolatedNetworks(cloudstackTestCase):
         # Test SSH after closing port 22
         expected = 1
         ssh_command = "ping -c 3 8.8.8.8"
-        check_string = "3 packets received"
+        check_string = "3" + " " + self.services["verify_ping_success"]
         result = check_router_command(virtual_machine, nat_rule.ipaddress, ssh_command, check_string, self)
 
         self.assertEqual(
@@ -977,7 +977,7 @@ class TestIsolatedNetworks(cloudstackTestCase):
 
         expected = 0
         ssh_command = "ping -c 3 8.8.8.8"
-        check_string = "3 packets received"
+        check_string = "3" + " " + self.services["verify_ping_success"]
         result = check_router_command(virtual_machine, nat_rule.ipaddress, ssh_command, check_string, self)
 
         self.assertEqual(

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -914,6 +914,7 @@ test_data = {
         "vlan": "untagged",
     },
     "ostype": "CentOS 5.6 (64-bit)",
+    "verify_ping_success": "received",
     "sleep": 90,
     "timeout": 10,
     "page": 1,


### PR DESCRIPTION
Some test cases were failing due to invalid check_string , proposing following modifications
1-Moving check_string to test_data.py
2-Since ping cmd reply is OS dependent ,for default templates os type CentOS changing check_string from "3 packets received" to "3 received"

[root@BPKxDmS ~]# ping -c 3 8.8.8.8
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=16.9 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=52 time=16.7 ms
64 bytes from 8.8.8.8: icmp_seq=3 ttl=52 time=17.0 ms

— 8.8.8.8 ping statistics —
3 packets transmitted, 3 received, 0% packet loss, time 2020ms
rtt min/avg/max/mdev = 16.720/16.896/17.015/0.196 ms
