### PR TITLE
CLOUDSTACK-9648: Fix release script to update checkstyle pom

### DIFF
--- a/tools/build/build_asf.sh
+++ b/tools/build/build_asf.sh
@@ -90,10 +90,11 @@ export currentversion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:eval
 echo "found $currentversion"
 
 echo 'setting version numbers'
-mvn versions:set -DnewVersion=$version -P vmware -P developer -P systemvm -P simulator -P baremetal -P ucs -Dnoredist
+
+mvn versions:set -DnewVersion=$version -P developer,systemvm -Dnoredist -Dsimulator
+mvn versions:set -DnewVersion=$version -pl tools/checkstyle
 mv deps/XenServerJava/pom.xml.versionsBackup deps/XenServerJava/pom.xml
 perl -pi -e "s/<cs.xapi.version>6.2.0-1-SNAPSHOT<\/cs.xapi.version>/<cs.xapi.version>6.2.0-1<\/cs.xapi.version>/" pom.xml
-perl -pi -e "s/-SNAPSHOT//" tools/checkstyle/pom.xml
 perl -pi -e "s/-SNAPSHOT//" deps/XenServerJava/pom.xml
 perl -pi -e "s/-SNAPSHOT//" tools/apidoc/pom.xml
 perl -pi -e "s/-SNAPSHOT//" Dockerfile


### PR DESCRIPTION
This fixes build_asf.sh release script to update checkstyle pom.xml with the
provided new version.