### PR TITLE
CLOUDSTACK-9416 : Enabling Static NAT on an associated Public IP to one of the NICs (networks) of a multi-NIC VM fails due to a wrong (default) Guest VM IP being selected in the GUI

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -89,7 +89,7 @@
                 url: createURL('listNics'),
                 data: {
                     virtualmachineid: instance.id,
-                    nicId: instance.nic[0].id
+                    networkId: network.id
                 },
                 success: function(json) {
                     var nic = json.listnicsresponse.nic[0];


### PR DESCRIPTION
Bug in ACS master GUI: Enabling Static NAT on an associated Public IP to one of the NICs (networks) of a multi-NIC VM fails due to a wrong (default) Guest VM IP being selected in the GUI.

ERROR:
INFO  [c.c.a.ApiServer](catalina-exec-7:ctx-83926837 ctx-fc7aa5ed) VM ip 10.10.2.163 address not belongs to the vm

ACS GUI before the bug fix:

![network1](https://cloud.githubusercontent.com/assets/3722369/16091177/cff63836-3332-11e6-8854-c7e8222a7c67.png)
![network2](https://cloud.githubusercontent.com/assets/3722369/16091186/d7118ba2-3332-11e6-9143-ae0a5cd96235.png)

As you can see in the above attached ACS GUI screen shots, same (default) guest VM IP is being selected in the ACS GUI for both the NICs (networks) of the multi-NIC VM while enabling Static NAT on the corresponding associated Public IPs. Thus, we hit this issue.

ACS GUI after this bug fix:

![fixed_network1](https://cloud.githubusercontent.com/assets/3722369/16091242/1c1b3252-3333-11e6-82e5-071bd05a7edb.png)
![fixed_network2](https://cloud.githubusercontent.com/assets/3722369/16091245/1fd52696-3333-11e6-8f96-3f9ca0019af6.png)

As you can see in the above attached ACS GUI screen shots, this bug fix resolves the above mentioned issue.
