### PR TITLE
Fix the KVM hypervisor's handling of not-really-SCSI devices.

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
@@ -349,8 +349,8 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
         String search4 = "-lun-";
 
         if (!localPath.contains(search3)) {
-            // this volume doesn't below to this adaptor, so just return true
-            return true;
+            // this volume doesn't below to this adaptor, so just return false
+            return false;
         }
 
         int index = localPath.indexOf(search2);


### PR DESCRIPTION
Hi,

Thanks for developing and maintaining CloudStack!

What do you think about the attached trivial patch that lets the KVM storage pool use more than one type of storage adaptor?  If a disk is handled by another adaptor and a request to disconnect it comes in, the KVM storage pool might hand it off to the iSCSI storage adaptor first.  With the current iSCSI adaptor code, it will recognize that the disk is not one of its own and return "true", signalling to the storage pool that the disk has been successfully disconnected.  The patch makes it return "false" so that the storage pool will pass the request to the *next* storage adaptor in the pool which might very well actually handle it.

Thanks in advance for your time and attention, and keep up the great work!

Best regards,
Peter
