### PR TITLE
CLOUDSTACK-9561 After domain/account deletion, snapshot taken by the domain/account remains undeleted

### DIFF
--- a/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -96,7 +96,6 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     public List<VolumeVO> findByAccount(long accountId) {
         SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
         sc.setParameters("accountId", accountId);
-        sc.setParameters("state", Volume.State.Ready);
         return listBy(sc);
     }
 


### PR DESCRIPTION
While deleting the UserAccount Cleanup for the removed VMs/volumes are not happening. For the removed VMs, snapshots doesn't get cleaned. Only for running VMs(volumes in ready state) the cleanup happens. 

When the VM is desroyed, the volume is marked as destroyed and later storage garbage collector perform the cleanup. But if we try delete domain/account before storage garbage collector runs, then it fails.
