### PR TITLE
fix macchinina template specificied for vmware in Marvin tests

### DIFF
--- a/test/integration/smoke/test_internal_lb.py
+++ b/test/integration/smoke/test_internal_lb.py
@@ -254,7 +254,7 @@ class Services:
                     "format": "ova",
                     "hypervisor": "vmware",
                     "ostype": "Other PV (64-bit)",
-                    "url": "http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.vmdk.bz2",
+                    "url": "http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.ova",
                     "requireshvm": "True",
                 }
             }

--- a/test/integration/smoke/test_vpc_vpn.py
+++ b/test/integration/smoke/test_vpc_vpn.py
@@ -253,7 +253,7 @@ class Services:
                     "format": "ova",
                     "hypervisor": "vmware",
                     "ostype": "Other PV (64-bit)",
-                    "url": "http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.vmdk.bz2",
+                    "url": "http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-vmware.ova",
                     "requireshvm": "True",
                 }
             }


### PR DESCRIPTION
fix macchinina template specificied for vmware - .vmdk.bz2 is not valid… for CloudStack. edit to use .ova