### PR TITLE
marvin: deploy clusters in separate threads

### DIFF
--- a/setup/dev/1kadvanced.cfg
+++ b/setup/dev/1kadvanced.cfg
@@ -1,0 +1,6034 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+{
+  "zones": [
+    {
+      "name": "Sandbox-simulator-1k", 
+      "guestcidraddress": "10.1.1.0/24", 
+      "dns1": "8.8.8.8", 
+      "physical_networks": [
+        {
+          "name": "Sandbox-pnet", 
+          "providers": [
+            {
+              "broadcastdomainrange": "ZONE", 
+              "name": "VirtualRouter"
+            }, 
+            {
+              "broadcastdomainrange": "ZONE", 
+              "name": "VpcVirtualRouter"
+            }, 
+            {
+              "broadcastdomainrange": "ZONE", 
+              "name": "InternalLbVm"
+            }
+          ], 
+          "broadcastdomainrange": "Zone", 
+          "vlan": "100-900", 
+          "traffictypes": [
+            {
+              "typ": "Guest"
+            }, 
+            {
+              "typ": "Management"
+            }, 
+            {
+              "typ": "Public"
+            }
+          ], 
+          "isolationmethods": [
+            "VLAN"
+          ]
+        }
+      ], 
+      "ipranges": [
+        {
+          "startip": "192.168.2.2", 
+          "endip": "192.168.2.200", 
+          "netmask": "255.255.0.0", 
+          "vlan": "50", 
+          "gateway": "192.168.2.1"
+        }
+      ], 
+      "networktype": "Advanced", 
+      "pods": [
+        {
+          "endip": "172.16.15.200", 
+          "name": "POD0", 
+          "startip": "172.16.15.2", 
+          "netmask": "255.255.0.0", 
+          "clusters": [
+            {
+              "clustername": "cluster1", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c1/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c1/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.1:/export/home/sandbox/primary0", 
+                  "name": "ps0-c1"
+                }, 
+                {
+                  "url": "nfs://10.147.28.1:/export/home/sandbox/primary1", 
+                  "name": "ps1-c1"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster2", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c2/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c2/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.2:/export/home/sandbox/primary0", 
+                  "name": "ps0-c2"
+                }, 
+                {
+                  "url": "nfs://10.147.28.2:/export/home/sandbox/primary1", 
+                  "name": "ps1-c2"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster3", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c3/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c3/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.3:/export/home/sandbox/primary0", 
+                  "name": "ps0-c3"
+                }, 
+                {
+                  "url": "nfs://10.147.28.3:/export/home/sandbox/primary1", 
+                  "name": "ps1-c3"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster4", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c4/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c4/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.4:/export/home/sandbox/primary0", 
+                  "name": "ps0-c4"
+                }, 
+                {
+                  "url": "nfs://10.147.28.4:/export/home/sandbox/primary1", 
+                  "name": "ps1-c4"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster5", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c5/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c5/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.5:/export/home/sandbox/primary0", 
+                  "name": "ps0-c5"
+                }, 
+                {
+                  "url": "nfs://10.147.28.5:/export/home/sandbox/primary1", 
+                  "name": "ps1-c5"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster6", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c6/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c6/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.6:/export/home/sandbox/primary0", 
+                  "name": "ps0-c6"
+                }, 
+                {
+                  "url": "nfs://10.147.28.6:/export/home/sandbox/primary1", 
+                  "name": "ps1-c6"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster7", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c7/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c7/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.7:/export/home/sandbox/primary0", 
+                  "name": "ps0-c7"
+                }, 
+                {
+                  "url": "nfs://10.147.28.7:/export/home/sandbox/primary1", 
+                  "name": "ps1-c7"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster8", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c8/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c8/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.8:/export/home/sandbox/primary0", 
+                  "name": "ps0-c8"
+                }, 
+                {
+                  "url": "nfs://10.147.28.8:/export/home/sandbox/primary1", 
+                  "name": "ps1-c8"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster9", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c9/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c9/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.9:/export/home/sandbox/primary0", 
+                  "name": "ps0-c9"
+                }, 
+                {
+                  "url": "nfs://10.147.28.9:/export/home/sandbox/primary1", 
+                  "name": "ps1-c9"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster10", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c10/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c10/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.10:/export/home/sandbox/primary0", 
+                  "name": "ps0-c10"
+                }, 
+                {
+                  "url": "nfs://10.147.28.10:/export/home/sandbox/primary1", 
+                  "name": "ps1-c10"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster11", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c11/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c11/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.11:/export/home/sandbox/primary0", 
+                  "name": "ps0-c11"
+                }, 
+                {
+                  "url": "nfs://10.147.28.11:/export/home/sandbox/primary1", 
+                  "name": "ps1-c11"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster12", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c12/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c12/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.12:/export/home/sandbox/primary0", 
+                  "name": "ps0-c12"
+                }, 
+                {
+                  "url": "nfs://10.147.28.12:/export/home/sandbox/primary1", 
+                  "name": "ps1-c12"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster13", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c13/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c13/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.13:/export/home/sandbox/primary0", 
+                  "name": "ps0-c13"
+                }, 
+                {
+                  "url": "nfs://10.147.28.13:/export/home/sandbox/primary1", 
+                  "name": "ps1-c13"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster14", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c14/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c14/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.14:/export/home/sandbox/primary0", 
+                  "name": "ps0-c14"
+                }, 
+                {
+                  "url": "nfs://10.147.28.14:/export/home/sandbox/primary1", 
+                  "name": "ps1-c14"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster15", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c15/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c15/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.15:/export/home/sandbox/primary0", 
+                  "name": "ps0-c15"
+                }, 
+                {
+                  "url": "nfs://10.147.28.15:/export/home/sandbox/primary1", 
+                  "name": "ps1-c15"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster16", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c16/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c16/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.16:/export/home/sandbox/primary0", 
+                  "name": "ps0-c16"
+                }, 
+                {
+                  "url": "nfs://10.147.28.16:/export/home/sandbox/primary1", 
+                  "name": "ps1-c16"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster17", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c17/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c17/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.17:/export/home/sandbox/primary0", 
+                  "name": "ps0-c17"
+                }, 
+                {
+                  "url": "nfs://10.147.28.17:/export/home/sandbox/primary1", 
+                  "name": "ps1-c17"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster18", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c18/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c18/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.18:/export/home/sandbox/primary0", 
+                  "name": "ps0-c18"
+                }, 
+                {
+                  "url": "nfs://10.147.28.18:/export/home/sandbox/primary1", 
+                  "name": "ps1-c18"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster19", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c19/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c19/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.19:/export/home/sandbox/primary0", 
+                  "name": "ps0-c19"
+                }, 
+                {
+                  "url": "nfs://10.147.28.19:/export/home/sandbox/primary1", 
+                  "name": "ps1-c19"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster20", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c20/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c20/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.20:/export/home/sandbox/primary0", 
+                  "name": "ps0-c20"
+                }, 
+                {
+                  "url": "nfs://10.147.28.20:/export/home/sandbox/primary1", 
+                  "name": "ps1-c20"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster21", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c21/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c21/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.21:/export/home/sandbox/primary0", 
+                  "name": "ps0-c21"
+                }, 
+                {
+                  "url": "nfs://10.147.28.21:/export/home/sandbox/primary1", 
+                  "name": "ps1-c21"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster22", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c22/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c22/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.22:/export/home/sandbox/primary0", 
+                  "name": "ps0-c22"
+                }, 
+                {
+                  "url": "nfs://10.147.28.22:/export/home/sandbox/primary1", 
+                  "name": "ps1-c22"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster23", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c23/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c23/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.23:/export/home/sandbox/primary0", 
+                  "name": "ps0-c23"
+                }, 
+                {
+                  "url": "nfs://10.147.28.23:/export/home/sandbox/primary1", 
+                  "name": "ps1-c23"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster24", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c24/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c24/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.24:/export/home/sandbox/primary0", 
+                  "name": "ps0-c24"
+                }, 
+                {
+                  "url": "nfs://10.147.28.24:/export/home/sandbox/primary1", 
+                  "name": "ps1-c24"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster25", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c25/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c25/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.25:/export/home/sandbox/primary0", 
+                  "name": "ps0-c25"
+                }, 
+                {
+                  "url": "nfs://10.147.28.25:/export/home/sandbox/primary1", 
+                  "name": "ps1-c25"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster26", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c26/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c26/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.26:/export/home/sandbox/primary0", 
+                  "name": "ps0-c26"
+                }, 
+                {
+                  "url": "nfs://10.147.28.26:/export/home/sandbox/primary1", 
+                  "name": "ps1-c26"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster27", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c27/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c27/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.27:/export/home/sandbox/primary0", 
+                  "name": "ps0-c27"
+                }, 
+                {
+                  "url": "nfs://10.147.28.27:/export/home/sandbox/primary1", 
+                  "name": "ps1-c27"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster28", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c28/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c28/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.28:/export/home/sandbox/primary0", 
+                  "name": "ps0-c28"
+                }, 
+                {
+                  "url": "nfs://10.147.28.28:/export/home/sandbox/primary1", 
+                  "name": "ps1-c28"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster29", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c29/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c29/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.29:/export/home/sandbox/primary0", 
+                  "name": "ps0-c29"
+                }, 
+                {
+                  "url": "nfs://10.147.28.29:/export/home/sandbox/primary1", 
+                  "name": "ps1-c29"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster30", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c30/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c30/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.30:/export/home/sandbox/primary0", 
+                  "name": "ps0-c30"
+                }, 
+                {
+                  "url": "nfs://10.147.28.30:/export/home/sandbox/primary1", 
+                  "name": "ps1-c30"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster31", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c31/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c31/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.31:/export/home/sandbox/primary0", 
+                  "name": "ps0-c31"
+                }, 
+                {
+                  "url": "nfs://10.147.28.31:/export/home/sandbox/primary1", 
+                  "name": "ps1-c31"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster32", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c32/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c32/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.32:/export/home/sandbox/primary0", 
+                  "name": "ps0-c32"
+                }, 
+                {
+                  "url": "nfs://10.147.28.32:/export/home/sandbox/primary1", 
+                  "name": "ps1-c32"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster33", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c33/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c33/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.33:/export/home/sandbox/primary0", 
+                  "name": "ps0-c33"
+                }, 
+                {
+                  "url": "nfs://10.147.28.33:/export/home/sandbox/primary1", 
+                  "name": "ps1-c33"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster34", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c34/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c34/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.34:/export/home/sandbox/primary0", 
+                  "name": "ps0-c34"
+                }, 
+                {
+                  "url": "nfs://10.147.28.34:/export/home/sandbox/primary1", 
+                  "name": "ps1-c34"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster35", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c35/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c35/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.35:/export/home/sandbox/primary0", 
+                  "name": "ps0-c35"
+                }, 
+                {
+                  "url": "nfs://10.147.28.35:/export/home/sandbox/primary1", 
+                  "name": "ps1-c35"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster36", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c36/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c36/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.36:/export/home/sandbox/primary0", 
+                  "name": "ps0-c36"
+                }, 
+                {
+                  "url": "nfs://10.147.28.36:/export/home/sandbox/primary1", 
+                  "name": "ps1-c36"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster37", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c37/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c37/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.37:/export/home/sandbox/primary0", 
+                  "name": "ps0-c37"
+                }, 
+                {
+                  "url": "nfs://10.147.28.37:/export/home/sandbox/primary1", 
+                  "name": "ps1-c37"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster38", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c38/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c38/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.38:/export/home/sandbox/primary0", 
+                  "name": "ps0-c38"
+                }, 
+                {
+                  "url": "nfs://10.147.28.38:/export/home/sandbox/primary1", 
+                  "name": "ps1-c38"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster39", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c39/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c39/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.39:/export/home/sandbox/primary0", 
+                  "name": "ps0-c39"
+                }, 
+                {
+                  "url": "nfs://10.147.28.39:/export/home/sandbox/primary1", 
+                  "name": "ps1-c39"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster40", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c40/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c40/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.40:/export/home/sandbox/primary0", 
+                  "name": "ps0-c40"
+                }, 
+                {
+                  "url": "nfs://10.147.28.40:/export/home/sandbox/primary1", 
+                  "name": "ps1-c40"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster41", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c41/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c41/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.41:/export/home/sandbox/primary0", 
+                  "name": "ps0-c41"
+                }, 
+                {
+                  "url": "nfs://10.147.28.41:/export/home/sandbox/primary1", 
+                  "name": "ps1-c41"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster42", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c42/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c42/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.42:/export/home/sandbox/primary0", 
+                  "name": "ps0-c42"
+                }, 
+                {
+                  "url": "nfs://10.147.28.42:/export/home/sandbox/primary1", 
+                  "name": "ps1-c42"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster43", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c43/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c43/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.43:/export/home/sandbox/primary0", 
+                  "name": "ps0-c43"
+                }, 
+                {
+                  "url": "nfs://10.147.28.43:/export/home/sandbox/primary1", 
+                  "name": "ps1-c43"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster44", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c44/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c44/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.44:/export/home/sandbox/primary0", 
+                  "name": "ps0-c44"
+                }, 
+                {
+                  "url": "nfs://10.147.28.44:/export/home/sandbox/primary1", 
+                  "name": "ps1-c44"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster45", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c45/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c45/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.45:/export/home/sandbox/primary0", 
+                  "name": "ps0-c45"
+                }, 
+                {
+                  "url": "nfs://10.147.28.45:/export/home/sandbox/primary1", 
+                  "name": "ps1-c45"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster46", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c46/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c46/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.46:/export/home/sandbox/primary0", 
+                  "name": "ps0-c46"
+                }, 
+                {
+                  "url": "nfs://10.147.28.46:/export/home/sandbox/primary1", 
+                  "name": "ps1-c46"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster47", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c47/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c47/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.47:/export/home/sandbox/primary0", 
+                  "name": "ps0-c47"
+                }, 
+                {
+                  "url": "nfs://10.147.28.47:/export/home/sandbox/primary1", 
+                  "name": "ps1-c47"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster48", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c48/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c48/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.48:/export/home/sandbox/primary0", 
+                  "name": "ps0-c48"
+                }, 
+                {
+                  "url": "nfs://10.147.28.48:/export/home/sandbox/primary1", 
+                  "name": "ps1-c48"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster49", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c49/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c49/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.49:/export/home/sandbox/primary0", 
+                  "name": "ps0-c49"
+                }, 
+                {
+                  "url": "nfs://10.147.28.49:/export/home/sandbox/primary1", 
+                  "name": "ps1-c49"
+                }
+              ]
+            }, 
+            {
+              "clustername": "cluster50", 
+              "hypervisor": "simulator", 
+              "hosts": [
+                {
+                  "url": "http://sim/c50/h1", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h2", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h3", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h4", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h5", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h6", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h7", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h8", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h9", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h10", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h11", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h12", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h13", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h14", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h15", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h16", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h17", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h18", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h19", 
+                  "username": "root", 
+                  "password": "password"
+                }, 
+                {
+                  "url": "http://sim/c50/h20", 
+                  "username": "root", 
+                  "password": "password"
+                }
+              ], 
+              "clustertype": "CloudManaged", 
+              "primaryStorages": [
+                {
+                  "url": "nfs://10.147.28.50:/export/home/sandbox/primary0", 
+                  "name": "ps0-c50"
+                }, 
+                {
+                  "url": "nfs://10.147.28.50:/export/home/sandbox/primary1", 
+                  "name": "ps1-c50"
+                }
+              ]
+            }
+          ], 
+          "gateway": "172.16.15.1"
+        }
+      ], 
+      "internaldns1": "10.147.28.6", 
+      "secondaryStorages": [
+        {
+          "url": "nfs://10.147.28.6:/export/home/sandbox/secondary", 
+          "provider": "NFS"
+        }
+      ]
+    }
+  ], 
+  "dbSvr": {
+    "dbSvr": "localhost", 
+    "passwd": "cloud", 
+    "db": "cloud", 
+    "port": 3306, 
+    "user": "cloud"
+  }, 
+  "logger": {
+    "LogFolderPath": "/tmp/"
+  }, 
+  "globalConfig": [
+    {
+      "name": "network.gc.wait", 
+      "value": "20"
+    }, 
+    {
+      "name": "storage.cleanup.interval", 
+      "value": "40"
+    }, 
+    {
+      "name": "vm.op.wait.interval", 
+      "value": "5"
+    }, 
+    {
+      "name": "default.page.size", 
+      "value": "500"
+    }, 
+    {
+      "name": "network.gc.interval", 
+      "value": "20"
+    }, 
+    {
+      "name": "instance.name", 
+      "value": "QA"
+    }, 
+    {
+      "name": "workers", 
+      "value": "32"
+    }, 
+    {
+      "name": "account.cleanup.interval", 
+      "value": "20"
+    }, 
+    {
+      "name": "guest.domain.suffix", 
+      "value": "sandbox.simulator"
+    }, 
+    {
+      "name": "expunge.delay", 
+      "value": "20"
+    }, 
+    {
+      "name": "vm.allocation.algorithm", 
+      "value": "random"
+    }, 
+    {
+      "name": "expunge.interval", 
+      "value": "20"
+    }, 
+    {
+      "name": "expunge.workers", 
+      "value": "3"
+    }, 
+    {
+      "name": "check.pod.cidrs", 
+      "value": "true"
+    }, 
+    {
+      "name": "secstorage.allowed.internal.sites", 
+      "value": "10.147.28.0/24"
+    }, 
+    {
+      "name": "direct.agent.load.size", 
+      "value": "1000"
+    }, 
+    {
+      "name": "ping.interval", 
+      "value": "10"
+    }, 
+    {
+      "name": "ping.timeout", 
+      "value": "1.5"
+    }
+  ], 
+  "mgtSvr": [
+    {
+      "passwd": "password", 
+      "hypervisor": "simulator", 
+      "useHttps": "False", 
+      "certPath": "NA", 
+      "user": "root", 
+      "mgtSvrIp": "localhost", 
+      "port": 8096, 
+      "certCAPath": "NA"
+    }
+  ]
+}


### PR DESCRIPTION
This speeds up cluster deployment by Marvin, each cluster deployment can be
executed in separate threads. This for example, allows for setting up a Simulator
based environment with 1000s of hosts across 10s clusters in significantly
less time.
