### PR TITLE
CLOUDSTACK-9592 Empty responses from site to site connection status a…

### DIFF
--- a/core/src/com/cloud/agent/api/CheckS2SVpnConnectionsAnswer.java
+++ b/core/src/com/cloud/agent/api/CheckS2SVpnConnectionsAnswer.java
@@ -76,4 +76,14 @@ public class CheckS2SVpnConnectionsAnswer extends Answer {
         }
         return null;
     }
+
+    public boolean isIPPresent(String ip) {
+        if (this.getResult()) {
+            Boolean status = ipToConnected.get(ip);
+            if (status != null) {
+                return true;
+            }
+        }
+        return  false;
+    }
 }

--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -899,18 +899,22 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                         }
                         final Site2SiteVpnConnection.State oldState = conn.getState();
                         final Site2SiteCustomerGateway gw = _s2sCustomerGatewayDao.findById(conn.getCustomerGatewayId());
-                        if (answer.isConnected(gw.getGatewayIp())) {
-                            conn.setState(Site2SiteVpnConnection.State.Connected);
-                        } else {
-                            conn.setState(Site2SiteVpnConnection.State.Disconnected);
-                        }
-                        _s2sVpnConnectionDao.persist(conn);
-                        if (oldState != conn.getState()) {
-                            final String title = "Site-to-site Vpn Connection to " + gw.getName() + " just switch from " + oldState + " to " + conn.getState();
-                            final String context = "Site-to-site Vpn Connection to " + gw.getName() + " on router " + router.getHostName() + "(id: " + router.getId() + ") "
-                                    + " just switch from " + oldState + " to " + conn.getState();
-                            s_logger.info(context);
-                            _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_DOMAIN_ROUTER, router.getDataCenterId(), router.getPodIdToDeployIn(), title, context);
+
+                        if (answer.isIPPresent(gw.getGatewayIp())) {
+                            if (answer.isConnected(gw.getGatewayIp())) {
+                                conn.setState(Site2SiteVpnConnection.State.Connected);
+                            } else {
+                                conn.setState(Site2SiteVpnConnection.State.Disconnected);
+                            }
+                            _s2sVpnConnectionDao.persist(conn);
+                            if (oldState != conn.getState()) {
+                                final String title = "Site-to-site Vpn Connection to " + gw.getName() + " just switched from " + oldState + " to " + conn.getState();
+                                final String context =
+                                        "Site-to-site Vpn Connection to " + gw.getName() + " on router " + router.getHostName() + "(id: " + router.getId() + ") " +
+                                                " just switched from " + oldState + " to " + conn.getState();
+                                s_logger.info(context);
+                                _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_DOMAIN_ROUTER, router.getDataCenterId(), router.getPodIdToDeployIn(), title, context);
+                            }
                         }
                     } finally {
                         _s2sVpnConnectionDao.releaseFromLockTable(lock.getId());


### PR DESCRIPTION
CLOUDSTACK-9592 Empty responses from site to site connection status are not handled propertly

vpn connection status gives responses like the below sometimes
Processing: { Ans: , MgmtId: 7203499016310, via: 1(10.147.28.37), Ver: v1, Flags: 110, [{"com.cloud.agent.api.CheckS2SVpnConnectionsAnswer":{"ipToConnected":{},"ipToDetail":{},"details":"","result":true,"wait":0}}] }
2016-09-27 08:52:19,211 DEBUG [c.c.a.t.Request] (RouterStatusMonitor-1:ctx-c20f391d) (logid:c217239d) Seq 1-2315413158421863581: Received: { Ans: , MgmtId: 7203499016310, via: 1(10.147.28.37), Ver: v1, Flags: 110,
{ CheckS2SVpnConnectionsAnswer }
In the above scenario, the bug in the processing of this response assumes the connection is disconnected even though it is not disconnected and there would be two consecutive alerts in logs as well as emails even though there is not actual disconnection and reconnection
Site-to-site Vpn Connection XYZ-VPN on router r-197-VM(id: 197) just switch from Disconnected to Connected
Site-to-site Vpn Connection to D1 site to site VPN on router r-372-VM(id: 372) just switch from Connected to Disconnected
