### PR TITLE
CLOUDSTACK-9470: [BLOCKER] Bug in SshHelper affecting interaction with vRouter in VmwareResource and HypervDirectConnectResource

### DIFF
--- a/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
+++ b/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
@@ -22,6 +22,10 @@ package com.cloud.utils.ssh;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 
 import org.apache.log4j.Logger;
 
@@ -195,6 +199,16 @@ public class SshHelper {
             }
 
             String result = sbResult.toString();
+
+            if (StringUtils.isBlank(result)) {
+                try {
+                    result = IOUtils.toString(stdout, StandardCharsets.UTF_8);
+                }
+                catch (IOException e) {
+                    s_logger.error("Couldn't get content of input stream due to: " + e.getMessage());
+                    return new Pair<Boolean, String>(false, result);
+                }
+            }
 
             if (sess.getExitStatus() == null) {
                 //Exit status is NOT available. Returning failure result.


### PR DESCRIPTION
JIRA TICKET:
https://issues.apache.org/jira/browse/CLOUDSTACK-9470

## Problem
In a Vmware environment, running `test_network_acl` we examined why it was failing, it was discovered an issue on `VmwareResource`:

```java
private int findRouterEthDeviceIndex(String domrName, String routerIp, String mac) throws Exception {
        VmwareManager mgr = getServiceContext().getStockObject(VmwareManager.CONTEXT_STOCK_NAME);

        s_logger.info("findRouterEthDeviceIndex. mac: " + mac);

        // TODO : this is a temporary very inefficient solution, will refactor it later
        Pair<Boolean, String> result = SshHelper.sshExecute(routerIp, DefaultDomRSshPort, "root", mgr.getSystemVMKeyFile(), null, "ls /proc/sys/net/ipv4/conf");
...
}
```

Command sent to router returned a pair which its first parameter was always true but second parameter sometimes it was null and sometimes the correct output for given command.

## Solution
Examining `SshHelper` we discovered that cases in which second parameter in result was null, didn't consume stdout properly