### PR TITLE
CLOUDSTACK-9428: Fix for CLOUDSTACK-9211 - Improve performance of 3D GPU support in cloud-plugin-hypervisor-vmware

### DIFF
--- a/api/src/com/cloud/vm/VmDetailConstants.java
+++ b/api/src/com/cloud/vm/VmDetailConstants.java
@@ -23,4 +23,5 @@ public interface VmDetailConstants {
     public static final String NESTED_VIRTUALIZATION_FLAG = "nestedVirtualizationFlag";
     public static final String HYPERVISOR_TOOLS_VERSION = "hypervisortoolsversion";
     public static final String DATA_DISK_CONTROLLER = "dataDiskController";
+    public static final String SVGA_VRAM_SIZE = "svga.vramSize";
 }

--- a/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
+++ b/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
@@ -19,13 +19,14 @@ package com.cloud.hypervisor.vmware.resource;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Matchers.eq;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,8 +35,10 @@ import org.apache.cloudstack.storage.command.CopyCommand;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.powermock.api.mockito.PowerMockito;
@@ -43,6 +46,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.vmware.vim25.VirtualDevice;
+import com.vmware.vim25.VirtualDeviceConfigSpec;
 import com.vmware.vim25.VirtualMachineConfigSpec;
 import com.vmware.vim25.VirtualMachineVideoCard;
 import com.cloud.agent.api.Command;
@@ -99,6 +103,10 @@ public class VmwareResourceTest {
     @Mock
     VirtualMachineTO vmSpec3dgpu;
     @Mock
+    VirtualMachineVideoCard videoCard;
+    @Mock
+    VirtualDevice virtualDevice;
+    @Mock
     DataTO srcDataTO;
     @Mock
     NfsTO srcDataNfsTO;
@@ -107,9 +115,11 @@ public class VmwareResourceTest {
 
     private static final Integer NFS_VERSION = Integer.valueOf(3);
     private static final Integer NFS_VERSION_NOT_PRESENT = null;
+    private static final long VRAM_MEMORY_SIZE = 131072l;
+    private static final long VIDEO_CARD_MEMORY_SIZE = 65536l;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
         storageCmd = PowerMockito.mock(CopyCommand.class);
         doReturn(context).when(_resource).getServiceContext(null);
@@ -117,6 +127,7 @@ public class VmwareResourceTest {
         when(storageCmd.getSrcTO()).thenReturn(srcDataTO);
         when(srcDataTO.getDataStore()).thenReturn(srcDataNfsTO);
         when(srcDataNfsTO.getNfsVersion()).thenReturn(NFS_VERSION);
+        when(videoCard.getVideoRamSizeInKB()).thenReturn(VIDEO_CARD_MEMORY_SIZE);
     }
 
     //Test successful scaling up the vm
@@ -138,19 +149,56 @@ public class VmwareResourceTest {
     }
 
     @Test
-    public void testStartVm3dgpuEnabled() throws Exception{
+    public void testConfigureVideoCardSvgaVramProvided() throws Exception {
         Map<String, String> specDetails = new HashMap<String, String>();
-        specDetails.put("svga.vramSize", "131072");
+        specDetails.put("svga.vramSize", String.valueOf(VRAM_MEMORY_SIZE));
         when(vmSpec3dgpu.getDetails()).thenReturn(specDetails);
 
-        VirtualMachineVideoCard videoCard = mock(VirtualMachineVideoCard.class);
-        when(videoCard.getVideoRamSizeInKB()).thenReturn(65536l);
-        when(vmMo3dgpu.getAllDeviceList()).thenReturn(Arrays.asList((VirtualDevice) videoCard));
+        _resource.configureVideoCard(vmMo3dgpu, vmSpec3dgpu, vmConfigSpec);
+        verify(_resource).setNewVRamSizeVmVideoCard(vmMo3dgpu, VRAM_MEMORY_SIZE, vmConfigSpec);
+    }
 
-        when(vmMo3dgpu.configureVm(any(VirtualMachineConfigSpec.class))).thenReturn(true);
+    @Test
+    public void testConfigureVideoCardNotSvgaVramProvided() throws Exception {
+        _resource.configureVideoCard(vmMo3dgpu, vmSpec3dgpu, vmConfigSpec);
+        verify(_resource, never()).setNewVRamSizeVmVideoCard(vmMo3dgpu, VRAM_MEMORY_SIZE, vmConfigSpec);
+    }
 
-        _resource.postVideoCardMemoryConfigBeforeStart(vmMo3dgpu, vmSpec3dgpu);
-        verify(vmMo3dgpu).configureVm(any(VirtualMachineConfigSpec.class));
+    @Test
+    public void testModifyVmVideoCardVRamSizeDifferentVramSizes() {
+        _resource.modifyVmVideoCardVRamSize(videoCard, vmMo3dgpu, VRAM_MEMORY_SIZE, vmConfigSpec);
+        verify(_resource).configureSpecVideoCardNewVRamSize(videoCard, VRAM_MEMORY_SIZE, vmConfigSpec);
+    }
+
+    @Test
+    public void testModifyVmVideoCardVRamSizeEqualSizes() {
+        _resource.modifyVmVideoCardVRamSize(videoCard, vmMo3dgpu, VIDEO_CARD_MEMORY_SIZE, vmConfigSpec);
+        verify(_resource, never()).configureSpecVideoCardNewVRamSize(videoCard, VIDEO_CARD_MEMORY_SIZE, vmConfigSpec);
+    }
+
+    @Test
+    public void testSetNewVRamSizeVmVideoCardPresent() throws Exception {
+        when(vmMo3dgpu.getAllDeviceList()).thenReturn(Arrays.asList(videoCard, virtualDevice));
+        _resource.setNewVRamSizeVmVideoCard(vmMo3dgpu, VRAM_MEMORY_SIZE, vmConfigSpec);
+        verify(_resource).modifyVmVideoCardVRamSize(videoCard, vmMo3dgpu, VRAM_MEMORY_SIZE, vmConfigSpec);
+    }
+
+    @Test
+    public void testSetNewVRamSizeVmVideoCardNotPresent() throws Exception {
+        when(vmMo3dgpu.getAllDeviceList()).thenReturn(Arrays.asList(virtualDevice));
+        _resource.setNewVRamSizeVmVideoCard(vmMo3dgpu, VRAM_MEMORY_SIZE, vmConfigSpec);
+        verify(_resource, never()).modifyVmVideoCardVRamSize(any(VirtualMachineVideoCard.class), eq(vmMo3dgpu), eq(VRAM_MEMORY_SIZE), eq(vmConfigSpec));
+    }
+
+    @Test
+    public void testConfigureSpecVideoCardNewVRamSize() {
+        when(vmConfigSpec.getDeviceChange()).thenReturn(new ArrayList<VirtualDeviceConfigSpec>());
+        _resource.configureSpecVideoCardNewVRamSize(videoCard, VRAM_MEMORY_SIZE, vmConfigSpec);
+
+        InOrder inOrder = Mockito.inOrder(videoCard, vmConfigSpec);
+        inOrder.verify(videoCard).setVideoRamSizeInKB(VRAM_MEMORY_SIZE);
+        inOrder.verify(videoCard).setUseAutoDetect(false);
+        inOrder.verify(vmConfigSpec).getDeviceChange();
     }
 
     // ---------------------------------------------------------------------------------------------------

--- a/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
+++ b/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
@@ -24,20 +24,19 @@ from marvin.cloudstackTestCase import cloudstackTestCase
 
 # base - contains all resources as entities and defines create, delete,
 # list operations on them
-from marvin.lib.base import Account, VirtualMachine, ServiceOffering
+from marvin.lib.base import Account, VirtualMachine, ServiceOffering, NetworkOffering, Network, Template
 
 # utils - utility classes for common cleanup, external library wrappers etc
-from marvin.lib.utils import cleanup_resources
+from marvin.lib.utils import cleanup_resources, get_hypervisor_type, validateList
 
 # common - commonly used methods for all tests are listed here
 from marvin.lib.common import get_zone, get_domain, get_template, list_hosts
 
 from marvin.sshClient import SshClient
 
-from marvin.codes import FAILED
+from marvin.codes import FAILED, PASS
 
 from nose.plugins.attrib import attr
-
 
 class TestDeployvGPUenabledVM(cloudstackTestCase):
 
@@ -100,48 +99,76 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
     def setUp(self):
         self.testdata = self.testClient.getParsedTestDataConfig()["vgpu"]
         self.apiclient = self.testClient.getApiClient()
+	self.dbclient = self.testClient.getDbConnection()
         if self.noSuitableHost or self.unsupportedHypervisor:
-            self.skipTest("Skipping test because suitable hypervisor/host not\
-                    present")
+            self.hypervisor = get_hypervisor_type(self.apiclient)
+            if self.hypervisor.lower() not in ["vmware"]:
+	            self.skipTest("Skipping test because suitable hypervisor/host not\
+        	            present")
+            self.testdata = self.testClient.getParsedTestDataConfig()
 
         # Get Zone, Domain and Default Built-in template
         self.domain = get_domain(self.apiclient)
-        self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
-        self.testdata["mode"] = self.zone.networktype
-        # Before running this test, register a windows template with ostype as
-        # 'Windows 7 (32-bit)'
+	self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
+
+        # Before running this test for Xen Server, register a windows template with ostype as
+	# 'Windows 7 (32-bit)'
         self.template = get_template(
-            self.apiclient,
-            self.zone.id,
-            self.testdata["ostype"])
+		self.apiclient,
+	        self.zone.id,
+        	self.testdata["ostype"])
 
-        if self.template == FAILED:
-            assert False, "get_template() failed to return template with description %s" % self.testdata[
-                "ostype"]
-        # create a user account
+	# create a user account
         self.account = Account.create(
-            self.apiclient,
-            self.testdata["account"],
-            domainid=self.domain.id
+	        self.apiclient,
+        	self.testdata["account"],
+		domainid=self.domain.id
         )
+	self.cleanup = []
 
-        self.testdata["small"]["zoneid"] = self.zone.id
-        self.testdata["small"]["template"] = self.template.id
+	if self.hypervisor.lower() in ["xenserver"]:
+	        self.testdata["mode"] = self.zone.networktype
 
-        self.testdata["service_offerings"]["vgpu260qwin"]["serviceofferingdetails"] = [
-            {
-                'pciDevice': 'Group of NVIDIA Corporation GK107GL [GRID K1] GPUs'}, {
-                'vgpuType': 'GRID K120Q'}]
-        # create a service offering
-        self.service_offering = ServiceOffering.create(
-            self.apiclient,
-            self.testdata["service_offerings"]["vgpu260qwin"],
-        )
-        # build cleanup list
-        self.cleanup = [
-            self.service_offering,
-            self.account
-        ]
+	        if self.template == FAILED:
+        	    assert False, "get_template() failed to return template with description %s" % self.testdata[
+                	"ostype"]
+
+	        self.testdata["small"]["zoneid"] = self.zone.id
+        	self.testdata["small"]["template"] = self.template.id
+
+	        self.testdata["service_offerings"]["vgpu260qwin"]["serviceofferingdetails"] = [
+        	    {
+                	'pciDevice': 'Group of NVIDIA Corporation GK107GL [GRID K1] GPUs'}, {
+	                'vgpuType': 'GRID K120Q'}]
+        	# create a service offering
+	        self.service_offering = ServiceOffering.create(
+        	    self.apiclient,
+	            self.testdata["service_offerings"]["vgpu260qwin"],
+        	)
+	        # build cleanup list
+        	self.cleanup = [
+	            self.service_offering,
+        	    self.account
+	        ]
+	elif self.hypervisor.lower() in ["vmware"]:
+		self.testdata["isolated_network"]["zoneid"] = self.zone.id
+		self.userapiclient = self.testClient.getUserApiClient(
+         		UserName=self.account.name,
+		        DomainName=self.account.domain
+	        )
+		self.service_offering = ServiceOffering.create(
+	            self.apiclient,
+        	    self.testdata["service_offering"])
+	        self.cleanup.append(self.service_offering)
+
+		# Create Shared Network Offering
+        	self.isolated_network_offering = NetworkOffering.create(
+	            self.apiclient,
+        	    self.testdata["isolated_network_offering"])
+	        self.cleanup.append(self.isolated_network_offering)
+        	# Enable Isolated Network offering
+	        self.isolated_network_offering.update(self.apiclient, state='Enabled')
+		
 
     @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
     def test_deploy_vgpu_enabled_vm(self):
@@ -152,6 +179,10 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
         # 2. Virtual Machine is vGPU enabled (via SSH)
         # 3. listVirtualMachines returns accurate information
         """
+
+	if self.hypervisor.lower() not in ["xenserver"]:
+            self.skipTest("This test case is written specifically\
+                    for XenServer hypervisor")
         self.virtual_machine = VirtualMachine.create(
             self.apiclient,
             self.testdata["small"],
@@ -228,3 +259,80 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             cleanup_resources(self.apiclient, self.cleanup)
         except Exception as e:
             self.debug("Warning! Exception in tearDown: %s" % e)
+
+    @attr(tags=["advanced"])
+    def test_3d_gpu_support(self):
+        """
+
+        # 1. Register a template for VMware with nicAdapter vmxnet3 and 3D GPU details
+        # 2. Deploy a VM using this template
+        # 3. Create an isolated network
+        # 4. Add network to VM
+        # 5. Verify vm details for 3D GPU details
+        """
+
+        if self.hypervisor.lower() not in ["vmware"]:
+            self.skipTest("This test case is written specifically\
+                    for Vmware hypervisor")
+
+        # Register a private template in the account with nic adapter vmxnet3
+        # Also add required 3D GPU details for enabling it
+        template = Template.register(
+            self.userapiclient,
+            self.testdata["configurableData"]["vmxnet3template"],
+            zoneid=self.zone.id,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            details=[{"mks.enable3d" : "true", "mks.use3dRenderer" : "automatic",
+                     "svga.autodetect" : "false", "svga.vramSize" : "131072"}]
+        )
+        self.cleanup.append(template)
+        template.download(self.apiclient)
+
+        templates = Template.list(
+            self.userapiclient,
+            listall=True,
+            id=template.id,
+            templatefilter="self"
+        )
+
+        self.assertEqual(
+            validateList(templates)[0],
+            PASS,
+            "Templates list validation failed"
+        )
+
+        self.testdata["virtual_machine"]["zoneid"] = self.zone.id
+        self.testdata["virtual_machine"]["template"] = template.id
+
+        virtual_machine = VirtualMachine.create(
+            self.apiclient,
+            self.testdata["virtual_machine"],
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            templateid=template.id,
+            serviceofferingid=self.service_offering.id)
+
+        isolated_network = Network.create(
+            self.apiclient,
+            self.testdata["isolated_network"],
+            self.account.name,
+            self.account.domainid,
+            networkofferingid=self.isolated_network_offering.id)
+
+        virtual_machine.add_nic(self.apiclient, isolated_network.id)
+
+        qresultset = self.dbclient.execute("select id from vm_instance where uuid = '%s';"      % virtual_machine.id)
+        vm_id = qresultset[0]
+        qresultset = self.dbclient.execute("select name, value from user_vm_details where vm_id = '%d';"        % vm_id)
+        detailKeys = [x[0] for x in qresultset]
+
+        self.assertTrue('mks.enable3d' in detailKeys and 'mks.use3dRenderer' in detailKeys and 'svga.autodetect' in detailKeys and 'svga.vramSize' in detailKeys, "VM details do not contain 3D GPU details")
+
+        self.assertEquals('true', qresultset[detailKeys.index('mks.enable3d')][1], "Expected detail 'mks.enable3d'='true'")
+
+        self.assertEquals('automatic', qresultset[detailKeys.index('mks.use3dRenderer')][1], "Expected detail 'mks.use3dRenderer'='automatic'")
+
+        self.assertEquals('false', qresultset[detailKeys.index('svga.autodetect')][1], "Expected detail 'svga.autodetect'='false'")
+
+        self.assertEquals('131072', qresultset[detailKeys.index('svga.vramSize')][1], "Expected detail 'svga.vramSize'='131072'")


### PR DESCRIPTION
JIRA TICKET: https://issues.apache.org/jira/browse/CLOUDSTACK-9428

### Introduction

On #1310 passing vRAM size to support 3D GPU problem was addressed on VMware. It was found out that it could be improved to increase performance by reducing extra API calls, as we'll describe later

### Improvement
On WMware, `VmwareResource` manages execution of `StartCommand.` Before sending power on command to ESXi hypervisor, vm is configured by calling `reconfigVMTask` web method on vSphere's client `VimPortType` web service.
It was found out that we were using this method 2 times when passing vRAM size, as it implied creating a new vm config spec only editing video card specs and making an extra call to `reconfigVMTask.`

We propose reducing the extra web service call by adjusting vm's config spec. This way video card gets properly configured (when passing vRAM size) in the same configure call, increasing performance.

### Use case (passing vRAM size)
* Deploy a new VM, let its id be X
* Stop VM
* Execute SQL, where X is vm's id and Z is vRAM size (in kB): 
````
INSERT INTO cloud.user_vm_details (vm_id, name, value) VALUES (X, 'mks.enable3d', 'true');
INSERT INTO cloud.user_vm_details (vm_id, name, value) VALUES (X, 'mks.use3dRenderer', 'automatic');
INSERT INTO cloud.user_vm_details (vm_id, name, value) VALUES (X, 'svga.autodetect', 'false');
INSERT INTO cloud.user_vm_details (vm_id, name, value) VALUES (X, 'svga.vramSize', Z);
````
* Start VM