### PR TITLE
CLOUDSTACK-9633: Revert addition of `vhd` extention to snapshots

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -529,7 +529,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
                         // finalPath = folder + File.separator +
                         // snapshotBackupUuid;
                     } else {
-                        finalPath = folder + File.separator + snapshotBackupUuid + ".vhd";
+                        finalPath = folder + File.separator + snapshotBackupUuid;
                     }
 
                 } finally {
@@ -562,7 +562,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
                     final String[] tmp = result.split("#");
                     snapshotBackupUuid = tmp[0];
                     physicalSize = Long.parseLong(tmp[1]);
-                    finalPath = folder + File.separator + snapshotBackupUuid + ".vhd";
+                    finalPath = folder + File.separator + snapshotBackupUuid;
                 }
             }
             final String volumeUuid = snapshotTO.getVolume().getPath();

--- a/tools/marvin/marvin/lib/utils.py
+++ b/tools/marvin/marvin/lib/utils.py
@@ -292,7 +292,7 @@ def is_snapshot_on_nfs(apiclient, dbconn, config, zoneid, snapshotid):
     # snapshot extension to be appended to the snapshot path obtained from db
     snapshot_extensions = {"vmware": ".ovf",
                             "kvm": "",
-                            "xenserver": "",
+                            "xenserver": ".vhd",
                             "simulator":""}
 
     qresultset = dbconn.execute(


### PR DESCRIPTION
This reverts commit f1fd325c085cd61336ac616ba76e2c1f3f916cd1 and changes
introduced in commit f46651e6721106941deeb6b5e6bf51d7e9efc61c that changed the
snapshot file name to include a `vhd` extension.

With this change, CloudStack users should not hit upgrade issues.

Reference: https://github.com/apache/cloudstack/pull/1600#pullrequestreview-10955963