### PR TITLE
CLOUDSTACK-9613: Unable to set NAT rules on any interfaces except first interface of VM.

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -78,18 +78,13 @@
             });
 
         } else { //non-portable IP which has only one NIC
-            /*
-            var nic = $.grep(instance.nic, function(nic) {
-                return nic.networkid == network.id;
-            })[0];
-            */
 
             // Get NIC IPs
             $.ajax({
                 url: createURL('listNics'),
                 data: {
                     virtualmachineid: instance.id,
-                    nicId: instance.nic[0].id
+                    networkid: network.id
                 },
                 success: function(json) {
                     var nic = json.listnicsresponse.nic[0];


### PR DESCRIPTION
Description:
=========
VMs have multiple network interfaces.
It is not possible to set a NAT rule on any of the interfaces except the first interface of the VM from UI. Because the UI only lists the IPs of the first interface.

The rules can only be set on the "default" interface but even after setting the secondary as the default interface the outcome is still the same. Only the first interface is listed in the UI as available for setting NAT rules.

Steps to Reproduce:
===============
1. Create two networks.
2. Create a VM.
3. Attach both the networks to the VM.
4. Create NAT rules using both the networks.
5. Observe the add VM section while creating the rule.
6. The same IPs appear for both the case.

Please see the below snaps to observe the issue clearly.

VM NIC1
![image](https://cloud.githubusercontent.com/assets/12583725/20597703/4a1df876-b26b-11e6-9f49-5488f587315f.png)

VM NIC2
![image](https://cloud.githubusercontent.com/assets/12583725/20597724/64447ce8-b26b-11e6-8504-7c1e1723eeea.png)

Creating NAT rule from Network-1
![image](https://cloud.githubusercontent.com/assets/12583725/20597740/7a49b440-b26b-11e6-8127-948f547adb01.png)

Add VMs section
![image](https://cloud.githubusercontent.com/assets/12583725/20597766/94e1164a-b26b-11e6-95f0-cd9cd361ba4d.png)

Creating NAT rule from Network-2
![image](https://cloud.githubusercontent.com/assets/12583725/20597775/a11af656-b26b-11e6-93c5-0b55e434d788.png)

Add VMs section
![image](https://cloud.githubusercontent.com/assets/12583725/20597779/a6684992-b26b-11e6-9671-743870a096e6.png)

Expected:
========

Add VMs section from Network-1
![image](https://cloud.githubusercontent.com/assets/12583725/20597858/1c31d120-b26c-11e6-9d77-396177c66999.png)


Add VMs section from Network-2
![image](https://cloud.githubusercontent.com/assets/12583725/20597850/0dcc5a1a-b26c-11e6-9b42-67fc6a3e19c1.png)

Resolution:
========
Instead of always passing the id of the first nic, passing the id of
the nic which is on the same network as the IP address of which
we are enabling port-forwarding/load-balancing.