### PR TITLE
SSVM downloader now handles redirects properly.

### DIFF
--- a/core/src/com/cloud/storage/template/HttpTemplateDownloader.java
+++ b/core/src/com/cloud/storage/template/HttpTemplateDownloader.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Date;
 
 import org.apache.cloudstack.utils.imagestore.ImageStoreUtil;
@@ -117,7 +116,7 @@ public class HttpTemplateDownloader extends ManagedContextRunnable implements Te
             request = new GetMethod(downloadUrl);
             request.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, myretryhandler);
             completionCallback = callback;
-            //this.request.setFollowRedirects(false);
+            this.request.setFollowRedirects(true);
 
             File f = File.createTempFile("dnld", "tmp_", new File(toDir));
 
@@ -232,8 +231,7 @@ public class HttpTemplateDownloader extends ManagedContextRunnable implements Te
                 remoteSize = maxTemplateSizeInBytes;
             }
 
-            URL url = new URL(getDownloadUrl());
-            InputStream in = url.openStream();
+            InputStream in = request.getResponseBodyAsStream();
 
             RandomAccessFile out = new RandomAccessFile(file, "rw");
             out.seek(localFileSize);


### PR DESCRIPTION
New version of #1607, opened against 4.9 so it can be forward merged.

**Original Description**
Previously it was using the HttpClient to make an initial request to an ISO. This would follow redirects. Then it would make another request using built-in Java URL and InputStream, which doesn't follow redirects. This results in the ISO getting stuck at 0% forever and also causing DOS effects.