### PR TITLE
oobm: simply change password transactional logic

### DIFF
--- a/client/WEB-INF/classes/resources/messages.properties
+++ b/client/WEB-INF/classes/resources/messages.properties
@@ -1016,6 +1016,7 @@ label.outofbandmanagement.driver=Driver
 label.outofbandmanagement.disable=Disable Out-of-band Management
 label.outofbandmanagement.enable=Enable Out-of-band Management
 label.outofbandmanagement.password=Password
+label.outofbandmanagement.reenterpassword=Re-enter Password
 label.outofbandmanagement.port=Port
 label.outofbandmanagement.username=Username
 message.outofbandmanagement.changepassword=Change Out-of-band Management password

--- a/ui/dictionary.jsp
+++ b/ui/dictionary.jsp
@@ -999,6 +999,7 @@ dictionary = {
 'label.outofbandmanagement.disable': '<fmt:message key="label.outofbandmanagement.disable" />',
 'label.outofbandmanagement.enable': '<fmt:message key="label.outofbandmanagement.enable" />',
 'label.outofbandmanagement.password': '<fmt:message key="label.outofbandmanagement.password" />',
+'label.outofbandmanagement.reenterpassword': '<fmt:message key="label.outofbandmanagement.reenterpassword" />',
 'label.outofbandmanagement.port': '<fmt:message key="label.outofbandmanagement.port" />',
 'label.outofbandmanagement.timeout': '<fmt:message key="label.outofbandmanagement.timeout" />',
 'label.outofbandmanagement.username': '<fmt:message key="label.outofbandmanagement.username" />',

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -16814,10 +16814,21 @@
                                                 required: false
                                             },
                                         },
+                                        reenterpassword: {
+                                            label: 'label.outofbandmanagement.reenterpassword',
+                                            isPassword: true,
+                                            validation: {
+                                                required: false
+                                            }
+                                        },
                                     }
                                 },
                                 action: function (args) {
                                     var data = args.data;
+                                    if (data.password != data.reenterpassword) {
+                                        args.response.error("Passwords do not match");
+                                        return;
+                                    }
                                     data.hostid = args.context.hosts[0].id;
                                     $.ajax({
                                         url: createURL('changeOutOfBandManagementPassword'),


### PR DESCRIPTION
- Simplifies change password transactional logic without using pessmistic locks
- Adds a re-enter password field in the UI to valid ipmi/oobm password