### PR TITLE
[CLOUDSTACK-9644] Adding missing bits field to TemplateResponse

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/TemplateResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/TemplateResponse.java
@@ -169,6 +169,10 @@ public class TemplateResponse extends BaseResponseWithTagInformation implements 
     @Param(description = "additional key/value details tied with template")
     private Map details;
 
+    @SerializedName(ApiConstants.BITS)
+    @Param(description="the processor bit size", since = "4.10")
+    private int bits;
+
     @SerializedName(ApiConstants.SSHKEY_ENABLED)
     @Param(description = "true if template is sshkey enabled, false otherwise")
     private Boolean sshKeyEnabled;
@@ -347,4 +351,7 @@ public class TemplateResponse extends BaseResponseWithTagInformation implements 
         return zoneId;
     }
 
+    public void setBits(int bits) {
+        this.bits = bits;
+    }
 }

--- a/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -284,6 +284,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
 
         isoResponse.setOsTypeId(iso.getGuestOSUuid());
         isoResponse.setOsTypeName(iso.getGuestOSName());
+        isoResponse.setBits(iso.getBits());
 
         // populate owner.
         ApiResponseHelper.populateOwner(isoResponse, iso);


### PR DESCRIPTION
This pull request adds a bits field for template size, and sets it equal to ISO size.
