### PR TITLE
CLOUDSTACK-9500: remove the IP from the databag if it is not used

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_forwardingrules.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_forwardingrules.py
@@ -64,6 +64,10 @@ def merge(dbag, rules):
                             print "removing index %s" % str(index)
                     if not index == -1:
                         del dbag[source_ip][index]
+                        # If all forwarding rules have been deleted
+                        # remove IP from databag
+                        if dbag[source_ip] == []:
+                            del dbag[source_ip]
 
     return dbag
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
@@ -38,7 +38,8 @@ def merge(dbag, ip):
         ip['nw_type'] = 'public'
     if ip['nw_type'] == 'control':
         dbag['eth' + str(ip['nic_dev_id'])] = [ip]
-    else:
+    # if ip['add'] is false, the IP will be removed from the databag
+    elif ip['add']:
         dbag.setdefault('eth' + str(ip['nic_dev_id']), []).append(ip)
 
     return dbag


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-9500

This removes the IP from the databags ips.json and forwardingrules.json when the IP is unused.
