### PR TITLE
Fix docker image build for cloudstack-management

### DIFF
--- a/tools/build/build_asf.sh
+++ b/tools/build/build_asf.sh
@@ -96,7 +96,6 @@ perl -pi -e "s/<cs.xapi.version>6.2.0-1-SNAPSHOT<\/cs.xapi.version>/<cs.xapi.ver
 perl -pi -e "s/-SNAPSHOT//" tools/checkstyle/pom.xml
 perl -pi -e "s/-SNAPSHOT//" deps/XenServerJava/pom.xml
 perl -pi -e "s/-SNAPSHOT//" tools/apidoc/pom.xml
-perl -pi -e "s/-SNAPSHOT//" Dockerfile
 perl -pi -e "s/-SNAPSHOT//" build/replace.properties
 perl -pi -e "s/-SNAPSHOT//" services/console-proxy/plugin/pom.xml
 perl -pi -e "s/-SNAPSHOT//" tools/marvin/setup.py
@@ -104,6 +103,9 @@ perl -pi -e "s/-SNAPSHOT//" tools/marvin/marvin/deployAndRun.py
 perl -pi -e "s/-SNAPSHOT//" services/iam/plugin/pom.xml
 perl -pi -e "s/-SNAPSHOT//" services/iam/pom.xm
 perl -pi -e "s/-SNAPSHOT//" services/iam/server/pom.xml
+perl -pi -e "s/-SNAPSHOT//" tools/docker/Dockerfile
+perl -pi -e "s/-SNAPSHOT//" tools/docker/Dockerfile.marvin
+perl -pi -e "s/-SNAPSHOT//" tools/docker/Dockerfile.centos6
 
 case "$currentversion" in 
   *-SNAPSHOT*)

--- a/tools/build/setnextversion.sh
+++ b/tools/build/setnextversion.sh
@@ -73,6 +73,16 @@ perl -pi -e "s/$currentversion/$version/" services/iam/pom.xm
 perl -pi -e "s/$currentversion/$version/" services/iam/server/pom.xml
 perl -pi -e "s/$currentversion/$version/" tools/checkstyle/pom.xml
 perl -pi -e "s/$currentversion/$version/" services/console-proxy/plugin/pom.xml
+# Dockerfiles
+perl -pi -e "s/Version=\"$currentversion\"/Version=\"$version\"/" tools/docker/Dockerfile
+perl -pi -e "s/Version=\"$currentversion\"/Version=\"$version\"/" tools/docker/Dockerfile.marvin
+# centos6 based dockerfile
+perl -pi -e "s/Version=\"$currentversion\"/Version=\"$version\"/" tools/docker/Dockerfile.centos6
+perl -pi -e "s/cloudstack-common-(.*).el6.x86_64.rpm/cloudstack-common-${version}.el6.x86_64.rpm/" tools/docker/Dockerfile.centos6
+perl -pi -e "s/cloudstack-management-(.*)el6.x86_64.rpm/cloudstack-management-${version}.el6.x86_64.rpm/" tools/docker/Dockerfile.centos6
+perl -pi -e "s/Marvin-(.*).tar.gz/Marvin-${version}.tar.gz/" tools/docker/Dockerfile.marvin
+# systemtpl.sh:  system vm template version without -SNAPSHOT
+
 git clean -f
 
 echo 'commit changes'

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -20,16 +20,19 @@
 FROM ubuntu:14.04
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.6.0"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.10.0.0-SNAPSHOT"
 
 RUN apt-get -y update && apt-get install -y \
     genisoimage \
+    libffi-dev \
+    libssl-dev \
     git \
     maven \
     openjdk-7-jdk \
     python-dev \
     python-setuptools \
     python-pip \
+    python-mysql.connector \
     supervisor
 
 RUN echo 'mysql-server mysql-server/root_password password root' |  debconf-set-selections; \
@@ -40,7 +43,7 @@ RUN apt-get install -qqy mysql-server && \
 
 RUN (/usr/bin/mysqld_safe &); sleep 5; mysqladmin -u root -proot password ''
 
-RUN pip install --allow-external mysql-connector-python mysql-connector-python
+#RUN pip install --allow-external mysql-connector-python mysql-connector-python
 
 COPY tools/docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY . ./root
@@ -49,10 +52,10 @@ WORKDIR /root
 RUN mvn -Pdeveloper -Dsimulator -DskipTests clean install
 
 RUN (/usr/bin/mysqld_safe &); \
-    sleep 3; \
+    sleep 5; \
     mvn -Pdeveloper -pl developer -Ddeploydb; \
     mvn -Pdeveloper -pl developer -Ddeploydb-simulator; \
-    MARVIN_FILE=`find tools/marvin/dist/ -name "Marvin*.tar.gz"` \
+    MARVIN_FILE=`find /root/tools/marvin/dist/ -name "Marvin*.tar.gz"`; \
     pip install $MARVIN_FILE
 
 EXPOSE 8080 8096

--- a/tools/docker/Dockerfile.centos6
+++ b/tools/docker/Dockerfile.centos6
@@ -18,14 +18,16 @@
 FROM centos:6
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.6.0"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.10.0.0-SNAPSHOT"
 
-ENV PKG_URL=http://jenkins.buildacloud.org/job/package-rhel63-master/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64
+ENV PKG_URL=https://builds.cloudstack.org/job/package-master-rhel63/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64
 
 # install CloudStack
+RUN rpm -i http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.3-1.el6.x86_64.rpm
+
 RUN yum install -y nc wget \
-    ${PKG_URL}/cloudstack-common-4.6.0-SNAPSHOT.el6.x86_64.rpm \
-    ${PKG_URL}/cloudstack-management-4.6.0-SNAPSHOT.el6.x86_64.rpm
+    ${PKG_URL}/cloudstack-common-4.10.0.0-SNAPSHOT.el6.x86_64.rpm \
+    ${PKG_URL}/cloudstack-management-4.10.0.0-SNAPSHOT.el6.x86_64.rpm
 
 RUN cd /etc/cloudstack/management; \
     ln -s tomcat6-nonssl.conf tomcat6.conf; \

--- a/tools/docker/Dockerfile.marvin
+++ b/tools/docker/Dockerfile.marvin
@@ -20,14 +20,16 @@
 FROM python:2
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.6.0"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.10.0.0-SNAPSHOT"
 
 ENV WORK_DIR=/marvin
 
-ENV PKG_URL=http://jenkins.buildacloud.org/job/cloudstack-marvin-master/lastSuccessfulBuild/artifact/tools/marvin/dist/Marvin-4.6.0-SNAPSHOT.tar.gz
+ENV PKG_URL=https://builds.cloudstack.org/job/build-master-marvin/lastSuccessfulBuild/artifact/tools/marvin/dist/Marvin-4.10.0.0-SNAPSHOT.tar.gz
 
+RUN apt-get update && apt-get install -y vim
 RUN pip install --upgrade paramiko nose requests
-RUN pip install --allow-external mysql-connector-python mysql-connector-python
+#RUN pip install --allow-external mysql-connector-python mysql-connector-python
+RUN pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
 RUN pip install ${PKG_URL}
 
 RUN mkdir -p ${WORK_DIR}

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -37,7 +37,7 @@ docker run -ti --rm --name marvin --link simulator:8096 cloudstack/marvin
 Deploy Cloud using marvin:
 
 ```
-docker run -ti --rm --link simulator:8096 cloudstack/marvin python /root/tools/marvin/marvin/deployDataCenter.py -i /root/setup/dev/advanced.cfg
+docker run -ti --rm --link simulator:8096 cloudstack/marvin python /marvin/marvin/deployDataCenter.py -i /marvin/dev/advanced.cfg
 ```
 
 Perform Smoke tests against CloudStack Simulator containter:


### PR DESCRIPTION
CLOUDSTACK-9651

Fix Docker images build for 4.10.0.0:
- simulator
- marvin
- management_centos6

Squashed version of #1435.
