### PR TITLE
CLOUDSTACK-9562 Linux Guest VM get wrong default route when there are…

### DIFF
--- a/systemvm/patches/debian/config/etc/vpcdnsmasq.conf
+++ b/systemvm/patches/debian/config/etc/vpcdnsmasq.conf
@@ -460,3 +460,4 @@ log-facility=/var/log/dnsmasq.log
 # Include a another lot of configuration options.
 #conf-file=/etc/dnsmasq.more.conf
 conf-dir=/etc/dnsmasq.d
+dhcp-optsfile=/etc/dhcpopts.txt


### PR DESCRIPTION
… multiple Nic
# REPRO STEPS
1. Log as admin, create a VM CentOSx64 integrate with default network "Admin-Network" (gateway is 10.1.1.1)
2. Create a VPC "TestVpc" and inside network named "TechNet" (gateway is 10.0.0.1)
3. Add VPC network to VM as NIC 2
4. Reboot VM and examine VM default VR changed to VPC default gateway

dhcp options entries getting updated on the VR properly, but still they are not taking effect. Once we restart the dnsmasq service the issue is resolved. This is because dhcp-opsfile entry to dnsmasq.conf was made after service start and sending SIGHUP does not reload dnsmasq configuration. Thus adding dhcp-opsfile entry to vpcdnsmasq.conf helped to fix the issue. 
