### PR TITLE
CLOUDSTACK-9401 : Support for Internal DNS in Nuage VSP plugin

### DIFF
--- a/api/src/com/cloud/network/element/DnsServiceProvider.java
+++ b/api/src/com/cloud/network/element/DnsServiceProvider.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.network.element;
+
+import com.cloud.deploy.DeployDestination;
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.network.Network;
+import com.cloud.vm.NicProfile;
+import com.cloud.vm.ReservationContext;
+import com.cloud.vm.VirtualMachineProfile;
+
+public interface DnsServiceProvider extends NetworkElement {
+    boolean addDnsEntry(Network network, NicProfile nic, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
+        throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException;
+
+    boolean configDnsSupportForSubnet(Network network, NicProfile nic, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
+        throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException;
+
+    boolean removeDnsSupportForSubnet(Network network) throws ResourceUnavailableException;
+}

--- a/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.ConfigKey.Scope;
-
 import com.cloud.deploy.DataCenterDeployment;
 import com.cloud.deploy.DeployDestination;
 import com.cloud.deploy.DeploymentPlan;
@@ -39,6 +38,7 @@ import com.cloud.network.Network.Service;
 import com.cloud.network.NetworkProfile;
 import com.cloud.network.PhysicalNetwork;
 import com.cloud.network.element.DhcpServiceProvider;
+import com.cloud.network.element.DnsServiceProvider;
 import com.cloud.network.element.LoadBalancingServiceProvider;
 import com.cloud.network.element.StaticNatServiceProvider;
 import com.cloud.network.element.UserDataServiceProvider;
@@ -218,6 +218,8 @@ public interface NetworkOrchestrationService {
     Nic savePlaceholderNic(Network network, String ip4Address, String ip6Address, Type vmType);
 
     DhcpServiceProvider getDhcpServiceProvider(Network network);
+
+    DnsServiceProvider getDnsServiceProvider(Network network);
 
     void removeDhcpServiceInSubnet(Nic nic);
 

--- a/plugins/network-elements/nuage-vsp/pom.xml
+++ b/plugins/network-elements/nuage-vsp/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>net.nuage.vsp</groupId>
       <artifactId>nuage-vsp-acs-client</artifactId>
-      <version>3.2.8.0</version>
+      <version>3.2.8.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/PingNuageVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/PingNuageVspCommand.java
@@ -19,6 +19,8 @@
 
 package com.cloud.agent.api;
 
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import com.cloud.host.Host;
 
 public class PingNuageVspCommand extends PingCommand {
@@ -38,19 +40,18 @@ public class PingNuageVspCommand extends PingCommand {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof PingNuageVspCommand)) return false;
-        if (!super.equals(o)) return false;
 
         PingNuageVspCommand that = (PingNuageVspCommand) o;
 
-        if (shouldAudit != that.shouldAudit) return false;
-
-        return true;
+        return super.equals(that)
+                && shouldAudit == that.shouldAudit;
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (shouldAudit ? 1 : 0);
-        return result;
+        return new HashCodeBuilder()
+            .appendSuper(super.hashCode())
+            .append(shouldAudit)
+            .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ApplyStaticNatVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ApplyStaticNatVspCommand.java
@@ -19,11 +19,15 @@
 
 package com.cloud.agent.api.element;
 
-import com.cloud.agent.api.Command;
+import java.util.List;
+import java.util.Objects;
+
 import net.nuage.vsp.acs.client.api.model.VspNetwork;
 import net.nuage.vsp.acs.client.api.model.VspStaticNat;
 
-import java.util.List;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.cloud.agent.api.Command;
 
 public class ApplyStaticNatVspCommand extends Command {
 
@@ -51,24 +55,26 @@ public class ApplyStaticNatVspCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ApplyStaticNatVspCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof ApplyStaticNatVspCommand)) {
+            return false;
+        }
 
         ApplyStaticNatVspCommand that = (ApplyStaticNatVspCommand) o;
 
-        if (_network != null ? !_network.equals(that._network) : that._network != null) return false;
-        if (_staticNatDetails != null ? !_staticNatDetails.equals(that._staticNatDetails) : that._staticNatDetails != null)
-            return false;
-
-        return true;
+        return super.equals(that)
+                && Objects.equals(_network, that._network)
+                && Objects.equals(_staticNatDetails, that._staticNatDetails);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_network != null ? _network.hashCode() : 0);
-        result = 31 * result + (_staticNatDetails != null ? _staticNatDetails.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_network)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ImplementVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ImplementVspCommand.java
@@ -19,36 +19,37 @@
 
 package com.cloud.agent.api.element;
 
-import com.cloud.agent.api.Command;
+import java.util.List;
+import java.util.Objects;
+
 import net.nuage.vsp.acs.client.api.model.VspAclRule;
+import net.nuage.vsp.acs.client.api.model.VspDhcpDomainOption;
 import net.nuage.vsp.acs.client.api.model.VspNetwork;
 
-import java.util.List;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.cloud.agent.api.Command;
 
 public class ImplementVspCommand extends Command {
 
     private final VspNetwork _network;
-    private final List<String> _dnsServers;
     private final List<VspAclRule> _ingressFirewallRules;
     private final List<VspAclRule> _egressFirewallRules;
     private final List<String> _floatingIpUuids;
+    private final VspDhcpDomainOption _dhcpOption;
 
-    public ImplementVspCommand(VspNetwork network, List<String> dnsServers, List<VspAclRule> ingressFirewallRules,
-            List<VspAclRule> egressFirewallRules, List<String> floatingIpUuids) {
+    public ImplementVspCommand(VspNetwork network, List<VspAclRule> ingressFirewallRules,
+                               List<VspAclRule> egressFirewallRules, List<String> floatingIpUuids, VspDhcpDomainOption dhcpOption) {
         super();
         this._network = network;
-        this._dnsServers = dnsServers;
         this._ingressFirewallRules = ingressFirewallRules;
         this._egressFirewallRules = egressFirewallRules;
         this._floatingIpUuids = floatingIpUuids;
+        this._dhcpOption = dhcpOption;
     }
 
     public VspNetwork getNetwork() {
         return _network;
-    }
-
-    public List<String> getDnsServers() {
-        return _dnsServers;
     }
 
     public List<VspAclRule> getIngressFirewallRules() {
@@ -63,6 +64,10 @@ public class ImplementVspCommand extends Command {
         return _floatingIpUuids;
     }
 
+    public VspDhcpDomainOption getDhcpOption() {
+        return _dhcpOption;
+    }
+
     @Override
     public boolean executeInSequence() {
         return false;
@@ -70,32 +75,30 @@ public class ImplementVspCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ImplementVspCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof ImplementVspCommand)) {
+            return false;
+        }
 
         ImplementVspCommand that = (ImplementVspCommand) o;
 
-        if (_dnsServers != null ? !_dnsServers.equals(that._dnsServers) : that._dnsServers != null) return false;
-        if (_egressFirewallRules != null ? !_egressFirewallRules.equals(that._egressFirewallRules) : that._egressFirewallRules != null)
-            return false;
-        if (_floatingIpUuids != null ? !_floatingIpUuids.equals(that._floatingIpUuids) : that._floatingIpUuids != null)
-            return false;
-        if (_ingressFirewallRules != null ? !_ingressFirewallRules.equals(that._ingressFirewallRules) : that._ingressFirewallRules != null)
-            return false;
-        if (_network != null ? !_network.equals(that._network) : that._network != null) return false;
-
-        return true;
+        return super.equals(that)
+            && Objects.equals(_network, that._network)
+            && Objects.equals(_dhcpOption, that._dhcpOption)
+            && Objects.equals(_floatingIpUuids, that._floatingIpUuids)
+            && Objects.equals(_ingressFirewallRules, that._ingressFirewallRules)
+            && Objects.equals(_egressFirewallRules, that._egressFirewallRules);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_network != null ? _network.hashCode() : 0);
-        result = 31 * result + (_dnsServers != null ? _dnsServers.hashCode() : 0);
-        result = 31 * result + (_ingressFirewallRules != null ? _ingressFirewallRules.hashCode() : 0);
-        result = 31 * result + (_egressFirewallRules != null ? _egressFirewallRules.hashCode() : 0);
-        result = 31 * result + (_floatingIpUuids != null ? _floatingIpUuids.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_network)
+                .append(_dhcpOption)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ShutDownVpcVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ShutDownVpcVspCommand.java
@@ -19,9 +19,12 @@
 
 package com.cloud.agent.api.element;
 
-import com.cloud.agent.api.Command;
-
 import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.cloud.agent.api.Command;
 
 public class ShutDownVpcVspCommand extends Command {
 
@@ -61,29 +64,30 @@ public class ShutDownVpcVspCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ShutDownVpcVspCommand)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ShutDownVpcVspCommand)) {
+            return false;
+        }
         if (!super.equals(o)) return false;
 
         ShutDownVpcVspCommand that = (ShutDownVpcVspCommand) o;
 
-        if (_domainRouterUuids != null ? !_domainRouterUuids.equals(that._domainRouterUuids) : that._domainRouterUuids != null)
-            return false;
-        if (_domainTemplateName != null ? !_domainTemplateName.equals(that._domainTemplateName) : that._domainTemplateName != null)
-            return false;
-        if (_domainUuid != null ? !_domainUuid.equals(that._domainUuid) : that._domainUuid != null) return false;
-        if (_vpcUuid != null ? !_vpcUuid.equals(that._vpcUuid) : that._vpcUuid != null) return false;
-
-        return true;
+        return super.equals(that)
+            && Objects.equals(_domainUuid, that._domainUuid)
+            && Objects.equals(_vpcUuid, that._vpcUuid)
+            && Objects.equals(_domainTemplateName, that._domainTemplateName)
+            && Objects.equals(_domainRouterUuids, that._domainRouterUuids);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_domainUuid != null ? _domainUuid.hashCode() : 0);
-        result = 31 * result + (_vpcUuid != null ? _vpcUuid.hashCode() : 0);
-        result = 31 * result + (_domainTemplateName != null ? _domainTemplateName.hashCode() : 0);
-        result = 31 * result + (_domainRouterUuids != null ? _domainRouterUuids.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_domainUuid)
+                .append(_vpcUuid)
+                .append(_domainTemplateName)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ShutDownVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/element/ShutDownVspCommand.java
@@ -19,45 +19,32 @@
 
 package com.cloud.agent.api.element;
 
-import java.util.List;
 import java.util.Objects;
 
-import net.nuage.vsp.acs.client.api.model.VspAclRule;
+import net.nuage.vsp.acs.client.api.model.VspDhcpDomainOption;
 import net.nuage.vsp.acs.client.api.model.VspNetwork;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.cloud.agent.api.Command;
 
-public class ApplyAclRuleVspCommand extends Command {
+public class ShutDownVspCommand extends Command {
 
-    private final VspAclRule.ACLType _aclType;
     private final VspNetwork _network;
-    private final List<VspAclRule> _aclRules;
-    private final boolean _networkReset;
+    private final VspDhcpDomainOption _dhcpOptions;
 
-    public ApplyAclRuleVspCommand(VspAclRule.ACLType aclType, VspNetwork network, List<VspAclRule> aclRules, boolean networkReset) {
+    public ShutDownVspCommand(VspNetwork network, VspDhcpDomainOption dhcpOptions) {
         super();
-        this._aclType = aclType;
         this._network = network;
-        this._aclRules = aclRules;
-        this._networkReset = networkReset;
-    }
-
-    public VspAclRule.ACLType getAclType() {
-        return _aclType;
+        this._dhcpOptions = dhcpOptions;
     }
 
     public VspNetwork getNetwork() {
         return _network;
     }
 
-    public List<VspAclRule> getAclRules() {
-        return _aclRules;
-    }
-
-    public boolean isNetworkReset() {
-        return _networkReset;
+    public VspDhcpDomainOption getDhcpOptions() {
+        return _dhcpOptions;
     }
 
     @Override
@@ -70,27 +57,28 @@ public class ApplyAclRuleVspCommand extends Command {
         if (this == o) {
             return true;
         }
-
-        if (!(o instanceof ApplyAclRuleVspCommand)) {
+        if (!(o instanceof ShutDownVspCommand)) {
             return false;
         }
 
-        ApplyAclRuleVspCommand that = (ApplyAclRuleVspCommand) o;
+        ShutDownVspCommand that = (ShutDownVspCommand) o;
 
         return super.equals(that)
-                && _networkReset == that._networkReset
-                && Objects.equals(_aclType, that._aclType)
-                && Objects.equals(_network, that._network)
-                && Objects.equals(_aclRules, that._aclRules);
+                && Objects.equals(_dhcpOptions, that._dhcpOptions)
+                && Objects.equals(_network, that._network);
     }
+
+
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(_aclType)
-                .append(_network)
-                .append(_networkReset)
-                .toHashCode();
+        return Objects.hash(_network, _dhcpOptions);
+    }
+
+    public String toDetailString() {
+        return new ToStringBuilder(this)
+                .append("network", _network)
+                .append("dhcpOptions", _dhcpOptions)
+                .toString();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/DeallocateVmVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/DeallocateVmVspCommand.java
@@ -19,10 +19,15 @@
 
 package com.cloud.agent.api.guru;
 
-import com.cloud.agent.api.Command;
+import java.util.Objects;
+
 import net.nuage.vsp.acs.client.api.model.VspNetwork;
 import net.nuage.vsp.acs.client.api.model.VspNic;
 import net.nuage.vsp.acs.client.api.model.VspVm;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.cloud.agent.api.Command;
 
 public class DeallocateVmVspCommand extends Command {
 
@@ -56,25 +61,29 @@ public class DeallocateVmVspCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DeallocateVmVspCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof DeallocateVmVspCommand)) {
+            return false;
+        }
 
         DeallocateVmVspCommand that = (DeallocateVmVspCommand) o;
 
-        if (_network != null ? !_network.equals(that._network) : that._network != null) return false;
-        if (_nic != null ? !_nic.equals(that._nic) : that._nic != null) return false;
-        if (_vm != null ? !_vm.equals(that._vm) : that._vm != null) return false;
-
-        return true;
+        return super.equals(that)
+                && Objects.equals(_network, that._network)
+                && Objects.equals(_nic, that._nic)
+                && Objects.equals(_vm, that._vm);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_network != null ? _network.hashCode() : 0);
-        result = 31 * result + (_vm != null ? _vm.hashCode() : 0);
-        result = 31 * result + (_nic != null ? _nic.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+            .appendSuper(super.hashCode())
+            .append(_network)
+            .append(_vm)
+            .append(_nic)
+            .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/ImplementNetworkVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/ImplementNetworkVspCommand.java
@@ -19,28 +19,33 @@
 
 package com.cloud.agent.api.guru;
 
-import com.cloud.agent.api.Command;
+import java.util.Objects;
+
+import net.nuage.vsp.acs.client.api.model.VspDhcpDomainOption;
 import net.nuage.vsp.acs.client.api.model.VspNetwork;
 
-import java.util.List;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import com.cloud.agent.api.Command;
 
 public class ImplementNetworkVspCommand extends Command {
 
     private final VspNetwork _network;
-    private final List<String> _dnsServers;
+    private final VspDhcpDomainOption _dhcpOption;
 
-    public ImplementNetworkVspCommand(VspNetwork network, List<String> dnsServers) {
+    public ImplementNetworkVspCommand(VspNetwork network, VspDhcpDomainOption dhcpOption) {
         super();
         this._network = network;
-        this._dnsServers = dnsServers;
+        this._dhcpOption = dhcpOption;
     }
 
     public VspNetwork getNetwork() {
         return _network;
     }
 
-    public List<String> getDnsServers() {
-        return _dnsServers;
+    public VspDhcpDomainOption getDhcpOption() {
+        return _dhcpOption;
     }
 
     @Override
@@ -50,23 +55,34 @@ public class ImplementNetworkVspCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ImplementNetworkVspCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof ImplementNetworkVspCommand)) {
+            return false;
+        }
 
         ImplementNetworkVspCommand that = (ImplementNetworkVspCommand) o;
 
-        if (_dnsServers != null ? !_dnsServers.equals(that._dnsServers) : that._dnsServers != null) return false;
-        if (_network != null ? !_network.equals(that._network) : that._network != null) return false;
-
-        return true;
+        return super.equals(that)
+            && Objects.equals(_dhcpOption, that._dhcpOption)
+            && Objects.equals(_network, that._network);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_network != null ? _network.hashCode() : 0);
-        result = 31 * result + (_dnsServers != null ? _dnsServers.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_network)
+                .append(_dhcpOption)
+                .toHashCode();
+    }
+
+    public String toDetailString() {
+        return new ToStringBuilder(this)
+                .append("network", _network)
+                .append("dhcpOption", _dhcpOption)
+                .toString();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/ReserveVmInterfaceVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/ReserveVmInterfaceVspCommand.java
@@ -19,11 +19,17 @@
 
 package com.cloud.agent.api.guru;
 
-import com.cloud.agent.api.Command;
+import java.util.Objects;
+
+import net.nuage.vsp.acs.client.api.model.VspDhcpVMOption;
 import net.nuage.vsp.acs.client.api.model.VspNetwork;
 import net.nuage.vsp.acs.client.api.model.VspNic;
 import net.nuage.vsp.acs.client.api.model.VspStaticNat;
 import net.nuage.vsp.acs.client.api.model.VspVm;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.cloud.agent.api.Command;
 
 public class ReserveVmInterfaceVspCommand extends Command {
 
@@ -31,13 +37,15 @@ public class ReserveVmInterfaceVspCommand extends Command {
     private final VspVm _vm;
     private final VspNic _nic;
     private final VspStaticNat _staticNat;
+    private final  VspDhcpVMOption _dhcpOption;
 
-    public ReserveVmInterfaceVspCommand(VspNetwork network, VspVm vm, VspNic nic, VspStaticNat staticNat) {
+    public ReserveVmInterfaceVspCommand(VspNetwork network, VspVm vm, VspNic nic, VspStaticNat staticNat, VspDhcpVMOption dhcpOption) {
         super();
         this._network = network;
         this._vm = vm;
         this._nic = nic;
         this._staticNat = staticNat;
+        this._dhcpOption = dhcpOption;
     }
 
     public VspNetwork getNetwork() {
@@ -56,6 +64,10 @@ public class ReserveVmInterfaceVspCommand extends Command {
         return _staticNat;
     }
 
+    public VspDhcpVMOption getDhcpOption() {
+        return _dhcpOption;
+    }
+
     @Override
     public boolean executeInSequence() {
         return false;
@@ -63,27 +75,33 @@ public class ReserveVmInterfaceVspCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ReserveVmInterfaceVspCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof ReserveVmInterfaceVspCommand)) {
+            return false;
+        }
 
         ReserveVmInterfaceVspCommand that = (ReserveVmInterfaceVspCommand) o;
 
-        if (_network != null ? !_network.equals(that._network) : that._network != null) return false;
-        if (_nic != null ? !_nic.equals(that._nic) : that._nic != null) return false;
-        if (_staticNat != null ? !_staticNat.equals(that._staticNat) : that._staticNat != null) return false;
-        if (_vm != null ? !_vm.equals(that._vm) : that._vm != null) return false;
-
-        return true;
+        return super.equals(that)
+                && Objects.equals(_network, that._network)
+                && Objects.equals(_nic, that._nic)
+                && Objects.equals(_dhcpOption, that._dhcpOption)
+                && Objects.equals(_staticNat, that._staticNat)
+                && Objects.equals(_vm, that._vm);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_network != null ? _network.hashCode() : 0);
-        result = 31 * result + (_vm != null ? _vm.hashCode() : 0);
-        result = 31 * result + (_nic != null ? _nic.hashCode() : 0);
-        result = 31 * result + (_staticNat != null ? _staticNat.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_network)
+                .append(_vm)
+                .append(_nic)
+                .append(_staticNat)
+                .append(_dhcpOption)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/TrashNetworkVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/TrashNetworkVspCommand.java
@@ -19,8 +19,13 @@
 
 package com.cloud.agent.api.guru;
 
-import com.cloud.agent.api.Command;
+import java.util.Objects;
+
 import net.nuage.vsp.acs.client.api.model.VspNetwork;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.cloud.agent.api.Command;
 
 public class TrashNetworkVspCommand extends Command {
 
@@ -42,21 +47,25 @@ public class TrashNetworkVspCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TrashNetworkVspCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof TrashNetworkVspCommand)) {
+            return false;
+        }
 
         TrashNetworkVspCommand that = (TrashNetworkVspCommand) o;
 
-        if (_network != null ? !_network.equals(that._network) : that._network != null) return false;
-
-        return true;
+        return super.equals(that)
+                && Objects.equals(_network, that._network);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_network != null ? _network.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_network)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/UpdateDhcpOptionVspCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/guru/UpdateDhcpOptionVspCommand.java
@@ -17,42 +17,35 @@
 // under the License.
 //
 
-package com.cloud.agent.api.sync;
+package com.cloud.agent.api.guru;
 
+import java.util.List;
 import java.util.Objects;
 
-import net.nuage.vsp.acs.client.api.model.VspDomain;
+import net.nuage.vsp.acs.client.api.model.VspDhcpVMOption;
+import net.nuage.vsp.acs.client.api.model.VspNetwork;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.cloud.agent.api.Command;
 
-public class SyncDomainCommand extends Command {
+public class UpdateDhcpOptionVspCommand extends Command {
 
-    public enum Type { ADD, REMOVE }
-    private final VspDomain _domain;
-    private final Type _action;
+    private final List<VspDhcpVMOption> _dhcpOptions;
+    private final VspNetwork _network;
 
-    public SyncDomainCommand(VspDomain domain, Type action) {
-        super();
-        this._domain = domain;
-        this._action = action;
+    public UpdateDhcpOptionVspCommand(List<VspDhcpVMOption> dhcpOptions, VspNetwork network) {
+        this._dhcpOptions = dhcpOptions;
+        this._network = network;
     }
 
-    public VspDomain getDomain() {
-        return _domain;
+    public List<VspDhcpVMOption> getDhcpOptions() {
+        return _dhcpOptions;
     }
 
-    public Type getAction() {
-        return _action;
-    }
-
-    public boolean isToAdd() {
-        return Type.ADD.equals(_action);
-    }
-
-    public boolean isToRemove() {
-        return Type.REMOVE.equals(_action);
+    public VspNetwork getNetwork() {
+        return _network;
     }
 
     @Override
@@ -62,23 +55,33 @@ public class SyncDomainCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SyncDomainCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
 
-        SyncDomainCommand that = (SyncDomainCommand) o;
+        if (!(o instanceof UpdateDhcpOptionVspCommand)) {
+            return false;
+        }
+
+        UpdateDhcpOptionVspCommand that = (UpdateDhcpOptionVspCommand) o;
 
         return super.equals(that)
-                && Objects.equals(_action, that._action)
-                && Objects.equals(_domain, that._domain);
+                && Objects.equals(_network, that._network)
+                && Objects.equals(_dhcpOptions, that._dhcpOptions);
     }
 
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
                 .appendSuper(super.hashCode())
-                .append(_domain)
-                .append(_action)
+                .append(_network)
                 .toHashCode();
+    }
+
+    public String toDetailString() {
+        return new ToStringBuilder(this)
+                .append("network", _network)
+                .append("dhcpOptions", _dhcpOptions)
+                .toString();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/manager/GetApiDefaultsAnswer.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/manager/GetApiDefaultsAnswer.java
@@ -19,8 +19,13 @@
 
 package com.cloud.agent.api.manager;
 
-import com.cloud.agent.api.Answer;
+import java.util.Objects;
+
 import net.nuage.vsp.acs.client.api.model.VspApiDefaults;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import com.cloud.agent.api.Answer;
 
 public class GetApiDefaultsAnswer extends Answer {
 
@@ -41,21 +46,25 @@ public class GetApiDefaultsAnswer extends Answer {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GetApiDefaultsAnswer)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof GetApiDefaultsAnswer)) {
+            return false;
+        }
 
         GetApiDefaultsAnswer that = (GetApiDefaultsAnswer) o;
 
-        if (_apiDefaults != null ? !_apiDefaults.equals(that._apiDefaults) : that._apiDefaults != null) return false;
-
-        return true;
+        return super.equals(that)
+                && Objects.equals(_apiDefaults, that._apiDefaults);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_apiDefaults != null ? _apiDefaults.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_apiDefaults)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/manager/SupportedApiVersionCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/manager/SupportedApiVersionCommand.java
@@ -19,6 +19,10 @@
 
 package com.cloud.agent.api.manager;
 
+import java.util.Objects;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import com.cloud.agent.api.Command;
 
 public class SupportedApiVersionCommand extends Command {
@@ -41,21 +45,26 @@ public class SupportedApiVersionCommand extends Command {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SupportedApiVersionCommand)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof SupportedApiVersionCommand)) {
+            return false;
+        }
 
         SupportedApiVersionCommand that = (SupportedApiVersionCommand) o;
 
-        if (_apiVersion != null ? !_apiVersion.equals(that._apiVersion) : that._apiVersion != null) return false;
+        return super.equals(that)
+                && Objects.equals(_apiVersion, that._apiVersion);
 
-        return true;
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_apiVersion != null ? _apiVersion.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_apiVersion)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/sync/SyncDomainAnswer.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/sync/SyncDomainAnswer.java
@@ -19,6 +19,8 @@
 
 package com.cloud.agent.api.sync;
 
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import com.cloud.agent.api.Answer;
 
 public class SyncDomainAnswer extends Answer {
@@ -37,21 +39,26 @@ public class SyncDomainAnswer extends Answer {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SyncDomainAnswer)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof SyncDomainAnswer)) {
+            return false;
+        }
 
         SyncDomainAnswer that = (SyncDomainAnswer) o;
 
-        if (_success != that._success) return false;
-
-        return true;
+        return super.equals(that)
+                && _success == that._success;
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_success ? 1 : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_success)
+                .toHashCode();
+
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/sync/SyncNuageVspCmsIdAnswer.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/sync/SyncNuageVspCmsIdAnswer.java
@@ -19,6 +19,10 @@
 
 package com.cloud.agent.api.sync;
 
+import java.util.Objects;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import com.cloud.agent.api.Answer;
 
 public class SyncNuageVspCmsIdAnswer extends Answer {
@@ -48,26 +52,29 @@ public class SyncNuageVspCmsIdAnswer extends Answer {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SyncNuageVspCmsIdAnswer)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof SyncNuageVspCmsIdAnswer)) {
+            return false;
+        }
 
         SyncNuageVspCmsIdAnswer that = (SyncNuageVspCmsIdAnswer) o;
 
-        if (_success != that._success) return false;
-        if (_nuageVspCmsId != null ? !_nuageVspCmsId.equals(that._nuageVspCmsId) : that._nuageVspCmsId != null)
-            return false;
-        if (_syncType != that._syncType) return false;
-
-        return true;
+        return super.equals(that)
+                && _success == that._success
+                && Objects.equals(_syncType, that._syncType)
+                && Objects.equals(_nuageVspCmsId, that._nuageVspCmsId);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_success ? 1 : 0);
-        result = 31 * result + (_nuageVspCmsId != null ? _nuageVspCmsId.hashCode() : 0);
-        result = 31 * result + (_syncType != null ? _syncType.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_syncType)
+                .append(_nuageVspCmsId)
+                .append(_success)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/sync/SyncNuageVspCmsIdCommand.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/agent/api/sync/SyncNuageVspCmsIdCommand.java
@@ -19,6 +19,10 @@
 
 package com.cloud.agent.api.sync;
 
+import java.util.Objects;
+
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import com.cloud.agent.api.Command;
 
 public class SyncNuageVspCmsIdCommand extends Command {
@@ -55,18 +59,17 @@ public class SyncNuageVspCmsIdCommand extends Command {
 
         SyncNuageVspCmsIdCommand that = (SyncNuageVspCmsIdCommand) o;
 
-        if (_nuageVspCmsId != null ? !_nuageVspCmsId.equals(that._nuageVspCmsId) : that._nuageVspCmsId != null)
-            return false;
-        if (_syncType != that._syncType) return false;
-
-        return true;
+        return super.equals(that)
+                && Objects.equals(_syncType, that._syncType)
+                && Objects.equals(_nuageVspCmsId, that._nuageVspCmsId);
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (_syncType != null ? _syncType.hashCode() : 0);
-        result = 31 * result + (_nuageVspCmsId != null ? _nuageVspCmsId.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(_syncType)
+                .append(_nuageVspCmsId)
+                .toHashCode();
     }
 }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/element/NuageVspElement.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/element/NuageVspElement.java
@@ -19,6 +19,31 @@
 
 package com.cloud.network.element;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.log4j.Logger;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import net.nuage.vsp.acs.client.api.model.VspAclRule;
+import net.nuage.vsp.acs.client.api.model.VspDhcpDomainOption;
+import net.nuage.vsp.acs.client.api.model.VspNetwork;
+import net.nuage.vsp.acs.client.api.model.VspStaticNat;
+
+import org.apache.cloudstack.api.InternalIdentity;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.network.ExternalNetworkDeviceManager;
+import org.apache.cloudstack.network.topology.NetworkTopologyContext;
+import org.apache.cloudstack.resourcedetail.VpcDetailVO;
+import org.apache.cloudstack.resourcedetail.dao.VpcDetailsDao;
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.StartupCommand;
@@ -27,6 +52,7 @@ import com.cloud.agent.api.element.ApplyAclRuleVspCommand;
 import com.cloud.agent.api.element.ApplyStaticNatVspCommand;
 import com.cloud.agent.api.element.ImplementVspCommand;
 import com.cloud.agent.api.element.ShutDownVpcVspCommand;
+import com.cloud.agent.api.element.ShutDownVspCommand;
 import com.cloud.dc.VlanVO;
 import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.dc.dao.VlanDao;
@@ -60,6 +86,7 @@ import com.cloud.network.dao.PhysicalNetworkDao;
 import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.network.manager.NuageVspManager;
 import com.cloud.network.manager.NuageVspManagerImpl;
+import com.cloud.network.router.VpcVirtualNetworkApplianceManager;
 import com.cloud.network.rules.FirewallRule;
 import com.cloud.network.rules.FirewallRule.FirewallRuleType;
 import com.cloud.network.rules.FirewallRuleVO;
@@ -74,12 +101,14 @@ import com.cloud.network.vpc.VpcOfferingServiceMapVO;
 import com.cloud.network.vpc.dao.VpcDao;
 import com.cloud.network.vpc.dao.VpcOfferingServiceMapDao;
 import com.cloud.offering.NetworkOffering;
+import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
 import com.cloud.resource.ResourceManager;
 import com.cloud.resource.ResourceStateAdapter;
 import com.cloud.resource.ServerResource;
 import com.cloud.resource.UnableDeleteHostException;
+import com.cloud.util.NuageVspEntityBuilder;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.DomainRouterVO;
@@ -89,28 +118,6 @@ import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-import com.cloud.util.NuageVspEntityBuilder;
-import net.nuage.vsp.acs.client.api.model.VspAclRule;
-import net.nuage.vsp.acs.client.api.model.VspNetwork;
-import net.nuage.vsp.acs.client.api.model.VspStaticNat;
-import org.apache.cloudstack.api.InternalIdentity;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.cloudstack.network.ExternalNetworkDeviceManager;
-import org.apache.cloudstack.resourcedetail.VpcDetailVO;
-import org.apache.cloudstack.resourcedetail.dao.VpcDetailsDao;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.log4j.Logger;
-
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class NuageVspElement extends AdapterBase implements ConnectivityProvider, IpDeployer, SourceNatServiceProvider, StaticNatServiceProvider, FirewallServiceProvider,
         DhcpServiceProvider, ResourceStateAdapter, VpcProvider, NetworkACLServiceProvider {
@@ -169,8 +176,16 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
     NuageVspEntityBuilder _nuageVspEntityBuilder;
     @Inject
     VpcDetailsDao _vpcDetailsDao;
+
+    @Inject
+    NetworkModel _networkMgr;
+    @Inject
+    NetworkTopologyContext networkTopologyContext;
     @Inject
     DomainRouterDao _routerDao;
+    @Inject
+    VpcVirtualNetworkApplianceManager _routerMgr;
+
 
     @Override
     public boolean applyIps(Network network, List<? extends PublicIpAddress> ipAddress, Set<Service> service) throws ResourceUnavailableException {
@@ -257,8 +272,7 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
         }
 
 
-        VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(network, false);
-        List<String> dnsServers = _nuageVspManager.getDnsDetails(network);
+        VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(network, true);
         List<VspAclRule> ingressFirewallRules = getFirewallRulesToApply(network, FirewallRule.TrafficType.Ingress);
         List<VspAclRule> egressFirewallRules = getFirewallRulesToApply(network, FirewallRule.TrafficType.Egress);
 
@@ -267,9 +281,9 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
         for (IPAddressVO ip : ips) {
             floatingIpUuids.add(ip.getUuid());
         }
-
+        VspDhcpDomainOption vspDhcpOptions = _nuageVspEntityBuilder.buildNetworkDhcpOption(network, offering);
         HostVO nuageVspHost = getNuageVspHost(network.getPhysicalNetworkId());
-        ImplementVspCommand cmd = new ImplementVspCommand(vspNetwork, dnsServers, ingressFirewallRules, egressFirewallRules, floatingIpUuids);
+        ImplementVspCommand cmd = new ImplementVspCommand(vspNetwork, ingressFirewallRules, egressFirewallRules, floatingIpUuids, vspDhcpOptions);
         Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
         if (answer == null || !answer.getResult()) {
             s_logger.error("ImplementVspCommand for network " + network.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
@@ -277,7 +291,6 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
                 throw new ResourceUnavailableException(answer.getDetails(), Network.class, network.getId());
             }
         }
-
         return true;
     }
 
@@ -335,7 +348,21 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
         if (!canHandle(network, Service.Connectivity)) {
             return false;
         }
-
+        if (cleanup && isDnsSupportedByVR(network)) {
+            // The network is restarted, possibly the domain name is changed, update the dhcpOptions as soon as possible
+            NetworkOfferingVO networkOfferingVO = _ntwkOfferingDao.findById(network.getNetworkOfferingId());
+            VspDhcpDomainOption vspDhcpOptions = _nuageVspEntityBuilder.buildNetworkDhcpOption(network, networkOfferingVO);
+            VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(network, false);
+            HostVO nuageVspHost = getNuageVspHost(network.getPhysicalNetworkId());
+            ShutDownVspCommand cmd = new ShutDownVspCommand(vspNetwork, vspDhcpOptions);
+            Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
+            if (answer == null || !answer.getResult()) {
+                s_logger.error("ShutDownVspCommand for network " + network.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
+                if ((null != answer) && (null != answer.getDetails())) {
+                    throw new ResourceUnavailableException(answer.getDetails(), Network.class, network.getId());
+                }
+            }
+        }
         return true;
     }
 
@@ -436,10 +463,17 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
         return true;
     }
 
+    private boolean isDnsSupportedByVR(Network network) {
+        return (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dns) &&
+                ( _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dns,  Provider.VirtualRouter) ||
+                        _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dns,  Provider.VPCVirtualRouter)));
+    }
+
     @Override
     public boolean removeDhcpSupportForSubnet(Network network) throws ResourceUnavailableException {
         return true;
     }
+
 
     @Override
     public boolean applyStaticNats(Network config, List<? extends StaticNat> rules) throws ResourceUnavailableException {

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/resource/NuageVspResource.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/resource/NuageVspResource.java
@@ -19,6 +19,24 @@
 
 package com.cloud.network.resource;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+
+import javax.naming.ConfigurationException;
+
+import net.nuage.vsp.acs.NuageVspPluginClientLoader;
+import net.nuage.vsp.acs.client.api.NuageVspApiClient;
+import net.nuage.vsp.acs.client.api.NuageVspElementClient;
+import net.nuage.vsp.acs.client.api.NuageVspGuruClient;
+import net.nuage.vsp.acs.client.api.NuageVspManagerClient;
+import net.nuage.vsp.acs.client.common.model.Pair;
+
+import org.apache.log4j.Logger;
+
+import com.google.common.base.Strings;
+
 import com.cloud.agent.IAgentControl;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
@@ -34,10 +52,12 @@ import com.cloud.agent.api.element.ApplyAclRuleVspCommand;
 import com.cloud.agent.api.element.ApplyStaticNatVspCommand;
 import com.cloud.agent.api.element.ImplementVspCommand;
 import com.cloud.agent.api.element.ShutDownVpcVspCommand;
+import com.cloud.agent.api.element.ShutDownVspCommand;
 import com.cloud.agent.api.guru.DeallocateVmVspCommand;
 import com.cloud.agent.api.guru.ImplementNetworkVspCommand;
 import com.cloud.agent.api.guru.ReserveVmInterfaceVspCommand;
 import com.cloud.agent.api.guru.TrashNetworkVspCommand;
+import com.cloud.agent.api.guru.UpdateDhcpOptionVspCommand;
 import com.cloud.agent.api.manager.GetApiDefaultsAnswer;
 import com.cloud.agent.api.manager.GetApiDefaultsCommand;
 import com.cloud.agent.api.manager.SupportedApiVersionCommand;
@@ -51,20 +71,6 @@ import com.cloud.util.NuageVspUtil;
 import com.cloud.utils.StringUtils;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.exception.CloudRuntimeException;
-import com.google.common.base.Strings;
-import net.nuage.vsp.acs.NuageVspPluginClientLoader;
-import net.nuage.vsp.acs.client.api.NuageVspApiClient;
-import net.nuage.vsp.acs.client.api.NuageVspElementClient;
-import net.nuage.vsp.acs.client.api.NuageVspGuruClient;
-import net.nuage.vsp.acs.client.api.NuageVspManagerClient;
-import net.nuage.vsp.acs.client.common.model.Pair;
-import org.apache.log4j.Logger;
-
-import javax.naming.ConfigurationException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
 
 import static com.cloud.agent.api.sync.SyncNuageVspCmsIdCommand.SyncType;
 
@@ -291,6 +297,8 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
             return executeRequest((DeallocateVmVspCommand)cmd);
         } else if (cmd instanceof TrashNetworkVspCommand) {
             return executeRequest((TrashNetworkVspCommand)cmd);
+        } else if (cmd instanceof UpdateDhcpOptionVspCommand) {
+            return executeRequest((UpdateDhcpOptionVspCommand)cmd);
         }
         //Element commands
         else if (cmd instanceof ImplementVspCommand) {
@@ -301,6 +309,8 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
             return executeRequest((ApplyStaticNatVspCommand)cmd);
         } else if (cmd instanceof ShutDownVpcVspCommand) {
             return executeRequest((ShutDownVpcVspCommand)cmd);
+        } else if (cmd instanceof ShutDownVspCommand) {
+            return executeRequest((ShutDownVspCommand)cmd);
         }
         //Sync Commands
         else if (cmd instanceof SyncNuageVspCmsIdCommand) {
@@ -344,10 +354,10 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
     private Answer executeRequest(ImplementNetworkVspCommand cmd) {
         try {
             isNuageVspGuruLoaded();
-            _nuageVspGuruClient.implement(cmd.getNetwork(), cmd.getDnsServers());
+            _nuageVspGuruClient.implement(cmd.getNetwork(), cmd.getDhcpOption());
             return new Answer(cmd, true, "Created network mapping to " + cmd.getNetwork().getName() + " on Nuage VSD " + _hostName);
         } catch (ExecutionException | ConfigurationException e) {
-            s_logger.error("Failure during " + cmd + " on Nuage VSD " + _hostName, e);
+            s_logger.error("Failure during " + cmd.toDetailString() + " on Nuage VSD " + _hostName, e);
             return new Answer(cmd, e);
         }
     }
@@ -355,7 +365,7 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
     private Answer executeRequest(ReserveVmInterfaceVspCommand cmd) {
         try {
             isNuageVspGuruLoaded();
-            _nuageVspGuruClient.reserve(cmd.getNetwork(), cmd.getVm(), cmd.getNic(), cmd.getStaticNat());
+            _nuageVspGuruClient.reserve(cmd.getNetwork(), cmd.getVm(), cmd.getNic(), cmd.getStaticNat(), cmd.getDhcpOption());
             return new Answer(cmd, true, "Created NIC that maps to nicUuid" + cmd.getNic().getUuid() + " on Nuage VSD " + _hostName);
         } catch (ExecutionException | ConfigurationException e) {
             s_logger.error("Failure during " + cmd + " on Nuage VSD " + _hostName, e);
@@ -386,6 +396,17 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
         }
     }
 
+    private Answer executeRequest(UpdateDhcpOptionVspCommand cmd) {
+        try {
+            isNuageVspManagerLoaded();
+            _nuageVspGuruClient.applyDhcpOptions(cmd.getDhcpOptions(), cmd.getNetwork());
+            return new Answer(cmd, true, "Update DhcpOptions on VM's in network: " + cmd.getNetwork().getName() + " on Nuage VSD " + _hostName);
+        } catch (ExecutionException | ConfigurationException e) {
+            s_logger.error("Failure during " + cmd.toDetailString() + " on Nuage VSD " + _hostName, e);
+            return new Answer(cmd, e);
+        }
+    }
+
     private Answer executeRequest(ApplyStaticNatVspCommand cmd) {
         try {
             isNuageVspElementLoaded();
@@ -400,7 +421,7 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
     private Answer executeRequest(ImplementVspCommand cmd) {
         try {
             isNuageVspElementLoaded();
-            boolean success = _nuageVspElementClient.implement(cmd.getNetwork(), cmd.getDnsServers(), cmd.getIngressFirewallRules(),
+            boolean success = _nuageVspElementClient.implement(cmd.getNetwork(), cmd.getDhcpOption(), cmd.getIngressFirewallRules(),
                     cmd.getEgressFirewallRules(), cmd.getFloatingIpUuids());
             return new Answer(cmd, success, "Implemented network " + cmd.getNetwork().getUuid() + " on Nuage VSD " + _hostName);
         } catch (ExecutionException | ConfigurationException e) {
@@ -427,6 +448,17 @@ public class NuageVspResource extends ManagerBase implements ServerResource {
             return new Answer(cmd, true, "Shutdown VPC " + cmd.getVpcUuid() + " on Nuage VSD " + _hostName);
         } catch (ExecutionException | ConfigurationException e) {
             s_logger.error("Failure during " + cmd + " on Nuage VSD " + _hostName, e);
+            return new Answer(cmd, e);
+        }
+    }
+
+    private Answer executeRequest(ShutDownVspCommand cmd) {
+        try {
+            isNuageVspElementLoaded();
+            _nuageVspElementClient.shutdownNetwork(cmd.getNetwork(), cmd.getDhcpOptions());
+            return new Answer(cmd, true, "Shutdown VPC " + cmd.getNetwork().getUuid()+ " on Nuage VSD " + _hostName);
+        } catch (ConfigurationException e) {
+            s_logger.error("Failure during " + cmd.toDetailString() + " on Nuage VSD " + _hostName, e);
             return new Answer(cmd, e);
         }
     }

--- a/plugins/network-elements/nuage-vsp/test/com/cloud/NuageTest.java
+++ b/plugins/network-elements/nuage-vsp/test/com/cloud/NuageTest.java
@@ -19,6 +19,26 @@
 
 package com.cloud;
 
+import java.util.ArrayList;
+
+import net.nuage.vsp.acs.client.api.model.VspAclRule;
+import net.nuage.vsp.acs.client.api.model.VspDhcpDomainOption;
+import net.nuage.vsp.acs.client.api.model.VspDhcpVMOption;
+import net.nuage.vsp.acs.client.api.model.VspDomain;
+import net.nuage.vsp.acs.client.api.model.VspNetwork;
+import net.nuage.vsp.acs.client.api.model.VspNic;
+import net.nuage.vsp.acs.client.api.model.VspStaticNat;
+import net.nuage.vsp.acs.client.api.model.VspVm;
+import net.nuage.vsp.acs.client.common.model.Pair;
+
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.google.common.collect.Lists;
+
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+
 import com.cloud.dc.VlanVO;
 import com.cloud.domain.Domain;
 import com.cloud.network.Network;
@@ -30,17 +50,6 @@ import com.cloud.util.NuageVspEntityBuilder;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.NicVO;
 import com.cloud.vm.VirtualMachine;
-import net.nuage.vsp.acs.client.api.model.VspAclRule;
-import net.nuage.vsp.acs.client.api.model.VspDomain;
-import net.nuage.vsp.acs.client.api.model.VspNetwork;
-import net.nuage.vsp.acs.client.api.model.VspNic;
-import net.nuage.vsp.acs.client.api.model.VspStaticNat;
-import net.nuage.vsp.acs.client.api.model.VspVm;
-import net.nuage.vsp.acs.client.common.model.Pair;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.junit.Before;
-
-import java.util.ArrayList;
 
 import static com.cloud.network.manager.NuageVspManager.NuageVspIsolatedNetworkDomainTemplateName;
 import static com.cloud.network.manager.NuageVspManager.NuageVspSharedNetworkDomainTemplateName;
@@ -48,18 +57,20 @@ import static com.cloud.network.manager.NuageVspManager.NuageVspVpcDomainTemplat
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class NuageTest {
 
     protected static final long NETWORK_ID = 42L;
-    protected NetworkModel _networkModel = mock(NetworkModel.class);
-    protected ConfigurationDao _configurationDao = mock(ConfigurationDao.class);
-    protected NuageVspEntityBuilder _nuageVspEntityBuilder = mock(NuageVspEntityBuilder.class);
+
+    @Mock protected NetworkModel _networkModel;
+    @Mock protected ConfigurationDao _configurationDao;
+    @Mock protected NuageVspEntityBuilder _nuageVspEntityBuilder;
 
     @Before
     public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
         // Standard responses
         when(_networkModel.isProviderForNetwork(Network.Provider.NuageVsp, NETWORK_ID)).thenReturn(true);
         when(_configurationDao.getValue(NuageVspIsolatedNetworkDomainTemplateName.key())).thenReturn("IsolatedDomainTemplate");
@@ -151,6 +162,25 @@ public class NuageTest {
                 .sourceCidrList(new ArrayList<String>())
                 .priority(1)
                 .type(VspAclRule.ACLType.NetworkACL)
+                .build();
+    }
+
+    protected VspDhcpDomainOption buildspDhcpDomainOption () {
+        return new VspDhcpDomainOption.Builder()
+                .vrIsDnsProvider(true)
+                .networkDomain("networkDomain")
+                .dnsServers(Lists.newArrayList("10.10.10.10", "20.20.20.20"))
+                .build();
+    }
+
+    protected VspDhcpVMOption buildspDhcpVMOption () {
+        return new VspDhcpVMOption.Builder()
+                .defaultHasDns(true)
+                .hostname("VMx")
+                .networkHasDns(true)
+                .isDefaultInterface(true)
+                .domainRouter(false)
+                .nicUuid("aaaa-bbbbbbbb-ccccccc")
                 .build();
     }
 

--- a/plugins/network-elements/nuage-vsp/test/com/cloud/network/element/NuageVspElementTest.java
+++ b/plugins/network-elements/nuage-vsp/test/com/cloud/network/element/NuageVspElementTest.java
@@ -19,6 +19,23 @@
 
 package com.cloud.network.element;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.google.common.collect.Lists;
+
+import org.apache.cloudstack.resourcedetail.dao.VpcDetailsDao;
+
 import com.cloud.NuageTest;
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -63,18 +80,6 @@ import com.cloud.util.NuageVspEntityBuilder;
 import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.dao.DomainRouterDao;
-import com.google.common.collect.Lists;
-import org.apache.cloudstack.resourcedetail.dao.VpcDetailsDao;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -85,45 +90,29 @@ import static org.mockito.Mockito.when;
 
 public class NuageVspElementTest extends NuageTest {
 
+    @InjectMocks
     private NuageVspElement _nuageVspElement = new NuageVspElement();
 
-    private NetworkServiceMapDao _networkServiceMapDao = mock(NetworkServiceMapDao.class);
-    private AgentManager _agentManager = mock(AgentManager.class);
-    private HostDao _hostDao = mock(HostDao.class);
-    private NuageVspDao _nuageVspDao = mock(NuageVspDao.class);
-    private DomainDao _domainDao = mock(DomainDao.class);
-    private NetworkOfferingDao _networkOfferingDao = mock(NetworkOfferingDao.class);
-    private NetworkOfferingServiceMapDao _networkOfferingServiceMapDao = mock(NetworkOfferingServiceMapDao.class);
-    private NuageVspManager _nuageVspManager = mock(NuageVspManager.class);
-    private FirewallRulesDao _firewallRulesDao = mock(FirewallRulesDao.class);
-    private IPAddressDao _ipAddressDao = mock(IPAddressDao.class);
-    private PhysicalNetworkDao _physicalNetworkDao = mock(PhysicalNetworkDao.class);
-    private NuageVspEntityBuilder _nuageVspEntityBuilder = mock(NuageVspEntityBuilder.class);
-    private VpcDetailsDao _vpcDetailsDao = mock(VpcDetailsDao.class);
-    private DomainRouterDao _domainRouterDao = mock(DomainRouterDao.class);
+    @Mock private NetworkServiceMapDao _networkServiceMapDao;
+    @Mock private AgentManager _agentManager;
+    @Mock private HostDao _hostDao;
+    @Mock private NuageVspDao _nuageVspDao;
+    @Mock private DomainDao _domainDao;
+    @Mock private NetworkOfferingDao _networkOfferingDao;
+    @Mock private NetworkOfferingServiceMapDao _networkOfferingServiceMapDao;
+    @Mock private NuageVspManager _nuageVspManager;
+    @Mock private FirewallRulesDao _firewallRulesDao;
+    @Mock private IPAddressDao _ipAddressDao;
+    @Mock private PhysicalNetworkDao _physicalNetworkDao;
+    @Mock private NuageVspEntityBuilder _nuageVspEntityBuilder;
+    @Mock private VpcDetailsDao _vpcDetailsDao;
+    @Mock private DomainRouterDao _domainRouterDao;
+    @Mock private ResourceManager _resourceManager;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
-
-        _nuageVspElement._resourceMgr = mock(ResourceManager.class);
-        _nuageVspElement._ntwkSrvcDao = _networkServiceMapDao;
-        _nuageVspElement._networkModel = _networkModel;
-        _nuageVspElement._agentMgr = _agentManager;
-        _nuageVspElement._hostDao = _hostDao;
-        _nuageVspElement._nuageVspDao = _nuageVspDao;
-        _nuageVspElement._ntwkOfferingSrvcDao = _networkOfferingServiceMapDao;
-        _nuageVspElement._domainDao = _domainDao;
-        _nuageVspElement._ntwkOfferingDao = _networkOfferingDao;
-        _nuageVspElement._configDao = _configurationDao;
-        _nuageVspElement._nuageVspManager = _nuageVspManager;
-        _nuageVspElement._firewallRulesDao = _firewallRulesDao;
-        _nuageVspElement._ipAddressDao = _ipAddressDao;
-        _nuageVspElement._physicalNetworkDao = _physicalNetworkDao;
         _nuageVspElement._nuageVspEntityBuilder = _nuageVspEntityBuilder;
-        _nuageVspElement._vpcDetailsDao = _vpcDetailsDao;
-        _nuageVspElement._routerDao = _domainRouterDao;
-
         _nuageVspElement.configure("NuageVspTestElement", Collections.<String, Object>emptyMap());
     }
 

--- a/plugins/network-elements/nuage-vsp/test/com/cloud/network/guru/NuageVspGuestNetworkGuruTest.java
+++ b/plugins/network-elements/nuage-vsp/test/com/cloud/network/guru/NuageVspGuestNetworkGuruTest.java
@@ -19,6 +19,19 @@
 
 package com.cloud.network.guru;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+
 import com.cloud.NuageTest;
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -66,21 +79,15 @@ import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.NicDao;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 
 import static com.cloud.network.manager.NuageVspManager.NuageVspIsolatedNetworkDomainTemplateName;
 import static com.cloud.network.manager.NuageVspManager.NuageVspSharedNetworkDomainTemplateName;
 import static com.cloud.network.manager.NuageVspManager.NuageVspVpcDomainTemplateName;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -89,49 +96,35 @@ import static org.mockito.Mockito.when;
 
 public class NuageVspGuestNetworkGuruTest extends NuageTest {
     private static final long NETWORK_ID = 42L;
-    private PhysicalNetworkDao _physicalNetworkDao = mock(PhysicalNetworkDao.class);
-    private DataCenterDao _dataCenterDao = mock(DataCenterDao.class);
-    private NetworkOfferingServiceMapDao _networkOfferingServiceMapDao = mock(NetworkOfferingServiceMapDao.class);
-    private AgentManager _agentManager = mock(AgentManager.class);
-    private NetworkModel _networkModel = mock(NetworkModel.class);
-    private AccountDao _accountDao = mock(AccountDao.class);
-    private DomainDao _domainDao = mock(DomainDao.class);
-    private NicDao _nicDao = mock(NicDao.class);
-    private NetworkOfferingDao _networkOfferingDao = mock(NetworkOfferingDao.class);
-    private NuageVspDao _nuageVspDao = mock(NuageVspDao.class);
-    private HostDao _hostDao = mock(HostDao.class);
-    private NetworkDao _networkDao = mock(NetworkDao.class);
-    private ConfigurationDao _configurationDao = mock(ConfigurationDao.class);
-    private IPAddressDao _ipAddressDao = mock(IPAddressDao.class);
-    private NuageVspManager _nuageVspManager = mock(NuageVspManager.class);
-    private ConfigurationManager _configurationManager = mock(ConfigurationManager.class);
-    private NetworkDetailsDao _networkDetailsDao = mock(NetworkDetailsDao.class);
+    @Mock private PhysicalNetworkDao _physicalNetworkDao;
+    @Mock private DataCenterDao _dataCenterDao;
+    @Mock private NetworkOfferingServiceMapDao _networkOfferingServiceMapDao;
+    @Mock private AgentManager _agentManager;
+    @Mock private NetworkModel _networkModel;
+    @Mock private AccountDao _accountDao;
+    @Mock private DomainDao _domainDao;
+    @Mock private NicDao _nicDao;
+    @Mock private NetworkOfferingDao _networkOfferingDao;
+    @Mock private NuageVspDao _nuageVspDao;
+    @Mock private HostDao _hostDao;
+    @Mock private NetworkDao _networkDao;
+    @Mock private ConfigurationDao _configurationDao;
+    @Mock private IPAddressDao _ipAddressDao;
+    @Mock private NuageVspManager _nuageVspManager;
+    @Mock private ConfigurationManager _configurationManager;
+    @Mock private NetworkDetailsDao _networkDetailsDao;
+    @Mock private PhysicalNetworkVO physnet;
+
+    @InjectMocks
     private NuageVspGuestNetworkGuru _nuageVspGuestNetworkGuru;
 
     @Before
     public void setUp() throws Exception {
+        _nuageVspGuestNetworkGuru = new NuageVspGuestNetworkGuru();
+
         super.setUp();
 
-        _nuageVspGuestNetworkGuru = new NuageVspGuestNetworkGuru();
-        _nuageVspGuestNetworkGuru._physicalNetworkDao = _physicalNetworkDao;
-        _nuageVspGuestNetworkGuru._physicalNetworkDao = _physicalNetworkDao;
-        _nuageVspGuestNetworkGuru._nuageVspDao = _nuageVspDao;
-        _nuageVspGuestNetworkGuru._dcDao = _dataCenterDao;
-        _nuageVspGuestNetworkGuru._ntwkOfferingSrvcDao = _networkOfferingServiceMapDao;
-        _nuageVspGuestNetworkGuru._networkModel = _networkModel;
-        _nuageVspGuestNetworkGuru._hostDao = _hostDao;
-        _nuageVspGuestNetworkGuru._agentMgr = _agentManager;
-        _nuageVspGuestNetworkGuru._networkDao = _networkDao;
-        _nuageVspGuestNetworkGuru._accountDao = _accountDao;
-        _nuageVspGuestNetworkGuru._domainDao = _domainDao;
-        _nuageVspGuestNetworkGuru._nicDao = _nicDao;
-        _nuageVspGuestNetworkGuru._ntwkOfferingDao = _networkOfferingDao;
-        _nuageVspGuestNetworkGuru._configDao = _configurationDao;
-        _nuageVspGuestNetworkGuru._ipAddressDao = _ipAddressDao;
-        _nuageVspGuestNetworkGuru._nuageVspManager = _nuageVspManager;
-        _nuageVspGuestNetworkGuru._configMgr = _configurationManager;
         _nuageVspGuestNetworkGuru._nuageVspEntityBuilder = _nuageVspEntityBuilder;
-        _nuageVspGuestNetworkGuru._networkDetailsDao = _networkDetailsDao;
 
         final DataCenterVO dc = mock(DataCenterVO.class);
         when(dc.getNetworkType()).thenReturn(NetworkType.Advanced);
@@ -142,41 +135,51 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         when(_configurationDao.getValue(NuageVspIsolatedNetworkDomainTemplateName.key())).thenReturn("IsolatedDomainTemplate");
         when(_configurationDao.getValue(NuageVspVpcDomainTemplateName.key())).thenReturn("VpcDomainTemplate");
         when(_configurationDao.getValue(NuageVspSharedNetworkDomainTemplateName.key())).thenReturn("SharedDomainTemplate");
+
+        when(_physicalNetworkDao.findById(any(Long.class))).thenReturn(physnet);
+        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("VSP"));
+        when(physnet.getId()).thenReturn(NETWORK_ID);
+
+        final HostVO host = mock(HostVO.class);
+        when(_hostDao.findById(NETWORK_ID)).thenReturn(host);
+        when(host.getId()).thenReturn(NETWORK_ID);
+        when(_agentManager.easySend(eq(NETWORK_ID), any(Command.class))).thenReturn(new Answer(null));
+
+        final NuageVspDeviceVO device = mock(NuageVspDeviceVO.class);
+        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(device));
+        when(device.getId()).thenReturn(1L);
+        when(device.getHostId()).thenReturn(NETWORK_ID);
     }
 
     @Test
     public void testCanHandle() {
         final NetworkOffering offering = mock(NetworkOffering.class);
         when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(offering.getGuestType()).thenReturn(GuestType.Isolated);
         when(offering.getIsPersistent()).thenReturn(false);
         when(_configurationManager.isOfferingForVpc(any(NetworkOffering.class))).thenReturn(false);
 
-        final PhysicalNetworkVO physnet = mock(PhysicalNetworkVO.class);
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList(new String[] {"VSP"}));
-        when(physnet.getId()).thenReturn(NETWORK_ID);
-
         when(_networkOfferingServiceMapDao.areServicesSupportedByNetworkOffering(NETWORK_ID, Service.Connectivity)).thenReturn(true);
 
-        assertTrue(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Advanced, physnet) == true);
+        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
+        when(offering.getGuestType()).thenReturn(GuestType.Isolated);
+        assertThat(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Advanced, physnet), is(true));
 
         // Not supported TrafficType != Guest
         when(offering.getTrafficType()).thenReturn(TrafficType.Management);
-        assertFalse(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Advanced, physnet) == true);
+        assertThat(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Advanced, physnet), is(false));
 
         // Supported: GuestType Shared
         when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
         when(offering.getGuestType()).thenReturn(GuestType.Shared);
-        assertTrue(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Advanced, physnet) == true);
+        assertThat(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Advanced, physnet), is(true));
 
         // Not supported: Basic networking
         when(offering.getGuestType()).thenReturn(GuestType.Isolated);
-        assertFalse(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Basic, physnet) == true);
+        assertThat(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Basic, physnet), is(false));
 
         // Not supported: IsolationMethod != STT
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList(new String[] {"VLAN"}));
-        assertFalse(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Advanced, physnet) == true);
+        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("VLAN"));
+        assertThat(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Basic, physnet), is(false));
 
         // Not supported: Non-persistent VPC tier
         when(_configurationManager.isOfferingForVpc(any(NetworkOffering.class))).thenReturn(true);
@@ -185,13 +188,8 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
 
     @Test
     public void testDesign() {
-        final PhysicalNetworkVO physnet = mock(PhysicalNetworkVO.class);
-        when(_physicalNetworkDao.findById((Long)any())).thenReturn(physnet);
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList(new String[] {"VSP"}));
-        when(physnet.getId()).thenReturn(NETWORK_ID);
-
         final NuageVspDeviceVO device = mock(NuageVspDeviceVO.class);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(new NuageVspDeviceVO[]{device}));
+        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(device));
         when(device.getId()).thenReturn(1L);
 
         final NetworkOffering offering = mock(NetworkOffering.class);
@@ -208,22 +206,17 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         final Account account = mock(Account.class);
 
         final Network designednetwork = _nuageVspGuestNetworkGuru.design(offering, plan, network, account);
-        assertTrue(designednetwork != null);
-        assertTrue(designednetwork.getBroadcastDomainType() == BroadcastDomainType.Vsp);
+        assertThat(designednetwork, notNullValue(Network.class));
+        assertThat(designednetwork.getBroadcastDomainType(), is(BroadcastDomainType.Vsp));
 
         // Can't design non-persistent VPC tier
         when(_configurationManager.isOfferingForVpc(any(NetworkOffering.class))).thenReturn(true);
-        assertNull(_nuageVspGuestNetworkGuru.design(offering, plan, network, account));
+        assertThat(_nuageVspGuestNetworkGuru.design(offering, plan, network, account), nullValue(Network.class));
     }
 
     @Test
     public void testDesignNoElementOnPhysicalNetwork() {
-        final PhysicalNetworkVO physnet = mock(PhysicalNetworkVO.class);
-        when(_physicalNetworkDao.findById((Long)any())).thenReturn(physnet);
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList(new String[] {"STT"}));
-        when(physnet.getId()).thenReturn(NETWORK_ID);
-
-        mock(NuageVspDeviceVO.class);
+        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("STT"));
         when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Collections.<NuageVspDeviceVO>emptyList());
 
         final NetworkOffering offering = mock(NetworkOffering.class);
@@ -241,12 +234,7 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
 
     @Test
     public void testDesignNoIsolationMethodVSP() {
-        final PhysicalNetworkVO physnet = mock(PhysicalNetworkVO.class);
-        when(_physicalNetworkDao.findById((Long)any())).thenReturn(physnet);
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList(new String[] {"VLAN"}));
-        when(physnet.getId()).thenReturn(NETWORK_ID);
-
-        mock(NuageVspDeviceVO.class);
+        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("VLAN"));
         when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Collections.<NuageVspDeviceVO>emptyList());
 
         final NetworkOffering offering = mock(NetworkOffering.class);
@@ -289,7 +277,10 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         when(nicvo.getId()).thenReturn(NETWORK_ID);
         when(nicvo.getMacAddress()).thenReturn("aa-aa-aa-aa-aa-aa");
         when(nicvo.getUuid()).thenReturn("aaaa-fffff");
+        when(nicvo.getNetworkId()).thenReturn(NETWORK_ID);
+        when(nicvo.getInstanceId()).thenReturn(NETWORK_ID);
         when(_nicDao.findById(NETWORK_ID)).thenReturn(nicvo);
+        when(_nicDao.findDefaultNicForVM(NETWORK_ID)).thenReturn(nicvo);
 
         final VirtualMachine vm = mock(VirtualMachine.class);
         when(vm.getId()).thenReturn(NETWORK_ID);
@@ -310,20 +301,9 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         when(ntwkoffering.getId()).thenReturn(NETWORK_ID);
         when(_networkOfferingDao.findById(NETWORK_ID)).thenReturn(ntwkoffering);
 
-        final HostVO host = mock(HostVO.class);
-        when(host.getId()).thenReturn(NETWORK_ID);
-        final NuageVspDeviceVO nuageVspDevice = mock(NuageVspDeviceVO.class);
-        when(nuageVspDevice.getHostId()).thenReturn(NETWORK_ID);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(new NuageVspDeviceVO[]{nuageVspDevice}));
-        when(_hostDao.findById(NETWORK_ID)).thenReturn(host);
-
         when(_networkDao.acquireInLockTable(NETWORK_ID, 1200)).thenReturn(network);
         when(_ipAddressDao.findByVmIdAndNetworkId(NETWORK_ID, NETWORK_ID)).thenReturn(null);
         when(_domainDao.findById(NETWORK_ID)).thenReturn(mock(DomainVO.class));
-
-        final Answer answer = mock(Answer.class);
-        when(answer.getResult()).thenReturn(true);
-        when(_agentManager.easySend(eq(NETWORK_ID), (Command)any())).thenReturn(answer);
 
         _nuageVspGuestNetworkGuru.reserve(nicProfile, network, vmProfile, mock(DeployDestination.class), mock(ReservationContext.class));
     }
@@ -368,19 +348,9 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         final AccountVO accountVo = mock(AccountVO.class);
         when(_accountDao.findById(NETWORK_ID)).thenReturn(accountVo);
 
-        final HostVO host = mock(HostVO.class);
-        when(host.getId()).thenReturn(NETWORK_ID);
-        final NuageVspDeviceVO nuageVspDevice = mock(NuageVspDeviceVO.class);
-        when(nuageVspDevice.getHostId()).thenReturn(NETWORK_ID);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(new NuageVspDeviceVO[]{nuageVspDevice}));
-        when(_hostDao.findById(NETWORK_ID)).thenReturn(host);
         when(_networkDao.acquireInLockTable(NETWORK_ID, 1200)).thenReturn(network);
         when(_nuageVspManager.getDnsDetails(network)).thenReturn(new ArrayList<String>());
         when(_nuageVspManager.getGatewaySystemIds()).thenReturn(new ArrayList<String>());
-
-        final Answer answer = mock(Answer.class);
-        when(answer.getResult()).thenReturn(true);
-        when(_agentManager.easySend(eq(NETWORK_ID), (Command)any())).thenReturn(answer);
 
         final DataCenter dc = mock(DataCenter.class);
         when(dc.getId()).thenReturn(NETWORK_ID);
@@ -429,17 +399,6 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         when(vmProfile.getInstanceName()).thenReturn("Test-VM");
         when(vmProfile.getVirtualMachine()).thenReturn(vm);
 
-        final HostVO host = mock(HostVO.class);
-        when(host.getId()).thenReturn(NETWORK_ID);
-        final NuageVspDeviceVO nuageVspDevice = mock(NuageVspDeviceVO.class);
-        when(nuageVspDevice.getHostId()).thenReturn(NETWORK_ID);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(new NuageVspDeviceVO[]{nuageVspDevice}));
-        when(_hostDao.findById(NETWORK_ID)).thenReturn(host);
-
-        final Answer answer = mock(Answer.class);
-        when(answer.getResult()).thenReturn(true);
-        when(_agentManager.easySend(eq(NETWORK_ID), (Command)any())).thenReturn(answer);
-
         _nuageVspGuestNetworkGuru.deallocate(network, nicProfile, vmProfile);
     }
 
@@ -464,18 +423,8 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         when(domain.getUuid()).thenReturn("aaaaaa");
         when(_domainDao.findById(NETWORK_ID)).thenReturn(domain);
 
-        final HostVO host = mock(HostVO.class);
-        when(host.getId()).thenReturn(NETWORK_ID);
-        final NuageVspDeviceVO nuageVspDevice = mock(NuageVspDeviceVO.class);
-        when(nuageVspDevice.getHostId()).thenReturn(NETWORK_ID);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(new NuageVspDeviceVO[]{nuageVspDevice}));
-        when(_hostDao.findById(NETWORK_ID)).thenReturn(host);
         when(_nuageVspManager.getDnsDetails(network)).thenReturn(new ArrayList<String>());
         when(_nuageVspManager.getGatewaySystemIds()).thenReturn(new ArrayList<String>());
-
-        final Answer answer = mock(Answer.class);
-        when(answer.getResult()).thenReturn(true);
-        when(_agentManager.easySend(eq(NETWORK_ID), (Command)any())).thenReturn(answer);
 
         assertTrue(_nuageVspGuestNetworkGuru.trash(network, offering));
     }

--- a/plugins/network-elements/nuage-vsp/test/com/cloud/network/resource/NuageVspResourceTest.java
+++ b/plugins/network-elements/nuage-vsp/test/com/cloud/network/resource/NuageVspResourceTest.java
@@ -19,6 +19,30 @@
 
 package com.cloud.network.resource;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.naming.ConfigurationException;
+
+import net.nuage.vsp.acs.client.api.NuageVspApiClient;
+import net.nuage.vsp.acs.client.api.NuageVspElementClient;
+import net.nuage.vsp.acs.client.api.NuageVspGuruClient;
+import net.nuage.vsp.acs.client.api.model.VspAclRule;
+import net.nuage.vsp.acs.client.api.model.VspDhcpDomainOption;
+import net.nuage.vsp.acs.client.api.model.VspDhcpVMOption;
+import net.nuage.vsp.acs.client.api.model.VspNetwork;
+import net.nuage.vsp.acs.client.api.model.VspNic;
+import net.nuage.vsp.acs.client.api.model.VspStaticNat;
+import net.nuage.vsp.acs.client.api.model.VspVm;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
 import com.cloud.NuageTest;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.PingCommand;
@@ -31,25 +55,6 @@ import com.cloud.agent.api.guru.ImplementNetworkVspCommand;
 import com.cloud.agent.api.guru.ReserveVmInterfaceVspCommand;
 import com.cloud.agent.api.guru.TrashNetworkVspCommand;
 import com.cloud.host.Host;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import net.nuage.vsp.acs.client.api.NuageVspApiClient;
-import net.nuage.vsp.acs.client.api.NuageVspElementClient;
-import net.nuage.vsp.acs.client.api.NuageVspGuruClient;
-import net.nuage.vsp.acs.client.api.model.VspAclRule;
-import net.nuage.vsp.acs.client.api.model.VspNetwork;
-import net.nuage.vsp.acs.client.api.model.VspNic;
-import net.nuage.vsp.acs.client.api.model.VspStaticNat;
-import net.nuage.vsp.acs.client.api.model.VspVm;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-
-import javax.naming.ConfigurationException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
@@ -151,8 +156,9 @@ public class NuageVspResourceTest extends NuageTest {
         _resource.configure("NuageVspResource", _hostDetails);
 
         VspNetwork vspNetwork = buildVspNetwork();
-        ImplementNetworkVspCommand cmd = new ImplementNetworkVspCommand(vspNetwork, new ArrayList<String>());
-        doAnswer(genericAnswer).when(_mockNuageVspGuruClient).implement(vspNetwork, new ArrayList<String>());
+        VspDhcpDomainOption vspDhcpOptions = buildspDhcpDomainOption();
+        ImplementNetworkVspCommand cmd = new ImplementNetworkVspCommand(vspNetwork, vspDhcpOptions);
+        doAnswer(genericAnswer).when(_mockNuageVspGuruClient).implement(vspNetwork, vspDhcpOptions);
         com.cloud.agent.api.Answer implNtwkAns = _resource.executeRequest(cmd);
         assertTrue(implNtwkAns.getResult());
     }
@@ -165,8 +171,9 @@ public class NuageVspResourceTest extends NuageTest {
         VspVm vspVm = buildVspVm();
         VspNic vspNic = buildVspNic();
         VspStaticNat vspStaticNat = buildVspStaticNat();
-        ReserveVmInterfaceVspCommand cmd = new ReserveVmInterfaceVspCommand(vspNetwork, vspVm, vspNic, vspStaticNat);
-        doAnswer(genericAnswer).when(_mockNuageVspGuruClient).reserve(vspNetwork, vspVm, vspNic, vspStaticNat);
+        VspDhcpVMOption vspDhcpOption = buildspDhcpVMOption();
+        ReserveVmInterfaceVspCommand cmd = new ReserveVmInterfaceVspCommand(vspNetwork, vspVm, vspNic, vspStaticNat, vspDhcpOption);
+        doAnswer(genericAnswer).when(_mockNuageVspGuruClient).reserve(vspNetwork, vspVm, vspNic, vspStaticNat, vspDhcpOption);
         Answer rsrvVmInfAns = _resource.executeRequest(cmd);
         assertTrue(rsrvVmInfAns.getResult());
     }

--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -42,6 +42,11 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import org.apache.log4j.Logger;
+import org.cloud.network.router.deployment.RouterDeploymentDefinitionBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
 import org.apache.cloudstack.alert.AlertService;
 import org.apache.cloudstack.alert.AlertService.AlertType;
 import org.apache.cloudstack.api.command.admin.router.RebootRouterCmd;
@@ -61,10 +66,6 @@ import org.apache.cloudstack.network.topology.NetworkTopology;
 import org.apache.cloudstack.network.topology.NetworkTopologyContext;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.cloudstack.utils.usage.UsageUtils;
-import org.apache.log4j.Logger;
-import org.cloud.network.router.deployment.RouterDeploymentDefinitionBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.Listener;
@@ -1758,7 +1759,8 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     }
 
     protected void finalizeUserDataAndDhcpOnStart(final Commands cmds, final DomainRouterVO router, final Provider provider, final Long guestNetworkId) {
-        if (_networkModel.isProviderSupportServiceInNetwork(guestNetworkId, Service.Dhcp, provider)) {
+        if (_networkModel.isProviderSupportServiceInNetwork(guestNetworkId, Service.Dhcp, provider)
+                || _networkModel.isProviderSupportServiceInNetwork(guestNetworkId, Service.Dns, provider)) {
             // Resend dhcp
             s_logger.debug("Reapplying dhcp entries as a part of domR " + router + " start...");
             _commandSetupHelper.createDhcpEntryCommandsForVMs(router, cmds, guestNetworkId);

--- a/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -59,6 +59,7 @@ import com.cloud.network.PhysicalNetworkTrafficType;
 import com.cloud.network.dao.NetworkServiceMapDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.element.DhcpServiceProvider;
+import com.cloud.network.element.DnsServiceProvider;
 import com.cloud.network.element.LoadBalancingServiceProvider;
 import com.cloud.network.element.NetworkElement;
 import com.cloud.network.element.StaticNatServiceProvider;
@@ -823,6 +824,11 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
 
     @Override
     public DhcpServiceProvider getDhcpServiceProvider(Network network) {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public DnsServiceProvider getDnsServiceProvider(Network network) {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 

--- a/test/integration/plugins/nuagevsp/nuageTestCase.py
+++ b/test/integration/plugins/nuagevsp/nuageTestCase.py
@@ -40,35 +40,77 @@ from marvin.lib.base import (EgressFireWallRule,
 from marvin.lib.common import (get_domain,
                                get_template,
                                get_zone)
-from marvin.lib.utils import cleanup_resources
 from marvin.cloudstackAPI import restartVPC
 # Import System Modules
 import importlib
+import functools
 import logging
 import socket
 import sys
 import time
+from retry import retry
+
+
+class needscleanup(object):
+    def __init__(self, method):
+        self.method = method
+
+    def __get__(self, obj=None, objtype=None):
+        @functools.wraps(self.method)
+        def _wrapper(*args, **kwargs):
+            wants_cleanup = True
+            if "cleanup" in kwargs:
+                wants_cleanup = kwargs["cleanup"]
+                del kwargs["cleanup"]
+            if obj is not None:
+                result = self.method(obj, *args, **kwargs)
+                if hasattr(obj, 'cleanup'):
+                    cleanup = obj.cleanup
+            else:
+                result = self.method(objtype, *args, **kwargs)
+                cleanup = objtype._cleanup
+            if wants_cleanup:
+                cleanup.append(result)
+            return result
+        return _wrapper
 
 
 class nuageTestCase(cloudstackTestCase):
 
     @classmethod
-    def setUpClass(cls, zone=None):
+    def setUpClass(cls):
         cls.debug("setUpClass nuageTestCase")
 
         # We want to fail quicker, if it's a failure
         socket.setdefaulttimeout(60)
 
-        test_client = super(nuageTestCase, cls).getClsTestClient()
-        cls.api_client = test_client.getApiClient()
-        cls.db_client = test_client.getDbConnection()
-        cls.test_data = test_client.getParsedTestDataConfig()
+        cls.test_client = super(nuageTestCase, cls).getClsTestClient()
+        cls.api_client = cls.test_client.getApiClient()
+        cls.db_client = cls.test_client.getDbConnection()
+        cls.test_data = cls.test_client.getParsedTestDataConfig()
 
+        # Get Zone details
+        cls.getZoneDetails()
+
+        # Configure VSD sessions
+        cls.configureVSDSessions()
+
+        # Create service offering
+        cls.service_offering = ServiceOffering.create(
+            cls.api_client,
+            cls.test_data["service_offering"]
+        )
+        cls._cleanup = [cls.service_offering]
+
+        cls.debug("setUpClass nuageTestCase [DONE]")
+
+    @classmethod
+    def getZoneDetails(cls, zone=None):
         # Get Zone, Domain and templates
-        cls.zone = get_zone(cls.api_client,
-                            zone_name=zone.name if zone else None,
-                            zone_id=zone.id if zone else None
-                            )
+        cls.zone = zone if zone else get_zone(
+            cls.api_client,
+            zone_name=cls.test_client.getZoneForTests()
+        )
         cls.domain = get_domain(cls.api_client)
         cls.template = get_template(cls.api_client,
                                     cls.zone.id,
@@ -77,73 +119,97 @@ class nuageTestCase(cloudstackTestCase):
         cls.test_data["virtual_machine"]["zoneid"] = cls.zone.id
         cls.test_data["virtual_machine"]["template"] = cls.template.id
 
-        # Create service offering
-        cls.service_offering = ServiceOffering.create(cls.api_client,
-                                                      cls.test_data["service_offering"]
-                                                      )
-        cls._cleanup = [cls.service_offering]
-
         # Check if the host hypervisor type is simulator
-        cls.isSimulator = Hypervisor.list(cls.api_client, zoneid=cls.zone.id)[0].name == "Simulator"
+        hypervisors = Hypervisor.list(cls.api_client, zoneid=cls.zone.id)
+        assert hypervisors is not None and len(hypervisors) > 0, \
+            "Expected at least one hypervisor"
+        cls.isSimulator = any(map(lambda h: h.name == "Simulator",
+                                  hypervisors))
 
         # Get configured Nuage VSP device details
         try:
-            physical_networks = PhysicalNetwork.list(cls.api_client, zoneid=cls.zone.id)
-            for pn in physical_networks:
-                if pn.isolationmethods == "VSP":
-                    cls.vsp_physical_network = pn
-                    break
-            cls.nuage_vsp_device = Nuage.list(cls.api_client,
-                                              physicalnetworkid=cls.vsp_physical_network.id
-                                              )[0]
-            pns = cls.config.zones[0].physical_networks
-            providers = filter(lambda physical_network: "VSP" in physical_network.isolationmethods, pns)[0].providers
-            devices = filter(lambda provider: provider.name == "NuageVsp", providers)[0].devices
-            cls.nuage_vsp_device.username = devices[0].username
-            cls.nuage_vsp_device.password = devices[0].password
+            physical_networks = PhysicalNetwork.list(
+                cls.api_client,
+                zoneid=cls.zone.id
+            )
+
+            cls.vsp_physical_network = next(pn for pn in physical_networks
+                                            if pn.isolationmethods == "VSP")
+            cls.nuage_vsp_device = Nuage.list(
+                cls.api_client,
+                physicalnetworkid=cls.vsp_physical_network.id)[0]
+
+            # Take username and password from the datacenter config file,
+            # as they are not returned by the API.
+            config_nuage_device = next(device for zone in cls.config.zones
+                                       if zone.name == cls.zone.name
+                                       for physnet in zone.physical_networks
+                                       if "VSP" in physnet.isolationmethods
+                                       for provider in physnet.providers
+                                       if provider.name == "NuageVsp"
+                                       for device in provider.devices)
+
+            cls.nuage_vsp_device.username = config_nuage_device.username
+            cls.nuage_vsp_device.password = config_nuage_device.password
             cls.cms_id = cls.nuage_vsp_device.cmsid
         except Exception as e:
             cls.tearDownClass()
-            raise unittest.SkipTest("Warning: Could not get configured Nuage VSP device details - %s" % e)
+            raise unittest.SkipTest("Warning: Could not get configured "
+                                    "Nuage VSP device details - %s" % e)
+        return
 
-        # VSD is a programmable policy and analytics engine of Nuage VSP SDN platform
-        # vspk is a Python SDK for Nuage VSP's VSD
-        # libVSD is a library that wraps vspk package
+    @classmethod
+    def configureVSDSessions(cls):
+        # VSD is a programmable policy and analytics engine of Nuage VSP SDN
+        # platform; vspk is a Python SDK for Nuage VSP's VSD; libVSD is a
+        # library that wraps vspk package
         try:
-            vspk_module = "vspk." + cls.nuage_vsp_device.apiversion if int(cls.nuage_vsp_device.apiversion[1]) >= 4 \
-                else "vspk.vsdk." + cls.nuage_vsp_device.apiversion
+            vspk_module = "vspk." + cls.nuage_vsp_device.apiversion
             cls.vsdk = importlib.import_module(vspk_module)
+        except ImportError as e:
+            try:
+                vspk_module = "vspk.vsdk." + cls.nuage_vsp_device.apiversion
+                cls.vsdk = importlib.import_module(vspk_module)
+            except ImportError:
+                cls.tearDownClass()
+                raise unittest.SkipTest("Warning: vspk import failure"
+                                        " - %s" % e)
+
+        try:
             from libVSD import ApiClient, VSDHelpers
-        except Exception as e:
+        except ImportError as e:
             cls.tearDownClass()
-            raise unittest.SkipTest("Warning: vspk (and/or) libVSD package import failure - %s" % e)
+            raise unittest.SkipTest("Warning: libVSD package import failure "
+                                    "- %s" % e)
 
         # Configure VSD session
-        cls._session = cls.vsdk.NUVSDSession(username=cls.nuage_vsp_device.username,
-                                             password=cls.nuage_vsp_device.password,
-                                             enterprise="csp",
-                                             api_url="https://%s:%d" % (cls.nuage_vsp_device.hostname,
-                                                                        cls.nuage_vsp_device.port)
-                                             )
+        cls._session = cls.vsdk.NUVSDSession(
+            username=cls.nuage_vsp_device.username,
+            password=cls.nuage_vsp_device.password,
+            enterprise="csp",
+            api_url="https://%s:%d" % (cls.nuage_vsp_device.hostname,
+                                       cls.nuage_vsp_device.port)
+            )
         cls._session.start()
 
         # Configure libVSD session
         root = logging.getLogger()
         log_handler = logging.StreamHandler(sys.stdout)
-        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        formatter = logging.Formatter('%(asctime)s - %(name)s - '
+                                      '%(levelname)s - %(message)s')
         log_handler.setFormatter(formatter)
         root.addHandler(log_handler)
         vsd_info = cls.nuage_vsp_device.__dict__
         cls.debug("Nuage VSP device (VSD) details - %s" % vsd_info)
-        vsd_api_client = ApiClient(address=vsd_info["hostname"],
-                                   user=vsd_info["username"],
-                                   password=vsd_info["password"],
-                                   version=vsd_info["apiversion"][1] + "." + vsd_info["apiversion"][3]
-                                   )
+        vsd_api_client = ApiClient(
+            address=vsd_info["hostname"],
+            user=vsd_info["username"],
+            password=vsd_info["password"],
+            version=vsd_info["apiversion"][1] + "." + vsd_info["apiversion"][3]
+        )
         vsd_api_client.new_session()
         cls.vsd = VSDHelpers(vsd_api_client)
-
-        cls.debug("setUpClass nuageTestCase [DONE]")
+        return
 
     def setUp(self):
         self.cleanup = []
@@ -151,11 +217,19 @@ class nuageTestCase(cloudstackTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        try:
-            # Cleanup resources used
-            cleanup_resources(cls.api_client, cls._cleanup)
-        except Exception as e:
-            cls.debug("Warning: Exception during cleanup: %s" % e)
+        # Cleanup resources used
+        cls.debug("Cleaning up the resources")
+        for obj in reversed(cls._cleanup):
+            try:
+                if isinstance(obj, VirtualMachine):
+                    obj.delete(cls.api_client, expunge=True)
+                else:
+                    obj.delete(cls.api_client)
+            except Exception as e:
+                cls.error("Failed to cleanup %s, got %s" % (obj, e))
+        # cleanup_resources(cls.api_client, cls._cleanup)
+        cls._cleanup = []
+        cls.debug("Cleanup complete!")
         return
 
     def tearDown(self):
@@ -175,45 +249,44 @@ class nuageTestCase(cloudstackTestCase):
         return
 
     # create_VpcOffering - Creates VPC offering
-    def create_VpcOffering(self, vpc_offering, suffix=None):
-        self.debug("Creating VPC offering")
+    @needscleanup
+    def create_VpcOffering(cls, vpc_offering, suffix=None):
+        cls.debug("Creating VPC offering")
         if suffix:
             vpc_offering["name"] = "VPC_OFF-" + str(suffix)
-        vpc_off = VpcOffering.create(self.api_client,
+        vpc_off = VpcOffering.create(cls.api_client,
                                      vpc_offering
                                      )
         # Enable VPC offering
-        vpc_off.update(self.api_client, state="Enabled")
-        self.cleanup.append(vpc_off)
-        self.debug("Created and Enabled VPC offering")
+        vpc_off.update(cls.api_client, state="Enabled")
+        cls.debug("Created and Enabled VPC offering")
         return vpc_off
 
     # create_Vpc - Creates VPC with the given VPC offering
-    def create_Vpc(self, vpc_offering, cidr='10.1.0.0/16', testdata=None, account=None, networkDomain=None,
-                   cleanup=True):
+    @needscleanup
+    def create_Vpc(cls, vpc_offering, cidr='10.1.0.0/16', testdata=None,
+                   account=None, networkDomain=None):
         if not account:
-            account = self.account
-        self.debug("Creating a VPC in the account - %s" % account.name)
+            account = cls.account
+        cls.debug("Creating a VPC in the account - %s" % account.name)
         if not testdata:
-            testdata = self.test_data["vpc"]
+            testdata = cls.test_data["vpc"]
             testdata["name"] = "TestVPC-" + cidr + "-" + str(vpc_offering.name)
             testdata["displaytext"] = "Test VPC"
             testdata["cidr"] = cidr
-        vpc = VPC.create(self.api_client,
+        vpc = VPC.create(cls.api_client,
                          testdata,
                          vpcofferingid=vpc_offering.id,
-                         zoneid=self.zone.id,
+                         zoneid=cls.zone.id,
                          account=account.name,
                          domainid=account.domainid,
                          networkDomain=networkDomain
                          )
-        self.debug("Created VPC with ID - %s" % vpc.id)
-        if cleanup:
-            self.cleanup.append(vpc)
+        cls.debug("Created VPC with ID - %s" % vpc.id)
         return vpc
 
     # restart_Vpc - Restarts the given VPC with/without cleanup
-    def restart_Vpc(self, vpc, cleanup=None):
+    def restart_Vpc(self, vpc, cleanup=False):
         self.debug("Restarting VPC with ID - %s" % vpc.id)
         cmd = restartVPC.restartVPCCmd()
         cmd.id = vpc.id
@@ -223,54 +296,57 @@ class nuageTestCase(cloudstackTestCase):
         self.debug("Restarted VPC with ID - %s" % vpc.id)
 
     # create_NetworkOffering - Creates Network offering
-    def create_NetworkOffering(self, net_offering, suffix=None, conserve_mode=False):
-        self.debug("Creating Network offering")
+    @needscleanup
+    def create_NetworkOffering(cls, net_offering, suffix=None,
+                               conserve_mode=False):
+        cls.debug("Creating Network offering")
         if suffix:
             net_offering["name"] = "NET_OFF-" + str(suffix)
-        nw_off = NetworkOffering.create(self.api_client,
+        nw_off = NetworkOffering.create(cls.api_client,
                                         net_offering,
                                         conservemode=conserve_mode
                                         )
         # Enable Network offering
-        nw_off.update(self.api_client, state="Enabled")
-        self.cleanup.append(nw_off)
-        self.debug("Created and Enabled Network offering")
+        nw_off.update(cls.api_client, state="Enabled")
+        cls.debug("Created and Enabled Network offering")
         return nw_off
 
     # create_Network - Creates network with the given Network offering
-    def create_Network(self, nw_off, gateway="10.1.1.1", netmask="255.255.255.0", vpc=None, acl_list=None,
-                       testdata=None, account=None, cleanup=True):
+    @needscleanup
+    def create_Network(cls, nw_off, gateway="10.1.1.1",
+                       netmask="255.255.255.0", vpc=None, acl_list=None,
+                       testdata=None, account=None):
         if not account:
-            account = self.account
-        self.debug("Creating a network in the account - %s" % account.name)
+            account = cls.account
+        cls.debug("Creating a network in the account - %s" % account.name)
         if not testdata:
-            testdata = self.test_data["network"]
-            testdata["name"] = "TestNetwork-" + gateway + "-" + str(nw_off.name)
+            testdata = cls.test_data["network"]
+            testdata["name"] = "TestNet-" + gateway + "-" + str(nw_off.name)
             testdata["displaytext"] = "Test Network"
             testdata["netmask"] = netmask
-        network = Network.create(self.api_client,
+        network = Network.create(cls.api_client,
                                  testdata,
                                  accountid=account.name,
                                  domainid=account.domainid,
                                  networkofferingid=nw_off.id,
-                                 zoneid=self.zone.id,
+                                 zoneid=cls.zone.id,
                                  gateway=gateway,
-                                 vpcid=vpc.id if vpc else self.vpc.id if hasattr(self, "vpc") else None,
+                                 vpcid=vpc.id if vpc else cls.vpc.id
+                                 if hasattr(cls, "vpc") else None,
                                  aclid=acl_list.id if acl_list else None
                                  )
-        self.debug("Created network with ID - %s" % network.id)
-        if cleanup:
-            self.cleanup.append(network)
+        cls.debug("Created network with ID - %s" % network.id)
         return network
 
     # upgrade_Network - Upgrades the given network
-    def upgrade_Network(self, nw_off, network):
+    def upgrade_Network(self, nw_off, network, forced=True):
         if not hasattr(nw_off, "id"):
-            nw_off = self.create_NetworkOffering(nw_off, network.gateway)
+            nw_off = self.create_NetworkOffering(nw_off)
         self.debug("Updating Network with ID - %s" % network.id)
         network.update(self.api_client,
                        networkofferingid=nw_off.id,
-                       changecidr=False
+                       changecidr=False,
+                       forced=forced
                        )
         self.debug("Updated network with ID - %s" % network.id)
 
@@ -283,7 +359,9 @@ class nuageTestCase(cloudstackTestCase):
         self.debug("Deleted Network with ID - %s" % network.id)
 
     # create_VM - Creates VM in the given network(s)
-    def create_VM(self, network_list, host_id=None, start_vm=True, testdata=None, account=None, cleanup=True):
+    @needscleanup
+    def create_VM(cls, network_list, host_id=None, start_vm=True,
+                  testdata=None, account=None):
         network_ids = []
         if isinstance(network_list, list):
             for network in network_list:
@@ -291,45 +369,48 @@ class nuageTestCase(cloudstackTestCase):
         else:
             network_ids.append(str(network_list.id))
         if not account:
-            account = self.account
-        self.debug("Creating VM in network(s) with ID(s) - %s in the account - %s" % (network_ids, account.name))
+            account = cls.account
+        cls.debug("Creating VM in network(s) with ID(s) - %s in the "
+                  "account - %s" % (network_ids, account.name))
         if not testdata:
-            testdata = self.test_data["virtual_machine"]
-        vm = VirtualMachine.create(self.api_client,
+            testdata = cls.test_data["virtual_machine"]
+        vm = VirtualMachine.create(cls.api_client,
                                    testdata,
                                    accountid=account.name,
                                    domainid=account.domainid,
-                                   serviceofferingid=self.service_offering.id,
-                                   templateid=self.template.id,
-                                   zoneid=self.zone.id,
+                                   serviceofferingid=cls.service_offering.id,
+                                   templateid=cls.template.id,
+                                   zoneid=cls.zone.id,
                                    networkids=network_ids,
                                    startvm=start_vm,
                                    hostid=host_id
                                    )
-        self.debug("Created VM with ID - %s in network(s) with ID(s) - %s" % (vm.id, network_ids))
-        if cleanup:
-            self.cleanup.append(vm)
+        cls.debug("Created VM with ID - %s in network(s) with ID(s) - %s"
+                  % (vm.id, network_ids))
         return vm
 
-    # nic_operation_VM - Performs NIC operations such as add, remove, and update default NIC in the given VM and network
-    def nic_operation_VM(self, vm, network, operation="update"):
-        self.debug("Performing %s NIC operation in VM with ID - %s and network with ID - %s" %
-                   (operation, vm.id, network.id))
-        for nic in vm.nic:
+    # nic_operation_VM - Performs NIC operations such as add, remove, and
+    # update default NIC in the given VM and network
+    def nic_operation_VM(self, vm, network, operation="add"):
+        self.debug("Performing %s NIC operation in VM with ID - %s and "
+                   "network with ID - %s" % (operation, vm.id, network.id))
+        if operation is "add":
+            vm.add_nic(self.api_client, network.id)
+            self.debug("Added NIC in VM with ID - %s and network with ID - %s"
+                       % (vm.id, network.id))
+        vm_info = VirtualMachine.list(self.api_client, id=vm.id)[0]
+        for nic in vm_info.nic:
             if nic.networkid == network.id:
                 nic_id = nic.id
         if operation is "update":
             vm.update_default_nic(self.api_client, nic_id)
-            self.debug("Updated default NIC to NIC with ID - %s in VM with ID - %s and network with ID - %s" %
+            self.debug("Updated default NIC to NIC with ID - %s in VM with ID "
+                       "- %s and network with ID - %s" %
                        (nic_id, vm.id, network.id))
         if operation is "remove":
             vm.remove_nic(self.api_client, nic_id)
-            self.debug("Removed NIC with ID - %s in VM with ID - %s and network with ID - %s" %
-                       (nic_id, vm.id, network.id))
-        if operation is "add":
-            vm.add_nic(self.api_client, network.id)
-            self.debug("Added NIC with ID - %s in VM with ID - %s and network with ID - %s" %
-                       (nic_id, vm.id, network.id))
+            self.debug("Removed NIC with ID - %s in VM with ID - %s and "
+                       "network with ID - %s" % (nic_id, vm.id, network.id))
 
     # migrate_VM - Migrates VM to another host, if available
     def migrate_VM(self, vm):
@@ -339,9 +420,11 @@ class nuageTestCase(cloudstackTestCase):
                          "List hosts should return a valid list"
                          )
         # Remove the host of current VM from the hosts list
-        hosts[:] = [host for host in hosts if host.id != vm.hostid]
+        vm_info = VirtualMachine.list(self.api_client, id=vm.id)[0]
+        hosts[:] = [host for host in hosts if host.id != vm_info.hostid]
         if len(hosts) <= 0:
-            self.skipTest("No host available for migration. Test requires at-least 2 hosts")
+            self.skipTest("No host available for migration. "
+                          "Test requires at-least 2 hosts")
         host = hosts[0]
         self.debug("Migrating VM with ID: %s to Host: %s" % (vm.id, host.id))
         try:
@@ -360,60 +443,75 @@ class nuageTestCase(cloudstackTestCase):
 
     # get_Router - Returns router for the given network
     def get_Router(self, network):
-        self.debug("Finding the virtual router for network with ID - %s" % network.id)
+        self.debug("Finding the virtual router for network with ID - %s" %
+                   network.id)
         routers = Router.list(self.api_client,
                               networkid=network.id,
                               listall=True
                               )
         self.assertEqual(isinstance(routers, list), True,
-                         "List routers should return a valid virtual router for network"
+                         "List routers should return a valid virtual router "
+                         "for network"
                          )
         return routers[0]
 
-    # acquire_PublicIPAddress - Acquires public IP address for the given network/VPC
+    # acquire_PublicIPAddress - Acquires public IP address for the given
+    # network/VPC
     def acquire_PublicIPAddress(self, network, vpc=None, account=None):
         if not account:
             account = self.account
-        self.debug("Associating public IP for network with ID - %s in the account - %s" % (network.id, account.name))
+        self.debug("Associating public IP for network with ID - %s in the "
+                   "account - %s" % (network.id, account.name))
         public_ip = PublicIPAddress.create(self.api_client,
                                            accountid=account.name,
                                            domainid=account.domainid,
                                            zoneid=self.zone.id,
-                                           networkid=network.id if vpc is None else None,
-                                           vpcid=vpc.id if vpc else self.vpc.id if hasattr(self, "vpc") else None
+                                           networkid=network.id
+                                           if vpc is None else None,
+                                           vpcid=vpc.id if vpc else self.vpc.id
+                                           if hasattr(self, "vpc") else None
                                            )
-        self.debug("Associated public IP address - %s with network with ID - %s" %
-                   (public_ip.ipaddress.ipaddress, network.id))
+        self.debug("Associated public IP address - %s with network with ID - "
+                   "%s" % (public_ip.ipaddress.ipaddress, network.id))
         return public_ip
 
-    # create_StaticNatRule_For_VM - Creates Static NAT rule on the given public IP for the given VM in the given network
-    def create_StaticNatRule_For_VM(self, vm, public_ip, network, vmguestip=None):
-        self.debug("Enabling Static NAT rule on public IP - %s for VM with ID - %s in network with ID - %s" %
+    # create_StaticNatRule_For_VM - Creates Static NAT rule on the given
+    # public IP for the given VM in the given network
+    def create_StaticNatRule_For_VM(self, vm, public_ip, network,
+                                    vmguestip=None):
+        self.debug("Enabling Static NAT rule on public IP - %s for VM with ID "
+                   "- %s in network with ID - %s" %
                    (public_ip.ipaddress.ipaddress, vm.id, network.id))
-        static_nat_rule = StaticNATRule.enable(self.api_client,
-                                               ipaddressid=public_ip.ipaddress.id,
-                                               virtualmachineid=vm.id,
-                                               networkid=network.id,
-                                               vmguestip=vmguestip
-                                               )
-        self.debug("Static NAT rule enabled on public IP - %s for VM with ID - %s in network with ID - %s" %
+        static_nat_rule = StaticNATRule.enable(
+            self.api_client,
+            ipaddressid=public_ip.ipaddress.id,
+            virtualmachineid=vm.id,
+            networkid=network.id,
+            vmguestip=vmguestip
+        )
+        self.debug("Static NAT rule enabled on public IP - %s for VM with ID "
+                   "- %s in network with ID - %s" %
                    (public_ip.ipaddress.ipaddress, vm.id, network.id))
         return static_nat_rule
 
-    # delete_StaticNatRule_For_VM - Deletes Static NAT rule on the given public IP
+    # delete_StaticNatRule_For_VM - Deletes Static NAT rule on the given
+    # public IP
     def delete_StaticNatRule_For_VM(self, public_ip):
-        self.debug("Disabling Static NAT rule on public IP - %s" % public_ip.ipaddress.ipaddress)
+        self.debug("Disabling Static NAT rule on public IP - %s" %
+                   public_ip.ipaddress.ipaddress)
         StaticNATRule.disable(self.api_client,
                               ipaddressid=public_ip.ipaddress.id
                               )
-        self.debug("Static NAT rule disabled on public IP - %s" % public_ip.ipaddress.ipaddress)
+        self.debug("Static NAT rule disabled on public IP - %s" %
+                   public_ip.ipaddress.ipaddress)
 
-    # create_FirewallRule - Creates (Ingress) Firewall rule on the given Static NAT rule enabled public IP for Isolated
-    # networks
+    # create_FirewallRule - Creates (Ingress) Firewall rule on the given
+    # Static NAT rule enabled public IP for Isolated networks
     def create_FirewallRule(self, public_ip, rule=None):
         if not rule:
             rule = self.test_data["ingress_rule"]
-        self.debug("Adding an (Ingress) Firewall rule to make Guest VMs accessible through Static NAT rule - %s" % rule)
+        self.debug("Adding an (Ingress) Firewall rule to make Guest VMs "
+                   "accessible through Static NAT rule - %s" % rule)
         return FireWallRule.create(self.api_client,
                                    ipaddressid=public_ip.ipaddress.id,
                                    protocol=rule["protocol"],
@@ -422,9 +520,11 @@ class nuageTestCase(cloudstackTestCase):
                                    endport=rule["endport"]
                                    )
 
-    # create_EgressFirewallRule - Creates Egress Firewall rule in the given Isolated network
+    # create_EgressFirewallRule - Creates Egress Firewall rule in the given
+    # Isolated network
     def create_EgressFirewallRule(self, network, rule):
-        self.debug("Adding an Egress Firewall rule to allow/deny outgoing traffic from Guest VMs - %s" % rule)
+        self.debug("Adding an Egress Firewall rule to allow/deny outgoing "
+                   "traffic from Guest VMs - %s" % rule)
         return EgressFireWallRule.create(self.api_client,
                                          networkid=network.id,
                                          protocol=rule["protocol"],
@@ -443,8 +543,10 @@ class nuageTestCase(cloudstackTestCase):
                                      vpcid=vpc.id
                                      )
 
-    # create_NetworkAclRule - Creates Ingress/Egress Network ACL rule in the given VPC network/acl list
-    def create_NetworkAclRule(self, rule, traffic_type="Ingress", network=None, acl_list=None):
+    # create_NetworkAclRule - Creates Ingress/Egress Network ACL rule in the
+    # given VPC network/acl list
+    def create_NetworkAclRule(self, rule, traffic_type="Ingress", network=None,
+                              acl_list=None):
         self.debug("Adding NetworkACL rule - %s" % rule)
         if acl_list:
             return NetworkACL.create(self.api_client,
@@ -461,22 +563,24 @@ class nuageTestCase(cloudstackTestCase):
                                      )
 
     # ssh_into_VM - Gets into the shell of the given VM using its public IP
-    def ssh_into_VM(self, vm, public_ip, reconnect=True):
-        self.debug("SSH into VM with ID - %s on public IP address - %s" % (vm.id, public_ip.ipaddress.ipaddress))
-        tries = 0
-        while tries < 3:
-            try:
-                ssh_client = vm.get_ssh_client(ipaddress=public_ip.ipaddress.ipaddress, reconnect=reconnect)
-            except Exception as e:
-                self.debug("Failed to SSH into VM: %s" % e)
-                self.debug("Waiting for the VM to be fully resolved for SSH connection...")
-                time.sleep(120)
-                self.debug("Retrying SSH into VM...")
-                tries += 1
-                continue
-            self.debug("Successful to SSH into VM with ID - %s on public IP address - %s" %
+    def ssh_into_VM(self, vm, public_ip, reconnect=True, negative_test=False):
+        self.debug("SSH into VM with ID - %s on public IP address - %s" %
+                   (vm.id, public_ip.ipaddress.ipaddress))
+        tries = 1 if negative_test else 3
+
+        @retry(tries=tries)
+        def retry_ssh():
+            ssh_client = vm.get_ssh_client(
+                ipaddress=public_ip.ipaddress.ipaddress,
+                reconnect=reconnect,
+                retries=3 if negative_test else 30
+            )
+            self.debug("Successful to SSH into VM with ID - %s on "
+                       "public IP address - %s" %
                        (vm.id, public_ip.ipaddress.ipaddress))
             return ssh_client
+
+        return retry_ssh()
 
     # execute_cmd - Executes the given command on the given ssh client
     def execute_cmd(self, ssh_client, cmd):
@@ -490,41 +594,56 @@ class nuageTestCase(cloudstackTestCase):
             self.debug("SSH client executed command result is None")
         return ret_data
 
-    # wget_from_server - Fetches index.html file from a web server listening on the given public IP address and port
-    def wget_from_server(self, public_ip, port):
+    # wget_from_server - Fetches file with the given file name from a web
+    # server listening on the given public IP address and port
+    def wget_from_server(self, public_ip, port, file_name="index.html"):
         import urllib
-        self.debug("wget index.html file from a http web server listening on public IP address - %s and port - %s" %
-                   (public_ip.ipaddress.ipaddress, port))
-        filename, headers = urllib.urlretrieve("http://%s:%s/index.html" % (public_ip.ipaddress.ipaddress, port),
-                                               filename="index.html"
-                                               )
+        self.debug("wget file - %s from a http web server listening on "
+                   "public IP address - %s and port - %s" %
+                   (file_name, public_ip.ipaddress.ipaddress, port))
+        filename, headers = urllib.urlretrieve(
+            "http://%s:%s/%s" %
+            (public_ip.ipaddress.ipaddress, port, file_name),
+            filename=file_name
+        )
         return filename, headers
 
-    # validate_NetworkServiceProvider - Validates the given Network Service Provider in the Nuage VSP Physical Network,
-    # matches the given provider name and state against the list of providers fetched
+    # validate_NetworkServiceProvider - Validates the given Network Service
+    # Provider in the Nuage VSP Physical Network, matches the given provider
+    # name and state against the list of providers fetched
     def validate_NetworkServiceProvider(self, provider_name, state=None):
-        """Validates the Network Service Provider in the Nuage VSP Physical Network"""
-        self.debug("Validating the creation and state of Network Service Provider - %s" % provider_name)
-        providers = NetworkServiceProvider.list(self.api_client,
-                                                name=provider_name,
-                                                physicalnetworkid=self.vsp_physical_network.id)
+        """Validates the Network Service Provider in the Nuage VSP Physical
+        Network"""
+        self.debug("Validating the creation and state of Network Service "
+                   "Provider - %s" % provider_name)
+        providers = NetworkServiceProvider.list(
+            self.api_client,
+            name=provider_name,
+            physicalnetworkid=self.vsp_physical_network.id
+        )
         self.assertEqual(isinstance(providers, list), True,
-                         "List Network Service Provider should return a valid list"
+                         "List Network Service Provider should return a "
+                         "valid list"
                          )
         self.assertEqual(provider_name, providers[0].name,
-                         "Name of the Network Service Provider should match with the returned list data"
+                         "Name of the Network Service Provider should match "
+                         "with the returned list data"
                          )
         if state:
             self.assertEqual(providers[0].state, state,
-                             "Network Service Provider state should be '%s'" % state
+                             "Network Service Provider state should be '%s'" %
+                             state
                              )
-        self.debug("Successfully validated the creation and state of Network Service Provider - %s" % provider_name)
+        self.debug("Successfully validated the creation and state of Network "
+                   "Service Provider - %s" % provider_name)
 
-    # validate_VpcOffering - Validates the given VPC offering, matches the given VPC offering name and state against the
-    # list of VPC offerings fetched
+    # validate_VpcOffering - Validates the given VPC offering, matches the
+    # given VPC offering name and state against the list of VPC offerings
+    # fetched
     def validate_VpcOffering(self, vpc_offering, state=None):
         """Validates the VPC offering"""
-        self.debug("Validating the creation and state of VPC offering - %s" % vpc_offering.name)
+        self.debug("Validating the creation and state of VPC offering - %s" %
+                   vpc_offering.name)
         vpc_offs = VpcOffering.list(self.api_client,
                                     id=vpc_offering.id
                                     )
@@ -532,15 +651,18 @@ class nuageTestCase(cloudstackTestCase):
                          "List VPC offering should return a valid list"
                          )
         self.assertEqual(vpc_offering.name, vpc_offs[0].name,
-                         "Name of the VPC offering should match with the returned list data"
+                         "Name of the VPC offering should match with the "
+                         "returned list data"
                          )
         if state:
             self.assertEqual(vpc_offs[0].state, state,
                              "VPC offering state should be '%s'" % state
                              )
-        self.debug("Successfully validated the creation and state of VPC offering - %s" % vpc_offering.name)
+        self.debug("Successfully validated the creation and state of VPC "
+                   "offering - %s" % vpc_offering.name)
 
-    # validate_Vpc - Validates the given VPC, matches the given VPC name and state against the list of VPCs fetched
+    # validate_Vpc - Validates the given VPC, matches the given VPC name and
+    # state against the list of VPCs fetched
     def validate_Vpc(self, vpc, state=None):
         """Validates the VPC"""
         self.debug("Validating the creation and state of VPC - %s" % vpc.name)
@@ -551,19 +673,23 @@ class nuageTestCase(cloudstackTestCase):
                          "List VPC should return a valid list"
                          )
         self.assertEqual(vpc.name, vpcs[0].name,
-                         "Name of the VPC should match with the returned list data"
+                         "Name of the VPC should match with the returned "
+                         "list data"
                          )
         if state:
             self.assertEqual(vpcs[0].state, state,
                              "VPC state should be '%s'" % state
                              )
-        self.debug("Successfully validated the creation and state of VPC - %s" % vpc.name)
+        self.debug("Successfully validated the creation and state of VPC - %s"
+                   % vpc.name)
 
-    # validate_NetworkOffering - Validates the given Network offering, matches the given network offering name and state
-    # against the list of network offerings fetched
+    # validate_NetworkOffering - Validates the given Network offering, matches
+    # the given network offering name and state against the list of network
+    # offerings fetched
     def validate_NetworkOffering(self, net_offering, state=None):
         """Validates the Network offering"""
-        self.debug("Validating the creation and state of Network offering - %s" % net_offering.name)
+        self.debug("Validating the creation and state of Network offering - %s"
+                   % net_offering.name)
         net_offs = NetworkOffering.list(self.api_client,
                                         id=net_offering.id
                                         )
@@ -571,19 +697,22 @@ class nuageTestCase(cloudstackTestCase):
                          "List Network offering should return a valid list"
                          )
         self.assertEqual(net_offering.name, net_offs[0].name,
-                         "Name of the Network offering should match with the returned list data"
+                         "Name of the Network offering should match with the "
+                         "returned list data"
                          )
         if state:
             self.assertEqual(net_offs[0].state, state,
                              "Network offering state should be '%s'" % state
                              )
-        self.debug("Successfully validated the creation and state of Network offering - %s" % net_offering.name)
+        self.debug("Successfully validated the creation and state of Network "
+                   "offering - %s" % net_offering.name)
 
-    # validate_Network - Validates the given network, matches the given network name and state against the list of
-    # networks fetched
+    # validate_Network - Validates the given network, matches the given network
+    # name and state against the list of networks fetched
     def validate_Network(self, network, state=None):
         """Validates the network"""
-        self.debug("Validating the creation and state of Network - %s" % network.name)
+        self.debug("Validating the creation and state of Network - %s" %
+                   network.name)
         networks = Network.list(self.api_client,
                                 id=network.id
                                 )
@@ -591,15 +720,18 @@ class nuageTestCase(cloudstackTestCase):
                          "List network should return a valid list"
                          )
         self.assertEqual(network.name, networks[0].name,
-                         "Name of the network should match with with the returned list data"
+                         "Name of the network should match with with the "
+                         "returned list data"
                          )
         if state:
             self.assertEqual(networks[0].state, state,
                              "Network state should be '%s'" % state
                              )
-        self.debug("Successfully validated the creation and state of Network - %s" % network.name)
+        self.debug("Successfully validated the creation and state of Network "
+                   "- %s" % network.name)
 
-    # check_VM_state - Checks if the given VM is in the expected state form the list of fetched VMs
+    # check_VM_state - Checks if the given VM is in the expected state form the
+    # list of fetched VMs
     def check_VM_state(self, vm, state=None):
         """Validates the VM state"""
         self.debug("Validating the deployment and state of VM - %s" % vm.name)
@@ -614,12 +746,15 @@ class nuageTestCase(cloudstackTestCase):
             self.assertEqual(vms[0].state, state,
                              "Virtual machine is not in the expected state"
                              )
-        self.debug("Successfully validated the deployment and state of VM - %s" % vm.name)
+        self.debug("Successfully validated the deployment and state of VM - %s"
+                   % vm.name)
 
-    # check_Router_state - Checks if the given router is in the expected state form the list of fetched routers
+    # check_Router_state - Checks if the given router is in the expected state
+    # form the list of fetched routers
     def check_Router_state(self, router, state=None):
         """Validates the Router state"""
-        self.debug("Validating the deployment and state of Router - %s" % router.name)
+        self.debug("Validating the deployment and state of Router - %s" %
+                   router.name)
         routers = Router.list(self.api_client,
                               id=router.id,
                               listall=True
@@ -631,13 +766,16 @@ class nuageTestCase(cloudstackTestCase):
             self.assertEqual(routers[0].state, state,
                              "Virtual router is not in the expected state"
                              )
-        self.debug("Successfully validated the deployment and state of Router - %s" % router.name)
+        self.debug("Successfully validated the deployment and state of Router "
+                   "- %s" % router.name)
 
-    # validate_PublicIPAddress - Validates if the given public IP address is in the expected state form the list of
-    # fetched public IP addresses
-    def validate_PublicIPAddress(self, public_ip, network, static_nat=False, vm=None):
+    # validate_PublicIPAddress - Validates if the given public IP address is in
+    # the expected state form the list of fetched public IP addresses
+    def validate_PublicIPAddress(self, public_ip, network, static_nat=False,
+                                 vm=None):
         """Validates the Public IP Address"""
-        self.debug("Validating the assignment and state of public IP address - %s" % public_ip.ipaddress.ipaddress)
+        self.debug("Validating the assignment and state of public IP address "
+                   "- %s" % public_ip.ipaddress.ipaddress)
         public_ips = PublicIPAddress.list(self.api_client,
                                           id=public_ip.ipaddress.id,
                                           networkid=network.id,
@@ -645,181 +783,240 @@ class nuageTestCase(cloudstackTestCase):
                                           listall=True
                                           )
         self.assertEqual(isinstance(public_ips, list), True,
-                         "List public IP for network should return a valid list"
+                         "List public IP for network should return a "
+                         "valid list"
                          )
-        self.assertEqual(public_ips[0].ipaddress, public_ip.ipaddress.ipaddress,
-                         "List public IP for network should list the assigned public IP address"
+        self.assertEqual(public_ips[0].ipaddress,
+                         public_ip.ipaddress.ipaddress,
+                         "List public IP for network should list the assigned "
+                         "public IP address"
                          )
         self.assertEqual(public_ips[0].state, "Allocated",
                          "Assigned public IP is not in the allocated state"
                          )
         if static_nat and vm:
             self.assertEqual(public_ips[0].virtualmachineid, vm.id,
-                             "Static NAT rule is not enabled for the VM on the assigned public IP"
+                             "Static NAT rule is not enabled for the VM on "
+                             "the assigned public IP"
                              )
-        self.debug("Successfully validated the assignment and state of public IP address - %s" %
-                   public_ip.ipaddress.ipaddress)
+        self.debug("Successfully validated the assignment and state of public "
+                   "IP address - %s" % public_ip.ipaddress.ipaddress)
 
-    # VSD verifications
-    # VSD is a programmable policy and analytics engine of Nuage VSP SDN platform
+    # VSD verifications; VSD is a programmable policy and analytics engine of
+    # Nuage VSP SDN platform
 
-    # get_externalID_filter - Returns corresponding external ID filter of the given object in VSD
+    # get_externalID_filter - Returns corresponding external ID filter of the
+    # given object in VSD
     def get_externalID_filter(self, object_id):
         ext_id = object_id + "@" + self.cms_id
         return self.vsd.set_externalID_filter(ext_id)
 
     # fetch_by_externalID - Returns VSD object with the given external ID
     def fetch_by_externalID(self, fetcher, *cs_objects):
-        """ Fetches a child object by external id using the given fetcher, and uuids of the given cloudstack objects.
+        """ Fetches a child object by external id using the given fetcher, and
+        uuids of the given cloudstack objects.
         E.G.
-          - fetch_by_external_id(vsdk.NUSubnet(id="954de425-b860-410b-be09-c560e7dbb474").vms, cs_vm)
-          - fetch_by_external_id(session.user.floating_ips, cs_network, cs_public_ip)
+          - fetch_by_external_id(vsdk.NUSubnet
+          (id="954de425-b860-410b-be09-c560e7dbb474").vms, cs_vm)
+          - fetch_by_external_id
+          (session.user.floating_ips, cs_network, cs_public_ip)
         :param fetcher: VSPK Fetcher to use to find the child entity
         :param cs_objects: Cloudstack objects to take the UUID from.
         :return: the VSPK object having the correct externalID
         """
-        return fetcher.get_first(filter="externalID BEGINSWITH '%s'" % ":".join([o.id for o in cs_objects]))
+        return fetcher.get_first(filter="externalID BEGINSWITH '%s'" %
+                                        ":".join([o.id for o in cs_objects]))
 
-    # verify_vsd_network - Verifies the given domain and network/VPC against the corresponding installed enterprise,
-    # domain, zone, and subnet in VSD
+    # verify_vsd_network - Verifies the given CloudStack domain and network/VPC
+    # against the corresponding installed enterprise, domain, zone, and subnet
+    # in VSD
     def verify_vsd_network(self, domain_id, network, vpc=None):
-        self.debug("Verifying the creation and state of Network - %s in VSD" % network.name)
-        vsd_enterprise = self.vsd.get_enterprise(filter=self.get_externalID_filter(domain_id))
-        ext_network_filter = self.get_externalID_filter(vpc.id) if vpc else self.get_externalID_filter(network.id)
+        self.debug("Verifying the creation and state of Network - %s in VSD" %
+                   network.name)
+        vsd_enterprise = self.vsd.get_enterprise(
+            filter=self.get_externalID_filter(domain_id))
+        ext_network_filter = self.get_externalID_filter(vpc.id) if vpc \
+            else self.get_externalID_filter(network.id)
         vsd_domain = self.vsd.get_domain(filter=ext_network_filter)
         vsd_zone = self.vsd.get_zone(filter=ext_network_filter)
-        vsd_subnet = self.vsd.get_subnet(filter=self.get_externalID_filter(network.id))
+        vsd_subnet = self.vsd.get_subnet(
+            filter=self.get_externalID_filter(network.id))
         self.assertEqual(vsd_enterprise.name, domain_id,
-                         "VSD enterprise name should match CloudStack domain uuid"
+                         "VSD enterprise name should match CloudStack domain "
+                         "uuid"
                          )
         if vpc:
             self.assertEqual(vsd_domain.description, "VPC_" + vpc.name,
-                             "VSD domain description should match VPC name in CloudStack"
+                             "VSD domain description should match VPC name in "
+                             "CloudStack"
                              )
             self.assertEqual(vsd_zone.description, "VPC_" + vpc.name,
-                             "VSD zone description should match VPC name in CloudStack"
+                             "VSD zone description should match VPC name in "
+                             "CloudStack"
                              )
         else:
             self.assertEqual(vsd_domain.description, network.name,
-                             "VSD domain description should match network name in CloudStack"
+                             "VSD domain description should match network "
+                             "name in CloudStack"
                              )
             self.assertEqual(vsd_zone.description, network.name,
-                             "VSD zone description should match network name in CloudStack"
+                             "VSD zone description should match network name "
+                             "in CloudStack"
                              )
         self.assertEqual(vsd_subnet.description, network.name,
-                         "VSD subnet description should match network name in CloudStack"
+                         "VSD subnet description should match network name in "
+                         "CloudStack"
                          )
-        self.debug("Successfully verified the creation and state of Network - %s in VSD" % network.name)
+        self.debug("Successfully verified the creation and state of Network "
+                   "- %s in VSD" % network.name)
 
-    # verify_vsd_vm - Verifies the given VM deployment and state in VSD
-    def verify_vsd_vm(self, vm, stopped=None):
-        self.debug("Verifying the deployment and state of VM - %s in VSD" % vm.name)
+    # verify_vsd_object_status - Verifies the given CloudStack object status in
+    # VSD
+    def verify_vsd_object_status(self, cs_object, stopped):
+        vsd_object = self.vsd.get_vm(
+            filter=self.get_externalID_filter(cs_object.id))
+        expected_status = cs_object.state.upper() if not stopped \
+            else "DELETE_PENDING"
+        tries = 0
+        while (vsd_object.status != expected_status) and (tries < 3):
+            self.debug("Waiting for the CloudStack object " + cs_object.name +
+                       " to be fully resolved in VSD...")
+            time.sleep(30)
+            self.debug("Rechecking the CloudStack object " + cs_object.name +
+                       " status in VSD...")
+            vsd_object = self.vsd.get_vm(
+                filter=self.get_externalID_filter(cs_object.id))
+            tries += 1
+        self.assertEqual(vsd_object.status, expected_status,
+                         "Object " + cs_object.name +
+                         " state in VSD should match its state in CloudStack"
+                         )
+
+    # verify_vsd_vm - Verifies the given CloudStack VM deployment and status in
+    # VSD
+    def verify_vsd_vm(self, vm, stopped=False):
+        self.debug("Verifying the deployment and state of VM - %s in VSD" %
+                   vm.name)
         vsd_vm = self.vsd.get_vm(filter=self.get_externalID_filter(vm.id))
         self.assertNotEqual(vsd_vm, None,
                             "VM data format in VSD should not be of type None"
                             )
-        for nic in vm.nic:
-            vsd_subnet = self.vsd.get_subnet(filter=self.get_externalID_filter(nic.networkid))
-            vsd_vport = self.vsd.get_vport(subnet=vsd_subnet, filter=self.get_externalID_filter(nic.id))
-            vsd_vm_interface = self.vsd.get_vm_interface(filter=self.get_externalID_filter(nic.id))
+        vm_info = VirtualMachine.list(self.api_client, id=vm.id)[0]
+        for nic in vm_info.nic:
+            vsd_subnet = self.vsd.get_subnet(
+                filter=self.get_externalID_filter(nic.networkid))
+            vsd_vport = self.vsd.get_vport(
+                subnet=vsd_subnet, filter=self.get_externalID_filter(nic.id))
+            vsd_vm_interface = self.vsd.get_vm_interface(
+                filter=self.get_externalID_filter(nic.id))
             self.assertEqual(vsd_vport.active, True,
                              "VSD VM vport should be active"
                              )
             self.assertEqual(vsd_vm_interface.ip_address, nic.ipaddress,
-                             "VSD VM interface IP address should match VM's NIC IP address in CloudStack"
+                             "VSD VM interface IP address should match VM's "
+                             "NIC IP address in CloudStack"
                              )
         if not self.isSimulator:
-            if stopped:
-                self.assertEqual(vsd_vm.status, "DELETE_PENDING",
-                                 "VM state in VSD should be DELETE_PENDING"
-                                 )
-            else:
-                self.assertEqual(vsd_vm.status, vm.state.upper(),
-                                 "VM state in VSD should match its state in CloudStack"
-                                 )
-        self.debug("Successfully verified the deployment and state of VM - %s in VSD" % vm.name)
+            self.verify_vsd_object_status(vm, stopped)
+        self.debug("Successfully verified the deployment and state of VM - %s "
+                   "in VSD" % vm.name)
 
-    # verify_vsd_router - Verifies the given network router deployment and state in VSD
-    def verify_vsd_router(self, router, stopped=None):
-        self.debug("Verifying the deployment and state of Router - %s in VSD" % router.name)
-        vsd_router = self.vsd.get_vm(filter=self.get_externalID_filter(router.id))
+    # verify_vsd_router - Verifies the given CloudStack network router
+    # deployment and status in VSD
+    def verify_vsd_router(self, router, stopped=False):
+        self.debug("Verifying the deployment and state of Router - %s in VSD" %
+                   router.name)
+        vsd_router = self.vsd.get_vm(
+            filter=self.get_externalID_filter(router.id))
         self.assertNotEqual(vsd_router, None,
-                            "Router data format in VSD should not be of type None"
+                            "Router data format in VSD should not be of type "
+                            "None"
                             )
         if not self.isSimulator:
-            if stopped:
-                self.assertEqual(vsd_router.status, "DELETE_PENDING",
-                                 "Router state in VSD should be DELETE_PENDING"
-                                 )
-            else:
-                self.assertEqual(vsd_router.status, router.state.upper(),
-                                 "Router state in VSD should match its state in CloudStack"
-                                 )
-        self.debug("Successfully verified the deployment and state of Router - %s in VSD" % router.name)
+            self.verify_vsd_object_status(router, stopped)
+        self.debug("Successfully verified the deployment and state of Router "
+                   "- %s in VSD" % router.name)
 
-    # verify_vsd_lb_device - Verifies the given LB device deployment and state in VSD
-    def verify_vsd_lb_device(self, lb_device, stopped=None):
-        self.debug("Verifying the deployment and state of LB device - %s in VSD" % lb_device.name)
-        vsd_lb_device = self.vsd.get_vm(filter=self.get_externalID_filter(lb_device.id))
+    # verify_vsd_lb_device - Verifies the given CloudStack LB device deployment
+    # and status in VSD
+    def verify_vsd_lb_device(self, lb_device, stopped=False):
+        self.debug("Verifying the deployment and state of LB device - %s in "
+                   "VSD" % lb_device.name)
+        vsd_lb_device = self.vsd.get_vm(
+            filter=self.get_externalID_filter(lb_device.id))
         self.assertNotEqual(vsd_lb_device, None,
-                            "LB device data format in VSD should not be of type None"
+                            "LB device data format in VSD should not be of "
+                            "type None"
                             )
         if not self.isSimulator:
-            if stopped:
-                self.assertEqual(vsd_lb_device.status, "DELETE_PENDING",
-                                 "LB device state in VSD should be DELETE_PENDING"
-                                 )
-            else:
-                self.assertEqual(vsd_lb_device.status, lb_device.state.upper(),
-                                 "LB device state in VSD should match its state in CloudStack"
-                                 )
-        self.debug("Successfully verified the deployment and state of LB device - %s in VSD" % lb_device.name)
+            self.verify_vsd_object_status(lb_device, stopped)
+        self.debug("Successfully verified the deployment and state of LB "
+                   "device - %s in VSD" % lb_device.name)
 
-    # verify_vsd_floating_ip -  Verifies the Static NAT rule on the given public IP of the given VM in the given network
-    # against the corresponding installed Floating IP in VSD
+    # verify_vsd_floating_ip -  Verifies the CloudStack Static NAT rule on the
+    # given public IP of the given VM in the given network against the
+    # corresponding installed Floating IP in VSD
     def verify_vsd_floating_ip(self, network, vm, public_ipaddress, vpc=None):
-        self.debug("Verifying the assignment and state of public IP address - %s in VSD" % public_ipaddress.ipaddress)
-        ext_fip_filter = self.get_externalID_filter(vpc.id + ":" + public_ipaddress.id) if vpc else \
-            self.get_externalID_filter(network.id + ":" + public_ipaddress.id)
+        self.debug("Verifying the assignment and state of public IP address "
+                   "- %s in VSD" % public_ipaddress.ipaddress)
+        ext_fip_filter = self.get_externalID_filter(vpc.id + ":" +
+                                                    public_ipaddress.id) \
+            if vpc else self.get_externalID_filter(network.id + ":" +
+                                                   public_ipaddress.id)
         vsd_fip = self.vsd.get_floating_ip(filter=ext_fip_filter)
         self.assertEqual(vsd_fip.address, public_ipaddress.ipaddress,
-                         "Floating IP address in VSD should match acquired public IP address in CloudStack"
+                         "Floating IP address in VSD should match acquired "
+                         "public IP address in CloudStack"
                          )
         self.assertEqual(vsd_fip.assigned, True,
                          "Floating IP in VSD should be assigned"
                          )
-        ext_network_filter = self.get_externalID_filter(vpc.id) if vpc else self.get_externalID_filter(network.id)
+        ext_network_filter = self.get_externalID_filter(vpc.id) if vpc \
+            else self.get_externalID_filter(network.id)
         vsd_domain = self.vsd.get_domain(filter=ext_network_filter)
         self.assertEqual(vsd_domain.id, vsd_fip.parent_id,
-                         "Floating IP in VSD should be associated with the correct VSD domain, which in turn should "
-                         "correspond to the correct VPC (or) network in CloudStack"
+                         "Floating IP in VSD should be associated with the "
+                         "correct VSD domain, which in turn should correspond "
+                         "to the correct VPC (or) network in CloudStack"
                          )
-        vsd_subnet = self.vsd.get_subnet(filter=self.get_externalID_filter(network.id))
-        for nic in vm.nic:
+        vsd_subnet = self.vsd.get_subnet(
+            filter=self.get_externalID_filter(network.id))
+        vm_info = VirtualMachine.list(self.api_client, id=vm.id)[0]
+        for nic in vm_info.nic:
             if nic.networkid == network.id:
-                vsd_vport = self.vsd.get_vport(subnet=vsd_subnet, filter=self.get_externalID_filter(nic.id))
+                vsd_vport = self.vsd.get_vport(
+                    subnet=vsd_subnet,
+                    filter=self.get_externalID_filter(nic.id))
         self.assertEqual(vsd_vport.associated_floating_ip_id, vsd_fip.id,
-                         "Floating IP in VSD should be associated to the correct VSD vport, which in turn should "
-                         "correspond to the correct Static NAT rule enabled VM and network in CloudStack"
+                         "Floating IP in VSD should be associated to the "
+                         "correct VSD vport, which in turn should correspond "
+                         "to the correct Static NAT rule enabled VM and "
+                         "network in CloudStack"
                          )
-        self.debug("Successfully verified the assignment and state of public IP address - %s in VSD" %
-                   public_ipaddress.ipaddress)
+        self.debug("Successfully verified the assignment and state of public "
+                   "IP address - %s in VSD" % public_ipaddress.ipaddress)
 
-    # verify_vsd_firewall_rule - Verifies the given Network Firewall (Ingress/Egress ACL) rule against the corresponding
-    # installed firewall rule in VSD
+    # verify_vsd_firewall_rule - Verifies the given CloudStack Network Firewall
+    # (Ingress/Egress ACL) rule against the corresponding installed firewall
+    # rule in VSD
     def verify_vsd_firewall_rule(self, firewall_rule, traffic_type="Ingress"):
-        self.debug("Verifying the creation and state of Network Firewall (Ingress/Egress ACL) rule with ID - %s in VSD"
-                   % firewall_rule.id)
+        self.debug("Verifying the creation and state of Network Firewall "
+                   "(Ingress/Egress ACL) rule with ID - %s in VSD" %
+                   firewall_rule.id)
         ext_fw_rule_filter = self.get_externalID_filter(firewall_rule.id)
-        vsd_fw_rule = self.vsd.get_egress_acl_entry(filter=ext_fw_rule_filter) if traffic_type is "Ingress" else \
-            self.vsd.get_ingress_acl_entry(filter=ext_fw_rule_filter)
+        vsd_fw_rule = self.vsd.get_egress_acl_entry(
+            filter=ext_fw_rule_filter) if traffic_type is "Ingress" \
+            else self.vsd.get_ingress_acl_entry(filter=ext_fw_rule_filter)
         self.assertEqual(vsd_fw_rule.policy_state, "LIVE",
-                         "Ingress/Egress ACL rule's policy state in VSD should be LIVE"
+                         "Ingress/Egress ACL rule's policy state in VSD "
+                         "should be LIVE"
                          )
-        dest_port = str(firewall_rule.startport) + "-" + str(firewall_rule.endport)
+        dest_port = \
+            str(firewall_rule.startport) + "-" + str(firewall_rule.endport)
         self.assertEqual(vsd_fw_rule.destination_port, dest_port,
-                         "Ingress/Egress ACL rule's destination port in VSD should match corresponding rule's "
-                         "destination port in CloudStack"
+                         "Ingress/Egress ACL rule's destination port in VSD "
+                         "should match corresponding rule's destination port "
+                         "in CloudStack"
                          )
         vsd_protocol = int(vsd_fw_rule.protocol)
         protocol = "tcp"
@@ -830,8 +1027,9 @@ class nuageTestCase(cloudstackTestCase):
         elif vsd_protocol == 17:
             protocol = "udp"
         self.assertEqual(protocol, firewall_rule.protocol.lower(),
-                         "Ingress/Egress ACL rule's protocol in VSD should match corresponding rule's protocol in "
-                         "CloudStack"
+                         "Ingress/Egress ACL rule's protocol in VSD should "
+                         "match corresponding rule's protocol in CloudStack"
                          )
-        self.debug("Successfully verified the creation and state of Network Firewall (Ingress/Egress ACL) rule with ID "
-                   "- %s in VSD" % firewall_rule.id)
+        self.debug("Successfully verified the creation and state of Network "
+                   "Firewall (Ingress/Egress ACL) rule with ID - %s in VSD" %
+                   firewall_rule.id)

--- a/test/integration/plugins/nuagevsp/test_nuage_internal_dns.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_internal_dns.py
@@ -1,0 +1,523 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+""" Component tests for Internal DNS functionality with Nuage VSP SDN plugin
+"""
+# Import Local Modules
+from nuageTestCase import nuageTestCase
+from marvin.cloudstackAPI import updateZone
+from marvin.lib.base import Account, Network
+# Import System Modules
+from nose.plugins.attrib import attr
+
+
+class TestNuageInternalDns(nuageTestCase):
+    DNS = "06"
+    HOSTNAME = "0c"
+    DOMAINNAME = "0f"
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestNuageInternalDns, cls).setUpClass()
+        cls.dnsdata = cls.test_data["nuagevsp"]
+        return
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.account = Account.create(
+            self.apiclient,
+            self.test_data["account"],
+            admin=True,
+            domainid=self.domain.id
+        )
+        self.test_data["virtual_machine"]["displayname"] = "vm1"
+        self.test_data["virtual_machine"]["name"] = "vm1"
+
+        self.cleanup = [self.account]
+        return
+
+    # Creates and verifies the firewall rule
+    def create_and_verify_fw(self, vm, public_ip, network):
+        self.debug("Create and verify firewall rule")
+        self.create_StaticNatRule_For_VM(vm, public_ip, network)
+
+        # VSD verification
+        self.verify_vsd_floating_ip(network, vm, public_ip.ipaddress)
+
+        fw_rule = self.create_FirewallRule(
+            public_ip, self.test_data["ingress_rule"])
+        self.verify_vsd_firewall_rule(fw_rule)
+
+    def verify_vsd_dhcp_option(self, dhcp_type, value, subnet_or_vm_interface,
+                               is_vm_interface=False):
+        self.debug("Verifying the creation and value of DHCP option type - %s "
+                   "in VSD" % dhcp_type)
+        found_dhcp_type = False
+        if is_vm_interface:
+            dhcp_options = self.vsd.get_vm_interface_dhcpoptions(
+                filter=self.get_externalID_filter(subnet_or_vm_interface.id))
+        else:
+            dhcp_options = self.vsd.get_subnet_dhcpoptions(
+                filter=self.get_externalID_filter(subnet_or_vm_interface.id))
+        for dhcp_option in dhcp_options:
+            self.debug("dhcptype option is %s:" % dhcp_option.actual_type)
+            self.debug("dhcptype expected value is option is %s:" % dhcp_type)
+            if dhcp_option.type == dhcp_type:
+                found_dhcp_type = True
+                if isinstance(dhcp_option.actual_values, list):
+                    self.debug("dhcptype actual value is %s:" %
+                               dhcp_option.actual_values)
+                    if value in dhcp_option.actual_values:
+                        self.debug("Excepted DHCP option value found in VSD")
+                    else:
+                        self.fail("Excepted DHCP option value not found in "
+                                  "VSD")
+                else:
+                    self.assertEqual(dhcp_options.actual_values, value,
+                                     "Expected DHCP option value is not same "
+                                     "in both CloudStack and VSD"
+                                     )
+        if not found_dhcp_type:
+            self.fail("Expected DHCP option type and value not found in the "
+                      "VSD")
+        self.debug("Successfully verified the creation and value of DHCP "
+                   "option type - %s in VSD" % dhcp_type)
+
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
+    def test_01_Isolated_Network_with_zone(self):
+        """ Verify InternalDns on Isolated Network
+        """
+
+        # Validate the following
+        # 1. Create an Isolated network - network1 (10.1.1.1/24) by using DNS
+        #    network offering.
+        # 2. Deploy vm1 in network1.
+        # 3. Verify dhcp option 06 and 0f for subnet
+        # 4. Verify dhcp option 06,15 and 0f for vm Interface.
+
+        # update Network Domain at zone level
+        cmd = updateZone.updateZoneCmd()
+        cmd.id = self.zone.id
+        cmd.domain = "isolated.com"
+        self.apiclient.updateZone(cmd)
+        self.debug("Creating and enabling Nuage Vsp Isolated Network "
+                   "offering...")
+        network_offering = self.create_NetworkOffering(
+            self.dnsdata["isolated_network_offering"])
+        self.validate_NetworkOffering(network_offering, state="Enabled")
+
+        network_1 = self.create_Network(network_offering)
+        vm_1 = self.create_VM(network_1)
+
+        # VSD verification
+        self.verify_vsd_network(self.domain.id, network_1)
+        self.verify_vsd_vm(vm_1)
+
+        # Internal DNS check point on VSD
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(self.DOMAINNAME, "isolated.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "isolated.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
+    def test_02_Isolated_Network(self):
+        """ Verify InternalDns on Isolated Network with ping by hostname
+        """
+
+        # Validate the following
+        # 1. Create an Isolated network - network1 (10.1.1.1/24) by using DNS
+        #    network offering.
+        # 2. Deploy vm1 in network1.
+        # 3. Verify dhcp option 06 and 0f for subnet
+        # 4. Verify dhcp option 06,15 and 0f for vm Interface.
+        # 5. Deploy VM2 in network1.
+        # 6. Verify end to end by pinging with hostname
+
+        cmd = updateZone.updateZoneCmd()
+        cmd.id = self.zone.id
+        cmd.domain = "isolated.com"
+        self.apiclient.updateZone(cmd)
+
+        self.debug("Creating and enabling Nuage Vsp Isolated Network "
+                   "offering...")
+        network_offering = self.create_NetworkOffering(
+            self.dnsdata["isolated_network_offering"])
+        self.validate_NetworkOffering(network_offering, state="Enabled")
+
+        network_1 = self.create_Network(network_offering)
+        vm_1 = self.create_VM(network_1)
+
+        # VSD verification
+        self.verify_vsd_network(self.domain.id, network_1)
+        self.verify_vsd_vm(vm_1)
+
+        # Internal DNS check point on VSD
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(self.DOMAINNAME, "isolated.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "isolated.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+        self.test_data["virtual_machine"]["displayname"] = "vm2"
+        self.test_data["virtual_machine"]["name"] = "vm2"
+        vm_2 = self.create_VM(network_1)
+        self.test_data["virtual_machine"]["displayname"] = "vm1"
+        self.test_data["virtual_machine"]["name"] = "vm1"
+        self.verify_vsd_vm(vm_2)
+        for nic in vm_2.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "isolated.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm2", nic, True)
+
+        public_ip_1 = self.acquire_PublicIPAddress(network_1)
+        self.create_and_verify_fw(vm_1, public_ip_1, network_1)
+
+        vm_public_ip = public_ip_1.ipaddress.ipaddress
+
+        try:
+            vm_1.ssh_ip = vm_public_ip
+            vm_1.ssh_port = self.test_data["virtual_machine"]["ssh_port"]
+            vm_1.username = self.test_data["virtual_machine"]["username"]
+            vm_1.password = self.test_data["virtual_machine"]["password"]
+            self.debug("SSHing into VM: %s with %s" %
+                       (vm_1.ssh_ip, vm_1.password))
+
+            ssh = vm_1.get_ssh_client(ipaddress=vm_public_ip)
+
+        except Exception as e:
+            self.fail("SSH into VM failed with exception %s" % e)
+
+        cmd = 'ping -c 2 vm2'
+        self.debug("ping vm2 by hostname with command: " + cmd)
+        outputlist = ssh.execute(cmd)
+        self.debug("command is executed properly " + cmd)
+        completeoutput = str(outputlist).strip('[]')
+        self.debug("complete output is " + completeoutput)
+        expectedlist = ['2 received', 'vm2.isolated.com', vm_2.ipaddress]
+        for item in expectedlist:
+            if item in completeoutput:
+                self.debug("excepted value found in vm: " + item)
+            else:
+                self.fail("excepted value not found in vm: " + item)
+
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
+    def test_03_Update_Network_with_Domain(self):
+        """ Verify update NetworkDomain for InternalDns on Isolated Network
+        """
+
+        # Validate the following
+        # 1. Create an Isolated network - network1 (10.1.1.1/24) by using DNS
+        #    network offering.
+        # 2. Deploy vm1 in network1.
+        # 3. Verify dhcp option 06 and 0f for subnet
+        # 4. Verify dhcp option 06,15 and 0f for vm Interface.
+        # 5. Update Network domain and verify it is properly updated
+
+        # update Network Domain at zone level
+        cmd = updateZone.updateZoneCmd()
+        cmd.id = self.zone.id
+        cmd.domain = "isolated.com"
+        self.apiclient.updateZone(cmd)
+
+        self.debug("Creating and enabling Nuage Vsp Isolated Network "
+                   "offering...")
+        network_offering = self.create_NetworkOffering(
+            self.dnsdata["isolated_network_offering"])
+        self.validate_NetworkOffering(network_offering, state="Enabled")
+
+        network_1 = self.create_Network(network_offering)
+        vm_1 = self.create_VM(network_1)
+
+        # VSD verification
+        self.verify_vsd_network(self.domain.id, network_1)
+        self.verify_vsd_vm(vm_1)
+
+        # Internal DNS check point on VSD
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(self.DOMAINNAME, "isolated.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "isolated.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+        update_response = Network.update(
+            network_1, self.apiclient, id=network_1.id,
+            networkdomain="update.com", changecidr=False)
+        completeoutput = str(update_response).strip('[]')
+        self.debug("network update response is " + completeoutput)
+        self.assertEqual("update.com", update_response.networkdomain,
+                         "Network Domain is not updated as expected"
+                         )
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(self.DOMAINNAME, "update.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "update.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
+    def test_04_Update_Network_with_Domain(self):
+        """ Verify update NetworkDomain for InternalDns on Isolated Network
+        with ping VM
+        """
+
+        # Validate the following
+        # 1. Create an Isolated network - network1 (10.1.1.1/24) by using DNS
+        #    network offering.
+        # 2. Deploy vm1 in network1.
+        # 3. Verify dhcp option 06 and 0f for subnet
+        # 4. Verify dhcp option 06,15 and 0f for vm Interface.
+        # 5. Update Network domain and verify it is properly updated
+
+        # update Network Domain at zone level
+        cmd = updateZone.updateZoneCmd()
+        cmd.id = self.zone.id
+        cmd.domain = "isolated.com"
+        self.apiclient.updateZone(cmd)
+
+        self.debug("Creating and enabling Nuage Vsp Isolated Network "
+                   "offering...")
+        network_offering = self.create_NetworkOffering(
+            self.dnsdata["isolated_network_offering"])
+        self.validate_NetworkOffering(network_offering, state="Enabled")
+
+        network_1 = self.create_Network(network_offering)
+        vm_1 = self.create_VM(network_1)
+
+        # VSD verification
+        self.verify_vsd_network(self.domain.id, network_1)
+        self.verify_vsd_vm(vm_1)
+
+        # Internal DNS check point on VSD
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(
+            self.DOMAINNAME, "isolated.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "isolated.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+        update_response = Network.update(
+            network_1, self.apiclient, id=network_1.id,
+            networkdomain="update.com", changecidr=False)
+        completeoutput = str(update_response).strip('[]')
+        self.debug("network update response is " + completeoutput)
+        self.assertEqual("update.com", update_response.networkdomain,
+                         "Network Domain is not updated as expected"
+                         )
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(self.DOMAINNAME, "update.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "update.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+        # stop and start VM to get new DHCP option
+        try:
+            vm_1.stop(self.apiclient)
+        except Exception as e:
+            self.fail("Failed to stop the virtual instances, %s" % e)
+
+        try:
+            vm_1.start(self.apiclient)
+        except Exception as e:
+            self.fail("Failed to start the virtual instances, %s" % e)
+
+        self.test_data["virtual_machine"]["displayname"] = "vm2"
+        self.test_data["virtual_machine"]["name"] = "vm2"
+        vm_2 = self.create_VM(network_1)
+        self.test_data["virtual_machine"]["displayname"] = "vm1"
+        self.test_data["virtual_machine"]["name"] = "vm1"
+        self.verify_vsd_vm(vm_2)
+        for nic in vm_2.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(
+                self.DOMAINNAME, "update.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm2", nic, True)
+
+        public_ip_1 = self.acquire_PublicIPAddress(network_1)
+        self.create_and_verify_fw(vm_1, public_ip_1, network_1)
+
+        vm_public_ip = public_ip_1.ipaddress.ipaddress
+
+        try:
+            vm_1.ssh_ip = vm_public_ip
+            vm_1.ssh_port = self.test_data["virtual_machine"]["ssh_port"]
+            vm_1.username = self.test_data["virtual_machine"]["username"]
+            vm_1.password = self.test_data["virtual_machine"]["password"]
+            self.debug("SSHing into VM: %s with %s" %
+                       (vm_1.ssh_ip, vm_1.password))
+
+            ssh = vm_1.get_ssh_client(ipaddress=vm_public_ip)
+
+        except Exception as e:
+            self.fail("SSH into VM failed with exception: %s " % e)
+
+        cmd = 'ping -c 2 vm2'
+        self.debug("ping vm2 by hostname with command: " + cmd)
+        outputlist = ssh.execute(cmd)
+        self.debug("command is executed properly " + cmd)
+        completeoutput = str(outputlist).strip('[]')
+        self.debug("complete output is " + completeoutput)
+        expectedlist = ['2 received', 'vm2.update.com', vm_2.ipaddress]
+        for item in expectedlist:
+            if item in completeoutput:
+                self.debug("excepted value found in vm: " + item)
+            else:
+                self.fail("excepted value not found in vm: " + item)
+
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
+    def test_05_VPC_Network_With_InternalDns(self):
+        """ Verify InternalDns on VPC Network
+        """
+
+        # Validate the following
+        # 1. Create a VPC and tier network by using DNS network offering.
+        # 2. Deploy vm1 in tier network.
+        # 3. Verify dhcp option 06 and 0f for subnet
+        # 4. Verify dhcp option 06,15 and 0f for vm Interface.
+
+        cmd = updateZone.updateZoneCmd()
+        cmd.id = self.zone.id
+        cmd.domain = "vpc.com"
+        self.apiclient.updateZone(cmd)
+        vpc_off = self.create_VpcOffering(self.dnsdata["vpc_offering"])
+        self.validate_VpcOffering(vpc_off, state="Enabled")
+
+        vpc = self.create_Vpc(vpc_off, cidr='10.1.0.0/16', cleanup=False)
+
+        self.debug("Creating Nuage Vsp VPC Network offering...")
+        network_offering = self.create_NetworkOffering(
+            self.dnsdata["vpc_network_offering"])
+        self.validate_NetworkOffering(network_offering, state="Enabled")
+        network_1 = self.create_Network(
+            network_offering, gateway='10.1.1.1', vpc=vpc)
+
+        vm_1 = self.create_VM(network_1)
+
+        # VSD verification
+        self.verify_vsd_network(self.domain.id, network_1, vpc)
+        self.verify_vsd_vm(vm_1)
+
+        # Internal DNS check point on VSD
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(self.DOMAINNAME, "vpc.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(self.DOMAINNAME, "vpc.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
+    def test_06_VPC_Network_With_InternalDns(self):
+        """ Verify InternalDns on VPC Network by ping with hostname
+        """
+
+        # Validate the following
+        # 1. Create a VPC and Tier network by using DNS network offering.
+        # 2. Deploy vm1 in Tier network network1.
+        # 3. Verify dhcp option 06 and 0f for subnet
+        # 4. Verify dhcp option 06,15 and 0f for vm Interface.
+        # 5. Deploy Vm2.
+        # 6. Verify end to end by pinging with hostname
+
+        cmd = updateZone.updateZoneCmd()
+        cmd.id = self.zone.id
+        cmd.domain = "vpc.com"
+        self.apiclient.updateZone(cmd)
+
+        vpc_off = self.create_VpcOffering(self.dnsdata["vpc_offering"])
+        self.validate_VpcOffering(vpc_off, state="Enabled")
+        vpc = self.create_Vpc(vpc_off, cidr='10.1.0.0/16', cleanup=False)
+
+        self.debug("Creating Nuage Vsp VPC Network offering...")
+        network_offering = self.create_NetworkOffering(
+            self.dnsdata["vpc_network_offering"])
+        self.validate_NetworkOffering(network_offering, state="Enabled")
+        network_1 = self.create_Network(
+            network_offering, gateway='10.1.1.1', vpc=vpc)
+
+        vm_1 = self.create_VM(network_1)
+
+        # VSD verification
+        self.verify_vsd_network(self.domain.id, network_1, vpc)
+        self.verify_vsd_vm(vm_1)
+        # Internal DNS check point on VSD
+        self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", network_1)
+        self.verify_vsd_dhcp_option(self.DOMAINNAME, "vpc.com", network_1)
+        for nic in vm_1.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(self.DOMAINNAME, "vpc.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm1", nic, True)
+
+        self.test_data["virtual_machine"]["displayname"] = "vm2"
+        self.test_data["virtual_machine"]["name"] = "vm2"
+        vm_2 = self.create_VM(network_1)
+        self.test_data["virtual_machine"]["displayname"] = "vm1"
+        self.test_data["virtual_machine"]["name"] = "vm1"
+        self.verify_vsd_vm(vm_2)
+        for nic in vm_2.nic:
+            self.verify_vsd_dhcp_option(self.DNS, "10.1.1.2", nic, True)
+            self.verify_vsd_dhcp_option(self.DOMAINNAME, "vpc.com", nic, True)
+            self.verify_vsd_dhcp_option(self.HOSTNAME, "vm2", nic, True)
+
+        public_ip_1 = self.acquire_PublicIPAddress(network_1, vpc)
+        self.create_StaticNatRule_For_VM(vm_1, public_ip_1, network_1)
+        # Adding Network ACL rule in the Public tier
+        self.debug("Adding Network ACL rule to make the created NAT rule "
+                   "(SSH) accessible...")
+        public_ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=network_1)
+
+        # VSD verification
+        self.verify_vsd_firewall_rule(public_ssh_rule)
+        vm_public_ip = public_ip_1.ipaddress.ipaddress
+
+        try:
+            vm_1.ssh_ip = vm_public_ip
+            vm_1.ssh_port = self.test_data["virtual_machine"]["ssh_port"]
+            vm_1.username = self.test_data["virtual_machine"]["username"]
+            vm_1.password = self.test_data["virtual_machine"]["password"]
+            self.debug("SSHing into VM: %s with %s" %
+                       (vm_1.ssh_ip, vm_1.password))
+
+            ssh = vm_1.get_ssh_client(ipaddress=vm_public_ip)
+
+        except Exception as e:
+            self.fail("SSH into VM failed with exception %s" % e)
+
+        cmd = 'ping -c 2 vm2'
+        self.debug("ping vm2 by hostname with command: " + cmd)
+        outputlist = ssh.execute(cmd)
+        self.debug("command is executed properly " + cmd)
+        completeoutput = str(outputlist).strip('[]')
+        self.debug("complete output is " + completeoutput)
+        expectedlist = ['2 received', 'vm2.vpc.com', vm_2.ipaddress]
+        for item in expectedlist:
+            if item in completeoutput:
+                self.debug("excepted value found in vm: " + item)
+            else:
+                self.fail("excepted value not found in vm: " + item)

--- a/test/integration/plugins/nuagevsp/test_nuage_password_reset.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_password_reset.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-""" Component tests for user data and password reset functionality with Nuage VSP SDN plugin
+""" Component tests for user data and password reset functionality with
+Nuage VSP SDN plugin
 """
 # Import Local Modules
 from nuageTestCase import nuageTestCase
@@ -31,7 +32,8 @@ import base64
 
 
 class TestNuagePasswordReset(nuageTestCase):
-    """Test user data and password reset functionality with Nuage VSP SDN plugin
+    """Test user data and password reset functionality with
+    Nuage VSP SDN plugin
     """
 
     @classmethod
@@ -60,22 +62,26 @@ class TestNuagePasswordReset(nuageTestCase):
         if isinstance(list_volume, list):
             self.volume = list_volume[0]
         else:
-            raise Exception("Exception: Unable to find root volume for VM with ID - %s" % vm.id)
-        self.pw_enabled_template = Template.create(self.api_client,
-                                                   self.test_data["template"],
-                                                   self.volume.id,
-                                                   account=self.account.name,
-                                                   domainid=self.account.domainid
-                                                   )
+            raise Exception("Exception: Unable to find root volume for VM "
+                            "with ID - %s" % vm.id)
+        self.pw_enabled_template = Template.create(
+            self.api_client,
+            self.test_data["template"],
+            self.volume.id,
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
         self.assertEqual(self.pw_enabled_template.passwordenabled, True,
-                         "template is not passwordenabled"
+                         "Template is not password enabled"
                          )
         self.cleanup.append(self.pw_enabled_template)
         self.debug("Created guest VM template")
 
-    # updateTemplate - Updates value of the guest VM template's password enabled setting
+    # updateTemplate - Updates value of the guest VM template's password
+    # enabled setting
     def updateTemplate(self, value):
-        self.debug("Updating value of guest VM template's password enabled setting")
+        self.debug("Updating value of guest VM template's password enabled "
+                   "setting")
         cmd = updateTemplate.updateTemplateCmd()
         cmd.id = self.template.id
         cmd.passwordenabled = value
@@ -96,7 +102,8 @@ class TestNuagePasswordReset(nuageTestCase):
         user_data_url = 'curl "http://' + gateway + ':80/latest/user-data"'
         return user_data_url
 
-    # create_and_verify_fw - Creates and verifies (Ingress) firewall rule with a Static NAT rule enabled public IP
+    # create_and_verify_fw - Creates and verifies (Ingress) firewall rule with
+    # a Static NAT rule enabled public IP
     def create_and_verify_fw(self, vm, public_ip, network):
         self.debug("Creating and verifying firewall rule")
         self.create_StaticNatRule_For_VM(vm, public_ip, network)
@@ -104,7 +111,8 @@ class TestNuagePasswordReset(nuageTestCase):
         # VSD verification
         self.verify_vsd_floating_ip(network, vm, public_ip.ipaddress)
 
-        fw_rule = self.create_FirewallRule(public_ip, self.test_data["ingress_rule"])
+        fw_rule = self.create_FirewallRule(
+            public_ip, self.test_data["ingress_rule"])
 
         # VSD verification
         self.verify_vsd_firewall_rule(fw_rule)
@@ -122,14 +130,17 @@ class TestNuagePasswordReset(nuageTestCase):
             if vm.state != 'Stopped':
                 raise Exception("Failed to stop VM (ID: %s) " % self.vm.id)
         else:
-            raise Exception("Invalid response from list_virtual_machines VM (ID: %s) " % self.vm.id)
+            raise Exception("Invalid response from list_virtual_machines VM "
+                            "(ID: %s) " % self.vm.id)
         self.debug("Stopped VM")
 
-    # install_cloud_set_guest_password_script - Installs the cloud-set-guest-password script from people.apache.org in
-    # the given VM (SSH client)
+    # install_cloud_set_guest_password_script - Installs the
+    # cloud-set-guest-password script from people.apache.org in the given VM
+    # (SSH client)
     def install_cloud_set_guest_password_script(self, ssh_client):
         self.debug("Installing cloud-set-guest-password script")
-        cmd = "cd /etc/init.d;wget http://people.apache.org/~tsp/cloud-set-guest-password"
+        cmd = "cd /etc/init.d;wget http://people.apache.org/~tsp/" \
+              "cloud-set-guest-password"
         result = self.execute_cmd(ssh_client, cmd)
         self.debug("wget file cloud-set-guest-password: " + result)
         if "200 OK" not in result:
@@ -145,53 +156,71 @@ class TestNuagePasswordReset(nuageTestCase):
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
     def test_nuage_UserDataPasswordReset(self):
-        """Test user data and password reset functionality with Nuage VSP SDN plugin
+        """Test user data and password reset functionality with
+        Nuage VSP SDN plugin
         """
 
-        # 1. Create an Isolated Network with Nuage VSP Isolated Network offering, check if it is successfully created
-        #    and is in the "Allocated" state.
+        # 1. Create an Isolated Network with Nuage VSP Isolated Network
+        #    offering, check if it is successfully created and is in the
+        #    "Allocated" state.
         # 2. Set password enabled to false in the guest VM template.
-        # 3. Deploy a VM in the created Isolated network with user data, check if the Isolated network state is changed
-        #    to "Implemented", and both the VM & VR are successfully deployed and are in the "Running" state.
-        # 4. Verify that the guest VM template is not password enabled by checking the deployed VM's password
-        #    (password == "password").
-        # 5. SSH into the deployed VM and verify its user data (expected user data == actual user data).
-        # 6. Check for cloud-set-guest-password script in the deployed VM for testing password reset functionality.
-        # 7. if cloud-set-guest-password script does not exist in the deployed VM:
-        #       7.1  Install the cloud-set-guest-password script from people.apache.org in the deployed VM.
-        #       7.2  Stop the deployed VM, and create a new password enabled guest VM template with it.
-        #       7.3  Deploy a new VM in the created Isolated network with the newly created guest VM template,
-        #            check if the VM is successfully deployed and is in the "Running" state.
-        #       7.4  Verify that the new guest VM template is password enabled by checking the newly deployed VM's
-        #            password (password != "password").
+        # 3. Deploy a VM in the created Isolated network with user data, check
+        #    if the Isolated network state is changed to "Implemented", and
+        #    both the VM & VR are successfully deployed and are in the
+        #    "Running" state.
+        # 4. Verify that the guest VM template is not password enabled by
+        #    checking the deployed VM's password (password == "password").
+        # 5. SSH into the deployed VM and verify its user data
+        #    (expected user data == actual user data).
+        # 6. Check for cloud-set-guest-password script in the deployed VM for
+        #    testing password reset functionality.
+        # 7. if cloud-set-guest-password script does not exist in the deployed
+        #    VM:
+        #       7.1  Install the cloud-set-guest-password script from
+        #            people.apache.org in the deployed VM.
+        #       7.2  Stop the deployed VM, and create a new password enabled
+        #            guest VM template with it.
+        #       7.3  Deploy a new VM in the created Isolated network with the
+        #            newly created guest VM template, check if the VM is
+        #            successfully deployed and is in the "Running" state.
+        #       7.4  Verify that the new guest VM template is password enabled
+        #            by checking the newly deployed VM's password
+        #            (password != "password").
         #       7.5  SSH into the newly deployed VM for verifying its password.
         # 8. else cloud-set-guest-password script exists in the deployed VM:
         #       8.1  Change password enabled to true in the guest VM template.
         #       8.2  Verify that the guest VM template is password enabled.
         # 9. Reset VM password, and start the VM.
-        # 10. Verify that the new guest VM template is password enabled by checking the VM's password
-        #     (password != "password").
-        # 11. SSH into the VM for verifying its new password after its password reset.
-        # 12. Set password enabled to the default value in the guest VM template.
+        # 10. Verify that the new guest VM template is password enabled by
+        #     checking the VM's password (password != "password").
+        # 11. SSH into the VM for verifying its new password after its password
+        #     reset.
+        # 12. Set password enabled to the default value in the guest VM
+        #     template.
         # 13. Delete all the created objects (cleanup).
 
-        self.debug("Testing user data & password reset functionality in an Isolated network...")
+        self.debug("Testing user data & password reset functionality in an "
+                   "Isolated network...")
 
         self.debug("Creating an Isolated network...")
-        net_off = self.create_NetworkOffering(self.test_data["nuagevsp"]["isolated_network_offering"])
+        net_off = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["isolated_network_offering"])
         self.network = self.create_Network(net_off)
         self.validate_Network(self.network, state="Allocated")
 
-        self.debug("Setting password enabled to false in the guest VM template...")
+        self.debug("Setting password enabled to false in the guest VM "
+                   "template...")
         self.defaultTemplateVal = self.template.passwordenabled
         if self.template.passwordenabled:
             self.updateTemplate(False)
 
-        self.debug("Deploying a VM in the created Isolated network with user data...")
+        self.debug("Deploying a VM in the created Isolated network with user "
+                   "data...")
         expected_user_data = "hello world vm1"
         user_data = base64.b64encode(expected_user_data)
         self.test_data["virtual_machine_userdata"]["userdata"] = user_data
-        self.vm_1 = self.create_VM(self.network, testdata=self.test_data["virtual_machine_userdata"])
+        self.vm_1 = self.create_VM(
+            self.network, testdata=self.test_data["virtual_machine_userdata"])
         self.validate_Network(self.network, state="Implemented")
         vr = self.get_Router(self.network)
         self.check_Router_state(vr, state="Running")
@@ -202,11 +231,15 @@ class TestNuagePasswordReset(nuageTestCase):
         self.verify_vsd_router(vr)
         self.verify_vsd_vm(self.vm_1)
 
-        self.debug("verifying that the guest VM template is not password enabled...")
-        self.debug("VM - %s password - %s !" % (self.vm_1.name, self.vm_1.password))
-        self.assertEqual(self.vm_1.password, self.test_data["virtual_machine_userdata"]["password"],
-                         "Password is enabled for the VM (vm_1)"
-                         )
+        self.debug("verifying that the guest VM template is not password "
+                   "enabled...")
+        self.debug("VM - %s password - %s !" %
+                   (self.vm_1.name, self.vm_1.password))
+        self.assertEqual(
+            self.vm_1.password,
+            self.test_data["virtual_machine_userdata"]["password"],
+            "Password is enabled for the VM (vm_1)"
+        )
 
         self.debug("SSHing into the VM for verifying its user data...")
         public_ip_1 = self.acquire_PublicIPAddress(self.network)
@@ -214,27 +247,35 @@ class TestNuagePasswordReset(nuageTestCase):
         ssh = self.ssh_into_VM(self.vm_1, public_ip_1)
         user_data_cmd = self.get_userdata_url(self.vm_1)
         self.debug("Getting user data with command: " + user_data_cmd)
-        actual_user_data = base64.b64decode(self.execute_cmd(ssh, user_data_cmd))
-        self.debug("Actual user data - " + actual_user_data + ", Expected user data - " + expected_user_data)
+        actual_user_data = base64.b64decode(self.execute_cmd
+                                            (ssh, user_data_cmd))
+        self.debug("Actual user data - " + actual_user_data +
+                   ", Expected user data - " + expected_user_data)
         self.assertEqual(actual_user_data, expected_user_data,
                          "Un-expected VM (VM_1) user data"
                          )
 
-        self.debug("Checking for cloud-set-guest-password script in the VM for testing password reset functionality...")
+        self.debug("Checking for cloud-set-guest-password script in the VM "
+                   "for testing password reset functionality...")
         ls_cmd = "ls /etc/init.d/cloud-set-guest-password"
         ls_result = self.execute_cmd(ssh, ls_cmd)
         ls_result = ls_result.lower()
         self.debug("Response from ls_cmd: " + ls_result)
         if "no such file" in ls_result:
             self.debug("No cloud-set-guest-password script in the VM")
-            self.debug("Installing the cloud-set-guest-password script from people.apache.org in the VM...")
+            self.debug("Installing the cloud-set-guest-password script from "
+                       "people.apache.org in the VM...")
             self.install_cloud_set_guest_password_script(ssh)
-            self.debug("Stopping the VM, and creating a new password enabled guest VM template with it...")
+            self.debug("Stopping the VM, and creating a new password enabled "
+                       "guest VM template with it...")
             self.stop_vm(self.vm_1)
             self.create_template(self.vm_1)
 
-            self.debug("Deploying a new VM in the created Isolated network with the newly created guest VM template...")
-            self.vm_2 = self.create_VM(self.network, testdata=self.test_data["virtual_machine_userdata"])
+            self.debug("Deploying a new VM in the created Isolated network "
+                       "with the newly created guest VM template...")
+            self.vm_2 = self.create_VM(
+                self.network,
+                testdata=self.test_data["virtual_machine_userdata"])
             self.debug("Starting the VM...")
             vm_2a = self.vm_2.start(self.api_client)
             self.vm_2.password = vm_2a.password.strip()
@@ -243,11 +284,15 @@ class TestNuagePasswordReset(nuageTestCase):
             # VSD verification
             self.verify_vsd_vm(self.vm_2)
 
-            self.debug("verifying that the guest VM template is password enabled...")
-            self.debug("VM - %s password - %s !" % (self.vm_2.name, self.vm_2.password))
-            self.assertNotEqual(self.vm_2.password, self.test_data["virtual_machine_userdata"]["password"],
-                                "Password is not enabled for the VM"
-                                )
+            self.debug("verifying that the guest VM template is password "
+                       "enabled...")
+            self.debug("VM - %s password - %s !" %
+                       (self.vm_2.name, self.vm_2.password))
+            self.assertNotEqual(
+                self.vm_2.password,
+                self.test_data["virtual_machine_userdata"]["password"],
+                "Password is not enabled for the VM"
+            )
 
             self.debug("SSHing into the VM for verifying its password...")
             public_ip_2 = self.acquire_PublicIPAddress(self.network)
@@ -272,14 +317,20 @@ class TestNuagePasswordReset(nuageTestCase):
         self.debug("Starting the VM")
         vm_test.start(self.api_client)
 
-        self.debug("verifying that the guest VM template is password enabled...")
-        self.debug("VM - %s password - %s !" % (vm_test.name, vm_test.password))
-        self.assertNotEqual(vm_test.password, self.test_data["virtual_machine_userdata"]["password"],
-                            "Password is not enabled for the VM"
-                            )
+        self.debug("verifying that the guest VM template is password "
+                   "enabled...")
+        self.debug("VM - %s password - %s !" %
+                   (vm_test.name, vm_test.password))
+        self.assertNotEqual(
+            vm_test.password,
+            self.test_data["virtual_machine_userdata"]["password"],
+            "Password is not enabled for the VM"
+        )
 
-        self.debug("SSHing into the VM for verifying its new password after its password reset...")
+        self.debug("SSHing into the VM for verifying its new password after "
+                   "its password reset...")
         self.ssh_into_VM(vm_test, vm_test_public_ip)
 
-        self.debug("Setting password enabled to the default value in the guest VM template...")
+        self.debug("Setting password enabled to the default value in the "
+                   "guest VM template...")
         self.updateTemplate(self.defaultTemplateVal)

--- a/test/integration/plugins/nuagevsp/test_nuage_vpc_internal_lb.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vpc_internal_lb.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-""" Component tests for VPC Internal Load Balancer functionality with Nuage VSP SDN plugin
+""" Component tests for VPC Internal Load Balancer functionality with
+Nuage VSP SDN plugin
 """
 # Import Local Modules
 from nuageTestCase import nuageTestCase
@@ -51,28 +52,35 @@ class TestNuageInternalLb(nuageTestCase):
         self.cleanup = [self.account]
         return
 
-    # create_Internal_LB_Rule - Creates Internal LB rule in the given VPC network
-    def create_Internal_LB_Rule(self, network, vm_array=None, services=None, source_ip=None):
-        self.debug("Creating Internal LB rule in VPC network with ID - %s" % network.id)
+    # create_Internal_LB_Rule - Creates Internal LB rule in the given
+    # VPC network
+    def create_Internal_LB_Rule(self, network, vm_array=None, services=None,
+                                source_ip=None):
+        self.debug("Creating Internal LB rule in VPC network with ID - %s" %
+                   network.id)
         if not services:
             services = self.test_data["internal_lbrule"]
-        int_lb_rule = ApplicationLoadBalancer.create(self.api_client,
-                                                     services=services,
-                                                     sourcenetworkid=network.id,
-                                                     networkid=network.id,
-                                                     sourceipaddress=source_ip
-                                                     )
+        int_lb_rule = ApplicationLoadBalancer.create(
+            self.api_client,
+            services=services,
+            sourcenetworkid=network.id,
+            networkid=network.id,
+            sourceipaddress=source_ip
+        )
         self.debug("Created Internal LB rule")
         # Assigning VMs to the created Internal Load Balancer rule
         if vm_array:
-            self.debug("Assigning virtual machines - %s to the created Internal LB rule" % vm_array)
+            self.debug("Assigning virtual machines - %s to the created "
+                       "Internal LB rule" % vm_array)
             int_lb_rule.assign(self.api_client, vms=vm_array)
             self.debug("Assigned VMs to the created Internal LB rule")
         return int_lb_rule
 
     # validate_Internal_LB_Rule - Validates the given Internal LB rule,
-    # matches the given Internal LB rule name and state against the list of Internal LB rules fetched
-    def validate_Internal_LB_Rule(self, int_lb_rule, state=None, vm_array=None):
+    # matches the given Internal LB rule name and state against the list of
+    # Internal LB rules fetched
+    def validate_Internal_LB_Rule(self, int_lb_rule, state=None,
+                                  vm_array=None):
         """Validates the Internal LB Rule"""
         self.debug("Check if the Internal LB Rule is created successfully ?")
         int_lb_rules = ApplicationLoadBalancer.list(self.api_client,
@@ -82,38 +90,45 @@ class TestNuageInternalLb(nuageTestCase):
                          "List Internal LB Rule should return a valid list"
                          )
         self.assertEqual(int_lb_rule.name, int_lb_rules[0].name,
-                         "Name of the Internal LB Rule should match with the returned list data"
+                         "Name of the Internal LB Rule should match with the "
+                         "returned list data"
                          )
         if state:
             self.assertEqual(int_lb_rules[0].loadbalancerrule[0].state, state,
                              "Internal LB Rule state should be '%s'" % state
                              )
         if vm_array:
-            instance_ids = [instance.id for instance in int_lb_rules[0].loadbalancerinstance]
+            instance_ids = [instance.id for instance in
+                            int_lb_rules[0].loadbalancerinstance]
             for vm in vm_array:
                 self.assertEqual(vm.id in instance_ids, True,
-                                 "Internal LB instance list should have the VM with ID - %s" % vm.id
+                                 "Internal LB instance list should have the "
+                                 "VM with ID - %s" % vm.id
                                  )
-        self.debug("Internal LB Rule creation successfully validated for %s" % int_lb_rule.name)
+        self.debug("Internal LB Rule creation successfully validated for %s" %
+                   int_lb_rule.name)
 
     # list_InternalLbVms - Lists deployed Internal LB VM instances
     def list_InternalLbVms(self, network_id=None, source_ip=None):
-        listInternalLoadBalancerVMsCmd = listInternalLoadBalancerVMs.listInternalLoadBalancerVMsCmd()
+        listInternalLoadBalancerVMsCmd = \
+            listInternalLoadBalancerVMs.listInternalLoadBalancerVMsCmd()
         listInternalLoadBalancerVMsCmd.account = self.account.name
         listInternalLoadBalancerVMsCmd.domainid = self.account.domainid
         if network_id:
             listInternalLoadBalancerVMsCmd.networkid = network_id
-        internal_lb_vms = self.api_client.listInternalLoadBalancerVMs(listInternalLoadBalancerVMsCmd)
+        internal_lb_vms = self.api_client.listInternalLoadBalancerVMs(
+            listInternalLoadBalancerVMsCmd)
         if source_ip:
             return [internal_lb_vm for internal_lb_vm in internal_lb_vms
                     if str(internal_lb_vm.guestipaddress) == source_ip]
         else:
             return internal_lb_vms
 
-    # get_InternalLbVm - Returns Internal LB VM instance for the given VPC network and source ip
+    # get_InternalLbVm - Returns Internal LB VM instance for the given VPC
+    # network and source ip
     def get_InternalLbVm(self, network, source_ip):
-        self.debug("Finding the InternalLbVm for network with ID - %s and source IP address - %s" %
-                   (network.id, source_ip))
+        self.debug("Finding the InternalLbVm for network with ID - %s and "
+                   "source IP address - %s" % (network.id, source_ip))
         internal_lb_vms = self.list_InternalLbVms(network.id, source_ip)
         self.assertEqual(isinstance(internal_lb_vms, list), True,
                          "List InternalLbVms should return a valid list"
@@ -121,7 +136,7 @@ class TestNuageInternalLb(nuageTestCase):
         return internal_lb_vms[0]
 
     # stop_InternalLbVm - Stops the given Internal LB VM instance
-    def stop_InternalLbVm(self, int_lb_vm, force=None):
+    def stop_InternalLbVm(self, int_lb_vm, force=False):
         self.debug("Stopping InternalLbVm with ID - %s" % int_lb_vm.id)
         cmd = stopInternalLoadBalancerVM.stopInternalLoadBalancerVMCmd()
         cmd.id = int_lb_vm.id
@@ -136,8 +151,9 @@ class TestNuageInternalLb(nuageTestCase):
         cmd.id = int_lb_vm.id
         self.api_client.startInternalLoadBalancerVM(cmd)
 
-    # check_InternalLbVm_state - Checks if the Internal LB VM instance of the given VPC network and source IP is in the
-    # expected state form the list of fetched Internal LB VM instances
+    # check_InternalLbVm_state - Checks if the Internal LB VM instance of the
+    # given VPC network and source IP is in the expected state form the list of
+    # fetched Internal LB VM instances
     def check_InternalLbVm_state(self, network, source_ip, state=None):
         self.debug("Check if the InternalLbVm is in state - %s" % state)
         internal_lb_vms = self.list_InternalLbVms(network.id, source_ip)
@@ -148,24 +164,32 @@ class TestNuageInternalLb(nuageTestCase):
             self.assertEqual(internal_lb_vms[0].state, state,
                              "InternalLbVm is not in the expected state"
                              )
-        self.debug("InternalLbVm instance - %s is in the expected state - %s" % (internal_lb_vms[0].name, state))
+        self.debug("InternalLbVm instance - %s is in the expected state - %s" %
+                   (internal_lb_vms[0].name, state))
 
     # wget_from_vm_cmd - From within the given VM (ssh client),
     # fetches index.html file of web server running with the given public IP
     def wget_from_vm_cmd(self, ssh_client, ip_address, port):
-        cmd = "wget --no-cache -t 1 http://" + ip_address + ":" + str(port) + "/"
+        wget_file = ""
+        cmd = "wget --no-cache --output-document=index.html -t 1 http://" + \
+              ip_address + ":" + str(port) + "/"
         response = self.execute_cmd(ssh_client, cmd)
-        if "200 OK" not in response:
-            self.fail("Failed to wget from a VM with http server IP address - %s" % ip_address)
-        # Reading the wget file
-        cmd = "cat index.html"
-        wget_file = self.execute_cmd(ssh_client, cmd)
-        # Removing the wget file
-        cmd = "rm -r index.html"
-        self.execute_cmd(ssh_client, cmd)
+        if "200 OK" in response:
+            self.debug("wget from a VM with http server IP address "
+                       "- %s is successful" % ip_address)
+            # Reading the wget file
+            cmd = "cat index.html"
+            wget_file = self.execute_cmd(ssh_client, cmd)
+            # Removing the wget file
+            cmd = "rm -r index.html"
+            self.execute_cmd(ssh_client, cmd)
+        else:
+            self.debug("Failed to wget from a VM with http server IP address "
+                       "- %s" % ip_address)
         return wget_file
 
-    # verify_lb_wget_file - Verifies that the given wget file (index.html) belongs to the given Internal LB rule
+    # verify_lb_wget_file - Verifies that the given wget file (index.html)
+    # belongs to the given Internal LB rule
     # assigned VMs (vm array)
     def verify_lb_wget_file(self, wget_file, vm_array):
         wget_server_ip = None
@@ -174,93 +198,120 @@ class TestNuageInternalLb(nuageTestCase):
                 if str(nic.ipaddress) in str(wget_file):
                     wget_server_ip = str(nic.ipaddress)
         if wget_server_ip:
-            self.debug("Verified wget file from an Internal Load Balanced VM with http server IP address - %s"
-                       % wget_server_ip)
+            self.debug("Verified wget file from an Internal Load Balanced VM "
+                       "with http server IP address - %s" % wget_server_ip)
         else:
-            self.fail("Did not wget file from the Internal Load Balanced VMs - %s" % vm_array)
+            self.fail("Did not wget file from the Internal Load Balanced VMs "
+                      "- %s" % vm_array)
         return wget_server_ip
 
-    # validate_internallb_algorithm_traffic - Validates Internal LB algorithms by performing multiple wget traffic tests
-    # against the given Internal LB VM instance (source port)
-    def validate_internallb_algorithm_traffic(self, ssh_client, source_ip, port, vm_array, algorithm):
+    # validate_internallb_algorithm_traffic - Validates Internal LB algorithms
+    # by performing multiple wget traffic tests against the given Internal LB
+    # VM instance (source port)
+    def validate_internallb_algorithm_traffic(self, ssh_client, source_ip,
+                                              port, vm_array, algorithm):
         # Internal LB (wget) traffic tests
         iterations = 2 * len(vm_array)
         wget_files = []
         for i in range(iterations):
-            wget_files.append(self.wget_from_vm_cmd(ssh_client, source_ip, port))
+            wget_files.append(
+                self.wget_from_vm_cmd(ssh_client, source_ip, port))
         # Verifying Internal LB (wget) traffic tests
         wget_servers_ip_list = []
         for i in range(iterations):
-            wget_servers_ip_list.append(self.verify_lb_wget_file(wget_files[i], vm_array))
+            wget_servers_ip_list.append(
+                self.verify_lb_wget_file(wget_files[i], vm_array))
         # Validating Internal LB algorithm
         if algorithm == "roundrobin" or algorithm == "leastconn":
             for i in range(iterations):
-                if wget_servers_ip_list.count(wget_servers_ip_list[i]) is not 2:
-                    self.fail("Round Robin Internal LB algorithm validation failed - %s" % wget_servers_ip_list)
-            self.debug("Successfully validated Round Robin/Least connections Internal LB algorithm - %s" %
-                       wget_servers_ip_list)
+                if wget_servers_ip_list.count(wget_servers_ip_list[i]) \
+                        is not 2:
+                    self.fail("Round Robin Internal LB algorithm validation "
+                              "failed - %s" % wget_servers_ip_list)
+            self.debug("Successfully validated Round Robin/Least connections "
+                       "Internal LB algorithm - %s" % wget_servers_ip_list)
         if algorithm == "source":
             for i in range(iterations):
-                if wget_servers_ip_list.count(wget_servers_ip_list[i]) is not iterations:
-                    self.fail("Source Internal LB algorithm validation failed - %s" % wget_servers_ip_list)
-            self.debug("Successfully validated Source Internal LB algorithm - %s" % wget_servers_ip_list)
+                if wget_servers_ip_list.count(wget_servers_ip_list[i]) \
+                        is not iterations:
+                    self.fail("Source Internal LB algorithm validation failed "
+                              "- %s" % wget_servers_ip_list)
+            self.debug("Successfully validated Source Internal LB algorithm - "
+                       "%s" % wget_servers_ip_list)
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_01_nuage_internallb_vpc_Offering(self):
-        """Test Nuage VSP VPC Offering with different combinations of LB service providers
+        """Test Nuage VSP VPC Offering with different combinations of LB
+        service providers
         """
 
-        # 1. Verify that the network service providers supported by Nuage VSP for VPC Internal LB functionality are all
-        #    successfully created and enabled.
-        # 2. Create Nuage VSP VPC offering with LB service provider as "InternalLbVm", check if it is successfully
-        #    created and enabled. Verify that the VPC creation succeeds with this VPC offering.
-        # 3. Create Nuage VSP VPC offering with LB service provider as "VpcVirtualRouter", check if it is successfully
-        #    created and enabled. Verify that the VPC creation fails with this VPC offering as Nuage VSP does not
-        #    support provider "VpcVirtualRouter" for service LB.
-        # 4. Create Nuage VSP VPC offering with LB service provider as "Netscaler", check if it is successfully
-        #    created and enabled. Verify that the VPC creation fails with this VPC offering as Nuage VSP does not
-        #    support provider "Netscaler" for service LB.
+        # 1. Verify that the network service providers supported by Nuage VSP
+        #    for VPC Internal LB functionality are all successfully created and
+        #    enabled.
+        # 2. Create Nuage VSP VPC offering with LB service provider as
+        #    "InternalLbVm", check if it is successfully created and enabled.
+        #    Verify that the VPC creation succeeds with this VPC offering.
+        # 3. Create Nuage VSP VPC offering with LB service provider as
+        #    "VpcVirtualRouter", check if it is successfully created and
+        #    enabled. Verify that the VPC creation fails with this VPC offering
+        #    as Nuage VSP does not support provider "VpcVirtualRouter" for
+        #    service LB.
+        # 4. Create Nuage VSP VPC offering with LB service provider as
+        #    "Netscaler", check if it is successfully created and enabled.
+        #    Verify that the VPC creation fails with this VPC offering as Nuage
+        #    VSP does not support provider "Netscaler" for service LB.
         # 5. Delete all the created objects (cleanup).
 
-        self.debug("Validating network service providers supported by Nuage VSP for VPC Internal LB functionality")
+        self.debug("Validating network service providers supported by Nuage "
+                   "VSP for VPC Internal LB functionality")
         providers = ["NuageVsp", "VpcVirtualRouter", "InternalLbVm"]
         for provider in providers:
             self.validate_NetworkServiceProvider(provider, state="Enabled")
 
         # Creating VPC offerings
-        self.debug("Creating Nuage VSP VPC offering with LB service provider as InternalLbVm...")
-        vpc_off_1 = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with LB service provider "
+                   "as InternalLbVm...")
+        vpc_off_1 = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC offering with LB service provider as VpcVirtualRouter...")
-        vpc_offering_lb = copy.deepcopy(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with LB service provider "
+                   "as VpcVirtualRouter...")
+        vpc_offering_lb = copy.deepcopy(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         vpc_offering_lb["serviceProviderList"]["Lb"] = "VpcVirtualRouter"
         vpc_off_2 = self.create_VpcOffering(vpc_offering_lb)
         self.validate_VpcOffering(vpc_off_2, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC offering with LB service provider as Netscaler...")
+        self.debug("Creating Nuage VSP VPC offering with LB service provider "
+                   "as Netscaler...")
         vpc_offering_lb["serviceProviderList"]["Lb"] = "Netscaler"
         vpc_off_3 = self.create_VpcOffering(vpc_offering_lb)
         self.validate_VpcOffering(vpc_off_3, state="Enabled")
 
         self.debug("Creating Nuage VSP VPC offering without LB service...")
-        vpc_off_4 = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering"])
+        vpc_off_4 = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering"])
         self.validate_VpcOffering(vpc_off_4, state="Enabled")
 
         # Creating VPCs
-        self.debug("Creating a VPC with LB service provider as InternalLbVm...")
+        self.debug("Creating a VPC with LB service provider as "
+                   "InternalLbVm...")
         vpc_1 = self.create_Vpc(vpc_off_1, cidr='10.1.0.0/16')
         self.validate_Vpc(vpc_1, state="Enabled")
 
-        self.debug("Creating a VPC with LB service provider as VpcVirtualRouter...")
+        self.debug("Creating a VPC with LB service provider as "
+                   "VpcVirtualRouter...")
         with self.assertRaises(Exception):
             self.create_Vpc(vpc_off_2, cidr='10.1.0.0/16')
-        self.debug("Nuage VSP does not support provider VpcVirtualRouter for service LB for VPCs")
+        self.debug("Nuage VSP does not support provider VpcVirtualRouter for "
+                   "service LB for VPCs")
 
         self.debug("Creating a VPC with LB service provider as Netscaler...")
         with self.assertRaises(Exception):
             self.create_Vpc(vpc_off_3, cidr='10.1.0.0/16')
-        self.debug("Nuage VSP does not support provider Netscaler for service LB for VPCs")
+        self.debug("Nuage VSP does not support provider Netscaler for service "
+                   "LB for VPCs")
 
         self.debug("Creating a VPC without LB service...")
         vpc_2 = self.create_Vpc(vpc_off_4, cidr='10.1.0.0/16')
@@ -268,32 +319,43 @@ class TestNuageInternalLb(nuageTestCase):
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_02_nuage_internallb_vpc_network_offering(self):
-        """Test Nuage VSP VPC Network Offering with and without Internal LB service
+        """Test Nuage VSP VPC Network Offering with and without Internal LB
+        service
         """
 
-        # 1. Create Nuage VSP VPC Network offering with LB Service Provider as "InternalLbVm" and LB Service Capability
-        #    "lbSchemes" as "internal", check if it is successfully created and enabled. Verify that the VPC network
-        #    creation succeeds with this Network offering.
-        # 2. Recreate above Network offering with ispersistent False, check if it is successfully created and enabled.
-        #    Verify that the VPC network creation fails with this Network offering as Nuage VSP does not support non
-        #    persistent VPC networks.
-        # 3. Recreate above Network offering with conserve mode On, check if the network offering creation failed
-        #    as only networks with conserve mode Off can belong to VPC.
-        # 4. Create Nuage VSP VPC Network offering with LB Service Provider as "InternalLbVm" and LB Service Capability
-        #    "lbSchemes" as "public", check if the network offering creation failed as "public" lbScheme is not
-        #    supported for LB Service Provider "InternalLbVm".
-        # 5. Create Nuage VSP VPC Network offering without Internal LB Service, check if it is successfully created and
-        #    enabled. Verify that the VPC network creation succeeds with this Network offering.
-        # 6. Recreate above Network offering with ispersistent False, check if it is successfully created and enabled.
-        #    Verify that the VPC network creation fails with this Network offering as Nuage VSP does not support non
-        #    persistent VPC networks.
-        # 7. Recreate the above Network offering with conserve mode On, check if the network offering creation failed
-        #    as only networks with conserve mode Off can belong to VPC.
+        # 1. Create Nuage VSP VPC Network offering with LB Service Provider as
+        #    "InternalLbVm" and LB Service Capability "lbSchemes" as
+        #    "internal", check if it is successfully created and enabled.
+        #    Verify that the VPC network creation succeeds with this Network
+        #    offering.
+        # 2. Recreate above Network offering with ispersistent False, check if
+        #    it is successfully created and enabled.Verify that the VPC network
+        #    creation fails with this Network offering as Nuage VSP does not
+        #    support non persistent VPC networks.
+        # 3. Recreate above Network offering with conserve mode On, check if
+        #    the network offering creation failed as only networks with
+        #    conserve mode Off can belong to VPC.
+        # 4. Create Nuage VSP VPC Network offering with LB Service Provider as
+        #    "InternalLbVm" and LB Service Capability "lbSchemes" as "public",
+        #    check if the network offering creation failed as "public" lbScheme
+        #    is not supported for LB Service Provider "InternalLbVm".
+        # 5. Create Nuage VSP VPC Network offering without Internal LB Service,
+        #    check if it is successfully created and enabled. Verify that the
+        #    VPC network creation succeeds with this Network offering.
+        # 6. Recreate above Network offering with ispersistent False, check if
+        #    it is successfully created and enabled. Verify that the VPC
+        #    network creation fails with this Network offering as Nuage VSP
+        #    does not support non persistent VPC networks.
+        # 7. Recreate the above Network offering with conserve mode On, check
+        #    if the network offering creation failed as only networks with
+        #    conserve mode Off can belong to VPC.
         # 8. Delete all the created objects (cleanup).
 
         # Creating VPC offering
-        self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
-        vpc_off = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with Internal LB "
+                   "service...")
+        vpc_off = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off, state="Enabled")
 
         # Creating VPC
@@ -302,50 +364,71 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Vpc(vpc, state="Enabled")
 
         # Creating network offerings
-        self.debug("Creating Nuage VSP VPC Network offering with LB Service Provider as InternalLbVm and LB Service "
-                   "Capability lbSchemes as internal...")
-        net_off_1 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
+        self.debug("Creating Nuage VSP VPC Network offering with LB Service "
+                   "Provider as InternalLbVm and LB Service Capability "
+                   "lbSchemes as internal...")
+        net_off_1 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         self.validate_NetworkOffering(net_off_1, state="Enabled")
 
-        self.debug("Recreating above Network offering with ispersistent False...")
-        vpc_net_off_lb_non_persistent = copy.deepcopy(self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
+        self.debug("Recreating above Network offering with ispersistent "
+                   "False...")
+        vpc_net_off_lb_non_persistent = copy.deepcopy(
+            self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         vpc_net_off_lb_non_persistent["ispersistent"] = "False"
         net_off_2 = self.create_NetworkOffering(vpc_net_off_lb_non_persistent)
         self.validate_NetworkOffering(net_off_2, state="Enabled")
 
-        self.debug("Recreating above Network offering with conserve mode On...")
+        self.debug("Recreating above Network offering with conserve mode "
+                   "On...")
         with self.assertRaises(Exception):
-            self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"],
-                                        conserve_mode=True)
-        self.debug("Network offering creation failed as only networks with conserve mode Off can belong to VPC")
+            self.create_NetworkOffering(
+                self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"],
+                conserve_mode=True)
+        self.debug("Network offering creation failed as only networks with "
+                   "conserve mode Off can belong to VPC")
 
-        self.debug("Creating Nuage VSP VPC Network offering with LB Service Provider as InternalLbVm and LB Service "
-                   "Capability lbSchemes as public...")
-        network_offering_internal_lb = copy.deepcopy(self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
-        network_offering_internal_lb["serviceCapabilityList"]["Lb"]["lbSchemes"] = "public"
+        self.debug("Creating Nuage VSP VPC Network offering with LB Service "
+                   "Provider as InternalLbVm and LB Service Capability "
+                   "lbSchemes as public...")
+        network_offering_internal_lb = copy.deepcopy(
+            self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
+        service_list = network_offering_internal_lb["serviceCapabilityList"]
+        service_list["Lb"]["lbSchemes"] = "public"
+        network_offering_internal_lb["serviceCapabilityList"] = service_list
         with self.assertRaises(Exception):
             self.create_NetworkOffering(network_offering_internal_lb)
-        self.debug("Network offering creation failed as public lbScheme is not supported for LB Service Provider "
-                   "InternalLbVm")
+        self.debug("Network offering creation failed as public lbScheme is "
+                   "not supported for LB Service Provider InternalLbVm")
 
-        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
-        net_off_3 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Creating Nuage VSP VPC Network offering without Internal "
+                   "LB service...")
+        net_off_3 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_3, state="Enabled")
 
-        self.debug("Recreating above Network offering with ispersistent False...")
-        vpc_net_off_non_persistent = copy.deepcopy(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Recreating above Network offering with ispersistent "
+                   "False...")
+        vpc_net_off_non_persistent = copy.deepcopy(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         vpc_net_off_non_persistent["ispersistent"] = "False"
         net_off_4 = self.create_NetworkOffering(vpc_net_off_non_persistent)
         self.validate_NetworkOffering(net_off_4, state="Enabled")
 
-        self.debug("Recreating above Network offering with conserve mode On...")
+        self.debug("Recreating above Network offering with conserve mode "
+                   "On...")
         with self.assertRaises(Exception):
-            self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"], conserve_mode=True)
-        self.debug("Network offering creation failed as only networks with conserve mode Off can belong to VPC")
+            self.create_NetworkOffering(
+                self.test_data["nuagevsp"]["vpc_network_offering"],
+                conserve_mode=True)
+        self.debug("Network offering creation failed as only networks with "
+                   "conserve mode Off can belong to VPC")
 
         # Creating VPC networks in the VPC
-        self.debug("Creating a persistent VPC network with Internal LB service...")
-        internal_tier = self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc)
+        self.debug("Creating a persistent VPC network with Internal LB "
+                   "service...")
+        internal_tier = self.create_Network(
+            net_off_1, gateway='10.1.1.1', vpc=vpc)
         self.validate_Network(internal_tier, state="Implemented")
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
@@ -354,13 +437,16 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_network(self.domain.id, internal_tier, vpc)
         self.verify_vsd_router(vr)
 
-        self.debug("Creating a non persistent VPC network with Internal LB service...")
+        self.debug("Creating a non persistent VPC network with Internal LB "
+                   "service...")
         with self.assertRaises(Exception):
             self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
         self.debug("Nuage VSP does not support non persistent VPC networks")
 
-        self.debug("Creating a persistent VPC network without Internal LB service...")
-        public_tier = self.create_Network(net_off_3, gateway='10.1.3.1', vpc=vpc)
+        self.debug("Creating a persistent VPC network without Internal LB "
+                   "service...")
+        public_tier = self.create_Network(
+            net_off_3, gateway='10.1.3.1', vpc=vpc)
         self.validate_Network(public_tier, state="Implemented")
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
@@ -369,7 +455,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_network(self.domain.id, public_tier, vpc)
         self.verify_vsd_router(vr)
 
-        self.debug("Creating a non persistent VPC network without Internal LB service...")
+        self.debug("Creating a non persistent VPC network without Internal LB "
+                   "service...")
         with self.assertRaises(Exception):
             self.create_Network(net_off_4, gateway='10.1.4.1', vpc=vpc)
         self.debug("Nuage VSP does not support non persistent VPC networks")
@@ -379,36 +466,52 @@ class TestNuageInternalLb(nuageTestCase):
         """Test Nuage VSP VPC Networks with and without Internal LB service
         """
 
-        # 1. Create Nuage VSP VPC offering with Internal LB service, check if it is successfully created and enabled.
-        # 2. Create Nuage VSP VPC offering without Internal LB service, check if it is successfully created and enabled.
-        # 3. Create a VPC "vpc_1" with Internal LB service, check if it is successfully created and enabled.
-        # 4. Create a VPC "vpc_2" without Internal LB service, check if it is successfully created and enabled.
-        # 5. Create Nuage VSP VPC Network offering with Internal LB service, check if it is successfully created and
-        #    enabled.
-        # 6. Create Nuage VSP VPC Network offering without Internal LB service, check if it is successfully created and
-        #    enabled.
-        # 7. Create a VPC network in vpc_1 with Internal LB service and spawn a VM, check if the tier is added to the
-        #    VPC VR, and the VM is deployed successfully in the tier.
-        # 8. Create one more VPC network in vpc_1 with Internal LB service and spawn a VM, check if the tier is added
-        #    to the VPC VR, and the VM is deployed successfully in the tier.
-        # 9. Create a VPC network in vpc_2 with Internal LB service, check if the tier creation failed.
-        # 10. Create a VPC network in vpc_1 without Internal LB service and spawn a VM, check if the tier is added to
-        #     the VPC VR, and the VM is deployed successfully in the tier.
-        # 11. Create a VPC network in vpc_2 without Internal LB service and spawn a VM, check if the tier is added to
-        #     the VPC VR, and the VM is deployed successfully in the tier.
-        # 12. Upgrade the VPC network with Internal LB service to one with no Internal LB service and vice-versa, check
-        #     if the VPC Network offering upgrade passed in both directions.
-        # 13. Delete the VPC network with Internal LB service, check if the tier is successfully deleted.
-        # 14. Recreate the VPC network with Internal LB service, check if the tier is successfully re-created.
+        # 1. Create Nuage VSP VPC offering with Internal LB service, check if
+        #    it is successfully created and enabled.
+        # 2. Create Nuage VSP VPC offering without Internal LB service, check
+        #    if it is successfully created and enabled.
+        # 3. Create a VPC "vpc_1" with Internal LB service, check if it is
+        #    successfully created and enabled.
+        # 4. Create a VPC "vpc_2" without Internal LB service, check if it is
+        #    successfully created and enabled.
+        # 5. Create Nuage VSP VPC Network offering with Internal LB service,
+        #    check if it is successfully created and enabled.
+        # 6. Create Nuage VSP VPC Network offering without Internal LB service,
+        #    check if it is successfully created and enabled.
+        # 7. Create a VPC network in vpc_1 with Internal LB service and spawn a
+        #    VM, check if the tier is added to the VPC VR, and the VM is
+        #    deployed successfully in the tier.
+        # 8. Create one more VPC network in vpc_1 with Internal LB service and
+        #    spawn a VM, check if the tier is added to the VPC VR, and the VM
+        #    is deployed successfully in the tier.
+        # 9. Create a VPC network in vpc_2 with Internal LB service, check if
+        #    the tier creation failed.
+        # 10. Create a VPC network in vpc_1 without Internal LB service and
+        #     spawn a VM, check if the tier is added to the VPC VR, and the VM
+        #     is deployed successfully in the tier.
+        # 11. Create a VPC network in vpc_2 without Internal LB service and
+        #     spawn a VM, check if the tier is added to the VPC VR, and the VM
+        #     is deployed successfully in the tier.
+        # 12. Upgrade the VPC network with Internal LB service to one with no
+        #     Internal LB service and vice-versa, check if the VPC Network
+        #     offering upgrade passed in both directions.
+        # 13. Delete the VPC network with Internal LB service, check if the
+        #     tier is successfully deleted.
+        # 14. Recreate the VPC network with Internal LB service, check if the
+        #     tier is successfully re-created.
         # 15. Delete all the created objects (cleanup).
 
         # Creating VPC offerings
-        self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
-        vpc_off_1 = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with Internal LB "
+                   "service...")
+        vpc_off_1 = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC offering without Internal LB service...")
-        vpc_off_2 = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering"])
+        self.debug("Creating Nuage VSP VPC offering without Internal LB "
+                   "service...")
+        vpc_off_2 = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering"])
         self.validate_VpcOffering(vpc_off_2, state="Enabled")
 
         # Creating VPCs
@@ -421,18 +524,23 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Vpc(vpc_2, state="Enabled")
 
         # Creating network offerings
-        self.debug("Creating Nuage VSP VPC Network offering with Internal LB service...")
+        self.debug("Creating Nuage VSP VPC Network offering with Internal LB "
+                   "service...")
         net_off_1 = self.create_NetworkOffering(
             self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         self.validate_NetworkOffering(net_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
-        net_off_2 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Creating Nuage VSP VPC Network offering without Internal "
+                   "LB service...")
+        net_off_2 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_2, state="Enabled")
 
         # Creating VPC networks in VPCs, and deploying VMs
-        self.debug("Creating a VPC network in vpc_1 with Internal LB service...")
-        internal_tier_1 = self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc_1)
+        self.debug("Creating a VPC network in vpc_1 with Internal LB "
+                   "service...")
+        internal_tier_1 = self.create_Network(
+            net_off_1, gateway='10.1.1.1', vpc=vpc_1)
         self.validate_Network(internal_tier_1, state="Implemented")
         vr_1 = self.get_Router(internal_tier_1)
         self.check_Router_state(vr_1, state="Running")
@@ -446,8 +554,10 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_router(vr_1)
         self.verify_vsd_vm(internal_vm_1)
 
-        self.debug("Creating one more VPC network in vpc_1 with Internal LB service...")
-        internal_tier_2 = self.create_Network(net_off_1, gateway='10.1.2.1', vpc=vpc_1)
+        self.debug("Creating one more VPC network in vpc_1 with Internal LB "
+                   "service...")
+        internal_tier_2 = self.create_Network(
+            net_off_1, gateway='10.1.2.1', vpc=vpc_1)
         self.validate_Network(internal_tier_2, state="Implemented")
         vr_1 = self.get_Router(internal_tier_2)
         self.check_Router_state(vr_1, state="Running")
@@ -461,13 +571,17 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_router(vr_1)
         self.verify_vsd_vm(internal_vm_2)
 
-        self.debug("Creating a VPC network in vpc_2 with Internal LB service...")
+        self.debug("Creating a VPC network in vpc_2 with Internal LB "
+                   "service...")
         with self.assertRaises(Exception):
             self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc_2)
-        self.debug("VPC Network creation failed as vpc_2 does not support Internal Lb service")
+        self.debug("VPC Network creation failed as vpc_2 does not support "
+                   "Internal Lb service")
 
-        self.debug("Creating a VPC network in vpc_1 without Internal LB service...")
-        public_tier_1 = self.create_Network(net_off_2, gateway='10.1.3.1', vpc=vpc_1)
+        self.debug("Creating a VPC network in vpc_1 without Internal LB "
+                   "service...")
+        public_tier_1 = self.create_Network(
+            net_off_2, gateway='10.1.3.1', vpc=vpc_1)
         self.validate_Network(public_tier_1, state="Implemented")
         vr_1 = self.get_Router(public_tier_1)
         self.check_Router_state(vr_1, state="Running")
@@ -481,8 +595,10 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_router(vr_1)
         self.verify_vsd_vm(public_vm_1)
 
-        self.debug("Creating a VPC network in vpc_2 without Internal LB service...")
-        public_tier_2 = self.create_Network(net_off_2, gateway='10.1.1.1', vpc=vpc_2)
+        self.debug("Creating a VPC network in vpc_2 without Internal LB "
+                   "service...")
+        public_tier_2 = self.create_Network(
+            net_off_2, gateway='10.1.1.1', vpc=vpc_2)
         self.validate_Network(public_tier_2, state="Implemented")
         vr_2 = self.get_Router(public_tier_2)
         self.check_Router_state(vr_2, state="Running")
@@ -497,7 +613,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(public_vm_2)
 
         # Upgrading a VPC network
-        self.debug("Upgrading a VPC network with Internal LB Service to one without Internal LB Service...")
+        self.debug("Upgrading a VPC network with Internal LB Service to one "
+                   "without Internal LB Service...")
         self.upgrade_Network(net_off_2, internal_tier_2)
         self.validate_Network(internal_tier_2, state="Implemented")
         vr_1 = self.get_Router(internal_tier_2)
@@ -509,7 +626,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_router(vr_1)
         self.verify_vsd_vm(internal_vm_2)
 
-        self.debug("Upgrading a VPC network without Internal LB Service to one with Internal LB Service...")
+        self.debug("Upgrading a VPC network without Internal LB Service to "
+                   "one with Internal LB Service...")
         self.upgrade_Network(net_off_1, internal_tier_2)
         self.validate_Network(internal_tier_2, state="Implemented")
         vr_1 = self.get_Router(internal_tier_2)
@@ -535,7 +653,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.debug("VPC network successfully deleted in VSD")
 
         self.debug("Recreating a VPC network with Internal LB Service...")
-        internal_tier_2 = self.create_Network(net_off_1, gateway='10.1.2.1', vpc=vpc_1)
+        internal_tier_2 = self.create_Network(
+            net_off_1, gateway='10.1.2.1', vpc=vpc_1)
         internal_vm_2 = self.create_VM(internal_tier_2)
         self.validate_Network(internal_tier_2, state="Implemented")
         vr_1 = self.get_Router(internal_tier_2)
@@ -549,38 +668,50 @@ class TestNuageInternalLb(nuageTestCase):
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_04_nuage_internallb_rules(self):
-        """Test Nuage VSP VPC Internal LB functionality with different combinations of Internal LB rules
+        """Test Nuage VSP VPC Internal LB functionality with different
+        combinations of Internal LB rules
         """
 
-        # 1. Create an Internal LB Rule with source IP Address specified, check if the Internal LB Rule is successfully
-        #    created.
-        # 2. Create an Internal LB Rule without source IP Address specified, check if the Internal LB Rule is
-        #    successfully created.
-        # 3. Create an Internal LB Rule when the specified source IP Address is outside the VPC network (tier) CIDR
-        #    range, check if the Internal LB Rule creation failed as the requested source IP is not in the network's
+        # 1. Create an Internal LB Rule with source IP Address specified, check
+        #    if the Internal LB Rule is successfully created.
+        # 2. Create an Internal LB Rule without source IP Address specified,
+        #    check if the Internal LB Rule is successfully created.
+        # 3. Create an Internal LB Rule when the specified source IP Address is
+        #    outside the VPC network (tier) CIDR range, check if the Internal
+        #    LB Rule creation failed as the requested source IP is not in the
+        #    network's CIDR subnet.
+        # 4. Create an Internal LB Rule when the specified source IP Address is
+        #    outside the VPC super CIDR range, check if the Internal LB Rule
+        #    creation failed as the requested source IP is not in the network's
         #    CIDR subnet.
-        # 4. Create an Internal LB Rule when the specified source IP Address is outside the VPC super CIDR range,
-        #    check if the Internal LB Rule creation failed as the requested source IP is not in the network's CIDR
-        #    subnet.
-        # 5. Create an Internal LB Rule in the tier with LB service provider as VpcInlineLbVm, check if the Internal LB
-        #    Rule creation failed as Scheme Internal is not supported by this network offering.
-        # 6. Create multiple Internal LB Rules using different Load Balancing source IP Addresses, check if the Internal
+        # 5. Create an Internal LB Rule in the tier with LB service provider as
+        #    VpcInlineLbVm, check if the Internal LB Rule creation failed as
+        #    Scheme Internal is not supported by this network offering.
+        # 6. Create multiple Internal LB Rules using different Load Balancing
+        #    source IP Addresses, check if the Internal LB Rules are
+        #    successfully created.
+        # 7. Create multiple Internal LB Rules with different ports but using
+        #    the same Load Balancing source IP Address, check if the Internal
         #    LB Rules are successfully created.
-        # 7. Create multiple Internal LB Rules with different ports but using the same Load Balancing source IP Address,
-        #    check if the Internal LB Rules are successfully created.
-        # 8. Create multiple Internal LB Rules with same ports and using the same Load Balancing source IP Address,
-        #    check if the second Internal LB Rule creation failed as it conflicts with the first Internal LB rule.
-        # 9. Attach a VM to the above created Internal LB Rules, check if the VM is successfully attached to the
-        #    Internal LB Rules.
-        # 10. Verify the InternalLbVm deployment after successfully creating the first Internal LB Rule and attaching a
-        #     VM to it.
-        # 11. Verify the failure of attaching a VM from a different tier to an Internal LB Rule created on a tier.
-        # 12. Delete the above created Internal LB Rules, check if the Internal LB Rules are successfully deleted.
+        # 8. Create multiple Internal LB Rules with same ports and using the
+        #    same Load Balancing source IP Address, check if the second
+        #    Internal LB Rule creation failed as it conflicts with the first
+        #    Internal LB rule.
+        # 9. Attach a VM to the above created Internal LB Rules, check if the
+        #    VM is successfully attached to the Internal LB Rules.
+        # 10. Verify the InternalLbVm deployment after successfully creating
+        #     the first Internal LB Rule and attaching a VM to it.
+        # 11. Verify the failure of attaching a VM from a different tier to an
+        #     Internal LB Rule created on a tier.
+        # 12. Delete the above created Internal LB Rules, check if the Internal
+        #     LB Rules are successfully deleted.
         # 13. Delete all the created objects (cleanup).
 
         # Creating a VPC offering
-        self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
-        vpc_off = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with Internal LB "
+                   "service...")
+        vpc_off = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off, state="Enabled")
 
         # Creating a VPC
@@ -589,18 +720,22 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Vpc(vpc, state="Enabled")
 
         # Creating network offerings
-        self.debug("Creating Nuage VSP VPC Network offering with Internal LB service...")
+        self.debug("Creating Nuage VSP VPC Network offering with Internal LB "
+                   "service...")
         net_off_1 = self.create_NetworkOffering(
             self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         self.validate_NetworkOffering(net_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
-        net_off_2 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Creating Nuage VSP VPC Network offering without Internal "
+                   "LB service...")
+        net_off_2 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_2, state="Enabled")
 
         # Creating VPC networks in the VPC, and deploying VMs
         self.debug("Creating a VPC network with Internal LB service...")
-        internal_tier = self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc)
+        internal_tier = self.create_Network(
+            net_off_1, gateway='10.1.1.1', vpc=vpc)
         self.validate_Network(internal_tier, state="Implemented")
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
@@ -615,7 +750,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
-        public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
+        public_tier = self.create_Network(
+            net_off_2, gateway='10.1.2.1', vpc=vpc)
         self.validate_Network(public_tier, state="Implemented")
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
@@ -630,14 +766,17 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(public_vm)
 
         # Creating Internal LB Rules
-        self.debug("Creating an Internal LB Rule without source IP Address specified...")
+        self.debug("Creating an Internal LB Rule without source IP Address "
+                   "specified...")
         int_lb_rule = self.create_Internal_LB_Rule(internal_tier)
         self.validate_Internal_LB_Rule(int_lb_rule, state="Add")
 
         # Validating InternalLbVm deployment
         with self.assertRaises(Exception):
-            self.check_InternalLbVm_state(internal_tier, int_lb_rule.sourceipaddress)
-        self.debug("InternalLbVm is not deployed in the network as there are no VMs assigned to this Internal LB Rule")
+            self.check_InternalLbVm_state(
+                internal_tier, int_lb_rule.sourceipaddress)
+        self.debug("InternalLbVm is not deployed in the network as there are "
+                   "no VMs assigned to this Internal LB Rule")
 
         self.debug('Deleting the Internal LB Rule - %s' % int_lb_rule.name)
         int_lb_rule.delete(self.api_client)
@@ -647,14 +786,18 @@ class TestNuageInternalLb(nuageTestCase):
 
         free_source_ip = int_lb_rule.sourceipaddress
 
-        self.debug("Creating an Internal LB Rule with source IP Address specified...")
-        int_lb_rule = self.create_Internal_LB_Rule(internal_tier, source_ip=free_source_ip)
+        self.debug("Creating an Internal LB Rule with source IP Address "
+                   "specified...")
+        int_lb_rule = self.create_Internal_LB_Rule(
+            internal_tier, source_ip=free_source_ip)
         self.validate_Internal_LB_Rule(int_lb_rule, state="Add")
 
         # Validating InternalLbVm deployment
         with self.assertRaises(Exception):
-            self.check_InternalLbVm_state(internal_tier, int_lb_rule.sourceipaddress)
-        self.debug("InternalLbVm is not deployed in the network as there are no VMs assigned to this Internal LB Rule")
+            self.check_InternalLbVm_state(
+                internal_tier, int_lb_rule.sourceipaddress)
+        self.debug("InternalLbVm is not deployed in the network as there are "
+                   "no VMs assigned to this Internal LB Rule")
 
         self.debug('Deleting the Internal LB Rule - %s' % int_lb_rule.name)
         int_lb_rule.delete(self.api_client)
@@ -662,58 +805,79 @@ class TestNuageInternalLb(nuageTestCase):
             self.validate_Internal_LB_Rule(int_lb_rule)
         self.debug("Internal LB Rule successfully deleted in CloudStack")
 
-        self.debug("Creating an Internal LB Rule when the specified source IP Address is outside the VPC network CIDR "
-                   "range...")
+        self.debug("Creating an Internal LB Rule when the specified source IP "
+                   "Address is outside the VPC network CIDR range...")
         with self.assertRaises(Exception):
             self.create_Internal_LB_Rule(internal_tier, source_ip="10.1.1.256")
-        self.debug("Internal LB Rule creation failed as the requested IP is not in the network's CIDR subnet")
+        self.debug("Internal LB Rule creation failed as the requested IP is "
+                   "not in the network's CIDR subnet")
 
-        self.debug("Creating an Internal LB Rule when the specified source IP Address is outside the VPC super CIDR "
-                   "range...")
+        self.debug("Creating an Internal LB Rule when the specified source IP "
+                   "Address is outside the VPC super CIDR range...")
         with self.assertRaises(Exception):
             self.create_Internal_LB_Rule(internal_tier, source_ip="10.2.1.256")
-        self.debug("Internal LB Rule creation failed as the requested IP is not in the network's CIDR subnet")
+        self.debug("Internal LB Rule creation failed as the requested IP is "
+                   "not in the network's CIDR subnet")
 
-        self.debug("Creating an Internal LB Rule in a VPC network without Internal Lb service...")
+        self.debug("Creating an Internal LB Rule in a VPC network without "
+                   "Internal Lb service...")
         with self.assertRaises(Exception):
             self.create_Internal_LB_Rule(public_tier)
-        self.debug("Internal LB Rule creation failed as Scheme Internal is not supported by this network offering")
+        self.debug("Internal LB Rule creation failed as Scheme Internal is "
+                   "not supported by this network offering")
 
-        self.debug("Creating multiple Internal LB Rules using different Load Balancing source IP Addresses...")
-        int_lb_rule_1 = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active", vm_array=[internal_vm])
-        int_lb_rule_2 = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active", vm_array=[internal_vm])
+        self.debug("Creating multiple Internal LB Rules using different Load "
+                   "Balancing source IP Addresses...")
+        int_lb_rule_1 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active", vm_array=[internal_vm])
+        int_lb_rule_2 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active", vm_array=[internal_vm])
 
         # Validating InternalLbVms deployment and state
-        int_lb_vm_1 = self.get_InternalLbVm(internal_tier, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
-        int_lb_vm_2 = self.get_InternalLbVm(internal_tier, int_lb_rule_2.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_2.sourceipaddress, state="Running")
+        int_lb_vm_1 = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm_2 = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_2.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_2.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_1)
         self.verify_vsd_lb_device(int_lb_vm_2)
 
-        self.debug('Removing VMs from the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
+        self.debug('Removing VMs from the Internal LB Rules - %s, %s' %
+                   (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.remove(self.api_client, vms=[internal_vm])
         with self.assertRaises(Exception):
-            self.validate_Internal_LB_Rule(int_lb_rule_1, vm_array=[internal_vm])
-        self.debug("VMs successfully removed from the Internal LB Rule in CloudStack")
+            self.validate_Internal_LB_Rule(
+                int_lb_rule_1, vm_array=[internal_vm])
+        self.debug("VMs successfully removed from the Internal LB Rule in "
+                   "CloudStack")
         int_lb_rule_2.remove(self.api_client, vms=[internal_vm])
         with self.assertRaises(Exception):
-            self.validate_Internal_LB_Rule(int_lb_rule_2, vm_array=[internal_vm])
-        self.debug("VMs successfully removed from the Internal LB Rule in CloudStack")
+            self.validate_Internal_LB_Rule(
+                int_lb_rule_2, vm_array=[internal_vm])
+        self.debug("VMs successfully removed from the Internal LB Rule in "
+                   "CloudStack")
 
         # Validating InternalLbVms state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_2.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_2.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_1)
         self.verify_vsd_lb_device(int_lb_vm_2)
 
-        self.debug('Deleting the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
+        self.debug('Deleting the Internal LB Rules - %s, %s' %
+                   (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.delete(self.api_client)
         with self.assertRaises(Exception):
             self.validate_Internal_LB_Rule(int_lb_rule_1)
@@ -725,10 +889,12 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Validating InternalLbVms un-deployment
         with self.assertRaises(Exception):
-            self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress)
+            self.check_InternalLbVm_state(
+                internal_tier, int_lb_rule_1.sourceipaddress)
         self.debug("InternalLbVm successfully destroyed in CloudStack")
         with self.assertRaises(Exception):
-            self.check_InternalLbVm_state(internal_tier, int_lb_rule_2.sourceipaddress)
+            self.check_InternalLbVm_state(
+                internal_tier, int_lb_rule_2.sourceipaddress)
         self.debug("InternalLbVm successfully destroyed in CloudStack")
 
         # VSD Verification
@@ -739,41 +905,52 @@ class TestNuageInternalLb(nuageTestCase):
             self.verify_vsd_lb_device(int_lb_vm_2)
         self.debug("InternalLbVm successfully destroyed in VSD")
 
-        self.debug("Creating multiple Internal LB Rules with different ports but using the same Load Balancing source "
-                   "IP Address...")
-        int_lb_rule_1 = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active", vm_array=[internal_vm])
-        int_lb_rule_2 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_1.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active", vm_array=[internal_vm])
+        self.debug("Creating multiple Internal LB Rules with different ports "
+                   "but using the same Load Balancing source IP Address...")
+        int_lb_rule_1 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active", vm_array=[internal_vm])
+        int_lb_rule_2 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_1.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active", vm_array=[internal_vm])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm = self.get_InternalLbVm(internal_tier, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
-        self.debug('Removing VMs from the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
+        self.debug('Removing VMs from the Internal LB Rules - %s, %s' %
+                   (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.remove(self.api_client, vms=[internal_vm])
         with self.assertRaises(Exception):
-            self.validate_Internal_LB_Rule(int_lb_rule_1, vm_array=[internal_vm])
-        self.debug("VMs successfully removed from the Internal LB Rule in CloudStack")
+            self.validate_Internal_LB_Rule(
+                int_lb_rule_1, vm_array=[internal_vm])
+        self.debug("VMs successfully removed from the Internal LB Rule in "
+                   "CloudStack")
         int_lb_rule_2.remove(self.api_client, vms=[internal_vm])
         with self.assertRaises(Exception):
-            self.validate_Internal_LB_Rule(int_lb_rule_2, vm_array=[internal_vm])
-        self.debug("VMs successfully removed from the Internal LB Rule in CloudStack")
+            self.validate_Internal_LB_Rule(
+                int_lb_rule_2, vm_array=[internal_vm])
+        self.debug("VMs successfully removed from the Internal LB Rule in "
+                   "CloudStack")
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
-        self.debug('Deleting the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
+        self.debug('Deleting the Internal LB Rules - %s, %s' %
+                   (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.delete(self.api_client)
         with self.assertRaises(Exception):
             self.validate_Internal_LB_Rule(int_lb_rule_1)
@@ -785,7 +962,8 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Validating InternalLbVm un-deployment
         with self.assertRaises(Exception):
-            self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress)
+            self.check_InternalLbVm_state(
+                internal_tier, int_lb_rule_1.sourceipaddress)
         self.debug("InternalLbVm successfully destroyed in CloudStack")
 
         # VSD Verification
@@ -793,29 +971,39 @@ class TestNuageInternalLb(nuageTestCase):
             self.verify_vsd_lb_device(int_lb_vm)
         self.debug("InternalLbVm successfully destroyed in VSD")
 
-        self.debug("Creating multiple Internal LB Rules with same ports and using the same Load Balancing source IP "
-                   "Address...")
-        int_lb_rule = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
-        self.validate_Internal_LB_Rule(int_lb_rule, state="Active", vm_array=[internal_vm])
+        self.debug("Creating multiple Internal LB Rules with same ports and "
+                   "using the same Load Balancing source IP Address...")
+        int_lb_rule = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule, state="Active", vm_array=[internal_vm])
         with self.assertRaises(Exception):
-            self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm], source_ip=int_lb_rule.sourceipaddress)
-        self.debug("Internal LB Rule creation failed as it conflicts with the existing rule")
+            self.create_Internal_LB_Rule(
+                internal_tier, vm_array=[internal_vm],
+                source_ip=int_lb_rule.sourceipaddress)
+        self.debug("Internal LB Rule creation failed as it conflicts with the "
+                   "existing rule")
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm = self.get_InternalLbVm(internal_tier, int_lb_rule.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule.sourceipaddress, state="Running")
+        int_lb_vm = self.get_InternalLbVm(
+            internal_tier, int_lb_rule.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
-        self.debug('Removing VMs from the Internal LB Rule - %s' % int_lb_rule.name)
+        self.debug('Removing VMs from the Internal LB Rule - %s' %
+                   int_lb_rule.name)
         int_lb_rule.remove(self.api_client, vms=[internal_vm])
         with self.assertRaises(Exception):
             self.validate_Internal_LB_Rule(int_lb_rule, vm_array=[internal_vm])
-        self.debug("VMs successfully removed from the Internal LB Rule in CloudStack")
+        self.debug("VMs successfully removed from the Internal LB Rule in "
+                   "CloudStack")
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
@@ -828,7 +1016,8 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Validating InternalLbVm un-deployment
         with self.assertRaises(Exception):
-            self.check_InternalLbVm_state(internal_tier, int_lb_rule.sourceipaddress)
+            self.check_InternalLbVm_state(
+                internal_tier, int_lb_rule.sourceipaddress)
         self.debug("InternalLbVm successfully destroyed in CloudStack")
 
         # VSD Verification
@@ -836,38 +1025,50 @@ class TestNuageInternalLb(nuageTestCase):
             self.verify_vsd_lb_device(int_lb_vm)
         self.debug("InternalLbVm successfully destroyed in VSD")
 
-        self.debug("Attaching a VM from a different tier to an Internal LB Rule created on a tier...")
+        self.debug("Attaching a VM from a different tier to an Internal LB "
+                   "Rule created on a tier...")
         with self.assertRaises(Exception):
             self.create_Internal_LB_Rule(internal_tier, vm_array=[public_vm])
-        self.debug("Internal LB Rule creation failed as the VM belongs to a different network")
+        self.debug("Internal LB Rule creation failed as the VM belongs to a "
+                   "different network")
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
     def test_05_nuage_internallb_traffic(self):
-        """Test Nuage VSP VPC Internal LB functionality by performing (wget) traffic tests within a VPC
+        """Test Nuage VSP VPC Internal LB functionality by performing (wget)
+        traffic tests within a VPC
         """
 
-        # 1. Create an Internal LB Rule "internal_lbrule" with source IP Address specified on the Internal tier, check
-        #    if the Internal LB Rule is successfully created.
-        # 2. Create an Internal LB Rule "internal_lbrule_http" with source IP Address (same as above) specified on the
-        #    Internal tier, check if the Internal LB Rule is successfully created.
-        # 3. Attach a VM to the above created Internal LB Rules, check if the InternalLbVm is successfully deployed in
-        #    the Internal tier.
-        # 4. Deploy two more VMs in the Internal tier, check if the VMs are successfully deployed.
-        # 5. Attach the newly deployed VMs to the above created Internal LB Rules, verify the validity of the above
-        #    created Internal LB Rules over three Load Balanced VMs in the Internal tier.
-        # 6. Create the corresponding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible,
-        #    check if the Network ACL rules are successfully added to the internal tier.
-        # 7. Validate the Internal LB functionality by performing (wget) traffic tests from a VM in the Public tier to
-        #    the Internal load balanced guest VMs in the Internal tier, using Static NAT functionality to access (ssh)
-        #    the VM on the Public tier.
-        # 8. Verify that the InternalLbVm gets destroyed when the last Internal LB rule is removed from the Internal
-        #    tier.
-        # 9. Repeat the above steps for one more Internal tier as well, validate the Internal LB functionality.
+        # 1. Create an Internal LB Rule "internal_lbrule" with source IP
+        #    Address specified on the Internal tier, check if the Internal LB
+        #    Rule is successfully created.
+        # 2. Create an Internal LB Rule "internal_lbrule_http" with source IP
+        #    Address (same as above) specified on the Internal tier, check if
+        #    the Internal LB Rule is successfully created.
+        # 3. Attach a VM to the above created Internal LB Rules, check if the
+        #    InternalLbVm is successfully deployed in the Internal tier.
+        # 4. Deploy two more VMs in the Internal tier, check if the VMs are
+        #    successfully deployed.
+        # 5. Attach the newly deployed VMs to the above created Internal LB
+        #    Rules, verify the validity of the above created Internal LB Rules
+        #    over three Load Balanced VMs in the Internal tier.
+        # 6. Create the corresponding Network ACL rules to make the created
+        #    Internal LB rules (SSH & HTTP) accessible, check if the Network
+        #    ACL rules are successfully added to the internal tier.
+        # 7. Validate the Internal LB functionality by performing (wget)
+        #    traffic tests from a VM in the Public tier to the Internal load
+        #    balanced guest VMs in the Internal tier, using Static NAT
+        #    functionality to access (ssh) the VM on the Public tier.
+        # 8. Verify that the InternalLbVm gets destroyed when the last Internal
+        #    LB rule is removed from the Internal tier.
+        # 9. Repeat the above steps for one more Internal tier as well,
+        #    validate the Internal LB functionality.
         # 10. Delete all the created objects (cleanup).
 
         # Creating a VPC offering
-        self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
-        vpc_off = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with Internal LB "
+                   "service...")
+        vpc_off = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off, state="Enabled")
 
         # Creating a VPC
@@ -876,18 +1077,22 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Vpc(vpc, state="Enabled")
 
         # Creating network offerings
-        self.debug("Creating Nuage VSP VPC Network offering with Internal LB service...")
+        self.debug("Creating Nuage VSP VPC Network offering with Internal LB "
+                   "service...")
         net_off_1 = self.create_NetworkOffering(
             self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         self.validate_NetworkOffering(net_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
-        net_off_2 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Creating Nuage VSP VPC Network offering without Internal "
+                   "LB service...")
+        net_off_2 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_2, state="Enabled")
 
         # Creating VPC networks in the VPC, and deploying VMs
         self.debug("Creating a VPC network with Internal LB service...")
-        internal_tier_1 = self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc)
+        internal_tier_1 = self.create_Network(
+            net_off_1, gateway='10.1.1.1', vpc=vpc)
         self.validate_Network(internal_tier_1, state="Implemented")
         vr = self.get_Router(internal_tier_1)
         self.check_Router_state(vr, state="Running")
@@ -902,7 +1107,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm_1)
 
         self.debug("Creating one more VPC network with Internal LB service...")
-        internal_tier_2 = self.create_Network(net_off_1, gateway='10.1.2.1', vpc=vpc)
+        internal_tier_2 = self.create_Network(
+            net_off_1, gateway='10.1.2.1', vpc=vpc)
         self.validate_Network(internal_tier_2, state="Implemented")
         vr = self.get_Router(internal_tier_2)
         self.check_Router_state(vr, state="Running")
@@ -917,7 +1123,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm_2)
 
         self.debug("Creating a VPC network without Internal LB service...")
-        public_tier = self.create_Network(net_off_2, gateway='10.1.3.1', vpc=vpc)
+        public_tier = self.create_Network(
+            net_off_2, gateway='10.1.3.1', vpc=vpc)
         self.validate_Network(public_tier, state="Implemented")
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
@@ -932,25 +1139,31 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(public_vm)
 
         # Creating Internal LB Rules in the Internal tiers
-        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
-        int_lb_rule_1 = self.create_Internal_LB_Rule(internal_tier_1, vm_array=[internal_vm_1])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active", vm_array=[internal_vm_1])
-        int_lb_rule_2 = self.create_Internal_LB_Rule(internal_tier_1,
-                                                     vm_array=[internal_vm_1],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_1.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active", vm_array=[internal_vm_1])
+        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the "
+                   "same Load Balancing source IP Address...")
+        int_lb_rule_1 = self.create_Internal_LB_Rule(
+            internal_tier_1, vm_array=[internal_vm_1])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active", vm_array=[internal_vm_1])
+        int_lb_rule_2 = self.create_Internal_LB_Rule(
+            internal_tier_1, vm_array=[internal_vm_1],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_1.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active", vm_array=[internal_vm_1])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm_1 = self.get_InternalLbVm(internal_tier_1, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier_1, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm_1 = self.get_InternalLbVm(
+            internal_tier_1, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier_1, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_1)
 
         # Deploying more VMs in the Internal tier
-        self.debug("Deploying two more VMs in network - %s" % internal_tier_1.name)
+        self.debug("Deploying two more VMs in network - %s" %
+                   internal_tier_1.name)
         internal_vm_1_1 = self.create_VM(internal_tier_1)
         internal_vm_1_2 = self.create_VM(internal_tier_1)
 
@@ -959,49 +1172,64 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm_1_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
-        self.debug("Adding two more virtual machines to the created Internal LB rules...")
-        int_lb_rule_1.assign(self.api_client, [internal_vm_1_1, internal_vm_1_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active",
-                                       vm_array=[internal_vm_1, internal_vm_1_1, internal_vm_1_2])
-        int_lb_rule_2.assign(self.api_client, [internal_vm_1_1, internal_vm_1_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active",
-                                       vm_array=[internal_vm_1, internal_vm_1_1, internal_vm_1_2])
+        self.debug("Adding two more virtual machines to the created Internal "
+                   "LB rules...")
+        int_lb_rule_1.assign(
+            self.api_client, [internal_vm_1_1, internal_vm_1_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active",
+            vm_array=[internal_vm_1, internal_vm_1_1, internal_vm_1_2])
+        int_lb_rule_2.assign(
+            self.api_client, [internal_vm_1_1, internal_vm_1_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active",
+            vm_array=[internal_vm_1, internal_vm_1_1, internal_vm_1_2])
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier_1, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier_1, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_1)
 
         # Adding Network ACL rules in the Internal tier
-        self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
-        ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=internal_tier_1)
-        http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier_1)
+        self.debug("Adding Network ACL rules to make the created Internal LB "
+                   "rules (SSH & HTTP) accessible...")
+        ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=internal_tier_1)
+        http_rule = self.create_NetworkAclRule(
+            self.test_data["http_rule"], network=internal_tier_1)
 
         # VSD verification
         self.verify_vsd_firewall_rule(ssh_rule)
         self.verify_vsd_firewall_rule(http_rule)
 
         # Creating Internal LB Rules in the Internal tier
-        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
-        int_lb_rule_3 = self.create_Internal_LB_Rule(internal_tier_2, vm_array=[internal_vm_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_3, state="Active", vm_array=[internal_vm_2])
-        int_lb_rule_4 = self.create_Internal_LB_Rule(internal_tier_2,
-                                                     vm_array=[internal_vm_2],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_3.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_4, state="Active", vm_array=[internal_vm_2])
+        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the "
+                   "same Load Balancing source IP Address...")
+        int_lb_rule_3 = self.create_Internal_LB_Rule(
+            internal_tier_2, vm_array=[internal_vm_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_3, state="Active", vm_array=[internal_vm_2])
+        int_lb_rule_4 = self.create_Internal_LB_Rule(
+            internal_tier_2, vm_array=[internal_vm_2],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_3.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_4, state="Active", vm_array=[internal_vm_2])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm_2 = self.get_InternalLbVm(internal_tier_2, int_lb_rule_3.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier_2, int_lb_rule_3.sourceipaddress, state="Running")
+        int_lb_vm_2 = self.get_InternalLbVm(
+            internal_tier_2, int_lb_rule_3.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier_2, int_lb_rule_3.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_2)
 
         # Deploying more VMs in the Internal tier
-        self.debug("Deploying two more VMs in network - %s" % internal_tier_2.name)
+        self.debug("Deploying two more VMs in network - %s" %
+                   internal_tier_2.name)
         internal_vm_2_1 = self.create_VM(internal_tier_2)
         internal_vm_2_2 = self.create_VM(internal_tier_2)
 
@@ -1010,24 +1238,33 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm_2_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
-        self.debug("Adding two more virtual machines to the created Internal LB rules...")
-        int_lb_rule_3.assign(self.api_client, [internal_vm_2_1, internal_vm_2_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_3, state="Active",
-                                       vm_array=[internal_vm_2, internal_vm_2_1, internal_vm_2_2])
-        int_lb_rule_4.assign(self.api_client, [internal_vm_2_1, internal_vm_2_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_4, state="Active",
-                                       vm_array=[internal_vm_2, internal_vm_2_1, internal_vm_2_2])
+        self.debug("Adding two more virtual machines to the created Internal "
+                   "LB rules...")
+        int_lb_rule_3.assign(
+            self.api_client, [internal_vm_2_1, internal_vm_2_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_3, state="Active",
+            vm_array=[internal_vm_2, internal_vm_2_1, internal_vm_2_2])
+        int_lb_rule_4.assign(
+            self.api_client, [internal_vm_2_1, internal_vm_2_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_4, state="Active",
+            vm_array=[internal_vm_2, internal_vm_2_1, internal_vm_2_2])
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier_2, int_lb_rule_3.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier_2, int_lb_rule_3.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_2)
 
         # Adding Network ACL rules in the Internal tier
-        self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
-        ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=internal_tier_2)
-        http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier_2)
+        self.debug("Adding Network ACL rules to make the created Internal LB "
+                   "rules (SSH & HTTP) accessible...")
+        ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=internal_tier_2)
+        http_rule = self.create_NetworkAclRule(
+            self.test_data["http_rule"], network=internal_tier_2)
 
         # VSD verification
         self.verify_vsd_firewall_rule(ssh_rule)
@@ -1037,50 +1274,58 @@ class TestNuageInternalLb(nuageTestCase):
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
-        self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
-        public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
+        self.debug("Adding Network ACL rule to make the created NAT rule "
+                   "(SSH) accessible...")
+        public_ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
         self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic tests
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file_1 = self.wget_from_vm_cmd(ssh_client,
-                                            int_lb_rule_1.sourceipaddress,
-                                            self.test_data["http_rule"]["publicport"]
-                                            )
+        wget_file_1 = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file_2 = self.wget_from_vm_cmd(ssh_client,
-                                            int_lb_rule_3.sourceipaddress,
-                                            self.test_data["http_rule"]["publicport"]
-                                            )
+        wget_file_2 = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_3.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic tests
-        self.verify_lb_wget_file(wget_file_1, [internal_vm_1, internal_vm_1_1, internal_vm_1_2])
-        self.verify_lb_wget_file(wget_file_2, [internal_vm_2, internal_vm_2_1, internal_vm_2_2])
+        self.verify_lb_wget_file(
+            wget_file_1, [internal_vm_1, internal_vm_1_1, internal_vm_1_2])
+        self.verify_lb_wget_file(
+            wget_file_2, [internal_vm_2, internal_vm_2_1, internal_vm_2_2])
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
     def test_06_nuage_internallb_algorithms_traffic(self):
-        """Test Nuage VSP VPC Internal LB functionality with different LB algorithms by performing (wget) traffic tests
-        within a VPC
+        """Test Nuage VSP VPC Internal LB functionality with different LB
+        algorithms by performing (wget) traffic tests within a VPC
         """
 
-        # Repeat the tests in the testcase "test_05_nuage_internallb_traffic" with different Internal LB algorithms:
+        # Repeat the tests in the testcase "test_05_nuage_internallb_traffic"
+        # with different Internal LB algorithms:
         # 1. Round Robin
         # 2. Least connections
         # 3. Source
-        # Verify the above Internal LB algorithms by performing multiple (wget) traffic tests within a VPC.
+        # Verify the above Internal LB algorithms by performing multiple (wget)
+        # traffic tests within a VPC.
         # Delete all the created objects (cleanup).
 
         # Creating a VPC offering
-        self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
-        vpc_off = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with Internal LB "
+                   "service...")
+        vpc_off = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off, state="Enabled")
 
         # Creating a VPC
@@ -1089,18 +1334,22 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Vpc(vpc, state="Enabled")
 
         # Creating network offerings
-        self.debug("Creating Nuage VSP VPC Network offering with Internal LB service...")
+        self.debug("Creating Nuage VSP VPC Network offering with Internal LB "
+                   "service...")
         net_off_1 = self.create_NetworkOffering(
             self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         self.validate_NetworkOffering(net_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
-        net_off_2 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Creating Nuage VSP VPC Network offering without Internal "
+                   "LB service...")
+        net_off_2 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_2, state="Enabled")
 
         # Creating VPC networks in the VPC, and deploying VMs
         self.debug("Creating a VPC network with Internal LB service...")
-        internal_tier = self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc)
+        internal_tier = self.create_Network(
+            net_off_1, gateway='10.1.1.1', vpc=vpc)
         self.validate_Network(internal_tier, state="Implemented")
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
@@ -1115,7 +1364,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
-        public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
+        public_tier = self.create_Network(
+            net_off_2, gateway='10.1.2.1', vpc=vpc)
         self.validate_Network(public_tier, state="Implemented")
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
@@ -1129,26 +1379,33 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_router(vr)
         self.verify_vsd_vm(public_vm)
 
-        # Creating Internal LB Rules in the Internal tier with Round Robin Algorithm
-        self.debug("Creating two Internal LB Rules (SSH & HTTP) with Round Robin Algorithm...")
-        int_lb_rule_1 = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active", vm_array=[internal_vm])
-        int_lb_rule_2 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_1.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active", vm_array=[internal_vm])
+        # Creating Internal LB Rules in the Internal tier with Round Robin
+        # Algorithm
+        self.debug("Creating two Internal LB Rules (SSH & HTTP) with Round "
+                   "Robin Algorithm...")
+        int_lb_rule_1 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active", vm_array=[internal_vm])
+        int_lb_rule_2 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_1.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active", vm_array=[internal_vm])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm_1 = self.get_InternalLbVm(internal_tier, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm_1 = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_1)
 
         # Deploying more VMs in the Internal tier
-        self.debug("Deploying two more VMs in network - %s" % internal_tier.name)
+        self.debug("Deploying two more VMs in network - %s" %
+                   internal_tier.name)
         internal_vm_1 = self.create_VM(internal_tier)
         internal_vm_2 = self.create_VM(internal_tier)
 
@@ -1157,74 +1414,92 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
-        self.debug("Adding two more virtual machines to the created Internal LB rules...")
+        self.debug("Adding two more virtual machines to the created Internal "
+                   "LB rules...")
         int_lb_rule_1.assign(self.api_client, [internal_vm_1, internal_vm_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
         int_lb_rule_2.assign(self.api_client, [internal_vm_1, internal_vm_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_1)
 
-        # Creating Internal LB Rules in the Internal tier with Least connections Algorithm
-        self.debug("Creating two Internal LB Rules (SSH & HTTP) with Least connections Algorithm...")
+        # Creating Internal LB Rules in the Internal tier with Least
+        # connections Algorithm
+        self.debug("Creating two Internal LB Rules (SSH & HTTP) with Least "
+                   "connections Algorithm...")
         self.test_data["internal_lbrule"]["algorithm"] = "leastconn"
-        int_lb_rule_3 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm, internal_vm_1, internal_vm_2],
-                                                     services=self.test_data["internal_lbrule"]
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_3, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        int_lb_rule_3 = self.create_Internal_LB_Rule(
+            internal_tier,
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2],
+            services=self.test_data["internal_lbrule"])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_3, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
         self.test_data["internal_lbrule_http"]["algorithm"] = "leastconn"
-        int_lb_rule_4 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm, internal_vm_1, internal_vm_2],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_3.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_4, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        int_lb_rule_4 = self.create_Internal_LB_Rule(
+            internal_tier,
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_3.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_4, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm_2 = self.get_InternalLbVm(internal_tier, int_lb_rule_3.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_3.sourceipaddress, state="Running")
+        int_lb_vm_2 = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_3.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_3.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_2)
 
         # Creating Internal LB Rules in the Internal tier with Source Algorithm
-        self.debug("Creating two Internal LB Rules (SSH & HTTP) with Source Algorithm...")
+        self.debug("Creating two Internal LB Rules (SSH & HTTP) with Source "
+                   "Algorithm...")
         self.test_data["internal_lbrule"]["algorithm"] = "source"
-        int_lb_rule_5 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm, internal_vm_1, internal_vm_2],
-                                                     services=self.test_data["internal_lbrule"]
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_5, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        int_lb_rule_5 = self.create_Internal_LB_Rule(
+            internal_tier,
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2],
+            services=self.test_data["internal_lbrule"])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_5, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
         self.test_data["internal_lbrule_http"]["algorithm"] = "source"
-        int_lb_rule_6 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm, internal_vm_1, internal_vm_2],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_5.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_6, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        int_lb_rule_6 = self.create_Internal_LB_Rule(
+            internal_tier,
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_5.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_6, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm_3 = self.get_InternalLbVm(internal_tier, int_lb_rule_5.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_5.sourceipaddress, state="Running")
+        int_lb_vm_3 = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_5.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_5.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm_3)
 
         # Adding Network ACL rules in the Internal tier
-        self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
-        ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=internal_tier)
-        http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier)
+        self.debug("Adding Network ACL rules to make the created Internal LB "
+                   "rules (SSH & HTTP) accessible...")
+        ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=internal_tier)
+        http_rule = self.create_NetworkAclRule(
+            self.test_data["http_rule"], network=internal_tier)
 
         # VSD verification
         self.verify_vsd_firewall_rule(ssh_rule)
@@ -1234,74 +1509,79 @@ class TestNuageInternalLb(nuageTestCase):
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
-        self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
-        public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
+        self.debug("Adding Network ACL rule to make the created NAT rule "
+                   "(SSH) accessible...")
+        public_ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
         self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic tests with Round Robin Algorithm
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        self.validate_internallb_algorithm_traffic(ssh_client,
-                                                   int_lb_rule_1.sourceipaddress,
-                                                   self.test_data["http_rule"]["publicport"],
-                                                   [internal_vm, internal_vm_1, internal_vm_2],
-                                                   "roundrobin"
-                                                   )
+        self.validate_internallb_algorithm_traffic(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"],
+            [internal_vm, internal_vm_1, internal_vm_2], "roundrobin")
 
         # Internal LB (wget) traffic tests with Least connections Algorithm
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        self.validate_internallb_algorithm_traffic(ssh_client,
-                                                   int_lb_rule_3.sourceipaddress,
-                                                   self.test_data["http_rule"]["publicport"],
-                                                   [internal_vm, internal_vm_1, internal_vm_2],
-                                                   "leastconn"
-                                                   )
+        self.validate_internallb_algorithm_traffic(
+            ssh_client, int_lb_rule_3.sourceipaddress,
+            self.test_data["http_rule"]["publicport"],
+            [internal_vm, internal_vm_1, internal_vm_2], "leastconn")
 
         # Internal LB (wget) traffic tests with Source Algorithm
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        self.validate_internallb_algorithm_traffic(ssh_client,
-                                                   int_lb_rule_5.sourceipaddress,
-                                                   self.test_data["http_rule"]["publicport"],
-                                                   [internal_vm, internal_vm_1, internal_vm_2],
-                                                   "source"
-                                                   )
+        self.validate_internallb_algorithm_traffic(
+            ssh_client, int_lb_rule_5.sourceipaddress,
+            self.test_data["http_rule"]["publicport"],
+            [internal_vm, internal_vm_1, internal_vm_2], "source")
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
     def test_07_nuage_internallb_vpc_network_restarts_traffic(self):
-        """Test Nuage VSP VPC Internal LB functionality with restarts of VPC network components by performing (wget)
-        traffic tests within a VPC
+        """Test Nuage VSP VPC Internal LB functionality with restarts of VPC
+        network components by performing (wget) traffic tests within a VPC
         """
 
-        # Repeat the tests in the testcase "test_05_nuage_internallb_traffic" with restarts of VPC networks (tiers):
-        # 1. Restart tier with InternalLbVm (cleanup = false), verify that the InternalLbVm gets destroyed and deployed
-        #    again in the Internal tier.
-        # 2. Restart tier with InternalLbVm (cleanup = true), verify that the InternalLbVm gets destroyed and deployed
-        #    again in the Internal tier.
-        # 3. Restart tier without InternalLbVm (cleanup = false), verify that this restart has no effect on the
-        #    InternalLbVm functionality.
-        # 4. Restart tier without InternalLbVm (cleanup = true), verify that this restart has no effect on the
-        #    InternalLbVm functionality.
-        # 5. Stop all the VMs configured with InternalLbVm, verify that the InternalLbVm gets destroyed in the Internal
+        # Repeat the tests in the testcase "test_05_nuage_internallb_traffic"
+        # with restarts of VPC networks (tiers):
+        # 1. Restart tier with InternalLbVm (cleanup = false), verify that the
+        #    InternalLbVm gets destroyed and deployed again in the Internal
         #    tier.
-        # 6. Start all the VMs configured with InternalLbVm, verify that the InternalLbVm gets deployed again in the
-        #    Internal tier.
-        # 7. Restart VPC (cleanup = false), verify that the VPC VR gets rebooted and this restart has no effect on the
-        #    InternalLbVm functionality.
-        # 7. Restart VPC (cleanup = true), verify that the VPC VR gets rebooted and this restart has no effect on the
-        #    InternalLbVm functionality.
-        # Verify the above restarts of VPC networks (tiers) by performing (wget) traffic tests within a VPC.
+        # 2. Restart tier with InternalLbVm (cleanup = true), verify that the
+        #    InternalLbVm gets destroyed and deployed again in the Internal
+        #    tier.
+        # 3. Restart tier without InternalLbVm (cleanup = false), verify that
+        #    this restart has no effect on the InternalLbVm functionality.
+        # 4. Restart tier without InternalLbVm (cleanup = true), verify that
+        #    this restart has no effect on the InternalLbVm functionality.
+        # 5. Stop all the VMs configured with InternalLbVm, verify that the
+        #    InternalLbVm gets destroyed in the Internal tier.
+        # 6. Start all the VMs configured with InternalLbVm, verify that the
+        #    InternalLbVm gets deployed again in the Internal tier.
+        # 7. Restart VPC (cleanup = false), verify that the VPC VR gets
+        #    rebooted and this restart has no effect on the InternalLbVm
+        #    functionality.
+        # 7. Restart VPC (cleanup = true), verify that the VPC VR gets rebooted
+        #    and this restart has no effect on the InternalLbVm functionality.
+        # Verify the above restarts of VPC networks (tiers) by performing
+        # (wget) traffic tests within a VPC.
         # Delete all the created objects (cleanup).
 
         # Creating a VPC offering
-        self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
-        vpc_off = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with Internal LB "
+                   "service...")
+        vpc_off = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off, state="Enabled")
 
         # Creating a VPC
@@ -1310,18 +1590,22 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Vpc(vpc, state="Enabled")
 
         # Creating network offerings
-        self.debug("Creating Nuage VSP VPC Network offering with Internal LB service...")
+        self.debug("Creating Nuage VSP VPC Network offering with Internal LB "
+                   "service...")
         net_off_1 = self.create_NetworkOffering(
             self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         self.validate_NetworkOffering(net_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
-        net_off_2 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Creating Nuage VSP VPC Network offering without Internal "
+                   "LB service...")
+        net_off_2 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_2, state="Enabled")
 
         # Creating VPC networks in the VPC, and deploying VMs
         self.debug("Creating a VPC network with Internal LB service...")
-        internal_tier = self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc)
+        internal_tier = self.create_Network(
+            net_off_1, gateway='10.1.1.1', vpc=vpc)
         self.validate_Network(internal_tier, state="Implemented")
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
@@ -1336,7 +1620,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
-        public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
+        public_tier = self.create_Network(
+            net_off_2, gateway='10.1.2.1', vpc=vpc)
         self.validate_Network(public_tier, state="Implemented")
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
@@ -1351,25 +1636,31 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(public_vm)
 
         # Creating Internal LB Rules in the Internal tier
-        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
-        int_lb_rule_1 = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active", vm_array=[internal_vm])
-        int_lb_rule_2 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_1.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active", vm_array=[internal_vm])
+        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the "
+                   "same Load Balancing source IP Address...")
+        int_lb_rule_1 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active", vm_array=[internal_vm])
+        int_lb_rule_2 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_1.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active", vm_array=[internal_vm])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm = self.get_InternalLbVm(internal_tier, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Deploying more VMs in the Internal tier
-        self.debug("Deploying two more VMs in network - %s" % internal_tier.name)
+        self.debug("Deploying two more VMs in network - %s" %
+                   internal_tier.name)
         internal_vm_1 = self.create_VM(internal_tier)
         internal_vm_2 = self.create_VM(internal_tier)
 
@@ -1378,24 +1669,31 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
-        self.debug("Adding two more virtual machines to the created Internal LB rules...")
+        self.debug("Adding two more virtual machines to the created Internal "
+                   "LB rules...")
         int_lb_rule_1.assign(self.api_client, [internal_vm_1, internal_vm_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
         int_lb_rule_2.assign(self.api_client, [internal_vm_1, internal_vm_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Adding Network ACL rules in the Internal tier
-        self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
-        ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=internal_tier)
-        http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier)
+        self.debug("Adding Network ACL rules to make the created Internal LB "
+                   "rules (SSH & HTTP) accessible...")
+        ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=internal_tier)
+        http_rule = self.create_NetworkAclRule(
+            self.test_data["http_rule"], network=internal_tier)
 
         # VSD verification
         self.verify_vsd_firewall_rule(ssh_rule)
@@ -1405,27 +1703,31 @@ class TestNuageInternalLb(nuageTestCase):
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
-        self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
-        public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
+        self.debug("Adding Network ACL rule to make the created NAT rule "
+                   "(SSH) accessible...")
+        public_ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
         self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(ssh_client,
-                                          int_lb_rule_1.sourceipaddress,
-                                          self.test_data["http_rule"]["publicport"]
-                                          )
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Restart Internal tier (cleanup = false)
         # InternalLbVm gets destroyed and deployed again in the Internal tier
@@ -1448,33 +1750,23 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Validating InternalLbVm state
         # InternalLbVm gets destroyed and deployed again in the Internal tier
-        int_lb_vm = self.get_InternalLbVm(internal_tier, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        tries = 0
-        while tries < 10:
-            try:
-                wget_file = self.wget_from_vm_cmd(ssh_client,
-                                                  int_lb_rule_1.sourceipaddress,
-                                                  self.test_data["http_rule"]["publicport"]
-                                                  )
-            except Exception as e:
-                self.debug("Failed to wget file via the InternalLbVm after re-starting the Internal tier: %s" % e)
-                self.debug("Waiting for the InternalLbVm in the Internal tier to be fully resolved for (wget) traffic "
-                           "test...")
-                time.sleep(30)
-                tries += 1
-                continue
-            self.debug("Internal LB (wget) traffic test is successful after re-starting the Internal tier")
-            break
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Restart Internal tier (cleanup = true)
         # InternalLbVm gets destroyed and deployed again in the Internal tier
@@ -1497,34 +1789,23 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Validating InternalLbVm state
         # InternalLbVm gets destroyed and deployed again in the Internal tier
-        int_lb_vm = self.get_InternalLbVm(internal_tier, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        tries = 0
-        while tries < 10:
-            try:
-                wget_file = self.wget_from_vm_cmd(ssh_client,
-                                                  int_lb_rule_1.sourceipaddress,
-                                                  self.test_data["http_rule"]["publicport"]
-                                                  )
-            except Exception as e:
-                self.debug("Failed to wget file via the InternalLbVm after re-starting the Internal tier with cleanup: "
-                           "%s" % e)
-                self.debug("Waiting for the InternalLbVm in the Internal tier to be fully resolved for (wget) traffic "
-                           "test...")
-                time.sleep(30)
-                tries += 1
-                continue
-            self.debug("Internal LB (wget) traffic test is successful after re-starting the Internal tier with cleanup")
-            break
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Restart Public tier (cleanup = false)
         # This restart has no effect on the InternalLbVm functionality
@@ -1533,30 +1814,33 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Network(public_tier, state="Implemented")
         self.check_Router_state(vr, state="Running")
         self.check_VM_state(public_vm, state="Running")
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
         self.verify_vsd_network(self.domain.id, public_tier, vpc)
         self.verify_vsd_router(vr)
         self.verify_vsd_vm(public_vm)
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
         self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(ssh_client,
-                                          int_lb_rule_1.sourceipaddress,
-                                          self.test_data["http_rule"]["publicport"]
-                                          )
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Restart Public tier (cleanup = true)
         # This restart has no effect on the InternalLbVm functionality
@@ -1565,33 +1849,37 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Network(public_tier, state="Implemented")
         self.check_Router_state(vr, state="Running")
         self.check_VM_state(public_vm, state="Running")
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
         self.verify_vsd_network(self.domain.id, public_tier, vpc)
         self.verify_vsd_router(vr)
         self.verify_vsd_vm(public_vm)
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
         self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(ssh_client,
-                                          int_lb_rule_1.sourceipaddress,
-                                          self.test_data["http_rule"]["publicport"]
-                                          )
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Stopping VMs in the Internal tier
-        # wget traffic test fails as all the VMs in the Internal tier are in stopped state
+        # wget traffic test fails as all the VMs in the Internal tier are in
+        # stopped state
         self.debug("Stopping all the VMs in the Internal tier...")
         internal_vm.stop(self.api_client)
         internal_vm_1.stop(self.api_client)
@@ -1612,22 +1900,28 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
+
+        # Verifying Internal LB (wget) traffic test
         with self.assertRaises(Exception):
-            self.wget_from_vm_cmd(ssh_client,
-                                  int_lb_rule_1.sourceipaddress,
-                                  self.test_data["http_rule"]["publicport"]
-                                  )
-        self.debug("Failed to wget file as all the VMs in the Internal tier are in stopped state")
+            self.verify_lb_wget_file(
+                wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.debug("Failed to wget file as all the VMs in the Internal tier "
+                   "are in stopped state")
 
         # Starting VMs in the Internal tier
-        # wget traffic test succeeds as all the VMs in the Internal tier are back in running state
+        # wget traffic test succeeds as all the VMs in the Internal tier are
+        # back in running state
         self.debug("Starting all the VMs in the Internal tier...")
         internal_vm.start(self.api_client)
         internal_vm_1.start(self.api_client)
@@ -1648,7 +1942,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
@@ -1656,26 +1951,21 @@ class TestNuageInternalLb(nuageTestCase):
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while tries < 10:
-            try:
-                wget_file = self.wget_from_vm_cmd(ssh_client,
-                                                  int_lb_rule_1.sourceipaddress,
-                                                  self.test_data["http_rule"]["publicport"]
-                                                  )
-            except Exception as e:
-                self.debug("Failed to wget file via the InternalLbVm after re-starting all the VMs in the Internal tier"
-                           ": %s" % e)
-                self.debug("Waiting for the InternalLbVm and all the VMs in the Internal tier to be fully resolved for "
-                           "(wget) traffic test...")
-                time.sleep(30)
-                tries += 1
-                continue
-            self.debug("Internal LB (wget) traffic test is successful after re-starting all the VMs in the Internal "
-                       "tier")
-            break
+        while tries < 25:
+            wget_file = self.wget_from_vm_cmd(
+                ssh_client, int_lb_rule_1.sourceipaddress,
+                self.test_data["http_rule"]["publicport"])
+            if wget_file != "":
+                break
+            self.debug("Waiting for the InternalLbVm and all the VMs in the "
+                       "Internal tier to be fully resolved for (wget) traffic "
+                       "test...")
+            time.sleep(60)
+            tries += 1
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Restarting VPC (cleanup = false)
         # VPC VR gets destroyed and deployed again in the VPC
@@ -1690,7 +1980,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm, state="Running")
         self.check_VM_state(internal_vm_1, state="Running")
         self.check_VM_state(internal_vm_2, state="Running")
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
         self.verify_vsd_network(self.domain.id, public_tier, vpc)
@@ -1700,26 +1991,28 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm)
         self.verify_vsd_vm(internal_vm_1)
         self.verify_vsd_vm(internal_vm_2)
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
         self.verify_vsd_firewall_rule(public_ssh_rule)
         self.verify_vsd_firewall_rule(ssh_rule)
         self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(ssh_client,
-                                          int_lb_rule_1.sourceipaddress,
-                                          self.test_data["http_rule"]["publicport"]
-                                          )
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Restarting VPC (cleanup = true)
         # VPC VR gets destroyed and deployed again in the VPC
@@ -1734,7 +2027,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm, state="Running")
         self.check_VM_state(internal_vm_1, state="Running")
         self.check_VM_state(internal_vm_2, state="Running")
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
         self.verify_vsd_network(self.domain.id, public_tier, vpc)
@@ -1744,48 +2038,55 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm)
         self.verify_vsd_vm(internal_vm_1)
         self.verify_vsd_vm(internal_vm_2)
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
         self.verify_vsd_firewall_rule(public_ssh_rule)
         self.verify_vsd_firewall_rule(ssh_rule)
         self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(ssh_client,
-                                          int_lb_rule_1.sourceipaddress,
-                                          self.test_data["http_rule"]["publicport"]
-                                          )
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
     def test_08_nuage_internallb_appliance_operations_traffic(self):
-        """Test Nuage VSP VPC Internal LB functionality with InternalLbVm appliance operations by performing (wget)
-        traffic tests within a VPC
+        """Test Nuage VSP VPC Internal LB functionality with InternalLbVm
+        appliance operations by performing (wget) traffic tests within a VPC
         """
 
-        # Repeat the tests in the testcase "test_05_nuage_internallb_traffic" with InternalLbVm appliance operations:
-        # 1. Verify the InternalLbVm deployment by creating the Internal LB Rules when the VPC VR is in Stopped state,
-        #    VPC VR has no effect on the InternalLbVm functionality.
+        # Repeat the tests in the testcase "test_05_nuage_internallb_traffic"
+        # with InternalLbVm appliance operations:
+        # 1. Verify the InternalLbVm deployment by creating the Internal LB
+        #    Rules when the VPC VR is in Stopped state, VPC VR has no effect on
+        #    the InternalLbVm functionality.
         # 2. Stop the InternalLbVm when the VPC VR is in Stopped State
         # 3. Start the InternalLbVm when the VPC VR is in Stopped state
         # 4. Stop the InternalLbVm when the VPC VR is in Running State
         # 5. Start the InternalLbVm when the VPC VR is in Running state
         # 6. Force stop the InternalLbVm when the VPC VR is in Running State
         # 7. Start the InternalLbVm when the VPC VR is in Running state
-        # Verify the above restarts of VPC networks by performing (wget) traffic tests within a VPC.
+        # Verify the above restarts of VPC networks by performing (wget)
+        # traffic tests within a VPC.
         # Delete all the created objects (cleanup).
 
         # Creating a VPC offering
-        self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
-        vpc_off = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering_lb"])
+        self.debug("Creating Nuage VSP VPC offering with Internal LB "
+                   "service...")
+        vpc_off = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering_lb"])
         self.validate_VpcOffering(vpc_off, state="Enabled")
 
         # Creating a VPC
@@ -1794,18 +2095,22 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Vpc(vpc, state="Enabled")
 
         # Creating network offerings
-        self.debug("Creating Nuage VSP VPC Network offering with Internal LB service...")
+        self.debug("Creating Nuage VSP VPC Network offering with Internal LB "
+                   "service...")
         net_off_1 = self.create_NetworkOffering(
             self.test_data["nuagevsp"]["vpc_network_offering_internal_lb"])
         self.validate_NetworkOffering(net_off_1, state="Enabled")
 
-        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
-        net_off_2 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        self.debug("Creating Nuage VSP VPC Network offering without Internal "
+                   "LB service...")
+        net_off_2 = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_2, state="Enabled")
 
         # Creating VPC networks in the VPC, and deploying VMs
         self.debug("Creating a VPC network with Internal LB service...")
-        internal_tier = self.create_Network(net_off_1, gateway='10.1.1.1', vpc=vpc)
+        internal_tier = self.create_Network(
+            net_off_1, gateway='10.1.1.1', vpc=vpc)
         self.validate_Network(internal_tier, state="Implemented")
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
@@ -1820,7 +2125,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
-        public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
+        public_tier = self.create_Network(
+            net_off_2, gateway='10.1.2.1', vpc=vpc)
         self.validate_Network(public_tier, state="Implemented")
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
@@ -1847,25 +2153,31 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_network(self.domain.id, internal_tier, vpc)
 
         # Creating Internal LB Rules in the Internal tier
-        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
-        int_lb_rule_1 = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active", vm_array=[internal_vm])
-        int_lb_rule_2 = self.create_Internal_LB_Rule(internal_tier,
-                                                     vm_array=[internal_vm],
-                                                     services=self.test_data["internal_lbrule_http"],
-                                                     source_ip=int_lb_rule_1.sourceipaddress
-                                                     )
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active", vm_array=[internal_vm])
+        self.debug("Creating two Internal LB Rules (SSH & HTTP) using the "
+                   "same Load Balancing source IP Address...")
+        int_lb_rule_1 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active", vm_array=[internal_vm])
+        int_lb_rule_2 = self.create_Internal_LB_Rule(
+            internal_tier, vm_array=[internal_vm],
+            services=self.test_data["internal_lbrule_http"],
+            source_ip=int_lb_rule_1.sourceipaddress)
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active", vm_array=[internal_vm])
 
         # Validating InternalLbVm deployment and state
-        int_lb_vm = self.get_InternalLbVm(internal_tier, int_lb_rule_1.sourceipaddress)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        int_lb_vm = self.get_InternalLbVm(
+            internal_tier, int_lb_rule_1.sourceipaddress)
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Deploying more VMs in the Internal tier
-        self.debug("Deploying two more VMs in network - %s" % internal_tier.name)
+        self.debug("Deploying two more VMs in network - %s" %
+                   internal_tier.name)
         internal_vm_1 = self.create_VM(internal_tier)
         internal_vm_2 = self.create_VM(internal_tier)
 
@@ -1874,24 +2186,31 @@ class TestNuageInternalLb(nuageTestCase):
         self.verify_vsd_vm(internal_vm_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
-        self.debug("Adding two more virtual machines to the created Internal LB rules...")
+        self.debug("Adding two more virtual machines to the created Internal "
+                   "LB rules...")
         int_lb_rule_1.assign(self.api_client, [internal_vm_1, internal_vm_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_1, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_1, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
         int_lb_rule_2.assign(self.api_client, [internal_vm_1, internal_vm_2])
-        self.validate_Internal_LB_Rule(int_lb_rule_2, state="Active",
-                                       vm_array=[internal_vm, internal_vm_1, internal_vm_2])
+        self.validate_Internal_LB_Rule(
+            int_lb_rule_2, state="Active",
+            vm_array=[internal_vm, internal_vm_1, internal_vm_2])
 
         # Validating InternalLbVm state
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Adding Network ACL rules in the Internal tier
-        self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
-        ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=internal_tier)
-        http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier)
+        self.debug("Adding Network ACL rules to make the created Internal LB "
+                   "rules (SSH & HTTP) accessible...")
+        ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=internal_tier)
+        http_rule = self.create_NetworkAclRule(
+            self.test_data["http_rule"], network=internal_tier)
 
         # VSD verification
         self.verify_vsd_firewall_rule(ssh_rule)
@@ -1901,72 +2220,70 @@ class TestNuageInternalLb(nuageTestCase):
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
-        self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
+        self.validate_PublicIPAddress(
+            public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(
+            public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
-        self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
-        public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
+        self.debug("Adding Network ACL rule to make the created NAT rule "
+                   "(SSH) accessible...")
+        public_ssh_rule = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
         self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(ssh_client,
-                                          int_lb_rule_1.sourceipaddress,
-                                          self.test_data["http_rule"]["publicport"]
-                                          )
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # # Stopping the InternalLbVm when the VPC VR is in Stopped state
         self.stop_InternalLbVm(int_lb_vm)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm, stopped=True)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
+
+        # Verifying Internal LB (wget) traffic test
         with self.assertRaises(Exception):
-            self.wget_from_vm_cmd(ssh_client,
-                                  int_lb_rule_1.sourceipaddress,
-                                  self.test_data["http_rule"]["publicport"]
-                                  )
-        self.debug("Failed to wget file as the InternalLbVm is in stopped state")
+            self.verify_lb_wget_file(
+                wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.debug("Failed to wget file as the InternalLbVm is in stopped"
+                   " state")
 
         # # Starting the InternalLbVm when the VPC VR is in Stopped state
         self.start_InternalLbVm(int_lb_vm)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        tries = 0
-        while tries < 10:
-            try:
-                wget_file = self.wget_from_vm_cmd(ssh_client,
-                                                  int_lb_rule_1.sourceipaddress,
-                                                  self.test_data["http_rule"]["publicport"]
-                                                  )
-            except Exception as e:
-                self.debug("Failed to wget file via the InternalLbVm after re-starting the InternalLbVm appliance: %s"
-                           % e)
-                self.debug("Waiting for the InternalLbVm to be fully resolved for (wget) traffic test...")
-                time.sleep(30)
-                tries += 1
-                continue
-            self.debug("Internal LB (wget) traffic test is successful after re-starting the InternalLbVm appliance")
-            break
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # Starting the VPC VR
         # VPC VR has no effect on the InternalLbVm functionality
@@ -1982,90 +2299,78 @@ class TestNuageInternalLb(nuageTestCase):
 
         # # Stopping the InternalLbVm when the VPC VR is in Running state
         self.stop_InternalLbVm(int_lb_vm)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm, stopped=True)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
+
+        # Verifying Internal LB (wget) traffic test
         with self.assertRaises(Exception):
-            self.wget_from_vm_cmd(ssh_client,
-                                  int_lb_rule_1.sourceipaddress,
-                                  self.test_data["http_rule"]["publicport"]
-                                  )
-        self.debug("Failed to wget file as the InternalLbVm is in stopped state")
+            self.verify_lb_wget_file(
+                wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.debug("Failed to wget file as the InternalLbVm is in stopped"
+                   " state")
 
         # # Starting the InternalLbVm when the VPC VR is in Running state
         self.start_InternalLbVm(int_lb_vm)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        tries = 0
-        while tries < 10:
-            try:
-                wget_file = self.wget_from_vm_cmd(ssh_client,
-                                                  int_lb_rule_1.sourceipaddress,
-                                                  self.test_data["http_rule"]["publicport"]
-                                                  )
-            except Exception as e:
-                self.debug("Failed to wget file via the InternalLbVm after re-starting the InternalLbVm appliance: %s"
-                           % e)
-                self.debug("Waiting for the InternalLbVm to be fully resolved for (wget) traffic test...")
-                time.sleep(30)
-                tries += 1
-                continue
-            self.debug("Internal LB (wget) traffic test is successful after re-starting the InternalLbVm appliance")
-            break
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
         # # Force Stopping the InternalLbVm when the VPC VR is in Running state
         self.stop_InternalLbVm(int_lb_vm, force=True)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm, stopped=True)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
+
+        # Verifying Internal LB (wget) traffic test
         with self.assertRaises(Exception):
-            self.wget_from_vm_cmd(ssh_client,
-                                  int_lb_rule_1.sourceipaddress,
-                                  self.test_data["http_rule"]["publicport"]
-                                  )
-        self.debug("Failed to wget file as the InternalLbVm is in stopped state")
+            self.verify_lb_wget_file(
+                wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.debug("Failed to wget file as the InternalLbVm is in stopped"
+                   " state")
 
         # # Starting the InternalLbVm when the VPC VR is in Running state
         self.start_InternalLbVm(int_lb_vm)
-        self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
+        self.check_InternalLbVm_state(
+            internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
         self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        tries = 0
-        while tries < 10:
-            try:
-                wget_file = self.wget_from_vm_cmd(ssh_client,
-                                                  int_lb_rule_1.sourceipaddress,
-                                                  self.test_data["http_rule"]["publicport"]
-                                                  )
-            except Exception as e:
-                self.debug("Failed to wget file via the InternalLbVm after re-starting the InternalLbVm appliance: %s"
-                           % e)
-                self.debug("Waiting for the InternalLbVm to be fully resolved for (wget) traffic test...")
-                time.sleep(30)
-                tries += 1
-                continue
-            self.debug("Internal LB (wget) traffic test is successful after re-starting the InternalLbVm appliance")
-            break
+        wget_file = self.wget_from_vm_cmd(
+            ssh_client, int_lb_rule_1.sourceipaddress,
+            self.test_data["http_rule"]["publicport"])
 
         # Verifying Internal LB (wget) traffic test
-        self.verify_lb_wget_file(wget_file, [internal_vm, internal_vm_1, internal_vm_2])
+        self.verify_lb_wget_file(
+            wget_file, [internal_vm, internal_vm_1, internal_vm_2])

--- a/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-""" Component tests for basic VPC Network functionality with Nuage VSP SDN plugin
+""" Component tests for basic VPC Network functionality with
+Nuage VSP SDN plugin
 """
 # Import Local Modules
 from nuageTestCase import nuageTestCase
@@ -30,7 +31,7 @@ class TestNuageVpcNetwork(nuageTestCase):
 
     @classmethod
     def setUpClass(cls, zone=None):
-        super(TestNuageVpcNetwork, cls).setUpClass(zone=zone)
+        super(TestNuageVpcNetwork, cls).setUpClass()
         return
 
     def setUp(self):
@@ -48,20 +49,26 @@ class TestNuageVpcNetwork(nuageTestCase):
         """ Test basic VPC Network functionality with Nuage VSP SDN plugin
         """
 
-        # 1. Create Nuage VSP VPC offering, check if it is successfully created and enabled.
-        # 2. Create a VPC with Nuage VSP VPC offering, check if it is successfully created and enabled.
-        # 3. Create Nuage VSP VPC Network offering, check if it is successfully created and enabled.
+        # 1. Create Nuage VSP VPC offering, check if it is successfully
+        #    created and enabled.
+        # 2. Create a VPC with Nuage VSP VPC offering, check if it is
+        #    successfully created and enabled.
+        # 3. Create Nuage VSP VPC Network offering, check if it is successfully
+        #    created and enabled.
         # 4. Create an ACL list in the created VPC, and add an ACL item to it.
-        # 5. Create a VPC Network with Nuage VSP VPC Network offering and the created ACL list, check if it is
-        #    successfully created, is in the "Implemented" state, and is added to the VPC VR.
-        # 6. Deploy a VM in the created VPC network, check if the VM is successfully deployed and is in the "Running"
-        #    state.
-        # 7. Verify that the created ACL item is successfully implemented in Nuage VSP.
+        # 5. Create a VPC Network with Nuage VSP VPC Network offering and the
+        #    created ACL list, check if it is successfully created, is in the
+        #    "Implemented" state, and is added to the VPC VR.
+        # 6. Deploy a VM in the created VPC network, check if the VM is
+        #    successfully deployed and is in the "Running" state.
+        # 7. Verify that the created ACL item is successfully implemented in
+        #    Nuage VSP.
         # 8. Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering...")
-        vpc_offering = self.create_VpcOffering(self.test_data["nuagevsp"]["vpc_offering"])
+        vpc_offering = self.create_VpcOffering(
+            self.test_data["nuagevsp"]["vpc_offering"])
         self.validate_VpcOffering(vpc_offering, state="Enabled")
 
         # Creating a VPC
@@ -71,18 +78,23 @@ class TestNuageVpcNetwork(nuageTestCase):
 
         # Creating a network offering
         self.debug("Creating Nuage VSP VPC Network offering...")
-        network_offering = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
+        network_offering = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(network_offering, state="Enabled")
 
         # Creating an ACL list
-        acl_list = self.create_NetworkAclList(name="acl", description="acl", vpc=vpc)
+        acl_list = self.create_NetworkAclList(
+            name="acl", description="acl", vpc=vpc)
 
         # Creating an ACL item
-        acl_item = self.create_NetworkAclRule(self.test_data["ingress_rule"], acl_list=acl_list)
+        acl_item = self.create_NetworkAclRule(
+            self.test_data["ingress_rule"], acl_list=acl_list)
 
         # Creating a VPC network in the VPC
-        self.debug("Creating a VPC network with Nuage VSP VPC Network offering...")
-        vpc_network = self.create_Network(network_offering, vpc=vpc, acl_list=acl_list)
+        self.debug("Creating a VPC network with Nuage VSP VPC Network "
+                   "offering...")
+        vpc_network = self.create_Network(
+            network_offering, vpc=vpc, acl_list=acl_list)
         self.validate_Network(vpc_network, state="Implemented")
         vr = self.get_Router(vpc_network)
         self.check_Router_state(vr, state="Running")
@@ -99,18 +111,25 @@ class TestNuageVpcNetwork(nuageTestCase):
         # VSD verification for ACL item
         self.verify_vsd_firewall_rule(acl_item)
 
-    @attr(tags=["advanced", "nuagevsp", "multizone"], required_hardware="false")
+    @attr(
+        tags=["advanced", "nuagevsp", "multizone"], required_hardware="false")
     def test_nuage_vpc_network_multizone(self):
-        """ Test basic VPC Network functionality with Nuage VSP SDN plugin on multiple zones
+        """ Test basic VPC Network functionality with Nuage VSP SDN plugin on
+        multiple zones
         """
 
-        # Repeat the tests in the above testcase "test_nuage_vpc_network" on multiple zones
+        # Repeat the tests in the above testcase "test_nuage_vpc_network" on
+        # multiple zones
 
-        self.debug("Testing basic VPC Network functionality with Nuage VSP SDN plugin on multiple zones...")
+        self.debug("Testing basic VPC Network functionality with Nuage VSP "
+                   "SDN plugin on multiple zones...")
         zones = Zone.list(self.api_client)
         if len(zones) == 1:
             self.skipTest("There is only one Zone configured: skipping test")
         for zone in zones:
             self.debug("Zone - %s" % zone.name)
-            self.setUpClass(zone=zone)
+            # Get Zone details
+            self.getZoneDetails()
+            # Configure VSD sessions
+            self.configureVSDSessions()
             self.test_nuage_vpc_network()

--- a/test/integration/plugins/nuagevsp/test_nuage_vsp.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vsp.py
@@ -45,89 +45,110 @@ class TestNuageVsp(nuageTestCase):
         self.cleanup = [self.account]
         return
 
-    # validate_NuageVspDevice - Validates the addition of Nuage VSP device in the Nuage VSP Physical Network
+    # validate_NuageVspDevice - Validates the addition of Nuage VSP device in
+    # the Nuage VSP Physical Network
     def validate_NuageVspDevice(self):
-        """Validates the addition of Nuage VSP device in the Nuage VSP Physical Network"""
-        self.debug("Validating the addition of Nuage VSP device in the Nuage VSP Physical Network - %s" %
-                   self.vsp_physical_network.id)
-        nuage_vsp_device = Nuage.list(self.api_client,
-                                      physicalnetworkid=self.vsp_physical_network.id
-                                      )
+        """Validates the addition of Nuage VSP device in the
+        Nuage VSP Physical Network"""
+        self.debug("Validating the addition of Nuage VSP device in the Nuage "
+                   "VSP Physical Network - %s" % self.vsp_physical_network.id)
+        nuage_vsp_device = Nuage.list(
+            self.api_client,
+            physicalnetworkid=self.vsp_physical_network.id
+        )
         self.assertEqual(isinstance(nuage_vsp_device, list), True,
                          "List Nuage VSP device should return a valid list"
                          )
-        self.debug("Successfully validated the addition of Nuage VSP device in the Nuage VSP Physical Network - %s" %
+        self.debug("Successfully validated the addition of Nuage VSP device "
+                   "in the Nuage VSP Physical Network - %s" %
                    self.vsp_physical_network.id)
 
-    # delete_NuageVspDevice - Deletes the Nuage VSP device in the Nuage VSP Physical Network
+    # delete_NuageVspDevice - Deletes the Nuage VSP device in the Nuage VSP
+    # Physical Network
     def delete_NuageVspDevice(self):
         """Deletes the Nuage VSP device in the Nuage VSP Physical Network"""
-        self.debug("Deleting the Nuage VSP device in the Nuage VSP Physical Network - %s" %
-                   self.vsp_physical_network.id)
-        nuage_vsp_device = Nuage.list(self.api_client,
-                                      physicalnetworkid=self.vsp_physical_network.id
-                                      )[0]
+        self.debug("Deleting the Nuage VSP device in the Nuage VSP Physical "
+                   "Network - %s" % self.vsp_physical_network.id)
+        nuage_vsp_device = Nuage.list(
+            self.api_client,
+            physicalnetworkid=self.vsp_physical_network.id)[0]
         cmd = deleteNuageVspDevice.deleteNuageVspDeviceCmd()
         cmd.vspdeviceid = nuage_vsp_device.vspdeviceid
         self.api_client.deleteNuageVspDevice(cmd)
-        self.debug("Successfully deleted the Nuage VSP device in the Nuage VSP Physical Network - %s" %
-                   self.vsp_physical_network.id)
+        self.debug("Successfully deleted the Nuage VSP device in the Nuage "
+                   "VSP Physical Network - %s" % self.vsp_physical_network.id)
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_nuage_vsp_device(self):
         """ Test Nuage VSP device in the Nuage VSP Physical Network
         """
 
-        # 1. Verify that the Nuage VSP network service provider is successfully created and enabled in the Nuage VSP
-        #    Physical Network.
-        # 2. Verify that the Nuage VSP device is successfully created in the Nuage VSP Physical Network.
-        # 3. Delete the Nuage VSP device in the Nuage VSP Physical Network, verify that the Nuage VSP device is
-        #    successfully deleted in the Nuage VSP Physical Network.
-        # 4. Add the Nuage VSP device in the Nuage VSP Physical Network with invalid VSD credentials, verify that the
-        #    Nuage VSP device failed to add in the Nuage VSP Physical Network.
-        # 5. Add the Nuage VSP device in the Nuage VSP Physical Network with valid VSD credentials, verify that the
-        #    Nuage VSP device is successfully added in the Nuage VSP Physical Network.
+        # 1. Verify that the Nuage VSP network service provider is successfully
+        #    created and enabled in the Nuage VSP Physical Network.
+        # 2. Verify that the Nuage VSP device is successfully created in the
+        #    Nuage VSP Physical Network.
+        # 3. Delete the Nuage VSP device in the Nuage VSP Physical Network,
+        #    verify that the Nuage VSP device is successfully deleted in the
+        #    Nuage VSP Physical Network.
+        # 4. Add the Nuage VSP device in the Nuage VSP Physical Network with
+        #    invalid VSD credentials, verify that the Nuage VSP device failed
+        #    to add in the Nuage VSP Physical Network.
+        # 5. Add the Nuage VSP device in the Nuage VSP Physical Network with
+        #    valid VSD credentials, verify that the Nuage VSP device is
+        #    successfully added in the Nuage VSP Physical Network.
 
         # Nuage VSP network service provider validation
-        self.debug("Validating the Nuage VSP network service provider in the Nuage VSP Physical Network...")
+        self.debug("Validating the Nuage VSP network service provider in the "
+                   "Nuage VSP Physical Network...")
         self.validate_NetworkServiceProvider("NuageVsp", state="Enabled")
 
         # Nuage VSP device validation
-        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical "
+                   "Network...")
         self.validate_NuageVspDevice()
 
         # Nuage VSP device deletion
-        self.debug("Deleting the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.debug("Deleting the Nuage VSP device in the Nuage VSP Physical "
+                   "Network...")
         self.delete_NuageVspDevice()
 
         # Nuage VSP device validation
-        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical "
+                   "Network...")
         with self.assertRaises(Exception):
             self.validate_NuageVspDevice()
-        self.debug("Successfully deleted the Nuage VSP device in the Nuage VSP Physical Network")
+        self.debug("Successfully deleted the Nuage VSP device in the Nuage "
+                   "VSP Physical Network")
 
         # Adding the Nuage VSP device with invalid VSD credentials
-        self.debug("Adding the Nuage VSP device in the Nuage VSP Physical Network with invalid VSD credentials...")
+        self.debug("Adding the Nuage VSP device in the Nuage VSP Physical "
+                   "Network with invalid VSD credentials...")
         vsd_info = self.nuage_vsp_device.__dict__
         invalid_vsd_info = copy.deepcopy(vsd_info)
         invalid_vsd_info["password"] = ""
         with self.assertRaises(Exception):
-            Nuage.add(self.api_client, invalid_vsd_info, self.vsp_physical_network.id)
-        self.debug("Failed to add the Nuage VSP device in the Nuage VSP Physical Network due to invalid VSD "
-                   "credentials")
+            Nuage.add(
+                self.api_client, invalid_vsd_info,
+                self.vsp_physical_network.id)
+        self.debug("Failed to add the Nuage VSP device in the Nuage VSP "
+                   "Physical Network due to invalid VSD credentials")
 
         # Nuage VSP device validation
-        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.debug("Validating the Nuage VSP device in the Nuage VSP "
+                   "Physical Network...")
         with self.assertRaises(Exception):
             self.validate_NuageVspDevice()
-        self.debug("The Nuage VSP device is not added in the Nuage VSP Physical Network")
+        self.debug("The Nuage VSP device is not added in the Nuage VSP "
+                   "Physical Network")
 
         # Adding the Nuage VSP device with valid VSD credentials
-        self.debug("Adding the Nuage VSP device in the Nuage VSP Physical Network with valid VSD credentials...")
+        self.debug("Adding the Nuage VSP device in the Nuage VSP Physical "
+                   "Network with valid VSD credentials...")
         Nuage.add(self.api_client, vsd_info, self.vsp_physical_network.id)
 
         # Nuage VSP device validation
-        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical "
+                   "Network...")
         self.validate_NuageVspDevice()
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
@@ -135,26 +156,32 @@ class TestNuageVsp(nuageTestCase):
         """ Test Nuage VSP SDN plugin with basic Isolated Network functionality
         """
 
-        # 1. Verify that the Nuage VSP network service provider is successfully created and enabled.
-        # 2. Create and enable Nuage VSP Isolated Network offering, check if it is successfully created and enabled.
-        # 3. Create an Isolated Network with Nuage VSP Isolated Network offering, check if it is successfully created
-        #    and is in the "Allocated" state.
-        # 4. Deploy a VM in the created Isolated network, check if the Isolated network state is changed to
-        #    "Implemented", and both the VM & VR are successfully deployed and are in the "Running" state.
-        # 5. Deploy one more VM in the created Isolated network, check if the VM is successfully deployed and is in the
-        #    "Running" state.
-        # 6. Delete the created Isolated Network after destroying its VMs, check if the Isolated network is successfully
-        #    deleted.
+        # 1. Verify that the Nuage VSP network service provider is successfully
+        #    created and enabled.
+        # 2. Create and enable Nuage VSP Isolated Network offering, check if it
+        #    is successfully created and enabled.
+        # 3. Create an Isolated Network with Nuage VSP Isolated Network
+        #    offering, check if it is successfully created and is in the
+        #    "Allocated" state.
+        # 4. Deploy a VM in the created Isolated network, check if the Isolated
+        #    network state is changed to "Implemented", and both the VM & VR
+        #    are successfully deployed and are in the "Running" state.
+        # 5. Deploy one more VM in the created Isolated network, check if the
+        #    VM is successfully deployed and is in the "Running" state.
+        # 6. Delete the created Isolated Network after destroying its VMs,
+        #    check if the Isolated network is successfully deleted.
         # 7. Delete all the created objects (cleanup).
 
         # Creating a network offering
-        self.debug("Creating and enabling Nuage VSP Isolated Network offering...")
+        self.debug("Creating and enabling Nuage VSP Isolated Network "
+                   "offering...")
         network_offering = self.create_NetworkOffering(
             self.test_data["nuagevsp"]["isolated_network_offering"])
         self.validate_NetworkOffering(network_offering, state="Enabled")
 
         # Creating a network
-        self.debug("Creating an Isolated Network with Nuage VSP Isolated Network offering...")
+        self.debug("Creating an Isolated Network with Nuage VSP Isolated "
+                   "Network offering...")
         network = self.create_Network(network_offering)
         self.validate_Network(network, state="Allocated")
 
@@ -178,7 +205,8 @@ class TestNuageVsp(nuageTestCase):
         self.verify_vsd_vm(vm_2)
 
         # Deleting the network
-        self.debug("Deleting the Isolated Network with Nuage VSP Isolated Network offering...")
+        self.debug("Deleting the Isolated Network with Nuage VSP Isolated "
+                   "Network offering...")
         self.delete_VM(vm_1)
         self.delete_VM(vm_2)
         self.delete_Network(network)

--- a/tools/marvin/marvin/cloudstackTestCase.py
+++ b/tools/marvin/marvin/cloudstackTestCase.py
@@ -37,7 +37,7 @@ def user(Name, DomainName, AcctType):
 class cloudstackTestCase(unittest.case.TestCase):
     clstestclient = None
 
-    def assertElementInList(inp, toverify, responsevar=None, pos=0,
+    def assertElementInList(self, inp, toverify, responsevar=None, pos=0,
                             assertmsg="TC Failed for reason"):
         '''
         @Name: assertElementInList

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -1731,7 +1731,7 @@ test_data = {
             "name": 'nuage_marvin',
             "displaytext": 'nuage_marvin',
             "guestiptype": 'Isolated',
-            "supportedservices": 'Dhcp,SourceNat,Connectivity,StaticNat,UserData,Firewall',
+            "supportedservices": 'Dhcp,SourceNat,Connectivity,StaticNat,UserData,Firewall,Dns',
             "traffictype": 'GUEST',
             "availability": 'Optional',
             "serviceProviderList": {
@@ -1740,7 +1740,8 @@ test_data = {
                 "SourceNat": 'NuageVsp',
                 "Firewall": 'NuageVsp',
                 "Connectivity": 'NuageVsp',
-                "UserData": 'VirtualRouter'
+                "UserData": 'VirtualRouter',
+                "Dns": 'VirtualRouter'
             },
             "serviceCapabilityList": {
                     "SourceNat": {"SupportedSourceNatTypes": "perzone"}
@@ -1751,7 +1752,7 @@ test_data = {
             "name": 'nuage_vpc_marvin',
             "displaytext": 'nuage_vpc_marvin',
             "guestiptype": 'Isolated',
-            "supportedservices": 'Dhcp,StaticNat,SourceNat,NetworkACL,Connectivity,UserData',
+            "supportedservices": 'Dhcp,StaticNat,SourceNat,NetworkACL,Connectivity,UserData,Dns',
             "traffictype": 'GUEST',
             "availability": 'Optional',
             "useVpc": 'on',
@@ -1762,7 +1763,8 @@ test_data = {
                 "SourceNat": "NuageVsp",
                 "NetworkACL": "NuageVsp",
                 "Connectivity": "NuageVsp",
-                "UserData": "VpcVirtualRouter"
+                "UserData": "VpcVirtualRouter",
+                "Dns": "VpcVirtualRouter"
             },
             "serviceCapabilityList": {
                 "SourceNat": {"SupportedSourceNatTypes": "perzone"}
@@ -1772,7 +1774,7 @@ test_data = {
             "name": "nuage_vpc_marvin_internal_lb",
             "displaytext": "nuage_vpc_marvin_internal_lb",
             "guestiptype": 'Isolated',
-            "supportedservices": 'Dhcp,Lb,StaticNat,SourceNat,NetworkACL,Connectivity,UserData',
+            "supportedservices": 'Dhcp,Lb,StaticNat,SourceNat,NetworkACL,Connectivity,UserData,Dns',
             "traffictype": 'GUEST',
             "availability": 'Optional',
             "useVpc": 'on',
@@ -1784,7 +1786,8 @@ test_data = {
                 "SourceNat": "NuageVsp",
                 "NetworkACL": "NuageVsp",
                 "Connectivity": "NuageVsp",
-                "UserData": "VpcVirtualRouter"
+                "UserData": "VpcVirtualRouter",
+                "Dns": "VpcVirtualRouter"
             },
             "serviceCapabilityList": {
                 "SourceNat": {"SupportedSourceNatTypes": "perzone"},
@@ -1795,20 +1798,21 @@ test_data = {
         "vpc_offering": {
             "name": 'Nuage VSP VPC offering',
             "displaytext": 'Nuage VSP VPC offering',
-            "supportedservices": 'Dhcp,StaticNat,SourceNat,NetworkACL,Connectivity,UserData',
+            "supportedservices": 'Dhcp,StaticNat,SourceNat,NetworkACL,Connectivity,UserData,Dns',
             "serviceProviderList": {
                 "Dhcp": "NuageVsp",
                 "StaticNat": "NuageVsp",
                 "SourceNat": "NuageVsp",
                 "NetworkACL": "NuageVsp",
                 "Connectivity": "NuageVsp",
-                "UserData": "VpcVirtualRouter"
+                "UserData": "VpcVirtualRouter",
+                "Dns": "VpcVirtualRouter"
             }
         },
         "vpc_offering_lb": {
             "name": 'Nuage VSP VPC offering with Lb',
             "displaytext": 'Nuage VSP VPC offering with Lb',
-            "supportedservices": 'Dhcp,Lb,StaticNat,SourceNat,NetworkACL,Connectivity,UserData',
+            "supportedservices": 'Dhcp,Lb,StaticNat,SourceNat,NetworkACL,Connectivity,UserData,Dns',
             "serviceProviderList": {
                 "Dhcp": "NuageVsp",
                 "Lb": "InternalLbVm",
@@ -1816,7 +1820,8 @@ test_data = {
                 "SourceNat": "NuageVsp",
                 "NetworkACL": "NuageVsp",
                 "Connectivity": "NuageVsp",
-                "UserData": "VpcVirtualRouter"
+                "UserData": "VpcVirtualRouter",
+                "Dns": "VpcVirtualRouter"
             }
         }
     }

--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -56,6 +56,9 @@ setup(name="Marvin",
           "dnspython",
           "ipmisim >= 0.7"
       ],
+      extras_require={
+        "nuagevsp": ["libVSD", "PyYAML", "futures", "netaddr", "retries"]
+      },
       py_modules=['marvin.marvinPlugin'],
       zip_safe=False,
       entry_points={


### PR DESCRIPTION
Supporting Internal Dns by using Dns service provider as Virtual Router but Dhcp provider will be NuageVsp. The idea is here is to keep using Internal Dns service of cloudstack when network provider is some other vendor.

A sample network offering will be like below one:-
Service Provider
DHCP NuageVsp
DNS VirtualRouter/VpcVirtualRouter
UserData VirtualRouter/VpcVirtualRouter
Virtual Networking NuageVsp
SourceNat NuageVsp
StaticNat NuageVsp
NetworkAcl/Firewall NuageVsp
