### PR TITLE
CLOUDSTACK-9505: Fix test_deploy_vgpu_enabled tests cleanup

### DIFF
--- a/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
+++ b/test/integration/smoke/test_deploy_vgpu_enabled_vm.py
@@ -48,7 +48,6 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
         testClient = super(TestDeployvGPUenabledVM, self).getClsTestClient()
         self.apiclient = testClient.getApiClient()
         self.testdata = self.testClient.getParsedTestDataConfig()
-        self._cleanup = []
         self.unsupportedHypervisor = False
         self.noSuitableHost = False
         # Need to add check whether zone containing the xen hypervisor or not
@@ -85,7 +84,21 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             # No XenServer available with GPU Drivers installed
             self.noSuitableHost = True
             return
+        
+    def setUp(self):
+        self.testdata = self.testClient.getParsedTestDataConfig()["vgpu"]
+        self.apiclient = self.testClient.getApiClient()
+        self.dbclient = self.testClient.getDbConnection()
+        if self.noSuitableHost or self.unsupportedHypervisor:
+            self.hypervisor = get_hypervisor_type(self.apiclient)
+            if self.hypervisor.lower() not in ["vmware"]:
+	            self.skipTest("Skipping test because suitable hypervisor/host not\
+        	            present")
+            self.testdata = self.testClient.getParsedTestDataConfig()
+        
+        self.cleanup = []
 
+        # Get Zone, Domain and Default Built-in template
         self.domain = get_domain(self.apiclient)
         self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
         # Creating Account
@@ -94,80 +107,66 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             self.testdata["account"],
             domainid=self.domain.id
         )
-        self._cleanup.append(self.account)
 
-    def setUp(self):
-        self.testdata = self.testClient.getParsedTestDataConfig()["vgpu"]
-        self.apiclient = self.testClient.getApiClient()
-	self.dbclient = self.testClient.getDbConnection()
-        if self.noSuitableHost or self.unsupportedHypervisor:
-            self.hypervisor = get_hypervisor_type(self.apiclient)
-            if self.hypervisor.lower() not in ["vmware"]:
-	            self.skipTest("Skipping test because suitable hypervisor/host not\
-        	            present")
-            self.testdata = self.testClient.getParsedTestDataConfig()
+        if self.hypervisor.lower() in ["xenserver"]:
+            
+            # Before running this test for Xen Server, register a windows template with ostype as
+            # 'Windows 7 (32-bit)'
+            self.template = get_template(
+                self.apiclient,
+                self.zone.id,
+                self.testdata["ostype"])
+            self.cleanup.append(self.template)
+            
+            self.testdata["mode"] = self.zone.networktype
 
-        # Get Zone, Domain and Default Built-in template
-        self.domain = get_domain(self.apiclient)
-	self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
-
-        # Before running this test for Xen Server, register a windows template with ostype as
-	# 'Windows 7 (32-bit)'
-        self.template = get_template(
-		self.apiclient,
-	        self.zone.id,
-        	self.testdata["ostype"])
-
-	# create a user account
-        self.account = Account.create(
-	        self.apiclient,
-        	self.testdata["account"],
-		domainid=self.domain.id
-        )
-	self.cleanup = []
-
-	if self.hypervisor.lower() in ["xenserver"]:
-	        self.testdata["mode"] = self.zone.networktype
-
-	        if self.template == FAILED:
+            if self.template == FAILED:
         	    assert False, "get_template() failed to return template with description %s" % self.testdata[
                 	"ostype"]
 
-	        self.testdata["small"]["zoneid"] = self.zone.id
-        	self.testdata["small"]["template"] = self.template.id
+            self.testdata["small"]["zoneid"] = self.zone.id
+            self.testdata["small"]["template"] = self.template.id
 
-	        self.testdata["service_offerings"]["vgpu260qwin"]["serviceofferingdetails"] = [
+            self.testdata["service_offerings"]["vgpu260qwin"]["serviceofferingdetails"] = [
         	    {
                 	'pciDevice': 'Group of NVIDIA Corporation GK107GL [GRID K1] GPUs'}, {
 	                'vgpuType': 'GRID K120Q'}]
         	# create a service offering
-	        self.service_offering = ServiceOffering.create(
+            self.service_offering = ServiceOffering.create(
         	    self.apiclient,
 	            self.testdata["service_offerings"]["vgpu260qwin"],
         	)
-	        # build cleanup list
-        	self.cleanup = [
-	            self.service_offering,
-        	    self.account
-	        ]
-	elif self.hypervisor.lower() in ["vmware"]:
-		self.testdata["isolated_network"]["zoneid"] = self.zone.id
-		self.userapiclient = self.testClient.getUserApiClient(
+            self.cleanup.append(self.service_offering)
+            
+        elif self.hypervisor.lower() in ["vmware"]:
+            self.testdata["isolated_network"]["zoneid"] = self.zone.id
+            
+            self.userapiclient = self.testClient.getUserApiClient(
          		UserName=self.account.name,
 		        DomainName=self.account.domain
 	        )
-		self.service_offering = ServiceOffering.create(
+            self.service_offering = ServiceOffering.create(
 	            self.apiclient,
         	    self.testdata["service_offering"])
-	        self.cleanup.append(self.service_offering)
 
-		# Create Shared Network Offering
-        	self.isolated_network_offering = NetworkOffering.create(
+            # Create Shared Network Offering
+            self.isolated_network_offering = NetworkOffering.create(
 	            self.apiclient,
         	    self.testdata["isolated_network_offering"])
-	        self.cleanup.append(self.isolated_network_offering)
         	# Enable Isolated Network offering
-	        self.isolated_network_offering.update(self.apiclient, state='Enabled')
+            self.isolated_network_offering.update(self.apiclient, state='Enabled')
+            
+            # Register a private template in the account with nic adapter vmxnet3
+            # Also add required 3D GPU details for enabling it
+            self.template = Template.register(
+                self.userapiclient,
+                self.testdata["configurableData"]["vmxnet3template"],
+                zoneid=self.zone.id,
+                account=self.account.name,
+                domainid=self.account.domainid,
+                details=[{"mks.enable3d" : "true", "mks.use3dRenderer" : "automatic",
+                     "svga.autodetect" : "false", "svga.vramSize" : "131072"}]
+            )
 		
 
     @attr(tags=['advanced', 'basic', 'vgpu'], required_hardware="true")
@@ -179,10 +178,11 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
         # 2. Virtual Machine is vGPU enabled (via SSH)
         # 3. listVirtualMachines returns accurate information
         """
-
-	if self.hypervisor.lower() not in ["xenserver"]:
+        if self.hypervisor.lower() not in ["xenserver"]:
+            self.cleanup.append(self.account)
             self.skipTest("This test case is written specifically\
                     for XenServer hypervisor")
+            
         self.virtual_machine = VirtualMachine.create(
             self.apiclient,
             self.testdata["small"],
@@ -191,6 +191,7 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             serviceofferingid=self.service_offering.id,
             mode=self.testdata['mode']
         )
+        self.cleanup.append(self.virtual_machine)
 
         list_vms = VirtualMachine.list(
             self.apiclient,
@@ -240,11 +241,11 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
                 user=self.testdata['configurableData']['host']["username"],
                 passwd=self.testdata['configurableData']['host']["password"])
             res = sshClient.execute(
-                "xe vgpu-list vm-name-label=%s params=type-uuid %s" %
+                "xe vgpu-list vm-name-label=%s params=type-uuid %s" % 
                 (vm.instancename))
             self.debug("SSH result: %s" % res)
         except Exception as e:
-            self.fail("SSH Access failed for %s: %s" %
+            self.fail("SSH Access failed for %s: %s" % 
                       (hostip, e)
                       )
         result = str(res)
@@ -253,16 +254,18 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
             1,
             "VM is vGPU enabled."
         )
+        self.cleanup.append(self.account)
 
     def tearDown(self):
         try:
             cleanup_resources(self.apiclient, self.cleanup)
         except Exception as e:
             self.debug("Warning! Exception in tearDown: %s" % e)
+        return
 
     @attr(tags=["advanced"])
     def test_3d_gpu_support(self):
-        """
+        """Test 3D GPU support
 
         # 1. Register a template for VMware with nicAdapter vmxnet3 and 3D GPU details
         # 2. Deploy a VM using this template
@@ -270,29 +273,17 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
         # 4. Add network to VM
         # 5. Verify vm details for 3D GPU details
         """
-
         if self.hypervisor.lower() not in ["vmware"]:
+            self.cleanup.append(self.account)
             self.skipTest("This test case is written specifically\
                     for Vmware hypervisor")
 
-        # Register a private template in the account with nic adapter vmxnet3
-        # Also add required 3D GPU details for enabling it
-        template = Template.register(
-            self.userapiclient,
-            self.testdata["configurableData"]["vmxnet3template"],
-            zoneid=self.zone.id,
-            account=self.account.name,
-            domainid=self.account.domainid,
-            details=[{"mks.enable3d" : "true", "mks.use3dRenderer" : "automatic",
-                     "svga.autodetect" : "false", "svga.vramSize" : "131072"}]
-        )
-        self.cleanup.append(template)
-        template.download(self.apiclient)
+        self.template.download(self.apiclient)
 
         templates = Template.list(
             self.userapiclient,
             listall=True,
-            id=template.id,
+            id=self.template.id,
             templatefilter="self"
         )
 
@@ -303,28 +294,30 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
         )
 
         self.testdata["virtual_machine"]["zoneid"] = self.zone.id
-        self.testdata["virtual_machine"]["template"] = template.id
+        self.testdata["virtual_machine"]["template"] = self.template.id
 
-        virtual_machine = VirtualMachine.create(
+        self.virtual_machine = VirtualMachine.create(
             self.apiclient,
             self.testdata["virtual_machine"],
             accountid=self.account.name,
             domainid=self.account.domainid,
-            templateid=template.id,
+            templateid=self.template.id,
             serviceofferingid=self.service_offering.id)
 
-        isolated_network = Network.create(
+        self.isolated_network = Network.create(
             self.apiclient,
             self.testdata["isolated_network"],
             self.account.name,
             self.account.domainid,
             networkofferingid=self.isolated_network_offering.id)
 
-        virtual_machine.add_nic(self.apiclient, isolated_network.id)
+        self.virtual_machine.add_nic(self.apiclient, self.isolated_network.id)
+        
+        self.cleanup = [self.virtual_machine, self.isolated_network, self.isolated_network_offering, self.service_offering, self.account, self.template]
 
-        qresultset = self.dbclient.execute("select id from vm_instance where uuid = '%s';"      % virtual_machine.id)
+        qresultset = self.dbclient.execute("select id from vm_instance where uuid = '%s';" % self.virtual_machine.id)
         vm_id = qresultset[0]
-        qresultset = self.dbclient.execute("select name, value from user_vm_details where vm_id = '%d';"        % vm_id)
+        qresultset = self.dbclient.execute("select name, value from user_vm_details where vm_id = '%d';" % vm_id)
         detailKeys = [x[0] for x in qresultset]
 
         self.assertTrue('mks.enable3d' in detailKeys and 'mks.use3dRenderer' in detailKeys and 'svga.autodetect' in detailKeys and 'svga.vramSize' in detailKeys, "VM details do not contain 3D GPU details")
@@ -336,3 +329,5 @@ class TestDeployvGPUenabledVM(cloudstackTestCase):
         self.assertEquals('false', qresultset[detailKeys.index('svga.autodetect')][1], "Expected detail 'svga.autodetect'='false'")
 
         self.assertEquals('131072', qresultset[detailKeys.index('svga.vramSize')][1], "Expected detail 'svga.vramSize'='131072'")
+
+        return


### PR DESCRIPTION
JIRA TICKET: https://issues.apache.org/jira/browse/CLOUDSTACK-9505

## Description
Cleanup resources after running `test_deploy_vgpu_enabled.py`. Although test passes, resources are left and need to be cleaned up