### PR TITLE
Fixing test_router_dhcp outside ping response as it was failing the a…

### DIFF
--- a/test/integration/smoke/test_router_dhcphosts.py
+++ b/test/integration/smoke/test_router_dhcphosts.py
@@ -195,7 +195,7 @@ class TestRouterDHCPHosts(cloudstackTestCase):
             self.fail("Failed to SSH into VM - %s" % (nat_rule.ipaddress))
 
         self.assertEqual(
-                         result.count("3 packets received"),
+                         result.count("3 received"),
                          1,
                          "Ping to outside world from VM should be successful"
                          )


### PR DESCRIPTION
fixed small issue regarding outside ping in test_router_dhcp. 

Here are the marvin test run results:

$ nosetests --with-xunit --xunit-file=integration-test-results.xml --with-marvin --marvin-config=advanced_ccs.cfg -s -a tags=advanced,required_hardware=true --zone=zone1 --hypervisor=kvm cloudstack/test/integration/smoke/test_router_dhcphosts.py -vv
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']

```
==== Marvin Init Started ====

=== Marvin Parse Config Successful ===

=== Marvin Setting TestData Successful===

==== Log Folder Path: /tmp//MarvinLogs//Aug_30_2016_14_38_17_LKJXIO. All logs will be available here ====

=== Marvin Init Logging Successful===

==== Marvin Init Successful ====
Creating Admin Account for domain b1376fae-6e2a-11e6-bca7-000c290e77f6 on zone 7060c2b9-7ea2-475f-9b74-56ce80444feb
Creating Service Offering on zone 7060c2b9-7ea2-475f-9b74-56ce80444feb
Creating Network Offering on zone 7060c2b9-7ea2-475f-9b74-56ce80444feb
Creating Network for Account test-a-TestRouterDHCPHosts-MIM7KC using offering e9df309c-3537-4035-9168-17a5e3219415
Creating VM1 for Account test-a-TestRouterDHCPHosts-MIM7KC using offering a41fef95-7352-408a-af16-20e8573c9b47 with IP 10.1.1.50
Creating VM2 for Account test-a-TestRouterDHCPHosts-MIM7KC using offering a41fef95-7352-408a-af16-20e8573c9b47 with IP 10.1.1.51
Starting test_router_dhcphosts...
Creating Firewall rule for VM ID: 9e8e9843-95d4-432b-9ea2-da52ef016ffa
Creating NAT rule for VM ID: 9e8e9843-95d4-432b-9ea2-da52ef016ffa
Creating Firewall rule for VM ID: 69cbe80b-9335-40f7-8a5f-b9a72120fb1b
Creating NAT rule for VM ID: 69cbe80b-9335-40f7-8a5f-b9a72120fb1b
Testing SSH to VMs 9e8e9843-95d4-432b-9ea2-da52ef016ffa and 69cbe80b-9335-40f7-8a5f-b9a72120fb1b
SSH into VM with IP: 192.168.1.103
====Trying SSH Connection: Host:192.168.1.103 User:root                                   Port:222 RetryCnt:5===
SshClient: Exception under createConnection: ['Traceback (most recent call last):\n', '  File "/usr/local/lib/python2.7/site-packages/marvin/sshClient.py", line 121, in createConnection\n    timeout=self.timeout)\n', '  File "/usr/local/lib/python2.7/site-packages/paramiko/client.py", line 305, in connect\n    retry_on_signal(lambda: sock.connect(addr))\n', '  File "/usr/local/lib/python2.7/site-packages/paramiko/util.py", line 269, in retry_on_signal\n    return function()\n', '  File "/usr/local/lib/python2.7/site-packages/paramiko/client.py", line 305, in <lambda>\n    retry_on_signal(lambda: sock.connect(addr))\n', '  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth\n    return getattr(self._sock,name)(*args)\n', 'error: [Errno 51] Network is unreachable\n']
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/marvin/sshClient.py", line 121, in createConnection
    timeout=self.timeout)
  File "/usr/local/lib/python2.7/site-packages/paramiko/client.py", line 305, in connect
    retry_on_signal(lambda: sock.connect(addr))
  File "/usr/local/lib/python2.7/site-packages/paramiko/util.py", line 269, in retry_on_signal
    return function()
  File "/usr/local/lib/python2.7/site-packages/paramiko/client.py", line 305, in <lambda>
    retry_on_signal(lambda: sock.connect(addr))
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 51] Network is unreachable
====Trying SSH Connection: Host:192.168.1.103 User:root                                   Port:222 RetryCnt:4===
SshClient: Exception under createConnection: ['Traceback (most recent call last):\n', '  File "/usr/local/lib/python2.7/site-packages/marvin/sshClient.py", line 121, in createConnection\n    timeout=self.timeout)\n', '  File "/usr/local/lib/python2.7/site-packages/paramiko/client.py", line 324, in connect\n    raise NoValidConnectionsError(errors)\n', 'NoValidConnectionsError: [Errno None] Unable to connect to port 222 on 192.168.1.103\n']
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/marvin/sshClient.py", line 121, in createConnection
    timeout=self.timeout)
  File "/usr/local/lib/python2.7/site-packages/paramiko/client.py", line 324, in connect
    raise NoValidConnectionsError(errors)
NoValidConnectionsError: [Errno None] Unable to connect to port 222 on 192.168.1.103
====Trying SSH Connection: Host:192.168.1.103 User:root                                   Port:222 RetryCnt:3===
===SSH to Host 192.168.1.103 port : 222 SUCCESSFUL===
{Cmd: ping -c 3 8.8.8.8 via Host: 192.168.1.103} {returns: [u'PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.', u'64 bytes from 8.8.8.8: icmp_seq=1 ttl=58 time=2.24 ms', u'64 bytes from 8.8.8.8: icmp_seq=2 ttl=58 time=1.99 ms', u'64 bytes from 8.8.8.8: icmp_seq=3 ttl=58 time=1.98 ms', u'', u'--- 8.8.8.8 ping statistics ---', u'3 packets transmitted, 3 received, 0% packet loss, time 2000ms', u'rtt min/avg/max/mdev = 1.981/2.072/2.245/0.127 ms']}
SSH result: [u'PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.', u'64 bytes from 8.8.8.8: icmp_seq=1 ttl=58 time=2.24 ms', u'64 bytes from 8.8.8.8: icmp_seq=2 ttl=58 time=1.99 ms', u'64 bytes from 8.8.8.8: icmp_seq=3 ttl=58 time=1.98 ms', u'', u'--- 8.8.8.8 ping statistics ---', u'3 packets transmitted, 3 received, 0% packet loss, time 2000ms', u'rtt min/avg/max/mdev = 1.981/2.072/2.245/0.127 ms']; COUNT is ==> 0
SSH into VM with IP: 192.168.1.103
====Trying SSH Connection: Host:192.168.1.103 User:root                                   Port:223 RetryCnt:5===
====Trying SSH Connection: Host:192.168.1.103 User:root                                   Port:223 RetryCnt:5===
===SSH to Host 192.168.1.103 port : 223 SUCCESSFUL===
===SSH to Host 192.168.1.103 port : 223 SUCCESSFUL===
{Cmd: ping -c 3 8.8.8.8 via Host: 192.168.1.103} {returns: [u'PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.', u'64 bytes from 8.8.8.8: icmp_seq=1 ttl=58 time=2.05 ms', u'64 bytes from 8.8.8.8: icmp_seq=2 ttl=58 time=1.97 ms', u'64 bytes from 8.8.8.8: icmp_seq=3 ttl=58 time=1.95 ms', u'', u'--- 8.8.8.8 ping statistics ---', u'3 packets transmitted, 3 received, 0% packet loss, time 2000ms', u'rtt min/avg/max/mdev = 1.957/1.993/2.050/0.065 ms']}
{Cmd: ping -c 3 8.8.8.8 via Host: 192.168.1.103} {returns: [u'PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.', u'64 bytes from 8.8.8.8: icmp_seq=1 ttl=58 time=2.05 ms', u'64 bytes from 8.8.8.8: icmp_seq=2 ttl=58 time=1.97 ms', u'64 bytes from 8.8.8.8: icmp_seq=3 ttl=58 time=1.95 ms', u'', u'--- 8.8.8.8 ping statistics ---', u'3 packets transmitted, 3 received, 0% packet loss, time 2000ms', u'rtt min/avg/max/mdev = 1.957/1.993/2.050/0.065 ms']}
SSH result: [u'PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.', u'64 bytes from 8.8.8.8: icmp_seq=1 ttl=58 time=2.05 ms', u'64 bytes from 8.8.8.8: icmp_seq=2 ttl=58 time=1.97 ms', u'64 bytes from 8.8.8.8: icmp_seq=3 ttl=58 time=1.95 ms', u'', u'--- 8.8.8.8 ping statistics ---', u'3 packets transmitted, 3 received, 0% packet loss, time 2000ms', u'rtt min/avg/max/mdev = 1.957/1.993/2.050/0.065 ms']; COUNT is ==> 0
Testing DHCP hosts for VMs 9e8e9843-95d4-432b-9ea2-da52ef016ffa and 69cbe80b-9335-40f7-8a5f-b9a72120fb1b
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' RESULT IS ==> [u'10.1.1.50']
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' RESULT IS ==> [u'10.1.1.51']
Deleting and Expunging VM 9e8e9843-95d4-432b-9ea2-da52ef016ffa with ip 10.1.1.50
Creating new VM using the same IP as the one which was deleted => IP 10.1.1.50
Testing DHCP hosts for VMs aca195bf-cd37-4348-9e7c-375cb14beef7 and 69cbe80b-9335-40f7-8a5f-b9a72120fb1b
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.50']}
cat /etc/dhcphosts.txt | grep 10.1.1.50 | sed 's/\,/ /g' | awk '{print $2}' RESULT IS ==> [u'10.1.1.50']
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
====Trying SSH Connection: Host:192.168.1.221 User:root                                   Port:22 RetryCnt:60===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
===SSH to Host 192.168.1.221 port : 22 SUCCESSFUL===
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
{Cmd: ssh -i ~/.ssh/id_rsa.cloud -ostricthostkeychecking=no -oUserKnownHostsFile=/dev/null -p 3922 169.254.2.105 cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' via Host: 192.168.1.221} {returns: [u'10.1.1.51']}
cat /etc/dhcphosts.txt | grep 10.1.1.51 | sed 's/\,/ /g' | awk '{print $2}' RESULT IS ==> [u'10.1.1.51']
=== TestName: test_router_dhcphosts | Status : SUCCESS ===

===final results are now copied to: /tmp//MarvinLogs/test_router_dhcphosts_9144IS===
```
