### PR TITLE
CLOUDSTACK-9551: Move java tmp dir to cloudstack-agent's path to avoid

### DIFF
--- a/packaging/centos63/cloud-agent.rc
+++ b/packaging/centos63/cloud-agent.rc
@@ -26,6 +26,7 @@
 
 # set environment variables
 
+TMP=/usr/share/cloudstack-agent/tmp
 SHORTNAME=$(basename $0 | sed -e 's/^[SK][0-9][0-9]//')
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
@@ -40,6 +41,9 @@ if [ -z "$JSVC" ]; then
     echo no jsvc found in path;
     exit 1;
 fi
+
+# create java tmp dir if not found
+mkdir -m 0755 -p "$TMP"
 
 unset OPTIONS
 [ -r /etc/sysconfig/"$SHORTNAME" ] && source /etc/sysconfig/"$SHORTNAME"
@@ -64,7 +68,7 @@ export CLASSPATH="/usr/share/java/commons-daemon.jar:$ACP:$PCP:/etc/cloudstack/a
 start() {
     echo -n $"Starting $PROGNAME: "
     if hostname --fqdn >/dev/null 2>&1 ; then
-        $JSVC -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
+        $JSVC -Djava.io.tmpdir="$TMP" -Xms256m -Xmx2048m -cp "$CLASSPATH" -pidfile "$PIDFILE" \
             -errfile $LOGDIR/cloudstack-agent.err -outfile $LOGDIR/cloudstack-agent.out $CLASS
         RETVAL=$?
         echo

--- a/packaging/debian/cloudstack-agent.init
+++ b/packaging/debian/cloudstack-agent.init
@@ -33,6 +33,7 @@
 
 . /lib/lsb/init-functions
 
+TMP=/usr/share/cloudstack-agent/tmp
 SHORTNAME="cloudstack-agent"
 PIDFILE=/var/run/"$SHORTNAME".pid
 LOCKFILE=/var/lock/subsys/"$SHORTNAME"
@@ -44,6 +45,9 @@ SHUTDOWN_WAIT="30"
 
 unset OPTIONS
 [ -r /etc/default/"$SHORTNAME" ] && source /etc/default/"$SHORTNAME"
+
+# create java tmp dir if not found
+mkdir -m 0755 -p "$TMP"
 
 # The first existing directory is used for JAVA_HOME (if JAVA_HOME is not defined in $DEFAULT)
 JDK_DIRS="/usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-6-openjdk /usr/lib/jvm/java-6-openjdk-i386 /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-sun"
@@ -96,7 +100,7 @@ start() {
 
     wait_for_network
 
-    if start_daemon -p $PIDFILE $DAEMON -Xms256m -Xmx2048m -cp "$CLASSPATH" -Djna.nosys=true -pidfile "$PIDFILE" -errfile SYSLOG $CLASS
+    if start_daemon -p $PIDFILE $DAEMON -Djava.io.tmpdir="$TMP" -Xms256m -Xmx2048m -cp "$CLASSPATH" -Djna.nosys=true -pidfile "$PIDFILE" -errfile SYSLOG $CLASS
         RETVAL=$?
     then
         rc=0


### PR DESCRIPTION
Move java tmp dir to cloudstack-agent's path to avoid noexec on /tmp
