### PR TITLE
CLOUDSTACK-9625:Unable to scale VM from any offering to a dynamic offering

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
@@ -18,6 +18,9 @@ package org.apache.cloudstack.api.command.user.vm;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
 
 import org.apache.log4j.Logger;
 
@@ -78,9 +81,24 @@ public class ScaleVMCmd extends BaseAsyncCmd {
         return serviceOfferingId;
     }
 
+    //instead of reading a map directly we are using collections.
+    //it is because details.values() cannot be cast to a map.
+    //it gives a exception
     public Map<String, String> getDetails() {
-        return details;
+        Map<String, String> customparameterMap = new HashMap<String, String>();
+        if (details != null && details.size() != 0) {
+            Collection parameterCollection = details.values();
+            Iterator iter = parameterCollection.iterator();
+            while (iter.hasNext()) {
+                HashMap<String, String> value = (HashMap<String, String>)iter.next();
+                for (String key : value.keySet()) {
+                    customparameterMap.put(key, value.get(key));
+                }
+            }
+        }
+        return customparameterMap;
     }
+
 
     /////////////////////////////////////////////////////
     /////////////// API Implementation///////////////////

--- a/api/src/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
@@ -16,6 +16,9 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.vm;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
@@ -77,7 +80,18 @@ public class UpgradeVMCmd extends BaseCmd {
     }
 
     public Map<String, String> getDetails() {
-        return details;
+        Map<String, String> customparameterMap = new HashMap<String, String>();
+        if (details != null && details.size() != 0) {
+            Collection parameterCollection = details.values();
+            Iterator iter = parameterCollection.iterator();
+            while (iter.hasNext()) {
+                HashMap<String, String> value = (HashMap<String, String>)iter.next();
+                for (String key : value.keySet()) {
+                    customparameterMap.put(key, value.get(key));
+                }
+            }
+        }
+        return customparameterMap;
     }
 
     /////////////////////////////////////////////////////


### PR DESCRIPTION
1.create a custom service offering.
2.stop the running vm
3.scale the vm offering from small to custom offering by providing (customcpunumber=4,customcpuspeed=512,custommemory=256)

tried with other values as well.

actual result:
scaleVirtualMachine fails with error and its says enter valid value cpu core and value should be in between 1 to 2147483647 even though we enter cpucore as 4

test/integration/component/test_dynamic_compute_offering.py  also faling.

Test scale running VM from dynamic offering to dynamic offering ... === TestName: test_change_so_running_vm_dynamic_to_dynamic_1_ADMIN_ACCOUNT | Status : FAILED ===
FAIL
Test scale running VM from dynamic offering to dynamic offering ... === TestName: test_change_so_running_vm_dynamic_to_dynamic_2_USER_ACCOUNT | Status : FAILED ===
FAIL
Test scale running VM from dynamic offering to static offering ... === TestName: test_change_so_running_vm_dynamic_to_static_1_ADMIN_ACCOUNT | Status : FAILED ===
FAIL
Test scale running VM from dynamic offering to static offering ... === TestName: test_change_so_running_vm_dynamic_to_static_2_USER_ACCOUNT | Status : FAILED ===
FAIL
Test scale running VM from static offering to dynamic offering ... === TestName: test_change_so_running_vm_static_to_dynamic_1_ADMIN_ACCOUNT | Status : FAILED ===
FAIL
Test scale running VM from static offering to dynamic offering ... === TestName: test_change_so_running_vm_static_to_dynamic_2_USER_ACCOUNT | Status : FAILED ===
FAIL
Test scale running VM from static offering to static offering ... === TestName: test_change_so_running_vm_static_to_static_1_ADMIN_ACCOUNT | Status : FAILED ===
FAIL
Test scale running VM from static offering to static offering ... === TestName: test_change_so_running_vm_static_to_static_2_USER_ACCOUNT | Status : FAILED ===
FAIL
Test scale stopped VM from dynamic offering to dynamic offering ... === TestName: test_change_so_stopped_vm_dynamic_to_dynamic_1_ADMIN_ACCOUNT | Status : FAILED ===
FAIL
Test scale stopped VM from dynamic offering to dynamic offering ... === TestName: test_change_so_stopped_vm_dynamic_to_dynamic_2_USER_ACCOUNT | Status : FAILED ===
FAIL
Test scale stopped VM from dynamic offering to static offering ... === TestName: test_change_so_stopped_vm_dynamic_to_static_1_ADMIN_ACCOUNT | Status : SUCCESS ===
ok
Test scale stopped VM from dynamic offering to static offering ... === TestName: test_change_so_stopped_vm_dynamic_to_static_2_USER_ACCOUNT | Status : SUCCESS ===
ok
Test scale stopped VM from static offering to dynamic offering ... === TestName: test_change_so_stopped_vm_static_to_dynamic_1_ADMIN_ACCOUNT | Status : FAILED ===
FAIL
Test scale stopped VM from static offering to dynamic offering ... === TestName: test_change_so_stopped_vm_static_to_dynamic_2_USER_ACCOUNT | Status : FAILED ===
FAIL
Test scale stopped VM from static offering to static offering ... === TestName: test_change_so_stopped_vm_static_to_static_1_ADMIN_ACCOUNT | Status : SUCCESS ===
ok
Test scale stopped VM from static offering to static offering ... === TestName: test_change_so_stopped_vm_static_to_static_2_USER_ACCOUNT | Status : SUCCESS ===


Root Cause:
ParamUnpackWorker creates a Map\<String, Map\<String,String\>\>, which should be converted to a  Map\<String,String\>. 


