### PR TITLE
CLOUDSTACK-9502: DS template copies don’t get deleted in VMware ESXi with multiple clusters and zone wide storage (include CLOUDSTACK-9386 into 4.9 release branch)

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -5539,17 +5539,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             VmwareHypervisorHost hyperHost = getHyperHost(context, null);
             VolumeTO vol = cmd.getVolume();
 
-            ManagedObjectReference morDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, vol.getPoolUuid());
-            if (morDs == null) {
-                String msg = "Unable to find datastore based on volume mount point " + vol.getMountPoint();
-                s_logger.error(msg);
-                throw new Exception(msg);
-            }
+            VirtualMachineMO vmMo = findVmOnDatacenter(context, hyperHost, vol);
 
-            ManagedObjectReference morCluster = hyperHost.getHyperHostCluster();
-            ClusterMO clusterMo = new ClusterMO(context, morCluster);
-
-            VirtualMachineMO vmMo = clusterMo.findVmOnHyperHost(vol.getPath());
             if (vmMo != null && vmMo.isTemplate()) {
                 if (s_logger.isInfoEnabled()) {
                     s_logger.info("Destroy template volume " + vol.getPath());
@@ -5572,6 +5563,26 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             s_logger.error(msg, e);
             return new Answer(cmd, false, msg);
         }
+    }
+
+    /**
+     * Use data center to look for vm, instead of randomly picking up a cluster<br/>
+     * (in multiple cluster environments vm could not be found if wrong cluster was chosen)
+     * @param context vmware context
+     * @param hyperHost vmware hv host
+     * @param vol volume
+     * @return a virtualmachinemo if could be found on datacenter.
+     * @throws Exception if there is an error while finding vm
+     * @throws CloudRuntimeException if datacenter cannot be found
+     */
+    protected VirtualMachineMO findVmOnDatacenter(VmwareContext context, VmwareHypervisorHost hyperHost, VolumeTO vol) throws Exception {
+        DatacenterMO dcMo = new DatacenterMO(context, hyperHost.getHyperHostDatacenter());
+        if (dcMo.getMor() == null) {
+            String msg = "Unable to find VMware DC";
+            s_logger.error(msg);
+            throw new CloudRuntimeException(msg);
+        }
+        return dcMo.findVm(vol.getPath());
     }
 
     private String getAbsoluteVmdkFile(VirtualDisk disk) {

--- a/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
+++ b/plugins/hypervisors/vmware/test/com/cloud/hypervisor/vmware/resource/VmwareResourceTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +44,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.vmware.vim25.ManagedObjectReference;
 import com.vmware.vim25.VirtualDevice;
 import com.vmware.vim25.VirtualMachineConfigSpec;
 import com.vmware.vim25.VirtualMachineVideoCard;
@@ -51,15 +54,21 @@ import com.cloud.agent.api.ScaleVmCommand;
 import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.NfsTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.agent.api.to.VolumeTO;
+import com.cloud.hypervisor.vmware.mo.DatacenterMO;
 import com.cloud.hypervisor.vmware.mo.VirtualMachineMO;
 import com.cloud.hypervisor.vmware.mo.VmwareHypervisorHost;
 import com.cloud.hypervisor.vmware.util.VmwareContext;
 import com.cloud.storage.resource.VmwareStorageProcessor;
 import com.cloud.storage.resource.VmwareStorageSubsystemCommandHandler;
 
+import com.cloud.utils.exception.CloudRuntimeException;
+
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(CopyCommand.class)
+@PrepareForTest({CopyCommand.class, DatacenterMO.class, VmwareResource.class})
 public class VmwareResourceTest {
+
+    private static final String VOLUME_PATH = "XXXXXXXXXXXX";
 
     @Mock
     VmwareStorageProcessor storageProcessor;
@@ -102,6 +111,12 @@ public class VmwareResourceTest {
     DataTO srcDataTO;
     @Mock
     NfsTO srcDataNfsTO;
+    @Mock
+    VolumeTO volume;
+    @Mock
+    ManagedObjectReference mor;
+    @Mock
+    DatacenterMO datacenter;
 
     CopyCommand storageCmd;
 
@@ -117,6 +132,7 @@ public class VmwareResourceTest {
         when(storageCmd.getSrcTO()).thenReturn(srcDataTO);
         when(srcDataTO.getDataStore()).thenReturn(srcDataNfsTO);
         when(srcDataNfsTO.getNfsVersion()).thenReturn(NFS_VERSION);
+        when(volume.getPath()).thenReturn(VOLUME_PATH);
     }
 
     //Test successful scaling up the vm
@@ -210,4 +226,19 @@ public class VmwareResourceTest {
         verify(_resource, never()).examineStorageSubSystemCommandNfsVersion(storageCmd);
     }
 
+    @Test(expected=CloudRuntimeException.class)
+    public void testFindVmOnDatacenterNullHyperHostReference() throws Exception {
+        when(hyperHost.getMor()).thenReturn(null);
+        _resource.findVmOnDatacenter(context, hyperHost, volume);
+    }
+
+    @Test
+    public void testFindVmOnDatacenter() throws Exception {
+        when(hyperHost.getHyperHostDatacenter()).thenReturn(mor);
+        when(datacenter.getMor()).thenReturn(mor);
+        when(datacenter.findVm(VOLUME_PATH)).thenReturn(vmMo);
+        whenNew(DatacenterMO.class).withArguments(context, mor).thenReturn(datacenter);
+        VirtualMachineMO result = _resource.findVmOnDatacenter(context, hyperHost, volume);
+        assertEquals(vmMo, result);
+    }
 }


### PR DESCRIPTION
Include #1560 into 4.9 release branch
