### PR TITLE
improvement: systemvm slow operations

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -593,9 +593,11 @@ class CsIP:
         return ip in self.address.values()
 
     def arpPing(self):
+        if not self.address['gateway'] or self.address['gateway'] == 'None':
+            return
         cmd = "arping -c 1 -I %s -A -U -s %s %s" % (
             self.dev, self.address['public_ip'], self.address['gateway'])
-        CsHelper.execute(cmd)
+        CsHelper.execute_background(cmd)
 
     # Delete any ips that are configured but not in the bag
     def compare(self, bag):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -24,8 +24,16 @@ import logging
 import os.path
 import re
 import shutil
+
+try:
+    from subprocess import DEVNULL # py3k
+except ImportError:
+    import os
+    DEVNULL = open(os.devnull, 'wb')
+
 from netaddr import *
 from pprint import pprint
+
 
 PUBLIC_INTERFACES = {"router" : "eth2", "vpcrouter" : "eth1"}
 
@@ -180,11 +188,35 @@ def get_hostname():
 
 
 def execute(command):
-    """ Execute command """
+    """Execute a command in a new process and return stdout
+
+    The command is executed in a shell (which allow use of pipes and such),
+    wait for the command to terminate, and return stdout.
+
+    :param command: command with arguments to be executed,
+                    see :py:class:`subprocess.Popen`
+    :type command: str or list or tuple
+    :return: command stdout
+    :rtype: list
+    """
     logging.debug("Executing: %s" % command)
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    result = p.communicate()[0]
-    return result.splitlines()
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=DEVNULL, shell=True)
+    return p.communicate()[0].splitlines()
+
+
+def execute_background(command):
+    """Execute a command in a new process
+
+    The command is executed in a shell (which allow use of pipes and such).
+    The function does not wait command completion to return.
+
+    :param command: command with arguments to be executed,
+                    see :py:class:`subprocess.Popen`
+    :type command: str or list or tuple
+    :return: None
+    """
+    logging.debug("Executing: %s" % command)
+    subprocess.Popen(command, stdout=DEVNULL, stderr=DEVNULL, shell=True)
 
 
 def save_iptables(command, iptables_file):

--- a/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -230,12 +230,9 @@ class updateDataBag:
             dp['add'] = True
             dp['one_to_one_nat'] = False
             if nw_type == "public":
-                dp['gateway'] = self.qFile.data['cmd_line']['gateway']
+                dp['gateway'] = self.qFile.data['cmd_line'].get('gateway', 'None')
             else:
-                if('localgw' in self.qFile.data['cmd_line']):
-                    dp['gateway'] = self.qFile.data['cmd_line']['localgw']
-                else:
-                    dp['gateway'] = 'None'
+                dp['gateway'] = self.qFile.data['cmd_line'].get('localgw', 'None')
             dp['nic_dev_id'] = num
             dp['nw_type'] = nw_type
             qf = QueueFile()


### PR DESCRIPTION
On our setup we had issues with vrouters when a large number of VM were created at once.

The vrouters try to arping the gateway (to refresh the ARP cache I suppose), but in some case it take too much time and the vrouters got killed for being unresponsive.

The following patches attempt to solve this by:
- a96ab18f, 8908371b defensive fix, maybe a bug?
- fce10c55 do not block on arping command

This patch has been running for a month on our test environment and seems to solve the initial problem.

An operation (starting 220 VM on XenServer, shared storage) which took 46 mn, now take 4 mn (without errors).
