### PR TITLE
XenServer 7 Support

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -54,9 +54,9 @@ import com.cloud.hypervisor.xenserver.resource.XenServer600Resource;
 import com.cloud.hypervisor.xenserver.resource.XenServer610Resource;
 import com.cloud.hypervisor.xenserver.resource.XenServer620Resource;
 import com.cloud.hypervisor.xenserver.resource.XenServer620SP1Resource;
+import com.cloud.hypervisor.xenserver.resource.XenServer650Resource;
 import com.cloud.hypervisor.xenserver.resource.XenServerConnectionPool;
 import com.cloud.hypervisor.xenserver.resource.Xenserver625Resource;
-import com.cloud.hypervisor.xenserver.resource.XenServer650Resource;
 import com.cloud.resource.Discoverer;
 import com.cloud.resource.DiscovererBase;
 import com.cloud.resource.ResourceStateAdapter;
@@ -81,7 +81,6 @@ import com.xensource.xenapi.Session;
 import com.xensource.xenapi.Types.SessionAuthenticationFailed;
 import com.xensource.xenapi.Types.UuidInvalid;
 import com.xensource.xenapi.Types.XenAPIException;
-
 import org.apache.cloudstack.hypervisor.xenserver.XenserverConfigs;
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
@@ -89,7 +88,6 @@ import org.apache.xmlrpc.XmlRpcException;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 import javax.persistence.EntityExistsException;
-
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
@@ -408,8 +406,6 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
             return new XenServer600Resource();
         else if (prodBrand.equals("XenServer") && prodVersion.equals("6.1.0"))
             return new XenServer610Resource();
-        else if (prodBrand.equals("XenServer") && prodVersion.equals("6.5.0"))
-            return new XenServer650Resource();
         else if (prodBrand.equals("XenServer") && prodVersion.equals("6.2.0")) {
             if (hotfix != null && hotfix.equals(XenserverConfigs.XSHotFix62ESP1004)) {
                 return new Xenserver625Resource();
@@ -426,9 +422,18 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
             }
         } else if (prodBrand.equals("XCP_Kronos")) {
             return new XcpOssResource();
+        } else if (prodBrand.equals("XenServer")) {
+            final String[] items = prodVersion.split("\\.");
+            if ((Integer.parseInt(items[0]) > 6) ||
+                    (Integer.parseInt(items[0]) == 6 && Integer.parseInt(items[1]) >= 4)) {
+                s_logger.warn("defaulting to xenserver650 resource for product brand: " + prodBrand + " with product " +
+                        "version: " + prodVersion);
+                //default to xenserver650 resource.
+                return new XenServer650Resource();
+            }
         }
         String msg =
-                "Only support XCP 1.0.0, 1.1.0, 1.4.x, 1.5 beta, 1.6.x; XenServer 5.6,  XenServer 5.6 FP1, XenServer 5.6 SP2, Xenserver 6.0, 6.0.2, 6.1.0, 6.2.0, 6.5.0 but this one is " +
+                "Only support XCP 1.0.0, 1.1.0, 1.4.x, 1.5 beta, 1.6.x; XenServer 5.6,  XenServer 5.6 FP1, XenServer 5.6 SP2, Xenserver 6.0, 6.0.2, 6.1.0, 6.2.0, >6.4.0 but this one is " +
                         prodBrand + " " + prodVersion;
         s_logger.warn(msg);
         throw new RuntimeException(msg);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixHelper.java
@@ -227,12 +227,6 @@ public class CitrixHelper {
             prodVersion = record.softwareVersion.get("platform_version").trim();
         } else {
             prodVersion = prodVersion.trim();
-            final String[] items = prodVersion.split("\\.");
-            if (Integer.parseInt(items[0]) > 6) {
-                prodVersion = "6.5.0";
-            } else if (Integer.parseInt(items[0]) == 6 && Integer.parseInt(items[1]) >= 4) {
-                prodVersion = "6.5.0";
-            }
         }
         return prodVersion;
     }

--- a/scripts/vm/hypervisor/xenserver/cloudstack_pluginlib.py
+++ b/scripts/vm/hypervisor/xenserver/cloudstack_pluginlib.py
@@ -21,7 +21,10 @@ import ConfigParser
 import logging
 import os
 import subprocess
-import simplejson as json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 import copy
 
 from time import localtime, asctime

--- a/scripts/vm/hypervisor/xenserver/setup_heartbeat_sr.sh
+++ b/scripts/vm/hypervisor/xenserver/setup_heartbeat_sr.sh
@@ -72,7 +72,7 @@ else
       fi
       rm $link -f
     fi 
-    lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M
+    lvcreate VG_XenStorage-$2 -n hb-$1 --size 4M  --config global{metadata_read_only=0}
     if [ $? -ne 0 ]; then
       echo "#6# Unable to create heartbeat volume hb-$1"
       exit 0

--- a/setup/db/db/schema-490to4910.sql
+++ b/setup/db/db/schema-490to4910.sql
@@ -52,6 +52,7 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervis
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'Xenserver', '6.5.0', 'Ubuntu Trusty Tahr 14.04', 256, utc_timestamp(), 0);
 -- Ensure correct guest_os_name for guest OS type 'Windows Server 2008 R2 64-bit' for VMware
 UPDATE IGNORE `cloud`.`guest_os_hypervisor` SET guest_os_name = 'windows7Server64Guest' WHERE guest_os_id IN (SELECT id FROM guest_os WHERE display_name LIKE 'windows%2008%r2%64%') AND hypervisor_type = 'VMware' AND hypervisor_version != 'default';
+
 -- Adding hypervisor mappings for SUSE Linux guest OS variants on VMware 6.0
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '6.0', 'slesGuest', 40, utc_timestamp(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VMware', '6.0', 'sles10Guest', 41, utc_timestamp(), 0);

--- a/setup/db/db/schema-4910to4920.sql
+++ b/setup/db/db/schema-4910to4920.sql
@@ -1,0 +1,217 @@
+--;
+-- Stored procedure to do idempotent insert;
+--;
+
+DROP PROCEDURE IF EXISTS `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`;
+
+CREATE PROCEDURE `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`(
+                            IN in_hypervisor_type VARCHAR(32),
+                            IN in_hypervisor_version VARCHAR(32),
+                            IN in_guest_os_name VARCHAR(255),
+                            IN in_guest_os_id BIGINT(20) UNSIGNED,
+                            IN is_user_defined int(1) UNSIGNED)
+BEGIN
+        IF NOT EXISTS ((SELECT * FROM `cloud`.`guest_os_hypervisor` WHERE
+            hypervisor_type=in_hypervisor_type AND
+            hypervisor_version=in_hypervisor_version AND
+            guest_os_id = in_guest_os_id))
+        THEN
+                INSERT INTO `cloud`.`guest_os_hypervisor` (
+                        uuid,
+                        hypervisor_type,
+                        hypervisor_version,
+                        guest_os_name,
+                        guest_os_id,
+                        created,
+                        is_user_defined)
+                        VALUES (
+                            UUID(),
+                            in_hypervisor_type,
+                            in_hypervisor_version,
+                            in_guest_os_name,
+                            in_guest_os_id,
+                            utc_timestamp(),
+                            is_user_defined
+                        ); END IF; END;;
+
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 4.5 (32-bit)', 1,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 4.6 (32-bit)', 2,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 4.7 (32-bit)', 3,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 4.8 (32-bit)', 4,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 5,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 6,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 7,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 8,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 9,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 10,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 11,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 12,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 13,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 14,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 111,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 112,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 141,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 142,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 161,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 162,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 173,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 174,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 175,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 176,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 231,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 232,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (32-bit)', 139,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 5 (64-bit)', 140,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (32-bit)', 143,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (64-bit)', 144,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (32-bit)', 177,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (64-bit)', 178,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (32-bit)', 179,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (64-bit)', 180,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (32-bit)', 171,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (64-bit)', 172,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (32-bit)', 181,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (64-bit)', 182,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (32-bit)', 227,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (64-bit)', 228,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (32-bit)', 248,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 6 (64-bit)', 249,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'CentOS 7', 246,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Debian Squeeze 6.0 (32-bit)', 132,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Debian Squeeze 6.0 (64-bit)', 133,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Debian Wheezy 7.0 (32-bit)', 183,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Debian Wheezy 7.0 (64-bit)', 184,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 16,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 17,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 18,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 19,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 20,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 21,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 22,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 23,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 24,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 25,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 134,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 135,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 145,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 146,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 207,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 208,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 209,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 210,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 211,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 212,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (32-bit)', 233,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 5 (64-bit)', 234,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (32-bit)', 147,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (64-bit)', 148,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (32-bit)', 213,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (64-bit)', 214,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (32-bit)', 215,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (64-bit)', 216,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (32-bit)', 217,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (64-bit)', 218,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (32-bit)', 219,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (64-bit)', 220,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (32-bit)', 235,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (64-bit)', 236,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (32-bit)', 250,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Enterprise Linux 6 (64-bit)', 251,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Oracle Linux 7', 247,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 4.5 (32-bit)', 26,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 4.6 (32-bit)', 27,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 4.7 (32-bit)', 28,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 4.8 (32-bit)', 29,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 30,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 31,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 32,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 33,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 34,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 35,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 36,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 37,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 38,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 39,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 113,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 114,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 149,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 150,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 189,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 190,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 191,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 192,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 193,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 194,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (32-bit)', 237,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 5 (64-bit)', 238,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (32-bit)', 136,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (64-bit)', 137,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (32-bit)', 195,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (64-bit)', 196,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (32-bit)', 197,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (64-bit)', 198,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (32-bit)', 199,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (64-bit)', 204,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (32-bit)', 205,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (64-bit)', 206,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (32-bit)', 239,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 6 (64-bit)', 240,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Red Hat Enterprise Linux 7', 245,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP1 (32-bit)', 41,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP1 (64-bit)', 42,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP2 (32-bit)', 43,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP2 (64-bit)', 44,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP3 (32-bit)', 151,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP3 (64-bit)', 45,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP4 (32-bit)', 153,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 10 SP4 (64-bit)', 152,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 (32-bit)', 46,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 (64-bit)', 47,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 SP1 (32-bit)', 155,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 SP1 (64-bit)', 154,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 SP2 (32-bit)', 186,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 SP2 (64-bit)', 185,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 SP3 (32-bit)', 188,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 11 SP3 (32-bit)', 187,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'SUSE Linux Enterprise Server 12 (64-bit)', 244,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows 7 (32-bit)', 48,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows 7 (64-bit)', 49,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows 8 (32-bit)', 165,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows 8 (64-bit)', 166,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2003 (32-bit)', 50,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2003 (64-bit)', 51,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2003 (32-bit)', 87,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2003 (64-bit)', 88,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2003 (32-bit)', 89,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2003 (64-bit)', 90,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2008 (32-bit)', 52,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2008 (64-bit)', 53,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2008 R2 (64-bit)', 54,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2012 (64-bit)', 167,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows Server 2012 R2 (64-bit)', 168,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Windows XP SP3 (32-bit)', 58,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Lucid Lynx 10.04 (32-bit)', 121,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Lucid Lynx 10.04 (64-bit)', 126,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Maverick Meerkat 10.10 (32-bit) (experimental)', 156,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Maverick Meerkat 10.10 (64-bit) (experimental)', 157,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Precise Pangolin 12.04 (32-bit)', 163,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Precise Pangolin 12.04 (64-bit)', 164,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Trusty Tahr 14.04', 241,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Trusty Tahr 14.04', 254,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 169,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 170,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 98,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 99,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 60,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 103,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 200,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 201,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 59,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 100,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 202,  0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Other install media', 203,  0);
+
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Trusty Tahr 14.04', 255, 0);
+CALL `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`('Xenserver', '7.0.0', 'Ubuntu Trusty Tahr 14.04', 256, 0);
+
+DROP PROCEDURE `cloud`.`IDEMPOTENT_INSERT_GUESTOS_HYPERVISOR_MAPPING`

--- a/tools/marvin/marvin/lib/utils.py
+++ b/tools/marvin/marvin/lib/utils.py
@@ -19,6 +19,7 @@
 
 import marvin
 import os
+import re
 import time
 import logging
 import string
@@ -489,9 +490,11 @@ def checkVolumeSize(ssh_handle=None,
                 return FAILED
             for line in fdisk_output["stdout"]:
                 if volume_name in line:
-                    parts = line.strip().split()
-                    if str(parts[-2]) == str(size_to_verify):
-                        return [SUCCESS,str(parts[-2])]
+                    # Get the bytes from the output
+                    # Disk /dev/xvdb: 1 GiB, 1073741824 bytes, 2097152 sectors
+                    m = re.match('.*?(\d+) bytes.*', line)
+                    if m and str(m.group(1)) == str(size_to_verify):
+                        return [SUCCESS,str(m.group(1))]
             return [FAILED,"Volume Not Found"]
     except Exception, e:
         print "\n Exception Occurred under getDiskUsage: " \

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -9578,6 +9578,9 @@
                                     var currentPage = 1;
                                     var returnedHostCount = 0;
 
+                                    var returnedHostCountForXenServer700 = 0;  //'XenServer 7.0.0'
+                                    var returnedHostCpusocketsSumForXenServer700 = 0;
+
                                     var returnedHostCountForXenServer650 = 0;  //'XenServer 6.5.0'
                                     var returnedHostCpusocketsSumForXenServer650 = 0;
 
@@ -9606,7 +9609,12 @@
 
                                                 var items = json.listhostsresponse.host;
                                                 for (var i = 0; i < items.length; i++) {
-                                                    if (items[i].hypervisorversion == "6.5.0") {
+                                                    if (items[i].hypervisorversion == "7.0.0") {
+                                                        returnedHostCountForXenServer700 ++;
+                                                        if (items[i].cpusockets != undefined && isNaN(items[i].cpusockets) == false) {
+                                                            returnedHostCpusocketsSumForXenServer700 += items[i].cpusockets;
+                                                        }
+													} else if (items[i].hypervisorversion == "6.5.0") {
                                                         returnedHostCountForXenServer650 ++;
                                                         if (items[i].cpusockets != undefined && isNaN(items[i].cpusockets) == false) {
                                                             returnedHostCpusocketsSumForXenServer650 += items[i].cpusockets;
@@ -9630,6 +9638,12 @@
                                     }
 
                                     callListHostsWithPage();
+
+                                    array1.push({
+                                        hypervisor: 'XenServer 7.0.0',
+                                        hosts: returnedHostCountForXenServer700,
+                                        sockets: returnedHostCpusocketsSumForXenServer700
+                                    });
 
                                     array1.push({
                                         hypervisor: 'XenServer 6.5.0',


### PR DESCRIPTION
This PR adds support for XenServer 7. I have manually done the following tests
- Create a new cluster with XenServer7
- Add Primary storage: Should create an SR on XS7
- Add another XS7 host to the Pool 
- Add host2 to Cloudstack
- Create VM1 from template 
- Create VM2 from template 
- Ping/SSH VM1 to VM2 and vice-versa
- Stop/Delete/Expunge VM2
- Create Data disk 
- Attach it to VM1
- Create VM snaphsot of VM1
- Restore VM snapshot of VM1
- Delete VM snapshot of VM1
- Create Volume snapshot of Datadisk
- Create volume snapshot of Root disk
- Create new template from snapshot of root disk
- Create volume from snapshot of datadisk
- Detach datadisk volume
- Delete datadisk volume
- Aquire a public IP
- Create a static nat to VM1
- Live migrate VM1 while traffic on VM
- Delete VM1
