### PR TITLE
CLOUDSTACK-9438: Fix for CLOUDSTACK-9252 - Make NFS version changeable in UI

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/config/ListCfgsByCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/config/ListCfgsByCmd.java
@@ -28,6 +28,7 @@ import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.ClusterResponse;
 import org.apache.cloudstack.api.response.ConfigurationResponse;
+import org.apache.cloudstack.api.response.ImageStoreResponse;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.StoragePoolResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
@@ -76,6 +77,12 @@ public class ListCfgsByCmd extends BaseListCmd {
                description = "the ID of the Account to update the parameter value for corresponding account")
     private Long accountId;
 
+    @Parameter(name = ApiConstants.IMAGE_STORE_UUID,
+            type = CommandType.UUID,
+            entityType = ImageStoreResponse.class,
+            description = "the ID of the Image Store to update the parameter value for corresponding image store")
+    private Long imageStoreId;
+
     // ///////////////////////////////////////////////////
     // ///////////////// Accessors ///////////////////////
     // ///////////////////////////////////////////////////
@@ -102,6 +109,10 @@ public class ListCfgsByCmd extends BaseListCmd {
 
     public Long getAccountId() {
         return accountId;
+    }
+
+    public Long getImageStoreId() {
+        return imageStoreId;
     }
 
     @Override
@@ -146,6 +157,9 @@ public class ListCfgsByCmd extends BaseListCmd {
             }
             if (getAccountId() != null) {
                 cfgResponse.setScope("account");
+            }
+            if (getImageStoreId() != null){
+                cfgResponse.setScope("imagestore");
             }
             configResponses.add(cfgResponse);
         }

--- a/api/src/org/apache/cloudstack/api/command/admin/config/UpdateCfgCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/config/UpdateCfgCmd.java
@@ -19,8 +19,8 @@ package org.apache.cloudstack.api.command.admin.config;
 import com.google.common.base.Strings;
 import org.apache.cloudstack.acl.RoleService;
 import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseCmd;
@@ -29,6 +29,7 @@ import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.ClusterResponse;
 import org.apache.cloudstack.api.response.ConfigurationResponse;
+import org.apache.cloudstack.api.response.ImageStoreResponse;
 import org.apache.cloudstack.api.response.StoragePoolResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.config.Configuration;
@@ -75,6 +76,13 @@ public class UpdateCfgCmd extends BaseCmd {
                description = "the ID of the Account to update the parameter value for corresponding account")
     private Long accountId;
 
+    @Parameter(name = ApiConstants.IMAGE_STORE_UUID,
+            type = CommandType.UUID,
+            entityType = ImageStoreResponse.class,
+            description = "the ID of the Image Store to update the parameter value for corresponding image store",
+            validations = ApiArgValidator.PositiveNumber)
+    private Long imageStoreId;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -105,6 +113,10 @@ public class UpdateCfgCmd extends BaseCmd {
 
     public Long getAccountId() {
         return accountId;
+    }
+
+    public Long getImageStoreId() {
+        return imageStoreId;
     }
 
     /////////////////////////////////////////////////////

--- a/engine/components-api/src/com/cloud/capacity/CapacityManager.java
+++ b/engine/components-api/src/com/cloud/capacity/CapacityManager.java
@@ -73,6 +73,16 @@ public interface CapacityManager {
                     "If set to true, creates VMs as full clones on ESX hypervisor",
                     true,
                     ConfigKey.Scope.StoragePool);
+    static final ConfigKey<Integer> ImageStoreNFSVersion =
+            new ConfigKey<Integer>(
+                    Integer.class,
+                    "secstorage.nfs.version",
+                    "Advanced",
+                    null,
+                    "Enforces specific NFS version when mounting Secondary Storage. If NULL default selection is performed",
+                    true,
+                    ConfigKey.Scope.ImageStore,
+                    null);
 
     public boolean releaseVmCapacity(VirtualMachine vm, boolean moveFromReserved, boolean moveToReservered, Long hostId);
 

--- a/engine/schema/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -176,8 +176,8 @@
   <bean id="hostTagsDaoImpl" class="com.cloud.host.dao.HostTagsDaoImpl" />
   <bean id="hostTransferMapDaoImpl" class="com.cloud.cluster.agentlb.dao.HostTransferMapDaoImpl" />
   <bean id="iPAddressDaoImpl" class="com.cloud.network.dao.IPAddressDaoImpl" />
-  <bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.ImageStoreDaoImpl" />
-  <bean id="imageStoreDetailsDaoImpl" class="org.apache.cloudstack.storage.image.db.ImageStoreDetailsDaoImpl" />
+  <bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDaoImpl" />
+  <bean id="imageStoreDetailsDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDaoImpl" />
   <bean id="imageStoreJoinDaoImpl" class="com.cloud.api.query.dao.ImageStoreJoinDaoImpl" />
   <bean id="snapshotDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.SnapshotDataStoreDaoImpl" />
   <bean id="templateDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.TemplateDataStoreDaoImpl" />

--- a/engine/schema/src/org/apache/cloudstack/storage/datastore/db/ImageStoreDaoImpl.java
+++ b/engine/schema/src/org/apache/cloudstack/storage/datastore/db/ImageStoreDaoImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.cloudstack.storage.image.db;
+package org.apache.cloudstack.storage.datastore.db;
 
 import java.util.List;
 import java.util.Map;
@@ -26,8 +26,6 @@ import javax.naming.ConfigurationException;
 import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
-import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
-import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
 
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.ScopeType;

--- a/engine/schema/src/org/apache/cloudstack/storage/datastore/db/ImageStoreDetailVO.java
+++ b/engine/schema/src/org/apache/cloudstack/storage/datastore/db/ImageStoreDetailVO.java
@@ -23,18 +23,18 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.apache.cloudstack.api.InternalIdentity;
+import org.apache.cloudstack.api.ResourceDetail;
 
 @Entity
 @Table(name = "image_store_details")
-public class ImageStoreDetailVO implements InternalIdentity {
+public class ImageStoreDetailVO implements ResourceDetail {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     long id;
 
     @Column(name = "store_id")
-    long storeId;
+    long resourceId;
 
     @Column(name = "name")
     String name;
@@ -42,13 +42,17 @@ public class ImageStoreDetailVO implements InternalIdentity {
     @Column(name = "value")
     String value;
 
+    @Column(name = "display")
+    private boolean display = true;
+
     public ImageStoreDetailVO() {
     }
 
-    public ImageStoreDetailVO(long storeId, String name, String value) {
-        this.storeId = storeId;
+    public ImageStoreDetailVO(long storeId, String name, String value, boolean display) {
+        this.resourceId = storeId;
         this.name = name;
         this.value = value;
+        this.display = display;
     }
 
     @Override
@@ -56,28 +60,24 @@ public class ImageStoreDetailVO implements InternalIdentity {
         return id;
     }
 
-    public long getStoreId() {
-        return storeId;
+    @Override
+    public long getResourceId() {
+        return resourceId;
     }
 
-    public void setStoreId(long storeId) {
-        this.storeId = storeId;
-    }
-
+    @Override
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
+    @Override
     public String getValue() {
         return value;
     }
 
-    public void setValue(String value) {
-        this.value = value;
+    @Override
+    public boolean isDisplay() {
+        return display;
     }
 
 }

--- a/engine/schema/src/org/apache/cloudstack/storage/datastore/db/ImageStoreDetailsDao.java
+++ b/engine/schema/src/org/apache/cloudstack/storage/datastore/db/ImageStoreDetailsDao.java
@@ -18,9 +18,11 @@ package org.apache.cloudstack.storage.datastore.db;
 
 import java.util.Map;
 
+import org.apache.cloudstack.resourcedetail.ResourceDetailsDao;
+
 import com.cloud.utils.db.GenericDao;
 
-public interface ImageStoreDetailsDao extends GenericDao<ImageStoreDetailVO, Long> {
+public interface ImageStoreDetailsDao extends GenericDao<ImageStoreDetailVO, Long>, ResourceDetailsDao<ImageStoreDetailVO> {
 
     void update(long storeId, Map<String, String> details);
 

--- a/engine/storage/integration-test/test/resource/fakeDriverTestContext.xml
+++ b/engine/storage/integration-test/test/resource/fakeDriverTestContext.xml
@@ -35,8 +35,8 @@
         </property>
     </bean>
 
-    <bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.ImageStoreDaoImpl" />
-    <bean id="imageStoreDetailsDaoImpl" class="org.apache.cloudstack.storage.image.db.ImageStoreDetailsDaoImpl" />
+    <bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDaoImpl" />
+    <bean id="imageStoreDetailsDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDaoImpl" />
     <bean id="snapshotDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.SnapshotDataStoreDaoImpl" />
     <bean id="templateDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.TemplateDataStoreDaoImpl" />
     <bean id="volumeDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.VolumeDataStoreDaoImpl" />

--- a/engine/storage/integration-test/test/resources/storageContext.xml
+++ b/engine/storage/integration-test/test/resources/storageContext.xml
@@ -35,8 +35,8 @@
     </property>
   </bean>
 
-<bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.ImageStoreDaoImpl" />
-  <bean id="imageStoreDetailsDaoImpl" class="org.apache.cloudstack.storage.image.db.ImageStoreDetailsDaoImpl" /> 
+<bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDaoImpl" />
+  <bean id="imageStoreDetailsDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDaoImpl" /> 
   <bean id="snapshotDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.SnapshotDataStoreDaoImpl" /> 
   <bean id="templateDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.TemplateDataStoreDaoImpl" /> 
   <bean id="volumeDataStoreDaoImpl" class="org.apache.cloudstack.storage.image.db.VolumeDataStoreDaoImpl" />   

--- a/engine/storage/src/org/apache/cloudstack/storage/image/NfsImageStoreDriverImpl.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/NfsImageStoreDriverImpl.java
@@ -24,22 +24,23 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDao;
 
+import com.cloud.capacity.CapacityManager;
+
 public abstract class NfsImageStoreDriverImpl extends BaseImageStoreDriverImpl {
 
     @Inject
     ImageStoreDetailsDao _imageStoreDetailsDao;
 
-    private static final String NFS_VERSION_DETAILS_KEY = "nfs.version";
-
     /**
      * Retrieve NFS version to be used for imgStoreId store, if provided in image_store_details table
      * @param imgStoreId store id
-     * @return "nfs.version" associated value for imgStoreId in image_store_details table if exists, null if not
+     * @return "secstorage.nfs.version" associated value for imgStoreId in image_store_details table if exists, null if not
      */
     protected Integer getNfsVersion(long imgStoreId){
         Map<String, String> imgStoreDetails = _imageStoreDetailsDao.getDetails(imgStoreId);
-        if (imgStoreDetails != null && imgStoreDetails.containsKey(NFS_VERSION_DETAILS_KEY)){
-            String nfsVersionParam = imgStoreDetails.get(NFS_VERSION_DETAILS_KEY);
+        String nfsVersionKey = CapacityManager.ImageStoreNFSVersion.key();
+        if (imgStoreDetails != null && imgStoreDetails.containsKey(nfsVersionKey)){
+            String nfsVersionParam = imgStoreDetails.get(nfsVersionKey);
             return (nfsVersionParam != null ? Integer.valueOf(nfsVersionParam) : null);
         }
         return null;

--- a/engine/storage/src/org/apache/cloudstack/storage/image/datastore/ImageStoreHelper.java
+++ b/engine/storage/src/org/apache/cloudstack/storage/image/datastore/ImageStoreHelper.java
@@ -129,15 +129,12 @@ public class ImageStoreHelper {
             Iterator<String> keyIter = details.keySet().iterator();
             while (keyIter.hasNext()) {
                 String key = keyIter.next().toString();
-                ImageStoreDetailVO detail = new ImageStoreDetailVO();
-                detail.setStoreId(store.getId());
-                detail.setName(key);
                 String value = details.get(key);
                 // encrypt swift key or s3 secret key
                 if (key.equals(ApiConstants.KEY) || key.equals(ApiConstants.S3_SECRET_KEY)) {
                     value = DBEncryptionUtil.encrypt(value);
                 }
-                detail.setValue(value);
+                ImageStoreDetailVO detail = new ImageStoreDetailVO(store.getId(), key, value, true);
                 imageStoreDetailsDao.persist(detail);
             }
         }

--- a/framework/config/src/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -31,7 +31,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 public class ConfigKey<T> {
 
     public static enum Scope {
-        Global, Zone, Cluster, StoragePool, Account, ManagementServer
+        Global, Zone, Cluster, StoragePool, Account, ManagementServer, ImageStore
     }
 
     private final String _category;

--- a/framework/config/src/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
@@ -84,6 +84,7 @@ public class ConfigDepotImpl implements ConfigDepot, ConfigDepotAdmin {
         _scopeLevelConfigsMap.put(ConfigKey.Scope.Cluster, new HashSet<ConfigKey<?>>());
         _scopeLevelConfigsMap.put(ConfigKey.Scope.StoragePool, new HashSet<ConfigKey<?>>());
         _scopeLevelConfigsMap.put(ConfigKey.Scope.Account, new HashSet<ConfigKey<?>>());
+        _scopeLevelConfigsMap.put(ConfigKey.Scope.ImageStore, new HashSet<ConfigKey<?>>());
     }
 
     @Override

--- a/plugins/network-elements/juniper-contrail/test/org/apache/cloudstack/network/contrail/management/IntegrationTestConfiguration.java
+++ b/plugins/network-elements/juniper-contrail/test/org/apache/cloudstack/network/contrail/management/IntegrationTestConfiguration.java
@@ -80,8 +80,8 @@ import org.apache.cloudstack.region.dao.RegionDaoImpl;
 import org.apache.cloudstack.spring.lifecycle.registry.ExtensionRegistry;
 import org.apache.cloudstack.storage.datastore.PrimaryDataStoreProviderManager;
 import org.apache.cloudstack.storage.image.datastore.ImageStoreProviderManager;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDaoImpl;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDaoImpl;
-import org.apache.cloudstack.storage.image.db.ImageStoreDaoImpl;
 import org.apache.cloudstack.storage.image.db.TemplateDataStoreDaoImpl;
 import org.apache.cloudstack.usage.UsageService;
 

--- a/server/src/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/com/cloud/capacity/CapacityManagerImpl.java
@@ -1101,6 +1101,6 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {CpuOverprovisioningFactor, MemOverprovisioningFactor, StorageCapacityDisableThreshold, StorageOverprovisioningFactor,
-            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster, VmwareCreateCloneFull};
+            StorageAllocatedCapacityDisableThreshold, StorageOperationsExcludeCluster, VmwareCreateCloneFull, ImageStoreNFSVersion};
     }
 }

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1672,6 +1672,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final Long clusterId = cmd.getClusterId();
         final Long storagepoolId = cmd.getStoragepoolId();
         final Long accountId = cmd.getAccountId();
+        final Long imageStoreId = cmd.getImageStoreId();
         String scope = null;
         Long id = null;
         int paramCountCheck = 0;
@@ -1694,6 +1695,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         if (storagepoolId != null) {
             scope = ConfigKey.Scope.StoragePool.toString();
             id = storagepoolId;
+            paramCountCheck++;
+        }
+        if (imageStoreId != null) {
+            scope = ConfigKey.Scope.ImageStore.toString();
+            id = imageStoreId;
             paramCountCheck++;
         }
 

--- a/server/test/org/apache/cloudstack/networkoffering/ChildTestConfiguration.java
+++ b/server/test/org/apache/cloudstack/networkoffering/ChildTestConfiguration.java
@@ -41,6 +41,8 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.region.PortableIpDaoImpl;
 import org.apache.cloudstack.region.PortableIpRangeDaoImpl;
 import org.apache.cloudstack.region.dao.RegionDaoImpl;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDaoImpl;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDaoImpl;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDaoImpl;
 import org.apache.cloudstack.test.utils.SpringUtils;
 
@@ -131,7 +133,7 @@ import com.cloud.vm.dao.VMInstanceDaoImpl;
     NetworkDomainDaoImpl.class, HostDetailsDaoImpl.class, HostTagsDaoImpl.class, ClusterDaoImpl.class, FirewallRulesDaoImpl.class,
     FirewallRulesCidrsDaoImpl.class, PhysicalNetworkDaoImpl.class, PhysicalNetworkTrafficTypeDaoImpl.class, PhysicalNetworkServiceProviderDaoImpl.class,
     LoadBalancerDaoImpl.class, NetworkServiceMapDaoImpl.class, PrimaryDataStoreDaoImpl.class, StoragePoolDetailsDaoImpl.class,
-    PortableIpRangeDaoImpl.class, RegionDaoImpl.class, PortableIpDaoImpl.class, AccountGuestVlanMapDaoImpl.class},
+    PortableIpRangeDaoImpl.class, RegionDaoImpl.class, PortableIpDaoImpl.class, AccountGuestVlanMapDaoImpl.class, ImageStoreDaoImpl.class, ImageStoreDetailsDaoImpl.class},
                includeFilters = {@Filter(value = ChildTestConfiguration.Library.class, type = FilterType.CUSTOM)},
                useDefaultFilters = false)
 public class

--- a/setup/db/db/schema-481to490.sql
+++ b/setup/db/db/schema-481to490.sql
@@ -545,3 +545,6 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervis
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.0', 'centos64Guest', 228, now(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'centos64Guest', 228, now(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'centos64Guest', 228, now(), 0);
+
+ALTER TABLE `cloud`.`image_store_details` CHANGE COLUMN `value` `value` VARCHAR(255) NULL DEFAULT NULL COMMENT 'value of the detail', ADD COLUMN `display` tinyint(1) NOT 
+NULL DEFAULT '1' COMMENT 'True if the detail can be displayed to the end user' AFTER `value`;

--- a/test/integration/smoke/test_ssvm.py
+++ b/test/integration/smoke/test_ssvm.py
@@ -20,12 +20,13 @@
 from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.cloudstackAPI import (stopSystemVm,
                                   rebootSystemVm,
-                                  destroySystemVm)
+                                  destroySystemVm, updateConfiguration)
 from marvin.lib.utils import (cleanup_resources,
                               get_process_status,
-                              get_host_credentials)
+                              get_host_credentials,
+                              wait_until)
 from marvin.lib.base import (PhysicalNetwork,
-                             NetScaler)
+                             NetScaler, ImageStore)
 from marvin.lib.common import (get_zone,
                                list_hosts,
                                list_ssvms,
@@ -33,6 +34,7 @@ from marvin.lib.common import (get_zone,
                                list_vlan_ipranges)
 from nose.plugins.attrib import attr
 import telnetlib
+import logging
 
 # Import System modules
 import time
@@ -42,11 +44,18 @@ _multiprocess_shared_ = True
 class TestSSVMs(cloudstackTestCase):
 
     def setUp(self):
+	test_case = super(TestSSVMs, self)
         self.apiclient = self.testClient.getApiClient()
         self.hypervisor = self.testClient.getHypervisorInfo()
         self.cleanup = []
+        self.config = test_case.getClsConfig()
         self.services = self.testClient.getParsedTestDataConfig()
         self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
+
+        self.logger = logging.getLogger('TestSSVMs')
+        self.stream_handler = logging.StreamHandler()
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.addHandler(self.stream_handler)
 
         # Default sleep is set to 90 seconds, which is too long if the SSVM takes up to 2min to start.
         # Second sleep in the loop will waste test time.
@@ -1196,4 +1205,163 @@ class TestSSVMs(cloudstackTestCase):
 
         # Call to verify cloud process is running
         self.test_04_cpvm_internals()
+        return
+
+    @attr(
+        tags=[
+            "advanced",
+            "advancedns",
+            "smoke",
+            "basic",
+            "sg"],
+        required_hardware="true")
+    def test_11_ss_nfs_version_on_ssvm(self):
+        """Test NFS Version on Secondary Storage mounted properly on SSVM
+        """
+
+        # 1) List SSVM in zone
+        # 2) Get id and url from mounted nfs store
+        # 3) Update NFS version for previous image store
+        # 4) Stop SSVM
+        # 5) Check NFS version of mounted nfs store after SSVM starts 
+
+        nfs_version = self.config.nfsVersion
+        if nfs_version == None:
+            self.skipTest('No NFS version provided in test data')
+
+        #List SSVM for zone id
+        list_ssvm_response = list_ssvms(
+            self.apiclient,
+            systemvmtype='secondarystoragevm',
+            state='Running',
+            zoneid=self.zone.id
+        )
+        self.assertNotEqual(
+            list_ssvm_response,
+            None
+        )
+        self.assertEqual(
+            isinstance(list_ssvm_response, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        self.assertEqual(
+            len(list_ssvm_response),
+            1,
+            "Check list System VMs response"
+        )
+
+        ssvm = list_ssvm_response[0]
+        image_stores_response = ImageStore.list(self.apiclient,zoneid=self.zone.id)
+
+        if self.hypervisor.lower() in ('vmware', 'hyperv'):
+            # SSH into SSVMs is done via management server for Vmware and Hyper-V
+            result = get_process_status(
+                self.apiclient.connection.mgtSvr,
+                22,
+                self.apiclient.connection.user,
+                self.apiclient.connection.passwd,
+                ssvm.privateip,
+                "mount | grep 'type nfs'",
+                hypervisor=self.hypervisor)
+
+        for res in result:
+            split_res = res.split("on")
+            mounted_img_store_url = split_res[0].strip()
+            for img_store in image_stores_response:
+                img_store_url = str(img_store.url)
+                if img_store_url.startswith("nfs://"):
+                    img_store_url = img_store_url[6:]
+                    #Add colon after ip address to match output from mount command
+                    first_slash = img_store_url.find('/')
+                    img_store_url = img_store_url[0:first_slash] + ':' + img_store_url[first_slash:]
+                    if img_store_url == mounted_img_store_url:
+                        img_store_id = img_store.id
+                        break
+
+        self.assertNotEqual(
+            img_store_id,
+            None,
+            "Check image store id mounted on SSVM"
+        )
+
+        #Update NFS version for image store mounted on SSVM
+        updateConfigurationCmd = updateConfiguration.updateConfigurationCmd()
+        updateConfigurationCmd.name = "secstorage.nfs.version"
+        updateConfigurationCmd.value = nfs_version
+        updateConfigurationCmd.imagestoreuuid = img_store_id
+
+        updateConfigurationResponse = self.apiclient.updateConfiguration(updateConfigurationCmd)
+        self.logger.debug("updated the parameter %s with value %s"%(updateConfigurationResponse.name, updateConfigurationResponse.value))
+
+        #Stop SSVM
+        self.debug("Stopping SSVM: %s" % ssvm.id)
+        cmd = stopSystemVm.stopSystemVmCmd()
+        cmd.id = ssvm.id
+        self.apiclient.stopSystemVm(cmd)
+
+        def checkForRunningSSVM():
+            new_list_ssvm_response = list_ssvms(
+                self.apiclient,
+                id=ssvm.id
+            )
+            if isinstance(new_list_ssvm_response, list):
+                return new_list_ssvm_response[0].state == 'Running', None                
+            
+        res, _ = wait_until(self.services["sleep"], self.services["timeout"], checkForRunningSSVM)
+        if not res:
+            self.fail("List SSVM call failed!")
+        
+        new_list_ssvm_response = list_ssvms(
+                self.apiclient,
+                id=ssvm.id
+        )
+
+        self.assertNotEqual(
+            new_list_ssvm_response,
+            None
+        )
+        self.assertEqual(
+            isinstance(new_list_ssvm_response, list),
+            True,
+            "Check list response returns a valid list"
+        )
+        ssvm = new_list_ssvm_response[0]
+        self.debug("SSVM state after debug: %s" % ssvm.state)
+        self.assertEqual(
+            ssvm.state,
+            'Running',
+            "Check whether SSVM is running or not"
+        )
+        # Wait for the agent to be up
+        self.waitForSystemVMAgent(ssvm.name)
+
+        #Check NFS version on mounted image store
+        result = get_process_status(
+                self.apiclient.connection.mgtSvr,
+                22,
+                self.apiclient.connection.user,
+                self.apiclient.connection.passwd,
+                ssvm.privateip,
+                "mount | grep '%s'"%mounted_img_store_url,
+                hypervisor=self.hypervisor)
+
+        self.assertNotEqual(
+            result,
+            None
+        )
+        self.assertEqual(
+            len(result),
+            1,
+            "Check result length"
+        )
+
+        res = result[0]
+        mounted_nfs_version = res.split("vers=")[1][0:1]
+        self.assertEqual(
+            int(mounted_nfs_version),
+            int(nfs_version),
+            "Check mounted NFS version to be the same as provided"
+        )
+
         return

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -19974,28 +19974,58 @@
                                                 }
                                             });
                                         }
-                                    }
-
-                                    // Granular settings for storage pool for secondary storage is not required
-                                    /*  settings: {
-                                    title: 'label.menu.global.settings',
-                                    custom: cloudStack.uiCustom.granularSettings({
-                                    dataProvider: function(args) {
-                                    args.response.success({
-                                    data: [
-                                    { name: 'config.param.1', value: 1 },
-                                    { name: 'config.param.2', value: 2 }
-                                    ]
-                                    });
                                     },
-                                    actions: {
-                                    edit: function(args) {
-                                    // call updateStorageLevelParameters
-                                    args.response.success();
-                                    }
-                                    }
-                                    })
-                                    } */
+
+                                    // Granular settings for image store
+									settings: {
+										title: 'label.settings',
+										custom: cloudStack.uiCustom.granularSettings({
+											dataProvider: function (args) {
+
+												$.ajax({
+													url: createURL('listConfigurations&imagestoreuuid=' + args.context.secondaryStorage[0].id),
+													data: listViewDataProvider(args, {
+													},
+													{
+														searchBy: 'name'
+													}),
+													success: function (json) {
+														args.response.success({
+															data: json.listconfigurationsresponse.configuration
+														});
+													},
+
+													error: function (json) {
+														args.response.error(parseXMLHttpResponse(json));
+													}
+												});
+											},
+											actions: {
+												edit: function (args) {
+													// call updateStorageLevelParameters
+													var data = {
+														name: args.data.jsonObj.name,
+														value: args.data.value
+													};
+
+													$.ajax({
+														url: createURL('updateConfiguration&imagestoreuuid=' + args.context.secondaryStorage[0].id),
+														data: data,
+														success: function (json) {
+															var item = json.updateconfigurationresponse.configuration;
+															args.response.success({
+																data: item
+															});
+														},
+
+														error: function (json) {
+															args.response.error(parseXMLHttpResponse(json));
+														}
+													});
+												}
+											}
+										})
+									}
                                 }
                             }
                         }


### PR DESCRIPTION
JIRA TICKET: https://issues.apache.org/jira/browse/CLOUDSTACK-9438

### Introduction

From #1361 it was possible to configure NFS version for secondary storage mount. 
However, changing NFS version requires inserting an new detail on `image_store_details` table, with `name = 'nfs.version'` and `value = X` where X is desired NFS version, and then restarting management server for changes to take effect.

Our improvement aims to make NFS version changeable from UI, instead of previously described workflow.

### Proposed solution
Basically, NFS version is defined as an image store ConfigKey, this implied:
* Adding a new Config scope: **ImageStore**
* Make `ImageStoreDetailsDao` class to extend `ResourceDetailsDaoBase` and `ImageStoreDetailVO` implement `ResourceDetail`
* Insert `'display'` column on `image_store_details` table
* Extending `ListCfgsCmd` and `UpdateCfgCmd` to support **ImageStore** scope, which implied:
** Injecting `ImageStoreDetailsDao` and `ImageStoreDao` on `ConfigurationManagerImpl` class, on `cloud-server` module.

### Important
It is important to mention that `ImageStoreDaoImpl` and `ImageStoreDetailsDaoImpl` classes were moved from `cloud-engine-storage` to `cloud-engine-schema` module in order to Spring find those beans to inject on `ConfigurationManagerImpl` in `cloud-server` module.

We had this maven dependencies between modules:
* `cloud-server --> cloud-engine-schema`
* `cloud-engine-storage --> cloud-secondary-storage --> cloud-server`

As `ImageStoreDaoImpl` and `ImageStoreDetailsDao` were defined in `cloud-engine-storage`, and they needed in `cloud-server` module, to be injected on `ConfigurationManagerImpl`, if we added dependency from `cloud-server` to `cloud-engine-storage` we would introduce a dependency cycle. To avoid this cycle, we moved those classes to `cloud-engine-schema` module