### PR TITLE
Command route not available on CentOS 7

### DIFF
--- a/python/lib/cloudutils/networkConfig.py
+++ b/python/lib/cloudutils/networkConfig.py
@@ -41,7 +41,7 @@ class networkConfig:
         return devs
     @staticmethod
     def getDefaultNetwork():
-        cmd = bash("route -n|awk \'/^0.0.0.0/ {print $2,$8}\'") 
+        cmd = bash("ip route | awk \'/^default/ {print $3,$5}\'")
         if not cmd.isSuccess():
             logging.debug("Failed to get default route")
             raise CloudRuntimeException("Failed to get default route")


### PR DESCRIPTION
Hi guys,

The command route is not available on a fresh install of CentOS 7.
This one should be replace by ip route.

Command route make crash cloudstack-setup-agent on CentOS 7.
Another way is to make the net-tools paquet as dependencies of cloudstack-setup-agent.
