### PR TITLE
CLOUDSTACK-9589 vmName entries from host_details table for the VM's w…

### DIFF
--- a/setup/db/db/schema-4930to41000-cleanup.sql
+++ b/setup/db/db/schema-4930to41000-cleanup.sql
@@ -20,3 +20,5 @@
 --;
 
 DELETE FROM `cloud`.`configuration` WHERE name='consoleproxy.loadscan.interval';
+
+DELETE FROM `cloud`.`host_details` where name = 'vmName' and  value in (select name from `cloud`.`vm_instance`  where state = 'Expunging' and hypervisor_type ='BareMetal');


### PR DESCRIPTION
CLOUDSTACK-9589 vmName entries from host_details table for the VM's whose state is Expunging should be deleted during upgrade from older versions

Having vmName entries for VMs in 'expunging' states would cause with deploying VMs with matching host tags fail. So removing them during upgrade