### PR TITLE
[4.9/lts] CLOUDSTACK-9364: Add Ubuntu 16.04 as a guest OS

### DIFF
--- a/setup/db/db/schema-490to4910.sql
+++ b/setup/db/db/schema-490to4910.sql
@@ -22,12 +22,31 @@
 -- Fix default user role description
 UPDATE `cloud`.`roles` SET `description`='Default user role' WHERE `id`=4 AND `role_type`='User' AND `description`='Default Root Admin role';
 
-
+-- Fix mysql engine to innodb
 ALTER TABLE cloud.load_balancer_cert_map ENGINE=INNODB;
 ALTER TABLE cloud.monitoring_services ENGINE=INNODB;
 ALTER TABLE cloud.nic_ip_alias ENGINE=INNODB;
 ALTER TABLE cloud.sslcerts ENGINE=INNODB;
 ALTER TABLE cloud.op_lock ENGINE=INNODB;
 ALTER TABLE cloud.op_nwgrp_work ENGINE=INNODB;
-
 ALTER TABLE cloud_usage.quota_account ENGINE=INNODB;
+
+-- Add Ubuntu 16.04 LTS as support guest os
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (255, UUID(), 10, 'Ubuntu 16.04 (32-bit)', utc_timestamp());
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (256, UUID(), 10, 'Ubuntu 16.04 (64-bit)', utc_timestamp());
+-- Ubuntu 16.04 VMware guest os mapping
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '5.0', 'ubuntuGuest', 255, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '5.1', 'ubuntuGuest', 255, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '5.5', 'ubuntuGuest', 255, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '5.0', 'ubuntu64Guest', 256, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '5.1', 'ubuntu64Guest', 256, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '5.5', 'ubuntu64Guest', 256, utc_timestamp(), 0);
+-- Ubuntu 16.04 KVM guest os mapping
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Ubuntu 16.04', 255, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'Ubuntu 16.04', 256, utc_timestamp(), 0);
+-- Ubuntu 16.04 LXC guest os mapping
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'LXC', 'default', 'Ubuntu 16.04', 255, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'LXC', 'default', 'Ubuntu 16.04', 256, utc_timestamp(), 0);
+-- Ubuntu 16.04 XenServer guest os mapping
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'Xenserver', '6.5.0', 'Ubuntu Trusty Tahr 14.04', 255, utc_timestamp(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'Xenserver', '6.5.0', 'Ubuntu Trusty Tahr 14.04', 256, utc_timestamp(), 0);


### PR DESCRIPTION
Adds Ubuntu 16.04 as a supported guest os. This allows users to select
the OS when creating a template etc.

SQL queries tested and adapted from https://issues.apache.org/jira/browse/CLOUDSTACK-9364