### PR TITLE
CLOUDSTACK-9717: [VMware] RVRs have mismatching MAC addresses for extra public NICs.

### DIFF
--- a/engine/schema/src/com/cloud/vm/dao/NicDao.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicDao.java
@@ -77,5 +77,7 @@ public interface NicDao extends GenericDao<NicVO, Long> {
 
     NicVO getControlNicForVM(long vmId);
 
+    Long getPeerRouterId(String publicMacAddress, long routerId);
+
     List<NicVO> listByVmIdAndKeyword(long instanceId, String keyword);
 }


### PR DESCRIPTION
Problem:
[VMware] RVRs have mismatching MAC addresses for extra public NICs.

Root Cause:
MAC addresses for extra public NICs were assigned randomly for the routers. Network Orchestrator is unaware of the extra NICs info of the peer router as they are not persisted in the cloud database and so peer router MAC addresses info is not at all considered in case of RVR when assigning MAC addresses for extra public NICs.

Solution:
When RVR is enabled and Peer Router is available, get the MAC addresses of the extra public NICs from the Peer Router and set them to the router.