### PR TITLE
CLOUDSTACK-9701: Local storage capacity is not handled properly

### DIFF
--- a/server/src/com/cloud/resource/ResourceManagerImpl.java
+++ b/server/src/com/cloud/resource/ResourceManagerImpl.java
@@ -1181,6 +1181,13 @@ public class ResourceManagerImpl extends ManagerBase implements ResourceManager,
             final CapacityState capacityState =  nextState == ResourceState.Enabled ? CapacityState.Enabled : CapacityState.Disabled;
             final short[] capacityTypes = {Capacity.CAPACITY_TYPE_CPU, Capacity.CAPACITY_TYPE_MEMORY};
             _capacityDao.updateCapacityState(null, null, null, host.getId(), capacityState.toString(), capacityTypes);
+
+            final StoragePoolVO storagePool = _storageMgr.findLocalStorageOnHost(host.getId());
+
+            if(storagePool != null){
+                final short[] capacityTypesLocalStorage = {Capacity.CAPACITY_TYPE_LOCAL_STORAGE};
+                _capacityDao.updateCapacityState(null, null, null, storagePool.getId(), capacityState.toString(), capacityTypesLocalStorage);
+            }
         }
         return _hostDao.updateResourceState(currentState, event, nextState, host);
     }

--- a/server/src/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/com/cloud/storage/StorageManagerImpl.java
@@ -965,6 +965,19 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
                 }
             }
         }
+
+        if (storagePool.getScope() == ScopeType.HOST) {
+            List<StoragePoolHostVO> stoargePoolHostVO = _storagePoolHostDao.listByPoolId(storagePool.getId());
+
+            if(stoargePoolHostVO != null && !stoargePoolHostVO.isEmpty()){
+                HostVO host = _hostDao.findById(stoargePoolHostVO.get(0).getHostId());
+
+                if(host != null){
+                    capacityState = (host.getResourceState() == ResourceState.Disabled) ? CapacityState.Disabled : CapacityState.Enabled;
+                }
+            }
+        }
+
         if (capacities.size() == 0) {
             CapacityVO capacity =
                     new CapacityVO(storagePool.getId(), storagePool.getDataCenterId(), storagePool.getPodId(), storagePool.getClusterId(), allocated, totalOverProvCapacity,


### PR DESCRIPTION
…al storage in op_host_capacity is still enabled

Description
=========
When a host is disabled or removed, local storage related capacity data for the corresponding local storage of the host is still in enabled state.
This may not directly impact deploy VM functionality (for example) but it does show incorrect capacity calculations.

Steps
=====

1. Enable local storage for zone
2. Disable host or remove host (after adding it to maintenance mode)
3. Check op_host_capacity (capacity_state=9)

In either of the cases, the local storage related capacity is still enabled for the host.


```
mysql> select id, name, uuid, status,resource_state, type, removed from host where type = 'Routing';
+----+--------------------+--------------------------------------+--------+----------------+---------+---------+
| id | name               | uuid                                 | status | resource_state | type    | removed |
+----+--------------------+--------------------------------------+--------+----------------+---------+---------+
|  1 | xenserver-nvjxksqs | 16a922d0-7b4c-4c84-baad-5bd91542181c | Up     | Disabled       | Routing | NULL    |
|  4 | xenserver-hnkwhblp | 0e0f161a-7cf5-4e44-8bcc-a25ba7d798e5 | Up     | Enabled        | Routing | NULL    |
+----+--------------------+--------------------------------------+--------+----------------+---------+---------+
2 rows in set (0.00 sec)

mysql> select host_id, used_capacity, reserved_capacity, total_capacity, capacity_type, capacity_state from op_host_capacity where capacity_type=9;
+---------+---------------+-------------------+----------------+---------------+----------------+
| host_id | used_capacity | reserved_capacity | total_capacity | capacity_type | capacity_state |
+---------+---------------+-------------------+----------------+---------------+----------------+
|       3 |       4194304 |                 0 |   491505319936 |             9 | Enabled        |
|       4 |       4194304 |                 0 |   491505319936 |             9 | Enabled        |
+---------+---------------+-------------------+----------------+---------------+----------------+
2 rows in set (0.00 sec)

mysql> select id, name, removed, pool_type, capacity_bytes from storage_pool where id in (3,4);
+----+----------------------------------+---------+-----------+----------------+
| id | name                             | removed | pool_type | capacity_bytes |
+----+----------------------------------+---------+-----------+----------------+
|  3 | xenserver-nvjxksqs Local Storage | NULL    | LVM       |   491505319936 |
|  4 | xenserver-hnkwhblp Local Storage | NULL    | LVM       |   491505319936 |
+----+----------------------------------+---------+-----------+----------------+

mysql> select host_id, used_capacity, reserved_capacity, total_capacity, capacity_type, capacity_state from op_host_capacity where capacity_type in (0,1,3,9);
+---------+---------------+-------------------+----------------+---------------+----------------+
| host_id | used_capacity | reserved_capacity | total_capacity | capacity_type | capacity_state |
+---------+---------------+-------------------+----------------+---------------+----------------+
|       1 |    1342177280 |                 0 |    15721585024 |             0 | Disabled       |
|       1 |          1000 |                 0 |          12400 |             1 | Disabled       |
|       1 |  119954444288 |                 0 | 11804569632768 |             3 | Enabled        |
|       4 |    2013265920 |                 0 |    15721585024 |             0 | Enabled        |
|       4 |          2600 |                 0 |          12400 |             1 | Enabled        |
|       2 |             0 |                 0 | 11804569632768 |             3 | Enabled        |
|       3 |       4194304 |                 0 |   491505319936 |             9 | Disabled       |
|       4 |       4194304 |                 0 |   491505319936 |             9 | Enabled        |
+---------+---------------+-------------------+----------------+---------------+----------------+
8 rows in set (0.00 sec)


```

After fix:
```
mysql> select host_id, used_capacity, reserved_capacity, total_capacity, capacity_type, capacity_state from op_host_capacity where capacity_type in (0,1,3,9);
+---------+---------------+-------------------+----------------+---------------+----------------+
| host_id | used_capacity | reserved_capacity | total_capacity | capacity_type | capacity_state |
+---------+---------------+-------------------+----------------+---------------+----------------+
|       1 |    1342177280 |                 0 |    15721585024 |             0 | Disabled       |
|       1 |          1000 |                 0 |          12400 |             1 | Disabled       |
|       1 |  119954444288 |                 0 | 11804569632768 |             3 | Enabled        |
|       4 |    2013265920 |                 0 |    15721585024 |             0 | Enabled        |
|       4 |          2600 |                 0 |          12400 |             1 | Enabled        |
|       2 |             0 |                 0 | 11804569632768 |             3 | Enabled        |
|       3 |       4194304 |                 0 |   491505319936 |             9 | Disabled       |
|       4 |       4194304 |                 0 |   491505319936 |             9 | Enabled        |
+---------+---------------+-------------------+----------------+---------------+----------------+
8 rows in set (0.00 sec)
```
