### PR TITLE
CLOUDSTACK-9671: Fix sql change to corresponding version paths

### DIFF
--- a/setup/db/db/schema-481to490.sql
+++ b/setup/db/db/schema-481to490.sql
@@ -546,7 +546,3 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervis
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'centos64Guest', 228, now(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'centos64Guest', 228, now(), 0);
 
-ALTER TABLE `cloud`.`image_store_details` CHANGE COLUMN `value` `value` VARCHAR(255) NULL DEFAULT NULL COMMENT 'value of the detail', ADD COLUMN `display` tinyint(1) NOT 
-NULL DEFAULT '1' COMMENT 'True if the detail can be displayed to the end user' AFTER `value`;
-
-ALTER TABLE `snapshots` ADD COLUMN `location_type` VARCHAR(32) COMMENT 'Location of snapshot (ex. Primary)';

--- a/setup/db/db/schema-4910to41000.sql
+++ b/setup/db/db/schema-4910to41000.sql
@@ -48,3 +48,8 @@ CREATE TABLE `cloud`.`vlan_details` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `cloud`.`network_offerings` ADD COLUMN supports_public_access boolean default false;
+
+ALTER TABLE `cloud`.`image_store_details` CHANGE COLUMN `value` `value` VARCHAR(255) NULL DEFAULT NULL COMMENT 'value of the detail', ADD COLUMN `display` tinyint(1) NOT
+NULL DEFAULT '1' COMMENT 'True if the detail can be displayed to the end user' AFTER `value`;
+
+ALTER TABLE `snapshots` ADD COLUMN `location_type` VARCHAR(32) COMMENT 'Location of snapshot (ex. Primary)';


### PR DESCRIPTION
- Fixes issue of failing upgrade paths
- Moves schema changes from PR #1615 in the 4.9.1.0 to 4.10.0.0 sql path