### PR TITLE
CLOUDSTACK-9668 : disksizeallocated of PrimaryStorage is different fr…

### DIFF
--- a/server/src/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/com/cloud/storage/StorageManagerImpl.java
@@ -1005,7 +1005,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             _capacityDao.persist(capacity);
         } else {
             CapacityVO capacity = capacities.get(0);
-            if (capacity.getTotalCapacity() != totalOverProvCapacity || allocated != 0L || capacity.getCapacityState() != capacityState) {
+            if (capacity.getTotalCapacity() != totalOverProvCapacity || allocated != capacity.getUsedCapacity() || capacity.getCapacityState() != capacityState) {
                 capacity.setTotalCapacity(totalOverProvCapacity);
                 capacity.setUsedCapacity(allocated);
                 capacity.setCapacityState(capacityState);


### PR DESCRIPTION
…om the total size of a volume

update capacity if current allocated is different from used bytes in DB.



Disksizeallocated of PrimaryStorage is different from the total size of a volume.

steps to reproduce:
1. create another primary storage( apart from default) with storage tag (say tag1)
2. create a disk offering with storage tag as that step1.
3. create a data disk with above disk offering.
4. attach the disk to vm.
5. when capacity checker thread runs it will update the used_capacity. Note down the op_host_capacity details for pool created in step1.
6. detach the disk and destroy the volume.
7. when capacity checker thread runs it will not update the used_capacity to 0.

Root Cause: If all volumes have been removed from storage_pool then capacity checker does not update the op_host_capacity.
Resolution: Update capacity if current allocated is different from used bytes in DB.

```

public void createCapacityEntry(StoragePoolVO storagePool, short capacityType, long allocated) {
..
..
..

} else {
            CapacityVO capacity = capacities.get(0);
            if (capacity.getTotalCapacity() != totalOverProvCapacity || **allocated != 0L** || capacity.getCapacityState() != capacityState) { 
               ....
......
            }
        }

..
.
```

Test Result: 
Capacity checker runs every 5min. 
op_host_capacity data after adding a primary storage (id=2)

```
mysql> select id, host_id, used_capacity, reserved_capacity, total_capacity, update_time  from op_host_capacity where capacity_type=3;
+----+---------+---------------+-------------------+----------------+---------------------+
| id | host_id | used_capacity | reserved_capacity | total_capacity | update_time         |
+----+---------+---------------+-------------------+----------------+---------------------+
|  3 |       1 |   93110898688 |                 0 | 11804569632768 | 2016-12-21 14:20:34 |
| 14 |       2 |             0 |                 0 | 11804569632768 | 2016-12-21 14:10:43 |
+----+---------+---------------+-------------------+----------------+---------------------+
2 rows in set (0.00 sec)
```


op_host_capacity data after creating a disk of 5gb and ataching it to a VM.
```
mysql> select id, host_id, used_capacity, reserved_capacity, total_capacity, update_time  from op_host_capacity where capacity_type=3;
+----+---------+---------------+-------------------+----------------+---------------------+
| id | host_id | used_capacity | reserved_capacity | total_capacity | update_time         |
+----+---------+---------------+-------------------+----------------+---------------------+
|  3 |       1 |   93110898688 |                 0 | 11804569632768 | 2016-12-21 14:25:01 |
| 14 |       2 |    5368709120 |                 0 | 11804569632768 | 2016-12-21 14:25:01 |
+----+---------+---------------+-------------------+----------------+---------------------+
2 rows in set (0.00 sec)
```


op_host_capacity data after destrying the disk. Also creaed another disk(pool 1) and attached it to a VM. 

```
mysql> select id, host_id, used_capacity, reserved_capacity, total_capacity, update_time  from op_host_capacity where capacity_type=3;
+----+---------+---------------+-------------------+----------------+---------------------+
| id | host_id | used_capacity | reserved_capacity | total_capacity | update_time         |
+----+---------+---------------+-------------------+----------------+---------------------+
|  3 |       1 |   98479607808 |                 0 | 11804569632768 | 2016-12-21 14:30:21 |
| 14 |       2 |    5368709120 |                 0 | 11804569632768 | 2016-12-21 14:26:25 |
+----+---------+---------------+-------------------+----------------+---------------------+
2 rows in set (0.00 sec)
```

No change to used_capacity for pool id 2. But used_capacity got modified for pool 1.



After fix:

```
mysql> select id, host_id, used_capacity, reserved_capacity, total_capacity, update_time  from op_host_capacity where capacity_type=3;
+----+---------+---------------+-------------------+----------------+---------------------+
| id | host_id | used_capacity | reserved_capacity | total_capacity | update_time         |
+----+---------+---------------+-------------------+----------------+---------------------+
|  3 |       1 |   98479607808 |                 0 | 11804569632768 | 2016-12-21 14:39:25 |
| 14 |       2 |             0 |                 0 | 11804569632768 | 2016-12-21 14:39:07 |
+----+---------+---------------+-------------------+----------------+---------------------+
2 rows in set (0.00 sec)
```
