### PR TITLE
CLOUDSTACK-9404 Fixed ordering of network ACL rules being sent to the VR.

### DIFF
--- a/core/src/com/cloud/agent/api/routing/SetNetworkACLCommand.java
+++ b/core/src/com/cloud/agent/api/routing/SetNetworkACLCommand.java
@@ -45,12 +45,8 @@ public class SetNetworkACLCommand extends NetworkElementCommand {
 
     public String[][] generateFwRules() {
         final List<NetworkACLTO> aclList = Arrays.asList(rules);
-        Collections.sort(aclList, new Comparator<NetworkACLTO>() {
-            @Override
-            public int compare(final NetworkACLTO acl1, final NetworkACLTO acl2) {
-                return acl1.getNumber() < acl2.getNumber() ? 1 : -1;
-            }
-        });
+
+        orderNetworkAclRulesByRuleNumber(aclList);
 
         final String[][] result = new String[2][aclList.size()];
         int i = 0;
@@ -95,6 +91,15 @@ public class SetNetworkACLCommand extends NetworkElementCommand {
         }
 
         return result;
+    }
+
+    protected void orderNetworkAclRulesByRuleNumber(List<NetworkACLTO> aclList) {
+        Collections.sort(aclList, new Comparator<NetworkACLTO>() {
+            @Override
+            public int compare(final NetworkACLTO acl1, final NetworkACLTO acl2) {
+                return acl1.getNumber() > acl2.getNumber() ? 1 : -1;
+            }
+        });
     }
 
     public NicTO getNic() {

--- a/core/test/com/cloud/agent/api/routing/SetNetworkACLCommandTest.java
+++ b/core/test/com/cloud/agent/api/routing/SetNetworkACLCommandTest.java
@@ -1,3 +1,22 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
 package com.cloud.agent.api.routing;
 
 import static org.junit.Assert.assertEquals;

--- a/core/test/com/cloud/agent/api/routing/SetNetworkACLCommandTest.java
+++ b/core/test/com/cloud/agent/api/routing/SetNetworkACLCommandTest.java
@@ -1,0 +1,34 @@
+package com.cloud.agent.api.routing;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.cloud.agent.api.to.NetworkACLTO;
+import com.google.common.collect.Lists;
+
+public class SetNetworkACLCommandTest {
+
+    @Test
+    public void testNetworkAclRuleOrdering(){
+
+        //given
+        List<NetworkACLTO> aclList = Lists.newArrayList();
+
+        aclList.add(new NetworkACLTO(3, null, null, null, null, false, false, null, null, null, null, false, 3));
+        aclList.add(new NetworkACLTO(1, null, null, null, null, false, false, null, null, null, null, false, 1));
+        aclList.add(new NetworkACLTO(2, null, null, null, null, false, false, null, null, null, null, false, 2));
+
+        SetNetworkACLCommand cmd = new SetNetworkACLCommand(aclList, null);
+
+        //when
+        cmd.orderNetworkAclRulesByRuleNumber(aclList);
+
+        //then
+        for(int i=0; i< aclList.size();i++){
+            assertEquals(aclList.get(i).getNumber(), i+1);
+        }
+    }
+}


### PR DESCRIPTION
 The comparator was inverted.

Issue: https://issues.apache.org/jira/browse/CLOUDSTACK-9404

In this example, I created rules with the port numbers the same as the rule numbers.

Chain ACL_INBOUND_eth2 (1 references)
target     prot opt source               destination
ACCEPT     all  --  anywhere             225.0.0.50
ACCEPT     all  --  anywhere             vrrp.mcast.net
DROP       tcp  --  anywhere             anywhere             tcp dpt:netstat
DROP       tcp  --  anywhere             anywhere             tcp dpt:10
DROP       tcp  --  anywhere             anywhere             tcp dpt:5
DROP       tcp  --  anywhere             anywhere             tcp dpt:3
DROP       tcp  --  anywhere             anywhere             tcp dpt:2
DROP       all  --  anywhere             anywhere

We can see above that the rules are inverted.

After the fix:

Chain ACL_INBOUND_eth2 (1 references)
target     prot opt source               destination
ACCEPT     all  --  anywhere             225.0.0.50
ACCEPT     all  --  anywhere             vrrp.mcast.net
DROP       tcp  --  anywhere             anywhere             tcp dpt:2
DROP       tcp  --  anywhere             anywhere             tcp dpt:3
DROP       tcp  --  anywhere             anywhere             tcp dpt:5
DROP       tcp  --  anywhere             anywhere             tcp dpt:10
DROP       tcp  --  anywhere             anywhere             tcp dpt:netstat
DROP       all  --  anywhere             anywhere
