### PR TITLE
In comment, Add missing packages for Docker Ubuntu builds

### DIFF
--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -34,10 +34,10 @@ set -e
 # Assume that the cloudstack source is present in /tmp/cloudstack
 #
 # Ubuntu 16.04
-# docker run -ti -v /tmp:/src ubuntu:16.04 /bin/bash -c "apt-get update && apt-get install -y dpkg-dev python debhelper openjdk-8-jdk genisoimage python-mysql.connector maven lsb-release devscripts && /src/cloudstack/packaging/build-deb.sh"
+# docker run -ti -v /tmp:/src ubuntu:16.04 /bin/bash -c "apt-get update && apt-get install -y dpkg-dev python debhelper openjdk-8-jdk genisoimage python-mysql.connector maven lsb-release devscripts dh-systemd python-setuptools && /src/cloudstack/packaging/build-deb.sh"
 #
 # Ubuntu 14.04
-# docker run -ti -v /tmp:/src ubuntu:14.04 /bin/bash -c "apt-get update && apt-get install -y dpkg-dev python debhelper openjdk-7-jdk genisoimage python-mysql.connector maven lsb-release devscripts && /src/cloudstack/packaging/build-deb.sh"
+# docker run -ti -v /tmp:/src ubuntu:14.04 /bin/bash -c "apt-get update && apt-get install -y dpkg-dev python debhelper openjdk-7-jdk genisoimage python-mysql.connector maven lsb-release devscripts dh-systemd python-setuptools && /src/cloudstack/packaging/build-deb.sh"
 #
 
 cd `dirname $0`


### PR DESCRIPTION

Please note: No need to wait the results of Jenkins or Travis, this fix only add the missing packages in the docker command line to build CloudStack with Docker (for Ubuntu 14.04 and 16.04)

cc @wido 