### PR TITLE
Fixing erraneous guest_os_hypervisor mappings

### DIFF
--- a/setup/db/db/schema-481to490.sql
+++ b/setup/db/db/schema-481to490.sql
@@ -545,3 +545,14 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervis
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.0', 'centos64Guest', 228, now(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'centos64Guest', 228, now(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'centos64Guest', 228, now(), 0);
+
+
+
+UPDATE `cloud`.`guest_os_hypervisor` set `guest_os_name` = "Other PV (32-bit)" where `hypervisor_type` = "Xenserver" and `guest_os_id` = 139;
+UPDATE `cloud`.`guest_os_hypervisor` set `guest_os_name` = "Other PV (64-bit)" where `hypervisor_type` = "Xenserver" and `guest_os_id` = 140;
+UPDATE `cloud`.`guest_os_hypervisor` set `guest_os_id` = 163 where `hypervisor_type` = "VmWare" and `guest_os_id` = 162 and `guest_os_name` = "Ubuntu 12.04 (32-bit)";
+UPDATE `cloud`.`guest_os_hypervisor` set `guest_os_id` = 164 where `hypervisor_type` = "VmWare" and `guest_os_id` = 163 and `guest_os_name` = "Ubuntu 12.04 (64-bit)";
+UPDATE `cloud`.`guest_os_hypervisor` set `guest_os_name` = "Ubuntu 12.04" where `hypervisor_type` = "KVM" and `guest_os_id` = 163 and `guest_os_name` = "Ubuntu 10.04";
+DELETE FROM `cloud`.`guest_os_hypervisor` where `hypervisor_type` = "KVM" and `guest_os_id` = 162 and `guest_os_name` = "Ubuntu 10.04";
+UPDATE `cloud`.`guest_os_hypervisor` set `guest_os_name` = "Ubuntu 12.04" where `hypervisor_type` = "LXC" and `guest_os_id` = 163 and `guest_os_name` = "Ubuntu 10.04";
+DELETE FROM `cloud`.`guest_os_hypervisor` where `hypervisor_type` = "LXC" and `guest_os_id` = 162 and `guest_os_name` = "Ubuntu 10.04";


### PR DESCRIPTION
We noticed some discrepancies in the guest_os_hypervisor mappings, specifically Other PV being mapped to CentOS on Xenserver, Ubuntu 10.04 pointing to CentOS and Ubuntu 12 for VmWare, KVM, and LXC. Here are some queries to show the problematic mappings before correction:

```
mysql> SELECT h.id, hypervisor_type, hypervisor_version, h.guest_os_name, g.display_name FROM guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id
where h.id in ( 420, 497, 569, 672, 783, 912, 1061, 1211, 2153, 421, 498, 570, 673, 784, 913, 1062, 1212, 2154, 173, 253, 2018, 254, 2019);
+------+-----------------+--------------------+-----------------------+-----------------------+
| id   | hypervisor_type | hypervisor_version | guest_os_name         | display_name          |
+------+-----------------+--------------------+-----------------------+-----------------------+
|  173 | VmWare          | default            | Ubuntu 12.04 (32-bit) | CentOS 5.7 (64-bit)   |
|  253 | KVM             | default            | Ubuntu 10.04          | CentOS 5.7 (64-bit)   |
|  254 | KVM             | default            | Ubuntu 10.04          | Ubuntu 12.04 (32-bit) |
|  420 | Xenserver       | XCP 1.0            | CentOS 5 (32-bit)     | Other PV (32-bit)     |
|  421 | Xenserver       | XCP 1.0            | CentOS 5 (64-bit)     | Other PV (64-bit)     |
|  497 | Xenserver       | 5.6 FP1            | CentOS 5 (32-bit)     | Other PV (32-bit)     |
|  498 | Xenserver       | 5.6 FP1            | CentOS 5 (64-bit)     | Other PV (64-bit)     |
|  569 | Xenserver       | 5.6 SP2            | CentOS 5 (32-bit)     | Other PV (32-bit)     |
|  570 | Xenserver       | 5.6 SP2            | CentOS 5 (64-bit)     | Other PV (64-bit)     |
|  672 | Xenserver       | 6.0                | CentOS 5 (32-bit)     | Other PV (32-bit)     |
|  673 | Xenserver       | 6.0                | CentOS 5 (64-bit)     | Other PV (64-bit)     |
|  783 | Xenserver       | 6.0.2              | CentOS 5 (32-bit)     | Other PV (32-bit)     |
|  784 | Xenserver       | 6.0.2              | CentOS 5 (64-bit)     | Other PV (64-bit)     |
|  912 | Xenserver       | 6.1.0              | CentOS 5 (32-bit)     | Other PV (32-bit)     |
|  913 | Xenserver       | 6.1.0              | CentOS 5 (64-bit)     | Other PV (64-bit)     |
| 1061 | Xenserver       | 6.2.0              | CentOS 5 (32-bit)     | Other PV (32-bit)     |
| 1062 | Xenserver       | 6.2.0              | CentOS 5 (64-bit)     | Other PV (64-bit)     |
| 1211 | Xenserver       | 6.2.5              | CentOS 5 (32-bit)     | Other PV (32-bit)     |
| 1212 | Xenserver       | 6.2.5              | CentOS 5 (64-bit)     | Other PV (64-bit)     |
| 2018 | LXC             | default            | Ubuntu 10.04          | CentOS 5.7 (64-bit)   |
| 2019 | LXC             | default            | Ubuntu 10.04          | Ubuntu 12.04 (32-bit) |
| 2153 | Xenserver       | 6.5.0              | CentOS 5 (32-bit)     | Other PV (32-bit)     |
| 2154 | Xenserver       | 6.5.0              | CentOS 5 (64-bit)     | Other PV (64-bit)     |
+------+-----------------+--------------------+-----------------------+-----------------------+


mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "kvm" and guest_os_name like "ubuntu%" order by guest_os_name; 
+-----------------+--------------------+---------------+-----------------------+
| hypervisor_type | hypervisor_version | guest_os_name | display_name          |
+-----------------+--------------------+---------------+-----------------------+
| KVM             | default            | Ubuntu 10.04  | Ubuntu 10.04 (32-bit) |
| KVM             | default            | Ubuntu 10.04  | Ubuntu 12.04 (32-bit) |
| KVM             | default            | Ubuntu 10.04  | CentOS 5.7 (64-bit)   |
| KVM             | default            | Ubuntu 10.04  | Ubuntu 10.04 (64-bit) |
| KVM             | default            | Ubuntu 10.10  | Ubuntu 10.10 (64-bit) |
| KVM             | default            | Ubuntu 10.10  | Ubuntu 10.10 (32-bit) |
| KVM             | default            | Ubuntu 12.04  | Ubuntu 12.04 (64-bit) |
| KVM             | default            | Ubuntu 14.04  | Ubuntu 14.04 (64-bit) |
| KVM             | default            | Ubuntu 14.04  | Ubuntu 14.04 (32-bit) |
| KVM             | default            | Ubuntu 8.04   | Ubuntu 8.04 (64-bit)  |
| KVM             | default            | Ubuntu 8.04   | Ubuntu 8.04 (32-bit)  |
| KVM             | default            | Ubuntu 8.10   | Ubuntu 8.10 (64-bit)  |
| KVM             | default            | Ubuntu 8.10   | Ubuntu 8.10 (32-bit)  |
| KVM             | default            | Ubuntu 9.04   | Ubuntu 9.04 (64-bit)  |
| KVM             | default            | Ubuntu 9.04   | Ubuntu 9.04 (32-bit)  |
| KVM             | default            | Ubuntu 9.10   | Ubuntu 9.10 (64-bit)  |
| KVM             | default            | Ubuntu 9.10   | Ubuntu 9.10 (32-bit)  |
+-----------------+--------------------+---------------+-----------------------+


mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "vmware" and guest_os_name like "ubuntu %" order by guest_os_name; 
+-----------------+--------------------+-----------------------+-----------------------+
| hypervisor_type | hypervisor_version | guest_os_name         | display_name          |
+-----------------+--------------------+-----------------------+-----------------------+
| VmWare          | default            | Ubuntu 10.04 (32-bit) | Ubuntu 10.04 (32-bit) |
| VmWare          | default            | Ubuntu 10.04 (64-bit) | Ubuntu 10.04 (64-bit) |
| VmWare          | default            | Ubuntu 10.10 (32-bit) | Other Ubuntu (32-bit) |
| VmWare          | default            | Ubuntu 10.10 (64-bit) | Other Ubuntu (64-bit) |
| VmWare          | default            | Ubuntu 12.04 (32-bit) | CentOS 5.7 (64-bit)   |
| VmWare          | default            | Ubuntu 12.04 (64-bit) | Ubuntu 12.04 (32-bit) |
| VmWare          | default            | Ubuntu 8.04 (32-bit)  | Ubuntu 8.04 (32-bit)  |
| VmWare          | default            | Ubuntu 8.04 (64-bit)  | Ubuntu 8.04 (64-bit)  |
| VmWare          | default            | Ubuntu 8.10 (32-bit)  | Ubuntu 8.10 (32-bit)  |
| VmWare          | default            | Ubuntu 8.10 (64-bit)  | Ubuntu 8.10 (64-bit)  |
| VmWare          | default            | Ubuntu 9.04 (32-bit)  | Ubuntu 9.04 (32-bit)  |
| VmWare          | default            | Ubuntu 9.04 (64-bit)  | Ubuntu 9.04 (64-bit)  |
| VmWare          | default            | Ubuntu 9.10 (32-bit)  | Ubuntu 9.10 (32-bit)  |
| VmWare          | default            | Ubuntu 9.10 (64-bit)  | Ubuntu 9.10 (64-bit)  |
+-----------------+--------------------+-----------------------+-----------------------+


mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "xenserver" and guest_os_id=139;
+-----------------+--------------------+-------------------+-------------------+
| hypervisor_type | hypervisor_version | guest_os_name     | display_name      |
+-----------------+--------------------+-------------------+-------------------+
| XenServer       | default            | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | XCP 1.0            | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 5.6 FP1            | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 5.6 SP2            | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.0                | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.0.2              | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.1.0              | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.2.0              | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.2.5              | CentOS 5 (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.5.0              | CentOS 5 (32-bit) | Other PV (32-bit) |
+-----------------+--------------------+-------------------+-------------------+

mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "xenserver" and guest_os_id=140;
+-----------------+--------------------+-------------------+-------------------+
| hypervisor_type | hypervisor_version | guest_os_name     | display_name      |
+-----------------+--------------------+-------------------+-------------------+
| XenServer       | default            | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | XCP 1.0            | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 5.6 FP1            | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 5.6 SP2            | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.0                | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.0.2              | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.1.0              | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.2.0              | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.2.5              | CentOS 5 (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.5.0              | CentOS 5 (64-bit) | Other PV (64-bit) |
+-----------------+--------------------+-------------------+-------------------+

```

And here are the affected mappings after applying our fixes:

```
mysql> SELECT h.id, hypervisor_type, hypervisor_version, h.guest_os_name, g.display_name FROM guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id
    -> where h.id in ( 420, 497, 569, 672, 783, 912, 1061, 1211, 2153, 421, 498, 570, 673, 784, 913, 1062, 1212, 2154, 173, 253, 2018, 254, 2019);
+------+-----------------+--------------------+-----------------------+-----------------------+
| id   | hypervisor_type | hypervisor_version | guest_os_name         | display_name          |
+------+-----------------+--------------------+-----------------------+-----------------------+
|  173 | VmWare          | default            | Ubuntu 12.04 (32-bit) | Ubuntu 12.04 (32-bit) |
|  254 | KVM             | default            | Ubuntu 12.04          | Ubuntu 12.04 (32-bit) |
|  420 | Xenserver       | XCP 1.0            | Other PV (32-bit)     | Other PV (32-bit)     |
|  421 | Xenserver       | XCP 1.0            | Other PV (64-bit)     | Other PV (64-bit)     |
|  497 | Xenserver       | 5.6 FP1            | Other PV (32-bit)     | Other PV (32-bit)     |
|  498 | Xenserver       | 5.6 FP1            | Other PV (64-bit)     | Other PV (64-bit)     |
|  569 | Xenserver       | 5.6 SP2            | Other PV (32-bit)     | Other PV (32-bit)     |
|  570 | Xenserver       | 5.6 SP2            | Other PV (64-bit)     | Other PV (64-bit)     |
|  672 | Xenserver       | 6.0                | Other PV (32-bit)     | Other PV (32-bit)     |
|  673 | Xenserver       | 6.0                | Other PV (64-bit)     | Other PV (64-bit)     |
|  783 | Xenserver       | 6.0.2              | Other PV (32-bit)     | Other PV (32-bit)     |
|  784 | Xenserver       | 6.0.2              | Other PV (64-bit)     | Other PV (64-bit)     |
|  912 | Xenserver       | 6.1.0              | Other PV (32-bit)     | Other PV (32-bit)     |
|  913 | Xenserver       | 6.1.0              | Other PV (64-bit)     | Other PV (64-bit)     |
| 1061 | Xenserver       | 6.2.0              | Other PV (32-bit)     | Other PV (32-bit)     |
| 1062 | Xenserver       | 6.2.0              | Other PV (64-bit)     | Other PV (64-bit)     |
| 1211 | Xenserver       | 6.2.5              | Other PV (32-bit)     | Other PV (32-bit)     |
| 1212 | Xenserver       | 6.2.5              | Other PV (64-bit)     | Other PV (64-bit)     |
| 2019 | LXC             | default            | Ubuntu 12.04          | Ubuntu 12.04 (32-bit) |
| 2153 | Xenserver       | 6.5.0              | Other PV (32-bit)     | Other PV (32-bit)     |
| 2154 | Xenserver       | 6.5.0              | Other PV (64-bit)     | Other PV (64-bit)     |
+------+-----------------+--------------------+-----------------------+-----------------------+



mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "kvm" and guest_os_name like "ubuntu%" order by guest_os_name;
+-----------------+--------------------+---------------+-----------------------+
| hypervisor_type | hypervisor_version | guest_os_name | display_name          |
+-----------------+--------------------+---------------+-----------------------+
| KVM             | default            | Ubuntu 10.04  | Ubuntu 10.04 (32-bit) |
| KVM             | default            | Ubuntu 10.04  | Ubuntu 10.04 (64-bit) |
| KVM             | default            | Ubuntu 10.10  | Ubuntu 10.10 (64-bit) |
| KVM             | default            | Ubuntu 10.10  | Ubuntu 10.10 (32-bit) |
| KVM             | default            | Ubuntu 12.04  | Ubuntu 12.04 (64-bit) |
| KVM             | default            | Ubuntu 12.04  | Ubuntu 12.04 (32-bit) |
| KVM             | default            | Ubuntu 14.04  | Ubuntu 14.04 (64-bit) |
| KVM             | default            | Ubuntu 14.04  | Ubuntu 14.04 (32-bit) |
| KVM             | default            | Ubuntu 8.04   | Ubuntu 8.04 (64-bit)  |
| KVM             | default            | Ubuntu 8.04   | Ubuntu 8.04 (32-bit)  |
| KVM             | default            | Ubuntu 8.10   | Ubuntu 8.10 (64-bit)  |
| KVM             | default            | Ubuntu 8.10   | Ubuntu 8.10 (32-bit)  |
| KVM             | default            | Ubuntu 9.04   | Ubuntu 9.04 (64-bit)  |
| KVM             | default            | Ubuntu 9.04   | Ubuntu 9.04 (32-bit)  |
| KVM             | default            | Ubuntu 9.10   | Ubuntu 9.10 (64-bit)  |
| KVM             | default            | Ubuntu 9.10   | Ubuntu 9.10 (32-bit)  |
+-----------------+--------------------+---------------+-----------------------+

mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "vmware" and guest_os_name like "ubuntu %" order by guest_os_name;
+-----------------+--------------------+-----------------------+-----------------------+
| hypervisor_type | hypervisor_version | guest_os_name         | display_name          |
+-----------------+--------------------+-----------------------+-----------------------+
| VmWare          | default            | Ubuntu 10.04 (32-bit) | Ubuntu 10.04 (32-bit) |
| VmWare          | default            | Ubuntu 10.04 (64-bit) | Ubuntu 10.04 (64-bit) |
| VmWare          | default            | Ubuntu 10.10 (32-bit) | Other Ubuntu (32-bit) |
| VmWare          | default            | Ubuntu 10.10 (64-bit) | Other Ubuntu (64-bit) |
| VmWare          | default            | Ubuntu 12.04 (32-bit) | Ubuntu 12.04 (32-bit) |
| VmWare          | default            | Ubuntu 12.04 (64-bit) | Ubuntu 12.04 (64-bit) |
| VmWare          | default            | Ubuntu 8.04 (32-bit)  | Ubuntu 8.04 (32-bit)  |
| VmWare          | default            | Ubuntu 8.04 (64-bit)  | Ubuntu 8.04 (64-bit)  |
| VmWare          | default            | Ubuntu 8.10 (32-bit)  | Ubuntu 8.10 (32-bit)  |
| VmWare          | default            | Ubuntu 8.10 (64-bit)  | Ubuntu 8.10 (64-bit)  |
| VmWare          | default            | Ubuntu 9.04 (32-bit)  | Ubuntu 9.04 (32-bit)  |
| VmWare          | default            | Ubuntu 9.04 (64-bit)  | Ubuntu 9.04 (64-bit)  |
| VmWare          | default            | Ubuntu 9.10 (32-bit)  | Ubuntu 9.10 (32-bit)  |
| VmWare          | default            | Ubuntu 9.10 (64-bit)  | Ubuntu 9.10 (64-bit)  |
+-----------------+--------------------+-----------------------+-----------------------+

mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "xenserver" and guest_os_id=139;
+-----------------+--------------------+-------------------+-------------------+
| hypervisor_type | hypervisor_version | guest_os_name     | display_name      |
+-----------------+--------------------+-------------------+-------------------+
| XenServer       | default            | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | XCP 1.0            | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 5.6 FP1            | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 5.6 SP2            | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.0                | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.0.2              | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.1.0              | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.2.0              | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.2.5              | Other PV (32-bit) | Other PV (32-bit) |
| Xenserver       | 6.5.0              | Other PV (32-bit) | Other PV (32-bit) |
+-----------------+--------------------+-------------------+-------------------+


mysql> select h.hypervisor_type, h.hypervisor_version, h.guest_os_name,  g.display_name from guest_os_hypervisor h join guest_os g on g.id = h.guest_os_id where hypervisor_type = "xenserver" and guest_os_id=140;
+-----------------+--------------------+-------------------+-------------------+
| hypervisor_type | hypervisor_version | guest_os_name     | display_name      |
+-----------------+--------------------+-------------------+-------------------+
| XenServer       | default            | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | XCP 1.0            | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 5.6 FP1            | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 5.6 SP2            | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.0                | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.0.2              | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.1.0              | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.2.0              | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.2.5              | Other PV (64-bit) | Other PV (64-bit) |
| Xenserver       | 6.5.0              | Other PV (64-bit) | Other PV (64-bit) |
+-----------------+--------------------+-------------------+-------------------+
```
