### PR TITLE
CLOUDSTACK-9348: Reduce Nio selector wait time

### DIFF
--- a/utils/src/main/java/com/cloud/utils/nio/NioConnection.java
+++ b/utils/src/main/java/com/cloud/utils/nio/NioConnection.java
@@ -125,7 +125,7 @@ public abstract class NioConnection implements Callable<Boolean> {
     public Boolean call() throws NioConnectionException {
         while (_isRunning) {
             try {
-                _selector.select(1000);
+                _selector.select(100);
 
                 // Someone is ready for I/O, get the ready keys
                 final Set<SelectionKey> readyKeys = _selector.selectedKeys();


### PR DESCRIPTION
This reduced the Nio loop selector wait time, this way the selector will
check frequently (as much as 100ms per iteration) and handle any pending
connection/tasks. This would make reconnections very quick at the expense of
some CPU usage.

/cc @swill @kiwiflyer guys can you please apply this fix in your env and test if you're still able to produce any Nio related error b/w mgmt server(s) and kvm agent(s) not being able to connect quickly. Please also watch out for any increased CPU usage (there should not be any significant change), in which case we may increase the timeout from 100ms to 200-400ms.