### PR TITLE
CLOUDSTACK-9711: Fixed error reporting while adding vpn user

### DIFF
--- a/api/src/com/cloud/network/vpn/RemoteAccessVpnService.java
+++ b/api/src/com/cloud/network/vpn/RemoteAccessVpnService.java
@@ -43,7 +43,7 @@ public interface RemoteAccessVpnService {
 
     List<? extends VpnUser> listVpnUsers(long vpnOwnerId, String userName);
 
-    boolean applyVpnUsers(long vpnOwnerId, String userName);
+    boolean applyVpnUsers(long vpnOwnerId, String userName) throws ResourceUnavailableException;
 
     Pair<List<? extends RemoteAccessVpn>, Integer> searchForRemoteAccessVpns(ListRemoteAccessVpnsCmd cmd);
 

--- a/api/src/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
@@ -119,8 +119,12 @@ public class AddVpnUserCmd extends BaseAsyncCreateCmd {
     public void execute() {
         VpnUser vpnUser = _entityMgr.findById(VpnUser.class, getEntityId());
         Account account = _entityMgr.findById(Account.class, vpnUser.getAccountId());
-        if (!_ravService.applyVpnUsers(vpnUser.getAccountId(), userName)) {
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to add vpn user");
+        try {
+            if (!_ravService.applyVpnUsers(vpnUser.getAccountId(), userName)) {
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to add vpn user");
+            }
+        }catch (Exception ex) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to add vpn user due to resource unavailable");
         }
 
         VpnUsersResponse vpnResponse = new VpnUsersResponse();

--- a/api/src/org/apache/cloudstack/api/command/user/vpn/RemoveVpnUserCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vpn/RemoveVpnUserCmd.java
@@ -115,9 +115,14 @@ public class RemoveVpnUserCmd extends BaseAsyncCmd {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to remove vpn user");
         }
 
-        if (!_ravService.applyVpnUsers(owner.getId(), userName)) {
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to apply vpn user removal");
+        try {
+            if (!_ravService.applyVpnUsers(owner.getId(), userName)) {
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to apply vpn user removal");
+            }
+        }catch (Exception ex) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to remove vpn user due to resource unavailable");
         }
+
         SuccessResponse response = new SuccessResponse(getCommandName());
         setResponseObject(response);
     }

--- a/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -501,13 +501,14 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
 
     @DB
     @Override
-    public boolean applyVpnUsers(long vpnOwnerId, String userName) {
+    public boolean applyVpnUsers(long vpnOwnerId, String userName) throws  ResourceUnavailableException {
         Account caller = CallContext.current().getCallingAccount();
         Account owner = _accountDao.findById(vpnOwnerId);
         _accountMgr.checkAccess(caller, null, true, owner);
 
         s_logger.debug("Applying vpn users for " + owner);
         List<RemoteAccessVpnVO> vpns = _remoteAccessVpnDao.findByAccount(vpnOwnerId);
+        RemoteAccessVpnVO vpnTemp  = null;
 
         List<VpnUserVO> users = _vpnUsersDao.listByAccount(vpnOwnerId);
 
@@ -537,12 +538,14 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
                             } else {
                                 finals[i] = false;
                                 success = false;
+                                vpnTemp = vpn;
                             }
                         }
                     }
                 } catch (Exception e) {
                     s_logger.warn("Unable to apply vpn users ", e);
                     success = false;
+                    vpnTemp = vpn;
 
                     for (int i = 0; i < finals.length; i++) {
                         finals[i] = false;
@@ -573,6 +576,11 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
                 }
                 s_logger.warn("Failed to apply vpn for user " + user.getUsername() + ", accountId=" + user.getAccountId());
             }
+        }
+
+        if (!success) {
+            throw new  ResourceUnavailableException("Failed add vpn user due to Resource unavailable ",
+                    RemoteAccessVPNServiceProvider.class, vpnTemp.getId());
         }
 
         return success;


### PR DESCRIPTION

If configuring vpn user in one of the network fails the failure is ignored, failure should be shown in API response.