### PR TITLE
CLOUDSTACK-9507: ListVM response's guest_os id should be a UUID

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -284,7 +284,7 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
 
     @SerializedName(ApiConstants.OS_TYPE_ID)
     @Param(description = "OS type id of the vm", since = "4.4")
-    private Long osTypeId;
+    private String osTypeId;
 
     public UserVmResponse() {
         securityGroupList = new LinkedHashSet<SecurityGroupResponse>();
@@ -810,7 +810,7 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
         this.details = details;
     }
 
-    public void setOsTypeId(Long osTypeId) {
+    public void setOsTypeId(String osTypeId) {
         this.osTypeId = osTypeId;
     }
 }

--- a/server/src/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -191,7 +191,7 @@ public class UserVmJoinDaoImpl extends GenericDaoBaseWithTagInformation<UserVmJo
         userVmResponse.setPublicIpId(userVm.getPublicIpUuid());
         userVmResponse.setPublicIp(userVm.getPublicIpAddress());
         userVmResponse.setKeyPairName(userVm.getKeypairName());
-        userVmResponse.setOsTypeId(userVm.getGuestOsId());
+        userVmResponse.setOsTypeId(userVm.getGuestOsUuid());
 
         if (details.contains(VMDetails.all) || details.contains(VMDetails.stats)) {
             // stats calculation


### PR DESCRIPTION
The listVirtualMachines API response contains a guest os_type field which
is an integer, and therefore not useful or easily consumable. This fixes and
migrates the returned type from an id (integer) to a uuid (string). It makes
the response consistent with other API responses such as those of listTemplates
and allow end users to consume this uuid.

/cc @jburwell @karuturi -- this is a minor change. It may be debatable if this break api response compatibility, please advise.

@blueorangutan package
