### PR TITLE
CLOUDSTACK-9511: fix test_privategw_acl.py to handle multiple physical networks

### DIFF
--- a/test/integration/smoke/test_privategw_acl.py
+++ b/test/integration/smoke/test_privategw_acl.py
@@ -236,13 +236,13 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         self.cleanup = [vpc, vpc_off, self.account]
 
-        physical_networks = get_physical_networks(self.apiclient, self.zone.id)
-        if not physical_networks:
+        physical_network = self.get_guest_traffic_physical_network(self.apiclient, self.zone.id)
+        if not physical_network:
             self.fail("No Physical Networks found!")
 
         qresultset = self.dbclient.execute(
             "select vnet from op_dc_vnet_alloc where physical_network_id=\
-            (select id from physical_network where uuid='%s' ) and taken is NULL;" % physical_networks[0].id
+            (select id from physical_network where uuid='%s' ) and taken is NULL;" % physical_network.id
         )
         self.assertEqual(validateList(qresultset)[0],
                          PASS,
@@ -312,13 +312,13 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         self.cleanup = [vpc_1, vpc_2, vpc_off, self.account]
 
-        physical_networks = get_physical_networks(self.apiclient, self.zone.id)
-        if not physical_networks:
+        physical_network = self.get_guest_traffic_physical_network(self.apiclient, self.zone.id)
+        if not physical_network:
             self.fail("No Physical Networks found!")
 
         qresultset = self.dbclient.execute(
             "select vnet from op_dc_vnet_alloc where physical_network_id=\
-            (select id from physical_network where uuid='%s' ) and taken is NULL;" % physical_networks[0].id
+            (select id from physical_network where uuid='%s' ) and taken is NULL;" % physical_network.id
         )
         self.assertEqual(validateList(qresultset)[0],
                          PASS,
@@ -372,11 +372,11 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         self.cleanup = [vpc_1, vpc_off, self.account]
 
-        physical_networks = get_physical_networks(self.apiclient, self.zone.id)
-        if not physical_networks:
+        physical_network = self.get_guest_traffic_physical_network(self.apiclient, self.zone.id)
+        if not physical_network:
             self.fail("No Physical Networks found!")
 
-        vlans = physical_networks[0].vlan.split('-')
+        vlans = physical_network.vlan.split('-')
         vlan_1 = int(vlans[0])
 
         net_offering_no_lb = "network_offering_no_lb"
@@ -408,7 +408,7 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         public_ip_1 = self.acquire_publicip(vpc_1, network_1)
         nat_rule_1 = self.create_natrule(vpc_1, vm1, public_ip_1, network_1)
-        
+
         self.check_private_gateway_interfaces()
 
         self.check_pvt_gw_connectivity(vm1, public_ip_1, [vm2.nic[0].ipaddress, vm3.nic[0].ipaddress, vm4.nic[0].ipaddress])
@@ -589,14 +589,14 @@ class TestPrivateGwACL(cloudstackTestCase):
         return obj_network
 
     def createPvtGw(self, vpc, ip_address, gateway, aclId, vlan):
-        physical_networks = get_physical_networks(self.apiclient, self.zone.id)
-        if not physical_networks:
+        physical_network = self.get_guest_traffic_physical_network(self.apiclient, self.zone.id)
+        if not physical_network:
             self.fail("No Physical Networks found!")
 
-        self.logger.debug('::: Physical Networks ::: ==> %s' % physical_networks)
+        self.logger.debug('::: Physical Network ::: ==> %s' % physical_network)
 
         createPrivateGatewayCmd = createPrivateGateway.createPrivateGatewayCmd()
-        createPrivateGatewayCmd.physicalnetworkid = physical_networks[0].id
+        createPrivateGatewayCmd.physicalnetworkid = physical_network.id
         createPrivateGatewayCmd.gateway = gateway
         createPrivateGatewayCmd.netmask = "255.255.255.0"
         createPrivateGatewayCmd.ipaddress = ip_address
@@ -847,3 +847,11 @@ class TestPrivateGwACL(cloudstackTestCase):
 
         if cnts[vals.index(status_to_check)] != expected_count:
             self.fail("Expected '%s' routers at state '%s', but found '%s'!" % (expected_count, status_to_check, cnts[vals.index(status_to_check)]))
+
+    def get_guest_traffic_physical_network(self, apiclient, zoneid):
+        physical_networks = get_physical_networks(apiclient, zoneid)
+        if not physical_networks:
+            return None
+        for physical_network in physical_networks:
+            if physical_network.vlan:
+                return physical_network


### PR DESCRIPTION

modified script to handle case where there can be multple physical networks
in the zone

changes contained ONLY to the test script test_privategw_acl.py. 

test_01_vpc_privategw_acl (test_privategw_acl.TestPrivateGwACL) ... === TestName: test_01_vpc_privategw_acl | Status : SUCCESS ===
ok
test_02_vpc_privategw_static_routes (test_privategw_acl.TestPrivateGwACL) ... === TestName: test_02_vpc_privategw_static_routes | Status : SUCCESS ===
ok
test_03_vpc_privategw_restart_vpc_cleanup (test_privategw_acl.TestPrivateGwACL) ... === TestName: test_03_vpc_privategw_restart_vpc_cleanup | Status : SUCCESS ===
ok
test_04_rvpc_privategw_static_routes (test_privategw_acl.TestPrivateGwACL) ... === TestName: test_04_rvpc_privategw_static_routes | Status : SUCCESS ===
ok