### PR TITLE
CLOUDSTACK-9509: Host Connects Without Storage

### DIFF
--- a/engine/orchestration/test/com/cloud/agent/manager/AgentManagerImplTest.java
+++ b/engine/orchestration/test/com/cloud/agent/manager/AgentManagerImplTest.java
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.agent.manager;
+
+import com.cloud.agent.Listener;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ReadyCommand;
+import com.cloud.agent.api.StartupCommand;
+import com.cloud.agent.api.StartupRoutingCommand;
+import com.cloud.exception.ConnectionException;
+import com.cloud.host.HostVO;
+import com.cloud.host.Status;
+import com.cloud.host.dao.HostDao;
+import com.cloud.utils.Pair;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+public class AgentManagerImplTest {
+
+    private HostDao hostDao;
+    private Listener storagePoolMonitor;
+    private AgentAttache attache;
+    private AgentManagerImpl mgr = Mockito.spy(new AgentManagerImpl());
+    private HostVO host;
+    private StartupCommand[] cmds;
+
+    @Before
+    public void setUp() throws Exception {
+        host = new HostVO("some-Uuid");
+        host.setDataCenterId(1L);
+        cmds = new StartupCommand[]{new StartupRoutingCommand()};
+        attache = new ConnectedAgentAttache(null, 1L, "kvm-attache", null, false);
+
+        hostDao = Mockito.mock(HostDao.class);
+        storagePoolMonitor = Mockito.mock(Listener.class);
+
+        mgr._hostDao = hostDao;
+        mgr._hostMonitors = new ArrayList<>();
+        mgr._hostMonitors.add(new Pair<>(0, storagePoolMonitor));
+    }
+
+    @Test
+    public void testNotifyMonitorsOfConnectionNormal() throws ConnectionException {
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(host);
+        Mockito.doNothing().when(storagePoolMonitor).processConnect(Mockito.eq(host), Mockito.eq(cmds[0]), Mockito.eq(false));
+        Mockito.doReturn(true).when(mgr).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.any(Status.Event.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        Mockito.doReturn(Mockito.mock(Answer.class)).when(mgr).easySend(Mockito.anyLong(), Mockito.any(ReadyCommand.class));
+        Mockito.doReturn(true).when(mgr).agentStatusTransitTo(Mockito.eq(host), Mockito.eq(Status.Event.Ready), Mockito.anyLong());
+
+        final AgentAttache agentAttache = mgr.notifyMonitorsOfConnection(attache, cmds, false);
+        Assert.assertTrue(agentAttache.isReady()); // Agent is in UP state
+    }
+
+    @Test
+    public void testNotifyMonitorsOfConnectionWhenStoragePoolConnectionHostFailure() throws ConnectionException {
+        ConnectionException connectionException = new ConnectionException(true, "storage pool could not be connected on host");
+        Mockito.when(hostDao.findById(Mockito.anyLong())).thenReturn(host);
+        Mockito.doThrow(connectionException).when(storagePoolMonitor).processConnect(Mockito.eq(host), Mockito.eq(cmds[0]), Mockito.eq(false));
+        Mockito.doReturn(true).when(mgr).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.any(Status.Event.class), Mockito.anyBoolean(), Mockito.anyBoolean());
+        try {
+            mgr.notifyMonitorsOfConnection(attache, cmds, false);
+            Assert.fail("Connection Exception was expected");
+        } catch (ConnectionException e) {
+            Assert.assertEquals(e.getMessage(), connectionException.getMessage());
+        }
+        Mockito.verify(mgr, Mockito.times(1)).handleDisconnectWithoutInvestigation(Mockito.any(attache.getClass()), Mockito.eq(Status.Event.AgentDisconnected), Mockito.eq(true), Mockito.eq(true));
+    }
+}

--- a/server/src/com/cloud/storage/listener/StoragePoolMonitor.java
+++ b/server/src/com/cloud/storage/listener/StoragePoolMonitor.java
@@ -99,12 +99,14 @@ public class StoragePoolMonitor implements Listener {
                     }
 
                     Long hostId = host.getId();
-                    s_logger.debug("Host " + hostId + " connected, sending down storage pool information ...");
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug("Host " + hostId + " connected, connecting host to shared pool id " + pool.getId() + " and sending storage pool information ...");
+                    }
                     try {
                         _storageManager.connectHostToSharedPool(hostId, pool.getId());
                         _storageManager.createCapacityEntry(pool.getId());
                     } catch (Exception e) {
-                        s_logger.warn("Unable to connect host " + hostId + " to pool " + pool + " due to " + e.toString(), e);
+                        throw new ConnectionException(true, "Unable to connect host " + hostId + " to storage pool id " + pool.getId() + " due to " + e.toString(), e);
                     }
                 }
             }

--- a/server/test/com/cloud/storage/listener/StoragePoolMonitorTest.java
+++ b/server/test/com/cloud/storage/listener/StoragePoolMonitorTest.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.storage.listener;
+
+import com.cloud.agent.api.StartupRoutingCommand;
+import com.cloud.exception.ConnectionException;
+import com.cloud.exception.StorageUnavailableException;
+import com.cloud.host.HostVO;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.storage.ScopeType;
+import com.cloud.storage.StorageManagerImpl;
+import com.cloud.storage.StoragePoolStatus;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class StoragePoolMonitorTest {
+
+    private StorageManagerImpl storageManager;
+    private PrimaryDataStoreDao poolDao;
+    private StoragePoolMonitor storagePoolMonitor;
+    private HostVO host;
+    private StoragePoolVO pool;
+    private StartupRoutingCommand cmd;
+
+    @Before
+    public void setUp() throws Exception {
+        storageManager = Mockito.mock(StorageManagerImpl.class);
+        poolDao = Mockito.mock(PrimaryDataStoreDao.class);
+
+        storagePoolMonitor = new StoragePoolMonitor(storageManager, poolDao);
+        host = new HostVO("some-uuid");
+        pool = new StoragePoolVO();
+        pool.setScope(ScopeType.CLUSTER);
+        pool.setStatus(StoragePoolStatus.Up);
+        pool.setId(123L);
+        cmd = new StartupRoutingCommand();
+        cmd.setHypervisorType(Hypervisor.HypervisorType.KVM);
+    }
+
+    @Test
+    public void testProcessConnectStoragePoolNormal() throws Exception {
+        Mockito.when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
+        Mockito.when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+
+        storagePoolMonitor.processConnect(host, cmd, false);
+
+        Mockito.verify(storageManager, Mockito.times(1)).connectHostToSharedPool(Mockito.eq(host.getId()), Mockito.eq(pool.getId()));
+        Mockito.verify(storageManager, Mockito.times(1)).createCapacityEntry(Mockito.eq(pool.getId()));
+    }
+
+    @Test(expected = ConnectionException.class)
+    public void testProcessConnectStoragePoolFailureOnHost() throws Exception {
+        Mockito.when(poolDao.listBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ScopeType.class))).thenReturn(Collections.singletonList(pool));
+        Mockito.when(poolDao.findZoneWideStoragePoolsByTags(Mockito.anyLong(), Mockito.any(String[].class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.when(poolDao.findZoneWideStoragePoolsByHypervisor(Mockito.anyLong(), Mockito.any(Hypervisor.HypervisorType.class))).thenReturn(Collections.<StoragePoolVO>emptyList());
+        Mockito.doThrow(new StorageUnavailableException("unable to mount storage", 123L)).when(storageManager).connectHostToSharedPool(Mockito.anyLong(), Mockito.anyLong());
+
+        storagePoolMonitor.processConnect(host, cmd, false);
+    }
+}


### PR DESCRIPTION
KVM hosts on shared storage failure was accepted by mgmt server with the
host state as Up, even though there was no primary/shared storage available on
it. This patch offers a quick fix by throwing an exception in the storage monitor
which connects storage pool on host. The failure is trapped by agent manager
that disconnects the agent without any investigation.

Based on Lab tests, KVM agent may take upto 2 minutes to attempt NFS mount when
the storage is inaccessible (firewalled, or shutdown) before returning back with
an error. It is safe to assume that this won't add pressure on mgmt server due to
several reconnection attempts, and KVM agent would retry reconnection every 2
minutes.

For such KVM hosts, where failure happens due to storage issues; they will be
briefly put in Alert state but will be mostly be in Connecting state during which
the KVM host attempts to mount/reconfigure NFS storage pool.

/cc @jburwell @karuturi 
@blueorangutan package
