### PR TITLE
[CLOUDSTACK-9645] Followup fix for #1162: Add support for not (re)starting server after cloud-setup-management.

### DIFF
--- a/python/lib/cloudutils/serviceConfigServer.py
+++ b/python/lib/cloudutils/serviceConfigServer.py
@@ -137,9 +137,8 @@ class cloudManagementConfig(serviceCfgBase):
         except:
             pass
 
-        self.syscfg.svo.stopService("cloudstack-management")
-
         if self.syscfg.env.noStart == False:
+            self.syscfg.svo.stopService("cloudstack-management")
             if self.syscfg.svo.enableService("cloudstack-management"):
                 return True
             else:


### PR DESCRIPTION
New version against #1330, opened against master.

```
Moving stop of management in config inside if statement.

It will only run the stop command when --no-start is specified.
```
