### PR TITLE
CLOUDSTACK-9585 UI doesn't give an option to select the xentools version

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -2263,7 +2263,7 @@
                             if (isAdmin()) {
                                 hiddenFields = [];
                             } else {
-                                hiddenFields = ["hypervisor", 'xenserverToolsVersion61plus'];
+                                hiddenFields = ["hypervisor"];
                             }
 
                             if ('instances' in args.context && args.context.instances[0].hypervisor != 'XenServer') {
@@ -2381,12 +2381,7 @@
                             xenserverToolsVersion61plus: {
                                 label: 'label.Xenserver.Tools.Version61plus',
                                 isBoolean: true,
-                                isEditable: function () {
-                                    if (isAdmin())
-                                        return true;
-                                    else
-                                        return false;
-                                },
+                                isEditable: true,
                                 converter: cloudStack.converters.toBooleanText
                             },
 

--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -932,7 +932,6 @@ cloudStack.preFilter = {
                 args.$form.find('.form-item[rel=isPublic]').hide();
             }
             args.$form.find('.form-item[rel=isFeatured]').hide();
-            args.$form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
         }
     },
     addLoadBalancerDevice: function(args) { //add netscaler device OR add F5 device

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -1289,9 +1289,8 @@
                                     desc: '',
                                     preFilter: function(args) {
                                         if (args.context.volumes[0].hypervisor == "XenServer") {
-                                            if (isAdmin()) {
-                                                args.$form.find('.form-item[rel=xenserverToolsVersion61plus]').css('display', 'inline-block');
-                                            }
+                                            args.$form.find('.form-item[rel=xenserverToolsVersion61plus]').css('display', 'inline-block');
+
                                         }
                                     },
                                     fields: {

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -233,12 +233,11 @@
                                                     $form.find('.form-item[rel=keyboardType]').hide();
                                                     $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
                                                     $form.find('.form-item[rel=rootDiskControllerTypeKVM]').css('display', 'inline-block');
-
+                                                    $form.find('.form-item[rel=xenserverToolsVersion61plus]').css('display', 'inline-block');
                                                 } else {
                                                     $form.find('.form-item[rel=rootDiskControllerType]').hide();
                                                     $form.find('.form-item[rel=nicAdapterType]').hide();
                                                     $form.find('.form-item[rel=keyboardType]').hide();
-
                                                     $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
                                                     $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
                                                 }
@@ -252,7 +251,7 @@
                                         label: 'label.xenserver.tools.version.61.plus',
                                         isBoolean: true,
                                         isChecked: function (args) {
-                                            var b = false;
+                                             var b = true;
                                             if (isAdmin()) {
                                                 $.ajax({
                                                     url: createURL('listConfigurations'),
@@ -261,8 +260,8 @@
                                                     },
                                                     async: false,
                                                     success: function (json) {
-                                                        if (json.listconfigurationsresponse.configuration != null && json.listconfigurationsresponse.configuration[0].value == 'xenserver61') {
-                                                            b = true;
+                                                        if (json.listconfigurationsresponse.configuration != null && json.listconfigurationsresponse.configuration[0].value != 'xenserver61') {
+                                                            b = false;
                                                         }
                                                     }
                                                 });


### PR DESCRIPTION
UI doesn't give an option to select the xentools version while registering template for any user other than ROOT admin. Templates registered by other users are marked as 'xenserver56' and results in unsusable VMs due to the device_id:002 issue with windows if the template is having xentools version higher than 6.1 .
Repro Steps
Select register template as any other user than ROOT domain admin and UI doesn't give an option to select the xentools version.