### PR TITLE
systemd: Fix semicolon missing in b75e69

### DIFF
--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -27,7 +27,7 @@ EnvironmentFile=-/etc/default/cloudstack-agent
 ExecStart=/bin/sh -ec '\
     export ACP=`ls /usr/share/cloudstack-agent/lib/*.jar /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null|tr "\\n" ":"`; \
     export CLASSPATH="$ACP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"; \
-    mkdir -m 0755 -p ${JAVA_TMPDIR} \
+    mkdir -m 0755 -p ${JAVA_TMPDIR}; \
     ${JAVA} -Djava.io.tmpdir="${JAVA_TMPDIR}" -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
While forward merging PR #1728, and resolving merge issues a semi-colon was
not added causing cloudstack-agent to fail to start. This fixes the
issue of running agent on centos7.

Since, this is failing testing against centos7/kvm and an urgent merge is necessary. This affects both 4.9 and master branches.