### PR TITLE
Fix ajaxviewer.js to solve console on Firefox

### DIFF
--- a/systemvm/js/ajaxviewer.js
+++ b/systemvm/js/ajaxviewer.js
@@ -617,6 +617,7 @@ AjaxViewer.prototype = {
 		var img = $(this.img); 
 		this.fullImage = fullImage;
 		this.imgUrl=imageUrl;
+		this.imageLoaded = false;
 
 		img.attr('src', imageUrl).load(function() {
 			ajaxViewer.imageLoaded = true;


### PR DESCRIPTION
Mozilla Firefox displays white tile in place of cursor. The reason - function isImageLoaded() always returns true after first load and function checkUpdate() reloads too fast. 
Suggested fix - in refresh() method state imageLoaded should be reverted to false. This ensures that function checkUpdate() processes only when tile image is loaded.
