### PR TITLE
CLOUDSTACK-9618: Load Balancer configuration page does not have "Source" method in the drop down list.

### DIFF
--- a/plugins/network-elements/netscaler/src/com/cloud/network/element/NetscalerElement.java
+++ b/plugins/network-elements/netscaler/src/com/cloud/network/element/NetscalerElement.java
@@ -232,6 +232,10 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
 
     @Override
     public boolean validateLBRule(Network network, LoadBalancingRule rule) {
+        if (canHandle(network, Service.Lb)) {
+            String algo = rule.getAlgorithm();
+            return (algo.equals("roundrobin") || algo.equals("leastconn") || algo.equals("source"));
+        }
         return true;
     }
 
@@ -260,7 +264,7 @@ public class NetscalerElement extends ExternalLoadBalancerDeviceManagerImpl impl
         Map<Capability, String> lbCapabilities = new HashMap<Capability, String>();
 
         // Specifies that the RoundRobin and Leastconn algorithms are supported for load balancing rules
-        lbCapabilities.put(Capability.SupportedLBAlgorithms, "roundrobin,leastconn");
+        lbCapabilities.put(Capability.SupportedLBAlgorithms, "roundrobin, leastconn, source");
 
         // specifies that Netscaler network element can provided both shared and isolation modes
         lbCapabilities.put(Capability.SupportedLBIsolation, "dedicated, shared");


### PR DESCRIPTION
If we create an isolated network with NetScaler published service offering for Load balancing service, then the load balancing configuration UI does not show "Source" as one of the supported LB methods in the drop down list. It only shows "Round-Robin" and "LeastConnection" methods in the list. However, It successfully creates LB rule with "Source" as the LB method using API.