### PR TITLE
CLOUDSTACK-9612: Fixed issue in restarting redundant network with cle…

### DIFF
--- a/engine/schema/src/com/cloud/network/dao/NetworkVO.java
+++ b/engine/schema/src/com/cloud/network/dao/NetworkVO.java
@@ -104,7 +104,7 @@ public class NetworkVO implements Network {
     State state;
 
     @Column(name = "redundant")
-    boolean isRedundant;
+    boolean redundant;
 
     @Column(name = "dns1")
     String dns1;
@@ -205,7 +205,7 @@ public class NetworkVO implements Network {
         this.networkOfferingId = networkOfferingId;
         this.dataCenterId = dataCenterId;
         this.physicalNetworkId = physicalNetworkId;
-        this.isRedundant = isRedundant;
+        this.redundant = isRedundant;
         if (state == null) {
             this.state = State.Allocated;
         } else {
@@ -301,7 +301,7 @@ public class NetworkVO implements Network {
 
     @Override
     public boolean isRedundant() {
-        return this.isRedundant;
+        return this.redundant;
     }
 
     // don't use this directly when possible, use Network state machine instead
@@ -632,7 +632,7 @@ public class NetworkVO implements Network {
     }
 
     public void setIsReduntant(boolean reduntant) {
-        this.isRedundant = reduntant;
+        this.redundant = reduntant;
     }
 
 }


### PR DESCRIPTION

Rvr Network which is updated from the isolated network is failed to restart with cleanup set.

This is because there is convention issue with the getter setter name. Please check the ticket for the error details.
 Corrected the column name string.

Testing steps:
1. Create an isolated network
2. Create RVR offering
3. Update isolated to RVR offering.
4. Network update should success.
