### PR TITLE
[blocker] CLOUDSTACK-9452: add python-argparse dependency on el6,7 rpms

### DIFF
--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -96,6 +96,7 @@ management, and intelligence in CloudStack.
 %package common
 Summary: Apache CloudStack common files and scripts
 Requires: python
+Requires: python-argparse
 Obsoletes: cloud-test < 4.1.0 
 Obsoletes: cloud-scripts < 4.1.0
 Obsoletes: cloud-utils < 4.1.0

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -91,6 +91,7 @@ management, and intelligence in CloudStack.
 %package common
 Summary: Apache CloudStack common files and scripts
 Requires: python
+Requires: python-argparse
 Group:   System Environment/Libraries
 %description common
 The Apache CloudStack files shared between agent and management server

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1239,7 +1239,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         command.add("-p", cmdLine.replaceAll(" ", "%"));
         result = command.execute();
         if (result != null) {
-            s_logger.debug("passcmd failed:" + result);
+            s_logger.error("passcmd failed:" + result);
             return false;
         }
         return true;


### PR DESCRIPTION
The patchviasocket script was rewritten in Python from PR #1533 and made
assumptions that Python 2.7 would be available. In case of CentOS, python 2.7
may not be available or installed. This change ensures that python-argparse
is installed which is used by this script.

/cc @wido @sverrirab @karuturi @jburwell 

@blueorangutan package