### PR TITLE
BUG-ID: CLOUDSTACK-8284

### DIFF
--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -2050,7 +2050,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             // Update Resource count
             if (vm.getAccountId() != Account.ACCOUNT_ID_SYSTEM && !rootVol.isEmpty()) {
                 _resourceLimitMgr.decrementResourceCount(vm.getAccountId(), ResourceType.volume);
-                _resourceLimitMgr.recalculateResourceCount(vm.getAccountId(), vm.getDomainId(), ResourceType.primary_storage.getOrdinal());
+                _resourceLimitMgr.recalculateResourceCount(null/*acclountId*/, vm.getDomainId(), ResourceType.primary_storage.getOrdinal());
             }
 
             // Only if vm is not expunged already, cleanup it's resources


### PR DESCRIPTION
On expunge VM, initiate resource count update at domain
level. Setting accountId as null ensures resource count is done at domain level and any hierarchies below.