### PR TITLE
CLOUDSTACK-9422: Granular 'vmware.create.full.clone' as Primary Storage setting

### DIFF
--- a/core/src/org/apache/cloudstack/storage/to/PrimaryDataStoreTO.java
+++ b/core/src/org/apache/cloudstack/storage/to/PrimaryDataStoreTO.java
@@ -51,6 +51,7 @@ public class PrimaryDataStoreTO implements DataStoreTO {
     private final String url;
     private Map<String, String> details;
     private static final String pathSeparator = "/";
+    private Boolean fullCloneFlag;
 
     public PrimaryDataStoreTO(PrimaryDataStore dataStore) {
         this.uuid = dataStore.getUuid();
@@ -143,5 +144,13 @@ public class PrimaryDataStoreTO implements DataStoreTO {
             .append(poolType)
             .append("]")
             .toString();
+    }
+
+    public Boolean isFullCloneFlag() {
+        return fullCloneFlag;
+    }
+
+    public void setFullCloneFlag(Boolean fullCloneFlag) {
+        this.fullCloneFlag = fullCloneFlag;
     }
 }

--- a/engine/components-api/src/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/com/cloud/capacity/CapacityManager.java
@@ -35,6 +35,7 @@ public interface CapacityManager {
     static final String StorageCapacityDisableThresholdCK = "pool.storage.capacity.disablethreshold";
     static final String StorageOverprovisioningFactorCK = "storage.overprovisioning.factor";
     static final String StorageAllocatedCapacityDisableThresholdCK = "pool.storage.allocated.capacity.disablethreshold";
+    static final String VmwareCreateCloneFullCK = "vmware.create.full.clone";
 
     static final ConfigKey<Float> CpuOverprovisioningFactor = new ConfigKey<Float>(Float.class, CpuOverprovisioningFactorCK, "Advanced", "1.0",
         "Used for CPU overprovisioning calculation; available CPU will be (actualCpuCapacity * cpu.overprovisioning.factor)", true, ConfigKey.Scope.Cluster, null);
@@ -63,6 +64,15 @@ public interface CapacityManager {
                     true,
                     ConfigKey.Scope.Cluster,
                     null);
+    static final ConfigKey<Boolean> VmwareCreateCloneFull =
+            new ConfigKey<Boolean>(
+                    "Storage",
+                    Boolean.class,
+                    VmwareCreateCloneFullCK,
+                    "false",
+                    "If set to true, creates VMs as full clones on ESX hypervisor",
+                    true,
+                    ConfigKey.Scope.StoragePool);
 
     public boolean releaseVmCapacity(VirtualMachine vm, boolean moveFromReserved, boolean moveToReservered, Long hostId);
 

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -69,6 +69,7 @@ import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.DiskTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.agent.manager.allocator.PodAllocator;
+import com.cloud.capacity.CapacityManager;
 import com.cloud.cluster.ClusterManager;
 import com.cloud.configuration.Resource.ResourceType;
 import com.cloud.dc.DataCenter;
@@ -120,6 +121,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.vm.DiskProfile;
+import com.cloud.vm.UserVmCloneSettingVO;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
@@ -129,9 +131,15 @@ import com.cloud.vm.VmWorkAttachVolume;
 import com.cloud.vm.VmWorkMigrateVolume;
 import com.cloud.vm.VmWorkSerializer;
 import com.cloud.vm.VmWorkTakeVolumeSnapshot;
+import com.cloud.vm.dao.UserVmCloneSettingDao;
 import com.cloud.vm.dao.UserVmDao;
 
 public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrationService, Configurable {
+
+    public enum UserVmCloneType {
+        full, linked
+    }
+
     private static final Logger s_logger = Logger.getLogger(VolumeOrchestrator.class);
 
     @Inject
@@ -178,6 +186,8 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
     ClusterManager clusterManager;
     @Inject
     StorageManager storageMgr;
+    @Inject
+    protected UserVmCloneSettingDao _vmCloneSettingDao;
 
     private final StateMachine2<Volume.State, Volume.Event, Volume> _volStateMachine;
     protected List<StoragePoolAllocator> _storagePoolAllocators;
@@ -1353,6 +1363,33 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
             disk.setDetails(getDetails(volumeInfo, dataStore));
 
             vm.addDisk(disk);
+
+            // If hypervisor is vSphere, check for clone type setting.
+            if (vm.getHypervisorType().equals(HypervisorType.VMware)) {
+                // retrieve clone flag.
+                UserVmCloneType cloneType = UserVmCloneType.linked;
+                Boolean value = CapacityManager.VmwareCreateCloneFull.valueIn(vol.getPoolId());
+                if (value != null && value) {
+                    cloneType = UserVmCloneType.full;
+                }
+                try {
+                    UserVmCloneSettingVO cloneSettingVO = _vmCloneSettingDao.findByVmId(vm.getId());
+                    if (cloneSettingVO != null){
+                        if (! cloneSettingVO.getCloneType().equals(cloneType.toString())){
+                            cloneSettingVO.setCloneType(cloneType.toString());
+                            _vmCloneSettingDao.update(cloneSettingVO.getVmId(), cloneSettingVO);
+                        }
+                    }
+                    else {
+                        UserVmCloneSettingVO vmCloneSettingVO = new UserVmCloneSettingVO(vm.getId(), cloneType.toString());
+                        _vmCloneSettingDao.persist(vmCloneSettingVO);
+                    }
+                }
+                catch (Throwable e){
+                    s_logger.debug("[NSX_PLUGIN_LOG] ERROR: " + e.getMessage());
+                }
+            }
+
         }
     }
 

--- a/engine/schema/src/com/cloud/vm/UserVmCloneSettingVO.java
+++ b/engine/schema/src/com/cloud/vm/UserVmCloneSettingVO.java
@@ -46,4 +46,8 @@ public class UserVmCloneSettingVO {
     public String getCloneType() {
         return this.cloneType;
     }
+
+    public void setCloneType(String cloneType) {
+        this.cloneType = cloneType;
+    }
 }

--- a/engine/schema/src/com/cloud/vm/dao/UserVmCloneSettingDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/UserVmCloneSettingDaoImpl.java
@@ -45,7 +45,7 @@ public class UserVmCloneSettingDaoImpl extends GenericDaoBase<UserVmCloneSetting
     public void init() {
         // Initialize the search builders.
         vmIdSearch = createSearchBuilder();
-        vmIdSearch.and("vmId", vmIdSearch.entity().getCloneType(), Op.EQ);
+        vmIdSearch.and("vmId", vmIdSearch.entity().getVmId(), Op.EQ);
         vmIdSearch.done();
 
         cloneTypeSearch = createSearchBuilder();

--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -45,6 +45,7 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.RemoteHostEndPoint;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.image.datastore.ImageStoreEntity;
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -56,8 +57,10 @@ import com.cloud.agent.api.to.DataStoreTO;
 import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.NfsTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.capacity.CapacityManager;
 import com.cloud.configuration.Config;
 import com.cloud.host.Host;
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.StoragePool;
@@ -153,7 +156,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                 srcForCopy = cacheData = cacheMgr.createCacheObject(srcData, destScope);
             }
 
-            CopyCommand cmd = new CopyCommand(srcForCopy.getTO(), destData.getTO(), _primaryStorageDownloadWait, VirtualMachineManager.ExecuteInSequence.value());
+            CopyCommand cmd = new CopyCommand(srcForCopy.getTO(), addFullCloneFlagOnVMwareDest(destData.getTO()), _primaryStorageDownloadWait, VirtualMachineManager.ExecuteInSequence.value());
             EndPoint ep = destHost != null ? RemoteHostEndPoint.getHypervisorHostEndPoint(destHost) : selector.select(srcForCopy, destData);
             if (ep == null) {
                 String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
@@ -199,6 +202,23 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
             }
             throw new CloudRuntimeException(e.toString());
         }
+    }
+
+    /**
+     * Adds {@code 'vmware.create.full.clone'} value for a given primary storage, whose HV is VMware, on datastore's {@code fullCloneFlag} field
+     * @param dataTO Dest data store TO
+     * @return dataTO including fullCloneFlag, if provided
+     */
+    protected DataTO addFullCloneFlagOnVMwareDest(DataTO dataTO) {
+        if (dataTO != null && dataTO.getHypervisorType().equals(Hypervisor.HypervisorType.VMware)){
+            DataStoreTO dataStoreTO = dataTO.getDataStore();
+            if (dataStoreTO != null && dataStoreTO instanceof PrimaryDataStoreTO){
+                PrimaryDataStoreTO primaryDataStoreTO = (PrimaryDataStoreTO) dataStoreTO;
+                Boolean value = CapacityManager.VmwareCreateCloneFull.valueIn(primaryDataStoreTO.getId());
+                primaryDataStoreTO.setFullCloneFlag(value);
+            }
+        }
+        return dataTO;
     }
 
     protected Answer copyObject(DataObject srcData, DataObject destData) {
@@ -257,7 +277,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                 ep = selector.select(srcData, volObj);
             }
 
-            CopyCommand cmd = new CopyCommand(srcData.getTO(), volObj.getTO(), _createVolumeFromSnapshotWait, VirtualMachineManager.ExecuteInSequence.value());
+            CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneFlagOnVMwareDest(volObj.getTO()), _createVolumeFromSnapshotWait, VirtualMachineManager.ExecuteInSequence.value());
             Answer answer = null;
             if (ep == null) {
                 String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
@@ -280,7 +300,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
     }
 
     protected Answer cloneVolume(DataObject template, DataObject volume) {
-        CopyCommand cmd = new CopyCommand(template.getTO(), volume.getTO(), 0, VirtualMachineManager.ExecuteInSequence.value());
+        CopyCommand cmd = new CopyCommand(template.getTO(), addFullCloneFlagOnVMwareDest(volume.getTO()), 0, VirtualMachineManager.ExecuteInSequence.value());
         try {
             EndPoint ep = selector.select(volume.getDataStore());
             Answer answer = null;
@@ -330,7 +350,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
 
             objOnImageStore.processEvent(Event.CopyingRequested);
 
-            CopyCommand cmd = new CopyCommand(objOnImageStore.getTO(), destData.getTO(), _copyvolumewait, VirtualMachineManager.ExecuteInSequence.value());
+            CopyCommand cmd = new CopyCommand(objOnImageStore.getTO(), addFullCloneFlagOnVMwareDest(destData.getTO()), _copyvolumewait, VirtualMachineManager.ExecuteInSequence.value());
             EndPoint ep = selector.select(objOnImageStore, destData);
             if (ep == null) {
                 String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
@@ -477,7 +497,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
             ep = selector.select(srcData, destData);
         }
 
-        CopyCommand cmd = new CopyCommand(srcData.getTO(), destData.getTO(), _createprivatetemplatefromsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
+        CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneFlagOnVMwareDest(destData.getTO()), _createprivatetemplatefromsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
         Answer answer = null;
         if (ep == null) {
             String errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
@@ -513,7 +533,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                 Scope selectedScope = pickCacheScopeForCopy(srcData, destData);
                 cacheData = cacheMgr.getCacheObject(srcData, selectedScope);
 
-                CopyCommand cmd = new CopyCommand(srcData.getTO(), destData.getTO(), _backupsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
+                CopyCommand cmd = new CopyCommand(srcData.getTO(), addFullCloneFlagOnVMwareDest(destData.getTO()), _backupsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
                 cmd.setCacheTO(cacheData.getTO());
                 cmd.setOptions(options);
                 EndPoint ep = selector.select(srcData, destData);
@@ -525,6 +545,7 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
                     answer = ep.sendMessage(cmd);
                 }
             } else {
+                addFullCloneFlagOnVMwareDest(destData.getTO());
                 CopyCommand cmd = new CopyCommand(srcData.getTO(), destData.getTO(), _backupsnapshotwait, VirtualMachineManager.ExecuteInSequence.value());
                 cmd.setOptions(options);
                 EndPoint ep = selector.select(srcData, destData, StorageAction.BACKUPSNAPSHOT);

--- a/engine/storage/datamotion/test/org/apache/cloudstack/storage/motion/AncientDataMotionStrategyTest.java
+++ b/engine/storage/datamotion/test/org/apache/cloudstack/storage/motion/AncientDataMotionStrategyTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cloudstack.storage.motion;
+
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.any;
+
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cloud.agent.api.to.DataTO;
+import com.cloud.capacity.CapacityManager;
+import com.cloud.hypervisor.Hypervisor.HypervisorType;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(CapacityManager.class)
+public class AncientDataMotionStrategyTest {
+
+    @Spy
+    @InjectMocks
+    private AncientDataMotionStrategy strategy = new AncientDataMotionStrategy();
+
+    @Mock
+    DataTO dataTO;
+    @Mock
+    PrimaryDataStoreTO dataStoreTO;
+    @Mock
+    ConfigKey<Boolean> vmwareKey;
+
+    private static final long POOL_ID = 1l;
+    private static final Boolean FULL_CLONE_FLAG = true;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        replaceVmwareCreateCloneFullField();
+
+        when(vmwareKey.valueIn(POOL_ID)).thenReturn(FULL_CLONE_FLAG);
+
+        when(dataTO.getHypervisorType()).thenReturn(HypervisorType.VMware);
+        when(dataTO.getDataStore()).thenReturn(dataStoreTO);
+        when(dataStoreTO.getId()).thenReturn(POOL_ID);
+    }
+
+    private void replaceVmwareCreateCloneFullField() throws Exception {
+        Field field = CapacityManager.class.getDeclaredField("VmwareCreateCloneFull");
+        field.setAccessible(true);
+        // remove final modifier from field
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, vmwareKey);
+    }
+
+    @Test
+    public void testAddFullCloneFlagOnVMwareDest(){
+        strategy.addFullCloneFlagOnVMwareDest(dataTO);
+        verify(dataStoreTO).setFullCloneFlag(FULL_CLONE_FLAG);
+    }
+
+    @Test
+    public void testAddFullCloneFlagOnNotVmwareDest(){
+        when(dataTO.getHypervisorType()).thenReturn(HypervisorType.Any);
+        verify(dataStoreTO, never()).setFullCloneFlag(any(Boolean.class));
+    }
+
+}

--- a/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -114,11 +114,25 @@ import com.cloud.vm.VmDetailConstants;
 
 public class VmwareStorageProcessor implements StorageProcessor {
 
+    public enum VmwareStorageProcessorConfigurableFields {
+        NFS_VERSION("nfsVersion"), FULL_CLONE_FLAG("fullCloneFlag");
+
+        private String name;
+
+        VmwareStorageProcessorConfigurableFields(String name){
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
     private static final Logger s_logger = Logger.getLogger(VmwareStorageProcessor.class);
     private static final int DEFAULT_NFS_PORT = 2049;
 
     private final VmwareHostService hostService;
-    private final boolean _fullCloneFlag;
+    private boolean _fullCloneFlag;
     private final VmwareStorageMount mountService;
     private final VmwareResource resource;
     private final Integer _timeout;
@@ -2393,5 +2407,10 @@ public class VmwareStorageProcessor implements StorageProcessor {
     public void setNfsVersion(Integer nfsVersion){
         this._nfsVersion = nfsVersion;
         s_logger.debug("VmwareProcessor instance now using NFS version: " + nfsVersion);
+    }
+
+    public void setFullCloneFlag(boolean value){
+        this._fullCloneFlag = value;
+        s_logger.debug("VmwareProcessor instance - create full clone = " + (value ? "TRUE" : "FALSE"));
     }
 }

--- a/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareStorageSubsystemCommandHandler.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareStorageSubsystemCommandHandler.java
@@ -19,6 +19,7 @@
 package com.cloud.storage.resource;
 
 import java.io.File;
+import java.util.EnumMap;
 
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.storage.command.CopyCmdAnswer;
@@ -37,6 +38,7 @@ import com.cloud.agent.api.to.S3TO;
 import com.cloud.agent.api.to.SwiftTO;
 import com.cloud.hypervisor.vmware.manager.VmwareStorageManager;
 import com.cloud.storage.DataStoreRole;
+import com.cloud.storage.resource.VmwareStorageProcessor.VmwareStorageProcessorConfigurableFields;
 
 public class VmwareStorageSubsystemCommandHandler extends StorageSubsystemCommandHandlerBase {
 
@@ -66,21 +68,25 @@ public class VmwareStorageSubsystemCommandHandler extends StorageSubsystemComman
         this._nfsVersion = nfsVersion;
     }
 
-    /**
-     * Reconfigure NFS version for storage operations
-     * @param nfsVersion NFS version to set
-     * @return true if NFS version could be configured, false in other case
-     */
-    public boolean reconfigureNfsVersion(Integer nfsVersion){
-        try {
-            VmwareStorageProcessor processor = (VmwareStorageProcessor) this.processor;
-            processor.setNfsVersion(nfsVersion);
-            this._nfsVersion = nfsVersion;
-            return true;
-        } catch (Exception e){
-            s_logger.error("Error while reconfiguring NFS version " + nfsVersion);
-            return false;
+    public boolean reconfigureStorageProcessor(EnumMap<VmwareStorageProcessorConfigurableFields,Object> params) {
+        VmwareStorageProcessor processor = (VmwareStorageProcessor) this.processor;
+        for (VmwareStorageProcessorConfigurableFields key : params.keySet()){
+            switch (key){
+            case NFS_VERSION:
+                Integer nfsVersion = (Integer) params.get(key);
+                processor.setNfsVersion(nfsVersion);
+                this._nfsVersion = nfsVersion;
+                break;
+            case FULL_CLONE_FLAG:
+                boolean fullClone = (boolean) params.get(key);
+                processor.setFullCloneFlag(fullClone);
+                break;
+            default:
+                s_logger.error("Unknown reconfigurable field " + key.getName() + " for VmwareStorageProcessor");
+                return false;
+            }
         }
+        return true;
     }
 
     @Override
@@ -187,4 +193,5 @@ public class VmwareStorageSubsystemCommandHandler extends StorageSubsystemComman
             return super.execute(cmd);
         }
     }
+
 }

--- a/server/src/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/com/cloud/capacity/CapacityManagerImpl.java
@@ -1101,6 +1101,6 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {CpuOverprovisioningFactor, MemOverprovisioningFactor, StorageCapacityDisableThreshold, StorageOverprovisioningFactor,
-            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster};
+            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster, VmwareCreateCloneFull};
     }
 }

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -281,7 +281,6 @@ import com.cloud.vm.dao.InstanceGroupDao;
 import com.cloud.vm.dao.InstanceGroupVMMapDao;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.SecondaryStorageVmDao;
-import com.cloud.vm.dao.UserVmCloneSettingDao;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
@@ -295,10 +294,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     private static final int ACQUIRE_GLOBAL_LOCK_TIMEOUT_FOR_COOPERATION = 3; // 3
 
     // seconds
-
-    public enum UserVmCloneType {
-        full, linked
-    }
 
     @Inject
     EntityManager _entityMgr;
@@ -318,8 +313,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     protected TemplateDataStoreDao _templateStoreDao;
     @Inject
     protected DomainDao _domainDao = null;
-    @Inject
-    protected UserVmCloneSettingDao _vmCloneSettingDao = null;
     @Inject
     protected UserVmDao _vmDao = null;
     @Inject
@@ -3554,19 +3547,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     vm.setDisplayVm(isDisplayVm);
                 } else {
                     vm.setDisplayVm(true);
-                }
-
-                // If hypervisor is vSphere, check for clone type setting.
-                if (hypervisorType.equals(HypervisorType.VMware)) {
-                    // retrieve clone flag.
-                    UserVmCloneType cloneType = UserVmCloneType.linked;
-                    String value = _configDao.getValue(Config.VmwareCreateFullClone.key());
-                    if (value != null) {
-                        if (Boolean.parseBoolean(value) == true)
-                            cloneType = UserVmCloneType.full;
-                    }
-                    UserVmCloneSettingVO vmCloneSettingVO = new UserVmCloneSettingVO(id, cloneType.toString());
-                    _vmCloneSettingDao.persist(vmCloneSettingVO);
                 }
 
                 long guestOSId = template.getGuestOSId();


### PR DESCRIPTION
### Introduction

For VMware, It is possible to decide creating VMs as full clones on ESX HV, adjusting `vmware.create.full.clone` global setting. We would like to introduce this property as a primary storage detail, and use its value instead of global setting's value.

### Proposed solution
We propose introducing `fullCloneFlag` on `PrimaryDataStoreTO` sent on `CopyCommand`. This way we can reconfigure `VmwareStorageProcessor` and `VmwareStorageSubsystemCommandHandler` similar as it was done for `nfsVersion` but refactoring it to be more general.