### PR TITLE
Adding support for cross-cluster storage migration for managed storage when using XenServer

### DIFF
--- a/api/src/com/cloud/storage/StoragePool.java
+++ b/api/src/com/cloud/storage/StoragePool.java
@@ -104,4 +104,6 @@ public interface StoragePool extends Identity, InternalIdentity {
     boolean isInMaintenance();
 
     Hypervisor.HypervisorType getHypervisor();
+
+    boolean isManaged();
 }

--- a/core/src/com/cloud/agent/api/MigrateWithStorageReceiveCommand.java
+++ b/core/src/com/cloud/agent/api/MigrateWithStorageReceiveCommand.java
@@ -21,26 +21,25 @@ package com.cloud.agent.api;
 
 import java.util.List;
 
-import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.agent.api.to.VolumeTO;
 import com.cloud.utils.Pair;
 
 public class MigrateWithStorageReceiveCommand extends Command {
     VirtualMachineTO vm;
-    List<Pair<VolumeTO, StorageFilerTO>> volumeToFiler;
+    List<Pair<VolumeTO, String>> volumeToStorageUuid;
 
-    public MigrateWithStorageReceiveCommand(VirtualMachineTO vm, List<Pair<VolumeTO, StorageFilerTO>> volumeToFiler) {
+    public MigrateWithStorageReceiveCommand(VirtualMachineTO vm, List<Pair<VolumeTO, String>> volumeToStorageUuid) {
         this.vm = vm;
-        this.volumeToFiler = volumeToFiler;
+        this.volumeToStorageUuid = volumeToStorageUuid;
     }
 
     public VirtualMachineTO getVirtualMachine() {
         return vm;
     }
 
-    public List<Pair<VolumeTO, StorageFilerTO>> getVolumeToFiler() {
-        return volumeToFiler;
+    public List<Pair<VolumeTO, String>> getVolumeToStorageUuid() {
+        return volumeToStorageUuid;
     }
 
     @Override

--- a/core/test/org/apache/cloudstack/api/agent/test/BackupSnapshotCommandTest.java
+++ b/core/test/org/apache/cloudstack/api/agent/test/BackupSnapshotCommandTest.java
@@ -135,6 +135,9 @@ public class BackupSnapshotCommandTest {
         };
 
         @Override
+        public boolean isManaged() { return false; }
+
+        @Override
         public Long getPodId() {
             return 0L;
         }

--- a/core/test/org/apache/cloudstack/api/agent/test/CheckNetworkAnswerTest.java
+++ b/core/test/org/apache/cloudstack/api/agent/test/CheckNetworkAnswerTest.java
@@ -174,6 +174,9 @@ public class CheckNetworkAnswerTest {
             };
 
             @Override
+            public boolean isManaged() { return false; }
+
+            @Override
             public Long getPodId() {
                 return 0L;
             }

--- a/core/test/org/apache/cloudstack/api/agent/test/SnapshotCommandTest.java
+++ b/core/test/org/apache/cloudstack/api/agent/test/SnapshotCommandTest.java
@@ -136,6 +136,9 @@ public class SnapshotCommandTest {
         };
 
         @Override
+        public boolean isManaged() { return false; }
+
+        @Override
         public Long getPodId() {
             return 0L;
         }

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/PrimaryDataStoreDriver.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/PrimaryDataStoreDriver.java
@@ -25,6 +25,13 @@ import com.cloud.host.Host;
 import com.cloud.storage.StoragePool;
 
 public interface PrimaryDataStoreDriver extends DataStoreDriver {
+    String BASIC_CREATE = "basicCreate";
+    String BASIC_DELETE = "basicDelete";
+    String BASIC_DELETE_FAILURE = "basicDeleteFailure";
+    String BASIC_GRANT_ACCESS = "basicGrantAccess";
+    String BASIC_REVOKE_ACCESS = "basicRevokeAccess";
+    String BASIC_IQN = "basicIqn";
+
     ChapInfo getChapInfo(DataObject dataObject);
 
     boolean grantAccess(DataObject dataObject, Host host, DataStore dataStore);

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2045,62 +2045,74 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
     private Map<Volume, StoragePool> getPoolListForVolumesForMigration(final VirtualMachineProfile profile, final Host host, final Map<Long, Long> volumeToPool) {
         final List<VolumeVO> allVolumes = _volsDao.findUsableVolumesForInstance(profile.getId());
-        final Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<Volume, StoragePool> ();
+        final Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
+
         for (final VolumeVO volume : allVolumes) {
             final Long poolId = volumeToPool.get(Long.valueOf(volume.getId()));
-            final StoragePoolVO pool = _storagePoolDao.findById(poolId);
+            final StoragePoolVO destPool = _storagePoolDao.findById(poolId);
             final StoragePoolVO currentPool = _storagePoolDao.findById(volume.getPoolId());
             final DiskOfferingVO diskOffering = _diskOfferingDao.findById(volume.getDiskOfferingId());
-            if (pool != null) {
+
+            if (destPool != null) {
                 // Check if pool is accessible from the destination host and disk offering with which the volume was
                 // created is compliant with the pool type.
-                if (_poolHostDao.findByPoolHost(pool.getId(), host.getId()) == null || pool.isLocal() != diskOffering.getUseLocalStorage()) {
+                if (_poolHostDao.findByPoolHost(destPool.getId(), host.getId()) == null || destPool.isLocal() != diskOffering.getUseLocalStorage()) {
                     // Cannot find a pool for the volume. Throw an exception.
-                    throw new CloudRuntimeException("Cannot migrate volume " + volume + " to storage pool " + pool + " while migrating vm to host " + host +
+                    throw new CloudRuntimeException("Cannot migrate volume " + volume + " to storage pool " + destPool + " while migrating vm to host " + host +
                             ". Either the pool is not accessible from the host or because of the offering with which the volume is created it cannot be placed on " +
                             "the given pool.");
-                } else if (pool.getId() == currentPool.getId()) {
-                    // If the pool to migrate too is the same as current pool, the volume doesn't need to be migrated.
+                } else if (destPool.getId() == currentPool.getId()) {
+                    // If the pool to migrate to is the same as current pool, the volume doesn't need to be migrated.
                 } else {
-                    volumeToPoolObjectMap.put(volume, pool);
+                    volumeToPoolObjectMap.put(volume, destPool);
                 }
             } else {
-                // Find a suitable pool for the volume. Call the storage pool allocator to find the list of pools.
-                final DiskProfile diskProfile = new DiskProfile(volume, diskOffering, profile.getHypervisorType());
-                final DataCenterDeployment plan = new DataCenterDeployment(host.getDataCenterId(), host.getPodId(), host.getClusterId(), host.getId(), null, null);
-                final ExcludeList avoid = new ExcludeList();
-                boolean currentPoolAvailable = false;
+                if (currentPool.isManaged()) {
+                    volumeToPoolObjectMap.put(volume, currentPool);
+                } else {
+                    // Find a suitable pool for the volume. Call the storage pool allocator to find the list of pools.
 
-                final List<StoragePool> poolList = new ArrayList<StoragePool>();
-                for (final StoragePoolAllocator allocator : _storagePoolAllocators) {
-                    final List<StoragePool> poolListFromAllocator = allocator.allocateToPool(diskProfile, profile, plan, avoid, StoragePoolAllocator.RETURN_UPTO_ALL);
-                    if (poolListFromAllocator != null && !poolListFromAllocator.isEmpty()) {
-                        poolList.addAll(poolListFromAllocator);
-                    }
-                }
+                    final DiskProfile diskProfile = new DiskProfile(volume, diskOffering, profile.getHypervisorType());
+                    final DataCenterDeployment plan = new DataCenterDeployment(host.getDataCenterId(), host.getPodId(), host.getClusterId(), host.getId(), null, null);
 
-                if (poolList != null && !poolList.isEmpty()) {
-                    // Volume needs to be migrated. Pick the first pool from the list. Add a mapping to migrate the
-                    // volume to a pool only if it is required; that is the current pool on which the volume resides
-                    // is not available on the destination host.
-                    final Iterator<StoragePool> iter = poolList.iterator();
-                    while (iter.hasNext()) {
-                        if (currentPool.getId() == iter.next().getId()) {
-                            currentPoolAvailable = true;
-                            break;
+                    final List<StoragePool> poolList = new ArrayList<>();
+                    final ExcludeList avoid = new ExcludeList();
+
+                    for (final StoragePoolAllocator allocator : _storagePoolAllocators) {
+                        final List<StoragePool> poolListFromAllocator = allocator.allocateToPool(diskProfile, profile, plan, avoid, StoragePoolAllocator.RETURN_UPTO_ALL);
+
+                        if (poolListFromAllocator != null && !poolListFromAllocator.isEmpty()) {
+                            poolList.addAll(poolListFromAllocator);
                         }
                     }
 
-                    if (!currentPoolAvailable) {
-                        volumeToPoolObjectMap.put(volume, _storagePoolDao.findByUuid(poolList.get(0).getUuid()));
+                    boolean currentPoolAvailable = false;
+
+                    if (poolList != null && !poolList.isEmpty()) {
+                        // Volume needs to be migrated. Pick the first pool from the list. Add a mapping to migrate the
+                        // volume to a pool only if it is required; that is the current pool on which the volume resides
+                        // is not available on the destination host.
+
+                        final Iterator<StoragePool> iter = poolList.iterator();
+
+                        while (iter.hasNext()) {
+                            if (currentPool.getId() == iter.next().getId()) {
+                                currentPoolAvailable = true;
+
+                                break;
+                            }
+                        }
+
+                        if (!currentPoolAvailable) {
+                            volumeToPoolObjectMap.put(volume, _storagePoolDao.findByUuid(poolList.get(0).getUuid()));
+                        }
                     }
-                }
 
-
-                if (!currentPoolAvailable && !volumeToPoolObjectMap.containsKey(volume)) {
-                    // Cannot find a pool for the volume. Throw an exception.
-                    throw new CloudRuntimeException("Cannot find a storage pool which is available for volume " + volume + " while migrating virtual machine " +
-                            profile.getVirtualMachine() + " to host " + host);
+                    if (!currentPoolAvailable && !volumeToPoolObjectMap.containsKey(volume)) {
+                        // Cannot find a pool for the volume. Throw an exception.
+                        throw new CloudRuntimeException("Cannot find a storage pool which is available for volume " + volume + " while migrating virtual machine " +
+                                profile.getVirtualMachine() + " to host " + host);
+                    }
                 }
             }
         }

--- a/engine/schema/src/org/apache/cloudstack/storage/datastore/db/StoragePoolVO.java
+++ b/engine/schema/src/org/apache/cloudstack/storage/datastore/db/StoragePoolVO.java
@@ -231,6 +231,7 @@ public class StoragePoolVO implements StoragePool {
         this.managed = managed;
     }
 
+    @Override
     public boolean isManaged() {
         return managed;
     }

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageReceiveCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xen610/XenServer610MigrateWithStorageReceiveCommandWrapper.java
@@ -31,7 +31,6 @@ import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.MigrateWithStorageReceiveAnswer;
 import com.cloud.agent.api.MigrateWithStorageReceiveCommand;
 import com.cloud.agent.api.to.NicTO;
-import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.agent.api.to.VolumeTO;
 import com.cloud.hypervisor.xenserver.resource.XenServer610Resource;
@@ -56,7 +55,7 @@ public final class XenServer610MigrateWithStorageReceiveCommandWrapper extends C
     public Answer execute(final MigrateWithStorageReceiveCommand command, final XenServer610Resource xenServer610Resource) {
         final Connection connection = xenServer610Resource.getConnection();
         final VirtualMachineTO vmSpec = command.getVirtualMachine();
-        final List<Pair<VolumeTO, StorageFilerTO>> volumeToFiler = command.getVolumeToFiler();
+        final List<Pair<VolumeTO, String>> volumeToStorageUuid = command.getVolumeToStorageUuid();
 
         try {
             // In a cluster management server setup, the migrate with storage receive and send
@@ -69,10 +68,12 @@ public final class XenServer610MigrateWithStorageReceiveCommandWrapper extends C
             // storage send command execution.
             Gson gson = new Gson();
             // Get a map of all the SRs to which the vdis will be migrated.
-            final List<Pair<VolumeTO, Object>> volumeToSr = new ArrayList<Pair<VolumeTO, Object>>();
-            for (final Pair<VolumeTO, StorageFilerTO> entry : volumeToFiler) {
-                final StorageFilerTO storageFiler = entry.second();
-                final SR sr = xenServer610Resource.getStorageRepository(connection, storageFiler.getUuid());
+            final List<Pair<VolumeTO, Object>> volumeToSr = new ArrayList<>();
+
+            for (final Pair<VolumeTO, String> entry : volumeToStorageUuid) {
+                final String storageUuid = entry.second();
+                final SR sr = xenServer610Resource.getStorageRepository(connection, storageUuid);
+
                 volumeToSr.add(new Pair<VolumeTO, Object>(entry.first(), sr));
             }
 

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixCreateStoragePoolCommandWrapper.java
@@ -19,6 +19,8 @@
 
 package com.cloud.hypervisor.xenserver.resource.wrapper.xenbase;
 
+import java.util.Map;
+
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
@@ -39,20 +41,35 @@ public final class CitrixCreateStoragePoolCommandWrapper extends CommandWrapper<
     public Answer execute(final CreateStoragePoolCommand command, final CitrixResourceBase citrixResourceBase) {
         final Connection conn = citrixResourceBase.getConnection();
         final StorageFilerTO pool = command.getPool();
+
         try {
-            if (pool.getType() == StoragePoolType.NetworkFilesystem) {
-                citrixResourceBase.getNfsSR(conn, Long.toString(pool.getId()), pool.getUuid(), pool.getHost(), pool.getPath(), pool.toString());
-            } else if (pool.getType() == StoragePoolType.IscsiLUN) {
-                citrixResourceBase.getIscsiSR(conn, pool.getUuid(), pool.getHost(), pool.getPath(), null, null, false);
-            } else if (pool.getType() == StoragePoolType.PreSetup) {
-            } else {
-                return new Answer(command, false, "The pool type: " + pool.getType().name() + " is not supported.");
+            if (command.getCreateDatastore()) {
+                Map<String, String> details = command.getDetails();
+
+                String srNameLabel = details.get(CreateStoragePoolCommand.DATASTORE_NAME);
+                String storageHost = details.get(CreateStoragePoolCommand.STORAGE_HOST);
+                String iqn = details.get(CreateStoragePoolCommand.IQN);
+
+                citrixResourceBase.getIscsiSR(conn, srNameLabel, storageHost, iqn, null, null, false);
             }
+            else {
+                if (pool.getType() == StoragePoolType.NetworkFilesystem) {
+                    citrixResourceBase.getNfsSR(conn, Long.toString(pool.getId()), pool.getUuid(), pool.getHost(), pool.getPath(), pool.toString());
+                } else if (pool.getType() == StoragePoolType.IscsiLUN) {
+                    citrixResourceBase.getIscsiSR(conn, pool.getUuid(), pool.getHost(), pool.getPath(), null, null, false);
+                } else if (pool.getType() == StoragePoolType.PreSetup) {
+                } else {
+                    return new Answer(command, false, "The pool type: " + pool.getType().name() + " is not supported.");
+                }
+            }
+
             return new Answer(command, true, "success");
         } catch (final Exception e) {
             final String msg = "Catch Exception " + e.getClass().getName() + ", create StoragePool failed due to " + e.toString() + " on host:"
                     + citrixResourceBase.getHost().getUuid() + " pool: " + pool.getHost() + pool.getPath();
+
             s_logger.warn(msg, e);
+
             return new Answer(command, false, msg);
         }
     }

--- a/plugins/hypervisors/xenserver/src/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
+++ b/plugins/hypervisors/xenserver/src/org/apache/cloudstack/storage/motion/XenServerStorageMotionStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.cloudstack.storage.motion;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataMotionStrategy;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreDriver;
 import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
@@ -39,6 +41,8 @@ import org.springframework.stereotype.Component;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.CreateStoragePoolCommand;
+import com.cloud.agent.api.DeleteStoragePoolCommand;
 import com.cloud.agent.api.MigrateWithStorageAnswer;
 import com.cloud.agent.api.MigrateWithStorageCommand;
 import com.cloud.agent.api.MigrateWithStorageCompleteAnswer;
@@ -56,9 +60,12 @@ import com.cloud.host.Host;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.VolumeVO;
+import com.cloud.storage.VolumeDetailVO;
 import com.cloud.storage.dao.VolumeDao;
+import com.cloud.storage.dao.VolumeDetailsDao;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.Pair;
+import com.cloud.utils.StringUtils;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.dao.VMInstanceDao;
 
@@ -73,6 +80,8 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
     VolumeDataFactory volFactory;
     @Inject
     PrimaryDataStoreDao storagePoolDao;
+    @Inject
+    private VolumeDetailsDao volumeDetailsDao;
     @Inject
     VMInstanceDao instanceDao;
 
@@ -120,25 +129,175 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
         callback.complete(result);
     }
 
+    private String getBasicIqn(long volumeId) {
+        VolumeDetailVO volumeDetail = volumeDetailsDao.findDetail(volumeId, PrimaryDataStoreDriver.BASIC_IQN);
+
+        return volumeDetail.getValue();
+    }
+
+    /**
+     * Tell the underlying storage plug-in to create a new volume, put it in the VAG of the destination cluster, and
+     * send a command to the destination cluster to create an SR and to attach to the SR from all hosts in the cluster.
+     */
+    private String handleManagedVolumePreMigration(VolumeInfo volumeInfo, StoragePool storagePool, Host destHost) {
+        final PrimaryDataStoreDriver pdsd = (PrimaryDataStoreDriver)volumeInfo.getDataStore().getDriver();
+
+        VolumeDetailVO volumeDetailVo = new VolumeDetailVO(volumeInfo.getId(), PrimaryDataStoreDriver.BASIC_CREATE, Boolean.TRUE.toString(), false);
+
+        volumeDetailsDao.persist(volumeDetailVo);
+
+        pdsd.createAsync(volumeInfo.getDataStore(), volumeInfo, null);
+
+        volumeDetailVo = new VolumeDetailVO(volumeInfo.getId(), PrimaryDataStoreDriver.BASIC_GRANT_ACCESS, Boolean.TRUE.toString(), false);
+
+        volumeDetailsDao.persist(volumeDetailVo);
+
+        pdsd.grantAccess(volumeInfo, destHost, volumeInfo.getDataStore());
+
+        final Map<String, String> details = new HashMap<>();
+
+        final String iqn = getBasicIqn(volumeInfo.getId());
+
+        details.put(CreateStoragePoolCommand.DATASTORE_NAME, iqn);
+
+        details.put(CreateStoragePoolCommand.IQN, iqn);
+
+        details.put(CreateStoragePoolCommand.STORAGE_HOST, storagePool.getHostAddress());
+
+        details.put(CreateStoragePoolCommand.STORAGE_PORT, String.valueOf(storagePool.getPort()));
+
+        final CreateStoragePoolCommand cmd = new CreateStoragePoolCommand(true, storagePool);
+
+        cmd.setDetails(details);
+        cmd.setCreateDatastore(true);
+
+        final Answer answer = agentMgr.easySend(destHost.getId(), cmd);
+
+        if (answer == null || !answer.getResult()) {
+            String errMsg = "Error interacting with host (related to CreateStoragePoolCommand)" +
+                    (StringUtils.isNotBlank(answer.getDetails()) ? ": " + answer.getDetails() : "");
+
+            s_logger.error(errMsg);
+
+            throw new CloudRuntimeException(errMsg);
+        }
+
+        return iqn;
+    }
+
+    private void handleManagedVolumePostMigration(VolumeInfo volumeInfo, Host srcHost, VolumeObjectTO volumeTO) {
+        final Map<String, String> details = new HashMap<>();
+
+        details.put(DeleteStoragePoolCommand.DATASTORE_NAME, volumeInfo.get_iScsiName());
+
+        final DeleteStoragePoolCommand cmd = new DeleteStoragePoolCommand();
+
+        cmd.setDetails(details);
+        cmd.setRemoveDatastore(true);
+
+        final Answer answer = agentMgr.easySend(srcHost.getId(), cmd);
+
+        if (answer == null || !answer.getResult()) {
+            String errMsg = "Error interacting with host (related to DeleteStoragePoolCommand)" +
+                    (StringUtils.isNotBlank(answer.getDetails()) ? ": " + answer.getDetails() : "");
+
+            s_logger.error(errMsg);
+
+            throw new CloudRuntimeException(errMsg);
+        }
+
+        final PrimaryDataStoreDriver pdsd = (PrimaryDataStoreDriver)volumeInfo.getDataStore().getDriver();
+
+        pdsd.revokeAccess(volumeInfo, srcHost, volumeInfo.getDataStore());
+
+        VolumeDetailVO volumeDetailVo = new VolumeDetailVO(volumeInfo.getId(), PrimaryDataStoreDriver.BASIC_DELETE, Boolean.TRUE.toString(), false);
+
+        volumeDetailsDao.persist(volumeDetailVo);
+
+        pdsd.deleteAsync(volumeInfo.getDataStore(), volumeInfo, null);
+
+        VolumeVO volumeVO = volDao.findById(volumeInfo.getId());
+
+        volumeVO.setPath(volumeTO.getPath());
+
+        volDao.update(volumeVO.getId(), volumeVO);
+    }
+
+    private void handleManagedVolumesAfterFailedMigration(Map<VolumeInfo, DataStore> volumeToPool, Host destHost) {
+        for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
+            VolumeInfo volumeInfo = entry.getKey();
+            StoragePool storagePool = storagePoolDao.findById(volumeInfo.getPoolId());
+
+            if (storagePool.isManaged()) {
+                final Map<String, String> details = new HashMap<>();
+
+                details.put(DeleteStoragePoolCommand.DATASTORE_NAME, getBasicIqn(volumeInfo.getId()));
+
+                final DeleteStoragePoolCommand cmd = new DeleteStoragePoolCommand();
+
+                cmd.setDetails(details);
+                cmd.setRemoveDatastore(true);
+
+                final Answer answer = agentMgr.easySend(destHost.getId(), cmd);
+
+                if (answer == null || !answer.getResult()) {
+                    String errMsg = "Error interacting with host (related to handleManagedVolumesAfterFailedMigration)" +
+                            (StringUtils.isNotBlank(answer.getDetails()) ? ": " + answer.getDetails() : "");
+
+                    s_logger.error(errMsg);
+
+                    // no need to throw an exception here as the calling code is responsible for doing so
+                    // regardless of the success or lack thereof concerning this method
+                    return;
+                }
+
+                final PrimaryDataStoreDriver pdsd = (PrimaryDataStoreDriver)volumeInfo.getDataStore().getDriver();
+
+                VolumeDetailVO volumeDetailVo = new VolumeDetailVO(volumeInfo.getId(), PrimaryDataStoreDriver.BASIC_REVOKE_ACCESS, Boolean.TRUE.toString(), false);
+
+                volumeDetailsDao.persist(volumeDetailVo);
+
+                pdsd.revokeAccess(volumeInfo, destHost, volumeInfo.getDataStore());
+
+                volumeDetailVo = new VolumeDetailVO(volumeInfo.getId(), PrimaryDataStoreDriver.BASIC_DELETE_FAILURE, Boolean.TRUE.toString(), false);
+
+                volumeDetailsDao.persist(volumeDetailVo);
+
+                pdsd.deleteAsync(volumeInfo.getDataStore(), volumeInfo, null);
+            }
+        }
+    }
+
     private Answer migrateVmWithVolumesAcrossCluster(VMInstanceVO vm, VirtualMachineTO to, Host srcHost, Host destHost, Map<VolumeInfo, DataStore> volumeToPool)
             throws AgentUnavailableException {
+        // Initiate migration of a virtual machine with its volumes.
 
-        // Initiate migration of a virtual machine with it's volumes.
         try {
-            List<Pair<VolumeTO, StorageFilerTO>> volumeToFilerto = new ArrayList<Pair<VolumeTO, StorageFilerTO>>();
+            List<Pair<VolumeTO, String>> volumeToStorageUuid = new ArrayList<>();
+
             for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
-                VolumeInfo volume = entry.getKey();
-                VolumeTO volumeTo = new VolumeTO(volume, storagePoolDao.findById(volume.getPoolId()));
-                StorageFilerTO filerTo = new StorageFilerTO((StoragePool)entry.getValue());
-                volumeToFilerto.add(new Pair<VolumeTO, StorageFilerTO>(volumeTo, filerTo));
+                VolumeInfo volumeInfo = entry.getKey();
+                StoragePool storagePool = storagePoolDao.findById(volumeInfo.getPoolId());
+                VolumeTO volumeTo = new VolumeTO(volumeInfo, storagePool);
+
+                if (storagePool.isManaged()) {
+                    String iqn = handleManagedVolumePreMigration(volumeInfo, storagePool, destHost);
+
+                    volumeToStorageUuid.add(new Pair<>(volumeTo, iqn));
+                }
+                else {
+                    volumeToStorageUuid.add(new Pair<>(volumeTo, ((StoragePool)entry.getValue()).getPath()));
+                }
             }
 
             // Migration across cluster needs to be done in three phases.
             // 1. Send a migrate receive command to the destination host so that it is ready to receive a vm.
             // 2. Send a migrate send command to the source host. This actually migrates the vm to the destination.
             // 3. Complete the process. Update the volume details.
-            MigrateWithStorageReceiveCommand receiveCmd = new MigrateWithStorageReceiveCommand(to, volumeToFilerto);
+
+            MigrateWithStorageReceiveCommand receiveCmd = new MigrateWithStorageReceiveCommand(to, volumeToStorageUuid);
             MigrateWithStorageReceiveAnswer receiveAnswer = (MigrateWithStorageReceiveAnswer)agentMgr.send(destHost.getId(), receiveCmd);
+
             if (receiveAnswer == null) {
                 s_logger.error("Migration with storage of vm " + vm + " to host " + destHost + " failed.");
                 throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost);
@@ -150,16 +309,22 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
             MigrateWithStorageSendCommand sendCmd =
                     new MigrateWithStorageSendCommand(to, receiveAnswer.getVolumeToSr(), receiveAnswer.getNicToNetwork(), receiveAnswer.getToken());
             MigrateWithStorageSendAnswer sendAnswer = (MigrateWithStorageSendAnswer)agentMgr.send(srcHost.getId(), sendCmd);
+
             if (sendAnswer == null) {
+                handleManagedVolumesAfterFailedMigration(volumeToPool, destHost);
+
                 s_logger.error("Migration with storage of vm " + vm + " to host " + destHost + " failed.");
                 throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost);
             } else if (!sendAnswer.getResult()) {
+                handleManagedVolumesAfterFailedMigration(volumeToPool, destHost);
+
                 s_logger.error("Migration with storage of vm " + vm + " failed. Details: " + sendAnswer.getDetails());
                 throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost);
             }
 
             MigrateWithStorageCompleteCommand command = new MigrateWithStorageCompleteCommand(to);
             MigrateWithStorageCompleteAnswer answer = (MigrateWithStorageCompleteAnswer)agentMgr.send(destHost.getId(), command);
+
             if (answer == null) {
                 s_logger.error("Migration with storage of vm " + vm + " failed.");
                 throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost);
@@ -168,7 +333,7 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
                 throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost);
             } else {
                 // Update the volume details after migration.
-                updateVolumePathsAfterMigration(volumeToPool, answer.getVolumeTos());
+                updateVolumePathsAfterMigration(volumeToPool, answer.getVolumeTos(), srcHost);
             }
 
             return answer;
@@ -181,7 +346,7 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
     private Answer migrateVmWithVolumesWithinCluster(VMInstanceVO vm, VirtualMachineTO to, Host srcHost, Host destHost, Map<VolumeInfo, DataStore> volumeToPool)
             throws AgentUnavailableException {
 
-        // Initiate migration of a virtual machine with it's volumes.
+        // Initiate migration of a virtual machine with its volumes.
         try {
             List<Pair<VolumeTO, StorageFilerTO>> volumeToFilerto = new ArrayList<Pair<VolumeTO, StorageFilerTO>>();
             for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
@@ -201,7 +366,7 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
                 throw new CloudRuntimeException("Error while migrating the vm " + vm + " to host " + destHost + ". " + answer.getDetails());
             } else {
                 // Update the volume details after migration.
-                updateVolumePathsAfterMigration(volumeToPool, answer.getVolumeTos());
+                updateVolumePathsAfterMigration(volumeToPool, answer.getVolumeTos(), srcHost);
             }
 
             return answer;
@@ -211,28 +376,39 @@ public class XenServerStorageMotionStrategy implements DataMotionStrategy {
         }
     }
 
-    private void updateVolumePathsAfterMigration(Map<VolumeInfo, DataStore> volumeToPool, List<VolumeObjectTO> volumeTos) {
+    private void updateVolumePathsAfterMigration(Map<VolumeInfo, DataStore> volumeToPool, List<VolumeObjectTO> volumeTos, Host srcHost) {
         for (Map.Entry<VolumeInfo, DataStore> entry : volumeToPool.entrySet()) {
+            VolumeInfo volumeInfo = entry.getKey();
+            StoragePool storagePool = (StoragePool)entry.getValue();
+
             boolean updated = false;
-            VolumeInfo volume = entry.getKey();
-            StoragePool pool = (StoragePool)entry.getValue();
+
             for (VolumeObjectTO volumeTo : volumeTos) {
-                if (volume.getId() == volumeTo.getId()) {
-                    VolumeVO volumeVO = volDao.findById(volume.getId());
-                    Long oldPoolId = volumeVO.getPoolId();
-                    volumeVO.setPath(volumeTo.getPath());
-                    volumeVO.setFolder(pool.getPath());
-                    volumeVO.setPodId(pool.getPodId());
-                    volumeVO.setPoolId(pool.getId());
-                    volumeVO.setLastPoolId(oldPoolId);
-                    volDao.update(volume.getId(), volumeVO);
+                if (volumeInfo.getId() == volumeTo.getId()) {
+                    if (storagePool.isManaged()) {
+                        handleManagedVolumePostMigration(volumeInfo, srcHost, volumeTo);
+                    }
+                    else {
+                        VolumeVO volumeVO = volDao.findById(volumeInfo.getId());
+                        Long oldPoolId = volumeVO.getPoolId();
+
+                        volumeVO.setPath(volumeTo.getPath());
+                        volumeVO.setFolder(storagePool.getPath());
+                        volumeVO.setPodId(storagePool.getPodId());
+                        volumeVO.setPoolId(storagePool.getId());
+                        volumeVO.setLastPoolId(oldPoolId);
+
+                        volDao.update(volumeInfo.getId(), volumeVO);
+                    }
+
                     updated = true;
+
                     break;
                 }
             }
 
             if (!updated) {
-                s_logger.error("Volume path wasn't updated for volume " + volume + " after it was migrated.");
+                s_logger.error("The volume path wasn't updated for volume '" + volumeInfo + "' after it was migrated.");
             }
         }
     }

--- a/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/XenServer610WrapperTest.java
+++ b/plugins/hypervisors/xenserver/test/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/XenServer610WrapperTest.java
@@ -204,9 +204,9 @@ public class XenServer610WrapperTest {
         final StorageFilerTO storage1 = Mockito.mock(StorageFilerTO.class);
         final StorageFilerTO storage2 = Mockito.mock(StorageFilerTO.class);
 
-        final List<Pair<VolumeTO, StorageFilerTO>> volumeToFiler = new ArrayList<Pair<VolumeTO, StorageFilerTO>>();
-        volumeToFiler.add(new Pair<VolumeTO, StorageFilerTO>(vol1, storage1));
-        volumeToFiler.add(new Pair<VolumeTO, StorageFilerTO>(vol2, storage2));
+        final List<Pair<VolumeTO, String>> volumeToFiler = new ArrayList<>();
+        volumeToFiler.add(new Pair<>(vol1, storage1.getPath()));
+        volumeToFiler.add(new Pair<>(vol2, storage2.getPath()));
 
         final NicTO nicTO1 = Mockito.mock(NicTO.class);
         final NicTO nicTO2 = Mockito.mock(NicTO.class);

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1205,12 +1205,15 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                     srcHost.getHypervisorType(), srcHost.getHypervisorVersion());
             allHosts = allHostsPair.first();
             allHosts.remove(srcHost);
+
             for (final VolumeVO volume : volumes) {
-                final Long volClusterId = _poolDao.findById(volume.getPoolId()).getClusterId();
-                // only check for volume which are not in zone wide primary store, as only those may require storage motion
-                if (volClusterId != null) {
-                    for (final Iterator<HostVO> iterator = allHosts.iterator(); iterator.hasNext();) {
-                        final Host host = iterator.next();
+                final StoragePool storagePool = _poolDao.findById(volume.getPoolId());
+                final Long volClusterId = storagePool.getClusterId();
+
+                for (final Iterator<HostVO> iterator = allHosts.iterator(); iterator.hasNext();) {
+                    final Host host = iterator.next();
+
+                    if (volClusterId != null) {
                         if (!host.getClusterId().equals(volClusterId) || usesLocal) {
                             if (hasSuitablePoolsForVolume(volume, host, vmProfile)) {
                                 requiresStorageMotion.put(host, true);
@@ -1219,8 +1222,16 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                             }
                         }
                     }
+                    else {
+                        if (storagePool.isManaged()) {
+                            if (srcHost.getClusterId() != host.getClusterId()) {
+                                requiresStorageMotion.put(host, true);
+                            }
+                        }
+                    }
                 }
             }
+
             plan = new DataCenterDeployment(srcHost.getDataCenterId(), null, null, null, null, null);
         } else {
             final Long cluster = srcHost.getClusterId();
@@ -1249,7 +1260,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         for (final HostAllocator allocator : hostAllocators) {
-            if  (canMigrateWithStorage) {
+            if (canMigrateWithStorage) {
                 suitableHosts = allocator.allocateTo(vmProfile, plan, Host.Type.Routing, excludes, allHosts, HostAllocator.RETURN_UPTO_ALL, false);
             } else {
                 suitableHosts = allocator.allocateTo(vmProfile, plan, Host.Type.Routing, excludes, HostAllocator.RETURN_UPTO_ALL, false);

--- a/test/integration/plugins/solidfire/TestAddRemoveHosts.py
+++ b/test/integration/plugins/solidfire/TestAddRemoveHosts.py
@@ -21,6 +21,8 @@ import SignedAPICall
 import time
 import XenAPI
 
+from util import sf_util
+
 # All tests inherit from cloudstackTestCase
 from marvin.cloudstackTestCase import cloudstackTestCase
 
@@ -36,6 +38,15 @@ from marvin.lib.common import get_domain, get_template, get_zone, list_hosts, li
 from marvin.lib.utils import cleanup_resources
 
 from solidfire import solidfire_element_api as sf_api
+
+# Prerequisites:
+#  Only one zone
+#  Only one pod
+#  Only one cluster (two hosts with another added/removed during the tests)
+#
+# Running the tests:
+#  Set a breakpoint on each test after the first one. When the breakpoint is hit, reset the third
+#   host to a snapshot state and re-start it. Once it's up and running, run the test code.
 
 
 class TestData:
@@ -238,7 +249,7 @@ class TestAddRemoveHosts(cloudstackTestCase):
         try:
             cleanup_resources(cls.apiClient, cls._cleanup)
 
-            cls._purge_solidfire_volumes()
+            sf_util.purge_solidfire_volumes(cls.sf_client)
         except Exception as e:
             logging.debug("Exception in tearDownClass(cls): %s" % e)
 
@@ -286,7 +297,7 @@ class TestAddRemoveHosts(cloudstackTestCase):
 
         root_volume = self._get_root_volume(self.virtual_machine)
 
-        sf_iscsi_name = self._get_iqn(root_volume)
+        sf_iscsi_name = sf_util.get_iqn(self.cs_api, root_volume, self)
 
         self._perform_add_remove_host(primary_storage.id, sf_iscsi_name)
 
@@ -342,7 +353,7 @@ class TestAddRemoveHosts(cloudstackTestCase):
 
         root_volume = self._get_root_volume(self.virtual_machine)
 
-        sf_iscsi_name = self._get_iqn(root_volume)
+        sf_iscsi_name = sf_util.get_iqn(self.cs_api, root_volume, self)
 
         primarystorage2 = self.testdata[TestData.primaryStorage2]
 
@@ -596,19 +607,6 @@ class TestAddRemoveHosts(cloudstackTestCase):
 
         self.assert_(False, "Unable to locate the ROOT volume of the VM with the following ID: " + str(vm.id))
 
-    def _get_iqn(self, volume):
-        # Get volume IQN
-        sf_iscsi_name_request = {'volumeid': volume.id}
-        # put this commented line back once PR 1403 is in
-        # sf_iscsi_name_result = self.cs_api.getVolumeiScsiName(sf_iscsi_name_request)
-        sf_iscsi_name_result = self.cs_api.getSolidFireVolumeIscsiName(sf_iscsi_name_request)
-        # sf_iscsi_name = sf_iscsi_name_result['apivolumeiscsiname']['volumeiScsiName']
-        sf_iscsi_name = sf_iscsi_name_result['apisolidfirevolumeiscsiname']['solidFireVolumeIscsiName']
-
-        self._check_iscsi_name(sf_iscsi_name)
-
-        return sf_iscsi_name
-
     def _get_iqn_2(self, primary_storage):
         sql_query = "Select path From storage_pool Where uuid = '" + str(primary_storage.id) + "'"
 
@@ -616,13 +614,6 @@ class TestAddRemoveHosts(cloudstackTestCase):
         sql_result = self.dbConnection.execute(sql_query)
 
         return sql_result[0][0]
-
-    def _check_iscsi_name(self, sf_iscsi_name):
-        self.assertEqual(
-            sf_iscsi_name[0],
-            "/",
-            "The iSCSI name needs to start with a forward slash."
-        )
 
     def _get_host_iscsi_iqns(self):
         hosts = self.xen_session.xenapi.host.get_all()
@@ -687,24 +678,3 @@ class TestAddRemoveHosts(cloudstackTestCase):
         for host_iscsi_iqn in host_iscsi_iqns:
             # an error should occur if host_iscsi_iqn is not in sf_vag_initiators
             sf_vag_initiators.index(host_iscsi_iqn)
-
-    def _check_list(self, in_list, expected_size_of_list, err_msg):
-        self.assertEqual(
-            isinstance(in_list, list),
-            True,
-            "'in_list' is not a list."
-        )
-
-        self.assertEqual(
-            len(in_list),
-            expected_size_of_list,
-            err_msg
-        )
-
-    @classmethod
-    def _purge_solidfire_volumes(cls):
-        deleted_volumes = cls.sf_client.list_deleted_volumes()
-
-        for deleted_volume in deleted_volumes:
-            cls.sf_client.purge_deleted_volume(deleted_volume['volumeID'])
-

--- a/test/integration/plugins/solidfire/TestSnapshots.py
+++ b/test/integration/plugins/solidfire/TestSnapshots.py
@@ -21,6 +21,8 @@ import SignedAPICall
 import time
 import XenAPI
 
+from util import sf_util
+
 # All tests inherit from cloudstackTestCase
 from marvin.cloudstackTestCase import cloudstackTestCase
 
@@ -32,15 +34,17 @@ from nose.plugins.attrib import attr
 from marvin.lib.base import Account, DiskOffering, ServiceOffering, Snapshot, StoragePool, Template, User, VirtualMachine, Volume
 
 # common - commonly used methods for all tests are listed here
-from marvin.lib.common import get_domain, get_template, get_zone, list_clusters, list_hosts, list_volumes
+from marvin.lib.common import get_domain, get_template, get_zone, list_clusters, list_hosts, list_volumes, list_snapshots
 
 # utils - utility classes for common cleanup, external library wrappers, etc.
-from marvin.lib.utils import cleanup_resources
+from marvin.lib.utils import cleanup_resources, wait_until
 
 from solidfire import solidfire_element_api as sf_api
 
-# on April 10, 2016: Ran 3 tests in 7742.481s with three hosts
-# on May 2, 2016: Ran 3 tests in 7409.770s with two hosts
+# Prerequisites:
+#  Only one zone
+#  Only one pod
+#  Only one cluster
 
 
 class TestData():
@@ -334,7 +338,7 @@ class TestSnapshots(cloudstackTestCase):
 
             cls.primary_storage.delete(cls.apiClient)
 
-            cls._purge_solidfire_volumes()
+            sf_util.purge_solidfire_volumes(cls.sf_client)
         except Exception as e:
             logging.debug("Exception in tearDownClass(cls): %s" % e)
 
@@ -346,7 +350,7 @@ class TestSnapshots(cloudstackTestCase):
 
     @attr(hypervisor='XenServer')
     def test_01_create_volume_snapshot_using_sf_snapshot(self):
-        self._set_supports_resign(True)
+        sf_util.set_supports_resign(True, self.dbConnection)
 
         virtual_machine = VirtualMachine.create(
             self.apiClient,
@@ -365,24 +369,24 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_1_root_volume = list_volumes_response[0]
         vm_1_root_volume_name = vm_1_root_volume.name
 
-        sf_account_id = self._get_sf_account_id(self.account.id, self.primary_storage.id)
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self, TestSnapshots._sf_account_id_should_be_non_zero_int_err_msg)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume['volumeID'])
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         primary_storage_db_id = self._get_cs_storage_pool_db_id(self.primary_storage)
 
@@ -405,27 +409,27 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
 
         self._delete_and_test_snapshot(vol_snap_1)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
 
         self._delete_and_test_snapshot(vol_snap_2)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 0, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 0, self, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
 
         virtual_machine = VirtualMachine.create(
             self.apiClient,
@@ -444,22 +448,22 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_1_root_volume = list_volumes_response[0]
         vm_1_root_volume_name = vm_1_root_volume.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume['volumeID'])
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         vol_snap_1 = self._create_and_test_snapshot(vm_1_root_volume.id, sf_volume, primary_storage_db_id, 1, TestSnapshots._should_only_be_one_snapshot_in_list_err_msg)
 
@@ -492,22 +496,22 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_2_root_volume = list_volumes_response[0]
         vm_2_root_volume_name = vm_2_root_volume.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 2, self, TestSnapshots._should_be_two_volumes_in_list_err_msg)
 
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots_2 = self.sf_client.list_snapshots(volume_id=sf_volume_2['volumeID'])
 
-        self._check_list(sf_snapshots_2, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots_2, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         vol_snap_a = self._create_and_test_snapshot(vm_2_root_volume.id, sf_volume_2, primary_storage_db_id, 1, TestSnapshots._should_only_be_one_snapshot_in_list_err_msg)
 
@@ -518,15 +522,15 @@ class TestSnapshots(cloudstackTestCase):
         volume_created_from_snapshot_name = volume_created_from_snapshot.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 3, TestSnapshots._should_be_three_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 3, self, TestSnapshots._should_be_three_volumes_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
         sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
 
-        self._check_list(sf_volume_3['volumeAccessGroups'], 0, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
+        sf_util.check_list(sf_volume_3['volumeAccessGroups'], 0, self, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
 
         volume_created_from_snapshot = virtual_machine.attach_volume(
             self.apiClient,
@@ -538,9 +542,9 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 3, TestSnapshots._should_be_three_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 3, self, TestSnapshots._should_be_three_volumes_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
@@ -558,9 +562,9 @@ class TestSnapshots(cloudstackTestCase):
         self._delete_and_test_snapshot(vol_snap_1)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 2, self, TestSnapshots._should_be_two_volumes_in_list_err_msg)
 
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
         sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
@@ -568,9 +572,9 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine_2.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
 
@@ -579,7 +583,7 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         data_volume = list_volumes_response[0]
 
@@ -588,13 +592,13 @@ class TestSnapshots(cloudstackTestCase):
         data_volume.delete(self.apiClient)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 0, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 0, self, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
 
     @attr(hypervisor='XenServer')
     def test_02_create_volume_snapshot_using_sf_volume(self):
-        self._set_supports_resign(False)
+        sf_util.set_supports_resign(False, self.dbConnection)
 
         virtual_machine = VirtualMachine.create(
             self.apiClient,
@@ -613,24 +617,24 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_1_root_volume = list_volumes_response[0]
         vm_1_root_volume_name = vm_1_root_volume.name
 
-        sf_account_id = self._get_sf_account_id(self.account.id, self.primary_storage.id)
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self, TestSnapshots._sf_account_id_should_be_non_zero_int_err_msg)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume['volumeID'])
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         primary_storage_db_id = self._get_cs_storage_pool_db_id(self.primary_storage)
 
@@ -661,9 +665,9 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 2, self, TestSnapshots._should_be_two_volumes_in_list_err_msg)
 
         self._delete_and_test_snapshot_2(vol_snap_1, sf_account_id, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
@@ -686,22 +690,22 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_1_root_volume = list_volumes_response[0]
         vm_1_root_volume_name = vm_1_root_volume.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume['volumeID'])
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         sf_volume_id = sf_volume['volumeID']
         sf_volume_size = sf_volume['totalSize']
@@ -740,22 +744,22 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_2_root_volume = list_volumes_response[0]
         vm_2_root_volume_name = vm_2_root_volume.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 5, TestSnapshots._should_be_five_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 5, self, TestSnapshots._should_be_five_volumes_in_list_err_msg)
 
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots_2 = self.sf_client.list_snapshots(volume_id=sf_volume_2['volumeID'])
 
-        self._check_list(sf_snapshots_2, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots_2, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         sf_volume_id_2 = sf_volume_2['volumeID']
         sf_volume_size_2 = sf_volume_2['totalSize']
@@ -770,15 +774,15 @@ class TestSnapshots(cloudstackTestCase):
         volume_created_from_snapshot_name = volume_created_from_snapshot.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 7, TestSnapshots._should_be_seven_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 7, self, TestSnapshots._should_be_seven_volumes_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
         sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
 
-        self._check_list(sf_volume_3['volumeAccessGroups'], 0, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
+        sf_util.check_list(sf_volume_3['volumeAccessGroups'], 0, self, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
 
         volume_created_from_snapshot = virtual_machine.attach_volume(
             self.apiClient,
@@ -790,9 +794,9 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 5, TestSnapshots._should_be_five_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 5, self, TestSnapshots._should_be_five_volumes_in_list_err_msg)
 
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
         sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
@@ -811,16 +815,16 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine_2.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         list_volumes_response = list_volumes(
             self.apiClient,
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         data_volume = list_volumes_response[0]
 
@@ -829,9 +833,9 @@ class TestSnapshots(cloudstackTestCase):
         data_volume.delete(self.apiClient)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 0, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 0, self, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
 
         virtual_machine = VirtualMachine.create(
             self.apiClient,
@@ -850,15 +854,15 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_1_root_volume = list_volumes_response[0]
         vm_1_root_volume_name = vm_1_root_volume.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         time.sleep(60)
 
@@ -873,9 +877,9 @@ class TestSnapshots(cloudstackTestCase):
                                                       sf_account_id, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 2, self, TestSnapshots._should_be_two_volumes_in_list_err_msg)
 
         services = {"diskname": "Vol-1", "zoneid": self.testdata[TestData.zoneId], "size": 100, "ispublic": True}
 
@@ -884,13 +888,13 @@ class TestSnapshots(cloudstackTestCase):
         volume_created_from_snapshot_name = volume_created_from_snapshot.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 3, TestSnapshots._should_be_three_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 3, self, TestSnapshots._should_be_three_volumes_in_list_err_msg)
 
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
 
-        self._check_list(sf_volume_2['volumeAccessGroups'], 0, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
+        sf_util.check_list(sf_volume_2['volumeAccessGroups'], 0, self, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
 
         volume_created_from_snapshot = virtual_machine.attach_volume(
             self.apiClient,
@@ -910,16 +914,16 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         list_volumes_response = list_volumes(
             self.apiClient,
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vol_snap_a = self._create_and_test_snapshot_2(volume_created_from_snapshot.id, sf_volume_id_2, sf_volume_id + 4, primary_storage_db_id, sf_volume_size_2,
                                                       sf_account_id, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
@@ -931,9 +935,9 @@ class TestSnapshots(cloudstackTestCase):
         data_volume.delete(self.apiClient)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         list_volumes_response = list_volumes(
             self.apiClient,
@@ -950,7 +954,7 @@ class TestSnapshots(cloudstackTestCase):
 
     @attr(hypervisor='XenServer')
     def test_03_create_volume_snapshot_using_sf_volume_and_sf_snapshot(self):
-        self._set_supports_resign(False)
+        sf_util.set_supports_resign(False, self.dbConnection)
 
         virtual_machine = VirtualMachine.create(
             self.apiClient,
@@ -969,24 +973,24 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_1_root_volume = list_volumes_response[0]
         vm_1_root_volume_name = vm_1_root_volume.name
 
-        sf_account_id = self._get_sf_account_id(self.account.id, self.primary_storage.id)
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self, TestSnapshots._sf_account_id_should_be_non_zero_int_err_msg)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume['volumeID'])
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         primary_storage_db_id = self._get_cs_storage_pool_db_id(self.primary_storage)
 
@@ -999,7 +1003,7 @@ class TestSnapshots(cloudstackTestCase):
         vol_snap_2 = self._create_and_test_snapshot_2(vm_1_root_volume.id, sf_volume_id, sf_volume_id + 2, primary_storage_db_id, sf_volume_size,
                                                       sf_account_id, 3, TestSnapshots._should_be_three_volumes_in_list_err_msg)
 
-        self._set_supports_resign(True)
+        sf_util.set_supports_resign(True, self.dbConnection)
 
         vol_snap_a = self._create_and_test_snapshot(vm_1_root_volume.id, sf_volume, primary_storage_db_id, 1, TestSnapshots._should_only_be_one_snapshot_in_list_err_msg)
 
@@ -1030,31 +1034,31 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_2_root_volume = list_volumes_response[0]
         vm_2_root_volume_name = vm_2_root_volume.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 4, TestSnapshots._should_be_four_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 4, self, TestSnapshots._should_be_four_volumes_in_list_err_msg)
 
         sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume_2['volumeID'])
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         services = {"diskname": "Vol-1", "zoneid": self.testdata[TestData.zoneId], "size": 100, "ispublic": True}
 
         volume_created_from_snapshot_1 = Volume.create_from_snapshot(self.apiClient, vol_snap_2.id, services, account=self.account.name, domainid=self.domain.id)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 5, TestSnapshots._should_be_five_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 5, self, TestSnapshots._should_be_five_volumes_in_list_err_msg)
 
         volume_created_from_snapshot_1 = virtual_machine_2.attach_volume(
             self.apiClient,
@@ -1086,31 +1090,31 @@ class TestSnapshots(cloudstackTestCase):
             listall=True
         )
 
-        self._check_list(list_volumes_response, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         vm_3_root_volume = list_volumes_response[0]
         vm_3_root_volume_name = vm_3_root_volume.name
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 6, TestSnapshots._should_be_six_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 6, self, TestSnapshots._should_be_six_volumes_in_list_err_msg)
 
         sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, vm_3_root_volume_name)
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume_3['volumeID'])
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         services = {"diskname": "Vol-A", "zoneid": self.testdata[TestData.zoneId], "size": 100, "ispublic": True}
 
         volume_created_from_snapshot_a = Volume.create_from_snapshot(self.apiClient, vol_snap_b.id, services, account=self.account.name, domainid=self.domain.id)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 7, TestSnapshots._should_be_seven_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 7, self, TestSnapshots._should_be_seven_volumes_in_list_err_msg)
 
         volume_created_from_snapshot_a = virtual_machine_3.attach_volume(
             self.apiClient,
@@ -1120,84 +1124,319 @@ class TestSnapshots(cloudstackTestCase):
         virtual_machine.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
         # should still be 7 volumes because the SolidFire volume for the root disk of the VM just destroyed
         # is still needed for the SolidFire snapshots
-        self._check_list(sf_volumes, 7, TestSnapshots._should_be_seven_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 7, self, TestSnapshots._should_be_seven_volumes_in_list_err_msg)
 
         virtual_machine_2.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 6, TestSnapshots._should_be_six_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 6, self, TestSnapshots._should_be_six_volumes_in_list_err_msg)
 
         virtual_machine_3.delete(self.apiClient, True)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 5, TestSnapshots._should_be_five_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 5, self, TestSnapshots._should_be_five_volumes_in_list_err_msg)
 
         data_volume = Volume(volume_created_from_snapshot_a.__dict__)
 
         data_volume.delete(self.apiClient)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 4, TestSnapshots._should_be_four_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 4, self, TestSnapshots._should_be_four_volumes_in_list_err_msg)
 
         data_volume = Volume(volume_created_from_snapshot_1.__dict__)
 
         data_volume.delete(self.apiClient)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 3, TestSnapshots._should_be_three_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 3, self, TestSnapshots._should_be_three_volumes_in_list_err_msg)
 
         self._delete_and_test_snapshot_2(vol_snap_1, sf_account_id, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
 
         self._delete_and_test_snapshot(vol_snap_b)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
         # should still be 2 volumes because the SolidFire volume for the root disk of the VM just destroyed
         # is still needed for the SolidFire snapshots
-        self._check_list(sf_volumes, 2, TestSnapshots._should_be_two_volumes_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 2, self, TestSnapshots._should_be_two_volumes_in_list_err_msg)
 
         self._delete_and_test_snapshot(vol_snap_a)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, 1, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
 
         self._delete_and_test_snapshot_2(vol_snap_2, sf_account_id, 0, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
 
-    def _set_supports_resign(self, supports_resign):
-        supports_resign = str(supports_resign)
+    @attr(hypervisor='XenServer')
+    def test_04_create_volume_snapshot_using_sf_snapshot_and_archiving(self):
+        sf_util.set_supports_resign(True, self.dbConnection)
 
-        sql_query = "Update host_details Set value = '" + supports_resign + "' Where name = 'supportsResign'"
-
-        # make sure you can connect to MySQL: https://teamtreehouse.com/community/cant-connect-remotely-to-mysql-server-with-mysql-workbench
-        self.dbConnection.execute(sql_query)
-
-    def _check_list(self, in_list, expected_size_of_list, err_msg):
-        self.assertEqual(
-            isinstance(in_list, list),
-            True,
-            "'in_list' is not a list."
+        virtual_machine = VirtualMachine.create(
+            self.apiClient,
+            self.testdata[TestData.virtualMachine],
+            accountid=self.account.name,
+            zoneid=self.zone.id,
+            serviceofferingid=self.compute_offering.id,
+            templateid=self.template.id,
+            domainid=self.domain.id,
+            startvm=True
         )
 
-        self.assertEqual(
-            len(in_list),
-            expected_size_of_list,
-            err_msg
+        list_volumes_response = list_volumes(
+            self.apiClient,
+            virtualmachineid=virtual_machine.id,
+            listall=True
         )
+
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        vm_1_root_volume = list_volumes_response[0]
+        vm_1_root_volume_name = vm_1_root_volume.name
+
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self, TestSnapshots._sf_account_id_should_be_non_zero_int_err_msg)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
+
+        # Get snapshot information for volume from SolidFire cluster
+        sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume['volumeID'])
+
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+
+        primary_storage_db_id = self._get_cs_storage_pool_db_id(self.primary_storage)
+
+        vol_snap_1_archive = self._create_and_test_archive_snapshot(vm_1_root_volume.id, sf_volume)
+
+        vol_snap_2 = self._create_and_test_snapshot(vm_1_root_volume.id, sf_volume, primary_storage_db_id, 1, TestSnapshots._should_only_be_one_snapshot_in_list_err_msg)
+
+        vol_snap_3_archive = self._create_and_test_archive_snapshot(vm_1_root_volume.id, sf_volume)
+
+        vol_snap_4 = self._create_and_test_snapshot(vm_1_root_volume.id, sf_volume, primary_storage_db_id, 2, TestSnapshots._should_be_two_snapshots_in_list_err_msg)
+
+        self._delete_and_test_archive_snapshot(vol_snap_3_archive)
+
+        self._delete_and_test_snapshot(vol_snap_2)
+
+        self._delete_and_test_snapshot(vol_snap_4)
+
+        self._delete_and_test_archive_snapshot(vol_snap_1_archive)
+
+        vol_snap_1_archive = self._create_and_test_archive_snapshot(vm_1_root_volume.id, sf_volume)
+
+        vol_snap_2 = self._create_and_test_snapshot(vm_1_root_volume.id, sf_volume, primary_storage_db_id, 1, TestSnapshots._should_only_be_one_snapshot_in_list_err_msg)
+
+        virtual_machine.delete(self.apiClient, True)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
+
+        self._delete_and_test_archive_snapshot(vol_snap_1_archive)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
+
+        self._delete_and_test_snapshot(vol_snap_2)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 0, self, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
+
+        virtual_machine = VirtualMachine.create(
+            self.apiClient,
+            self.testdata[TestData.virtualMachine],
+            accountid=self.account.name,
+            zoneid=self.zone.id,
+            serviceofferingid=self.compute_offering.id,
+            templateid=self.template.id,
+            domainid=self.domain.id,
+            startvm=True
+        )
+
+        list_volumes_response = list_volumes(
+            self.apiClient,
+            virtualmachineid=virtual_machine.id,
+            listall=True
+        )
+
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        vm_1_root_volume = list_volumes_response[0]
+        vm_1_root_volume_name = vm_1_root_volume.name
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
+
+        # Get snapshot information for volume from SolidFire cluster
+        sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume['volumeID'])
+
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+
+        vol_snap_1 = self._create_and_test_snapshot(vm_1_root_volume.id, sf_volume, primary_storage_db_id, 1, TestSnapshots._should_only_be_one_snapshot_in_list_err_msg)
+
+        vol_snap_2_archive = self._create_and_test_archive_snapshot(vm_1_root_volume.id, sf_volume)
+
+        vol_snap_3 = self._create_and_test_snapshot(vm_1_root_volume.id, sf_volume, primary_storage_db_id, 2, TestSnapshots._should_be_two_snapshots_in_list_err_msg)
+
+        vol_snap_4_archive = self._create_and_test_archive_snapshot(vm_1_root_volume.id, sf_volume)
+
+        services = {"displaytext": "Template-1", "name": "Template-1-name", "ostype": "CentOS 5.6 (64-bit)", "ispublic": "true"}
+
+        template = Template.create_from_snapshot(self.apiClient, vol_snap_2_archive, services)
+
+        self.cleanup.append(template)
+
+        virtual_machine_dict = {"name": "TestVM2", "displayname": "Test VM 2"}
+
+        virtual_machine_2 = VirtualMachine.create(
+            self.apiClient,
+            virtual_machine_dict,
+            accountid=self.account.name,
+            zoneid=self.zone.id,
+            serviceofferingid=self.compute_offering.id,
+            templateid=template.id,
+            domainid=self.domain.id,
+            startvm=True
+        )
+
+        list_volumes_response = list_volumes(
+            self.apiClient,
+            virtualmachineid=virtual_machine_2.id,
+            listall=True
+        )
+
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        vm_2_root_volume = list_volumes_response[0]
+        vm_2_root_volume_name = vm_2_root_volume.name
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 2, self, TestSnapshots._should_be_two_volumes_in_list_err_msg)
+
+        sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
+
+        # Get snapshot information for volume from SolidFire cluster
+        sf_snapshots_2 = self.sf_client.list_snapshots(volume_id=sf_volume_2['volumeID'])
+
+        sf_util.check_list(sf_snapshots_2, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+
+        vol_snap_a_archive = self._create_and_test_archive_snapshot(vm_2_root_volume.id, sf_volume_2)
+
+        services = {"diskname": "Vol-1", "zoneid": self.testdata[TestData.zoneId], "ispublic": True}
+
+        volume_created_from_snapshot = Volume.create_from_snapshot(self.apiClient, vol_snap_a_archive.id, services, account=self.account.name, domainid=self.domain.id)
+
+        volume_created_from_snapshot_name = volume_created_from_snapshot.name
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 3, self, TestSnapshots._should_be_three_volumes_in_list_err_msg)
+
+        sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
+        sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
+        sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
+
+        sf_util.check_list(sf_volume_3['volumeAccessGroups'], 0, self, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
+
+        volume_created_from_snapshot = virtual_machine.attach_volume(
+            self.apiClient,
+            volume_created_from_snapshot
+        )
+
+        self._delete_and_test_archive_snapshot(vol_snap_a_archive)
+
+        virtual_machine.delete(self.apiClient, True)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 3, self, TestSnapshots._should_be_three_volumes_in_list_err_msg)
+
+        sf_volume = self._get_sf_volume_by_name(sf_volumes, vm_1_root_volume_name)
+        sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
+        sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
+
+        volume_created_from_snapshot = virtual_machine_2.attach_volume(
+            self.apiClient,
+            volume_created_from_snapshot
+        )
+
+        self._delete_and_test_archive_snapshot(vol_snap_4_archive)
+
+        self._delete_and_test_snapshot(vol_snap_1)
+
+        self._delete_and_test_archive_snapshot(vol_snap_2_archive)
+
+        self._delete_and_test_snapshot(vol_snap_3)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 2, self, TestSnapshots._should_be_two_volumes_in_list_err_msg)
+
+        sf_volume_2 = self._get_sf_volume_by_name(sf_volumes, vm_2_root_volume_name)
+        sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
+
+        virtual_machine_2.delete(self.apiClient, True)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        sf_volume_3 = self._get_sf_volume_by_name(sf_volumes, volume_created_from_snapshot_name)
+
+        list_volumes_response = list_volumes(
+            self.apiClient,
+            listall=True
+        )
+
+        sf_util.check_list(list_volumes_response, 1, self, TestSnapshots._should_only_be_one_volume_in_list_err_msg)
+
+        data_volume = list_volumes_response[0]
+
+        data_volume = Volume(data_volume.__dict__)
+
+        data_volume.delete(self.apiClient)
+
+        # Get volume information from SolidFire cluster
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_util.check_list(sf_volumes, 0, self, TestSnapshots._should_be_zero_volumes_in_list_err_msg)
 
     def _check_list_not_empty(self, in_list):
         self.assertEqual(
@@ -1214,7 +1453,7 @@ class TestSnapshots(cloudstackTestCase):
 
     # used when SolidFire snapshots are being used for CloudStack volume snapshots
     def _check_snapshot_details(self, sf_snapshot_details, cs_snapshot_id, sf_volume_id, sf_snapshot_id, storage_pool_id, sf_volume_size):
-        self._check_list(sf_snapshot_details, 5, TestSnapshots._should_be_five_items_in_list_err_msg)
+        sf_util.check_list(sf_snapshot_details, 5, self, TestSnapshots._should_be_five_items_in_list_err_msg)
 
         self._check_snapshot_detail(sf_snapshot_details, cs_snapshot_id, "takeSnapshot", "true")
         self._check_snapshot_detail(sf_snapshot_details, cs_snapshot_id, "volumeId", sf_volume_id)
@@ -1224,7 +1463,7 @@ class TestSnapshots(cloudstackTestCase):
 
     # used when SolidFire volumes are being used for CloudStack volume snapshots
     def _check_snapshot_details_2(self, sf_snapshot_details, cs_snapshot_id, sf_volume_id, storage_pool_id, sf_volume_size):
-        self._check_list(sf_snapshot_details, 5, TestSnapshots._should_be_five_items_in_list_err_msg)
+        sf_util.check_list(sf_snapshot_details, 5, self, TestSnapshots._should_be_five_items_in_list_err_msg)
 
         self._check_snapshot_detail(sf_snapshot_details, cs_snapshot_id, "volumeId", sf_volume_id)
         self._check_snapshot_detail(sf_snapshot_details, cs_snapshot_id, "sfStoragePoolId", storage_pool_id)
@@ -1334,19 +1573,6 @@ class TestSnapshots(cloudstackTestCase):
 
         return sf_volume
 
-    def _get_sf_account_id(self, cs_account_id, primary_storage_id):
-        sf_account_id_request = {'accountid': cs_account_id, 'storageid': primary_storage_id}
-        sf_account_id_result = self.cs_api.getSolidFireAccountId(sf_account_id_request)
-        sf_account_id = sf_account_id_result['apisolidfireaccountid']['solidFireAccountId']
-
-        self.assertEqual(
-            isinstance(sf_account_id, int),
-            True,
-            TestSnapshots._sf_account_id_should_be_non_zero_int_err_msg
-        )
-
-        return sf_account_id
-
     def _get_snapshot_detail(self, sf_snapshot_details_list, key):
         for sf_snapshot_detail_dict in sf_snapshot_details_list:
             if sf_snapshot_detail_dict["snapshotDetailsName"] == key:
@@ -1378,12 +1604,14 @@ class TestSnapshots(cloudstackTestCase):
             volume_id=volume_id_for_snapshot
         )
 
+        self._wait_for_snapshot_state(vol_snap.id, Snapshot.BACKED_UP)
+
         sf_volume_id = sf_volume['volumeID']
 
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume_id)
 
-        self._check_list(sf_snapshots, expected_num_snapshots, snapshot_err_msg)
+        sf_util.check_list(sf_snapshots, expected_num_snapshots, self, snapshot_err_msg)
 
         sf_snapshot = self._most_recent_sf_snapshot(sf_snapshots)
 
@@ -1397,6 +1625,32 @@ class TestSnapshots(cloudstackTestCase):
 
         return vol_snap
 
+    # used when SolidFire snapshots are being used for CloudStack volume snapshots to create a backup on secondary storage
+    def _create_and_test_archive_snapshot(self, volume_id_for_snapshot, sf_volume):
+        sf_volume_id = sf_volume['volumeID']
+
+        # Get snapshot information for volume from SolidFire cluster
+        sf_snapshots_orig = self.sf_client.list_snapshots(sf_volume_id)
+
+        vol_snap = Snapshot.create(
+            self.apiClient,
+            volume_id=volume_id_for_snapshot,
+            locationtype=2
+        )
+
+        self._wait_for_snapshot_state(vol_snap.id, Snapshot.BACKED_UP)
+
+        # Get snapshot information for volume from SolidFire cluster
+        sf_snapshots = self.sf_client.list_snapshots(sf_volume_id)
+
+        sf_util.check_list(sf_snapshots, len(sf_snapshots_orig), self, "A new SolidFire snapshot was detected.")
+
+        vol_snap_db_id = self._get_cs_volume_snapshot_db_id(vol_snap)
+
+        self._check_snapshot_details_do_not_exist(vol_snap_db_id)
+
+        return vol_snap
+
     # used when SolidFire volumes are being used for CloudStack volume snapshots
     def _create_and_test_snapshot_2(self, volume_id_for_snapshot, sf_volume_id, sf_volume_id_for_volume_snapshot, primary_storage_db_id, sf_volume_size,
                                     sf_account_id, expected_num_volumes, volume_err_msg):
@@ -1405,10 +1659,12 @@ class TestSnapshots(cloudstackTestCase):
             volume_id=volume_id_for_snapshot
         )
 
+        self._wait_for_snapshot_state(vol_snap.id, Snapshot.BACKED_UP)
+
         # Get snapshot information for volume from SolidFire cluster
         sf_snapshots = self.sf_client.list_snapshots(volume_id=sf_volume_id)
 
-        self._check_list(sf_snapshots, 0, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
+        sf_util.check_list(sf_snapshots, 0, self, TestSnapshots._should_be_zero_snapshots_in_list_err_msg)
 
         sf_snapshot_details_request = {'snapshotid': vol_snap.id}
         sf_snapshot_details_response = self.cs_api.getVolumeSnapshotDetails(sf_snapshot_details_request)
@@ -1419,15 +1675,37 @@ class TestSnapshots(cloudstackTestCase):
         self._check_snapshot_details_2(sf_snapshot_details, vol_snap_db_id, sf_volume_id_for_volume_snapshot, primary_storage_db_id, sf_volume_size)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, expected_num_volumes, volume_err_msg)
+        sf_util.check_list(sf_volumes, expected_num_volumes, self, volume_err_msg)
 
         sf_volume_for_snapshot = self._get_sf_volume_by_id(sf_volumes, sf_volume_id_for_volume_snapshot)
 
-        self._check_list(sf_volume_for_snapshot['volumeAccessGroups'], 0, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
+        sf_util.check_list(sf_volume_for_snapshot['volumeAccessGroups'], 0, self, TestSnapshots._should_be_zero_volume_access_groups_in_list_err_msg)
 
         return vol_snap
+
+    def _wait_for_snapshot_state(self, vol_snap_id, snapshot_state):
+        retry_interval = 10
+        num_tries = 10
+
+        wait_result, return_val = wait_until(retry_interval, num_tries, TestSnapshots._check_snapshot_state, self.apiClient, vol_snap_id, snapshot_state)
+
+        if not wait_result:
+            raise Exception(return_val)
+
+    @staticmethod
+    def _check_snapshot_state(api_client, vol_snap_id, snapshot_state):
+        volume_snapshot = list_snapshots(
+            api_client,
+            id=vol_snap_id,
+            listall=True
+        )[0]
+
+        if str(volume_snapshot.state).lower() == snapshot_state.lower():
+            return True, ""
+
+        return False, "The snapshot is not in the '" + snapshot_state + "' state. State = " + str(volume_snapshot.state)
 
     # used when SolidFire snapshots are being used for CloudStack volume snapshots
     def _delete_and_test_snapshot(self, vol_snap):
@@ -1450,6 +1728,10 @@ class TestSnapshots(cloudstackTestCase):
 
         self._check_snapshot_details_do_not_exist(vol_snap_db_id)
 
+    # used when SolidFire snapshots are being used for CloudStack volume snapshots to create a backup on secondary storage
+    def _delete_and_test_archive_snapshot(self, vol_snap):
+        vol_snap.delete(self.apiClient)
+
     # used when SolidFire volumes are being used for CloudStack volume snapshots
     def _delete_and_test_snapshot_2(self, vol_snap, sf_account_id, expected_num_volumes, volume_err_msg):
         vol_snap_db_id = self._get_cs_volume_snapshot_db_id(vol_snap)
@@ -1459,14 +1741,6 @@ class TestSnapshots(cloudstackTestCase):
         self._check_snapshot_details_do_not_exist(vol_snap_db_id)
 
         # Get volume information from SolidFire cluster
-        sf_volumes = self.sf_client.list_volumes_for_account(account_id=sf_account_id)
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
 
-        self._check_list(sf_volumes, expected_num_volumes, volume_err_msg)
-
-    @classmethod
-    def _purge_solidfire_volumes(cls):
-        deleted_volumes = cls.sf_client.list_deleted_volumes()
-
-        for deleted_volume in deleted_volumes:
-            cls.sf_client.purge_deleted_volume(deleted_volume['volumeID'])
-
+        sf_util.check_list(sf_volumes, expected_num_volumes, self, volume_err_msg)

--- a/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
+++ b/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
@@ -1,0 +1,697 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import random
+import SignedAPICall
+import XenAPI
+
+from util import sf_util
+
+# All tests inherit from cloudstackTestCase
+from marvin.cloudstackTestCase import cloudstackTestCase
+
+# base - contains all resources as entities and defines create, delete, list operations on them
+from marvin.lib.base import Account, DiskOffering, ServiceOffering, StoragePool, User, VirtualMachine, Volume
+
+# common - commonly used methods for all tests are listed here
+from marvin.lib.common import get_domain, get_template, get_zone, list_clusters, list_hosts, list_volumes
+
+# utils - utility classes for common cleanup, external library wrappers, etc.
+from marvin.lib.utils import cleanup_resources
+
+from solidfire import solidfire_element_api as sf_api
+
+# Prerequisites:
+#  Only one zone
+#  Only one pod
+#  Two clusters
+
+
+class TestData():
+    account = "account"
+    capacityBytes = "capacitybytes"
+    capacityIops = "capacityiops"
+    clusterId1 = "clusterId1"
+    clusterId2 = "clusterId2"
+    computeOffering1 = "computeoffering1"
+    computeOffering2 = "computeoffering2"
+    computeOffering3 = "computeoffering3"
+    diskName = "diskname"
+    diskOffering1 = "diskoffering1"
+    diskOffering2 = "diskoffering2"
+    domainId = "domainid"
+    hypervisor = "hypervisor"
+    login = "login"
+    mvip = "mvip"
+    name = "name"
+    password = "password"
+    podId = "podid"
+    port = "port"
+    primaryStorage = "primarystorage"
+    primaryStorage2 = "primarystorage2"
+    provider = "provider"
+    scope = "scope"
+    solidFire = "solidfire"
+    storageTag = "SolidFire_SAN_1"
+    storageTag2 = "SolidFire_Volume_1"
+    tags = "tags"
+    templateCacheName = "centos56-x86-64-xen"
+    templateName = "templatename"
+    testAccount = "testaccount"
+    url = "url"
+    user = "user"
+    username = "username"
+    virtualMachine = "virtualmachine"
+    virtualMachine2 = "virtualmachine2"
+    volume_1 = "volume_1"
+    xenServer = "xenserver"
+    zoneId = "zoneid"
+
+    def __init__(self):
+        self.testdata = {
+            TestData.solidFire: {
+                TestData.mvip: "192.168.139.112",
+                TestData.login: "admin",
+                TestData.password: "admin",
+                TestData.port: 443,
+                TestData.url: "https://192.168.139.112:443"
+            },
+            TestData.xenServer: {
+                TestData.username: "root",
+                TestData.password: "solidfire"
+            },
+            TestData.account: {
+                "email": "test@test.com",
+                "firstname": "John",
+                "lastname": "Doe",
+                "username": "test",
+                "password": "test"
+            },
+            TestData.testAccount: {
+                "email": "test2@test2.com",
+                "firstname": "Jane",
+                "lastname": "Doe",
+                "username": "test2",
+                "password": "test"
+            },
+            TestData.user: {
+                "email": "user@test.com",
+                "firstname": "Jane",
+                "lastname": "Doe",
+                "username": "testuser",
+                "password": "password"
+            },
+            TestData.primaryStorage: {
+                TestData.name: "SolidFire-%d" % random.randint(0, 100),
+                TestData.scope: "ZONE",
+                TestData.url: "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                       "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
+                       "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
+                       "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",
+                TestData.provider: "SolidFire",
+                TestData.tags: TestData.storageTag,
+                TestData.capacityIops: 4500000,
+                TestData.capacityBytes: 2251799813685248,
+                TestData.hypervisor: "Any",
+                TestData.zoneId: 1
+            },
+            TestData.primaryStorage2: {
+                TestData.name: "SolidFireShared-%d" % random.randint(0, 100),
+                TestData.scope: "CLUSTER",
+                TestData.url: "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
+                        "minIops=5000;maxIops=50000;burstIops=75000",
+                TestData.provider: "SolidFireShared",
+                TestData.tags: TestData.storageTag2,
+                TestData.capacityIops: 5000,
+                TestData.capacityBytes: 1099511627776,
+                TestData.hypervisor: "XenServer",
+                TestData.podId: 1,
+                TestData.zoneId: 1
+            },
+            TestData.virtualMachine: {
+                "name": "TestVM",
+                "displayname": "Test VM"
+            },
+            TestData.computeOffering1: {
+                "name": "SF_CO_1",
+                "displaytext": "SF_CO_1 (Min IOPS = 1,000; Max IOPS = 2,000)",
+                "cpunumber": 1,
+                "cpuspeed": 100,
+                "memory": 128,
+                "storagetype": "shared",
+                "customizediops": False,
+                "miniops": 1000,
+                "maxiops": 2000,
+                "hypervisorsnapshotreserve": 125,
+                TestData.tags: TestData.storageTag,
+            },
+            TestData.computeOffering2: {
+                "name": "SF_CO_2",
+                "displaytext": "SF_CO_2 (Min IOPS = 1,000; Max IOPS = 2,000)",
+                "cpunumber": 1,
+                "cpuspeed": 100,
+                "memory": 128,
+                "storagetype": "shared",
+                "customizediops": False,
+                "miniops": 1000,
+                "maxiops": 2000,
+                "hypervisorsnapshotreserve": 100,
+                TestData.tags: TestData.storageTag,
+            },
+            TestData.computeOffering3: {
+                "name": "SF_CO_3",
+                "displaytext": "SF_CO_3 Desc",
+                "cpunumber": 1,
+                "cpuspeed": 100,
+                "memory": 128,
+                "storagetype": "shared",
+                TestData.tags: TestData.storageTag2,
+            },
+            TestData.diskOffering1: {
+                "name": "SF_DO_1",
+                "displaytext": "SF_DO_1 (Min IOPS = 3,000; Max IOPS = 6,000)",
+                "disksize": 100,
+                "customizediops": False,
+                "miniops": 3000,
+                "maxiops": 6000,
+                "hypervisorsnapshotreserve": 125,
+                TestData.tags: TestData.storageTag,
+                "storagetype": "shared"
+            },
+            TestData.diskOffering2: {
+                "name": "SF_DO_2",
+                "displaytext": "SF_DO_2 (Min IOPS = 3,000; Max IOPS = 6,000)",
+                "disksize": 100,
+                "customizediops": False,
+                "miniops": 3000,
+                "maxiops": 6000,
+                "hypervisorsnapshotreserve": 100,
+                TestData.tags: TestData.storageTag,
+                "storagetype": "shared"
+            },
+            TestData.volume_1: {
+                TestData.diskName: "test-volume",
+            },
+            TestData.templateName: "CentOS 5.6(64-bit) no GUI (XenServer)",
+            TestData.zoneId: 1,
+            TestData.clusterId1: 1,
+            TestData.clusterId2: 2,
+            TestData.domainId: 1,
+            TestData.url: "192.168.129.50"
+        }
+
+
+class TestVMMigrationWithStorage(cloudstackTestCase):
+    _sf_account_id_should_be_non_zero_int_err_msg = "The SolidFire account ID should be a non-zero integer."
+
+    @classmethod
+    def setUpClass(cls):
+        # Set up API client
+        testclient = super(TestVMMigrationWithStorage, cls).getClsTestClient()
+        cls.apiClient = testclient.getApiClient()
+        cls.dbConnection = testclient.getDbConnection()
+
+        cls.testdata = TestData().testdata
+
+        xenserver = cls.testdata[TestData.xenServer]
+
+        # Set up xenAPI connection
+        host_ip = "https://" + \
+                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId1], name="XenServer-6.5-1")[0].ipaddress
+
+        # Set up XenAPI connection
+        cls.xen_session_1 = XenAPI.Session(host_ip)
+
+        cls.xen_session_1.xenapi.login_with_password(xenserver[TestData.username], xenserver[TestData.password])
+
+        # Set up xenAPI connection
+        host_ip = "https://" + \
+                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId2], name="XenServer-6.5-3")[0].ipaddress
+
+        # Set up XenAPI connection
+        cls.xen_session_2 = XenAPI.Session(host_ip)
+
+        cls.xen_session_2.xenapi.login_with_password(xenserver[TestData.username], xenserver[TestData.password])
+
+        # Set up SolidFire connection
+        cls.sf_client = sf_api.SolidFireAPI(endpoint_dict=cls.testdata[TestData.solidFire])
+
+        # Get Resources from Cloud Infrastructure
+        cls.zone = get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId])
+        cls.cluster_1 = list_clusters(cls.apiClient, id=cls.testdata[TestData.clusterId1])[0]
+        cls.cluster_2 = list_clusters(cls.apiClient, id=cls.testdata[TestData.clusterId2])[0]
+        cls.template = get_template(cls.apiClient, cls.zone.id, template_name=cls.testdata[TestData.templateName])
+        cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
+
+        # Create test account
+        cls.account = Account.create(
+            cls.apiClient,
+            cls.testdata["account"],
+            admin=1
+        )
+
+        # Set up connection to make customized API calls
+        cls.user = User.create(
+            cls.apiClient,
+            cls.testdata["user"],
+            account=cls.account.name,
+            domainid=cls.domain.id
+        )
+
+        url = cls.testdata[TestData.url]
+
+        api_url = "http://" + url + ":8080/client/api"
+        userkeys = User.registerUserKeys(cls.apiClient, cls.user.id)
+
+        cls.cs_api = SignedAPICall.CloudStack(api_url, userkeys.apikey, userkeys.secretkey)
+
+        primarystorage = cls.testdata[TestData.primaryStorage]
+
+        cls.primary_storage = StoragePool.create(
+            cls.apiClient,
+            primarystorage
+        )
+
+        cls.compute_offering_1 = ServiceOffering.create(
+            cls.apiClient,
+            cls.testdata[TestData.computeOffering1]
+        )
+
+        cls.compute_offering_2 = ServiceOffering.create(
+            cls.apiClient,
+            cls.testdata[TestData.computeOffering2]
+        )
+
+        cls.compute_offering_3 = ServiceOffering.create(
+            cls.apiClient,
+            cls.testdata[TestData.computeOffering3]
+        )
+
+        cls.disk_offering_1 = DiskOffering.create(
+            cls.apiClient,
+            cls.testdata[TestData.diskOffering1]
+        )
+
+        cls.disk_offering_2 = DiskOffering.create(
+            cls.apiClient,
+            cls.testdata[TestData.diskOffering2]
+        )
+
+        # Resources that are to be destroyed
+        cls._cleanup = [
+            cls.compute_offering_1,
+            cls.compute_offering_2,
+            cls.compute_offering_3,
+            cls.disk_offering_1,
+            cls.disk_offering_2,
+            cls.user,
+            cls.account
+        ]
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cleanup_resources(cls.apiClient, cls._cleanup)
+
+            cls.primary_storage.delete(cls.apiClient)
+        except Exception as e:
+            logging.debug("Exception in tearDownClass(cls): %s" % e)
+
+    def setUp(self):
+        self.cleanup = []
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiClient, self.cleanup)
+
+            sf_util.purge_solidfire_volumes(self.sf_client)
+        except Exception as e:
+            logging.debug("Exception in tearDownClass(self): %s" % e)
+
+    def test_01_storage_migrate_root_and_data_disks(self):
+        src_host, dest_host = self._get_source_and_dest_hosts()
+
+        virtual_machine = VirtualMachine.create(
+            self.apiClient,
+            self.testdata[TestData.virtualMachine],
+            accountid=self.account.name,
+            zoneid=self.zone.id,
+            serviceofferingid=self.compute_offering_1.id,
+            templateid=self.template.id,
+            domainid=self.domain.id,
+            hostid=src_host.id,
+            startvm=True
+        )
+
+        self.cleanup.append(virtual_machine)
+
+        cs_root_volume = list_volumes(self.apiClient, listall=True, virtualmachineid=virtual_machine.id)[0]
+
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self,
+                                                  TestVMMigrationWithStorage._sf_account_id_should_be_non_zero_int_err_msg)
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_root_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_root_volume.name, self)
+
+        cs_data_volume = Volume.create(
+            self.apiClient,
+            self.testdata[TestData.volume_1],
+            account=self.account.name,
+            domainid=self.domain.id,
+            zoneid=self.zone.id,
+            diskofferingid=self.disk_offering_1.id
+        )
+
+        self.cleanup.append(cs_data_volume)
+
+        cs_data_volume = virtual_machine.attach_volume(
+            self.apiClient,
+            cs_data_volume
+        )
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_data_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_data_volume.name, self)
+
+        sf_root_volume, sf_data_volume = self._migrate_and_verify(virtual_machine, dest_host, cs_root_volume, cs_data_volume, sf_account_id,
+                                                                  sf_root_volume, sf_data_volume, self.xen_session_1, self.xen_session_2)
+
+        src_host, dest_host = dest_host, src_host
+
+        self._migrate_and_verify(virtual_machine, dest_host, cs_root_volume, cs_data_volume, sf_account_id, sf_root_volume, sf_data_volume,
+                                 self.xen_session_2, self.xen_session_1)
+
+    def test_02_storage_migrate_root_and_data_disks(self):
+        primarystorage2 = self.testdata[TestData.primaryStorage2]
+
+        primary_storage_2 = StoragePool.create(
+            self.apiClient,
+            primarystorage2,
+            clusterid=self.cluster_1.id
+        )
+
+        primary_storage_3 = StoragePool.create(
+            self.apiClient,
+            primarystorage2,
+            clusterid=self.cluster_2.id
+        )
+
+        src_host, dest_host = self._get_source_and_dest_hosts()
+
+        virtual_machine = VirtualMachine.create(
+            self.apiClient,
+            self.testdata[TestData.virtualMachine],
+            accountid=self.account.name,
+            zoneid=self.zone.id,
+            serviceofferingid=self.compute_offering_3.id,
+            templateid=self.template.id,
+            domainid=self.domain.id,
+            hostid=src_host.id,
+            startvm=True
+        )
+
+        cs_data_volume = Volume.create(
+            self.apiClient,
+            self.testdata[TestData.volume_1],
+            account=self.account.name,
+            domainid=self.domain.id,
+            zoneid=self.zone.id,
+            diskofferingid=self.disk_offering_1.id
+        )
+
+        self.cleanup = [
+            virtual_machine,
+            cs_data_volume,
+            primary_storage_2,
+            primary_storage_3
+        ]
+
+        cs_data_volume = virtual_machine.attach_volume(
+            self.apiClient,
+            cs_data_volume
+        )
+
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self,
+                                                  TestVMMigrationWithStorage._sf_account_id_should_be_non_zero_int_err_msg)
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_data_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_data_volume.name, self)
+
+        sf_data_volume = self._migrate_and_verify_one_disk_only(virtual_machine, dest_host, cs_data_volume, sf_account_id,
+                                                                sf_data_volume, self.xen_session_1, self.xen_session_2)
+
+        src_host, dest_host = dest_host, src_host
+
+        self._migrate_and_verify_one_disk_only(virtual_machine, dest_host, cs_data_volume, sf_account_id, sf_data_volume,
+                                               self.xen_session_2, self.xen_session_1)
+
+    # The hypervisor snapshot reserve isn't large enough for either the compute or disk offering.
+    def test_03_storage_migrate_root_and_data_disks_fail(self):
+        self._execute_migration_failure(self.compute_offering_2.id, self.disk_offering_2.id)
+
+    # The hypervisor snapshot reserve isn't large enough for the compute offering.
+    def test_04_storage_migrate_root_disk_fails(self):
+        self._execute_migration_failure(self.compute_offering_2.id, self.disk_offering_1.id)
+
+    # The hypervisor snapshot reserve isn't large enough for the disk offering.
+    def test_05_storage_migrate_data_disk_fails(self):
+        self._execute_migration_failure(self.compute_offering_1.id, self.disk_offering_2.id)
+
+    def _execute_migration_failure(self, compute_offering_id, disk_offering_id):
+        src_host, dest_host = self._get_source_and_dest_hosts()
+
+        virtual_machine = VirtualMachine.create(
+            self.apiClient,
+            self.testdata[TestData.virtualMachine],
+            accountid=self.account.name,
+            zoneid=self.zone.id,
+            serviceofferingid=compute_offering_id,
+            templateid=self.template.id,
+            domainid=self.domain.id,
+            hostid=src_host.id,
+            startvm=True
+        )
+
+        self.cleanup.append(virtual_machine)
+
+        cs_root_volume = list_volumes(self.apiClient, listall=True, virtualmachineid=virtual_machine.id)[0]
+
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self,
+                                                  TestVMMigrationWithStorage._sf_account_id_should_be_non_zero_int_err_msg)
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_root_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_root_volume.name, self)
+
+        cs_data_volume = Volume.create(
+            self.apiClient,
+            self.testdata[TestData.volume_1],
+            account=self.account.name,
+            domainid=self.domain.id,
+            zoneid=self.zone.id,
+            diskofferingid=disk_offering_id
+        )
+
+        self.cleanup.append(cs_data_volume)
+
+        cs_data_volume = virtual_machine.attach_volume(
+            self.apiClient,
+            cs_data_volume
+        )
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        sf_data_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_data_volume.name, self)
+
+        self._fail_migrate_and_verify(virtual_machine, dest_host, cs_root_volume, cs_data_volume, sf_account_id,
+                                      sf_root_volume, sf_data_volume, self.xen_session_1, self.xen_session_2)
+
+    def _get_source_and_dest_hosts(self):
+        hosts = list_hosts(self.apiClient)
+
+        for host in hosts:
+            if host.name == "XenServer-6.5-1":
+                src_host = host
+            elif host.name == "XenServer-6.5-3":
+                dest_host = host
+
+        self.assertIsNotNone(src_host, "Could not locate the source host")
+
+        self.assertIsNotNone(dest_host, "Could not locate the destination host")
+
+        return src_host, dest_host
+
+    def _migrate_and_verify(self, virtual_machine, dest_host, cs_root_volume, cs_data_volume, sf_account_id, src_sf_root_volume, src_sf_data_volume,
+                            src_xen_session, dest_xen_session):
+        self._verifyFields(cs_root_volume, src_sf_root_volume)
+        self._verifyFields(cs_data_volume, src_sf_data_volume)
+
+        virtual_machine.migrate_vm_with_volume(self.apiClient, dest_host.id)
+
+        cs_root_volume = self._get_updated_cs_volume(cs_root_volume.id)
+        cs_data_volume = self._get_updated_cs_volume(cs_data_volume.id)
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        dest_sf_root_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_root_volume.name, self)
+        dest_sf_data_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_data_volume.name, self)
+
+        self._verifyFields(cs_root_volume, dest_sf_root_volume)
+        self._verifyFields(cs_data_volume, dest_sf_data_volume)
+
+        self._verify_no_basic_volume_details()
+
+        self._verify_different_volume_access_groups(src_sf_root_volume, dest_sf_root_volume)
+        self._verify_different_volume_access_groups(src_sf_data_volume, dest_sf_data_volume)
+
+        self._verify_same_account(src_sf_root_volume, dest_sf_root_volume)
+        self._verify_same_account(src_sf_data_volume, dest_sf_data_volume)
+
+        self._verifySfVolumeIds(src_sf_root_volume, dest_sf_root_volume)
+        self._verifySfVolumeIds(src_sf_data_volume, dest_sf_data_volume)
+
+        self._verify_xenserver_state(src_xen_session, src_sf_root_volume, dest_xen_session, dest_sf_root_volume)
+        self._verify_xenserver_state(src_xen_session, src_sf_data_volume, dest_xen_session, dest_sf_data_volume)
+
+        return dest_sf_root_volume, dest_sf_data_volume
+
+    def _migrate_and_verify_one_disk_only(self, virtual_machine, dest_host, cs_volume, sf_account_id, src_sf_volume, src_xen_session, dest_xen_session):
+        self._verifyFields(cs_volume, src_sf_volume)
+
+        virtual_machine.migrate_vm_with_volume(self.apiClient, dest_host.id)
+
+        cs_volume = self._get_updated_cs_volume(cs_volume.id)
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sf_client, sf_account_id)
+
+        dest_sf_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_volume.name, self)
+
+        self._verifyFields(cs_volume, dest_sf_volume)
+
+        self._verify_no_basic_volume_details()
+
+        self._verify_different_volume_access_groups(src_sf_volume, dest_sf_volume)
+
+        self._verify_same_account(src_sf_volume, dest_sf_volume)
+
+        self._verifySfVolumeIds(src_sf_volume, dest_sf_volume)
+
+        self._verify_xenserver_state(src_xen_session, src_sf_volume, dest_xen_session, dest_sf_volume)
+
+        return dest_sf_volume
+
+    def _fail_migrate_and_verify(self, virtual_machine, dest_host, cs_root_volume, cs_data_volume, sf_account_id, src_sf_root_volume, src_sf_data_volume,
+                                 src_xen_session, dest_xen_session):
+        self._verifyFields(cs_root_volume, src_sf_root_volume)
+        self._verifyFields(cs_data_volume, src_sf_data_volume)
+
+        class MigrationException(Exception):
+            def __init__(self, *args, **kwargs):
+                Exception.__init__(self, *args, **kwargs)
+
+        try:
+            virtual_machine.migrate_vm_with_volume(self.apiClient, dest_host.id)
+
+            raise MigrationException("The migration did not fail (as expected).")
+        except MigrationException:
+            raise
+        except Exception:
+            pass
+
+        self._verify_no_basic_volume_details()
+
+        cs_root_volume_refreshed = self._get_updated_cs_volume(cs_root_volume.id)
+        cs_data_volume_refreshed = self._get_updated_cs_volume(cs_data_volume.id)
+
+        self._verifyFields(cs_root_volume_refreshed, src_sf_root_volume)
+        self._verifyFields(cs_data_volume_refreshed, src_sf_data_volume)
+
+        sf_volumes = sf_util.get_not_active_sf_volumes(self.sf_client, sf_account_id)
+
+        dest_sf_root_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_root_volume.name, self)
+        dest_sf_data_volume = sf_util.check_and_get_sf_volume(sf_volumes, cs_data_volume.name, self)
+
+        self._verify_xenserver_state(dest_xen_session, dest_sf_root_volume, src_xen_session, src_sf_root_volume)
+        self._verify_xenserver_state(dest_xen_session, dest_sf_data_volume, src_xen_session, src_sf_data_volume)
+
+    def _verify_different_volume_access_groups(self, src_sf_volume, dest_sf_volume):
+        src_vags = src_sf_volume['volumeAccessGroups']
+
+        sf_util.check_list(src_vags, 1, self, "'src_vags' should be a list with only one element in it.")
+
+        dest_vags = dest_sf_volume['volumeAccessGroups']
+
+        sf_util.check_list(dest_vags, 1, self, "'dest_vags' should be a list with only one element in it.")
+
+        self.assertNotEqual(src_vags[0], dest_vags[0], "The source and destination volumes should not be in the same volume access group.")
+
+    def _get_updated_cs_volume(self, cs_volume_id):
+        return list_volumes(self.apiClient, listall=True, id=cs_volume_id)[0]
+
+    def _verify_same_account(self, src_sf_volume, dest_sf_volume):
+        self.assertEqual(src_sf_volume['accountID'], dest_sf_volume['accountID'], "The source and destination volumes should be in the same SolidFire account.")
+
+    def _verifySfVolumeIds(self, src_sf_volume, dest_sf_volume):
+        self.assert_(src_sf_volume['volumeID'] < dest_sf_volume['volumeID'],
+                     "The destination SolidFire root volume's ID should be greater than the id of the source one.")
+
+    # verify the name, folder, and iscsi_name
+    def _verifyFields(self, cs_volume, sf_volume):
+        self.assert_(cs_volume.name == sf_volume['name'], "The CloudStack volume name does not match the SolidFire volume name.")
+
+        cs_volume_folder = self._get_cs_volume_folder(cs_volume.id)
+
+        self.assert_(int(cs_volume_folder) == sf_volume['volumeID'], "The CloudStack folder name does not match the SolidFire volume ID.")
+
+        cs_volume_iscsi_name = self._get_cs_volume_iscsi_name(cs_volume.id)
+
+        self.assert_(cs_volume_iscsi_name == sf_util.format_iqn(sf_volume['iqn']), "The CloudStack volume iscsi_name does not match the SolidFire volume IQN.")
+
+    def _get_cs_volume_property(self, cs_volume_id, volume_property):
+        sql_query = "Select " + volume_property + " From volumes Where uuid = '" + cs_volume_id + "'"
+
+        # make sure you can connect to MySQL: https://teamtreehouse.com/community/cant-connect-remotely-to-mysql-server-with-mysql-workbench
+        sql_result = self.dbConnection.execute(sql_query)
+
+        return sql_result[0][0]
+
+    def _get_cs_volume_folder(self, cs_volume_id):
+        return self._get_cs_volume_property(cs_volume_id, "folder")
+
+    def _get_cs_volume_iscsi_name(self, cs_volume_id):
+        return self._get_cs_volume_property(cs_volume_id, "iscsi_name")
+
+    def _verify_no_basic_volume_details(self):
+        sql_query = "Select id From volume_details Where name like 'basic_'"
+
+        # make sure you can connect to MySQL: https://teamtreehouse.com/community/cant-connect-remotely-to-mysql-server-with-mysql-workbench
+        sql_result = self.dbConnection.execute(sql_query)
+
+        sf_util.check_list(sql_result, 0, self, "The cloud.volume_details table should not have any name fields that start with 'basic_'.")
+
+    def _verify_xenserver_state(self, xen_session_1, sf_volume_1, xen_session_2, sf_volume_2):
+        sr_name = sf_util.format_iqn(sf_volume_1["iqn"])
+
+        sf_util.check_xen_sr(sr_name, xen_session_1, self, False)
+
+        sr_name = sf_util.format_iqn(sf_volume_2["iqn"])
+
+        sf_util.check_xen_sr(sr_name, xen_session_2, self)

--- a/test/integration/plugins/solidfire/util/sf_util.py
+++ b/test/integration/plugins/solidfire/util/sf_util.py
@@ -1,0 +1,217 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+def check_list(in_list, expected_size_of_list, obj_assert, err_msg):
+    obj_assert.assertEqual(
+        isinstance(in_list, list),
+        True,
+        "'in_list' is not a list."
+    )
+
+    obj_assert.assertEqual(
+        len(in_list),
+        expected_size_of_list,
+        err_msg
+    )
+
+def get_sf_account_id(cs_api, cs_account_id, primary_storage_id, obj_assert, err_msg):
+    sf_account_id_request = {'accountid': cs_account_id, 'storageid': primary_storage_id}
+    sf_account_id_result = cs_api.getSolidFireAccountId(sf_account_id_request)
+    sf_account_id = sf_account_id_result['apisolidfireaccountid']['solidFireAccountId']
+
+    obj_assert.assertEqual(
+        isinstance(sf_account_id, int),
+        True,
+        err_msg
+    )
+
+    return sf_account_id
+
+def get_iqn(cs_api, volume, obj_assert):
+    # Get volume IQN
+    sf_iscsi_name_request = {'volumeid': volume.id}
+    sf_iscsi_name_result = cs_api.getVolumeiScsiName(sf_iscsi_name_request)
+    sf_iscsi_name = sf_iscsi_name_result['apivolumeiscsiname']['volumeiScsiName']
+
+    check_iscsi_name(sf_iscsi_name, obj_assert)
+
+    return sf_iscsi_name
+
+def check_iscsi_name(sf_iscsi_name, obj_assert):
+    obj_assert.assertEqual(
+        sf_iscsi_name[0],
+        "/",
+        "The iSCSI name needs to start with a forward slash."
+    )
+
+def set_supports_resign(supports_resign, db_connection):
+    _set_supports_resign_for_table(supports_resign, db_connection, "host_details")
+    _set_supports_resign_for_table(supports_resign, db_connection, "cluster_details")
+
+def _set_supports_resign_for_table(supports_resign, db_connection, table):
+    sql_query = "Update " + str(table) + " Set value = '" + str(supports_resign) + "' Where name = 'supportsResign'"
+
+    # make sure you can connect to MySQL: https://teamtreehouse.com/community/cant-connect-remotely-to-mysql-server-with-mysql-workbench
+    db_connection.execute(sql_query)
+
+def purge_solidfire_volumes(sf_client):
+    deleted_volumes = sf_client.list_deleted_volumes()
+
+    for deleted_volume in deleted_volumes:
+        sf_client.purge_deleted_volume(deleted_volume['volumeID'])
+
+def get_not_active_sf_volumes(sf_client, sf_account_id=None):
+    if sf_account_id is not None:
+        sf_volumes = sf_client.list_volumes_for_account(sf_account_id)
+
+        if sf_volumes is not None and len(sf_volumes) > 0:
+            sf_volumes = _get_not_active_sf_volumes_only(sf_volumes)
+    else:
+        sf_volumes = sf_client.list_deleted_volumes()
+
+    return sf_volumes
+
+def _get_not_active_sf_volumes_only(sf_volumes):
+    not_active_sf_volumes_only = []
+
+    for sf_volume in sf_volumes:
+        if sf_volume["status"] != "active":
+            not_active_sf_volumes_only.append(sf_volume)
+
+    return not_active_sf_volumes_only
+
+def get_active_sf_volumes(sf_client, sf_account_id=None):
+    if sf_account_id is not None:
+        sf_volumes = sf_client.list_volumes_for_account(sf_account_id)
+
+        if sf_volumes is not None and len(sf_volumes) > 0:
+            sf_volumes = _get_active_sf_volumes_only(sf_volumes)
+    else:
+        sf_volumes = sf_client.list_active_volumes()
+
+    return sf_volumes
+
+def _get_active_sf_volumes_only(sf_volumes):
+    active_sf_volumes_only = []
+
+    for sf_volume in sf_volumes:
+        if sf_volume["status"] == "active":
+            active_sf_volumes_only.append(sf_volume)
+
+    return active_sf_volumes_only
+
+def check_and_get_sf_volume(sf_volumes, sf_volume_name, obj_assert, should_exist=True):
+    sf_volume = None
+
+    for volume in sf_volumes:
+        if volume['name'] == sf_volume_name:
+            sf_volume = volume
+            break
+
+    if should_exist:
+        obj_assert.assertNotEqual(
+            sf_volume,
+            None,
+            "Check if SF volume was created in correct account: " + str(sf_volumes)
+        )
+    else:
+        obj_assert.assertEqual(
+            sf_volume,
+            None,
+            "Check if SF volume was deleted: " + str(sf_volumes)
+        )
+
+    return sf_volume
+
+def check_xen_sr(xen_sr_name, xen_session, obj_assert, should_exist=True):
+    xen_sr = xen_session.xenapi.SR.get_by_name_label(xen_sr_name)
+
+    if should_exist:
+        check_list(xen_sr, 1, obj_assert, "SR " + xen_sr_name + " doesn't exist, but should.")
+
+        sr_shared = xen_session.xenapi.SR.get_shared(xen_sr[0])
+
+        obj_assert.assertEqual(
+            sr_shared,
+            True,
+            "SR " + xen_sr_name + " is not shared, but should be."
+        )
+    else:
+        check_list(xen_sr, 0, obj_assert, "SR " + xen_sr_name + " exists, but shouldn't.")
+
+def check_vag(sf_volume, sf_vag_id, obj_assert):
+    obj_assert.assertEqual(
+        len(sf_volume['volumeAccessGroups']),
+        1,
+        "The volume should only be in one VAG."
+    )
+
+    obj_assert.assertEqual(
+        sf_volume['volumeAccessGroups'][0],
+        sf_vag_id,
+        "The volume is not in the VAG with the following ID: " + str(sf_vag_id) + "."
+    )
+
+def get_vag_id(cs_api, cluster_id, primary_storage_id, obj_assert):
+    # Get SF Volume Access Group ID
+    sf_vag_id_request = {'clusterid': cluster_id, 'storageid': primary_storage_id}
+    sf_vag_id_result = cs_api.getSolidFireVolumeAccessGroupId(sf_vag_id_request)
+    sf_vag_id = sf_vag_id_result['apisolidfirevolumeaccessgroupid']['solidFireVolumeAccessGroupId']
+
+    obj_assert.assertEqual(
+        isinstance(sf_vag_id, int),
+        True,
+        "The SolidFire VAG ID should be a non-zero integer."
+    )
+
+    return sf_vag_id
+
+def format_iqn(iqn):
+    return "/" + iqn + "/0"
+
+def check_size_and_iops(sf_volume, cs_volume, size, obj_assert):
+    obj_assert.assertEqual(
+        sf_volume['qos']['minIOPS'],
+        cs_volume.miniops,
+        "Check QoS - Min IOPS: " + str(sf_volume['qos']['minIOPS'])
+    )
+
+    obj_assert.assertEqual(
+        sf_volume['qos']['maxIOPS'],
+        cs_volume.maxiops,
+        "Check QoS - Max IOPS: " + str(sf_volume['qos']['maxIOPS'])
+    )
+
+    obj_assert.assertEqual(
+        sf_volume['totalSize'],
+        size,
+        "Check SolidFire volume size: " + str(sf_volume['totalSize'])
+    )
+
+def get_volume_size_with_hsr(cs_api, cs_volume, obj_assert):
+    # Get underlying SF volume size with hypervisor snapshot reserve
+    sf_volume_size_request = {'volumeid': cs_volume.id}
+    sf_volume_size_result = cs_api.getSolidFireVolumeSize(sf_volume_size_request)
+    sf_volume_size = sf_volume_size_result['apisolidfirevolumesize']['solidFireVolumeSize']
+
+    obj_assert.assertEqual(
+        isinstance(sf_volume_size, int),
+        True,
+        "The SolidFire volume size should be a non-zero integer."
+    )
+
+    return sf_volume_size


### PR DESCRIPTION
This PR adds support for cross-cluster storage migration of VMs that make use of managed storage with XenServer.

Managed storage is when you have a 1:1 mapping between a virtual disk and a volume on a SAN (in the case of XenServer, an SR is placed on this SAN volume and a single virtual disk placed in the SR).

Managed storage allows features such as storage QoS and SAN-side snapshots to work (sort of analogous to VMware VVols).

This PR focuses on enabling VMs that are using managed storage to be migrated across XenServer clusters.

I have successfully run the following tests on this branch:

TestVolumes.py
TestSnapshots.py
TestVMSnapshots.py
TestAddRemoveHosts.py
TestVMMigrationWithStorage.py (which is a new test that is being added with this PR)
