### PR TITLE
CLOUDSTACK-9534: Allow VR to be destroy in UI when in running state

### DIFF
--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -2585,6 +2585,11 @@
                                                 label: 'label.destroy.router',
                                                 messages: {
                                                     confirm: function (args) {
+                                                        if (args && args.context && args.context.routers[0]) {
+                                                            if (args.context.routers[0].state == 'Running') {
+                                                                return dictionary['message.action.stop.router'] + ' ' + dictionary['message.confirm.destroy.router'];
+                                                            }
+                                                        }
                                                         return 'message.confirm.destroy.router';
                                                     },
                                                     notification: function (args) {
@@ -3752,6 +3757,11 @@
                                                 label: 'label.destroy.router',
                                                 messages: {
                                                     confirm: function (args) {
+                                                        if (args && args.context && args.context.routers[0]) {
+                                                            if (args.context.routers[0].state == 'Running') {
+                                                                return dictionary['message.action.stop.router'] + ' ' + dictionary['message.confirm.destroy.router'];
+                                                            }
+                                                        }
                                                         return 'message.confirm.destroy.router';
                                                     },
                                                     notification: function (args) {
@@ -6674,6 +6684,11 @@
                                                 label: 'label.destroy.router',
                                                 messages: {
                                                     confirm: function (args) {
+                                                        if (args && args.context && args.context.routers[0]) {
+                                                            if (args.context.routers[0].state == 'Running') {
+                                                                return dictionary['message.action.stop.router'] + ' ' + dictionary['message.confirm.destroy.router'];
+                                                            }
+                                                        }
                                                         return 'message.confirm.destroy.router';
                                                     },
                                                     notification: function (args) {
@@ -9830,6 +9845,11 @@
                                         label: 'label.destroy.router',
                                         messages: {
                                             confirm: function (args) {
+                                                if (args && args.context && args.context.routers[0]) {
+                                                    if (args.context.routers[0].state == 'Running') {
+                                                        return dictionary['message.action.stop.router'] + ' ' + dictionary['message.confirm.destroy.router'];
+                                                    }
+                                                }
                                                 return 'message.confirm.destroy.router';
                                             },
                                             notification: function (args) {
@@ -20986,8 +21006,9 @@
             }
 
             allowedActions.push("restart");
-
+            allowedActions.push("remove");
             allowedActions.push("viewConsole");
+
             if (isAdmin())
             allowedActions.push("migrate");
         } else if (jsonObj.state == 'Stopped') {


### PR DESCRIPTION
This allows us to destroy a VR that is in running state from the UI. This action is possible via cloudmonkey/APIs, and would be useful for anyone who wants to simply destroy a VR from the UI without having to stop it first.

As this is a pure UI fix, manual testing would be needed but no regression integration testing is necessary.
/cc @jburwell @karuturi 

@blueorangutan package

Screenshot:

![screenshot from 2016-10-05 18-25-49](https://cloud.githubusercontent.com/assets/95203/19113882/398e8a8e-8b29-11e6-8e99-8f28def2e527.png)
