### PR TITLE
CLOUDSTACK-9535: [API] listVMSnapshots improvement

### DIFF
--- a/api/src/com/cloud/vm/snapshot/VMSnapshotService.java
+++ b/api/src/com/cloud/vm/snapshot/VMSnapshotService.java
@@ -27,11 +27,12 @@ import com.cloud.exception.InsufficientServerCapacityException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.uservm.UserVm;
+import com.cloud.utils.Pair;
 import com.cloud.vm.VirtualMachine;
 
 public interface VMSnapshotService {
 
-    List<? extends VMSnapshot> listVMSnapshots(ListVMSnapshotCmd cmd);
+    Pair<List<? extends VMSnapshot>, Integer> listVMSnapshots(ListVMSnapshotCmd cmd);
 
     VMSnapshot getVMSnapshotById(Long id);
 

--- a/api/src/org/apache/cloudstack/api/command/user/vmsnapshot/ListVMSnapshotCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vmsnapshot/ListVMSnapshotCmd.java
@@ -28,6 +28,7 @@ import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.UserVmResponse;
 import org.apache.cloudstack.api.response.VMSnapshotResponse;
 
+import com.cloud.utils.Pair;
 import com.cloud.vm.snapshot.VMSnapshot;
 
 @APICommand(name = "listVMSnapshot", description = "List virtual machine snapshot by conditions", responseObject = VMSnapshotResponse.class, since = "4.2.0", entityType = {VMSnapshot.class},
@@ -69,15 +70,15 @@ public class ListVMSnapshotCmd extends BaseListTaggedResourcesCmd {
 
     @Override
     public void execute() {
-        List<? extends VMSnapshot> result = _vmSnapshotService.listVMSnapshots(this);
+        Pair<List<? extends VMSnapshot>,Integer> result = _vmSnapshotService.listVMSnapshots(this);
         ListResponse<VMSnapshotResponse> response = new ListResponse<VMSnapshotResponse>();
         List<VMSnapshotResponse> snapshotResponses = new ArrayList<VMSnapshotResponse>();
-        for (VMSnapshot r : result) {
+        for (VMSnapshot r : result.first()) {
             VMSnapshotResponse vmSnapshotResponse = _responseGenerator.createVMSnapshotResponse(r);
             vmSnapshotResponse.setObjectName("vmSnapshot");
             snapshotResponses.add(vmSnapshotResponse);
         }
-        response.setResponses(snapshotResponses);
+        response.setResponses(snapshotResponses, result.second());
         response.setResponseName(getCommandName());
         setResponseObject(response);
     }

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -194,6 +194,7 @@ import com.cloud.configuration.ResourceLimit;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.dc.ClusterVO;
 import com.cloud.dc.DataCenter;
+import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.HostPodVO;
 import com.cloud.dc.Pod;
 import com.cloud.dc.StorageNetworkIpRange;
@@ -201,6 +202,7 @@ import com.cloud.dc.Vlan;
 import com.cloud.dc.Vlan.VlanType;
 import com.cloud.dc.VlanVO;
 import com.cloud.domain.Domain;
+import com.cloud.domain.DomainVO;
 import com.cloud.event.Event;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.PermissionDeniedException;
@@ -552,6 +554,10 @@ public class ApiResponseHelper implements ResponseGenerator {
         UserVm vm = ApiDBUtils.findUserVmById(vmSnapshot.getVmId());
         if (vm != null) {
             vmSnapshotResponse.setVirtualMachineid(vm.getUuid());
+            DataCenterVO datacenter = ApiDBUtils.findZoneById(vm.getDataCenterId());
+            if (datacenter != null) {
+                vmSnapshotResponse.setZoneId(datacenter.getUuid());
+            }
         }
         if (vmSnapshot.getParent() != null) {
             VMSnapshot vmSnapshotParent = ApiDBUtils.getVMSnapshotById(vmSnapshot.getParent());
@@ -565,6 +571,16 @@ public class ApiResponseHelper implements ResponseGenerator {
             vmSnapshotResponse.setProjectId(project.getUuid());
             vmSnapshotResponse.setProjectName(project.getName());
         }
+        Account account = ApiDBUtils.findAccountById(vmSnapshot.getAccountId());
+        if (account != null) {
+            vmSnapshotResponse.setAccountName(account.getAccountName());
+        }
+        DomainVO domain = ApiDBUtils.findDomainById(vmSnapshot.getDomainId());
+        if (domain != null) {
+            vmSnapshotResponse.setDomainId(domain.getUuid());
+            vmSnapshotResponse.setDomainName(domain.getName());
+        }
+
         vmSnapshotResponse.setCurrent(vmSnapshot.getCurrent());
         vmSnapshotResponse.setType(vmSnapshot.getType().toString());
         vmSnapshotResponse.setObjectName("vmsnapshot");

--- a/server/src/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
+++ b/server/src/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
@@ -163,7 +163,7 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
     }
 
     @Override
-    public List<VMSnapshotVO> listVMSnapshots(ListVMSnapshotCmd cmd) {
+    public Pair<List<? extends VMSnapshot>, Integer> listVMSnapshots(ListVMSnapshotCmd cmd) {
         Account caller = getCaller();
         List<Long> permittedAccounts = new ArrayList<Long>();
 
@@ -243,7 +243,8 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
             sc.setParameters("id", id);
         }
 
-        return _vmSnapshotDao.search(sc, searchFilter);
+        Pair<List<VMSnapshotVO>,Integer> searchAndCount = _vmSnapshotDao.searchAndCount(sc, searchFilter);
+        return new Pair<List<? extends VMSnapshot>, Integer>(searchAndCount.first(), searchAndCount.second());
 
     }
 


### PR DESCRIPTION
### Improvements
- Include missing fields in response: `account`, `domain`, `domainid`, `zoneid`
- Display total count of snapshots, not depending on page size

### Example
After creating 2 vm snapshots for a given vm, and making this API call: `command=listVMSnapshot&listAll=true&virtualmachineid=c8531ef8-8502-4b42-b1c5-c52ace0e7801&_=1475516598524&pagesize=1&page=1` we get this response:

```
<listvmsnapshotresponse cloud-stack-version="4.9.1.0-SNAPSHOT">
<count>2</count>
<vmSnapshot>
<id>88f7416a-8799-4245-99c6-c707cfbe6f47</id>
<name>i-2-10482-VM_VS_20161003174340</name>
<state>Ready</state>
<description>2</description>
<displayname>testsnap2</displayname>
<zoneid>0d074f25-ed31-482f-8bc5-44c9314fc417</zoneid>
<virtualmachineid>c8531ef8-8502-4b42-b1c5-c52ace0e7801</virtualmachineid>
<parent>24e44fe5-5f2e-4d35-a8f8-109b644a04e0</parent>
<parentName>testsnap</parentName>
<current>true</current>
<type>Disk</type>
<created>2016-10-03T10:43:40-0700</created>
<account>admin</account>
<domainid>5a7ffa07-3fca-11e5-9c45-005056ad45b7</domainid>
<domain>ROOT</domain>
</vmSnapshot>
</listvmsnapshotresponse>
```

**NOTES:** As in `listVirtualMachines`, despite `pagesize=1`, `count` field shows total snapshots count for given vm. Also, `account`, `domain`, `domainid`, `zoneid` fields are listed