### PR TITLE
CLOUDSTACK-9659: mismatch in traffic type in ip_associations.json and ips.json

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
@@ -41,6 +41,8 @@ def merge(dbag, ip):
     ip['network'] = str(ipo.network) + '/' + str(ipo.prefixlen)
     if 'nw_type' not in ip.keys():
         ip['nw_type'] = 'public'
+    else:
+        ip['nw_type'] = ip['nw_type'].lower()
     if ip['nw_type'] == 'control':
         dbag['eth' + str(nic_dev_id)] = [ip]
     else:


### PR DESCRIPTION
As part of the bug 'CLOUDSTACK-9339 Virtual Routers don't handle Multiple Public Interfaces correctly'
issue of mismatch of traffic type represented by 'nw_type' in config sent by management server in
ip_associations.json and how it is persisted in the ips.json data bag are differnet,
is addressed, however missed the change in final merge.
this bug is to add the functionality in cs_ip.py, to lower the traffic type sent by management server before persisting in the ips.json databag