### PR TITLE
ui: show resize volume button to all users

### DIFF
--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -2365,10 +2365,8 @@
             }
         }
 
-        if (jsonObj.hypervisor == "KVM" || jsonObj.hypervisor == "XenServer" || jsonObj.hypervisor == "VMware") {
-            if (jsonObj.state == "Ready" || jsonObj.state == "Allocated") {
-                allowedActions.push("resize");
-            }
+        if (jsonObj.state == "Ready" || jsonObj.state == "Allocated") {
+            allowedActions.push("resize");
         }
 
         if (jsonObj.state != "Allocated") {


### PR DESCRIPTION
![screenshot from 2016-06-23 12-29-56](https://cloud.githubusercontent.com/assets/95203/16294438/436f6dbc-393e-11e6-91b5-cb2e49a01cc6.png)

The resize volume is support on all major hypervisors (Xen, VMware, KVM).
The hypervisor key is returned by the list volumes response only for admins
but not for users or domain admin users. This removes the check, as the operation
is supported on all major hypervisors that CloudStack supports.

With this bug fix all users would see resize volume button in the UI.

/cc @swill 