### PR TITLE
Fix xapi pluginlib for XenServer 7

### DIFF
--- a/scripts/vm/hypervisor/xenserver/cloudstack_pluginlib.py
+++ b/scripts/vm/hypervisor/xenserver/cloudstack_pluginlib.py
@@ -21,7 +21,10 @@ import ConfigParser
 import logging
 import os
 import subprocess
-import simplejson as json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 import copy
 
 from time import localtime, asctime


### PR DESCRIPTION
This makes cloudstack_pluginlib.py compatible with XenServer 7 dom0, as (from what I gathered) simplejson was included by default as "json" in the version that XenServer 7 dom0 uses. (python --version returns 2.7.5).
This is the only issue I have found so far with this setup.