### PR TITLE
Fix GroupBy (+ having) condition and tests

### DIFF
--- a/framework/db/src/com/cloud/utils/db/GroupBy.java
+++ b/framework/db/src/com/cloud/utils/db/GroupBy.java
@@ -54,12 +54,9 @@ public class GroupBy<J extends SearchBase<?, T, R>, T, R> {
         return this;
     }
 
-    public J having(final Func func, final Object obj, final Op op, final Object value) {
+    public J having(final Func func, final Attribute obj, final Op op) {
         assert (_having == null) : "You can only specify one having in a group by";
-        final List<Attribute> attrs = _builder.getSpecifiedAttributes();
-        assert attrs.size() == 1 : "You didn't specified an attribute";
-
-        _having = new Having(func, attrs.get(0), op, value);
+        _having = new Having(func, obj, op);
         _builder.getSpecifiedAttributes().clear();
         return _builder;
     }
@@ -88,13 +85,11 @@ public class GroupBy<J extends SearchBase<?, T, R>, T, R> {
         public Func func;
         public Attribute attr;
         public Op op;
-        public Object value;
 
-        public Having(final Func func, final Attribute attr, final Op op, final Object value) {
+        public Having(final Func func, final Attribute attr, final Op op) {
             this.func = func;
             this.attr = attr;
             this.op = op;
-            this.value = value;
         }
 
         public void toSql(final StringBuilder builder) {

--- a/framework/db/test/com/cloud/utils/db/GroupByTest.java
+++ b/framework/db/test/com/cloud/utils/db/GroupByTest.java
@@ -21,6 +21,8 @@ package com.cloud.utils.db;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -32,6 +34,10 @@ import com.cloud.utils.db.SearchCriteria.Op;
 public class GroupByTest {
 
     protected static final String EXPECTED_QUERY = "BASE GROUP BY FIRST(TEST_TABLE.TEST_COLUMN), MAX(TEST_TABLE.TEST_COLUMN) HAVING COUNT(TEST_TABLE2.TEST_COLUMN2) > ? ";
+    protected static final DbTestDao dao = new DbTestDao();
+    protected static final String EXPECTED_QUERY_2 = "TEST GROUP BY test.fld_int HAVING SUM(test.fld_long) > ? ";
+    protected static final String FULL_EXPECTED_QUERY_2 = "SELECT test.fld_string FROM test WHERE test.fld_string = ?  GROUP BY test.fld_int HAVING SUM(test.fld_long) > ? ";
+
     @Test
     public void testToSql() {
         // Prepare
@@ -39,12 +45,13 @@ public class GroupByTest {
         final GroupByExtension groupBy = new GroupByExtension(new SearchBaseExtension(String.class, String.class));
 
         final Attribute att = new Attribute("TEST_TABLE", "TEST_COLUMN");
-        final Pair<Func, Attribute> pair1 = new Pair<SearchCriteria.Func, Attribute>(SearchCriteria.Func.FIRST, att);
-        final Pair<Func, Attribute> pair2 = new Pair<SearchCriteria.Func, Attribute>(SearchCriteria.Func.MAX, att);
-        groupBy._groupBys = new ArrayList<Pair<Func, Attribute>>();
+        final Attribute att2 = new Attribute("TEST_TABLE2", "TEST_COLUMN2");
+        final Pair<Func, Attribute> pair1 = new Pair<>(SearchCriteria.Func.FIRST, att);
+        final Pair<Func, Attribute> pair2 = new Pair<>(SearchCriteria.Func.MAX, att);
+        groupBy._groupBys = new ArrayList<>();
         groupBy._groupBys.add(pair1);
         groupBy._groupBys.add(pair2);
-        groupBy.having(SearchCriteria.Func.COUNT, att, Op.GT, "SOME_VALUE");
+        groupBy.having(SearchCriteria.Func.COUNT, att2, Op.GT);
 
         // Execute
         groupBy.toSql(sb);
@@ -52,6 +59,45 @@ public class GroupByTest {
         // Assert
         assertTrue("It didn't create the expected SQL query.", sb.toString().equals(EXPECTED_QUERY));
     }
+
+    @Test
+    public void testToSqlWithDao() {
+        StringBuilder sb = new StringBuilder("TEST");
+        SearchBuilder<DbTestVO> searchBuilder = dao.createSearchBuilder();
+        searchBuilder.selectFields(searchBuilder.entity().getFieldString());
+        searchBuilder.and("st", searchBuilder.entity().getFieldString(), SearchCriteria.Op.EQ);
+        GroupBy groupBy = searchBuilder.groupBy(searchBuilder.entity().getFieldInt());
+        groupBy.having(SearchCriteria.Func.SUM, dao.getAllAttributes().get("fieldLong"), SearchCriteria.Op.GT);
+        groupBy.toSql(sb);
+        assertTrue("It didn't create the expected SQL query.", sb.toString().equals(EXPECTED_QUERY_2));
+
+        searchBuilder.done();
+        SearchCriteria<DbTestVO> sc = searchBuilder.create();
+        sc.setGroupByValues(0);
+        sc.setParameters("st", "SOMETHING");
+
+        String clause = sc.getWhereClause();
+        if (clause != null && clause.length() == 0) {
+            clause = null;
+        }
+
+        final StringBuilder str = dao.createPartialSelectSql(sc, clause != null);
+        if (clause != null) {
+            str.append(clause);
+        }
+
+        Collection<JoinBuilder<SearchCriteria<?>>> joins;
+        joins = sc.getJoins();
+        if (joins != null) {
+            dao.addJoins(str, joins);
+        }
+
+        List<Object> groupByValues = dao.addGroupBy(str, sc);
+
+        assertTrue("It didn't create the expected SQL query.", str.toString().equals(FULL_EXPECTED_QUERY_2));
+        assertTrue("Incorrect group by parameter list", groupByValues.size() == 1);
+    }
+
 }
 
 class GroupByExtension extends GroupBy<SearchBaseExtension, String, String> {
@@ -66,13 +112,11 @@ class GroupByExtension extends GroupBy<SearchBaseExtension, String, String> {
     }
 }
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 class SearchBaseExtension extends SearchBase<SearchBaseExtension, String, String>{
 
     SearchBaseExtension(final Class entityType, final Class resultType) {
         super(entityType, resultType);
-        _specifiedAttrs = new ArrayList<Attribute>();
-        _specifiedAttrs.add(new Attribute("TEST_TABLE2", "TEST_COLUMN2"));
+        _specifiedAttrs = new ArrayList<>();
     }
 
     @Override


### PR DESCRIPTION
The GroupBy + having isn't used currently in the code but was not clean. It removes unused arguments and variables and adds a test based on a DAO to show a full example of how to use it.

Signed-off-by: Marc-Aurèle Brothier m@brothier.org
