### PR TITLE
Export UUID for zone creation event completion.

### DIFF
--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1770,6 +1770,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             @Override
             public DataCenterVO doInTransaction(final TransactionStatus status) {
                 final DataCenterVO zone = _zoneDao.persist(zoneFinal);
+                CallContext.current().putContextParameter(DataCenter.class, zone.getUuid());
                 if (domainId != null) {
                     // zone is explicitly dedicated to this domain
                     // create affinity group associated and dedicate the zone.


### PR DESCRIPTION
Action events have support for exporting their "first class entities" over the event bus, if it's turned on. This works mostly for BaseAsyncCmds and any synchronous command that operates on already-existing entities. They are populated by the ApiServer and found by ActionEventUtils.

Where it tends to falter is when dealing with synchronous creation commands. This commit makes createZone export the zone UUID over the event bus once the zone has been created.