### PR TITLE
CLOUDSTACK-9611: Dedicating a Guest VLAN range to Project does not work.

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/network/DedicateGuestVlanRangeCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/network/DedicateGuestVlanRangeCmd.java
@@ -50,17 +50,13 @@ public class DedicateGuestVlanRangeCmd extends BaseCmd {
     @Parameter(name = ApiConstants.VLAN_RANGE, type = CommandType.STRING, required = true, description = "guest vlan range to be dedicated")
     private String vlan;
 
-    @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, required = true, description = "account who will own the VLAN")
+    @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, description = "account who will own the VLAN")
     private String accountName;
 
     @Parameter(name = ApiConstants.PROJECT_ID, type = CommandType.UUID, entityType = ProjectResponse.class, description = "project who will own the VLAN")
     private Long projectId;
 
-    @Parameter(name = ApiConstants.DOMAIN_ID,
-               type = CommandType.UUID,
-               entityType = DomainResponse.class,
-               required = true,
-               description = "domain ID of the account owning a VLAN")
+    @Parameter(name = ApiConstants.DOMAIN_ID, type = CommandType.UUID, entityType = DomainResponse.class, description = "domain ID of the account owning a VLAN")
     private Long domainId;
 
     @Parameter(name = ApiConstants.PHYSICAL_NETWORK_ID,


### PR DESCRIPTION
Description:
=========

Trying to dedicate a guest VLAN range to an account fails. Either API documentation is wrong or code path needs to be corrected. If we pass both account and projectId parameters to the dedicateGuestVlanRange (which are not mentioned as mutually exclusive in API description) the API layer throws error saying both are mutually exclusive.

Steps to Reproduce:
===============
Create an account. Create a project in that account.

Go to Admin account and change the view to the above project.

Navigate to Infrastructure -> Zone -> Physical Network -> Guest -> Dedicate Guest VLAN range.

Try to dedicate the guest VLAN range from the project view for the account associated with the project.

It fails with error saying "accountName and projectId are mutually exclusive".

![image](https://cloud.githubusercontent.com/assets/12583725/20559763/15fe55d8-b19c-11e6-9996-62602d269f10.png)

![image](https://cloud.githubusercontent.com/assets/12583725/20559765/1957af36-b19c-11e6-938f-e9c7c9eee987.png)

Expected:
=======
The VLAN range should get dedicated to the project account.

![image](https://cloud.githubusercontent.com/assets/12583725/20559787/33ef67b2-b19c-11e6-90fd-41c9c583efd9.png)

![image](https://cloud.githubusercontent.com/assets/12583725/20559789/376cae22-b19c-11e6-9755-ff1e7237fb21.png)

Resolution:
========
Changed the account field of API to optional.
Even if the account name is passed while adding from a particular project view, then it is ignored in API.

Notes:
=====
If we do the dedication from default view then it works fine as no projectId is associated over there.