### PR TITLE
CLOUDSTACK-9463: Fix dynamic-roles migrate script for old format

### DIFF
--- a/scripts/util/migrate-dynamicroles.py
+++ b/scripts/util/migrate-dynamicroles.py
@@ -107,10 +107,10 @@ def main():
     apiMap = {}
     with open(options.commandsfile) as f:
         for line in f.readlines():
-            if not line or line == '' or line == '\n' or line.startswith('#'):
+            if not line or line == '' or line == '\n' or line == '\r\n' or line.startswith('#'):
                 continue
             name, value = line.split('=')
-            apiMap[name.strip()] = value.strip()
+            apiMap[name.strip()] = value.strip().split(';')[-1]
 
     # Rename and deprecate old commands.properties file
     if not dryrun:


### PR DESCRIPTION
The old commands.properties format included the full class name such as:

createAccount=com.cloud.api.commands.CreateAccountCmd;1

The migration script did not consider this format and fails. With this fix
the migration script will process both the formats, including processing a
commands.properties file with mixed format, for example:

    $ cat commands.properties
    ### Account commands
    createAccount=1
    deleteAccount=2
    markDefaultZoneForAccount=com.cloud.api.commands.MarkDefaultZoneForAccountCmd;3

    $ python scripts/util/migrate-dynamicroles.py -d -f commands.properties
    Apache CloudStack Role Permission Migration Tool
    (c) Apache CloudStack Authors and the ASF, under the Apache License, Version 2.0

    Running this migration tool will remove any default-role permissions from cloud.role_permissions. Do you want to continue? [y/N]y
    The commands.properties file has been deprecated and moved at: commands.properties.deprecated
    Running SQL query: DELETE FROM `cloud`.`role_permissions` WHERE `role_id` in (1,2,3,4);
    Running SQL query: INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) values (UUID(), 1, '*', 'ALLOW', 0);
    Running SQL query: INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) values (UUID(), 2, 'deleteAccount', 'ALLOW', 0);
    Running SQL query: INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) values (UUID(), 2, 'markDefaultZoneForAccount', 'ALLOW', 1);
    Static role permissions from commands.properties have been migrated into the db
    Running SQL query: UPDATE `cloud`.`configuration` SET value='true' where name='dynamic.apichecker.enabled'
    Dynamic role based API checker has been enabled!


/cc @jburwell @karuturi @PaulAngus 

Since we don't have any upgrade/marvin tests for this, the changes have been verified with above test as the script works against a commands.properties. A manual verification by anyone else would be required to validate the changes.