### PR TITLE
CLOUDSTACK-9719: [VMware] VR loses DHCP settings and VMs cannot obtain IP after HA recovery - Set high restart priority for the VR.

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/VmwareServerDiscoverer.java
@@ -29,7 +29,6 @@ import javax.naming.ConfigurationException;
 
 import org.apache.log4j.Logger;
 
-import com.vmware.vim25.ClusterDasConfigInfo;
 import com.vmware.vim25.ManagedObjectReference;
 
 import org.apache.cloudstack.api.ApiConstants;
@@ -344,8 +343,7 @@ public class VmwareServerDiscoverer extends DiscovererBase implements Discoverer
                     return null;
                 } else {
                     ClusterMO clusterMo = new ClusterMO(context, morCluster);
-                    ClusterDasConfigInfo dasConfig = clusterMo.getDasConfig();
-                    if (dasConfig != null && dasConfig.isEnabled() != null && dasConfig.isEnabled().booleanValue()) {
+                    if (clusterMo.isHAEnabled()) {
                         clusterDetails.put("NativeHA", "true");
                         _clusterDetailsDao.persist(clusterId, clusterDetails);
                     }

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/HostMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/HostMO.java
@@ -144,6 +144,26 @@ public class HostMO extends BaseMO implements VmwareHypervisorHost {
     }
 
     @Override
+    public boolean isHAEnabled() throws Exception {
+        ManagedObjectReference morParent = getParentMor();
+        if (morParent.getType().equals("ClusterComputeResource")) {
+            ClusterMO clusterMo = new ClusterMO(_context, morParent);
+            return clusterMo.isHAEnabled();
+        }
+
+        return false;
+    }
+
+    @Override
+    public void setRestartPriorityForVM(VirtualMachineMO vmMo, String priority) throws Exception {
+        ManagedObjectReference morParent = getParentMor();
+        if (morParent.getType().equals("ClusterComputeResource")) {
+            ClusterMO clusterMo = new ClusterMO(_context, morParent);
+            clusterMo.setRestartPriorityForVM(vmMo, priority);
+        }
+    }
+
+    @Override
     public String getHyperHostDefaultGateway() throws Exception {
         List<HostIpRouteEntry> entries = getHostIpRouteEntries();
         for (HostIpRouteEntry entry : entries) {

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/VmwareHypervisorHost.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/VmwareHypervisorHost.java
@@ -37,6 +37,10 @@ public interface VmwareHypervisorHost {
 
     ClusterDasConfigInfo getDasConfig() throws Exception;
 
+    boolean isHAEnabled() throws Exception;
+
+    void setRestartPriorityForVM(VirtualMachineMO vmMo, String priority) throws Exception;
+
     ManagedObjectReference getHyperHostDatacenter() throws Exception;
 
     ManagedObjectReference getHyperHostOwnerResourcePool() throws Exception;


### PR DESCRIPTION
[VMware] VR loses DHCP settings and VMs cannot obtain IP after HA recovery.
Fix: Set high restart priority for the VR.

Test scenarios:
- Enable cluster HA after VR is created. Now stop and start VR and check its restart priority, should be High.
- Enable cluster HA before VR is created. Now create some VM and verify that VR created must have High restart priority.

Issue validation steps:
- Create a VMware setup with a cluster having 2 ESXi hosts and Enable HA at cluster level in vCenter.
- Creat a Network offering with DHCP and source NAT
- Create few VMs using network created above and Ensure that router VM is created with restart priority set to High.
- Make the ESXi host (where router VM is running) unreachable.
- Verified that router VM is first migrated to other host and VMs acquire IP via DHCP.