### PR TITLE
[blocker] CLOUDSTACK-9437: Fix outbound traffic after upgrade and cleanup for allow all traffic

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -263,6 +263,14 @@ class CsAcl(CsDataBag):
                 rstr = rstr.replace("  ", " ").lstrip()
                 self.fw.append([self.table, self.count, rstr])
 
+
+    def flushAllowAllEgressRules(self):
+        logging.debug("Flush allow 'all' egress firewall rule")
+        # Ensure that FW_EGRESS_RULES chain exists
+        CsHelper.execute("iptables-save | grep '^:FW_EGRESS_RULES' || iptables -t filter -N FW_EGRESS_RULES")
+        CsHelper.execute("iptables-save | grep '^-A FW_EGRESS_RULES -j ACCEPT$' | sed 's/^-A/iptables -t filter -D/g' | bash")
+
+
     def process(self):
         for item in self.dbag:
             if item == "id":
@@ -975,6 +983,7 @@ def main(argv):
         acls.process()
 
         acls = CsAcl('firewallrules', config)
+        acls.flushAllowAllEgressRules()
         acls.process()
 
         fwd = CsForwardingRules("forwardingrules", config)


### PR DESCRIPTION
    CLOUDSTACK-9437: Create egress chain on upgrade and cleanup for allow all traffic
    
    - Ensure that FW_EGRESS_RULE chain exists after upgrading the router
    - Flush allow all egress rule on 0.0.0.0/0, if such a rule exists in the config
      it will be added later (CLOUDSTACK-9437)

/cc @swill @jburwell @PaulAngus @remibergsma @wilderrodrigues 