### PR TITLE
CLOUDSTACK-9584: Fix intermittent test failure in `test_volumes`

### DIFF
--- a/test/integration/component/test_volumes.py
+++ b/test/integration/component/test_volumes.py
@@ -1261,7 +1261,7 @@ class TestVolumes(cloudstackTestCase):
             zoneid=self.zone.id,
             account=domuser.name,
             domainid=dom.id,
-            diskofferingid=diskoffering[0].id
+            diskofferingid=filter(lambda x: not x.iscustomized, diskoffering)[0].id
         )
         self.assertTrue(
             vol is not None, "volume creation fails in domain %s as user %s" %


### PR DESCRIPTION
The component/test_volume failures happen when disk offering is random selected to be a custom one. This fixes that.