### PR TITLE
CLOUDSTACK-9583: VR: In CsDhcp.py preseed both hostaname and localhost to resolve to 127.0.0.1

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -106,12 +106,10 @@ class CsDhcp(CsDataBag):
             return
 
     def preseed(self):
-        self.add_host("127.0.0.1", "localhost")
+        self.add_host("127.0.0.1", "localhost %s" % CsHelper.get_hostname())
         self.add_host("::1", "localhost ip6-localhost ip6-loopback")
         self.add_host("ff02::1", "ip6-allnodes")
         self.add_host("ff02::2", "ip6-allrouters")
-        if self.config.is_vpc():
-            self.add_host("127.0.0.1", CsHelper.get_hostname())
         if self.config.is_router():
             self.add_host(self.config.address().get_guest_ip(), "%s data-server" % CsHelper.get_hostname())
 


### PR DESCRIPTION

ensuring for both vpc and non vpc vr, both localhost and hostname is resolved to 127.0.0.1