### PR TITLE
CLOUDSTACK-9650: Allow starting VMs regardless of cpu/memory cluster.…

### DIFF
--- a/api/src/com/cloud/deploy/DeploymentClusterPlanner.java
+++ b/api/src/com/cloud/deploy/DeploymentClusterPlanner.java
@@ -29,6 +29,7 @@ public interface DeploymentClusterPlanner extends DeploymentPlanner {
 
     static final String ClusterCPUCapacityDisableThresholdCK = "cluster.cpu.allocated.capacity.disablethreshold";
     static final String ClusterMemoryCapacityDisableThresholdCK = "cluster.memory.allocated.capacity.disablethreshold";
+    static final String ClusterThresholdEnabledCK = "cluster.threshold.enabled";
 
     static final ConfigKey<Float> ClusterCPUCapacityDisableThreshold =
         new ConfigKey<Float>(
@@ -46,6 +47,15 @@ public interface DeploymentClusterPlanner extends DeploymentPlanner {
             "0.85",
             "Percentage (as a value between 0 and 1) of memory utilization above which allocators will disable using the cluster for low memory available. Keep the corresponding notification threshold lower than this to be notified beforehand.",
             true, ConfigKey.Scope.Cluster, null);
+    static final ConfigKey<Boolean> ClusterThresholdEnabled =
+        new ConfigKey<Boolean>(
+            "Advanced",
+            Boolean.class,
+            ClusterThresholdEnabledCK,
+            "true",
+            "Enable/Disable cluster thresholds. If disabled, an instance can start in a cluster even though the threshold may be crossed.",
+            false,
+            ConfigKey.Scope.Zone);
 
     /**
      * This is called to determine list of possible clusters where a virtual

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1052,6 +1052,13 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                                 _resourceMgr.updateGPUDetails(destHostId, gpuDevice.getGroupDetails());
                             }
 
+                            // Remove the information on whether it was a deploy vm request.The deployvm=true information
+                            // is set only when the vm is being deployed. When a vm is started from a stop state the
+                            // information isn't set,
+                            if (_uservmDetailsDao.findDetail(vm.getId(), "deployvm") != null) {
+                                _uservmDetailsDao.removeDetail(vm.getId(), "deployvm");
+                            }
+
                             startedVm = vm;
                             if (s_logger.isDebugEnabled()) {
                                 s_logger.debug("Start completed for VM " + vm);

--- a/plugins/deployment-planners/implicit-dedication/test/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
+++ b/plugins/deployment-planners/implicit-dedication/test/org/apache/cloudstack/implicitplanner/ImplicitPlannerTest.java
@@ -94,6 +94,7 @@ import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachineProfileImpl;
 import com.cloud.vm.dao.UserVmDao;
+import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -120,6 +121,8 @@ public class ImplicitPlannerTest {
     StoragePoolHostDao poolHostDao;
     @Inject
     UserVmDao vmDao;
+    @Inject
+    UserVmDetailsDao vmDetailsDao;
     @Inject
     VMInstanceDao vmInstanceDao;
     @Inject
@@ -518,6 +521,11 @@ public class ImplicitPlannerTest {
         @Bean
         public UserVmDao userVmDao() {
             return Mockito.mock(UserVmDao.class);
+        }
+
+        @Bean
+        public UserVmDetailsDao userVmDetailsDao() {
+            return Mockito.mock(UserVmDetailsDao.class);
         }
 
         @Bean

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -3582,6 +3582,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 for (String key : customParameters.keySet()) {
                     vm.setDetail(key, customParameters.get(key));
                 }
+                vm.setDetail("deployvm", "true");
                 _vmDao.saveDetails(vm);
 
                 s_logger.debug("Allocating in the DB for vm");

--- a/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
+++ b/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
@@ -94,6 +94,7 @@ import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.AccountManager;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.vm.dao.UserVmDao;
+import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -130,6 +131,9 @@ public class DeploymentPlanningManagerImplTest {
     @Inject
     DedicatedResourceDao _dedicatedDao;
 
+    @Inject
+    UserVmDetailsDao vmDetailsDao;
+
     private static long domainId = 5L;
 
     private static long dataCenterId = 1L;
@@ -149,6 +153,8 @@ public class DeploymentPlanningManagerImplTest {
 
         VMInstanceVO vm = new VMInstanceVO();
         Mockito.when(vmProfile.getVirtualMachine()).thenReturn(vm);
+
+        Mockito.when(vmDetailsDao.listDetailsKeyPairs(Matchers.anyLong())).thenReturn(null);
 
         Mockito.when(_dcDao.findById(Matchers.anyLong())).thenReturn(dc);
         Mockito.when(dc.getId()).thenReturn(dataCenterId);
@@ -380,6 +386,11 @@ public class DeploymentPlanningManagerImplTest {
         @Bean
         public UserVmDao userVMDao() {
             return Mockito.mock(UserVmDao.class);
+        }
+
+        @Bean
+        public UserVmDetailsDao userVmDetailsDao() {
+            return Mockito.mock(UserVmDetailsDao.class);
         }
 
         @Bean


### PR DESCRIPTION
…disablethreshold setting

Introduced a global configuration flag 'cluster.threshold.enabled'. By default the flag is true.
If the value is false, then a VM can be started in a cluster even if the cluster thresholds are
crossed. However, for a new VM deployment the cluster threshold will always be honoured.