### PR TITLE
[4.9] CLOUDSTACK-9692: Fix password server issue in redundant VRs

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -137,7 +137,7 @@ class CsInterface:
         return self.get_attr("netmask")
 
     def get_gateway(self):
-        if self.config.is_vpc() or self.config.cmdline().is_redundant():
+        if self.config.is_vpc() or not self.is_guest():
             return self.get_attr("gateway")
         else:
             return self.config.cmdline().get_guest_gw()


### PR DESCRIPTION
The password server in RVRs has wrong parameters as the gateway of guest nics is None.
In this case, we should get the gateway from /var/cache/cloud/cmdline.
This issue is caused by commit 45642b83821ce0ecd6d4cddb76a77a2481e54d9a