### PR TITLE
CLOUDSTACK-8326: Always fill UDP checksums in DHCP replies in VR

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -359,6 +359,10 @@ class CsIP:
                         "-m state --state RELATED,ESTABLISHED " +
                         "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])
 
+        self.fw.append(["mangle", "front",
+                        "-A POSTROUTING " +
+                        "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
+
         if self.get_type() in ["public"]:
             self.fw.append(["mangle", "front",
                             "-A PREROUTING " +
@@ -375,9 +379,6 @@ class CsIP:
                             "-A VPN_%s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.address['public_ip']])
             self.fw.append(["mangle", "",
                             "-A VPN_%s -j RETURN" % self.address['public_ip']])
-            self.fw.append(["mangle", "front",
-                            "-A POSTROUTING " +
-                            "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
             self.fw.append(["nat", "",
                             "-A POSTROUTING -o eth2 -j SNAT --to-source %s" % self.address['public_ip']])
             self.fw.append(["mangle", "",
@@ -453,6 +454,8 @@ class CsIP:
                 ["mangle", "front", "-A ACL_OUTBOUND_%s -d 224.0.0.18/32 -j ACCEPT" % self.dev])
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p udp -m udp --dport 67 -j ACCEPT" % self.dev])
+            self.fw.append(
+                ["mangle", "front", "-A POSTROUTING " + "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
             self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p udp -m udp --dport 53 -s %s -j ACCEPT" % (self.dev, guestNetworkCidr)])
             self.fw.append(


### PR DESCRIPTION
In some cases the UDP checksums in packets from DHCP servers are
incorrect. This is a problem for some DHCP clients that ignore
packets with bad checksums. This patch inserts an iptables rule
to ensure DHCP servers always send packets with correct checksums.

Due to this bug DHCP offers are sometimes not accepted by Instances.

The end-result without this fix is no connectivity for the Instance
due to the lack of a IPv4 address.

Signed-off-by: Wido den Hollander <wido@widodh.nl>