### PR TITLE
CLOUDSTACK-9686: Fixed multiple entires for builtin template in template

### DIFF
--- a/engine/storage/image/src/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -265,7 +265,7 @@ public class TemplateServiceImpl implements TemplateService {
 
             for (VMTemplateVO template : toBeDownloaded) {
                 TemplateDataStoreVO tmpltHost = _vmTemplateStoreDao.findByStoreTemplate(store.getId(), template.getId());
-                if (tmpltHost == null || tmpltHost.getState() != ObjectInDataStoreStateMachine.State.Ready) {
+                if (tmpltHost == null) {
                     associateTemplateToZone(template.getId(), dcId);
                     s_logger.info("Downloading builtin template " + template.getUniqueName() + " to data center: " + dcId);
                     TemplateInfo tmplt = _templateFactory.getTemplate(template.getId(), DataStoreRole.Image);


### PR DESCRIPTION
store ref table so builtin template is never downloaded completely
 In handleSysTemplateDownload method creating template only if there exists no entry
handleTemplateSync will take care of other scenario