### PR TITLE
CLOUDSTACK-9498: VR CsFile search utility methods fail when search st…

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
@@ -66,7 +66,7 @@ class CsFile:
         logging.info("Wrote edited file %s" % self.filename)
         self.config = list(self.new_config)
         logging.info("Updated file in-cache configuration")
-        
+
 
     def dump(self):
         for line in self.new_config:
@@ -143,7 +143,7 @@ class CsFile:
             print ' line = ' +line
             if line.lstrip().startswith(ignoreLinesStartWith):
                 continue
-            if re.search(search, line):
+            if search in line:
                 found = True
                 break
 
@@ -157,7 +157,7 @@ class CsFile:
         for index, line in enumerate(self.new_config):
             if line.lstrip().startswith("#"):
                 continue
-            if not re.search(search, line):
+            if search not in line:
                 temp_config.append(line)
 
         self.new_config = list(temp_config)

--- a/test/integration/component/test_vpn_users.py
+++ b/test/integration/component/test_vpn_users.py
@@ -77,7 +77,7 @@ class Services:
                                 },
                          "vpn_user": {
                                    "username": "test",
-                                   "password": "test",
+                                   "password": "p@a#s=s.w_o-r+d",
                                 },
                          "natrule": {
                                    "privateport": 1701,


### PR DESCRIPTION
There is no real use of python 're' module  in CsFile.py utility methods searchString, deleteLine. Regular string search is sufficient. These methods are used only for VPN user add/delete. Since VPN user password can have python 're' module meta characters, it interfere with search functionality.

Replacing re.search() with regular string search instead.

Change is confined to VPN add/delete users. Have run the test/integration/component/test_vpn_users.py

VPN remote access user limit tests ... === TestName: test_01_VPN_user_limit | Status : SUCCESS ===
ok
Test create VPN when L2TP port in use ... === TestName: test_02_use_vpn_port | Status : SUCCESS ===
ok
Test create NAT rule when VPN when L2TP enabled ... === TestName: test_03_enable_vpn_use_port | Status : SUCCESS ===
ok
Test add new users to existing VPN ... === TestName: test_04_add_new_users | Status : SUCCESS ===
ok
Test add duplicate user to existing VPN ... === TestName: test_05_add_duplicate_user | Status : SUCCESS ===
ok
Test as global admin, add a new VPN user to an existing VPN entry ... === TestName: test_06_add_VPN_user_global_admin | Status : SUCCESS ===
ok
Test as domain admin, add a new VPN user to an existing VPN entry ... === TestName: test_07_add_VPN_user_domain_admin | Status : SUCCESS ===
ok
