### PR TITLE
CLOUDSTACK-9628: Fix Template Size in Swift as Secondary Storage

### DIFF
--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -1585,19 +1585,28 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                         String line = null;
                         String uniqName = null;
                         Long size = null;
+                        Long physicalSize = null;
                         String name = null;
                         while ((line = brf.readLine()) != null) {
                             if (line.startsWith("uniquename=")) {
                                 uniqName = line.split("=")[1];
                             } else if (line.startsWith("size=")) {
+                                physicalSize = Long.parseLong(line.split("=")[1]);
+                            } else if (line.startsWith("virtualsize=")){
                                 size = Long.parseLong(line.split("=")[1]);
                             } else if (line.startsWith("filename=")) {
                                 name = line.split("=")[1];
                             }
                         }
+
+                        //fallback
+                        if (size == null) {
+                            size = physicalSize;
+                        }
+
                         tempFile.delete();
                         if (uniqName != null) {
-                            TemplateProp prop = new TemplateProp(uniqName, container + File.separator + name, size, size, true, false);
+                            TemplateProp prop = new TemplateProp(uniqName, container + File.separator + name, size, physicalSize, true, false);
                             tmpltInfos.put(uniqName, prop);
                         }
                     } catch (IOException ex)
@@ -1615,7 +1624,6 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             }
         }
         return tmpltInfos;
-
     }
 
     Map<String, TemplateProp> s3ListTemplate(S3TO s3) {


### PR DESCRIPTION
Cloudstack incorrectly uses the physical size as the size of the
template. Ideally, the size should refelct the virtual size. This
PR fixes that issue.