### PR TITLE
CLOUDSTACK-9622 Localisation for 'Project' label on the top of Web UI

### DIFF
--- a/ui/scripts/ui-custom/projectSelect.js
+++ b/ui/scripts/ui-custom/projectSelect.js
@@ -22,7 +22,7 @@
         var $projectSelect = $('<select>').append(
             $('<option>').attr('value', '-1').html(_l('Default view'))
         );
-        var $label = $('<label>').html('Project:');
+        var $label = $('<label>').html(_l('label.project'));
 
         // Get project list
         cloudStack.projects.dataProvider({


### PR DESCRIPTION
[Base 4.9, forward to 4.10 too]

The label Project isn't localized.

Sample with chinese UI:
Current:
![selection_457](https://cloud.githubusercontent.com/assets/3995882/20648086/56e54cfe-b495-11e6-9e78-3590a24302d1.png)

With this PR:
![selection_456](https://cloud.githubusercontent.com/assets/3995882/20648088/6090960a-b495-11e6-9dc0-eb24e16dcdc6.png)

cc @rhtyd 