### PR TITLE
CLOUDSTACK-9558 Cleanup the snapshots on the primary storage of Xense…

### DIFF
--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
@@ -283,9 +283,10 @@ public class XenserverSnapshotStrategy extends SnapshotStrategyBase {
                     SnapshotInfo snapshotOnPrimaryInfo = snapshotDataFactory.getSnapshot(snapshotId, DataStoreRole.Primary);
                     long volumeId = snapshotOnPrimary.getVolumeId();
                     VolumeVO volumeVO = volumeDao.findById(volumeId);
-                    if (((PrimaryDataStoreImpl)snapshotOnPrimaryInfo.getDataStore()).getPoolType() == StoragePoolType.RBD && volumeVO != null) {
+                    if ( volumeVO != null) {
                         snapshotSvr.deleteSnapshot(snapshotOnPrimaryInfo);
                     }
+
                     snapshotOnPrimary.setState(State.Destroyed);
                     snapshotStoreDao.update(snapshotOnPrimary.getId(), snapshotOnPrimary);
                 }


### PR DESCRIPTION
Cleanup the snapshots on the primary storage of Xenserver after VM/Volume is expunged
Steps to reproduce the issue
===========================
i) Deploy a new VM in CCP on Xenserver
ii) Create a snapshot for the volume created in step i) from CCP. This step will create a snapshot on the primary storage and keeps it on storage as we use it as reference for the incremental snapshots
iii) Now destroy and expunge the VM created in step i)
You will notice that the volume for the VM ( created in step i) is deleted from the primary storage. However the snapshot created on primary ( as part of step ii)) still exists on the primary and this needs to be deleted manually by the admin.
Snapshot exists on the primary storage even after deleting the Volume.