### PR TITLE
CLOUDSTACK-9417: Usage module refactoring

### DIFF
--- a/debian/cloudstack-usage.install
+++ b/debian/cloudstack-usage.install
@@ -20,3 +20,5 @@
 /etc/init.d/cloudstack-usage
 /etc/cloudstack/usage/*
 /etc/default/cloudstack-usage
+/var/cache/cloudstack/usage
+

--- a/debian/cloudstack-usage.postinst
+++ b/debian/cloudstack-usage.postinst
@@ -43,6 +43,10 @@ case "$1" in
             rm -rf /etc/cloudstack/usage/key
             ln -s /etc/cloudstack/management/key /etc/cloudstack/usage/key
         fi
+
+        # Usage cache folder permissions
+        chmod 0770 /var/cache/cloudstack/usage
+        chgrp cloud /var/cache/cloudstack/usage
         ;;
 esac
 

--- a/debian/rules
+++ b/debian/rules
@@ -128,6 +128,7 @@ override_dh_auto_install:
 	mkdir $(DESTDIR)/$(SYSCONFDIR)/$(PACKAGE)/usage
 	mkdir $(DESTDIR)/usr/share/$(PACKAGE)-usage
 	mkdir $(DESTDIR)/usr/share/$(PACKAGE)-usage/plugins
+	mkdir $(DESTDIR)/var/cache/$(PACKAGE)/usage
 	install -D usage/target/cloud-usage-$(VERSION).jar $(DESTDIR)/usr/share/$(PACKAGE)-usage/lib/$(PACKAGE)-usage.jar
 	install -D usage/target/dependencies/* $(DESTDIR)/usr/share/$(PACKAGE)-usage/lib/
 	cp usage/target/transformed/db.properties $(DESTDIR)/$(SYSCONFDIR)/$(PACKAGE)/usage/

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -240,6 +240,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
@@ -329,6 +330,7 @@ chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 
@@ -572,6 +574,10 @@ fi
 pip install --upgrade http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
 pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 
+if [ -f "/usr/local/libexec/sanity-check-last-id" ]; then
+    cp /usr/local/libexec/sanity-check-last-id %{_localstatedir}/cache/%{name}/usage
+fi
+
 #No default permission as the permission setup is complex
 %files management
 %defattr(-,root,root,-)
@@ -670,6 +676,7 @@ pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 %attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
 %{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/usage
 
 %files cli
 %attr(0644,root,root) %{python_sitearch}/cloudapis.py

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -208,6 +208,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
@@ -301,6 +302,7 @@ chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 
@@ -474,6 +476,10 @@ fi
 pip install --upgrade http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
 pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 
+if [ -f "/usr/local/libexec/sanity-check-last-id" ]; then
+    cp /usr/local/libexec/sanity-check-last-id %{_localstatedir}/cache/%{name}/usage
+fi
+
 #No default permission as the permission setup is complex
 %files management
 %defattr(-,root,root,-)
@@ -573,6 +579,7 @@ pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz
 %attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
 %{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/usage
 
 %files cli
 %attr(0644,root,root) %{python_sitearch}/cloudapis.py

--- a/packaging/fedora20/cloud.spec
+++ b/packaging/fedora20/cloud.spec
@@ -221,6 +221,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
@@ -308,6 +309,7 @@ chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 
@@ -625,6 +627,7 @@ fi
 %attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
 %{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/usage
 
 %files cli
 %attr(0644,root,root) %{python_sitearch}/cloudapis.py

--- a/packaging/fedora21/cloud.spec
+++ b/packaging/fedora21/cloud.spec
@@ -221,6 +221,7 @@ mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/ipallocator
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 mkdir -p ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 mkdir -p ${RPM_BUILD_ROOT}%{_initrddir}
@@ -308,6 +309,7 @@ chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/mnt
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/work
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/management/temp
+chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/cache/%{name}/usage
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/management
 chmod 770 ${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}/agent
 
@@ -625,6 +627,7 @@ fi
 %attr(0644,root,root) %{_sysconfdir}/%{name}/usage/log4j-cloud.xml
 %{_defaultdocdir}/%{name}-usage-%{version}/LICENSE
 %{_defaultdocdir}/%{name}-usage-%{version}/NOTICE
+%dir %attr(0770,root,cloud) %{_localstatedir}/cache/%{name}/usage
 
 %files cli
 %attr(0644,root,root) %{python_sitearch}/cloudapis.py

--- a/usage/conf/log4j-cloud_usage.xml.in
+++ b/usage/conf/log4j-cloud_usage.xml.in
@@ -48,7 +48,7 @@ under the License.
       </rollingPolicy>
 
       <layout class="org.apache.log4j.EnhancedPatternLayout">
-         <param name="ConversionPattern" value="%-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%n"/>
+         <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%n"/>
       </layout>
    </appender>
 


### PR DESCRIPTION
JIRA Ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-9417
### Introduction

Usage sanity check file was not been updated on sanity check.

It is proposed:
- New usage folder `/var/cache/cloudstack/usage,` creation on `cloudstack-usage` package built.
- New sanity check file location in new folder `/var/cache/cloudstack/usage`
- Timestamp included in `usage.log` file
- Include `updateMaxId()` on sanity check as it wasn't being updated
