### PR TITLE
CLOUDSTACK-9603: 'concurrent.snapshots.threshold.perhost' parameter should not accept String.

### DIFF
--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -749,6 +749,9 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             } else if (type.equals(Float.class)) {
                 errMsg = "There was error in trying to parse value: " + value + ". Please enter a valid float value for parameter " + name;
                 Float.parseFloat(value);
+            } else if (type.equals(Long.class)) {
+                errMsg = "There was error in trying to parse value: " + value + ". Please enter a valid long value for parameter " + name;
+                Long.parseLong(value);
             }
         } catch (final Exception e) {
             // catching generic exception as some throws NullPointerException and some throws NumberFormatExcpeion

--- a/test/integration/component/test_concurrent_snapshots_limit.py
+++ b/test/integration/component/test_concurrent_snapshots_limit.py
@@ -297,3 +297,16 @@ class TestConcurrentSnapshotLimit(cloudstackTestCase):
                 more than concurrent.snapshots.threshold.perhost\
                 value successfully created")
         return
+
+    @attr(tags=["advanced", "basic"], required_hardware="false")
+    def test_03_concurrent_snapshot_global_value_assignment(self):
+        """ Test verifies that exception is raised if string value is assigned to
+             concurrent.snapshots.threshold.perhost parameter.
+        """
+        with self.assertRaises(Exception):
+           Configurations.update(
+             self.apiclient,
+             "concurrent.snapshots.threshold.perhost",
+             "String"
+           )
+        return


### PR DESCRIPTION
'concurrent.snapshots.threshold.perhost' is a  global and cluster level setting. It should accept only integer values but without this fix it is accepting string  as well.  For complete description please refer -> [CLOUDSTACK-9603](https://issues.apache.org/jira/browse/CLOUDSTACK-9603)