### PR TITLE
CLOUDSTACK-9647: NIC adapter type becomes e1000 , even after changing…

### DIFF
--- a/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -88,6 +88,10 @@ import com.cloud.vm.VirtualMachine.State;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.VirtualMachineProfile.Param;
 import com.cloud.vm.dao.VMInstanceDao;
+import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.hypervisor.HypervisorGuru;
+import com.cloud.hypervisor.HypervisorGuruManager;
 
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
@@ -114,6 +118,8 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     private NetworkACLItemDao _networkACLItemDao;
     @Inject
     private EntityManager _entityMgr;
+    @Inject
+    protected HypervisorGuruManager _hvGuruMgr;
 
     @Override
     public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
@@ -280,6 +286,16 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     public boolean finalizeCommandsOnStart(final Commands cmds, final VirtualMachineProfile profile) {
         final DomainRouterVO domainRouterVO = _routerDao.findById(profile.getId());
 
+        Map<String, String> details = new HashMap<String, String>();
+
+        if(profile.getHypervisorType() == Hypervisor.HypervisorType.VMware){
+            HypervisorGuru hvGuru = _hvGuruMgr.getGuru(profile.getHypervisorType());
+            VirtualMachineTO vmTO = hvGuru.implement(profile);
+            if(vmTO.getDetails() != null){
+                details = vmTO.getDetails();
+            }
+        }
+
         final boolean isVpc = domainRouterVO.getVpcId() != null;
         if (!isVpc) {
             return super.finalizeCommandsOnStart(cmds, profile);
@@ -338,7 +354,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                         }
                     }
                     final PlugNicCommand plugNicCmd = new PlugNicCommand(_nwHelper.getNicTO(domainRouterVO, publicNic.getNetworkId(), publicNic.getBroadcastUri().toString()),
-                            domainRouterVO.getInstanceName(), domainRouterVO.getType());
+                            domainRouterVO.getInstanceName(), domainRouterVO.getType(), details);
                     cmds.addCommand(plugNicCmd);
                     final VpcVO vpc = _vpcDao.findById(domainRouterVO.getVpcId());
                     final NetworkUsageCommand netUsageCmd = new NetworkUsageCommand(domainRouterVO.getPrivateIpAddress(), domainRouterVO.getInstanceName(), true, publicNic.getIPv4Address(), vpc.getCidr());
@@ -361,7 +377,7 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
                 for (final Pair<Nic, Network> nicNtwk : guestNics) {
                     final Nic guestNic = nicNtwk.first();
                     // plug guest nic
-                    final PlugNicCommand plugNicCmd = new PlugNicCommand(_nwHelper.getNicTO(domainRouterVO, guestNic.getNetworkId(), null), domainRouterVO.getInstanceName(), domainRouterVO.getType());
+                    final PlugNicCommand plugNicCmd = new PlugNicCommand(_nwHelper.getNicTO(domainRouterVO, guestNic.getNetworkId(), null), domainRouterVO.getInstanceName(), domainRouterVO.getType(), details);
                     cmds.addCommand(plugNicCmd);
                     if (!_networkModel.isPrivateGateway(guestNic.getNetworkId())) {
                         // set guest network


### PR DESCRIPTION
**Issue:**
NIC adapter type becomes e1000 , even after changing the global parameter "vmware.systemvm.nic.device.type" to vmxnet3.

**Description**

Repro steps:-

-> Set global parameter "vmware.systemvm.nic.device.type" to vmxnet3.
-> Created a VPC network and deployed a VM using the same network.
-> Checked the router details and found that for private network , it was showing nic adapter type as VMXNET3 and for other networks (public and guest) it was showing as E1000.
-> Rebooted the VPC network and checked it again, it was same as earlier.

/vmfs/volumes/3e5dffc5-9b91346e/r-2805-VM # grep virtualDev r-2805-VM.vmx
pciBridge4.virtualDev = "pcieRootPort"
pciBridge5.virtualDev = "pcieRootPort"
pciBridge6.virtualDev = "pcieRootPort"
pciBridge7.virtualDev = "pcieRootPort"
scsi0.virtualDev = "lsilogic"
ethernet0.virtualDev = "vmxnet3"
ethernet1.virtualDev = "e1000"
ethernet2.virtualDev = "e1000"
ethernet3.virtualDev = "e1000"

**Root Cause:**

While preparing PlugNicCommand for VPC Network, NIC adapter type is not used.

PlugNicCommand:

            "com.cloud.agent.api.PlugNicCommand": {
                "nic": {
                    "deviceId": 1,
                    "networkRateMbps": 200,
                    "defaultNic": true,
                    "pxeDisable": true,
                    "nicUuid": "9ae41bb1-dc22-4489-95f4-2c2659c99486",
                    "uuid": "4ffdfb14-7d47-4ffd-b7fb-85f171c349ff",
                    "ip": "10.104.92.161",
                    "netmask": "255.255.254.0",
                    "gateway": "10.104.92.1",
                    "mac": "06:f8:de:00:00:14",
                    "broadcastType": "Vlan",
                    "type": "Public",
                    "broadcastUri": "vlan://untagged",
                    "isolationUri": "vlan://untagged",
                    "isSecurityGroupEnabled": false
                },
                "instanceName": "r-2784-VM",
                "vmType": "DomainRouter",
                "wait": 0
            }

Code Snippet:

public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplianceManagerImpl implements VpcVirtualNetworkApplianceManager {

...
...

	 @Override
     public boolean finalizeCommandsOnStart(Commands cmds, VirtualMachineProfile profile) {


...
...
        //3) PREPARE PLUG NIC COMMANDS
        try {
            //add VPC router to public networks
            ...
            ..

                   final PlugNicCommand plugNicCmd = new PlugNicCommand(_nwHelper.getNicTO(domainRouterVO, publicNic.getNetworkId(), publicNic.getBroadcastUri().toString()),
                            domainRouterVO.getInstanceName(), domainRouterVO.getType());


...
...

            //add VPC router to guest networks
            for (Pair<Nic, Network> nicNtwk : guestNics) {
                Nic guestNic = nicNtwk.first();
                //plug guest nic
                final PlugNicCommand plugNicCmd = new PlugNicCommand(_nwHelper.getNicTO(domainRouterVO, guestNic.getNetworkId(), null), domainRouterVO.getInstanceName(), domainRouterVO.getType());
                cmds.addCommand(plugNicCmd);

...
	   }
...
...
}

**Solution:**
Fetch and add NIC adapter type to PlugNicCommand. 

Command After fix:

       {
         "com.cloud.agent.api.PlugNicCommand":{
            "nic":{
               "deviceId":2,
               "networkRateMbps":200,
               "defaultNic":false,
               "pxeDisable":true,
               "nicUuid":"06c1b9dc-9061-4bbf-8ad3-60baa3ee3e9a",
               "uuid":"381fc075-4035-40c3-a09c-84baf6f1a0b2",
               "ip":"10.147.100.10",
               "netmask":"255.255.255.0",
               "gateway":"10.147.100.1",
               "mac":"06:0f:88:00:01:48",
               "broadcastType":"Vlan",
               "type":"Guest",
               "broadcastUri":"vlan://100",
               "isolationUri":"vlan://100",
               "isSecurityGroupEnabled":false
            },
            "instanceName":"r-2808-VM",
            "vmType":"DomainRouter",
            "details":{
               "nicAdapter":"Vmxnet3",
               "vmware.reserve.cpu":"false",
               "vmware.reserve.mem":"false"
            },
            "wait":0
         }
      },

Before:

/vmfs/volumes/3e5dffc5-9b91346e/r-2805-VM # grep virtualDev r-2805-VM.vmx
pciBridge4.virtualDev = "pcieRootPort"
pciBridge5.virtualDev = "pcieRootPort"
pciBridge6.virtualDev = "pcieRootPort"
pciBridge7.virtualDev = "pcieRootPort"
scsi0.virtualDev = "lsilogic"
ethernet0.virtualDev = "vmxnet3"
ethernet1.virtualDev = "e1000"
ethernet2.virtualDev = "e1000"
ethernet3.virtualDev = "e1000"

After

/vmfs/volumes/3e5dffc5-9b91346e/r-2808-VM # grep virtualDev r-2808-VM.vmx
pciBridge4.virtualDev = "pcieRootPort"
pciBridge5.virtualDev = "pcieRootPort"
pciBridge6.virtualDev = "pcieRootPort"
pciBridge7.virtualDev = "pcieRootPort"
scsi0.virtualDev = "lsilogic"
ethernet0.virtualDev = "vmxnet3"
ethernet1.virtualDev = "vmxnet3"
ethernet2.virtualDev = "vmxnet3"
ethernet3.virtualDev = "vmxnet3"

