### PR TITLE
Fix debian build error due to commit 3315eb5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
 cloudstack (4.10.0-SNAPSHOT) unstable; urgency=low
+
+  * Update the version to 4.10.0.snapshot
+
+ -- the Apache CloudStack project <dev@cloudstack.apache.org>  Mon, 08 Aug 2016 11:22:34 +0530
+
 cloudstack (4.9.0) unstable; urgency=low
-
-  * Update the version to 4.9.0
-
- -- the Apache CloudStack project <dev@cloudstack.apache.org>  Mon, 25 Jul 2016 16:56:03 -0400
-
 
   [ Remi Bergsma ]
   * Update the version to 4.9.0.snapshot


### PR DESCRIPTION
debian build is broken due to the changelog changes in commit 3315eb5. Fixed the same.
To test, do a debian following the instructions at http://docs.cloudstack.apache.org/projects/cloudstack-installation/en/4.8/building_from_source.html#building-deb-packages

cc: @pdion891 @rhtyd Please review.