### PR TITLE
CLOUDSTACK-9566 instance-id metadata for baremetal VM returns ID

### DIFF
--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeManagerImpl.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalPxeManagerImpl.java
@@ -200,7 +200,7 @@ public class BaremetalPxeManagerImpl extends ManagerBase implements BaremetalPxe
         cmd.addVmData("metadata", "local-hostname", StringUtils.unicodeEscape(vm.getInstanceName()));
         cmd.addVmData("metadata", "public-ipv4", nic.getIPv4Address());
         cmd.addVmData("metadata", "public-hostname", StringUtils.unicodeEscape(vm.getInstanceName()));
-        cmd.addVmData("metadata", "instance-id", String.valueOf(vm.getId()));
+        cmd.addVmData("metadata", "instance-id", String.valueOf(vm.getUuid()));
         cmd.addVmData("metadata", "vm-id", String.valueOf(vm.getInstanceName()));
         cmd.addVmData("metadata", "public-keys", null);
         String cloudIdentifier = _configDao.getValue("cloud.identifier");


### PR DESCRIPTION
There is difference in instance-id metadata across baremetal and other hypervisors.  

On Baremetal
[root@ip-172-17-0-144 ~]# curl http://8.37.203.221/latest/meta-data/instance-id
6021

on Xen
[root@ip-172-17-2-103 ~]# curl http://172.17.0.252/latest/meta-data/instance-id
cbeb517a-e833-4a0c-b1e8-9ed70200fbbf

In both cases it should be vm's uuid. 
