### PR TITLE
CLOUDSTACK-9489: the new config vars that are added do not goto DB if…

### DIFF
--- a/framework/config/src/org/apache/cloudstack/framework/config/dao/ConfigurationDaoImpl.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/dao/ConfigurationDaoImpl.java
@@ -90,7 +90,6 @@ public class ConfigurationDaoImpl extends GenericDaoBase<ConfigurationVO, String
                 configurations = listIncludingRemovedBy(sc);
 
                 for (ConfigurationVO config : configurations) {
-                    if (config.getValue() != null)
                         _configs.put(config.getName(), config.getValue());
                 }
             }


### PR DESCRIPTION
… values are set to NULL, removing this check so the entries in DB are made with NULL values
