### PR TITLE
CLOUDSTACK-9456: Migrate master to Spring 4.x

### DIFF
--- a/api/resources/META-INF/cloudstack/api-config/spring-api-config-context.xml
+++ b/api/resources/META-INF/cloudstack/api-config/spring-api-config-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="apiServiceConfiguration" class="org.apache.cloudstack.config.ApiServiceConfiguration" />

--- a/api/resources/META-INF/cloudstack/api-planner/spring-api-planner-context.xml
+++ b/api/resources/META-INF/cloudstack/api-planner/spring-api-planner-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="UserDispersingPlanner" class="com.cloud.deploy.UserDispersingPlanner">

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -20,6 +20,13 @@
     <version>4.10.0.0-SNAPSHOT</version>
   </parent>
 
+  <repositories>
+    <repository>
+      <id>juniper-contrail</id>
+      <url>http://juniper.github.io/contrail-maven/snapshots</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>

--- a/client/resources/META-INF/cloudstack/webApplicationContext.xml
+++ b/client/resources/META-INF/cloudstack/webApplicationContext.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
     <!-- There is no reason to put anything here -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,7 @@
       <dependency>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-compress</artifactId>
-          <version>1.10</version>
+          <version>1.12</version>
       </dependency>
   </dependencies>
 

--- a/core/resources/META-INF/cloudstack/allocator/spring-core-allocator-context.xml
+++ b/core/resources/META-INF/cloudstack/allocator/spring-core-allocator-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
     <bean id="usageEventUtils" class="com.cloud.event.UsageEventUtils" />

--- a/core/resources/META-INF/cloudstack/allocator/spring-core-lifecycle-allocator-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/allocator/spring-core-lifecycle-allocator-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/api/spring-core-lifecycle-api-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/api/spring-core-lifecycle-api-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/bootstrap/spring-bootstrap-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/bootstrap/spring-bootstrap-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <context:annotation-config />

--- a/core/resources/META-INF/cloudstack/bootstrap/spring-bootstrap-context.xml
+++ b/core/resources/META-INF/cloudstack/bootstrap/spring-bootstrap-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.CloudStackLog4jSetup" />

--- a/core/resources/META-INF/cloudstack/compute/spring-core-lifecycle-compute-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/compute/spring-core-lifecycle-compute-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/core/spring-core-context.xml
+++ b/core/resources/META-INF/cloudstack/core/spring-core-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="componentContext" class="com.cloud.utils.component.ComponentContext">

--- a/core/resources/META-INF/cloudstack/core/spring-core-lifecycle-core-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/core/spring-core-lifecycle-core-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/core/spring-core-registry-core-context.xml
+++ b/core/resources/META-INF/cloudstack/core/spring-core-registry-core-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="userAuthenticatorsRegistry"

--- a/core/resources/META-INF/cloudstack/discoverer/spring-core-lifecycle-discoverer-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/discoverer/spring-core-lifecycle-discoverer-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/network/spring-core-lifecycle-network-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/network/spring-core-lifecycle-network-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/outofbandmanagement/spring-core-lifecycle-outofbandmanagement-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/outofbandmanagement/spring-core-lifecycle-outofbandmanagement-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/planner/spring-core-lifecycle-planner-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/planner/spring-core-lifecycle-planner-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/storage/spring-lifecycle-storage-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/storage/spring-lifecycle-storage-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle">

--- a/core/resources/META-INF/cloudstack/system/spring-core-system-context-inheritable.xml
+++ b/core/resources/META-INF/cloudstack/system/spring-core-system-context-inheritable.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
   <!--

--- a/core/resources/META-INF/cloudstack/system/spring-core-system-context.xml
+++ b/core/resources/META-INF/cloudstack/system/spring-core-system-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   <!--

--- a/engine/api/resources/META-INF/cloudstack/core/spring-engine-api-core-context.xml
+++ b/engine/api/resources/META-INF/cloudstack/core/spring-engine-api-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="clusterRestService"

--- a/engine/components-api/resources/META-INF/cloudstack/core/spring-engine-components-api-core-context.xml
+++ b/engine/components-api/resources/META-INF/cloudstack/core/spring-engine-components-api-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
 </beans>

--- a/engine/orchestration/resources/META-INF/cloudstack/core/spring-engine-orchestration-core-context.xml
+++ b/engine/orchestration/resources/META-INF/cloudstack/core/spring-engine-orchestration-core-context.xml
@@ -23,13 +23,13 @@
        xmlns:util="http://www.springframework.org/schema/util"
        
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/aop 
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                      http://www.springframework.org/schema/context/spring-context.xsd
                       http://www.springframework.org/schema/util
-                      http://www.springframework.org/schema/util/spring-util-3.0.xsd"
+                      http://www.springframework.org/schema/util/spring-util.xsd"
                       >
 
     <bean id="clusterBasedAgentLoadBalancerPlanner"

--- a/engine/orchestration/test/resource/provisioningContext.xml
+++ b/engine/orchestration/test/resource/provisioningContext.xml
@@ -21,13 +21,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                        http://www.springframework.org/schema/beans/spring-beans.xsd
                          http://www.springframework.org/schema/tx 
-       http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/tx/spring-tx.xsd
        http://www.springframework.org/schema/aop
-       http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/aop/spring-aop.xsd
                                  http://www.springframework.org/schema/context
-                                          http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                                          http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack.engine" />
   

--- a/engine/schema/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   <!--

--- a/engine/schema/resources/META-INF/cloudstack/system/spring-engine-schema-system-checkers-context.xml
+++ b/engine/schema/resources/META-INF/cloudstack/system/spring-engine-schema-system-checkers-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="databaseUpgradeChecker" class="com.cloud.upgrade.DatabaseUpgradeChecker" />

--- a/engine/storage/cache/resources/META-INF/cloudstack/core/spring-engine-storage-cache-core-context.xml
+++ b/engine/storage/cache/resources/META-INF/cloudstack/core/spring-engine-storage-cache-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="storageCacheRandomAllocator"

--- a/engine/storage/datamotion/resources/META-INF/cloudstack/core/spring-engine-storage-datamotion-core-context.xml
+++ b/engine/storage/datamotion/resources/META-INF/cloudstack/core/spring-engine-storage-datamotion-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="dataMotionServiceImpl"

--- a/engine/storage/datamotion/resources/META-INF/cloudstack/storage/spring-engine-storage-datamotion-storage-context.xml
+++ b/engine/storage/datamotion/resources/META-INF/cloudstack/storage/spring-engine-storage-datamotion-storage-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
     <bean id="ancientDataMotionStrategy"
         class="org.apache.cloudstack.storage.motion.AncientDataMotionStrategy" />

--- a/engine/storage/image/resources/META-INF/cloudstack/core/spring-engine-storage-image-core-context.xml
+++ b/engine/storage/image/resources/META-INF/cloudstack/core/spring-engine-storage-image-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="templateServiceImpl"

--- a/engine/storage/integration-test/test/resource/fakeDriverTestContext.xml
+++ b/engine/storage/integration-test/test/resource/fakeDriverTestContext.xml
@@ -13,13 +13,13 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                        http://www.springframework.org/schema/beans/spring-beans.xsd
                          http://www.springframework.org/schema/tx
-       http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/tx/spring-tx.xsd
        http://www.springframework.org/schema/aop
-       http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/aop/spring-aop.xsd
                                  http://www.springframework.org/schema/context
-                                          http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                                          http://www.springframework.org/schema/context/spring-context.xsd">
     <context:annotation-config />
 
     <bean id="componentContext" class="com.cloud.utils.component.ComponentContext" />

--- a/engine/storage/integration-test/test/resources/StorageAllocatorTestContext.xml
+++ b/engine/storage/integration-test/test/resources/StorageAllocatorTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:context="http://www.springframework.org/schema/context" xmlns:tx="http://www.springframework.org/schema/tx"
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack.storage" />

--- a/engine/storage/integration-test/test/resources/component.xml
+++ b/engine/storage/integration-test/test/resources/component.xml
@@ -22,13 +22,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 
   <!--

--- a/engine/storage/integration-test/test/resources/storageContext.xml
+++ b/engine/storage/integration-test/test/resources/storageContext.xml
@@ -13,13 +13,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                        http://www.springframework.org/schema/beans/spring-beans.xsd
                          http://www.springframework.org/schema/tx 
-       http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/tx/spring-tx.xsd
        http://www.springframework.org/schema/aop
-       http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/aop/spring-aop.xsd
                                  http://www.springframework.org/schema/context
-                                          http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                                          http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
     
    <bean id="componentContext" class="com.cloud.utils.component.ComponentContext" />

--- a/engine/storage/resources/META-INF/cloudstack/core/spring-engine-storage-core-context.xml
+++ b/engine/storage/resources/META-INF/cloudstack/core/spring-engine-storage-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <!--Image formats-->

--- a/engine/storage/resources/META-INF/cloudstack/storage-allocator/spring-engine-storage-storage-allocator-context.xml
+++ b/engine/storage/resources/META-INF/cloudstack/storage-allocator/spring-engine-storage-storage-allocator-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="LocalStoragePoolAllocator"

--- a/engine/storage/snapshot/resources/META-INF/cloudstack/core/spring-engine-storage-snapshot-core-context.xml
+++ b/engine/storage/snapshot/resources/META-INF/cloudstack/core/spring-engine-storage-snapshot-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="snapshotServiceImpl"

--- a/engine/storage/snapshot/resources/META-INF/cloudstack/storage/spring-engine-storage-snapshot-storage-context.xml
+++ b/engine/storage/snapshot/resources/META-INF/cloudstack/storage/spring-engine-storage-snapshot-storage-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="xenserverSnapshotStrategy"

--- a/engine/storage/snapshot/test/resources/SnapshotManagerTestContext.xml
+++ b/engine/storage/snapshot/test/resources/SnapshotManagerTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/engine/storage/volume/resources/META-INF/cloudstack/core/spring-engine-storage-volume-core-context.xml
+++ b/engine/storage/volume/resources/META-INF/cloudstack/core/spring-engine-storage-volume-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <!--Filesystem types -->

--- a/engine/storage/volume/test/resource/testContext.xml
+++ b/engine/storage/volume/test/resource/testContext.xml
@@ -21,13 +21,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                        http://www.springframework.org/schema/beans/spring-beans.xsd
                          http://www.springframework.org/schema/tx 
-       http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/tx/spring-tx.xsd
        http://www.springframework.org/schema/aop
-       http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/aop/spring-aop.xsd
                                  http://www.springframework.org/schema/context
-                                          http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                                          http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack.storage" />
   <context:component-scan

--- a/framework/cluster/resources/META-INF/cloudstack/core/spring-framework-cluster-core-context.xml
+++ b/framework/cluster/resources/META-INF/cloudstack/core/spring-framework-cluster-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="clusterServiceServletAdapter" class="com.cloud.cluster.ClusterServiceServletAdapter" />

--- a/framework/config/resources/META-INF/cloudstack/system/spring-framework-config-system-context-inheritable.xml
+++ b/framework/config/resources/META-INF/cloudstack/system/spring-framework-config-system-context-inheritable.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
   <bean class="org.apache.cloudstack.spring.lifecycle.registry.RegistryLifecycle" >

--- a/framework/config/resources/META-INF/cloudstack/system/spring-framework-config-system-context.xml
+++ b/framework/config/resources/META-INF/cloudstack/system/spring-framework-config-system-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="configurationDaoImpl"

--- a/framework/db/resources/META-INF/cloudstack/system/spring-framework-db-system-context.xml
+++ b/framework/db/resources/META-INF/cloudstack/system/spring-framework-db-system-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="entityManagerImpl" class="com.cloud.dao.EntityManagerImpl" />

--- a/framework/ipc/resources/META-INF/cloudstack/core/spring-framework-ipc-core-context.xml
+++ b/framework/ipc/resources/META-INF/cloudstack/core/spring-framework-ipc-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
   <!--

--- a/framework/ipc/test/resources/MessageBusTestContext.xml
+++ b/framework/ipc/test/resources/MessageBusTestContext.xml
@@ -22,13 +22,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
 
   <bean id="onwireRegistry" class="org.apache.cloudstack.framework.serializer.OnwireClassRegistry"

--- a/framework/ipc/test/resources/SampleManagementServerAppContext.xml
+++ b/framework/ipc/test/resources/SampleManagementServerAppContext.xml
@@ -23,13 +23,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack, com.cloud" />
 

--- a/framework/jobs/resources/META-INF/cloudstack/core/spring-framework-jobs-core-context.xml
+++ b/framework/jobs/resources/META-INF/cloudstack/core/spring-framework-jobs-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="asyncJobDaoImpl"

--- a/framework/jobs/test/resources/AsyncJobManagerTestContext.xml
+++ b/framework/jobs/test/resources/AsyncJobManagerTestContext.xml
@@ -21,13 +21,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
     <import resource="commonContext.xml"/>
     <import resource="classpath*:spring-framework-jobs-core-context.xml"/>
     <bean id="AsyncJobManagerTestConfiguration"

--- a/framework/jobs/test/resources/commonContext.xml
+++ b/framework/jobs/test/resources/commonContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
   <bean id="transactionContextBuilder" class="com.cloud.utils.db.TransactionContextBuilder" />

--- a/framework/quota/resources/META-INF/cloudstack/quota/spring-framework-quota-context.xml
+++ b/framework/quota/resources/META-INF/cloudstack/quota/spring-framework-quota-context.xml
@@ -12,10 +12,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="QuotaTariffDao" class="org.apache.cloudstack.quota.dao.QuotaTariffDaoImpl" />
     <bean id="QuotaAccountDao" class="org.apache.cloudstack.quota.dao.QuotaAccountDaoImpl" />

--- a/framework/security/resources/META-INF/cloudstack/core/spring-framework-security-core-context.xml
+++ b/framework/security/resources/META-INF/cloudstack/core/spring-framework-security-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
     <bean id="keystoreManagerImpl" class="org.apache.cloudstack.framework.security.keystore.KeystoreManagerImpl" />
     <bean id="keystoreDaoImpl" class="org.apache.cloudstack.framework.security.keystore.KeystoreDaoImpl" />

--- a/framework/spring/module/src/main/resources/org/apache/cloudstack/spring/module/model/impl/defaults-context.xml
+++ b/framework/spring/module/src/main/resources/org/apache/cloudstack/spring/module/model/impl/defaults-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="DefaultConfigResources" class="java.util.ArrayList" />
     <bean id="DefaultConfigProperties" class="java.util.Properties" />

--- a/framework/spring/module/src/test/resources/testfiles/all/empty-context-inheritable.xml
+++ b/framework/spring/module/src/test/resources/testfiles/all/empty-context-inheritable.xml
@@ -19,8 +19,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 </beans>

--- a/framework/spring/module/src/test/resources/testfiles/all/empty-context.xml
+++ b/framework/spring/module/src/test/resources/testfiles/all/empty-context.xml
@@ -19,8 +19,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 </beans>

--- a/framework/spring/module/src/test/resources/testfiles/all/empty2-context-inheritable.xml
+++ b/framework/spring/module/src/test/resources/testfiles/all/empty2-context-inheritable.xml
@@ -19,8 +19,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 </beans>

--- a/framework/spring/module/src/test/resources/testfiles/all/empty2-context.xml
+++ b/framework/spring/module/src/test/resources/testfiles/all/empty2-context.xml
@@ -19,8 +19,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 </beans>

--- a/framework/spring/module/src/test/resources/testfiles/good/empty-context.xml
+++ b/framework/spring/module/src/test/resources/testfiles/good/empty-context.xml
@@ -19,8 +19,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 </beans>

--- a/framework/spring/module/src/test/resources/testhierarchy/base/test-context-inheritable.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/base/test-context-inheritable.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="count" class="org.apache.cloudstack.spring.module.factory.ModuleBasedContextFactoryTest.InstantiationCounter" />
     

--- a/framework/spring/module/src/test/resources/testhierarchy/base/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/base/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="name" class="java.lang.String" >
         <constructor-arg value="base" />

--- a/framework/spring/module/src/test/resources/testhierarchy/child1-1/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/child1-1/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="name" class="java.lang.String" >
         <constructor-arg value="child1-1" />

--- a/framework/spring/module/src/test/resources/testhierarchy/child1/test-context-override.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/child1/test-context-override.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
     
     <bean id="override" class="java.lang.String" >
         <constructor-arg value="a string" />

--- a/framework/spring/module/src/test/resources/testhierarchy/child1/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/child1/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:annotation-config/>
 

--- a/framework/spring/module/src/test/resources/testhierarchy/child2/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/child2/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="name" class="java.lang.String" >
         <constructor-arg value="child2" />

--- a/framework/spring/module/src/test/resources/testhierarchy/excluded/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/excluded/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="name" class="java.lang.String" >
         <constructor-arg value="excluded" />

--- a/framework/spring/module/src/test/resources/testhierarchy/excluded2/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/excluded2/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="name" class="java.lang.String" >
         <constructor-arg value="excluded2" />

--- a/framework/spring/module/src/test/resources/testhierarchy/orphan-of-excluded/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/orphan-of-excluded/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="name" class="java.lang.String" >
         <constructor-arg value="orphan-of-excluded" />

--- a/framework/spring/module/src/test/resources/testhierarchy/orphan1/test-context.xml
+++ b/framework/spring/module/src/test/resources/testhierarchy/orphan1/test-context.xml
@@ -19,9 +19,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="name" class="java.lang.String" >
         <constructor-arg value="orphan1" />

--- a/plugins/acl/dynamic-role-based/resources/META-INF/cloudstack/acl-dynamic-role-based/spring-acl-dynamic-role-based-context.xml
+++ b/plugins/acl/dynamic-role-based/resources/META-INF/cloudstack/acl-dynamic-role-based/spring-acl-dynamic-role-based-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="DynamicRoleBasedAPIAccessChecker" class="org.apache.cloudstack.acl.DynamicRoleBasedAPIAccessChecker" >

--- a/plugins/acl/static-role-based/resources/META-INF/cloudstack/acl-static-role-based/spring-acl-static-role-based-context.xml
+++ b/plugins/acl/static-role-based/resources/META-INF/cloudstack/acl-static-role-based/spring-acl-static-role-based-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
     <bean id="StaticRoleBasedAPIAccessChecker" class="org.apache.cloudstack.acl.StaticRoleBasedAPIAccessChecker" >

--- a/plugins/affinity-group-processors/explicit-dedication/resources/META-INF/cloudstack/explicit-dedication/spring-explicit-dedication-context.xml
+++ b/plugins/affinity-group-processors/explicit-dedication/resources/META-INF/cloudstack/explicit-dedication/spring-explicit-dedication-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="ExplicitDedicationProcessor"

--- a/plugins/affinity-group-processors/host-anti-affinity/resources/META-INF/cloudstack/host-anti-affinity/spring-host-anti-affinity-context.xml
+++ b/plugins/affinity-group-processors/host-anti-affinity/resources/META-INF/cloudstack/host-anti-affinity/spring-host-anti-affinity-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="HostAntiAffinityProcessor"

--- a/plugins/api/rate-limit/resources/META-INF/cloudstack/rate-limit/spring-rate-limit-context.xml
+++ b/plugins/api/rate-limit/resources/META-INF/cloudstack/rate-limit/spring-rate-limit-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
       <bean id="apiRateLimitServiceImpl" class="org.apache.cloudstack.ratelimit.ApiRateLimitServiceImpl"/>

--- a/plugins/api/solidfire-intg-test/resources/META-INF/cloudstack/solidfire-intg-test/spring-solidfire-intg-test-context.xml
+++ b/plugins/api/solidfire-intg-test/resources/META-INF/cloudstack/solidfire-intg-test/spring-solidfire-intg-test-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
       <bean id="sfIntgTestUtil" class="org.apache.cloudstack.util.solidfire.SolidFireIntegrationTestUtil"/>

--- a/plugins/database/quota/resources/META-INF/cloudstack/quota/spring-quota-context.xml
+++ b/plugins/database/quota/resources/META-INF/cloudstack/quota/spring-quota-context.xml
@@ -20,10 +20,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="QuotaService" class="org.apache.cloudstack.quota.QuotaServiceImpl" />
     <bean id="QuotaResponseBuilder" class="org.apache.cloudstack.api.response.QuotaResponseBuilderImpl"/>

--- a/plugins/dedicated-resources/resources/META-INF/cloudstack/core/spring-dedicated-resources-core-context.xml
+++ b/plugins/dedicated-resources/resources/META-INF/cloudstack/core/spring-dedicated-resources-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="DedicatedResourceManagerImpl"

--- a/plugins/dedicated-resources/test/resource/dedicatedContext.xml
+++ b/plugins/dedicated-resources/test/resource/dedicatedContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
      <context:annotation-config />
      <context:component-scan

--- a/plugins/deployment-planners/implicit-dedication/resources/META-INF/cloudstack/implicit-dedication/spring-implicit-dedication-context.xml
+++ b/plugins/deployment-planners/implicit-dedication/resources/META-INF/cloudstack/implicit-dedication/spring-implicit-dedication-context.xml
@@ -12,10 +12,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="ImplicitDedicationPlanner" class="com.cloud.deploy.ImplicitDedicationPlanner">
         <property name="name" value="ImplicitDedicationPlanner" />

--- a/plugins/deployment-planners/user-concentrated-pod/resources/META-INF/cloudstack/user-concentrated-pod/spring-user-concentrated-pod-context.xml
+++ b/plugins/deployment-planners/user-concentrated-pod/resources/META-INF/cloudstack/user-concentrated-pod/spring-user-concentrated-pod-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   <bean id="UserConcentratedPodPlanner" class="com.cloud.deploy.UserConcentratedPodPlanner">

--- a/plugins/ha-planners/skip-heurestics/resources/META-INF/cloudstack/skip-heurestics/spring-skip-heurestics-context.xml
+++ b/plugins/ha-planners/skip-heurestics/resources/META-INF/cloudstack/skip-heurestics/spring-skip-heurestics-context.xml
@@ -12,10 +12,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="SkipHeuresticsPlanner" class="com.cloud.deploy.SkipHeuresticsPlanner">
         <property name="name" value="SkipHeuresticsPlanner" />

--- a/plugins/host-allocators/random/resources/META-INF/cloudstack/host-allocator-random/spring-host-allocator-random-context.xml
+++ b/plugins/host-allocators/random/resources/META-INF/cloudstack/host-allocator-random/spring-host-allocator-random-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="randomAllocator"

--- a/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-compute/spring-baremetal-compute-context.xml
+++ b/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-compute/spring-baremetal-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="BaremetalGuru" class="com.cloud.baremetal.manager.BareMetalGuru">

--- a/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-discoverer/spring-baremetal-discoverer-context.xml
+++ b/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-discoverer/spring-baremetal-discoverer-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="BareMetalDiscoverer" class="com.cloud.baremetal.manager.BareMetalDiscoverer">

--- a/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-network/spring-baremetal-network-context.xml
+++ b/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-network/spring-baremetal-network-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="BareMetalDhcp"

--- a/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-planner/spring-baremetal-planner-context.xml
+++ b/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-planner/spring-baremetal-planner-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="BareMetalPlanner" class="com.cloud.baremetal.manager.BareMetalPlanner">

--- a/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-storage/spring-baremetal-storage-context.xml
+++ b/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/baremetal-storage/spring-baremetal-storage-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="BareMetalTemplateAdapter" class="com.cloud.baremetal.manager.BareMetalTemplateAdapter" />

--- a/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/core/spring-baremetal-core-context.xml
+++ b/plugins/hypervisors/baremetal/resources/META-INF/cloudstack/core/spring-baremetal-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="BaremetalManager" class="com.cloud.baremetal.manager.BaremetalManagerImpl" />

--- a/plugins/hypervisors/hyperv/resources/META-INF/cloudstack/core/spring-hyperv-core-context.xml
+++ b/plugins/hypervisors/hyperv/resources/META-INF/cloudstack/core/spring-hyperv-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="HypervManager" class="com.cloud.hypervisor.hyperv.manager.HypervManagerImpl" />

--- a/plugins/hypervisors/hyperv/resources/META-INF/cloudstack/hyperv-compute/spring-hyperv-compute-context.xml
+++ b/plugins/hypervisors/hyperv/resources/META-INF/cloudstack/hyperv-compute/spring-hyperv-compute-context.xml
@@ -12,10 +12,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="HypervGuru" class="com.cloud.hypervisor.hyperv.guru.HypervGuru">
         <property name="name" value="HypervGuru" />

--- a/plugins/hypervisors/hyperv/resources/META-INF/cloudstack/hyperv-discoverer/spring-hyperv-discoverer-context.xml
+++ b/plugins/hypervisors/hyperv/resources/META-INF/cloudstack/hyperv-discoverer/spring-hyperv-discoverer-context.xml
@@ -12,10 +12,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="HypervServerDiscoverer"
         class="com.cloud.hypervisor.hyperv.discoverer.HypervServerDiscoverer">

--- a/plugins/hypervisors/kvm/resources/META-INF/cloudstack/kvm-compute/spring-kvm-compute-context.xml
+++ b/plugins/hypervisors/kvm/resources/META-INF/cloudstack/kvm-compute/spring-kvm-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="KVMInvestigator" class="com.cloud.ha.KVMInvestigator">

--- a/plugins/hypervisors/ovm/resources/META-INF/cloudstack/ovm-compute/spring-ovm-compute-context.xml
+++ b/plugins/hypervisors/ovm/resources/META-INF/cloudstack/ovm-compute/spring-ovm-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="OvmFencer" class="com.cloud.ovm.hypervisor.OvmFencer">

--- a/plugins/hypervisors/ovm/resources/META-INF/cloudstack/ovm-discoverer/spring-ovm-discoverer-context.xml
+++ b/plugins/hypervisors/ovm/resources/META-INF/cloudstack/ovm-discoverer/spring-ovm-discoverer-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="OvmDiscoverer" class="com.cloud.ovm.hypervisor.OvmDiscoverer">

--- a/plugins/hypervisors/ovm3/src/main/resources/META-INF/cloudstack/ovm3-compute/spring-ovm3-compute-context.xml
+++ b/plugins/hypervisors/ovm3/src/main/resources/META-INF/cloudstack/ovm3-compute/spring-ovm3-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="Ovm3Fencer" class="com.cloud.hypervisor.ovm3.resources.Ovm3FenceBuilder">

--- a/plugins/hypervisors/ovm3/src/main/resources/META-INF/cloudstack/ovm3-discoverer/spring-ovm3-discoverer-context.xml
+++ b/plugins/hypervisors/ovm3/src/main/resources/META-INF/cloudstack/ovm3-discoverer/spring-ovm3-discoverer-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="Ovm3Discoverer" class="com.cloud.hypervisor.ovm3.resources.Ovm3Discoverer">

--- a/plugins/hypervisors/simulator/resources/META-INF/cloudstack/core/spring-simulator-core-context.xml
+++ b/plugins/hypervisors/simulator/resources/META-INF/cloudstack/core/spring-simulator-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="mockConfigurationDaoImpl" class="com.cloud.simulator.dao.MockConfigurationDaoImpl" />

--- a/plugins/hypervisors/simulator/resources/META-INF/cloudstack/simulator-compute/spring-simulator-compute-context.xml
+++ b/plugins/hypervisors/simulator/resources/META-INF/cloudstack/simulator-compute/spring-simulator-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="SimulatorGuru" class="com.cloud.simulator.SimulatorGuru">

--- a/plugins/hypervisors/simulator/resources/META-INF/cloudstack/simulator-discoverer/spring-simulator-discover-context.xml
+++ b/plugins/hypervisors/simulator/resources/META-INF/cloudstack/simulator-discoverer/spring-simulator-discover-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="SimulatorDiscoverer" class="com.cloud.resource.SimulatorDiscoverer">

--- a/plugins/hypervisors/simulator/resources/META-INF/cloudstack/simulator-storage/spring-simulator-storage-context.xml
+++ b/plugins/hypervisors/simulator/resources/META-INF/cloudstack/simulator-storage/spring-simulator-storage-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="SimulatorImageStoreProviderImpl"

--- a/plugins/hypervisors/ucs/resources/META-INF/cloudstack/core/spring-ucs-core-context.xml
+++ b/plugins/hypervisors/ucs/resources/META-INF/cloudstack/core/spring-ucs-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="UcsManager" class="com.cloud.ucs.manager.UcsManagerImpl" />

--- a/plugins/hypervisors/vmware/resources/META-INF/cloudstack/core/spring-vmware-core-context.xml
+++ b/plugins/hypervisors/vmware/resources/META-INF/cloudstack/core/spring-vmware-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="VmwareManager"

--- a/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-compute/spring-vmware-compute-context.xml
+++ b/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-compute/spring-vmware-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="VmwareFencer" class="com.cloud.ha.VmwareFencer">

--- a/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-discoverer/spring-vmware-discoverer-context.xml
+++ b/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-discoverer/spring-vmware-discoverer-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="vmwareServerDiscoverer" class="com.cloud.hypervisor.vmware.VmwareServerDiscoverer">

--- a/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-network/spring-vmware-network-context.xml
+++ b/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-network/spring-vmware-network-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="CiscoNexus1000vVSM" class="com.cloud.network.element.CiscoNexusVSMElement">

--- a/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-storage/spring-vmware-storage-context.xml
+++ b/plugins/hypervisors/vmware/resources/META-INF/cloudstack/vmware-storage/spring-vmware-storage-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="vmwareStorageMotionStrategy"

--- a/plugins/hypervisors/xenserver/resources/META-INF/cloudstack/xenserver-compute/spring-xenserver-compute-context.xml
+++ b/plugins/hypervisors/xenserver/resources/META-INF/cloudstack/xenserver-compute/spring-xenserver-compute-context.xml
@@ -12,10 +12,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="XenServerFencer" class="com.cloud.ha.XenServerFencer">
         <property name="name" value="XenServerFenceBuilder" />

--- a/plugins/hypervisors/xenserver/resources/META-INF/cloudstack/xenserver-discoverer/spring-xenserver-discoverer-context.xml
+++ b/plugins/hypervisors/xenserver/resources/META-INF/cloudstack/xenserver-discoverer/spring-xenserver-discoverer-context.xml
@@ -12,10 +12,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="XcpServerDiscoverer"
         class="com.cloud.hypervisor.xenserver.discoverer.XcpServerDiscoverer">

--- a/plugins/network-elements/bigswitch/resources/META-INF/cloudstack/bigswitch/spring-bigswitch-context.xml
+++ b/plugins/network-elements/bigswitch/resources/META-INF/cloudstack/bigswitch/spring-bigswitch-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="bigSwitchBcfDaoImpl" class="com.cloud.network.dao.BigSwitchBcfDaoImpl" />

--- a/plugins/network-elements/brocade-vcs/resources/META-INF/cloudstack/vcs/spring-vcs-context.xml
+++ b/plugins/network-elements/brocade-vcs/resources/META-INF/cloudstack/vcs/spring-vcs-context.xml
@@ -12,10 +12,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="brocadeVcsDaoImpl" class="com.cloud.network.dao.BrocadeVcsDaoImpl" />
 	<bean id="brocadeVcsNetworkVlanMappingDaoImpl" class="com.cloud.network.dao.BrocadeVcsNetworkVlanMappingDaoImpl" />

--- a/plugins/network-elements/cisco-vnmc/resources/META-INF/cloudstack/cisco-vnmc/spring-cisco-vnmc-context.xml
+++ b/plugins/network-elements/cisco-vnmc/resources/META-INF/cloudstack/cisco-vnmc/spring-cisco-vnmc-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <!--

--- a/plugins/network-elements/elastic-loadbalancer/resources/META-INF/cloudstack/elb/spring-elb-context.xml
+++ b/plugins/network-elements/elastic-loadbalancer/resources/META-INF/cloudstack/elb/spring-elb-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   <bean id="elasticLoadBalancerManagerImpl" class="com.cloud.network.lb.ElasticLoadBalancerManagerImpl" />

--- a/plugins/network-elements/f5/resources/META-INF/cloudstack/f5/spring-f5-context.xml
+++ b/plugins/network-elements/f5/resources/META-INF/cloudstack/f5/spring-f5-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="F5BigIP" class="com.cloud.network.element.F5ExternalLoadBalancerElement">

--- a/plugins/network-elements/globodns/resources/META-INF/cloudstack/globodns/spring-globodns-context.xml
+++ b/plugins/network-elements/globodns/resources/META-INF/cloudstack/globodns/spring-globodns-context.xml
@@ -12,10 +12,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan base-package="com.globo.globodns.cloudstack" />
 

--- a/plugins/network-elements/globodns/test/com/globo/globodns/cloudstack/resource/GloboDnsResourceTest.java
+++ b/plugins/network-elements/globodns/test/com/globo/globodns/cloudstack/resource/GloboDnsResourceTest.java
@@ -37,13 +37,9 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import com.cloud.agent.api.Answer;
 import com.globo.globodns.client.GloboDns;
@@ -57,8 +53,6 @@ import com.globo.globodns.cloudstack.commands.CreateOrUpdateRecordAndReverseComm
 import com.globo.globodns.cloudstack.commands.RemoveDomainCommand;
 import com.globo.globodns.cloudstack.commands.RemoveRecordCommand;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(loader = AnnotationConfigContextLoader.class)
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class GloboDnsResourceTest {
 
@@ -75,7 +69,6 @@ public class GloboDnsResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        // ComponentContext.initComponentsLifeCycle();
 
         String name = "GloboDNS";
         Map<String, Object> params = new HashMap<String, Object>();

--- a/plugins/network-elements/internal-loadbalancer/resources/META-INF/cloudstack/core/spring-internallb-core-context.xml
+++ b/plugins/network-elements/internal-loadbalancer/resources/META-INF/cloudstack/core/spring-internallb-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="InternalLbVm"

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_element.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_element.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
      <context:annotation-config />
 

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_mgr.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_mgr.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
      <context:annotation-config />
 

--- a/plugins/network-elements/internal-loadbalancer/test/resources/lb_svc.xml
+++ b/plugins/network-elements/internal-loadbalancer/test/resources/lb_svc.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
      <context:annotation-config />
 

--- a/plugins/network-elements/juniper-contrail/resources/META-INF/cloudstack/contrail/spring-contrail-context.xml
+++ b/plugins/network-elements/juniper-contrail/resources/META-INF/cloudstack/contrail/spring-contrail-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
   <bean id="ContrailManager"
 	class="org.apache.cloudstack.network.contrail.management.ContrailManagerImpl"/>

--- a/plugins/network-elements/juniper-contrail/resources/META-INF/cloudstack/system/spring-contrail-system-context-inheritable.xml
+++ b/plugins/network-elements/juniper-contrail/resources/META-INF/cloudstack/system/spring-contrail-system-context-inheritable.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   <!--

--- a/plugins/network-elements/juniper-contrail/test/resources/commonContext.xml
+++ b/plugins/network-elements/juniper-contrail/test/resources/commonContext.xml
@@ -11,13 +11,13 @@
   xmlns:context="http://www.springframework.org/schema/context" xmlns:tx="http://www.springframework.org/schema/tx"
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
   <!-- <context:component-scan base-package="org.apache.cloudstack, com.cloud" /> -->

--- a/plugins/network-elements/juniper-contrail/test/resources/providerContext.xml
+++ b/plugins/network-elements/juniper-contrail/test/resources/providerContext.xml
@@ -21,13 +21,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
     <import resource="commonContext.xml"/>
     <bean id="ProviderTestConfiguration"
     	class="org.apache.cloudstack.network.contrail.management.ProviderTestConfiguration"/>

--- a/plugins/network-elements/juniper-contrail/test/resources/publicNetworkContext.xml
+++ b/plugins/network-elements/juniper-contrail/test/resources/publicNetworkContext.xml
@@ -13,13 +13,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
     <import resource="commonContext.xml"/>
     <bean id="PublicNetworkTestConfiguration"
     	class="org.apache.cloudstack.network.contrail.management.PublicNetworkTestConfiguration"/>

--- a/plugins/network-elements/juniper-srx/resources/META-INF/cloudstack/srx/spring-srx-context.xml
+++ b/plugins/network-elements/juniper-srx/resources/META-INF/cloudstack/srx/spring-srx-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="JuniperSRX"

--- a/plugins/network-elements/midonet/resources/META-INF/cloudstack/midonet/spring-midonet-context.xml
+++ b/plugins/network-elements/midonet/resources/META-INF/cloudstack/midonet/spring-midonet-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="MidoNetGuestNetworkGuru" class="com.cloud.network.guru.MidoNetGuestNetworkGuru">

--- a/plugins/network-elements/netscaler/resources/META-INF/cloudstack/netscaler/spring-netscaler-context.xml
+++ b/plugins/network-elements/netscaler/resources/META-INF/cloudstack/netscaler/spring-netscaler-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="netScalerPodDaoImpl" class="com.cloud.network.dao.NetScalerPodDaoImpl" />

--- a/plugins/network-elements/nicira-nvp/src/main/resources/META-INF/cloudstack/nvp/spring-nvp-context.xml
+++ b/plugins/network-elements/nicira-nvp/src/main/resources/META-INF/cloudstack/nvp/spring-nvp-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="niciraNvpDaoImpl" class="com.cloud.network.dao.NiciraNvpDaoImpl" />

--- a/plugins/network-elements/nuage-vsp/resources/META-INF/cloudstack/vsp/spring-vsp-context.xml
+++ b/plugins/network-elements/nuage-vsp/resources/META-INF/cloudstack/vsp/spring-vsp-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="nuageVspDaoImpl" class="com.cloud.network.dao.NuageVspDaoImpl" />

--- a/plugins/network-elements/opendaylight/src/main/resources/META-INF/cloudstack/opendaylight/spring-opendaylight-context.xml
+++ b/plugins/network-elements/opendaylight/src/main/resources/META-INF/cloudstack/opendaylight/spring-opendaylight-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="OpendaylightGuestNetworkGuru" class="org.apache.cloudstack.network.opendaylight.OpendaylightGuestNetworkGuru">

--- a/plugins/network-elements/ovs/resources/META-INF/cloudstack/ovs/spring-ovs-context.xml
+++ b/plugins/network-elements/ovs/resources/META-INF/cloudstack/ovs/spring-ovs-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="Ovs" class="com.cloud.network.element.OvsElement">

--- a/plugins/network-elements/palo-alto/resources/META-INF/cloudstack/paloalto/spring-paloalto-context.xml
+++ b/plugins/network-elements/palo-alto/resources/META-INF/cloudstack/paloalto/spring-paloalto-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="PaloAlto" class="com.cloud.network.element.PaloAltoExternalFirewallElement">

--- a/plugins/network-elements/stratosphere-ssp/resources/META-INF/cloudstack/ssp/spring-ssp-context.xml
+++ b/plugins/network-elements/stratosphere-ssp/resources/META-INF/cloudstack/ssp/spring-ssp-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="sspCredentialDaoImpl"

--- a/plugins/network-elements/vxlan/resources/META-INF/cloudstack/vxlan/spring-vxlan-context.xml
+++ b/plugins/network-elements/vxlan/resources/META-INF/cloudstack/vxlan/spring-vxlan-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="VxlanGuestNetworkGuru" class="com.cloud.network.guru.VxlanGuestNetworkGuru">

--- a/plugins/outofbandmanagement-drivers/ipmitool/resources/META-INF/cloudstack/ipmitool/spring-ipmitool-context.xml
+++ b/plugins/outofbandmanagement-drivers/ipmitool/resources/META-INF/cloudstack/ipmitool/spring-ipmitool-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="ipmitoolOutOfBandManagementDriver" class="org.apache.cloudstack.outofbandmanagement.driver.ipmitool.IpmitoolOutOfBandManagementDriver">

--- a/plugins/storage/image/default/resources/META-INF/cloudstack/storage-image-default/spring-storage-image-default-context.xml
+++ b/plugins/storage/image/default/resources/META-INF/cloudstack/storage-image-default/spring-storage-image-default-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="cloudStackImageStoreProviderImpl"

--- a/plugins/storage/image/s3/resources/META-INF/cloudstack/storage-image-s3/spring-storage-image-s3-context.xml
+++ b/plugins/storage/image/s3/resources/META-INF/cloudstack/storage-image-s3/spring-storage-image-s3-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="s3ImageStoreProviderImpl"

--- a/plugins/storage/image/swift/resources/META-INF/cloudstack/storage-image-swift/spring-storage-image-swift-context.xml
+++ b/plugins/storage/image/swift/resources/META-INF/cloudstack/storage-image-swift/spring-storage-image-swift-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="swiftImageStoreProviderImpl"

--- a/plugins/storage/volume/cloudbyte/resources/META-INF/cloudstack/storage-volume-cloudbyte/spring-storage-volume-cloudbyte-context.xml
+++ b/plugins/storage/volume/cloudbyte/resources/META-INF/cloudstack/storage-volume-cloudbyte/spring-storage-volume-cloudbyte-context.xml
@@ -23,10 +23,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="elastistorDataStoreProvider"

--- a/plugins/storage/volume/default/resources/META-INF/cloudstack/storage-volume-default/spring-storage-volume-default-context.xml
+++ b/plugins/storage/volume/default/resources/META-INF/cloudstack/storage-volume-default/spring-storage-volume-default-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="cloudStackPrimaryDataStoreProviderImpl"

--- a/plugins/storage/volume/nexenta/resources/META-INF.cloudstack.storage-volume-solidfire/spring-storage-volume-nexenta-context.xml
+++ b/plugins/storage/volume/nexenta/resources/META-INF.cloudstack.storage-volume-solidfire/spring-storage-volume-nexenta-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                           http://www.springframework.org/schema/context/spring-context.xsd">
 
   <bean id="nexentaStorDataStoreProvider"
         class="org.apache.cloudstack.storage.datastore.provider.NexentaPrimaryDataStoreProvider" />

--- a/plugins/storage/volume/solidfire/resources/META-INF/cloudstack/storage-volume-solidfire/spring-storage-volume-solidfire-context.xml
+++ b/plugins/storage/volume/solidfire/resources/META-INF/cloudstack/storage-volume-solidfire/spring-storage-volume-solidfire-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="solidFireDataStoreProvider"

--- a/plugins/storage/volume/solidfire/test/resource/storageContext.xml
+++ b/plugins/storage/volume/solidfire/test/resource/storageContext.xml
@@ -21,13 +21,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                        http://www.springframework.org/schema/beans/spring-beans.xsd
                          http://www.springframework.org/schema/tx 
-       http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/tx/spring-tx.xsd
        http://www.springframework.org/schema/aop
-       http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/aop/spring-aop.xsd
                                  http://www.springframework.org/schema/context
-                                          http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                                          http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack.storage" />
   <context:component-scan base-package="org.apache.cloudstack.engine.subsystem.api.storage" />

--- a/plugins/user-authenticators/ldap/resources/META-INF/cloudstack/ldap/spring-ldap-context.xml
+++ b/plugins/user-authenticators/ldap/resources/META-INF/cloudstack/ldap/spring-ldap-context.xml
@@ -20,10 +20,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="LdapAuthenticator" class="org.apache.cloudstack.ldap.LdapAuthenticator">
         <property name="name" value="LDAP" />

--- a/plugins/user-authenticators/md5/resources/META-INF/cloudstack/md5/spring-md5-context.xml
+++ b/plugins/user-authenticators/md5/resources/META-INF/cloudstack/md5/spring-md5-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="MD5UserAuthenticator" class="com.cloud.server.auth.MD5UserAuthenticator">

--- a/plugins/user-authenticators/pbkdf2/resources/META-INF/cloudstack/pbkdf2/spring-pbkdf2-context.xml
+++ b/plugins/user-authenticators/pbkdf2/resources/META-INF/cloudstack/pbkdf2/spring-pbkdf2-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
     <bean id="PBKDF2UserAuthenticator" class="org.apache.cloudstack.server.auth.PBKDF2UserAuthenticator">
         <property name="name" value="PBKDF2"/>

--- a/plugins/user-authenticators/plain-text/resources/META-INF/cloudstack/plaintext/spring-plaintext-context.xml
+++ b/plugins/user-authenticators/plain-text/resources/META-INF/cloudstack/plaintext/spring-plaintext-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="PlainTextUserAuthenticator" class="com.cloud.server.auth.PlainTextUserAuthenticator">

--- a/plugins/user-authenticators/saml2/resources/META-INF/cloudstack/saml2/spring-saml2-context.xml
+++ b/plugins/user-authenticators/saml2/resources/META-INF/cloudstack/saml2/spring-saml2-context.xml
@@ -20,10 +20,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
     xmlns:aop="http://www.springframework.org/schema/aop"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean id="SAML2UserAuthenticator" class="org.apache.cloudstack.saml.SAML2UserAuthenticator">
         <property name="name" value="SAML2"/>

--- a/plugins/user-authenticators/sha256salted/resources/META-INF/cloudstack/sha256salted/spring-sha256salted-context.xml
+++ b/plugins/user-authenticators/sha256salted/resources/META-INF/cloudstack/sha256salted/spring-sha256salted-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="SHA256SaltedUserAuthenticator" class="com.cloud.server.auth.SHA256SaltedUserAuthenticator">

--- a/pom.xml
+++ b/pom.xml
@@ -44,13 +44,6 @@
     <url>https://issues.apache.org/jira/browse/CLOUDSTACK</url>
   </issueManagement>
 
-  <repositories>
-    <repository>
-      <id>juniper-contrail</id>
-      <url>http://juniper.github.io/contrail-maven/snapshots</url>
-    </repository>
-  </repositories>
-
   <properties>
     <cs.jdk.version>1.7</cs.jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -58,7 +51,7 @@
 
     <cs.log4j.version>1.2.17</cs.log4j.version>
     <cs.log4j.extras.version>1.2.17</cs.log4j.extras.version>
-    <cs.cglib.version>3.2.1</cs.cglib.version>
+    <cs.cglib.version>3.2.4</cs.cglib.version>
     <cs.dbcp.version>1.4</cs.dbcp.version>
     <cs.pool.version>1.6</cs.pool.version>
     <cs.codec.version>1.10</cs.codec.version>
@@ -70,19 +63,19 @@
     <!-- do not forget to also upgrade hamcrest library with junit -->
     <cs.junit.version>4.12</cs.junit.version>
     <cs.hamcrest.version>1.3</cs.hamcrest.version>
-    <cs.junit.dataprovider.version>1.10.0</cs.junit.dataprovider.version>
+    <cs.junit.dataprovider.version>1.12.0</cs.junit.dataprovider.version>
     <cs.bcprov.version>1.55</cs.bcprov.version>
-    <cs.jsch.version>0.1.53</cs.jsch.version>
+    <cs.jsch.version>0.1.54</cs.jsch.version>
     <cs.jpa.version>2.1.1</cs.jpa.version>
     <cs.jasypt.version>1.9.2</cs.jasypt.version>
     <cs.trilead.version>1.0.0-build220</cs.trilead.version>
     <cs.ehcache.version>2.6.11</cs.ehcache.version>
     <cs.gson.version>1.7.2</cs.gson.version>
     <cs.guava-testlib.version>18.0</cs.guava-testlib.version>
-    <cs.guava.version>19.0</cs.guava.version>
+    <cs.guava.version>20.0</cs.guava.version>
     <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
     <cs.httpclient.version>4.5.2</cs.httpclient.version>
-    <cs.httpcore.version>4.4.4</cs.httpcore.version>
+    <cs.httpcore.version>4.4.5</cs.httpcore.version>
     <cs.commons-httpclient.version>3.1</cs.commons-httpclient.version>
     <cs.mysql.version>5.1.34</cs.mysql.version>
     <cs.xstream.version>1.4.9</cs.xstream.version>
@@ -98,17 +91,17 @@
     <cs.jstl-api.version>1.2.1</cs.jstl-api.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
     <cs.vmware.api.version>6.0</cs.vmware.api.version>
-    <org.springframework.version>3.2.16.RELEASE</org.springframework.version>
+    <org.springframework.version>4.3.4.RELEASE</org.springframework.version>
     <cs.mockito.version>1.10.19</cs.mockito.version>
     <cs.powermock.version>1.6.4</cs.powermock.version>
-    <cs.aws.sdk.version>1.10.64</cs.aws.sdk.version>
+    <cs.aws.sdk.version>1.11.61</cs.aws.sdk.version>
     <cs.jackson.version>2.7.1</cs.jackson.version>
     <cs.lang.version>2.6</cs.lang.version>
     <cs.commons-lang3.version>3.4</cs.commons-lang3.version>
-    <cs.commons-io.version>2.4</cs.commons-io.version>
-    <cs.commons-fileupload.version>1.3.1</cs.commons-fileupload.version>
+    <cs.commons-io.version>2.5</cs.commons-io.version>
+    <cs.commons-fileupload.version>1.3.2</cs.commons-fileupload.version>
     <cs.commons-collections.version>3.2.2</cs.commons-collections.version>
-    <cs.commons-validator.version>1.5.0</cs.commons-validator.version>
+    <cs.commons-validator.version>1.5.1</cs.commons-validator.version>
     <cs.reflections.version>0.9.10</cs.reflections.version>
     <cs.javassist.version>3.18.2-GA</cs.javassist.version>
     <cs.java-ipv6.version>0.16</cs.java-ipv6.version>
@@ -127,9 +120,9 @@
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
     <cs.batik.version>1.8</cs.batik.version>
     <cs.servicemix.version>2.3.4_1</cs.servicemix.version>
-    <cs.jetty.version>9.2.15.v20160210</cs.jetty.version>
+    <cs.jetty.version>9.2.19.v20160908</cs.jetty.version>
     <cs.cxf.version>3.1.4</cs.cxf.version>
-    <cs.groovy.version>2.4.6</cs.groovy.version>
+    <cs.groovy.version>2.4.7</cs.groovy.version>
     <cs.nitro.version>10.1</cs.nitro.version>
   </properties>
 

--- a/quickcloud/src/main/resources/META-INF/cloudstack/core/spring-quickcloud-core-context-override.xml
+++ b/quickcloud/src/main/resources/META-INF/cloudstack/core/spring-quickcloud-core-context-override.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
     <bean id="consoleProxyManagerImpl" class="com.cloud.consoleproxy.StaticConsoleProxyManager" />

--- a/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
+++ b/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
@@ -23,13 +23,13 @@
        xmlns:util="http://www.springframework.org/schema/util"
        
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/aop 
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                      http://www.springframework.org/schema/context/spring-context.xsd
                       http://www.springframework.org/schema/util
-                      http://www.springframework.org/schema/util/spring-util-3.0.xsd"
+                      http://www.springframework.org/schema/util/spring-util.xsd"
                       >
 
     <bean id="authenticationManagerImpl" class="com.cloud.api.auth.APIAuthenticationManagerImpl">

--- a/server/resources/META-INF/cloudstack/core/spring-server-core-misc-context.xml
+++ b/server/resources/META-INF/cloudstack/core/spring-server-core-misc-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
 

--- a/server/resources/META-INF/cloudstack/server-alert-adapter-backend/spring-server-alert-adapter-backend-context.xml
+++ b/server/resources/META-INF/cloudstack/server-alert-adapter-backend/spring-server-alert-adapter-backend-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="clusterAlertAdapter" class="com.cloud.alert.ClusterAlertAdapter" />

--- a/server/resources/META-INF/cloudstack/server-alert-adapter-compute/spring-server-alert-adapter-compute-context.xml
+++ b/server/resources/META-INF/cloudstack/server-alert-adapter-compute/spring-server-alert-adapter-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="consoleProxyAlertAdapter" class="com.cloud.alert.ConsoleProxyAlertAdapter" />

--- a/server/resources/META-INF/cloudstack/server-alert-adapter-storage/spring-server-alert-adapter-storage-context.xml
+++ b/server/resources/META-INF/cloudstack/server-alert-adapter-storage/spring-server-alert-adapter-storage-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="secondaryStorageVmAlertAdapter" class="com.cloud.alert.SecondaryStorageVmAlertAdapter" />

--- a/server/resources/META-INF/cloudstack/server-allocator/spring-server-allocator-context.xml
+++ b/server/resources/META-INF/cloudstack/server-allocator/spring-server-allocator-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="ConsoleProxyAllocator" class="com.cloud.consoleproxy.ConsoleProxyBalanceAllocator">

--- a/server/resources/META-INF/cloudstack/server-api/spring-server-api-context.xml
+++ b/server/resources/META-INF/cloudstack/server-api/spring-server-api-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="domainChecker" class="com.cloud.acl.DomainChecker" />

--- a/server/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
+++ b/server/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="KVMGuru" class="com.cloud.hypervisor.KVMGuru">

--- a/server/resources/META-INF/cloudstack/server-discoverer/spring-server-discoverer-context.xml
+++ b/server/resources/META-INF/cloudstack/server-discoverer/spring-server-discoverer-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
 

--- a/server/resources/META-INF/cloudstack/server-fencer/spring-server-fencer-context.xml
+++ b/server/resources/META-INF/cloudstack/server-fencer/spring-server-fencer-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   

--- a/server/resources/META-INF/cloudstack/server-investigator/spring-server-investigator-context.xml
+++ b/server/resources/META-INF/cloudstack/server-investigator/spring-server-investigator-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="CheckOnAgentInvestigator" class="com.cloud.ha.CheckOnAgentInvestigator">

--- a/server/resources/META-INF/cloudstack/server-network/spring-server-network-context.xml
+++ b/server/resources/META-INF/cloudstack/server-network/spring-server-network-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="StorageNetworkGuru" class="com.cloud.network.guru.StorageNetworkGuru">

--- a/server/resources/META-INF/cloudstack/server-planner/spring-server-planner-context.xml
+++ b/server/resources/META-INF/cloudstack/server-planner/spring-server-planner-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   <bean id="FirstFitPlanner" class="com.cloud.deploy.FirstFitPlanner">

--- a/server/resources/META-INF/cloudstack/server-storage/spring-server-storage-context.xml
+++ b/server/resources/META-INF/cloudstack/server-storage/spring-server-storage-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="secondaryStorageVmDefaultAllocator"

--- a/server/resources/META-INF/cloudstack/server-template-adapter/spring-server-template-adapter-context.xml
+++ b/server/resources/META-INF/cloudstack/server-template-adapter/spring-server-template-adapter-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
   <bean id="hypervisorTemplateAdapter" class="com.cloud.template.HypervisorTemplateAdapter" />

--- a/server/resources/META-INF/cloudstack/system/spring-server-system-context.xml
+++ b/server/resources/META-INF/cloudstack/system/spring-server-system-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="lockMasterListener" class="com.cloud.server.LockMasterListener" >

--- a/server/resources/com/cloud/upgrade/databaseCreatorContext.xml
+++ b/server/resources/com/cloud/upgrade/databaseCreatorContext.xml
@@ -22,13 +22,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
+++ b/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
@@ -31,7 +31,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
@@ -121,7 +123,7 @@ public class DeploymentPlanningManagerImplTest {
     @Inject
     DataCenterDao _dcDao;
 
-    @Inject
+    @Mock
     FirstFitPlanner _planner;
 
     @Inject
@@ -140,6 +142,8 @@ public class DeploymentPlanningManagerImplTest {
 
     @Before
     public void testSetUp() {
+        MockitoAnnotations.initMocks(this);
+
         ComponentContext.initComponentsLifeCycle();
 
         PlannerHostReservationVO reservationVO = new PlannerHostReservationVO(200L, 1L, 2L, 3L, PlannerResourceUsage.Shared);

--- a/server/test/resources/CloneSettingDaoTestContext.xml
+++ b/server/test/resources/CloneSettingDaoTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/server/test/resources/SecurityGroupManagerTestContext.xml
+++ b/server/test/resources/SecurityGroupManagerTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/server/test/resources/SnapshotDaoTestContext.xml
+++ b/server/test/resources/SnapshotDaoTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/server/test/resources/StoragePoolDaoTestContext.xml
+++ b/server/test/resources/StoragePoolDaoTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/server/test/resources/UserVMDaoTestContext.xml
+++ b/server/test/resources/UserVMDaoTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/server/test/resources/VpcApiUnitTestContext.xml
+++ b/server/test/resources/VpcApiUnitTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack, com.cloud" />

--- a/server/test/resources/VpcTestContext.xml
+++ b/server/test/resources/VpcTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/server/test/resources/appLoadBalancer.xml
+++ b/server/test/resources/appLoadBalancer.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
      <context:annotation-config />
 

--- a/server/test/resources/createNetworkOffering.xml
+++ b/server/test/resources/createNetworkOffering.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
      <context:annotation-config />
 

--- a/server/test/resources/testContext.xml
+++ b/server/test/resources/testContext.xml
@@ -22,13 +22,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/services/iam/plugin/resources/META-INF/cloudstack/iam-access-checkers/spring-iam-access-checkers-context.xml
+++ b/services/iam/plugin/resources/META-INF/cloudstack/iam-access-checkers/spring-iam-access-checkers-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
     <bean id="RoleBasedAPIAccessChecker" class="org.apache.cloudstack.iam.RoleBasedAPIAccessChecker" />

--- a/services/iam/server/resources/META-INF/cloudstack/core/spring-iam-server-context.xml
+++ b/services/iam/server/resources/META-INF/cloudstack/core/spring-iam-server-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >                     
 
     <bean id="IAMGroupDaoImpl" class="org.apache.cloudstack.iam.server.dao.IAMGroupDaoImpl" />

--- a/services/secondary-storage/controller/resources/META-INF/cloudstack/core/spring-services-secondary-storage-controller-core-context.xml
+++ b/services/secondary-storage/controller/resources/META-INF/cloudstack/core/spring-services-secondary-storage-controller-core-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
     <bean id="premiumSecondaryStorageManagerImpl" class="org.apache.cloudstack.secondarystorage.PremiumSecondaryStorageManagerImpl">
             <property name="secondaryStorageVmAllocators"

--- a/services/secondary-storage/server/resources/META-INF/cloudstack/secondary-storage-discoverer/spring-secondary-storage-discoverer-context.xml
+++ b/services/secondary-storage/server/resources/META-INF/cloudstack/secondary-storage-discoverer/spring-secondary-storage-discoverer-context.xml
@@ -21,10 +21,10 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
     <bean id="SecondaryStorageDiscoverer"

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>
-      <version>2.5.2</version>
+      <version>2.5.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/usage/resources/usageApplicationContext.xml
+++ b/usage/resources/usageApplicationContext.xml
@@ -20,13 +20,13 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:annotation-config />
 	<context:component-scan

--- a/usage/test/resources/UsageManagerTestContext.xml
+++ b/usage/test/resources/UsageManagerTestContext.xml
@@ -12,13 +12,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:tx="http://www.springframework.org/schema/tx" xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.4</version>
+      <version>3.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/utils/src/test/resources/com/cloud/utils/QualifierTestContext.xml
+++ b/utils/src/test/resources/com/cloud/utils/QualifierTestContext.xml
@@ -25,13 +25,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack, com.cloud" />
 

--- a/utils/src/test/resources/com/cloud/utils/db/transactionContextBuilderTest.xml
+++ b/utils/src/test/resources/com/cloud/utils/db/transactionContextBuilderTest.xml
@@ -25,13 +25,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
   <context:annotation-config />
   <context:component-scan base-package="org.apache.cloudstack, com.cloud" />
 

--- a/utils/src/test/resources/testContext.xml
+++ b/utils/src/test/resources/testContext.xml
@@ -24,13 +24,13 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:aop="http://www.springframework.org/schema/aop"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
                       http://www.springframework.org/schema/tx 
-                      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                      http://www.springframework.org/schema/tx/spring-tx.xsd
                       http://www.springframework.org/schema/aop
-                      http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/aop/spring-aop.xsd
                       http://www.springframework.org/schema/context
-                      http://www.springframework.org/schema/context/spring-context-3.0.xsd">                     
+                      http://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:annotation-config />
 


### PR DESCRIPTION
This changes makes CloudStack use spring 4:

```
- Bump spring-framework version to 4.x and Jetty to version that runs with JDK7
- Bump servet dependency version
- Migrates various xmls to use version independent schema uris
```

Outstanding issue:
    - Testing of various non-standard plugins such as network and storage plugins etc.

Since, this is a big change pinging for review -- @jburwell @karuturi @wido @murali-reddy @abhinandanprateek @DaanHoogland @GaborApatiNagy @JayapalUradi @kishankavala @K0zka @nvazquez @rafaelweingartner @pyr and others

@blueorangutan package
