### PR TITLE
CLOUDSTACK-9395: Add Virtio RNG device to Instances when configured

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -152,3 +152,22 @@ hypervisor.type=kvm
 # kvmclock.disable=false
 # Some newer linux kernels are incapable of reliably migrating vms with kvmclock
 # This is a workaround for the bug, admin can set this to true per-host
+#
+# vm.rng.enable=false
+# This enabled the VirtIO Random Number Generator device for guests.
+#
+# vm.rng.model=random
+# The model of VirtIO Random Number Generator (RNG) to present to the Guest.
+# Currently only 'random' is supported.
+#
+# vm.rng.path=/dev/random
+# Local Random Number Device Generator to use for VirtIO RNG for Guests.
+# This is usually /dev/random, but per platform this might be different
+#
+# vm.rng.rate.bytes=2048
+# The amount of bytes the Guest may request/obtain from the RNG in the period
+# specified below.
+#
+# vm.rng.rate.period=1000
+# The number of milliseconds in which the guest is allowed to obtain the bytes
+# specified above.

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1366,6 +1366,107 @@ public class LibvirtVMDef {
         }
     }
 
+    public static class RngDef {
+        enum RngModel {
+            VIRTIO("virtio");
+            String model;
+
+            RngModel(String model) {
+                this.model = model;
+            }
+
+            @Override
+            public String toString() {
+                return model;
+            }
+        }
+
+        enum RngBackendModel {
+            RANDOM("random"), EGD("egd");
+            String model;
+
+            RngBackendModel(String model) {
+                this.model = model;
+            }
+
+            @Override
+            public String toString() {
+                return model;
+            }
+        }
+
+        private String path = "/dev/random";
+        private RngModel rngModel = RngModel.VIRTIO;
+        private RngBackendModel rngBackendModel = RngBackendModel.RANDOM;
+        private int rngRateBytes = 2048;
+        private int rngRatePeriod = 1000;
+
+        public RngDef(String path) {
+            this.path = path;
+        }
+
+        public RngDef(String path, int rngRateBytes, int rngRatePeriod) {
+            this.path = path;
+            this.rngRateBytes = rngRateBytes;
+            this.rngRatePeriod = rngRatePeriod;
+        }
+
+        public RngDef(RngModel rngModel) {
+            this.rngModel = rngModel;
+        }
+
+        public RngDef(RngBackendModel rngBackendModel) {
+            this.rngBackendModel = rngBackendModel;
+        }
+
+        public RngDef(String path, RngBackendModel rngBackendModel) {
+            this.path = path;
+            this.rngBackendModel = rngBackendModel;
+        }
+
+        public RngDef(String path, RngBackendModel rngBackendModel, int rngRateBytes, int rngRatePeriod) {
+            this.path = path;
+            this.rngBackendModel = rngBackendModel;
+            this.rngRateBytes = rngRateBytes;
+            this.rngRatePeriod = rngRatePeriod;
+        }
+
+        public RngDef(String path, RngModel rngModel) {
+            this.path = path;
+            this.rngModel = rngModel;
+        }
+
+        public String getPath() {
+           return path;
+        }
+
+        public RngBackendModel getRngBackendModel() {
+            return rngBackendModel;
+        }
+
+        public RngModel getRngModel() {
+            return rngModel;
+        }
+
+        public int getRngRateBytes() {
+            return rngRateBytes;
+        }
+
+        public int getRngRatePeriod() {
+            return rngRatePeriod;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder rngBuilder = new StringBuilder();
+            rngBuilder.append("<rng model='" + rngModel + "'>\n");
+            rngBuilder.append("<rate period='" + rngRatePeriod + "' bytes='" + rngRateBytes + "' />\n");
+            rngBuilder.append("<backend model='" + rngBackendModel + "'>" + path + "</backend>");
+            rngBuilder.append("</rng>\n");
+            return rngBuilder.toString();
+        }
+    }
+
     public void setHvsType(String hvs) {
         _hvsType = hvs;
     }

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
@@ -23,6 +23,7 @@ import junit.framework.TestCase;
 import java.util.List;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.RngDef;
 
 public class LibvirtDomainXMLParserTest extends TestCase {
 
@@ -164,6 +165,10 @@ public class LibvirtDomainXMLParserTest extends TestCase {
                      "<alias name='balloon0'/>" +
                      "<address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>" +
                      "</memballoon>" +
+                     "<rng model='virtio'>" +
+                     "<rate period='5000' bytes='4096' />" +
+                     "<backend model='random'>/dev/random</backend>" +
+                     "</rng>" +
                      "</devices>" +
                      "<seclabel type='none'/>" +
                      "</domain>";
@@ -190,5 +195,11 @@ public class LibvirtDomainXMLParserTest extends TestCase {
             assertEquals(ifModel, ifs.get(i).getModel());
             assertEquals(ifType, ifs.get(i).getNetType());
         }
+
+        List<RngDef> rngs = parser.getRngs();
+        assertEquals("/dev/random", rngs.get(0).getPath());
+        assertEquals(RngDef.RngBackendModel.RANDOM, rngs.get(0).getRngBackendModel());
+        assertEquals(4096, rngs.get(0).getRngRateBytes());
+        assertEquals(5000, rngs.get(0).getRngRatePeriod());
     }
 }

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
@@ -118,4 +118,18 @@ public class LibvirtVMDefTest extends TestCase {
         assertTrue((hostOsVersion.first() == 6 && hostOsVersion.second() >= 5) || (hostOsVersion.first() >= 7));
     }
 
+    public void testChannelDef() {
+        LibvirtVMDef.RngDef.RngBackendModel backendModel = LibvirtVMDef.RngDef.RngBackendModel.RANDOM;
+        String path = "/dev/random";
+        int period = 2000;
+        int bytes = 2048;
+
+        LibvirtVMDef.RngDef def = new LibvirtVMDef.RngDef(path, backendModel, bytes, period);
+        assertEquals(def.getPath(), path);
+        assertEquals(def.getRngBackendModel(), backendModel);
+        assertEquals(def.getRngModel(), LibvirtVMDef.RngDef.RngModel.VIRTIO);
+        assertEquals(def.getRngRateBytes(), bytes);
+        assertEquals(def.getRngRatePeriod(), period);
+    }
+
 }


### PR DESCRIPTION
By adding a Random Number Generator device to Instances we can prevent
entropy starvation inside guest.

The default source is /dev/random on the host, but this can be configured
to another source when present, for example a hardware RNG.

When enabled it will add the following to the Instance's XML definition:
    
      <rng model='virtio'>
        <backend model='random'>/dev/random</backend>
      </rng>
    
If the Instance has the proper support, which most modern distributions have,
it will have a /dev/hwrng device which it can use for gathering entropy.
