### PR TITLE
test/integration: fix tearDown order in list_acl_ tests

### DIFF
--- a/test/integration/component/test_acl_listsnapshot.py
+++ b/test/integration/component/test_acl_listsnapshot.py
@@ -360,8 +360,8 @@ class TestSnapshotList(cloudstackTestCase):
                             cls.service_offering,
                             ]
         except Exception as e:
-                cls.domain_1.delete(cls.apiclient,cleanup="true")
                 cls.domain_2.delete(cls.apiclient,cleanup="true")
+                cls.domain_1.delete(cls.apiclient,cleanup="true")
                 cleanup_resources(cls.apiclient, cls.cleanup)
                 raise Exception("Failed to create the setup required to execute the test cases: %s" % e)
 
@@ -370,10 +370,11 @@ class TestSnapshotList(cloudstackTestCase):
         cls.apiclient = super(TestSnapshotList, cls).getClsTestClient().getApiClient()
         cls.apiclient.connection.apiKey = cls.default_apikey
         cls.apiclient.connection.securityKey = cls.default_secretkey
-        cls.domain_1.delete(cls.apiclient,cleanup="true")
-        cls.domain_2.delete(cls.apiclient,cleanup="true")
+        try:
+            cls.domain_2.delete(cls.apiclient,cleanup="true")
+            cls.domain_1.delete(cls.apiclient,cleanup="true")
+        except: pass
         cleanup_resources(cls.apiclient, cls.cleanup)
-        return
 
     def setUp(cls):
         cls.apiclient = cls.testClient.getApiClient()

--- a/test/integration/component/test_acl_listvm.py
+++ b/test/integration/component/test_acl_listvm.py
@@ -333,8 +333,8 @@ class TestVMList(cloudstackTestCase):
                             cls.service_offering,
                             ]
     	except Exception as e:
-        	cls.domain_1.delete(cls.apiclient,cleanup="true")
         	cls.domain_2.delete(cls.apiclient,cleanup="true")
+		cls.domain_1.delete(cls.apiclient,cleanup="true")
         	cleanup_resources(cls.apiclient, cls.cleanup)
 		raise Exception("Failed to create the setup required to execute the test cases: %s" % e)
 
@@ -343,10 +343,11 @@ class TestVMList(cloudstackTestCase):
         cls.apiclient = super(TestVMList, cls).getClsTestClient().getApiClient()
         cls.apiclient.connection.apiKey = cls.default_apikey
         cls.apiclient.connection.securityKey = cls.default_secretkey
-        cls.domain_1.delete(cls.apiclient,cleanup="true")
-        cls.domain_2.delete(cls.apiclient,cleanup="true")
+        try:
+            cls.domain_2.delete(cls.apiclient,cleanup="true")
+            cls.domain_1.delete(cls.apiclient,cleanup="true")
+        except: pass
         cleanup_resources(cls.apiclient, cls.cleanup)
-        return
 
     def setUp(cls):
         cls.apiclient = cls.testClient.getApiClient()

--- a/test/integration/component/test_acl_listvolume.py
+++ b/test/integration/component/test_acl_listvolume.py
@@ -345,8 +345,8 @@ class TestVolumeList(cloudstackTestCase):
                             cls.service_offering,
                             ]
         except Exception as e:
-                cls.domain_1.delete(cls.apiclient,cleanup="true")
                 cls.domain_2.delete(cls.apiclient,cleanup="true")
+                cls.domain_1.delete(cls.apiclient,cleanup="true")
                 cleanup_resources(cls.apiclient, cls.cleanup)
                 raise Exception("Failed to create the setup required to execute the test cases: %s" % e)
 
@@ -358,9 +358,10 @@ class TestVolumeList(cloudstackTestCase):
         cls.apiclient.connection.apiKey = cls.default_apikey
         cls.apiclient.connection.securityKey = cls.default_secretkey
         cleanup_resources(cls.apiclient, cls.cleanup)
-        cls.domain_1.delete(cls.apiclient,cleanup="true")
-        cls.domain_2.delete(cls.apiclient,cleanup="true")
-        return
+        try:
+            cls.domain_2.delete(cls.apiclient,cleanup="true")
+            cls.domain_1.delete(cls.apiclient,cleanup="true")
+        except: pass
 
     def setUp(cls):
         cls.apiclient = cls.testClient.getApiClient()


### PR DESCRIPTION
test/integration: fix tearDown order in list_acl_ tests
    
    In several of the list_acl_tests, the tests run for simulator only where
    in the (class) setup domains and accounts are created for the test. When the
    tests end the (class) teardown methods would delete and remove these resources.
    Due to dependence of one of the resources on the other, domain2 on domain1,
    domain2 needs to be removed/cleaned up before domain1. Due to this issue,
    several Travis test runs have failed in the past such as:
    
    https://travis-ci.org/apache/cloudstack/jobs/152610967
    https://travis-ci.org/apache/cloudstack/jobs/152610968
    
    Changing the order of cleanup fixes the tests.


/cc @jburwell @karuturi 

The fix is specific to tests that run 'only' on simulator with Travis. A passing Travis run should be enough to validate the changes.