### PR TITLE
CLOUDSTACK-9620: KVM enhancements for managed storage

### DIFF
--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreCapabilities.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreCapabilities.java
@@ -36,5 +36,9 @@ public enum DataStoreCapabilities {
     /**
      * indicates that this driver supports the "cloneOfSnapshot" property of cloud.snapshot_details (for creating a volume from a volume)
      */
-    CAN_CREATE_VOLUME_FROM_VOLUME
+    CAN_CREATE_VOLUME_FROM_VOLUME,
+    /**
+     * indicates that this driver supports reverting a volume to a snapshot state
+     */
+    CAN_REVERT_VOLUME_TO_SNAPSHOT
 }

--- a/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -1052,12 +1052,12 @@ public class VolumeServiceImpl implements VolumeService {
                 destPrimaryDataStore.getDriver().getCapabilities().get(DataStoreCapabilities.CAN_CREATE_VOLUME_FROM_VOLUME.toString())
         );
 
-        boolean computeZoneSupportsResign = computeZoneSupportsResign(destHost.getDataCenterId(), destHost.getHypervisorType());
+        boolean computeSupportsVolumeClone = computeSupportsVolumeClone(destHost.getDataCenterId(), destHost.getHypervisorType());
 
         AsyncCallFuture<VolumeApiResult> future = new AsyncCallFuture<>();
 
-        if (storageCanCloneVolume && computeZoneSupportsResign) {
-            s_logger.debug("Storage " + destDataStoreId + " can support cloning using a cached template and host cluster can perform UUID resigning.");
+        if (storageCanCloneVolume && computeSupportsVolumeClone) {
+            s_logger.debug("Storage " + destDataStoreId + " can support cloning using a cached template and compute side is OK with volume cloning.");
 
             TemplateInfo templateOnPrimary = destPrimaryDataStore.getTemplate(srcTemplateInfo.getId());
 
@@ -1094,7 +1094,11 @@ public class VolumeServiceImpl implements VolumeService {
         return future;
     }
 
-    private boolean computeZoneSupportsResign(long zoneId, HypervisorType hypervisorType) {
+    private boolean computeSupportsVolumeClone(long zoneId, HypervisorType hypervisorType) {
+        if (HypervisorType.KVM.equals(hypervisorType)) {
+            return true;
+        }
+
         return getHost(zoneId, hypervisorType, true) != null;
     }
 

--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/lifecycle/SolidFirePrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/lifecycle/SolidFirePrimaryDataStoreLifeCycle.java
@@ -30,6 +30,7 @@ import org.apache.log4j.Logger;
 import org.apache.cloudstack.engine.subsystem.api.storage.ClusterScope;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.HostScope;
+import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreLifeCycle;
 import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreParameters;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
@@ -41,7 +42,10 @@ import org.apache.cloudstack.storage.volume.datastore.PrimaryDataStoreHelper;
 
 import com.cloud.agent.api.StoragePoolInfo;
 import com.cloud.capacity.CapacityManager;
+import com.cloud.dc.ClusterVO;
+import com.cloud.dc.dao.ClusterDao;
 import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.resource.ResourceManager;
@@ -57,10 +61,13 @@ import com.cloud.storage.StoragePoolAutomation;
 import com.cloud.storage.VMTemplateStoragePoolVO;
 import com.cloud.utils.exception.CloudRuntimeException;
 
+import com.google.common.base.Preconditions;
+
 public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeCycle {
     private static final Logger s_logger = Logger.getLogger(SolidFirePrimaryDataStoreLifeCycle.class);
 
     @Inject private CapacityManager _capacityMgr;
+    @Inject private ClusterDao _clusterDao;
     @Inject private DataCenterDao _zoneDao;
     @Inject private PrimaryDataStoreDao _storagePoolDao;
     @Inject private PrimaryDataStoreHelper _dataStoreHelper;
@@ -77,6 +84,8 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
     public DataStore initialize(Map<String, Object> dsInfos) {
         String url = (String)dsInfos.get("url");
         Long zoneId = (Long)dsInfos.get("zoneId");
+        Long podId = (Long)dsInfos.get("podId");
+        Long clusterId = (Long)dsInfos.get("clusterId");
         String storagePoolName = (String)dsInfos.get("name");
         String providerName = (String)dsInfos.get("providerName");
         Long capacityBytes = (Long)dsInfos.get("capacityBytes");
@@ -84,6 +93,14 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
         String tags = (String)dsInfos.get("tags");
         @SuppressWarnings("unchecked")
         Map<String, String> details = (Map<String, String>)dsInfos.get("details");
+
+        if (podId != null && clusterId == null) {
+            throw new CloudRuntimeException("If the Pod ID is specified, the Cluster ID must also be specified.");
+        }
+
+        if (podId == null && clusterId != null) {
+            throw new CloudRuntimeException("If the Pod ID is not specified, the Cluster ID must also not be specified.");
+        }
 
         String storageVip = SolidFireUtil.getStorageVip(url);
         int storagePort = SolidFireUtil.getStoragePort(url);
@@ -104,13 +121,26 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
         parameters.setType(StoragePoolType.Iscsi);
         parameters.setUuid(UUID.randomUUID().toString());
         parameters.setZoneId(zoneId);
+        parameters.setPodId(podId);
+        parameters.setClusterId(clusterId);
         parameters.setName(storagePoolName);
         parameters.setProviderName(providerName);
         parameters.setManaged(true);
         parameters.setCapacityBytes(capacityBytes);
         parameters.setUsedBytes(0);
         parameters.setCapacityIops(capacityIops);
-        parameters.setHypervisorType(HypervisorType.Any);
+
+        if (clusterId != null) {
+            ClusterVO clusterVO = _clusterDao.findById(clusterId);
+
+            Preconditions.checkNotNull(clusterVO, "Unable to locate the specified cluster");
+
+            parameters.setHypervisorType(clusterVO.getHypervisorType());
+        }
+        else {
+            parameters.setHypervisorType(HypervisorType.Any);
+        }
+
         parameters.setTags(tags);
         parameters.setDetails(details);
 
@@ -166,9 +196,24 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
                           ". Exception: " + ex);
         }
 
+        if (lClusterDefaultMinIops < SolidFireUtil.MIN_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MIN_IOPS + "' must be greater than or equal to " +
+                SolidFireUtil.MIN_IOPS_PER_VOLUME + ".");
+        }
+
+        if (lClusterDefaultMinIops > SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MIN_IOPS + "' must be less than or equal to " +
+                SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME + ".");
+        }
+
         if (lClusterDefaultMinIops > lClusterDefaultMaxIops) {
             throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MIN_IOPS + "' must be less than or equal to the parameter '" +
                 SolidFireUtil.CLUSTER_DEFAULT_MAX_IOPS + "'.");
+        }
+
+        if (lClusterDefaultMaxIops > SolidFireUtil.MAX_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MAX_IOPS + "' must be less than or equal to " +
+                SolidFireUtil.MAX_IOPS_PER_VOLUME + ".");
         }
 
         if (Float.compare(fClusterDefaultBurstIopsPercentOfMaxIops, 1.0f) < 0) {
@@ -186,23 +231,35 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
     // do not implement this method for SolidFire's plug-in
     @Override
     public boolean attachHost(DataStore store, HostScope scope, StoragePoolInfo existingInfo) {
-        return true; // should be ignored for zone-wide-only plug-ins like SolidFire's
+        return true;
     }
 
-    // do not implement this method for SolidFire's plug-in
     @Override
-    public boolean attachCluster(DataStore store, ClusterScope scope) {
-        return true; // should be ignored for zone-wide-only plug-ins like SolidFire's
+    public boolean attachCluster(DataStore dataStore, ClusterScope scope) {
+        PrimaryDataStoreInfo primarystore = (PrimaryDataStoreInfo)dataStore;
+
+        List<HostVO> hosts =
+                _resourceMgr.listAllUpAndEnabledHosts(Host.Type.Routing, primarystore.getClusterId(), primarystore.getPodId(), primarystore.getDataCenterId());
+
+        for (HostVO host : hosts) {
+            try {
+                _storageMgr.connectHostToSharedPool(host.getId(), dataStore.getId());
+            } catch (Exception e) {
+                s_logger.warn("Unable to establish a connection between " + host + " and " + dataStore, e);
+            }
+        }
+
+        _dataStoreHelper.attachCluster(dataStore);
+
+        return true;
     }
 
     @Override
     public boolean attachZone(DataStore dataStore, ZoneScope scope, HypervisorType hypervisorType) {
-        _dataStoreHelper.attachZone(dataStore);
-
         List<HostVO> xenServerHosts = _resourceMgr.listAllUpAndEnabledHostsInOneZoneByHypervisor(HypervisorType.XenServer, scope.getScopeId());
         List<HostVO> vmWareServerHosts = _resourceMgr.listAllUpAndEnabledHostsInOneZoneByHypervisor(HypervisorType.VMware, scope.getScopeId());
         List<HostVO> kvmHosts = _resourceMgr.listAllUpAndEnabledHostsInOneZoneByHypervisor(HypervisorType.KVM, scope.getScopeId());
-        List<HostVO> hosts = new ArrayList<HostVO>();
+        List<HostVO> hosts = new ArrayList<>();
 
         hosts.addAll(xenServerHosts);
         hosts.addAll(vmWareServerHosts);
@@ -215,6 +272,8 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
                 s_logger.warn("Unable to establish a connection between " + host + " and " + dataStore, e);
             }
         }
+
+        _dataStoreHelper.attachZone(dataStore);
 
         return true;
     }

--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/lifecycle/SolidFireSharedPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/lifecycle/SolidFireSharedPrimaryDataStoreLifeCycle.java
@@ -168,6 +168,10 @@ public class SolidFireSharedPrimaryDataStoreLifeCycle implements PrimaryDataStor
         details.put(SolidFireUtil.CLUSTER_ADMIN_USERNAME, clusterAdminUsername);
         details.put(SolidFireUtil.CLUSTER_ADMIN_PASSWORD, clusterAdminPassword);
 
+        if (capacityBytes < SolidFireUtil.MIN_VOLUME_SIZE) {
+            capacityBytes = SolidFireUtil.MIN_VOLUME_SIZE;
+        }
+
         long lMinIops = 100;
         long lMaxIops = 15000;
         long lBurstIops = 15000;
@@ -214,8 +218,16 @@ public class SolidFireSharedPrimaryDataStoreLifeCycle implements PrimaryDataStor
             throw new CloudRuntimeException("The parameter '" + CAPACITY_IOPS + "' must be equal to the parameter '" + SolidFireUtil.MIN_IOPS + "'.");
         }
 
-        if (lMinIops > SolidFireUtil.MAX_IOPS_PER_VOLUME || lMaxIops > SolidFireUtil.MAX_IOPS_PER_VOLUME || lBurstIops > SolidFireUtil.MAX_IOPS_PER_VOLUME) {
-            throw new CloudRuntimeException("This volume cannot exceed " + NumberFormat.getInstance().format(SolidFireUtil.MAX_IOPS_PER_VOLUME) + " IOPS.");
+        if (lMinIops > SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("This volume's Min IOPS cannot exceed " + NumberFormat.getInstance().format(SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME) + " IOPS.");
+        }
+
+        if (lMaxIops > SolidFireUtil.MAX_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("This volume's Max IOPS cannot exceed " + NumberFormat.getInstance().format(SolidFireUtil.MAX_IOPS_PER_VOLUME) + " IOPS.");
+        }
+
+        if (lBurstIops > SolidFireUtil.MAX_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("This volume's Burst IOPS cannot exceed " + NumberFormat.getInstance().format(SolidFireUtil.MAX_IOPS_PER_VOLUME) + " IOPS.");
         }
 
         details.put(SolidFireUtil.MIN_IOPS, String.valueOf(lMinIops));
@@ -671,8 +683,8 @@ public class SolidFireSharedPrimaryDataStoreLifeCycle implements PrimaryDataStor
         long burstIops = currentBurstIops;
 
         if (capacityIops != null) {
-            if (capacityIops > SolidFireUtil.MAX_IOPS_PER_VOLUME) {
-                throw new CloudRuntimeException("This volume cannot exceed " + NumberFormat.getInstance().format(SolidFireUtil.MAX_IOPS_PER_VOLUME) + " IOPS.");
+            if (capacityIops > SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME) {
+                throw new CloudRuntimeException("This volume cannot exceed " + NumberFormat.getInstance().format(SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME) + " IOPS.");
             }
 
             float maxPercentOfMin = currentMaxIops / (float)currentMinIops;

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1218,16 +1218,29 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
                     if (volClusterId != null) {
                         if (!host.getClusterId().equals(volClusterId) || usesLocal) {
-                            if (hasSuitablePoolsForVolume(volume, host, vmProfile)) {
-                                requiresStorageMotion.put(host, true);
-                            } else {
+                            if (storagePool.isManaged()) {
+                                // At the time being, we do not support storage migration of a volume from managed storage unless the managed storage
+                                // is at the zone level and the source and target storage pool is the same.
+                                // If the source and target storage pool is the same and it is managed, then we still have to perform a storage migration
+                                // because we need to create a new target volume and copy the contents of the source volume into it before deleting the
+                                // source volume.
                                 iterator.remove();
+                            }
+                            else {
+                                if (hasSuitablePoolsForVolume(volume, host, vmProfile)) {
+                                    requiresStorageMotion.put(host, true);
+                                } else {
+                                    iterator.remove();
+                                }
                             }
                         }
                     }
                     else {
                         if (storagePool.isManaged()) {
                             if (srcHost.getClusterId() != host.getClusterId()) {
+                                // If the volume's storage pool is managed and at the zone level, then we still have to perform a storage migration
+                                // because we need to create a new target volume and copy the contents of the source volume into it before deleting
+                                // the source volume.
                                 requiresStorageMotion.put(host, true);
                             }
                         }

--- a/server/src/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/com/cloud/storage/StorageManagerImpl.java
@@ -1215,41 +1215,54 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         }
     }
 
+    /**
+     * This method only applies for managed storage.
+     *
+     * For XenServer and vSphere, see if we need to remove an SR or a datastore, then remove the underlying volume
+     * from any applicable access control list (before other code attempts to delete the volume that supports it).
+     *
+     * For KVM, just tell the underlying storage plug-in to remove the volume from any applicable access control list
+     * (before other code attempts to delete the volume that supports it).
+     */
     private void handleManagedStorage(Volume volume) {
         Long instanceId = volume.getInstanceId();
 
-        // The idea of this "if" statement is to see if we need to remove an SR/datastore before
-        // deleting the volume that supports it on a SAN. This only applies for managed storage.
         if (instanceId != null) {
             StoragePoolVO storagePool = _storagePoolDao.findById(volume.getPoolId());
 
             if (storagePool != null && storagePool.isManaged()) {
-                DataTO volTO = volFactory.getVolume(volume.getId()).getTO();
-                DiskTO disk = new DiskTO(volTO, volume.getDeviceId(), volume.getPath(), volume.getVolumeType());
-
-                DettachCommand cmd = new DettachCommand(disk, null);
-
-                cmd.setManaged(true);
-
-                cmd.setStorageHost(storagePool.getHostAddress());
-                cmd.setStoragePort(storagePool.getPort());
-
-                cmd.set_iScsiName(volume.get_iScsiName());
-
                 VMInstanceVO vmInstanceVO = _vmInstanceDao.findById(instanceId);
 
                 Long lastHostId = vmInstanceVO.getLastHostId();
 
                 if (lastHostId != null) {
-                    Answer answer = _agentMgr.easySend(lastHostId, cmd);
+                    HostVO host = _hostDao.findById(lastHostId);
+                    ClusterVO cluster = _clusterDao.findById(host.getClusterId());
+                    VolumeInfo volumeInfo = volFactory.getVolume(volume.getId());
 
-                    if (answer != null && answer.getResult()) {
-                        VolumeInfo volumeInfo = volFactory.getVolume(volume.getId());
-                        HostVO host = _hostDao.findById(lastHostId);
-
+                    if (cluster.getHypervisorType() == HypervisorType.KVM) {
                         volService.revokeAccess(volumeInfo, host, volumeInfo.getDataStore());
-                    } else {
-                        s_logger.warn("Unable to remove host-side clustered file system for the following volume: " + volume.getUuid());
+                    }
+                    else {
+                        DataTO volTO = volFactory.getVolume(volume.getId()).getTO();
+                        DiskTO disk = new DiskTO(volTO, volume.getDeviceId(), volume.getPath(), volume.getVolumeType());
+
+                        DettachCommand cmd = new DettachCommand(disk, null);
+
+                        cmd.setManaged(true);
+
+                        cmd.setStorageHost(storagePool.getHostAddress());
+                        cmd.setStoragePort(storagePool.getPort());
+
+                        cmd.set_iScsiName(volume.get_iScsiName());
+
+                        Answer answer = _agentMgr.easySend(lastHostId, cmd);
+
+                        if (answer != null && answer.getResult()) {
+                            volService.revokeAccess(volumeInfo, host, volumeInfo.getDataStore());
+                        } else {
+                            s_logger.warn("Unable to remove host-side clustered file system for the following volume: " + volume.getUuid());
+                        }
                     }
                 }
             }

--- a/server/test/com/cloud/storage/snapshot/SnapshotManagerTest.java
+++ b/server/test/com/cloud/storage/snapshot/SnapshotManagerTest.java
@@ -16,6 +16,9 @@
 // under the License.
 package com.cloud.storage.snapshot;
 
+import java.util.List;
+import java.util.UUID;
+
 import com.cloud.configuration.Resource.ResourceType;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.ResourceAllocationException;
@@ -67,9 +70,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-
-import java.util.List;
-import java.util.UUID;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -123,7 +123,7 @@ public class SnapshotManagerTest {
     @Mock
     DataStore storeMock;
     @Mock
-    SnapshotDataStoreDao _snapshotStoreDao;
+    SnapshotDataStoreDao snapshotStoreDao;
     @Mock
     SnapshotDataStoreVO snapshotStoreMock;
 
@@ -147,7 +147,7 @@ public class SnapshotManagerTest {
         _snapshotMgr._storagePoolDao = _storagePoolDao;
         _snapshotMgr._resourceMgr = _resourceMgr;
         _snapshotMgr._vmSnapshotDao = _vmSnapshotDao;
-        _snapshotMgr._snapshotStoreDao = _snapshotStoreDao;
+        _snapshotMgr._snapshotStoreDao = snapshotStoreDao;
 
         when(_snapshotDao.findById(anyLong())).thenReturn(snapshotMock);
         when(snapshotMock.getVolumeId()).thenReturn(TEST_VOLUME_ID);
@@ -254,6 +254,7 @@ public class SnapshotManagerTest {
         when(snapshotMock.getState()).thenReturn(Snapshot.State.Destroyed);
         when(snapshotMock.getAccountId()).thenReturn(2L);
         when(snapshotMock.getDataCenterId()).thenReturn(2L);
+
         _snapshotMgr.deleteSnapshot(TEST_SNAPSHOT_ID);
     }
 
@@ -305,11 +306,11 @@ public class SnapshotManagerTest {
         when(_vmDao.findById(anyLong())).thenReturn(vmMock);
         when(vmMock.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
         when(_vmSnapshotDao.findById(anyLong())).thenReturn(vmSnapshotMock);
-        when(_snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(null);
+        when(snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(null);
         when(snapshotFactory.getSnapshot(anyLong(), Mockito.any(DataStore.class))).thenReturn(snapshotInfoMock);
         when(storeMock.create(snapshotInfoMock)).thenReturn(snapshotInfoMock);
-        when(_snapshotStoreDao.findBySnapshot(anyLong(), any(DataStoreRole.class))).thenReturn(snapshotStoreMock);
-        when(_snapshotStoreDao.update(anyLong(), any(SnapshotDataStoreVO.class))).thenReturn(true);
+        when(snapshotStoreDao.findBySnapshot(anyLong(), any(DataStoreRole.class))).thenReturn(snapshotStoreMock);
+        when(snapshotStoreDao.update(anyLong(), any(SnapshotDataStoreVO.class))).thenReturn(true);
         when(_snapshotDao.update(anyLong(), any(SnapshotVO.class))).thenReturn(true);
         when(vmMock.getAccountId()).thenReturn(2L);
         when(snapshotStrategy.backupSnapshot(any(SnapshotInfo.class))).thenReturn(snapshotInfoMock);;;
@@ -324,7 +325,7 @@ public class SnapshotManagerTest {
         when(_vmDao.findById(anyLong())).thenReturn(vmMock);
         when(vmMock.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
         when(_vmSnapshotDao.findById(anyLong())).thenReturn(vmSnapshotMock);
-        when(_snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(snapshotStoreMock);
+        when(snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(snapshotStoreMock);
         when(snapshotStoreMock.getInstallPath()).thenReturn("VM_SNAPSHOT_NAME");
         when(vmSnapshotMock.getName()).thenReturn("VM_SNAPSHOT_NAME");
         Snapshot snapshot = _snapshotMgr.backupSnapshotFromVmSnapshot(TEST_SNAPSHOT_ID, TEST_VM_ID, TEST_VOLUME_ID, TEST_VM_SNAPSHOT_ID);

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -987,6 +987,12 @@ class Volume:
             cmd.domainid = services["domainid"]
         return Volume(apiclient.createVolume(cmd).__dict__)
 
+    @classmethod
+    def revertToSnapshot(cls, apiclient, volumeSnapshotId):
+        cmd = revertSnapshot.revertSnapshotCmd()
+        cmd.id = volumeSnapshotId
+        return apiclient.revertSnapshot(cmd)
+
     def delete(self, apiclient):
         """Delete Volume"""
         cmd = deleteVolume.deleteVolumeCmd()

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -17378,6 +17378,10 @@
                                                     id: "gluster",
                                                     description: "Gluster"
                                                 });
+                                                items.push({
+                                                    id: "custom",
+                                                    description: "custom"
+                                                });
                                                 args.response.success({
                                                     data: items
                                                 });


### PR DESCRIPTION
This PR contains changes mainly related to enhancing managed storage on KVM. I recently added these features to a custom build of 4.5 for a prospect (and, here, I'd like to place these changes in master):

Allow zone-wide primary storage based on a custom plug-in to be added via the GUI in a KVM-only environment.

Support for root disks on managed storage with KVM

Template caching with managed storage and KVM

Support for volume snapshots with managed storage on KVM

Added the ability to revert a volume to a snapshot on KVM

Updated some integration tests

Enforce that a SolidFire volume’s Min IOPS cannot exceed 15,000 and its Max and Burst IOPS cannot exceed 100,000.

A SolidFire volume must be at least one GB.

The storage driver should not remove the row from the cloud.template_spool_ref table.

Enable cluster-scoped managed storage

Only volumes from zone-wide managed storage can be storage motioned from a host in one cluster to a host in another cluster (cannot do so at the time being with volumes from cluster-scoped managed storage).

Updates for SAN-assisted snapshots

JIRA Ticket:
https://issues.apache.org/jira/browse/CLOUDSTACK-9620