### PR TITLE
Changing vlan to None since network offering being used has Specify Vlan set to No

### DIFF
--- a/test/integration/component/test_acl_isolatednetwork.py
+++ b/test/integration/component/test_acl_isolatednetwork.py
@@ -367,6 +367,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
         self.apiclient.connection.securityKey = self.user_root_secretkey
 	self.acldata["network"]["name"] = "root"
 	self.acldata["network"]["displayname"] = "root"
+	self.acldata["network"]["vlan"] = None
 
         network = Network.create(
                          self.apiclient,
@@ -390,6 +391,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
         self.apiclient.connection.securityKey = self.user_root_secretkey
 	self.acldata["network"]["name"] = "root_roota"
 	self.acldata["network"]["displayname"] = "root_roota"
+	self.acldata["network"]["vlan"] = None
 
         network = Network.create(
                          self.apiclient,
@@ -414,6 +416,7 @@ class TestIsolatedNetwork(cloudstackTestCase):
         self.apiclient.connection.securityKey = self.user_root_secretkey
 	self.acldata["network"]["name"] = "root_d11a"
 	self.acldata["network"]["displayname"] = "root_d11a"
+	self.acldata["network"]["vlan"] = None
 
         network = Network.create(
                          self.apiclient,


### PR DESCRIPTION
Default isolated network offering with SourceNat service has Specify Vlan parameter set to No. When specify vlan is "No" we can't pass vlan number for network creation api. Three tests are passing vlan id. Hence setting it to None.
# Test results:
# Validate that Admin should be able to create network for himslef ... === TestName: test_01_createNetwork_admin | Status : SUCCESS ===

ok
# Validate that Admin should be able to create network for users in his domain ... === TestName: test_02_createNetwork_admin_foruserinsamedomain | Status : SUCCESS ===

ok
# Validate that Admin should be able to create network for users in his sub domain ... === TestName: test_03_createNetwork_admin_foruserinotherdomain | Status : SUCCESS ===

ok

---

Ran 3 tests in 440.959s

OK
