### PR TITLE
CLOUDSTACK-9583: VR: In CsDhcp.py preseed both hostaname and localhost to resolve to 127.0.0.1

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -44,7 +44,7 @@ class CsDhcp(CsDataBag):
                 continue
             self.add(self.dbag[item])
         self.write_hosts()
-        
+
         if self.cloud.is_changed():
             self.delete_leases()
 
@@ -103,12 +103,10 @@ class CsDhcp(CsDataBag):
             return
 
     def preseed(self):
-        self.add_host("127.0.0.1", "localhost")
+        self.add_host("127.0.0.1", "localhost %s" % CsHelper.get_hostname())
         self.add_host("::1",     "localhost ip6-localhost ip6-loopback")
         self.add_host("ff02::1", "ip6-allnodes")
         self.add_host("ff02::2", "ip6-allrouters")
-        if self.config.is_vpc():
-            self.add_host("127.0.0.1", CsHelper.get_hostname())
         if self.config.is_router():
             self.add_host(self.config.address().get_guest_ip(), "%s data-server" % CsHelper.get_hostname())
 


### PR DESCRIPTION


The VR executes a ip route flush command as part of configurations. This command performs a
DNS lookup on the VR hostname. Since the VR does not have a DNS entry, the ip command would
wait 5 seconds before timing out and executing the flush operation. This fix adds the VR
hostname to /etc/hosts mapped to 127.0.0.1 to answer the DNS lookup – reducing the
execution time.