### PR TITLE
CLOUDSTACK-9564: Fix memory leaks in VmwareContextPool

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareContextFactory.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareContextFactory.java
@@ -77,7 +77,6 @@ public class VmwareContextFactory {
         context.registerStockObject("noderuninfo", String.format("%d-%d", s_clusterMgr.getManagementNodeId(), s_clusterMgr.getCurrentRunId()));
 
         context.setPoolInfo(s_pool, VmwareContextPool.composePoolKey(vCenterAddress, vCenterUserName));
-        s_pool.registerOutstandingContext(context);
 
         return context;
     }

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -5481,7 +5481,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             if (s_logger.isTraceEnabled()) {
                 s_logger.trace("Recycling threadlocal context to pool");
             }
-            context.getPool().returnContext(context);
+            context.getPool().registerContext(context);
         }
     }
 

--- a/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareSecondaryStorageContextFactory.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareSecondaryStorageContextFactory.java
@@ -49,7 +49,6 @@ public class VmwareSecondaryStorageContextFactory {
         assert (context != null);
 
         context.setPoolInfo(s_pool, VmwareContextPool.composePoolKey(vCenterAddress, vCenterUserName));
-        s_pool.registerOutstandingContext(context);
 
         return context;
     }

--- a/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareSecondaryStorageResourceHandler.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/storage/resource/VmwareSecondaryStorageResourceHandler.java
@@ -236,7 +236,7 @@ public class VmwareSecondaryStorageResourceHandler implements SecondaryStorageRe
             VmwareContext context = currentContext.get();
             currentContext.set(null);
             assert (context.getPool() != null);
-            context.getPool().returnContext(context);
+            context.getPool().registerContext(context);
         }
     }
 

--- a/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareContext.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/util/VmwareContext.java
@@ -666,7 +666,7 @@ public class VmwareContext {
             s_logger.warn("Unexpected exception: ", e);
         } finally {
             if (_pool != null) {
-                _pool.unregisterOutstandingContext(this);
+                _pool.unregisterContext(this);
             }
             unregisterOutstandingContext();
         }

--- a/vmware-base/test/com/cloud/hypervisor/vmware/util/VmwareContextPoolTest.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/util/VmwareContextPoolTest.java
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.hypervisor.vmware.util;
+
+import com.cloud.utils.concurrency.NamedThreadFactory;
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class VmwareContextPoolTest {
+
+    private class PoolClient implements Runnable {
+        private final VmwareContextPool pool;
+        private volatile Boolean canRun = true;
+        private int counter = 0;
+
+        public PoolClient(final VmwareContextPool pool) {
+            this.pool = pool;
+        }
+
+        public int count() {
+            return counter;
+        }
+
+        public void stop() {
+            canRun = false;
+        }
+
+        @Override
+        public void run() {
+            final String poolKey = pool.composePoolKey(vmwareAddress, vmwareUsername);
+            while (canRun) {
+                pool.registerContext(createDummyContext(pool, poolKey));
+                counter++;
+            }
+        }
+    }
+
+    private VmwareContextPool vmwareContextPool;
+    private VmwareContext vmwareContext;
+    private String vmwareAddress = "address";
+    private String vmwareUsername = "username";
+
+    private int contextLength = 10;
+    private Duration idleCheckInterval = Duration.millis(1000L);
+
+    public VmwareContext createDummyContext(final VmwareContextPool pool, final String poolKey) {
+        VmwareClient vimClient = new VmwareClient("someAddress");
+        VmwareContext context = new VmwareContext(vimClient, "someAddress");
+        context.setPoolInfo(pool, poolKey);
+        return context;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        final String poolKey = vmwareContextPool.composePoolKey(vmwareAddress, vmwareUsername);
+        vmwareContextPool = new VmwareContextPool(contextLength, idleCheckInterval);
+        vmwareContext = createDummyContext(vmwareContextPool, poolKey);
+    }
+
+    @Test
+    public void testRegisterContext() throws Exception {
+        vmwareContextPool.registerContext(vmwareContext);
+        Assert.assertEquals(vmwareContextPool.getContext(vmwareAddress, vmwareUsername), vmwareContext);
+    }
+
+    @Test
+    public void testUnregisterContext() throws Exception {
+        vmwareContextPool.unregisterContext(vmwareContext);
+        Assert.assertNull(vmwareContextPool.getContext(vmwareAddress, vmwareUsername));
+    }
+
+    @Test
+    public void testComposePoolKey() throws Exception {
+        Assert.assertEquals(vmwareContextPool.composePoolKey(vmwareAddress, vmwareUsername), vmwareUsername + "@" + vmwareAddress);
+    }
+
+    @Test
+    public void testMultithreadedPoolClients() throws Exception {
+        vmwareContextPool = Mockito.spy(vmwareContextPool);
+        final ExecutorService executor = Executors.newFixedThreadPool(10, new NamedThreadFactory("VmwareContextPoolClients"));
+        final List<PoolClient> clients = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            final PoolClient client = new PoolClient(vmwareContextPool);
+            clients.add(client);
+            executor.submit(client);
+        }
+        Thread.sleep(1000);
+        executor.shutdown();
+        int totalRegistrations = 0;
+        for (final PoolClient client : clients) {
+            client.stop();
+            totalRegistrations += client.count();
+        }
+        Mockito.verify(vmwareContextPool, Mockito.atLeast(totalRegistrations)).registerContext(Mockito.any(VmwareContext.class));
+        Assert.assertEquals(vmwareContextPool.composePoolKey(vmwareAddress, vmwareUsername),
+                vmwareContextPool.getContext(vmwareAddress, vmwareUsername).getPoolKey());
+    }
+}


### PR DESCRIPTION
In a recent management server crash, it was found that the largest contributor
to memory leak was in VmwareContextPool where a registry is held (arraylist)
that grows indefinitely. The list itself is not used anywhere or consumed. There
exists a hashmap (pool) that returns a list of contexts for existing poolkey
(address/username) that is used instead.

This fixes the issue by removing the arraylist registry, and limiting the
length of the context list for a given poolkey.

@blueorangutan package
