### PR TITLE
CLOUDSTACK-9685: delete snapshot on primary associated with a volume …

### DIFF
--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/XenserverSnapshotStrategy.java
@@ -129,7 +129,7 @@ public class XenserverSnapshotStrategy extends SnapshotStrategyBase {
             SnapshotDataStoreVO oldestSnapshotOnPrimary = snapshotStoreDao.findOldestSnapshotForVolume(snapshot.getVolumeId(), DataStoreRole.Primary);
             VolumeVO volume = volumeDao.findById(snapshot.getVolumeId());
             if (oldestSnapshotOnPrimary != null) {
-                if (oldestSnapshotOnPrimary.getDataStoreId() == volume.getPoolId()) {
+                if (oldestSnapshotOnPrimary.getDataStoreId() == volume.getPoolId() && oldestSnapshotOnPrimary.getId() != parentSnapshotOnPrimaryStore.getId()) {
                     int _deltaSnapshotMax = NumbersUtil.parseInt(configDao.getValue("snapshot.delta.max"),
                             SnapshotManager.DELTAMAX);
                     int deltaSnap = _deltaSnapshotMax;
@@ -151,7 +151,7 @@ public class XenserverSnapshotStrategy extends SnapshotStrategyBase {
                     } else {
                         fullBackup = false;
                     }
-                } else {
+                } else if (oldestSnapshotOnPrimary.getId() != parentSnapshotOnPrimaryStore.getId()){
                     // if there is an snapshot entry for previousPool(primary storage) of migrated volume, delete it becasue CS created one more snapshot entry for current pool
                     snapshotStoreDao.remove(oldestSnapshotOnPrimary.getId());
                 }

--- a/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -68,6 +68,8 @@ import org.apache.cloudstack.storage.command.CopyCmdAnswer;
 import org.apache.cloudstack.storage.command.DeleteCommand;
 import org.apache.cloudstack.storage.datastore.PrimaryDataStoreProviderManager;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
 import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.VolumeDataStoreVO;
 import org.apache.cloudstack.storage.image.store.TemplateObject;
@@ -140,6 +142,8 @@ public class VolumeServiceImpl implements VolumeService {
     VolumeDataStoreDao _volumeStoreDao;
     @Inject
     VMTemplatePoolDao _tmpltPoolDao;
+    @Inject
+    SnapshotDataStoreDao _snapshotStoreDao;
     @Inject
     VolumeDao _volumeDao;
     @Inject
@@ -358,6 +362,10 @@ public class VolumeServiceImpl implements VolumeService {
                 if (canVolumeBeRemoved(vo.getId())) {
                     s_logger.info("Volume " + vo.getId() + " is not referred anywhere, remove it from volumes table");
                     volDao.remove(vo.getId());
+                }
+                SnapshotDataStoreVO snapStoreVo = _snapshotStoreDao.findByVolume(vo.getId(), DataStoreRole.Primary);
+                if(snapStoreVo != null){
+                    _snapshotStoreDao.remove(snapStoreVo.getId());
                 }
             } else {
                 vo.processEvent(Event.OperationFailed);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -560,6 +560,9 @@ public class XenServerStorageProcessor implements StorageProcessor {
         String errorMsg = null;
         try {
             final VDI vdi = VDI.getByUuid(conn, volume.getPath());
+            for(VDI svdi : vdi.getSnapshots(conn)) {
+                deleteVDI(conn, svdi);
+            }
             deleteVDI(conn, vdi);
             return new Answer(null);
         } catch (final BadServerResponse e) {


### PR DESCRIPTION
…when that volume is deleted

     as that snapshot will never be going to use again and also it will fill up primary storage