### PR TITLE
[BLOCKER][FIX] CLOUDSTACK-9409: Add role_id to cloud_usage.account

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade481to490.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade481to490.java
@@ -103,8 +103,14 @@ public class Upgrade481to490 implements DbUpgrade {
                 s_logger.warn("cloud.account table already has the role_id column, skipping altering table and migration of accounts");
                 return;
             } else {
-                throw new CloudRuntimeException("Unable to create column quota_calculated in table cloud_usage.cloud_usage", e);
+                throw new CloudRuntimeException("Unable to create column role_id in table cloud.account", e);
             }
+        }
+
+        try (final PreparedStatement pstmt = conn.prepareStatement("ALTER TABLE `cloud_usage`.`account` ADD COLUMN `role_id` bigint(20) unsigned AFTER `type`")) {
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Unable to create column role_id in table cloud_usage.account", e);
         }
 
         migrateAccountsToDefaultRoles(conn);

--- a/engine/schema/src/com/cloud/usage/dao/UsageDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageDaoImpl.java
@@ -49,7 +49,7 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
     private static final String DELETE_ALL = "DELETE FROM cloud_usage";
     private static final String DELETE_ALL_BY_ACCOUNTID = "DELETE FROM cloud_usage WHERE account_id = ?";
     private static final String DELETE_ALL_BY_INTERVAL = "DELETE FROM cloud_usage WHERE end_date < DATE_SUB(CURRENT_DATE(), INTERVAL ? DAY)";
-    private static final String INSERT_ACCOUNT = "INSERT INTO cloud_usage.account (id, account_name, type, domain_id, removed, cleanup_needed) VALUES (?,?,?,?,?,?)";
+    private static final String INSERT_ACCOUNT = "INSERT INTO cloud_usage.account (id, account_name, type, role_id, domain_id, removed, cleanup_needed) VALUES (?,?,?,?,?,?,?)";
     private static final String INSERT_USER_STATS = "INSERT INTO cloud_usage.user_statistics (id, data_center_id, account_id, public_ip_address, device_id, device_type, network_id, net_bytes_received,"
             + " net_bytes_sent, current_bytes_received, current_bytes_sent, agg_bytes_received, agg_bytes_sent) VALUES (?,?,?,?,?,?,?,?,?,?, ?, ?, ?)";
 
@@ -113,16 +113,17 @@ public class UsageDaoImpl extends GenericDaoBase<UsageVO, Long> implements Usage
                 pstmt.setLong(1, acct.getId());
                 pstmt.setString(2, acct.getAccountName());
                 pstmt.setShort(3, acct.getType());
-                pstmt.setLong(4, acct.getDomainId());
+                pstmt.setLong(4, acct.getRoleId());
+                pstmt.setLong(5, acct.getDomainId());
 
                 Date removed = acct.getRemoved();
                 if (removed == null) {
-                    pstmt.setString(5, null);
+                    pstmt.setString(6, null);
                 } else {
-                    pstmt.setString(5, DateUtil.getDateDisplayString(TimeZone.getTimeZone("GMT"), acct.getRemoved()));
+                    pstmt.setString(6, DateUtil.getDateDisplayString(TimeZone.getTimeZone("GMT"), acct.getRemoved()));
                 }
 
-                pstmt.setBoolean(6, acct.getNeedsCleanup());
+                pstmt.setBoolean(7, acct.getNeedsCleanup());
 
                 pstmt.addBatch();
             }


### PR DESCRIPTION
Adds role_id column to cloud_usage.account, fixes UsageDaoImpl to insert
Accounts with role_id from account table. Without the fix, usage server fails to work.

This fixes a *blocker* for 4.9.0 reported by @nvazquez (thanks!)

/cc @swill @nvazquez for review and merge thanks.