### PR TITLE
CLOUDSTACK-9399 : NPE during deletion of host when clusterId is null

### DIFF
--- a/server/src/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/com/cloud/resource/ResourceManagerImpl.java
@@ -847,7 +847,7 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             return true;
         }
 
-        long clusterId = host.getClusterId();
+        Long clusterId = host.getClusterId();
 
         _agentMgr.notifyMonitorsOfHostAboutToBeRemoved(host.getId());
 
@@ -927,7 +927,9 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             }
         });
 
-        _agentMgr.notifyMonitorsOfRemovedHost(host.getId(), clusterId);
+        if (clusterId != null) {
+            _agentMgr.notifyMonitorsOfRemovedHost(host.getId(), clusterId);
+        }
 
         return true;
     }

--- a/test/integration/plugins/nuagevsp/nuageTestCase.py
+++ b/test/integration/plugins/nuagevsp/nuageTestCase.py
@@ -21,6 +21,7 @@
 from marvin.cloudstackTestCase import cloudstackTestCase, unittest
 from marvin.lib.base import (EgressFireWallRule,
                              FireWallRule,
+                             Host,
                              Hypervisor,
                              Network,
                              NetworkACL,
@@ -45,6 +46,8 @@ from marvin.cloudstackAPI import restartVPC
 import importlib
 import logging
 import socket
+import sys
+import time
 
 
 class nuageTestCase(cloudstackTestCase):
@@ -60,6 +63,7 @@ class nuageTestCase(cloudstackTestCase):
         cls.api_client = test_client.getApiClient()
         cls.db_client = test_client.getDbConnection()
         cls.test_data = test_client.getParsedTestDataConfig()
+
         # Get Zone, Domain and templates
         cls.zone = get_zone(cls.api_client,
                             zone_name=zone.name if zone else None,
@@ -79,6 +83,9 @@ class nuageTestCase(cloudstackTestCase):
                                                       )
         cls._cleanup = [cls.service_offering]
 
+        # Check if the host hypervisor type is simulator
+        cls.isSimulator = Hypervisor.list(cls.api_client, zoneid=cls.zone.id)[0].name == "Simulator"
+
         # Get configured Nuage VSP device details
         try:
             physical_networks = PhysicalNetwork.list(cls.api_client, zoneid=cls.zone.id)
@@ -97,42 +104,44 @@ class nuageTestCase(cloudstackTestCase):
             cls.cms_id = cls.nuage_vsp_device.cmsid
         except Exception as e:
             cls.tearDownClass()
-            raise unittest.SkipTest("Warning: Couldn't get configured Nuage VSP device details: %s" % e)
-
-        # Check if the host hypervisor type is simulator
-        cls.isSimulator = Hypervisor.list(cls.api_client, zoneid=cls.zone.id)[0].name == "Simulator"
+            raise unittest.SkipTest("Warning: Could not get configured Nuage VSP device details - %s" % e)
 
         # VSD is a programmable policy and analytics engine of Nuage VSP SDN platform
         # vspk is a Python SDK for Nuage VSP's VSD
-        # cms_vspk_wrapper is a library that wraps vspk package
+        # libVSD is a library that wraps vspk package
         try:
             vspk_module = "vspk." + cls.nuage_vsp_device.apiversion if int(cls.nuage_vsp_device.apiversion[1]) >= 4 \
                 else "vspk.vsdk." + cls.nuage_vsp_device.apiversion
             cls.vsdk = importlib.import_module(vspk_module)
-            vspk_utils_module = "vspk.utils" if int(cls.nuage_vsp_device.apiversion[1]) >= 4 \
-                else "vspk.vsdk." + cls.nuage_vsp_device.apiversion + ".utils"
-            vsdk_utils = importlib.import_module(vspk_utils_module)
-            set_log_level = getattr(vsdk_utils, "set_log_level")
-            from cms_vspk_wrapper.cms_vspk_wrapper import Cms_vspk_wrapper
-        except:
-            raise unittest.SkipTest("vspk (and/or) cms_vspk_wrapper import failure")
+            from libVSD import ApiClient, VSDHelpers
+        except Exception as e:
+            cls.tearDownClass()
+            raise unittest.SkipTest("Warning: vspk (and/or) libVSD package import failure - %s" % e)
 
         # Configure VSD session
         cls._session = cls.vsdk.NUVSDSession(username=cls.nuage_vsp_device.username,
                                              password=cls.nuage_vsp_device.password,
-                                             enterprise="csp", api_url="https://%s:%d" %
-                                                                       (cls.nuage_vsp_device.hostname,
+                                             enterprise="csp",
+                                             api_url="https://%s:%d" % (cls.nuage_vsp_device.hostname,
                                                                         cls.nuage_vsp_device.port)
                                              )
         cls._session.start()
 
-        # Configure cms_vspk_wrapper session
-        cls.log_handler = logging.getLogger("CSLog").handlers[0]
+        # Configure libVSD session
+        root = logging.getLogger()
+        log_handler = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        log_handler.setFormatter(formatter)
+        root.addHandler(log_handler)
         vsd_info = cls.nuage_vsp_device.__dict__
-        vsd_info["port"] = str(vsd_info["port"])
-        cls.vsd = Cms_vspk_wrapper(vsd_info, cls.log_handler)
-
-        set_log_level(logging.INFO)
+        cls.debug("Nuage VSP device (VSD) details - %s" % vsd_info)
+        vsd_api_client = ApiClient(address=vsd_info["hostname"],
+                                   user=vsd_info["username"],
+                                   password=vsd_info["password"],
+                                   version=vsd_info["apiversion"][1] + "." + vsd_info["apiversion"][3]
+                                   )
+        vsd_api_client.new_session()
+        cls.vsd = VSDHelpers(vsd_api_client)
 
         cls.debug("setUpClass nuageTestCase [DONE]")
 
@@ -180,17 +189,23 @@ class nuageTestCase(cloudstackTestCase):
         return vpc_off
 
     # create_Vpc - Creates VPC with the given VPC offering
-    def create_Vpc(self, vpc_offering, cidr="10.1.1.1/16", cleanup=True):
-        self.debug("Creating a VPC in the account - %s" % self.account.name)
-        self.test_data["vpc"]["name"] = "TestVPC"
-        self.test_data["vpc"]["displaytext"] = "TestVPC"
-        self.test_data["vpc"]["cidr"] = cidr
+    def create_Vpc(self, vpc_offering, cidr='10.1.0.0/16', testdata=None, account=None, networkDomain=None,
+                   cleanup=True):
+        if not account:
+            account = self.account
+        self.debug("Creating a VPC in the account - %s" % account.name)
+        if not testdata:
+            testdata = self.test_data["vpc"]
+            testdata["name"] = "TestVPC-" + cidr + "-" + str(vpc_offering.name)
+            testdata["displaytext"] = "Test VPC"
+            testdata["cidr"] = cidr
         vpc = VPC.create(self.api_client,
-                         self.test_data["vpc"],
+                         testdata,
                          vpcofferingid=vpc_offering.id,
                          zoneid=self.zone.id,
-                         account=self.account.name,
-                         domainid=self.account.domainid
+                         account=account.name,
+                         domainid=account.domainid,
+                         networkDomain=networkDomain
                          )
         self.debug("Created VPC with ID - %s" % vpc.id)
         if cleanup:
@@ -223,13 +238,20 @@ class nuageTestCase(cloudstackTestCase):
         return nw_off
 
     # create_Network - Creates network with the given Network offering
-    def create_Network(self, nw_off, gateway="10.1.1.1", netmask="255.255.255.0", vpc=None, acl_list=None):
-        self.debug("Creating a network in the account - %s" % self.account.name)
-        self.test_data["network"]["netmask"] = netmask
+    def create_Network(self, nw_off, gateway="10.1.1.1", netmask="255.255.255.0", vpc=None, acl_list=None,
+                       testdata=None, account=None, cleanup=True):
+        if not account:
+            account = self.account
+        self.debug("Creating a network in the account - %s" % account.name)
+        if not testdata:
+            testdata = self.test_data["network"]
+            testdata["name"] = "TestNetwork-" + gateway + "-" + str(nw_off.name)
+            testdata["displaytext"] = "Test Network"
+            testdata["netmask"] = netmask
         network = Network.create(self.api_client,
-                                 self.test_data["network"],
-                                 accountid=self.account.name,
-                                 domainid=self.account.domainid,
+                                 testdata,
+                                 accountid=account.name,
+                                 domainid=account.domainid,
                                  networkofferingid=nw_off.id,
                                  zoneid=self.zone.id,
                                  gateway=gateway,
@@ -237,7 +259,8 @@ class nuageTestCase(cloudstackTestCase):
                                  aclid=acl_list.id if acl_list else None
                                  )
         self.debug("Created network with ID - %s" % network.id)
-        self.cleanup.append(network)
+        if cleanup:
+            self.cleanup.append(network)
         return network
 
     # upgrade_Network - Upgrades the given network
@@ -259,24 +282,73 @@ class nuageTestCase(cloudstackTestCase):
             self.cleanup.remove(network)
         self.debug("Deleted Network with ID - %s" % network.id)
 
-    # create_VM - Creates VM in the given network, vm_key - Key for the services on the VM
-    def create_VM(self, network, vm_key="virtual_machine", host_id=None, start_vm=True):
-        self.debug("Creating VM in network with ID - %s" % network.id)
-        self.debug("Passed vm_key - %s" % vm_key)
-        self.test_data[vm_key]["zoneid"] = self.zone.id
-        self.test_data[vm_key]["template"] = self.template.id
+    # create_VM - Creates VM in the given network(s)
+    def create_VM(self, network_list, host_id=None, start_vm=True, testdata=None, account=None, cleanup=True):
+        network_ids = []
+        if isinstance(network_list, list):
+            for network in network_list:
+                network_ids.append(str(network.id))
+        else:
+            network_ids.append(str(network_list.id))
+        if not account:
+            account = self.account
+        self.debug("Creating VM in network(s) with ID(s) - %s in the account - %s" % (network_ids, account.name))
+        if not testdata:
+            testdata = self.test_data["virtual_machine"]
         vm = VirtualMachine.create(self.api_client,
-                                   self.test_data[vm_key],
-                                   accountid=self.account.name,
-                                   domainid=self.account.domainid,
+                                   testdata,
+                                   accountid=account.name,
+                                   domainid=account.domainid,
                                    serviceofferingid=self.service_offering.id,
-                                   networkids=[str(network.id)],
+                                   templateid=self.template.id,
+                                   zoneid=self.zone.id,
+                                   networkids=network_ids,
                                    startvm=start_vm,
                                    hostid=host_id
                                    )
-        self.debug("Created VM with ID - %s in network with ID - %s" % (vm.id, network.id))
-        self.cleanup.append(vm)
+        self.debug("Created VM with ID - %s in network(s) with ID(s) - %s" % (vm.id, network_ids))
+        if cleanup:
+            self.cleanup.append(vm)
         return vm
+
+    # nic_operation_VM - Performs NIC operations such as add, remove, and update default NIC in the given VM and network
+    def nic_operation_VM(self, vm, network, operation="update"):
+        self.debug("Performing %s NIC operation in VM with ID - %s and network with ID - %s" %
+                   (operation, vm.id, network.id))
+        for nic in vm.nic:
+            if nic.networkid == network.id:
+                nic_id = nic.id
+        if operation is "update":
+            vm.update_default_nic(self.api_client, nic_id)
+            self.debug("Updated default NIC to NIC with ID - %s in VM with ID - %s and network with ID - %s" %
+                       (nic_id, vm.id, network.id))
+        if operation is "remove":
+            vm.remove_nic(self.api_client, nic_id)
+            self.debug("Removed NIC with ID - %s in VM with ID - %s and network with ID - %s" %
+                       (nic_id, vm.id, network.id))
+        if operation is "add":
+            vm.add_nic(self.api_client, network.id)
+            self.debug("Added NIC with ID - %s in VM with ID - %s and network with ID - %s" %
+                       (nic_id, vm.id, network.id))
+
+    # migrate_VM - Migrates VM to another host, if available
+    def migrate_VM(self, vm):
+        self.debug("Checking if a host is available for migration...")
+        hosts = Host.listForMigration(self.api_client, virtualmachineid=vm.id)
+        self.assertEqual(isinstance(hosts, list), True,
+                         "List hosts should return a valid list"
+                         )
+        # Remove the host of current VM from the hosts list
+        hosts[:] = [host for host in hosts if host.id != vm.hostid]
+        if len(hosts) <= 0:
+            self.skipTest("No host available for migration. Test requires at-least 2 hosts")
+        host = hosts[0]
+        self.debug("Migrating VM with ID: %s to Host: %s" % (vm.id, host.id))
+        try:
+            vm.migrate(self.api_client, hostid=host.id)
+        except Exception as e:
+            self.fail("Failed to migrate instance, %s" % e)
+        self.debug("Migrated VM with ID: %s to Host: %s" % (vm.id, host.id))
 
     # delete_VM - Deletes the given VM
     def delete_VM(self, vm, expunge=True):
@@ -299,12 +371,14 @@ class nuageTestCase(cloudstackTestCase):
         return routers[0]
 
     # acquire_PublicIPAddress - Acquires public IP address for the given network/VPC
-    def acquire_PublicIPAddress(self, network, vpc=None):
-        self.debug("Associating public IP for network with ID - %s" % network.id)
+    def acquire_PublicIPAddress(self, network, vpc=None, account=None):
+        if not account:
+            account = self.account
+        self.debug("Associating public IP for network with ID - %s in the account - %s" % (network.id, account.name))
         public_ip = PublicIPAddress.create(self.api_client,
-                                           accountid=self.account.name,
+                                           accountid=account.name,
+                                           domainid=account.domainid,
                                            zoneid=self.zone.id,
-                                           domainid=self.account.domainid,
                                            networkid=network.id if vpc is None else None,
                                            vpcid=vpc.id if vpc else self.vpc.id if hasattr(self, "vpc") else None
                                            )
@@ -312,31 +386,34 @@ class nuageTestCase(cloudstackTestCase):
                    (public_ip.ipaddress.ipaddress, network.id))
         return public_ip
 
-    # create_StaticNatRule_For_VM - Creates static NAT rule on the given public IP for the given network and VM
+    # create_StaticNatRule_For_VM - Creates Static NAT rule on the given public IP for the given VM in the given network
     def create_StaticNatRule_For_VM(self, vm, public_ip, network, vmguestip=None):
-        self.debug("Enabling static NAT for public IP - %s" % public_ip.ipaddress.ipaddress)
-        StaticNATRule.enable(self.api_client,
-                             ipaddressid=public_ip.ipaddress.id,
-                             virtualmachineid=vm.id,
-                             networkid=network.id,
-                             vmguestip=vmguestip
-                             )
-        self.debug("Static NAT enabled for public IP - %s" % public_ip.ipaddress.ipaddress)
+        self.debug("Enabling Static NAT rule on public IP - %s for VM with ID - %s in network with ID - %s" %
+                   (public_ip.ipaddress.ipaddress, vm.id, network.id))
+        static_nat_rule = StaticNATRule.enable(self.api_client,
+                                               ipaddressid=public_ip.ipaddress.id,
+                                               virtualmachineid=vm.id,
+                                               networkid=network.id,
+                                               vmguestip=vmguestip
+                                               )
+        self.debug("Static NAT rule enabled on public IP - %s for VM with ID - %s in network with ID - %s" %
+                   (public_ip.ipaddress.ipaddress, vm.id, network.id))
+        return static_nat_rule
 
-    # delete_StaticNatRule_For_VM - Deletes static NAT rule on the given public IP for the given VM
-    def delete_StaticNatRule_For_VM(self, vm, public_ip):
-        self.debug("Disabling static NAT for public IP - %s" % public_ip.ipaddress.ipaddress)
+    # delete_StaticNatRule_For_VM - Deletes Static NAT rule on the given public IP
+    def delete_StaticNatRule_For_VM(self, public_ip):
+        self.debug("Disabling Static NAT rule on public IP - %s" % public_ip.ipaddress.ipaddress)
         StaticNATRule.disable(self.api_client,
-                              ipaddressid=public_ip.ipaddress.id,
-                              virtualmachineid=vm.id
+                              ipaddressid=public_ip.ipaddress.id
                               )
-        self.debug("Static NAT disabled for public IP - %s" % public_ip.ipaddress.ipaddress)
+        self.debug("Static NAT rule disabled on public IP - %s" % public_ip.ipaddress.ipaddress)
 
-    # create_FirewallRule - Creates Ingress firewall rule on the given public IP
+    # create_FirewallRule - Creates (Ingress) Firewall rule on the given Static NAT rule enabled public IP for Isolated
+    # networks
     def create_FirewallRule(self, public_ip, rule=None):
         if not rule:
             rule = self.test_data["ingress_rule"]
-        self.debug("Adding an Ingress Firewall rule to make Guest VMs accessible through Static NAT - %s" % rule)
+        self.debug("Adding an (Ingress) Firewall rule to make Guest VMs accessible through Static NAT rule - %s" % rule)
         return FireWallRule.create(self.api_client,
                                    ipaddressid=public_ip.ipaddress.id,
                                    protocol=rule["protocol"],
@@ -345,7 +422,7 @@ class nuageTestCase(cloudstackTestCase):
                                    endport=rule["endport"]
                                    )
 
-    # create_EgressFirewallRule - Creates Egress firewall rule on the given public IP
+    # create_EgressFirewallRule - Creates Egress Firewall rule in the given Isolated network
     def create_EgressFirewallRule(self, network, rule):
         self.debug("Adding an Egress Firewall rule to allow/deny outgoing traffic from Guest VMs - %s" % rule)
         return EgressFireWallRule.create(self.api_client,
@@ -366,7 +443,7 @@ class nuageTestCase(cloudstackTestCase):
                                      vpcid=vpc.id
                                      )
 
-    # create_NetworkAclRule - Creates Ingress/Egress network ACL rule in the given network/acl list
+    # create_NetworkAclRule - Creates Ingress/Egress Network ACL rule in the given VPC network/acl list
     def create_NetworkAclRule(self, rule, traffic_type="Ingress", network=None, acl_list=None):
         self.debug("Adding NetworkACL rule - %s" % rule)
         if acl_list:
@@ -383,11 +460,23 @@ class nuageTestCase(cloudstackTestCase):
                                      traffictype=traffic_type
                                      )
 
-    # ssh_into_VM - Gets into the shell of the given VM
-    def ssh_into_VM(self, vm, public_ip):
+    # ssh_into_VM - Gets into the shell of the given VM using its public IP
+    def ssh_into_VM(self, vm, public_ip, reconnect=True):
         self.debug("SSH into VM with ID - %s on public IP address - %s" % (vm.id, public_ip.ipaddress.ipaddress))
-        ssh_client = vm.get_ssh_client(ipaddress=public_ip.ipaddress.ipaddress)
-        return ssh_client
+        tries = 0
+        while tries < 3:
+            try:
+                ssh_client = vm.get_ssh_client(ipaddress=public_ip.ipaddress.ipaddress, reconnect=reconnect)
+            except Exception as e:
+                self.debug("Failed to SSH into VM: %s" % e)
+                self.debug("Waiting for the VM to be fully resolved for SSH connection...")
+                time.sleep(120)
+                self.debug("Retrying SSH into VM...")
+                tries += 1
+                continue
+            self.debug("Successful to SSH into VM with ID - %s on public IP address - %s" %
+                       (vm.id, public_ip.ipaddress.ipaddress))
+            return ssh_client
 
     # execute_cmd - Executes the given command on the given ssh client
     def execute_cmd(self, ssh_client, cmd):
@@ -401,11 +490,12 @@ class nuageTestCase(cloudstackTestCase):
             self.debug("SSH client executed command result is None")
         return ret_data
 
-    # wget_from_server - Fetches index.html file of web server running with the given public IP
-    def wget_from_server(self, public_ip):
+    # wget_from_server - Fetches index.html file from a web server listening on the given public IP address and port
+    def wget_from_server(self, public_ip, port):
         import urllib
-        self.debug("wget from a http server on public IP address - %s" % public_ip.ipaddress.ipaddress)
-        filename, headers = urllib.urlretrieve("http://%s/index.html" % public_ip.ipaddress.ipaddress,
+        self.debug("wget index.html file from a http web server listening on public IP address - %s and port - %s" %
+                   (public_ip.ipaddress.ipaddress, port))
+        filename, headers = urllib.urlretrieve("http://%s:%s/index.html" % (public_ip.ipaddress.ipaddress, port),
                                                filename="index.html"
                                                )
         return filename, headers
@@ -414,7 +504,7 @@ class nuageTestCase(cloudstackTestCase):
     # matches the given provider name and state against the list of providers fetched
     def validate_NetworkServiceProvider(self, provider_name, state=None):
         """Validates the Network Service Provider in the Nuage VSP Physical Network"""
-        self.debug("Check if the Network Service Provider is created successfully ?")
+        self.debug("Validating the creation and state of Network Service Provider - %s" % provider_name)
         providers = NetworkServiceProvider.list(self.api_client,
                                                 name=provider_name,
                                                 physicalnetworkid=self.vsp_physical_network.id)
@@ -426,15 +516,15 @@ class nuageTestCase(cloudstackTestCase):
                          )
         if state:
             self.assertEqual(providers[0].state, state,
-                             "Network Service Provider state should be in state - %s" % state
+                             "Network Service Provider state should be '%s'" % state
                              )
-        self.debug("Network Service Provider creation successfully validated for %s" % provider_name)
+        self.debug("Successfully validated the creation and state of Network Service Provider - %s" % provider_name)
 
-    # validate_VpcOffering - Validates the given VPC offering,
-    # matches the given VPC offering name and state against the list of VPC offerings fetched
+    # validate_VpcOffering - Validates the given VPC offering, matches the given VPC offering name and state against the
+    # list of VPC offerings fetched
     def validate_VpcOffering(self, vpc_offering, state=None):
         """Validates the VPC offering"""
-        self.debug("Check if the VPC offering is created successfully ?")
+        self.debug("Validating the creation and state of VPC offering - %s" % vpc_offering.name)
         vpc_offs = VpcOffering.list(self.api_client,
                                     id=vpc_offering.id
                                     )
@@ -446,15 +536,14 @@ class nuageTestCase(cloudstackTestCase):
                          )
         if state:
             self.assertEqual(vpc_offs[0].state, state,
-                             "VPC offering state should be in state - %s" % state
+                             "VPC offering state should be '%s'" % state
                              )
-        self.debug("VPC offering creation successfully validated for %s" % vpc_offering.name)
+        self.debug("Successfully validated the creation and state of VPC offering - %s" % vpc_offering.name)
 
-    # validate_Vpc - Validates the given VPC,
-    # matches the given VPC name and state against the list of VPCs fetched
+    # validate_Vpc - Validates the given VPC, matches the given VPC name and state against the list of VPCs fetched
     def validate_Vpc(self, vpc, state=None):
         """Validates the VPC"""
-        self.debug("Check if the VPC is created successfully ?")
+        self.debug("Validating the creation and state of VPC - %s" % vpc.name)
         vpcs = VPC.list(self.api_client,
                         id=vpc.id
                         )
@@ -466,15 +555,15 @@ class nuageTestCase(cloudstackTestCase):
                          )
         if state:
             self.assertEqual(vpcs[0].state, state,
-                             "VPC state should be in state - %s" % state
+                             "VPC state should be '%s'" % state
                              )
-        self.debug("VPC creation successfully validated for %s" % vpc.name)
+        self.debug("Successfully validated the creation and state of VPC - %s" % vpc.name)
 
-    # validate_NetworkOffering - Validates the given Network offering,
-    # matches the given network offering name and state against the list of network offerings fetched
+    # validate_NetworkOffering - Validates the given Network offering, matches the given network offering name and state
+    # against the list of network offerings fetched
     def validate_NetworkOffering(self, net_offering, state=None):
         """Validates the Network offering"""
-        self.debug("Check if the Network offering is created successfully ?")
+        self.debug("Validating the creation and state of Network offering - %s" % net_offering.name)
         net_offs = NetworkOffering.list(self.api_client,
                                         id=net_offering.id
                                         )
@@ -486,15 +575,15 @@ class nuageTestCase(cloudstackTestCase):
                          )
         if state:
             self.assertEqual(net_offs[0].state, state,
-                             "Network offering state should be in state - %s" % state
+                             "Network offering state should be '%s'" % state
                              )
-        self.debug("Network offering creation successfully validated for %s" % net_offering.name)
+        self.debug("Successfully validated the creation and state of Network offering - %s" % net_offering.name)
 
-    # validate_Network - Validates the given network,
-    # matches the given network name and state against the list of networks fetched
+    # validate_Network - Validates the given network, matches the given network name and state against the list of
+    # networks fetched
     def validate_Network(self, network, state=None):
-        """Validates the Network"""
-        self.debug("Check if the network is created successfully ?")
+        """Validates the network"""
+        self.debug("Validating the creation and state of Network - %s" % network.name)
         networks = Network.list(self.api_client,
                                 id=network.id
                                 )
@@ -506,14 +595,14 @@ class nuageTestCase(cloudstackTestCase):
                          )
         if state:
             self.assertEqual(networks[0].state, state,
-                             "Network state should be in state - %s" % state
+                             "Network state should be '%s'" % state
                              )
-        self.debug("Network creation successfully validated for %s" % network.name)
+        self.debug("Successfully validated the creation and state of Network - %s" % network.name)
 
     # check_VM_state - Checks if the given VM is in the expected state form the list of fetched VMs
     def check_VM_state(self, vm, state=None):
         """Validates the VM state"""
-        self.debug("Check if the VM instance is in state - %s" % state)
+        self.debug("Validating the deployment and state of VM - %s" % vm.name)
         vms = VirtualMachine.list(self.api_client,
                                   id=vm.id,
                                   listall=True
@@ -525,12 +614,12 @@ class nuageTestCase(cloudstackTestCase):
             self.assertEqual(vms[0].state, state,
                              "Virtual machine is not in the expected state"
                              )
-        self.debug("Virtual machine instance - %s is in the expected state - %s" % (vm.name, state))
+        self.debug("Successfully validated the deployment and state of VM - %s" % vm.name)
 
     # check_Router_state - Checks if the given router is in the expected state form the list of fetched routers
     def check_Router_state(self, router, state=None):
         """Validates the Router state"""
-        self.debug("Check if the virtual router instance is in state - %s" % state)
+        self.debug("Validating the deployment and state of Router - %s" % router.name)
         routers = Router.list(self.api_client,
                               id=router.id,
                               listall=True
@@ -542,13 +631,13 @@ class nuageTestCase(cloudstackTestCase):
             self.assertEqual(routers[0].state, state,
                              "Virtual router is not in the expected state"
                              )
-        self.debug("Virtual router instance - %s is in the expected state - %s" % (router.name, state))
+        self.debug("Successfully validated the deployment and state of Router - %s" % router.name)
 
     # validate_PublicIPAddress - Validates if the given public IP address is in the expected state form the list of
     # fetched public IP addresses
     def validate_PublicIPAddress(self, public_ip, network, static_nat=False, vm=None):
         """Validates the Public IP Address"""
-        self.debug("Check if the public IP is successfully assigned to the network ?")
+        self.debug("Validating the assignment and state of public IP address - %s" % public_ip.ipaddress.ipaddress)
         public_ips = PublicIPAddress.list(self.api_client,
                                           id=public_ip.ipaddress.id,
                                           networkid=network.id,
@@ -566,20 +655,22 @@ class nuageTestCase(cloudstackTestCase):
                          )
         if static_nat and vm:
             self.assertEqual(public_ips[0].virtualmachineid, vm.id,
-                             "Static NAT Rule not enabled for the VM using the assigned public IP"
+                             "Static NAT rule is not enabled for the VM on the assigned public IP"
                              )
-        self.debug("Assigned Public IP address - %s is successfully validated" % public_ip.ipaddress.ipaddress)
+        self.debug("Successfully validated the assignment and state of public IP address - %s" %
+                   public_ip.ipaddress.ipaddress)
 
     # VSD verifications
     # VSD is a programmable policy and analytics engine of Nuage VSP SDN platform
 
-    # get_externalID - Returns corresponding external ID of the given object in VSD
-    def get_externalID(self, object_id):
-        return object_id + "@" + self.cms_id
+    # get_externalID_filter - Returns corresponding external ID filter of the given object in VSD
+    def get_externalID_filter(self, object_id):
+        ext_id = object_id + "@" + self.cms_id
+        return self.vsd.set_externalID_filter(ext_id)
 
     # fetch_by_externalID - Returns VSD object with the given external ID
     def fetch_by_externalID(self, fetcher, *cs_objects):
-        """ Fetches a child object by external ID using the given fetcher, and uuids of the given cloudstack objects.
+        """ Fetches a child object by external id using the given fetcher, and uuids of the given cloudstack objects.
         E.G.
           - fetch_by_external_id(vsdk.NUSubnet(id="954de425-b860-410b-be09-c560e7dbb474").vms, cs_vm)
           - fetch_by_external_id(session.user.floating_ips, cs_network, cs_public_ip)
@@ -589,162 +680,148 @@ class nuageTestCase(cloudstackTestCase):
         """
         return fetcher.get_first(filter="externalID BEGINSWITH '%s'" % ":".join([o.id for o in cs_objects]))
 
-    # verify_vsp_network - Verifies the given domain and network/VPC
-    # against the corresponding installed enterprise, domain, zone, and subnet in VSD
-    def verify_vsp_network(self, domain_id, network, vpc=None):
-        vsd_enterprise = self.vsd.get_enterprise(name=domain_id)
+    # verify_vsd_network - Verifies the given domain and network/VPC against the corresponding installed enterprise,
+    # domain, zone, and subnet in VSD
+    def verify_vsd_network(self, domain_id, network, vpc=None):
+        self.debug("Verifying the creation and state of Network - %s in VSD" % network.name)
+        vsd_enterprise = self.vsd.get_enterprise(filter=self.get_externalID_filter(domain_id))
+        ext_network_filter = self.get_externalID_filter(vpc.id) if vpc else self.get_externalID_filter(network.id)
+        vsd_domain = self.vsd.get_domain(filter=ext_network_filter)
+        vsd_zone = self.vsd.get_zone(filter=ext_network_filter)
+        vsd_subnet = self.vsd.get_subnet(filter=self.get_externalID_filter(network.id))
+        self.assertEqual(vsd_enterprise.name, domain_id,
+                         "VSD enterprise name should match CloudStack domain uuid"
+                         )
         if vpc:
-            ext_network_id = self.get_externalID(vpc.id)
-        else:
-            ext_network_id = self.get_externalID(network.id)
-        ext_subnet_id = self.get_externalID(network.id)
-        vsd_domain = self.vsd.get_domain(externalID=ext_network_id)
-        vsd_zone = self.vsd.get_zone(externalID=ext_network_id)
-        vsd_subnet = self.vsd.get_subnet(externalID=ext_subnet_id)
-        self.debug("SHOW ENTERPRISE DATA FORMAT IN VSD")
-        self.debug(vsd_enterprise)
-        self.assertNotEqual(vsd_enterprise, None,
-                            "VSD Enterprise data format should not be a None type"
-                            )
-        self.debug("SHOW NETWORK DATA FORMAT IN VSD")
-        self.debug(vsd_domain)
-        self.debug(vsd_zone)
-        self.debug(vsd_subnet)
-        if vpc:
-            self.assertEqual(vsd_domain["description"], "VPC_" + vpc.name,
+            self.assertEqual(vsd_domain.description, "VPC_" + vpc.name,
                              "VSD domain description should match VPC name in CloudStack"
                              )
-            self.assertEqual(vsd_zone["description"], "VPC_" + vpc.name,
+            self.assertEqual(vsd_zone.description, "VPC_" + vpc.name,
                              "VSD zone description should match VPC name in CloudStack"
                              )
         else:
-            self.assertEqual(vsd_domain["description"], network.name,
+            self.assertEqual(vsd_domain.description, network.name,
                              "VSD domain description should match network name in CloudStack"
                              )
-            self.assertEqual(vsd_zone["description"], network.name,
+            self.assertEqual(vsd_zone.description, network.name,
                              "VSD zone description should match network name in CloudStack"
                              )
-        self.assertEqual(vsd_subnet["description"], network.name,
+        self.assertEqual(vsd_subnet.description, network.name,
                          "VSD subnet description should match network name in CloudStack"
                          )
+        self.debug("Successfully verified the creation and state of Network - %s in VSD" % network.name)
 
-    # verify_vsp_vm - Verifies the given VM deployment and state in VSD
-    def verify_vsp_vm(self, vm, stopped=None):
-        ext_vm_id = self.get_externalID(vm.id)
+    # verify_vsd_vm - Verifies the given VM deployment and state in VSD
+    def verify_vsd_vm(self, vm, stopped=None):
+        self.debug("Verifying the deployment and state of VM - %s in VSD" % vm.name)
+        vsd_vm = self.vsd.get_vm(filter=self.get_externalID_filter(vm.id))
+        self.assertNotEqual(vsd_vm, None,
+                            "VM data format in VSD should not be of type None"
+                            )
         for nic in vm.nic:
-            ext_network_id = self.get_externalID(nic.networkid)
-            ext_nic_id = self.get_externalID(nic.id)
-            vsd_vport = self.vsd.get_vport(subnet_externalID=ext_network_id, vport_externalID=ext_nic_id)
-            vsd_vm_interface = self.vsd.get_vm_interface(externalID=ext_nic_id)
-            self.debug("SHOW VPORT and VM INTERFACE DATA FORMAT IN VSD")
-            self.debug(vsd_vport)
-            self.debug(vsd_vm_interface)
-            self.assertEqual(vsd_vport["active"], True,
+            vsd_subnet = self.vsd.get_subnet(filter=self.get_externalID_filter(nic.networkid))
+            vsd_vport = self.vsd.get_vport(subnet=vsd_subnet, filter=self.get_externalID_filter(nic.id))
+            vsd_vm_interface = self.vsd.get_vm_interface(filter=self.get_externalID_filter(nic.id))
+            self.assertEqual(vsd_vport.active, True,
                              "VSD VM vport should be active"
                              )
-            self.assertEqual(vsd_vm_interface["IPAddress"], nic.ipaddress,
+            self.assertEqual(vsd_vm_interface.ip_address, nic.ipaddress,
                              "VSD VM interface IP address should match VM's NIC IP address in CloudStack"
                              )
-        vsd_vm = self.vsd.get_vm(externalID=ext_vm_id)
-        self.debug("SHOW VM DATA FORMAT IN VSD")
-        self.debug(vsd_vm)
         if not self.isSimulator:
             if stopped:
-                self.assertEqual(vsd_vm["status"], "DELETE_PENDING",
+                self.assertEqual(vsd_vm.status, "DELETE_PENDING",
                                  "VM state in VSD should be DELETE_PENDING"
                                  )
             else:
-                self.assertEqual(vsd_vm["status"], vm.state.upper(),
+                self.assertEqual(vsd_vm.status, vm.state.upper(),
                                  "VM state in VSD should match its state in CloudStack"
                                  )
+        self.debug("Successfully verified the deployment and state of VM - %s in VSD" % vm.name)
 
-    # verify_vsp_router - Verifies the given network router deployment and state in VSD
-    def verify_vsp_router(self, router, stopped=None):
-        ext_router_id = self.get_externalID(router.id)
-        vsd_router = self.vsd.get_vm(externalID=ext_router_id)
-        self.debug("SHOW VIRTUAL ROUTER DATA FORMAT IN VSD")
-        self.debug(vsd_router)
+    # verify_vsd_router - Verifies the given network router deployment and state in VSD
+    def verify_vsd_router(self, router, stopped=None):
+        self.debug("Verifying the deployment and state of Router - %s in VSD" % router.name)
+        vsd_router = self.vsd.get_vm(filter=self.get_externalID_filter(router.id))
+        self.assertNotEqual(vsd_router, None,
+                            "Router data format in VSD should not be of type None"
+                            )
         if not self.isSimulator:
             if stopped:
-                self.assertEqual(vsd_router["status"], "DELETE_PENDING",
+                self.assertEqual(vsd_router.status, "DELETE_PENDING",
                                  "Router state in VSD should be DELETE_PENDING"
                                  )
             else:
-                self.assertEqual(vsd_router["status"], router.state.upper(),
+                self.assertEqual(vsd_router.status, router.state.upper(),
                                  "Router state in VSD should match its state in CloudStack"
                                  )
+        self.debug("Successfully verified the deployment and state of Router - %s in VSD" % router.name)
 
-    # verify_vsp_LB_device - Verifies the given LB device deployment and state in VSD
-    def verify_vsp_LB_device(self, lb_device, stopped=None):
-        ext_lb_device_id = self.get_externalID(lb_device.id)
-        vsd_lb_device = self.vsd.get_vm(externalID=ext_lb_device_id)
-        self.debug("SHOW LB Device DATA FORMAT IN VSD")
-        self.debug(vsd_lb_device)
+    # verify_vsd_lb_device - Verifies the given LB device deployment and state in VSD
+    def verify_vsd_lb_device(self, lb_device, stopped=None):
+        self.debug("Verifying the deployment and state of LB device - %s in VSD" % lb_device.name)
+        vsd_lb_device = self.vsd.get_vm(filter=self.get_externalID_filter(lb_device.id))
+        self.assertNotEqual(vsd_lb_device, None,
+                            "LB device data format in VSD should not be of type None"
+                            )
         if not self.isSimulator:
             if stopped:
-                self.assertEqual(vsd_lb_device['status'], "DELETE_PENDING",
+                self.assertEqual(vsd_lb_device.status, "DELETE_PENDING",
                                  "LB device state in VSD should be DELETE_PENDING"
                                  )
             else:
-                self.assertEqual(vsd_lb_device['status'], lb_device.state.upper(),
+                self.assertEqual(vsd_lb_device.status, lb_device.state.upper(),
                                  "LB device state in VSD should match its state in CloudStack"
                                  )
+        self.debug("Successfully verified the deployment and state of LB device - %s in VSD" % lb_device.name)
 
-    # verify_vsp_floating_ip -  Verifies the static nat rule on the given public IP of the given network and VM
-    # against the corresponding installed FIP in VSD
-    def verify_vsp_floating_ip(self, network, vm, public_ipaddress, vpc=None):
-        if vpc:
-            ext_fip_id = self.get_externalID(vpc.id + ":" + public_ipaddress.id)
-        else:
-            ext_fip_id = self.get_externalID(network.id + ":" + public_ipaddress.id)
-        vsd_fip = self.vsd.get_floating_ip(externalID=ext_fip_id)
-        self.debug("SHOW FLOATING IP DATA FORMAT IN VSD")
-        self.debug(vsd_fip)
-        self.assertEqual(vsd_fip["address"], public_ipaddress.ipaddress,
+    # verify_vsd_floating_ip -  Verifies the Static NAT rule on the given public IP of the given VM in the given network
+    # against the corresponding installed Floating IP in VSD
+    def verify_vsd_floating_ip(self, network, vm, public_ipaddress, vpc=None):
+        self.debug("Verifying the assignment and state of public IP address - %s in VSD" % public_ipaddress.ipaddress)
+        ext_fip_filter = self.get_externalID_filter(vpc.id + ":" + public_ipaddress.id) if vpc else \
+            self.get_externalID_filter(network.id + ":" + public_ipaddress.id)
+        vsd_fip = self.vsd.get_floating_ip(filter=ext_fip_filter)
+        self.assertEqual(vsd_fip.address, public_ipaddress.ipaddress,
                          "Floating IP address in VSD should match acquired public IP address in CloudStack"
                          )
-        if vpc:
-            ext_network_id = self.get_externalID(vpc.id)
-        else:
-            ext_network_id = self.get_externalID(network.id)
-        vsd_domain = self.vsd.get_domain(externalID=ext_network_id)
-        self.debug("SHOW NETWORK DATA FORMAT IN VSD")
-        self.debug(vsd_domain)
-        self.assertEqual(vsd_domain["ID"], vsd_fip["parentID"],
-                         "Floating IP in VSD should be associated with the correct VSD domain, "
-                         "which in turn should correspond to the correct VPC (or) network in CloudStack"
+        self.assertEqual(vsd_fip.assigned, True,
+                         "Floating IP in VSD should be assigned"
                          )
-        ext_subnet_id = self.get_externalID(network.id)
-        vsd_subnet = self.vsd.get_subnet(externalID=ext_subnet_id)
+        ext_network_filter = self.get_externalID_filter(vpc.id) if vpc else self.get_externalID_filter(network.id)
+        vsd_domain = self.vsd.get_domain(filter=ext_network_filter)
+        self.assertEqual(vsd_domain.id, vsd_fip.parent_id,
+                         "Floating IP in VSD should be associated with the correct VSD domain, which in turn should "
+                         "correspond to the correct VPC (or) network in CloudStack"
+                         )
+        vsd_subnet = self.vsd.get_subnet(filter=self.get_externalID_filter(network.id))
         for nic in vm.nic:
-            if nic.networkname == vsd_subnet["description"]:
-                ext_network_id = self.get_externalID(nic.networkid)
-                ext_nic_id = self.get_externalID(nic.id)
-                vsd_vport = self.vsd.get_vport(subnet_externalID=ext_network_id, vport_externalID=ext_nic_id)
-                self.debug("SHOW VM VPORT DATA FORMAT IN VSD")
-                self.debug(vsd_vport)
-        self.assertEqual(vsd_vport["associatedFloatingIPID"], vsd_fip["ID"],
-                         "Floating IP in VSD should be associated to the correct VSD vport, "
-                         "which in turn should correspond to the correct Static NAT enabled VM "
-                         "and network in CloudStack"
+            if nic.networkid == network.id:
+                vsd_vport = self.vsd.get_vport(subnet=vsd_subnet, filter=self.get_externalID_filter(nic.id))
+        self.assertEqual(vsd_vport.associated_floating_ip_id, vsd_fip.id,
+                         "Floating IP in VSD should be associated to the correct VSD vport, which in turn should "
+                         "correspond to the correct Static NAT rule enabled VM and network in CloudStack"
                          )
+        self.debug("Successfully verified the assignment and state of public IP address - %s in VSD" %
+                   public_ipaddress.ipaddress)
 
-    # verify_vsp_firewall_rule - Verifies the given Ingress/Egress firewall rule
-    # against the corresponding installed firewall rule in VSD
-    def verify_vsp_firewall_rule(self, firewall_rule, traffic_type="Ingress"):
-        ext_fw_id = self.get_externalID(firewall_rule.id)
-        if traffic_type is "Ingress":
-            vsd_fw_rule = self.vsd.get_egress_acl_entry(externalID=ext_fw_id)
-        else:
-            vsd_fw_rule = self.vsd.get_ingress_acl_entry(externalID=ext_fw_id)
-        self.debug("SHOW ACL ENTRY IN VSD")
-        self.debug(vsd_fw_rule)
-        dest_port = str(firewall_rule.startport) + "-" + str(firewall_rule.endport)
-        self.assertEqual(vsd_fw_rule["destinationPort"], dest_port,
-                         "Destination port in VSD should match destination port in CloudStack"
+    # verify_vsd_firewall_rule - Verifies the given Network Firewall (Ingress/Egress ACL) rule against the corresponding
+    # installed firewall rule in VSD
+    def verify_vsd_firewall_rule(self, firewall_rule, traffic_type="Ingress"):
+        self.debug("Verifying the creation and state of Network Firewall (Ingress/Egress ACL) rule with ID - %s in VSD"
+                   % firewall_rule.id)
+        ext_fw_rule_filter = self.get_externalID_filter(firewall_rule.id)
+        vsd_fw_rule = self.vsd.get_egress_acl_entry(filter=ext_fw_rule_filter) if traffic_type is "Ingress" else \
+            self.vsd.get_ingress_acl_entry(filter=ext_fw_rule_filter)
+        self.assertEqual(vsd_fw_rule.policy_state, "LIVE",
+                         "Ingress/Egress ACL rule's policy state in VSD should be LIVE"
                          )
-        vsd_protocol = str(vsd_fw_rule["protocol"])
-        self.debug("vsd protocol - %s" % vsd_protocol)
+        dest_port = str(firewall_rule.startport) + "-" + str(firewall_rule.endport)
+        self.assertEqual(vsd_fw_rule.destination_port, dest_port,
+                         "Ingress/Egress ACL rule's destination port in VSD should match corresponding rule's "
+                         "destination port in CloudStack"
+                         )
+        vsd_protocol = int(vsd_fw_rule.protocol)
         protocol = "tcp"
         if vsd_protocol == 6:
             protocol = "tcp"
@@ -753,5 +830,8 @@ class nuageTestCase(cloudstackTestCase):
         elif vsd_protocol == 17:
             protocol = "udp"
         self.assertEqual(protocol, firewall_rule.protocol.lower(),
-                         "Protocol in VSD should match protocol in CloudStack"
+                         "Ingress/Egress ACL rule's protocol in VSD should match corresponding rule's protocol in "
+                         "CloudStack"
                          )
+        self.debug("Successfully verified the creation and state of Network Firewall (Ingress/Egress ACL) rule with ID "
+                   "- %s in VSD" % firewall_rule.id)

--- a/test/integration/plugins/nuagevsp/test_nuage_vpc_internal_lb.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vpc_internal_lb.py
@@ -136,7 +136,7 @@ class TestNuageInternalLb(nuageTestCase):
         cmd.id = int_lb_vm.id
         self.api_client.startInternalLoadBalancerVM(cmd)
 
-    # check_InternalLbVm_state - Checks if the Internal LB VM instance of the given VPC network and source ip is in the
+    # check_InternalLbVm_state - Checks if the Internal LB VM instance of the given VPC network and source IP is in the
     # expected state form the list of fetched Internal LB VM instances
     def check_InternalLbVm_state(self, network, source_ip, state=None):
         self.debug("Check if the InternalLbVm is in state - %s" % state)
@@ -220,7 +220,7 @@ class TestNuageInternalLb(nuageTestCase):
         # 4. Create Nuage VSP VPC offering with LB service provider as "Netscaler", check if it is successfully
         #    created and enabled. Verify that the VPC creation fails with this VPC offering as Nuage VSP does not
         #    support provider "Netscaler" for service LB.
-        # 5. Delete the created VPC offerings (cleanup).
+        # 5. Delete all the created objects (cleanup).
 
         self.debug("Validating network service providers supported by Nuage VSP for VPC Internal LB functionality")
         providers = ["NuageVsp", "VpcVirtualRouter", "InternalLbVm"]
@@ -271,7 +271,7 @@ class TestNuageInternalLb(nuageTestCase):
         """Test Nuage VSP VPC Network Offering with and without Internal LB service
         """
 
-        # 1. Create Nuage Vsp VPC Network offering with LB Service Provider as "InternalLbVm" and LB Service Capability
+        # 1. Create Nuage VSP VPC Network offering with LB Service Provider as "InternalLbVm" and LB Service Capability
         #    "lbSchemes" as "internal", check if it is successfully created and enabled. Verify that the VPC network
         #    creation succeeds with this Network offering.
         # 2. Recreate above Network offering with ispersistent False, check if it is successfully created and enabled.
@@ -279,17 +279,17 @@ class TestNuageInternalLb(nuageTestCase):
         #    persistent VPC networks.
         # 3. Recreate above Network offering with conserve mode On, check if the network offering creation failed
         #    as only networks with conserve mode Off can belong to VPC.
-        # 4. Create Nuage Vsp VPC Network offering with LB Service Provider as "InternalLbVm" and LB Service Capability
+        # 4. Create Nuage VSP VPC Network offering with LB Service Provider as "InternalLbVm" and LB Service Capability
         #    "lbSchemes" as "public", check if the network offering creation failed as "public" lbScheme is not
         #    supported for LB Service Provider "InternalLbVm".
-        # 5. Create Nuage Vsp VPC Network offering without Internal LB Service, check if it is successfully created and
+        # 5. Create Nuage VSP VPC Network offering without Internal LB Service, check if it is successfully created and
         #    enabled. Verify that the VPC network creation succeeds with this Network offering.
         # 6. Recreate above Network offering with ispersistent False, check if it is successfully created and enabled.
         #    Verify that the VPC network creation fails with this Network offering as Nuage VSP does not support non
         #    persistent VPC networks.
         # 7. Recreate the above Network offering with conserve mode On, check if the network offering creation failed
         #    as only networks with conserve mode Off can belong to VPC.
-        # 8. Delete the created Network offerings (cleanup).
+        # 8. Delete all the created objects (cleanup).
 
         # Creating VPC offering
         self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
@@ -328,7 +328,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.debug("Network offering creation failed as public lbScheme is not supported for LB Service Provider "
                    "InternalLbVm")
 
-        self.debug("Creating Nuage Vsp VPC Network offering without Internal LB service...")
+        self.debug("Creating Nuage VSP VPC Network offering without Internal LB service...")
         net_off_3 = self.create_NetworkOffering(self.test_data["nuagevsp"]["vpc_network_offering"])
         self.validate_NetworkOffering(net_off_3, state="Enabled")
 
@@ -351,8 +351,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_Router_state(vr, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
 
         self.debug("Creating a non persistent VPC network with Internal LB service...")
         with self.assertRaises(Exception):
@@ -366,8 +366,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_Router_state(vr, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
 
         self.debug("Creating a non persistent VPC network without Internal LB service...")
         with self.assertRaises(Exception):
@@ -437,14 +437,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr_1 = self.get_Router(internal_tier_1)
         self.check_Router_state(vr_1, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier_1.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm_1 = self.create_VM(internal_tier_1)
         self.check_VM_state(internal_vm_1, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier_1, vpc_1)
-        self.verify_vsp_router(vr_1)
-        self.verify_vsp_vm(internal_vm_1)
+        self.verify_vsd_network(self.domain.id, internal_tier_1, vpc_1)
+        self.verify_vsd_router(vr_1)
+        self.verify_vsd_vm(internal_vm_1)
 
         self.debug("Creating one more VPC network in vpc_1 with Internal LB service...")
         internal_tier_2 = self.create_Network(net_off_1, gateway='10.1.2.1', vpc=vpc_1)
@@ -452,14 +452,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr_1 = self.get_Router(internal_tier_2)
         self.check_Router_state(vr_1, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier_2.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm_2 = self.create_VM(internal_tier_2)
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier_2, vpc_1)
-        self.verify_vsp_router(vr_1)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_network(self.domain.id, internal_tier_2, vpc_1)
+        self.verify_vsd_router(vr_1)
+        self.verify_vsd_vm(internal_vm_2)
 
         self.debug("Creating a VPC network in vpc_2 with Internal LB service...")
         with self.assertRaises(Exception):
@@ -472,14 +472,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr_1 = self.get_Router(public_tier_1)
         self.check_Router_state(vr_1, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % public_tier_1.name)
+        self.debug("Deploying a VM in the created VPC network...")
         public_vm_1 = self.create_VM(public_tier_1)
         self.check_VM_state(public_vm_1, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier_1, vpc_1)
-        self.verify_vsp_router(vr_1)
-        self.verify_vsp_vm(public_vm_1)
+        self.verify_vsd_network(self.domain.id, public_tier_1, vpc_1)
+        self.verify_vsd_router(vr_1)
+        self.verify_vsd_vm(public_vm_1)
 
         self.debug("Creating a VPC network in vpc_2 without Internal LB service...")
         public_tier_2 = self.create_Network(net_off_2, gateway='10.1.1.1', vpc=vpc_2)
@@ -487,14 +487,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr_2 = self.get_Router(public_tier_2)
         self.check_Router_state(vr_2, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % public_tier_2.name)
+        self.debug("Deploying a VM in the created VPC network...")
         public_vm_2 = self.create_VM(public_tier_2)
         self.check_VM_state(public_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier_2, vpc_2)
-        self.verify_vsp_router(vr_2)
-        self.verify_vsp_vm(public_vm_2)
+        self.verify_vsd_network(self.domain.id, public_tier_2, vpc_2)
+        self.verify_vsd_router(vr_2)
+        self.verify_vsd_vm(public_vm_2)
 
         # Upgrading a VPC network
         self.debug("Upgrading a VPC network with Internal LB Service to one without Internal LB Service...")
@@ -505,9 +505,9 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier_2, vpc_1)
-        self.verify_vsp_router(vr_1)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_network(self.domain.id, internal_tier_2, vpc_1)
+        self.verify_vsd_router(vr_1)
+        self.verify_vsd_vm(internal_vm_2)
 
         self.debug("Upgrading a VPC network without Internal LB Service to one with Internal LB Service...")
         self.upgrade_Network(net_off_1, internal_tier_2)
@@ -517,9 +517,9 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier_2, vpc_1)
-        self.verify_vsp_router(vr_1)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_network(self.domain.id, internal_tier_2, vpc_1)
+        self.verify_vsd_router(vr_1)
+        self.verify_vsd_vm(internal_vm_2)
 
         # Deleting and re-creating a VPC network
         self.debug("Deleting a VPC network with Internal LB Service...")
@@ -531,7 +531,7 @@ class TestNuageInternalLb(nuageTestCase):
 
         # VSD verification
         with self.assertRaises(Exception):
-            self.verify_vsp_network(self.domain.id, internal_tier_2, vpc_1)
+            self.verify_vsd_network(self.domain.id, internal_tier_2, vpc_1)
         self.debug("VPC network successfully deleted in VSD")
 
         self.debug("Recreating a VPC network with Internal LB Service...")
@@ -543,9 +543,9 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier_2, vpc_1)
-        self.verify_vsp_router(vr_1)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_network(self.domain.id, internal_tier_2, vpc_1)
+        self.verify_vsd_router(vr_1)
+        self.verify_vsd_vm(internal_vm_2)
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_04_nuage_internallb_rules(self):
@@ -576,6 +576,7 @@ class TestNuageInternalLb(nuageTestCase):
         #     VM to it.
         # 11. Verify the failure of attaching a VM from a different tier to an Internal LB Rule created on a tier.
         # 12. Delete the above created Internal LB Rules, check if the Internal LB Rules are successfully deleted.
+        # 13. Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
@@ -604,14 +605,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm = self.create_VM(internal_tier)
         self.check_VM_state(internal_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
         public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
@@ -619,14 +620,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % public_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         public_vm = self.create_VM(public_tier)
         self.check_VM_state(public_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
 
         # Creating Internal LB Rules
         self.debug("Creating an Internal LB Rule without source IP Address specified...")
@@ -691,8 +692,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_2.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_1)
-        self.verify_vsp_LB_device(int_lb_vm_2)
+        self.verify_vsd_lb_device(int_lb_vm_1)
+        self.verify_vsd_lb_device(int_lb_vm_2)
 
         self.debug('Removing VMs from the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.remove(self.api_client, vms=[internal_vm])
@@ -709,8 +710,8 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_2.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_1)
-        self.verify_vsp_LB_device(int_lb_vm_2)
+        self.verify_vsd_lb_device(int_lb_vm_1)
+        self.verify_vsd_lb_device(int_lb_vm_2)
 
         self.debug('Deleting the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.delete(self.api_client)
@@ -732,10 +733,10 @@ class TestNuageInternalLb(nuageTestCase):
 
         # VSD Verification
         with self.assertRaises(Exception):
-            self.verify_vsp_LB_device(int_lb_vm_1)
+            self.verify_vsd_lb_device(int_lb_vm_1)
         self.debug("InternalLbVm successfully destroyed in VSD")
         with self.assertRaises(Exception):
-            self.verify_vsp_LB_device(int_lb_vm_2)
+            self.verify_vsd_lb_device(int_lb_vm_2)
         self.debug("InternalLbVm successfully destroyed in VSD")
 
         self.debug("Creating multiple Internal LB Rules with different ports but using the same Load Balancing source "
@@ -754,7 +755,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         self.debug('Removing VMs from the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.remove(self.api_client, vms=[internal_vm])
@@ -770,7 +771,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         self.debug('Deleting the Internal LB Rules - %s, %s' % (int_lb_rule_1.name, int_lb_rule_2.name))
         int_lb_rule_1.delete(self.api_client)
@@ -789,10 +790,10 @@ class TestNuageInternalLb(nuageTestCase):
 
         # VSD Verification
         with self.assertRaises(Exception):
-            self.verify_vsp_LB_device(int_lb_vm)
+            self.verify_vsd_lb_device(int_lb_vm)
         self.debug("InternalLbVm successfully destroyed in VSD")
 
-        self.debug("Creating multiple Internal LB Rules with same ports and using the same Load Balacing source IP "
+        self.debug("Creating multiple Internal LB Rules with same ports and using the same Load Balancing source IP "
                    "Address...")
         int_lb_rule = self.create_Internal_LB_Rule(internal_tier, vm_array=[internal_vm])
         self.validate_Internal_LB_Rule(int_lb_rule, state="Active", vm_array=[internal_vm])
@@ -805,7 +806,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         self.debug('Removing VMs from the Internal LB Rule - %s' % int_lb_rule.name)
         int_lb_rule.remove(self.api_client, vms=[internal_vm])
@@ -817,7 +818,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         self.debug('Deleting the Internal LB Rule - %s' % int_lb_rule.name)
         int_lb_rule.delete(self.api_client)
@@ -832,7 +833,7 @@ class TestNuageInternalLb(nuageTestCase):
 
         # VSD Verification
         with self.assertRaises(Exception):
-            self.verify_vsp_LB_device(int_lb_vm)
+            self.verify_vsd_lb_device(int_lb_vm)
         self.debug("InternalLbVm successfully destroyed in VSD")
 
         self.debug("Attaching a VM from a different tier to an Internal LB Rule created on a tier...")
@@ -862,6 +863,7 @@ class TestNuageInternalLb(nuageTestCase):
         # 8. Verify that the InternalLbVm gets destroyed when the last Internal LB rule is removed from the Internal
         #    tier.
         # 9. Repeat the above steps for one more Internal tier as well, validate the Internal LB functionality.
+        # 10. Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
@@ -890,14 +892,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(internal_tier_1)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier_1.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm_1 = self.create_VM(internal_tier_1)
         self.check_VM_state(internal_vm_1, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier_1, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm_1)
+        self.verify_vsd_network(self.domain.id, internal_tier_1, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm_1)
 
         self.debug("Creating one more VPC network with Internal LB service...")
         internal_tier_2 = self.create_Network(net_off_1, gateway='10.1.2.1', vpc=vpc)
@@ -905,14 +907,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(internal_tier_2)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier_2.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm_2 = self.create_VM(internal_tier_2)
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier_2, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_network(self.domain.id, internal_tier_2, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm_2)
 
         self.debug("Creating a VPC network without Internal LB service...")
         public_tier = self.create_Network(net_off_2, gateway='10.1.3.1', vpc=vpc)
@@ -920,14 +922,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % public_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         public_vm = self.create_VM(public_tier)
         self.check_VM_state(public_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
 
         # Creating Internal LB Rules in the Internal tiers
         self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
@@ -945,7 +947,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier_1, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_1)
+        self.verify_vsd_lb_device(int_lb_vm_1)
 
         # Deploying more VMs in the Internal tier
         self.debug("Deploying two more VMs in network - %s" % internal_tier_1.name)
@@ -953,8 +955,8 @@ class TestNuageInternalLb(nuageTestCase):
         internal_vm_1_2 = self.create_VM(internal_tier_1)
 
         # VSD verification
-        self.verify_vsp_vm(internal_vm_1_1)
-        self.verify_vsp_vm(internal_vm_1_2)
+        self.verify_vsd_vm(internal_vm_1_1)
+        self.verify_vsd_vm(internal_vm_1_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
         self.debug("Adding two more virtual machines to the created Internal LB rules...")
@@ -969,7 +971,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier_1, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_1)
+        self.verify_vsd_lb_device(int_lb_vm_1)
 
         # Adding Network ACL rules in the Internal tier
         self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
@@ -977,8 +979,8 @@ class TestNuageInternalLb(nuageTestCase):
         http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier_1)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
         # Creating Internal LB Rules in the Internal tier
         self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
@@ -996,7 +998,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier_2, int_lb_rule_3.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_2)
+        self.verify_vsd_lb_device(int_lb_vm_2)
 
         # Deploying more VMs in the Internal tier
         self.debug("Deploying two more VMs in network - %s" % internal_tier_2.name)
@@ -1004,8 +1006,8 @@ class TestNuageInternalLb(nuageTestCase):
         internal_vm_2_2 = self.create_VM(internal_tier_2)
 
         # VSD verification
-        self.verify_vsp_vm(internal_vm_2_1)
-        self.verify_vsp_vm(internal_vm_2_2)
+        self.verify_vsd_vm(internal_vm_2_1)
+        self.verify_vsd_vm(internal_vm_2_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
         self.debug("Adding two more virtual machines to the created Internal LB rules...")
@@ -1020,7 +1022,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier_2, int_lb_rule_3.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_2)
+        self.verify_vsd_lb_device(int_lb_vm_2)
 
         # Adding Network ACL rules in the Internal tier
         self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
@@ -1028,24 +1030,24 @@ class TestNuageInternalLb(nuageTestCase):
         http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier_2)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
-        # Creating Static NAT Rule for the VM in the Public tier
+        # Creating Static NAT rule for the VM in the Public tier
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
         self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
         public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(public_ssh_rule)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic tests
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1074,6 +1076,7 @@ class TestNuageInternalLb(nuageTestCase):
         # 2. Least connections
         # 3. Source
         # Verify the above Internal LB algorithms by performing multiple (wget) traffic tests within a VPC.
+        # Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
@@ -1102,14 +1105,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm = self.create_VM(internal_tier)
         self.check_VM_state(internal_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
         public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
@@ -1117,14 +1120,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % public_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         public_vm = self.create_VM(public_tier)
         self.check_VM_state(public_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
 
         # Creating Internal LB Rules in the Internal tier with Round Robin Algorithm
         self.debug("Creating two Internal LB Rules (SSH & HTTP) with Round Robin Algorithm...")
@@ -1142,7 +1145,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_1)
+        self.verify_vsd_lb_device(int_lb_vm_1)
 
         # Deploying more VMs in the Internal tier
         self.debug("Deploying two more VMs in network - %s" % internal_tier.name)
@@ -1150,8 +1153,8 @@ class TestNuageInternalLb(nuageTestCase):
         internal_vm_2 = self.create_VM(internal_tier)
 
         # VSD verification
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
         self.debug("Adding two more virtual machines to the created Internal LB rules...")
@@ -1166,7 +1169,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_1)
+        self.verify_vsd_lb_device(int_lb_vm_1)
 
         # Creating Internal LB Rules in the Internal tier with Least connections Algorithm
         self.debug("Creating two Internal LB Rules (SSH & HTTP) with Least connections Algorithm...")
@@ -1191,7 +1194,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_3.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_2)
+        self.verify_vsd_lb_device(int_lb_vm_2)
 
         # Creating Internal LB Rules in the Internal tier with Source Algorithm
         self.debug("Creating two Internal LB Rules (SSH & HTTP) with Source Algorithm...")
@@ -1216,7 +1219,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_5.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm_3)
+        self.verify_vsd_lb_device(int_lb_vm_3)
 
         # Adding Network ACL rules in the Internal tier
         self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
@@ -1224,24 +1227,24 @@ class TestNuageInternalLb(nuageTestCase):
         http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
-        # Creating Static NAT Rule for the VM in the Public tier
+        # Creating Static NAT rule for the VM in the Public tier
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
         self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
         public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(public_ssh_rule)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic tests with Round Robin Algorithm
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1289,9 +1292,12 @@ class TestNuageInternalLb(nuageTestCase):
         #    tier.
         # 6. Start all the VMs configured with InternalLbVm, verify that the InternalLbVm gets deployed again in the
         #    Internal tier.
-        # 7. Restart VPC, verify that the VPC VR gets rebooted and this restart has no effect on the InternalLbVm
-        #    functionality.
+        # 7. Restart VPC (cleanup = false), verify that the VPC VR gets rebooted and this restart has no effect on the
+        #    InternalLbVm functionality.
+        # 7. Restart VPC (cleanup = true), verify that the VPC VR gets rebooted and this restart has no effect on the
+        #    InternalLbVm functionality.
         # Verify the above restarts of VPC networks (tiers) by performing (wget) traffic tests within a VPC.
+        # Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
@@ -1320,14 +1326,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm = self.create_VM(internal_tier)
         self.check_VM_state(internal_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
         public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
@@ -1335,14 +1341,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % public_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         public_vm = self.create_VM(public_tier)
         self.check_VM_state(public_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
 
         # Creating Internal LB Rules in the Internal tier
         self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
@@ -1360,7 +1366,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Deploying more VMs in the Internal tier
         self.debug("Deploying two more VMs in network - %s" % internal_tier.name)
@@ -1368,8 +1374,8 @@ class TestNuageInternalLb(nuageTestCase):
         internal_vm_2 = self.create_VM(internal_tier)
 
         # VSD verification
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
         self.debug("Adding two more virtual machines to the created Internal LB rules...")
@@ -1384,7 +1390,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Adding Network ACL rules in the Internal tier
         self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
@@ -1392,24 +1398,24 @@ class TestNuageInternalLb(nuageTestCase):
         http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
-        # Creating Static NAT Rule for the VM in the Public tier
+        # Creating Static NAT rule for the VM in the Public tier
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
         self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
         public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(public_ssh_rule)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1432,13 +1438,13 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm)
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
         # InternalLbVm gets destroyed and deployed again in the Internal tier
@@ -1446,12 +1452,12 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while True:
+        while tries < 10:
             try:
                 wget_file = self.wget_from_vm_cmd(ssh_client,
                                                   int_lb_rule_1.sourceipaddress,
@@ -1459,8 +1465,6 @@ class TestNuageInternalLb(nuageTestCase):
                                                   )
             except Exception as e:
                 self.debug("Failed to wget file via the InternalLbVm after re-starting the Internal tier: %s" % e)
-                if tries == 10:
-                    break
                 self.debug("Waiting for the InternalLbVm in the Internal tier to be fully resolved for (wget) traffic "
                            "test...")
                 time.sleep(30)
@@ -1483,13 +1487,13 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm)
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
         # InternalLbVm gets destroyed and deployed again in the Internal tier
@@ -1497,12 +1501,12 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while True:
+        while tries < 10:
             try:
                 wget_file = self.wget_from_vm_cmd(ssh_client,
                                                   int_lb_rule_1.sourceipaddress,
@@ -1511,8 +1515,6 @@ class TestNuageInternalLb(nuageTestCase):
             except Exception as e:
                 self.debug("Failed to wget file via the InternalLbVm after re-starting the Internal tier with cleanup: "
                            "%s" % e)
-                if tries == 10:
-                    break
                 self.debug("Waiting for the InternalLbVm in the Internal tier to be fully resolved for (wget) traffic "
                            "test...")
                 time.sleep(30)
@@ -1534,17 +1536,17 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
-        self.verify_vsp_firewall_rule(public_ssh_rule)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Validating InternalLbVm state
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1566,17 +1568,17 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
-        self.verify_vsp_firewall_rule(public_ssh_rule)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Validating InternalLbVm state
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1601,19 +1603,19 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm_2, state="Stopped")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm, stopped=True)
-        self.verify_vsp_vm(internal_vm_1, stopped=True)
-        self.verify_vsp_vm(internal_vm_2, stopped=True)
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm, stopped=True)
+        self.verify_vsd_vm(internal_vm_1, stopped=True)
+        self.verify_vsd_vm(internal_vm_2, stopped=True)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1637,24 +1639,24 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_VM_state(internal_vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm)
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while True:
+        while tries < 10:
             try:
                 wget_file = self.wget_from_vm_cmd(ssh_client,
                                                   int_lb_rule_1.sourceipaddress,
@@ -1663,8 +1665,6 @@ class TestNuageInternalLb(nuageTestCase):
             except Exception as e:
                 self.debug("Failed to wget file via the InternalLbVm after re-starting all the VMs in the Internal tier"
                            ": %s" % e)
-                if tries == 10:
-                    break
                 self.debug("Waiting for the InternalLbVm and all the VMs in the Internal tier to be fully resolved for "
                            "(wget) traffic test...")
                 time.sleep(30)
@@ -1693,23 +1693,23 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
-        self.verify_vsp_vm(internal_vm)
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
-        self.verify_vsp_firewall_rule(public_ssh_rule)
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
+        self.verify_vsd_vm(internal_vm)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1737,23 +1737,23 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
-        self.verify_vsp_vm(internal_vm)
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
-        self.verify_vsp_firewall_rule(public_ssh_rule)
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
+        self.verify_vsd_vm(internal_vm)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
         # Validating InternalLbVm state
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1781,6 +1781,7 @@ class TestNuageInternalLb(nuageTestCase):
         # 6. Force stop the InternalLbVm when the VPC VR is in Running State
         # 7. Start the InternalLbVm when the VPC VR is in Running state
         # Verify the above restarts of VPC networks by performing (wget) traffic tests within a VPC.
+        # Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering with Internal LB service...")
@@ -1809,14 +1810,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(internal_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % internal_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         internal_vm = self.create_VM(internal_tier)
         self.check_VM_state(internal_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(internal_vm)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(internal_vm)
 
         self.debug("Creating a VPC network without Internal LB service...")
         public_tier = self.create_Network(net_off_2, gateway='10.1.2.1', vpc=vpc)
@@ -1824,14 +1825,14 @@ class TestNuageInternalLb(nuageTestCase):
         vr = self.get_Router(public_tier)
         self.check_Router_state(vr, state="Running")
 
-        self.debug("Deploying a VM in network - %s" % public_tier.name)
+        self.debug("Deploying a VM in the created VPC network...")
         public_vm = self.create_VM(public_tier)
         self.check_VM_state(public_vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(public_vm)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(public_vm)
 
         # Stopping the VPC VR
         # VPC VR has no effect on the InternalLbVm functionality
@@ -1841,9 +1842,9 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Network(internal_tier, state="Implemented")
 
         # VSD verification
-        self.verify_vsp_router(vr, stopped=True)
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr, stopped=True)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
 
         # Creating Internal LB Rules in the Internal tier
         self.debug("Creating two Internal LB Rules (SSH & HTTP) using the same Load Balancing source IP Address...")
@@ -1861,7 +1862,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Deploying more VMs in the Internal tier
         self.debug("Deploying two more VMs in network - %s" % internal_tier.name)
@@ -1869,8 +1870,8 @@ class TestNuageInternalLb(nuageTestCase):
         internal_vm_2 = self.create_VM(internal_tier)
 
         # VSD verification
-        self.verify_vsp_vm(internal_vm_1)
-        self.verify_vsp_vm(internal_vm_2)
+        self.verify_vsd_vm(internal_vm_1)
+        self.verify_vsd_vm(internal_vm_2)
 
         # Adding newly deployed VMs to the created Internal LB rules
         self.debug("Adding two more virtual machines to the created Internal LB rules...")
@@ -1885,7 +1886,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Adding Network ACL rules in the Internal tier
         self.debug("Adding Network ACL rules to make the created Internal LB rules (SSH & HTTP) accessible...")
@@ -1893,24 +1894,24 @@ class TestNuageInternalLb(nuageTestCase):
         http_rule = self.create_NetworkAclRule(self.test_data["http_rule"], network=internal_tier)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(ssh_rule)
-        self.verify_vsp_firewall_rule(http_rule)
+        self.verify_vsd_firewall_rule(ssh_rule)
+        self.verify_vsd_firewall_rule(http_rule)
 
-        # Creating Static NAT Rule for the VM in the Public tier
+        # Creating Static NAT rule for the VM in the Public tier
         public_ip = self.acquire_PublicIPAddress(public_tier, vpc)
         self.validate_PublicIPAddress(public_ip, public_tier)
         self.create_StaticNatRule_For_VM(public_vm, public_ip, public_tier)
         self.validate_PublicIPAddress(public_ip, public_tier, static_nat=True, vm=public_vm)
 
         # VSD verification
-        self.verify_vsp_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
+        self.verify_vsd_floating_ip(public_tier, public_vm, public_ip.ipaddress, vpc)
 
         # Adding Network ACL rule in the Public tier
         self.debug("Adding Network ACL rule to make the created NAT rule (SSH) accessible...")
         public_ssh_rule = self.create_NetworkAclRule(self.test_data["ingress_rule"], network=public_tier)
 
         # VSD verification
-        self.verify_vsp_firewall_rule(public_ssh_rule)
+        self.verify_vsd_firewall_rule(public_ssh_rule)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1927,7 +1928,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm, stopped=True)
+        self.verify_vsd_lb_device(int_lb_vm, stopped=True)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -1943,12 +1944,12 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while True:
+        while tries < 10:
             try:
                 wget_file = self.wget_from_vm_cmd(ssh_client,
                                                   int_lb_rule_1.sourceipaddress,
@@ -1957,8 +1958,6 @@ class TestNuageInternalLb(nuageTestCase):
             except Exception as e:
                 self.debug("Failed to wget file via the InternalLbVm after re-starting the InternalLbVm appliance: %s"
                            % e)
-                if tries == 10:
-                    break
                 self.debug("Waiting for the InternalLbVm to be fully resolved for (wget) traffic test...")
                 time.sleep(30)
                 tries += 1
@@ -1977,16 +1976,16 @@ class TestNuageInternalLb(nuageTestCase):
         self.validate_Network(internal_tier, state="Implemented")
 
         # VSD verification
-        self.verify_vsp_router(vr)
-        self.verify_vsp_network(self.domain.id, public_tier, vpc)
-        self.verify_vsp_network(self.domain.id, internal_tier, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_network(self.domain.id, public_tier, vpc)
+        self.verify_vsd_network(self.domain.id, internal_tier, vpc)
 
         # # Stopping the InternalLbVm when the VPC VR is in Running state
         self.stop_InternalLbVm(int_lb_vm)
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm, stopped=True)
+        self.verify_vsd_lb_device(int_lb_vm, stopped=True)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -2002,12 +2001,12 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while True:
+        while tries < 10:
             try:
                 wget_file = self.wget_from_vm_cmd(ssh_client,
                                                   int_lb_rule_1.sourceipaddress,
@@ -2016,8 +2015,6 @@ class TestNuageInternalLb(nuageTestCase):
             except Exception as e:
                 self.debug("Failed to wget file via the InternalLbVm after re-starting the InternalLbVm appliance: %s"
                            % e)
-                if tries == 10:
-                    break
                 self.debug("Waiting for the InternalLbVm to be fully resolved for (wget) traffic test...")
                 time.sleep(30)
                 tries += 1
@@ -2033,7 +2030,7 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Stopped")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm, stopped=True)
+        self.verify_vsd_lb_device(int_lb_vm, stopped=True)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
@@ -2049,12 +2046,12 @@ class TestNuageInternalLb(nuageTestCase):
         self.check_InternalLbVm_state(internal_tier, int_lb_rule_1.sourceipaddress, state="Running")
 
         # VSD Verification
-        self.verify_vsp_LB_device(int_lb_vm)
+        self.verify_vsd_lb_device(int_lb_vm)
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while True:
+        while tries < 10:
             try:
                 wget_file = self.wget_from_vm_cmd(ssh_client,
                                                   int_lb_rule_1.sourceipaddress,
@@ -2063,8 +2060,6 @@ class TestNuageInternalLb(nuageTestCase):
             except Exception as e:
                 self.debug("Failed to wget file via the InternalLbVm after re-starting the InternalLbVm appliance: %s"
                            % e)
-                if tries == 10:
-                    break
                 self.debug("Waiting for the InternalLbVm to be fully resolved for (wget) traffic test...")
                 time.sleep(30)
                 tries += 1

--- a/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
@@ -57,6 +57,7 @@ class TestNuageVpcNetwork(nuageTestCase):
         # 6. Deploy a VM in the created VPC network, check if the VM is successfully deployed and is in the "Running"
         #    state.
         # 7. Verify that the created ACL item is successfully implemented in Nuage VSP.
+        # 8. Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering...")
@@ -91,12 +92,12 @@ class TestNuageVpcNetwork(nuageTestCase):
         self.check_VM_state(vm, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, vpc_network, vpc)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(vm)
+        self.verify_vsd_network(self.domain.id, vpc_network, vpc)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(vm)
 
         # VSD verification for ACL item
-        self.verify_vsp_firewall_rule(acl_item)
+        self.verify_vsd_firewall_rule(acl_item)
 
     @attr(tags=["advanced", "nuagevsp", "multizone"], required_hardware="false")
     def test_nuage_vpc_network_multizone(self):

--- a/test/integration/plugins/nuagevsp/test_nuage_vsp.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vsp.py
@@ -166,16 +166,16 @@ class TestNuageVsp(nuageTestCase):
         self.check_VM_state(vm_1, state="Running")
 
         # VSD verification
-        self.verify_vsp_network(self.domain.id, network)
-        self.verify_vsp_router(vr)
-        self.verify_vsp_vm(vm_1)
+        self.verify_vsd_network(self.domain.id, network)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(vm_1)
 
         # Deploying one more VM in the network
         vm_2 = self.create_VM(network)
         self.check_VM_state(vm_2, state="Running")
 
         # VSD verification
-        self.verify_vsp_vm(vm_2)
+        self.verify_vsd_vm(vm_2)
 
         # Deleting the network
         self.debug("Deleting the Isolated Network with Nuage VSP Isolated Network offering...")
@@ -188,5 +188,5 @@ class TestNuageVsp(nuageTestCase):
 
         # VSD verification
         with self.assertRaises(Exception):
-            self.verify_vsp_network(self.domain.id, network)
+            self.verify_vsd_network(self.domain.id, network)
         self.debug("Isolated Network successfully deleted in VSD")

--- a/test/integration/plugins/nuagevsp/test_nuage_vsp.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vsp.py
@@ -19,9 +19,11 @@
 """
 # Import Local Modules
 from nuageTestCase import nuageTestCase
-from marvin.lib.base import Account
+from marvin.lib.base import Account, Nuage
+from marvin.cloudstackAPI import deleteNuageVspDevice
 # Import System Modules
 from nose.plugins.attrib import attr
+import copy
 
 
 class TestNuageVsp(nuageTestCase):
@@ -43,6 +45,91 @@ class TestNuageVsp(nuageTestCase):
         self.cleanup = [self.account]
         return
 
+    # validate_NuageVspDevice - Validates the addition of Nuage VSP device in the Nuage VSP Physical Network
+    def validate_NuageVspDevice(self):
+        """Validates the addition of Nuage VSP device in the Nuage VSP Physical Network"""
+        self.debug("Validating the addition of Nuage VSP device in the Nuage VSP Physical Network - %s" %
+                   self.vsp_physical_network.id)
+        nuage_vsp_device = Nuage.list(self.api_client,
+                                      physicalnetworkid=self.vsp_physical_network.id
+                                      )
+        self.assertEqual(isinstance(nuage_vsp_device, list), True,
+                         "List Nuage VSP device should return a valid list"
+                         )
+        self.debug("Successfully validated the addition of Nuage VSP device in the Nuage VSP Physical Network - %s" %
+                   self.vsp_physical_network.id)
+
+    # delete_NuageVspDevice - Deletes the Nuage VSP device in the Nuage VSP Physical Network
+    def delete_NuageVspDevice(self):
+        """Deletes the Nuage VSP device in the Nuage VSP Physical Network"""
+        self.debug("Deleting the Nuage VSP device in the Nuage VSP Physical Network - %s" %
+                   self.vsp_physical_network.id)
+        nuage_vsp_device = Nuage.list(self.api_client,
+                                      physicalnetworkid=self.vsp_physical_network.id
+                                      )[0]
+        cmd = deleteNuageVspDevice.deleteNuageVspDeviceCmd()
+        cmd.vspdeviceid = nuage_vsp_device.vspdeviceid
+        self.api_client.deleteNuageVspDevice(cmd)
+        self.debug("Successfully deleted the Nuage VSP device in the Nuage VSP Physical Network - %s" %
+                   self.vsp_physical_network.id)
+
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
+    def test_nuage_vsp_device(self):
+        """ Test Nuage VSP device in the Nuage VSP Physical Network
+        """
+
+        # 1. Verify that the Nuage VSP network service provider is successfully created and enabled in the Nuage VSP
+        #    Physical Network.
+        # 2. Verify that the Nuage VSP device is successfully created in the Nuage VSP Physical Network.
+        # 3. Delete the Nuage VSP device in the Nuage VSP Physical Network, verify that the Nuage VSP device is
+        #    successfully deleted in the Nuage VSP Physical Network.
+        # 4. Add the Nuage VSP device in the Nuage VSP Physical Network with invalid VSD credentials, verify that the
+        #    Nuage VSP device failed to add in the Nuage VSP Physical Network.
+        # 5. Add the Nuage VSP device in the Nuage VSP Physical Network with valid VSD credentials, verify that the
+        #    Nuage VSP device is successfully added in the Nuage VSP Physical Network.
+
+        # Nuage VSP network service provider validation
+        self.debug("Validating the Nuage VSP network service provider in the Nuage VSP Physical Network...")
+        self.validate_NetworkServiceProvider("NuageVsp", state="Enabled")
+
+        # Nuage VSP device validation
+        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.validate_NuageVspDevice()
+
+        # Nuage VSP device deletion
+        self.debug("Deleting the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.delete_NuageVspDevice()
+
+        # Nuage VSP device validation
+        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        with self.assertRaises(Exception):
+            self.validate_NuageVspDevice()
+        self.debug("Successfully deleted the Nuage VSP device in the Nuage VSP Physical Network")
+
+        # Adding the Nuage VSP device with invalid VSD credentials
+        self.debug("Adding the Nuage VSP device in the Nuage VSP Physical Network with invalid VSD credentials...")
+        vsd_info = self.nuage_vsp_device.__dict__
+        invalid_vsd_info = copy.deepcopy(vsd_info)
+        invalid_vsd_info["password"] = ""
+        with self.assertRaises(Exception):
+            Nuage.add(self.api_client, invalid_vsd_info, self.vsp_physical_network.id)
+        self.debug("Failed to add the Nuage VSP device in the Nuage VSP Physical Network due to invalid VSD "
+                   "credentials")
+
+        # Nuage VSP device validation
+        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        with self.assertRaises(Exception):
+            self.validate_NuageVspDevice()
+        self.debug("The Nuage VSP device is not added in the Nuage VSP Physical Network")
+
+        # Adding the Nuage VSP device with valid VSD credentials
+        self.debug("Adding the Nuage VSP device in the Nuage VSP Physical Network with valid VSD credentials...")
+        Nuage.add(self.api_client, vsd_info, self.vsp_physical_network.id)
+
+        # Nuage VSP device validation
+        self.debug("Validating the Nuage VSP device in the Nuage VSP Physical Network...")
+        self.validate_NuageVspDevice()
+
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_nuage_vsp(self):
         """ Test Nuage VSP SDN plugin with basic Isolated Network functionality
@@ -58,9 +145,7 @@ class TestNuageVsp(nuageTestCase):
         #    "Running" state.
         # 6. Delete the created Isolated Network after destroying its VMs, check if the Isolated network is successfully
         #    deleted.
-
-        self.debug("Validating the Nuage VSP network service provider...")
-        self.validate_NetworkServiceProvider("NuageVsp", state="Enabled")
+        # 7. Delete all the created objects (cleanup).
 
         # Creating a network offering
         self.debug("Creating and enabling Nuage VSP Isolated Network offering...")

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -13256,7 +13256,7 @@
                             dataType: "json",
                             async: false,
                             success: function(json) {
-                                var items = json.listnuagevspdeviceresponse.nuagevspdevice;
+                                var items = json.listnuagevspdevicesresponse.nuagevspdevice;
                                 args.response.success({
                                     data: items
                                 });
@@ -13325,7 +13325,7 @@
                                         dataType: "json",
                                         async: true,
                                         success: function(json) {
-                                            var item = json.listnuagevspdeviceresponse.nuagevspdevice[0];
+                                            var item = json.listnuagevspdevicesresponse.nuagevspdevice[0];
                                             args.response.success({
                                                 data: item
                                             });


### PR DESCRIPTION
In most network plugins, there's a Resource class which will handle the communication with the actual device / underlaying client / ... They're configured as a host, so ACS is able to send commands towards it. 

When they're configured as a host, the clusterId is not filled in since it's not relevant. Hence, the NPE while deleting this host because of ```long clusterId = host.getClusterId();```