### PR TITLE
Marvin Tests: Fix VPC network offering selection

### DIFF
--- a/test/integration/smoke/test_network_acl.py
+++ b/test/integration/smoke/test_network_acl.py
@@ -64,7 +64,7 @@ class TestNetworkACL(cloudstackTestCase):
         self.assert_(networkOffering is not None and len(networkOffering) > 0, "No VPC based network offering")
 
         # 1) Create VPC
-        vpcOffering = VpcOffering.list(self.apiclient,isdefault=True)
+        vpcOffering = VpcOffering.list(self.apiclient, name="Default VPC offering")
         self.assert_(vpcOffering is not None and len(vpcOffering)>0, "No VPC offerings found")
         self.services["vpc"] = {}
         self.services["vpc"]["name"] = "vpc-networkacl"


### PR DESCRIPTION
It appears that original code did not expect there to be an alternate default VPC offering (Nuage) .
VPC selection uses isdefault=True which selects the Nuage Network offering, stopping the test from being run.
Fix was to look for name="Default VPC Offering" instead.

Replaces PR #1652 (same content, differenet branch)