### PR TITLE
CLOUDSTACK-9684 Invalid zone id error while listing vmware zone

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -189,7 +189,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
 
     private String _rootDiskController = DiskControllerType.ide.toString();
 
-    private String _dataDiskController = DiskControllerType.osdefault.toString();
+    private final String _dataDiskController = DiskControllerType.osdefault.toString();
 
     private final Map<String, String> _storageMounts = new HashMap<String, String>();
 
@@ -1111,8 +1111,8 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
     @Override
     public boolean removeVmwareDatacenter(RemoveVmwareDcCmd cmd) throws ResourceInUseException {
         Long zoneId = cmd.getZoneId();
-        // Validate zone
-        validateZone(zoneId);
+        // Validate Id of zone
+        doesZoneExist(zoneId);
         // Zone validation to check if the zone already has resources.
         // Association of VMware DC to zone is not allowed if zone already has resources added.
         validateZoneWithResources(zoneId, "remove VMware datacenter to zone");
@@ -1180,10 +1180,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
 
     private void validateZone(Long zoneId) throws InvalidParameterValueException {
         // Check if zone with specified id exists
-        DataCenterVO zone = _dcDao.findById(zoneId);
-        if (zone == null) {
-            throw new InvalidParameterValueException("Can't find zone by the id specified.");
-        }
+        doesZoneExist(zoneId);
         // Check if zone is legacy zone
         if (isLegacyZone(zoneId)) {
             throw new InvalidParameterValueException("The specified zone is legacy zone. Adding VMware datacenter to legacy zone is not supported.");
@@ -1226,7 +1223,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         long vmwareDcId;
 
         // Validate if zone id parameter passed to API is valid
-        validateZone(zoneId);
+        doesZoneExist(zoneId);
 
         // Check if zone is associated with VMware DC
         vmwareDcZoneMap = _vmwareDcZoneMapDao.findByZoneId(zoneId);
@@ -1241,6 +1238,17 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
         // Currently a zone can have only 1 VMware DC associated with.
         // Returning list of VmwareDatacenterVO objects, in-line with future requirements, if any, like participation of multiple VMware DCs in a zone.
         return vmwareDcList;
+    }
+
+    private void doesZoneExist(Long zoneId) throws InvalidParameterValueException {
+        // Check if zone with specified id exists
+        DataCenterVO zone = _dcDao.findById(zoneId);
+        if (zone == null) {
+            throw new InvalidParameterValueException("Can't find zone by the id specified.");
+        }
+        if (s_logger.isTraceEnabled()) {
+            s_logger.trace("Zone with id:[" + zoneId + "] exists.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Issue
=====
While listing datacenters associated with a zone, only zone Id validation is required.
There is no need to have additional checks like zone is a legacy zone or not.

Fix
===
Removed unnecessary checks over zone ID and just checking if zone with specified ID exists or not.

Signed-off-by: Sateesh Chodapuneedi <sateesh.chodapuneedi@accelerite.com>