### PR TITLE
CLOUDSTACK-9639: Unable to create shared network with vLan isolation

### DIFF
--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3052,12 +3052,12 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             // Check if the new VLAN's subnet conflicts with the guest network
             // in
             // the specified zone (guestCidr is null for basic zone)
+            // when adding shared network with same cidr of zone guest cidr,
+            // if the specified vlan is not present in zone, physical network, allow to create the network as the isolation is based on VLAN.
             final String guestNetworkCidr = zone.getGuestNetworkCidr();
-            if (guestNetworkCidr != null) {
-                if (NetUtils.isNetworksOverlap(newCidr, guestNetworkCidr)) {
-                    throw new InvalidParameterValueException("The new IP range you have specified has  overlapped with the guest network in zone: " + zone.getName()
-                            + ". Please specify a different gateway/netmask.");
-                }
+            if (guestNetworkCidr != null && NetUtils.isNetworksOverlap(newCidr, guestNetworkCidr) && _zoneDao.findVnet(zoneId, physicalNetworkId, vlanId).isEmpty() != true) {
+                throw new InvalidParameterValueException("The new IP range you have specified has  overlapped with the guest network in zone: " + zone.getName()
+                        + "along with existing Vlan also. Please specify a different gateway/netmask");
             }
 
             // Check if there are any errors with the IP range


### PR DESCRIPTION
Description:
=========
Create shared network fails with Error.
While creating a shared network it fails to create with Error "The new IP range you have specified has overlapped with the guest network in the zone: XYZ. Please specify a different gateway/netmask"

Steps to Reproduce:
===============
1. Create an isolated network with a subnet eg: 10.1.1.0/24
2. Create a shared network with the same subnet but different VLAN, we should observe this issue.

Expected Behaviour:
===============
It shouldn't restrict the creation of the guest network with the same subnet as long as they are segmented by VLAN.

ACTUAL BEHAVIOR:
===============
It doesn't allow the creation of shared guest networks if there is any isolated guest network using the same subnet although it allows using the same subnet in multiple shared networks.

Cause:
=====
The issue is happening because, when Shared network is getting created we are checking if there is any guest network already implemented with the same CIDR and throwing the error without checking if they are having same VLAN also. Creating the same CIDR shared network with different VLAN should be allowed.

Fix:
===
When creating a shared network, if there is any existing guest network with the same CIDR, we check if they are having the same VLAN, if they are in same VLAN, then we don't allow creating it. If they are in the same CIDR with different VLAN then we allowing to create the network.