### PR TITLE
CLOUDSTACK-9630: Cannot use listNics API as advertised

### DIFF
--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3479,6 +3479,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         NicResponse response = new NicResponse();
         NetworkVO network = _entityMgr.findById(NetworkVO.class, result.getNetworkId());
         VMInstanceVO vm = _entityMgr.findById(VMInstanceVO.class, result.getInstanceId());
+        UserVmJoinVO userVm = _entityMgr.findById(UserVmJoinVO.class, result.getInstanceId());
 
         response.setId(result.getUuid());
         response.setNetworkid(network.getUuid());
@@ -3487,6 +3488,14 @@ public class ApiResponseHelper implements ResponseGenerator {
             response.setVmId(vm.getUuid());
         }
 
+        if (userVm != null){
+            if (userVm.getTrafficType() != null) {
+                response.setTrafficType(userVm.getTrafficType().toString());
+            }
+            if (userVm.getGuestType() != null) {
+                response.setType(userVm.getGuestType().toString());
+            }
+        }
         response.setIpaddress(result.getIPv4Address());
 
         if (result.getSecondaryIp()) {
@@ -3509,6 +3518,10 @@ public class ApiResponseHelper implements ResponseGenerator {
 
         if (result.getIPv6Address() != null) {
             response.setIp6Address(result.getIPv6Address());
+        }
+
+        if (result.getIPv6Cidr() != null) {
+            response.setIp6Cidr(result.getIPv6Cidr());
         }
 
         response.setDeviceId(String.valueOf(result.getDeviceId()));

--- a/test/integration/component/test_list_nics.py
+++ b/test/integration/component/test_list_nics.py
@@ -1,0 +1,150 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#Test from the Marvin - Testing in Python wiki
+from marvin.codes import FAILED
+
+#All tests inherit from cloudstackTestCase
+from marvin.cloudstackTestCase import cloudstackTestCase
+
+#Import Integration Libraries
+
+#base - contains all resources as entities and defines create, delete, list operations on them
+from marvin.lib.base import Account, VirtualMachine, ServiceOffering
+
+#utils - utility classes for common cleanup, external library wrappers etc
+from marvin.lib.utils import cleanup_resources
+
+#common - commonly used methods for all tests are listed here
+from marvin.lib.common import get_zone, get_domain, get_template
+
+from marvin.cloudstackAPI.listNics import listNicsCmd
+
+
+from nose.plugins.attrib import attr
+
+class TestDeployVM(cloudstackTestCase):
+    """Test deploy a VM into a user account
+    """
+
+    def setUp(self):
+        self.testdata = self.testClient.getParsedTestDataConfig()
+        self.apiclient = self.testClient.getApiClient()
+
+        # Get Zone, Domain and Default Built-in template
+        self.domain = get_domain(self.apiclient)
+        self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
+        self.testdata["mode"] = self.zone.networktype
+        self.template = get_template(self.apiclient, self.zone.id, self.testdata["ostype"])
+
+        if self.template == FAILED:
+            assert False, "get_template() failed to return template with description %s" % self.testdata["ostype"]
+
+        #create a user account
+        self.account = Account.create(
+            self.apiclient,
+            self.testdata["account"],
+            domainid=self.domain.id
+        )
+        #create a service offering
+        self.service_offering = ServiceOffering.create(
+            self.apiclient,
+            self.testdata["service_offerings"]["small"]
+        )
+        #build cleanup list
+        self.cleanup = [
+            self.service_offering,
+            self.account
+        ]
+
+        # Validate the following:
+        # 1. Virtual Machine is accessible via SSH
+        # 2. listVirtualMachines returns accurate information
+
+        self.virtual_machine = VirtualMachine.create(
+            self.apiclient,
+            self.testdata["virtual_machine"],
+            accountid=self.account.name,
+            zoneid=self.zone.id,
+            domainid=self.account.domainid,
+            serviceofferingid=self.service_offering.id,
+            templateid=self.template.id
+        )
+
+        list_vms = VirtualMachine.list(self.apiclient, id=self.virtual_machine.id)
+
+        self.debug(
+            "Verify listVirtualMachines response for virtual machine: %s"\
+            % self.virtual_machine.id
+        )
+
+        self.assertEqual(
+            isinstance(list_vms, list),
+            True,
+            "List VM response was not a valid list"
+        )
+        self.assertNotEqual(
+            len(list_vms),
+            0,
+            "List VM response was empty"
+        )
+
+        vm = list_vms[0]
+        self.assertEqual(
+            vm.id,
+            self.virtual_machine.id,
+            "Virtual Machine ids do not match"
+        )
+        self.assertEqual(
+            vm.name,
+            self.virtual_machine.name,
+            "Virtual Machine names do not match"
+        )
+        self.assertEqual(
+            vm.state,
+            "Running",
+            msg="VM is not in Running state"
+        )
+
+    @attr(tags = ['advanced',  'basic'], required_hardware="false")
+    def test_list_nics(self):
+        list_vms = VirtualMachine.list(self.apiclient, id=self.virtual_machine.id)
+        vmid = self.virtual_machine.id
+        cmd = listNicsCmd()
+        cmd.virtualmachineid = vmid
+        list_nics =  self.apiclient.listNics(cmd)
+
+        nic = list_nics[0]
+
+        self.assertIsNotNone(
+            nic.type,
+            "Nic Type is %s" % nic.type
+        )
+
+        self.assertIsNotNone(
+            nic.traffictype,
+            "Nic traffictype is %s" % nic.traffictype
+        )
+
+
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            self.debug("Warning! Exception in tearDown: %s" % e)
+        return


### PR DESCRIPTION


listNics API for a VM, "type" was not returned within API response.

EXPECTED BEHAVIOR
==================
The listNics API response return type of NIC (type), as specified in https://cloudstack.apache.org/api/apidocs-4.8/user/listNics.html

ACTUAL BEHAVIOR
==================
The listNics API response does not return type of NIC.

(local) 🐵 > list nics virtualmachineid=a69edaf5-8f21-41ff-8c05-263dc4bd5354
count = 1
nic:
id = 211e0d46-6b94-4425-99f7-e8e9efea2472
deviceid = 0
gateway = 10.1.1.1
ipaddress = 10.1.1.45
isdefault = True
macaddress = 02:00:06:f6:00:01
netmask = 255.255.255.0
networkid = c08fddf1-fd77-4810-a062-ea9d03c5c7e6
virtualmachineid = a69edaf5-8f21-41ff-8c05-263dc4bd5354

Solution:
added "type" details for listNics API response.

After Fix:

(local) 🐵 > list nics virtualmachineid=a69edaf5-8f21-41ff-8c05-263dc4bd5354 
count = 1
nic:
id = 211e0d46-6b94-4425-99f7-e8e9efea2472
broadcasturi = vlan://743
deviceid = 0
gateway = 10.1.1.1
ipaddress = 10.1.1.45
isdefault = True
isolationuri = vlan://743
macaddress = 02:00:06:f6:00:01
netmask = 255.255.255.0
networkid = c08fddf1-fd77-4810-a062-ea9d03c5c7e6
traffictype = Guest
**type = Isolated**
virtualmachineid = a69edaf5-8f21-41ff-8c05-263dc4bd5354