### PR TITLE
[lts/blocker] CLOUDSTACK-9467: Add symlink to key file for usage server

### DIFF
--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -552,6 +552,10 @@ if [ -f "%{_sysconfdir}/%{name}/management/key" ]; then
     ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
 fi
 
+if [ ! -f "%{_sysconfdir}/%{name}/usage/key" ]; then
+    ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
+fi
+
 %post marvin
 pip install --upgrade http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
 pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -449,6 +449,10 @@ if [ -f "%{_sysconfdir}/%{name}/management/key" ]; then
     ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
 fi
 
+if [ ! -f "%{_sysconfdir}/%{name}/usage/key" ]; then
+    ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
+fi
+
 %post marvin
 pip install --upgrade http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
 pip install --upgrade /usr/share/cloudstack-marvin/Marvin-*.tar.gz


### PR DESCRIPTION
On fresh installation, the usage server fails to start if the `key` file does
not exist in its classpath. The issue is reproducible in environments (such as Trillian)
where the usage server is installed before cloudstack-setup-databases has been called.
Before the cloudstack db has been setup, the key file does not exist at its
default location and installation of usage-server fails to add a symlink to the
key file.

This fix adds a default symlink to `/etc/cloudstack/management/key` if a
symlink/file does not already exist in the /etc/cloudstack/usage directory.

On new installation, in the post-installation steps it checks if the symlink
or file exists, and adds a symlink if it does not exist. On existing
installations, if symlink or file exists then it will skip adding symlink.

/cc @jburwell @PaulAngus @karuturi 
@blueorangutan package