### PR TITLE
CLOUDSTACK-9564: Fix NPE due to intermittent test assertion

### DIFF
--- a/vmware-base/test/com/cloud/hypervisor/vmware/util/VmwareContextPoolTest.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/util/VmwareContextPoolTest.java
@@ -114,7 +114,5 @@ public class VmwareContextPoolTest {
             totalRegistrations += client.count();
         }
         Mockito.verify(vmwareContextPool, Mockito.atLeast(totalRegistrations)).registerContext(Mockito.any(VmwareContext.class));
-        Assert.assertEquals(vmwareContextPool.composePoolKey(vmwareAddress, vmwareUsername),
-                vmwareContextPool.getContext(vmwareAddress, vmwareUsername).getPoolKey());
     }
 }


### PR DESCRIPTION
The test assertion on a pool object may return a null object, as objects
can be randomly expired/tombstoned. This will fix a NPE sometimes seen due
to recently merge for the fix for CLOUDSTACK-9564.

(we can merge this if Travis passes)

/cc @abhinandanprateek @murali-reddy 