### PR TITLE
CLOUDSTACK-9699: Add global setting for enable/disable Metrics feature

### DIFF
--- a/api/src/org/apache/cloudstack/api/ResponseGenerator.java
+++ b/api/src/org/apache/cloudstack/api/ResponseGenerator.java
@@ -37,6 +37,7 @@ import org.apache.cloudstack.api.response.CapacityResponse;
 import org.apache.cloudstack.api.response.ClusterResponse;
 import org.apache.cloudstack.api.response.ConditionResponse;
 import org.apache.cloudstack.api.response.ConfigurationResponse;
+import org.apache.cloudstack.api.response.CapabilitiesResponse;
 import org.apache.cloudstack.api.response.CounterResponse;
 import org.apache.cloudstack.api.response.CreateCmdResponse;
 import org.apache.cloudstack.api.response.DiskOfferingResponse;
@@ -214,6 +215,8 @@ public interface ResponseGenerator {
     ServiceOfferingResponse createServiceOfferingResponse(ServiceOffering offering);
 
     ConfigurationResponse createConfigurationResponse(Configuration cfg);
+
+    CapabilitiesResponse createCapabilitiesResponse(Map<String, Object> capabilities);
 
     SnapshotResponse createSnapshotResponse(Snapshot snapshot);
 

--- a/api/src/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
@@ -59,6 +59,8 @@ public class ListCapabilitiesCmd extends BaseCmd {
         response.setKVMSnapshotEnabled((Boolean)capabilities.get("KVMSnapshotEnabled"));
         response.setAllowUserViewDestroyedVM((Boolean)capabilities.get("allowUserViewDestroyedVM"));
         response.setAllowUserExpungeRecoverVM((Boolean)capabilities.get("allowUserExpungeRecoverVM"));
+        response.setDefaultPageSize((Integer)capabilities.get("defaultPageSize"));
+        response.setEnableMetricsUI((Boolean)capabilities.get("enableMetricsUI"));
         if (capabilities.containsKey("apiLimitInterval")) {
             response.setApiLimitInterval((Integer)capabilities.get("apiLimitInterval"));
         }

--- a/api/src/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/config/ListCapabilitiesCmd.java
@@ -44,29 +44,11 @@ public class ListCapabilitiesCmd extends BaseCmd {
 
     @Override
     public void execute() {
+
         Map<String, Object> capabilities = _mgr.listCapabilities(this);
-        CapabilitiesResponse response = new CapabilitiesResponse();
-        response.setSecurityGroupsEnabled((Boolean)capabilities.get("securityGroupsEnabled"));
-        response.setDynamicRolesEnabled(roleService.isEnabled());
-        response.setCloudStackVersion((String)capabilities.get("cloudStackVersion"));
-        response.setUserPublicTemplateEnabled((Boolean)capabilities.get("userPublicTemplateEnabled"));
-        response.setSupportELB((String)capabilities.get("supportELB"));
-        response.setProjectInviteRequired((Boolean)capabilities.get("projectInviteRequired"));
-        response.setAllowUsersCreateProjects((Boolean)capabilities.get("allowusercreateprojects"));
-        response.setDiskOffMinSize((Long)capabilities.get("customDiskOffMinSize"));
-        response.setDiskOffMaxSize((Long)capabilities.get("customDiskOffMaxSize"));
-        response.setRegionSecondaryEnabled((Boolean)capabilities.get("regionSecondaryEnabled"));
-        response.setKVMSnapshotEnabled((Boolean)capabilities.get("KVMSnapshotEnabled"));
-        response.setAllowUserViewDestroyedVM((Boolean)capabilities.get("allowUserViewDestroyedVM"));
-        response.setAllowUserExpungeRecoverVM((Boolean)capabilities.get("allowUserExpungeRecoverVM"));
-        response.setDefaultPageSize((Integer)capabilities.get("defaultPageSize"));
-        response.setEnableMetricsUI((Boolean)capabilities.get("enableMetricsUI"));
-        if (capabilities.containsKey("apiLimitInterval")) {
-            response.setApiLimitInterval((Integer)capabilities.get("apiLimitInterval"));
-        }
-        if (capabilities.containsKey("apiLimitMax")) {
-            response.setApiLimitMax((Integer)capabilities.get("apiLimitMax"));
-        }
+
+        CapabilitiesResponse response = _responseGenerator.
+                                        createCapabilitiesResponse(capabilities);
         response.setObjectName("capability");
         response.setResponseName(getCommandName());
         this.setResponseObject(response);

--- a/api/src/org/apache/cloudstack/api/response/CapabilitiesResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/CapabilitiesResponse.java
@@ -84,12 +84,8 @@ public class CapabilitiesResponse extends BaseResponse {
     @Param(description = "true if the user can recover and expunge virtualmachines, false otherwise", since = "4.6.0")
     private boolean allowUserExpungeRecoverVM;
 
-    @SerializedName("defaultpagesize")
-    @Param(description = "Default page size global configuration parameter", since="4.7.1")
-    private Integer defaultPageSize;
-
     @SerializedName("enablemetricsui")
-    @Param(description = "True if metrics UI needs to be shown. False otherwise.", since="4.7.1")
+    @Param(description = "True if metrics UI needs to be shown. False otherwise.", since="4.10.0.0")
     private Boolean enableMetricsUI;
 
     public void setSecurityGroupsEnabled(boolean securityGroupsEnabled) {
@@ -150,10 +146,6 @@ public class CapabilitiesResponse extends BaseResponse {
 
     public void setAllowUserExpungeRecoverVM(boolean allowUserExpungeRecoverVM) {
         this.allowUserExpungeRecoverVM = allowUserExpungeRecoverVM;
-    }
-
-    public void setDefaultPageSize(Integer defaultPageSize) {
-        this.defaultPageSize = defaultPageSize;
     }
 
     public void setEnableMetricsUI(Boolean enableMetricsUI) {

--- a/api/src/org/apache/cloudstack/api/response/CapabilitiesResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/CapabilitiesResponse.java
@@ -84,6 +84,14 @@ public class CapabilitiesResponse extends BaseResponse {
     @Param(description = "true if the user can recover and expunge virtualmachines, false otherwise", since = "4.6.0")
     private boolean allowUserExpungeRecoverVM;
 
+    @SerializedName("defaultpagesize")
+    @Param(description = "Default page size global configuration parameter", since="4.7.1")
+    private Integer defaultPageSize;
+
+    @SerializedName("enablemetricsui")
+    @Param(description = "True if metrics UI needs to be shown. False otherwise.", since="4.7.1")
+    private Boolean enableMetricsUI;
+
     public void setSecurityGroupsEnabled(boolean securityGroupsEnabled) {
         this.securityGroupsEnabled = securityGroupsEnabled;
     }
@@ -142,5 +150,13 @@ public class CapabilitiesResponse extends BaseResponse {
 
     public void setAllowUserExpungeRecoverVM(boolean allowUserExpungeRecoverVM) {
         this.allowUserExpungeRecoverVM = allowUserExpungeRecoverVM;
+    }
+
+    public void setDefaultPageSize(Integer defaultPageSize) {
+        this.defaultPageSize = defaultPageSize;
+    }
+
+    public void setEnableMetricsUI(Boolean enableMetricsUI) {
+        this.enableMetricsUI = enableMetricsUI;
     }
 }

--- a/api/test/org/apache/cloudstack/api/command/test/ListCapabilitiesCmdTest.java
+++ b/api/test/org/apache/cloudstack/api/command/test/ListCapabilitiesCmdTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.cloudstack.api.command.test;
 
 

--- a/api/test/org/apache/cloudstack/api/command/test/ListCapabilitiesCmdTest.java
+++ b/api/test/org/apache/cloudstack/api/command/test/ListCapabilitiesCmdTest.java
@@ -1,0 +1,63 @@
+package org.apache.cloudstack.api.command.test;
+
+
+import com.cloud.server.ManagementService;
+import com.cloud.utils.Pair;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.apache.cloudstack.api.ResponseGenerator;
+import org.apache.cloudstack.api.command.admin.config.ListCfgsByCmd;
+import org.apache.cloudstack.api.command.user.config.ListCapabilitiesCmd;
+import org.apache.cloudstack.api.response.CapabilitiesResponse;
+import org.apache.cloudstack.api.response.ConfigurationResponse;
+import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.config.Configuration;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ListCapabilitiesCmdTest extends TestCase {
+
+    private ListCapabilitiesCmd listCapabilitiesCmd;
+    private ManagementService mgr;
+    private ResponseGenerator responseGenerator;
+
+    @Override
+    @Before
+    public void setUp() {
+        responseGenerator = Mockito.mock(ResponseGenerator.class);
+        mgr = Mockito.mock(ManagementService.class);
+        listCapabilitiesCmd = new ListCapabilitiesCmd();
+    }
+
+    @Test
+    public void testCreateSuccess() {
+
+        listCapabilitiesCmd._mgr = mgr;
+        listCapabilitiesCmd._responseGenerator = responseGenerator;
+
+        Map<String, Object> result = new HashMap<String, Object>();
+
+        try {
+            Mockito.when(mgr.listCapabilities(listCapabilitiesCmd)).thenReturn(result);
+        } catch (Exception e) {
+            Assert.fail("Received exception when success expected " + e.getMessage());
+        }
+
+        CapabilitiesResponse capResponse = new CapabilitiesResponse();
+        Mockito.when(responseGenerator.createCapabilitiesResponse(result)).thenReturn(capResponse);
+
+        listCapabilitiesCmd.execute();
+        Mockito.verify(responseGenerator).createCapabilitiesResponse(result);
+
+        CapabilitiesResponse actualResponse = (CapabilitiesResponse) listCapabilitiesCmd.getResponseObject();
+
+        Assert.assertEquals(capResponse, actualResponse);
+    }
+
+}

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -192,6 +192,7 @@ import org.apache.cloudstack.api.response.AutoScalePolicyResponse;
 import org.apache.cloudstack.api.response.AutoScaleVmGroupResponse;
 import org.apache.cloudstack.api.response.AutoScaleVmProfileResponse;
 import org.apache.cloudstack.api.response.CapabilityResponse;
+import org.apache.cloudstack.api.response.CapabilitiesResponse;
 import org.apache.cloudstack.api.response.CapacityResponse;
 import org.apache.cloudstack.api.response.ClusterResponse;
 import org.apache.cloudstack.api.response.ConditionResponse;
@@ -459,6 +460,32 @@ public class ApiResponseHelper implements ResponseGenerator {
         cfgResponse.setObjectName("configuration");
 
         return cfgResponse;
+    }
+
+    @Override
+    public CapabilitiesResponse createCapabilitiesResponse(Map<String, Object> capabilities) {
+        CapabilitiesResponse response = new CapabilitiesResponse();
+        response.setSecurityGroupsEnabled((Boolean)capabilities.get("securityGroupsEnabled"));
+        response.setCloudStackVersion((String)capabilities.get("cloudStackVersion"));
+        response.setUserPublicTemplateEnabled((Boolean)capabilities.get("userPublicTemplateEnabled"));
+        response.setSupportELB((String)capabilities.get("supportELB"));
+        response.setProjectInviteRequired((Boolean)capabilities.get("projectInviteRequired"));
+        response.setAllowUsersCreateProjects((Boolean)capabilities.get("allowusercreateprojects"));
+        response.setDiskOffMinSize((Long)capabilities.get("customDiskOffMinSize"));
+        response.setDiskOffMaxSize((Long)capabilities.get("customDiskOffMaxSize"));
+        response.setRegionSecondaryEnabled((Boolean)capabilities.get("regionSecondaryEnabled"));
+        response.setKVMSnapshotEnabled((Boolean)capabilities.get("KVMSnapshotEnabled"));
+        response.setAllowUserViewDestroyedVM((Boolean)capabilities.get("allowUserViewDestroyedVM"));
+        response.setAllowUserExpungeRecoverVM((Boolean)capabilities.get("allowUserExpungeRecoverVM"));
+        response.setEnableMetricsUI((Boolean)capabilities.get("enableMetricsUI"));
+        if (capabilities.containsKey("apiLimitInterval")) {
+            response.setApiLimitInterval((Integer)capabilities.get("apiLimitInterval"));
+        }
+        if (capabilities.containsKey("apiLimitMax")) {
+            response.setApiLimitMax((Integer)capabilities.get("apiLimitMax"));
+        }
+        return response;
+
     }
 
     @Override

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -684,8 +684,17 @@ import com.cloud.vm.dao.VMInstanceDao;
 public class ManagementServerImpl extends ManagerBase implements ManagementServer, Configurable {
     public static final Logger s_logger = Logger.getLogger(ManagementServerImpl.class.getName());
 
+    static final ConfigKey<Boolean> enableMetricsUI = new ConfigKey<Boolean>(
+                    "Advanced",
+                    Boolean.class,
+                    "enable.metrics.ui",
+                    "false",
+                    "Enable/disable metrics related screens in the management server console",
+                    true);
     static final ConfigKey<Integer> vmPasswordLength = new ConfigKey<Integer>("Advanced", Integer.class, "vm.password.length", "10",
                                                                                       "Specifies the length of a randomly generated password", false);
+
+
     @Inject
     public AccountManager _accountMgr;
     @Inject
@@ -3068,7 +3077,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {vmPasswordLength};
+        return new ConfigKey<?>[] {vmPasswordLength, enableMetricsUI};
     }
 
     protected class EventPurgeTask extends ManagedContextRunnable {
@@ -3450,6 +3459,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         capabilities.put("KVMSnapshotEnabled", KVMSnapshotEnabled);
         capabilities.put("allowUserViewDestroyedVM", allowUserViewDestroyedVM);
         capabilities.put("allowUserExpungeRecoverVM", allowUserExpungeRecoverVM);
+        capabilities.put("enableMetricsUI", enableMetricsUI.value());
+
         if (apiLimitEnabled) {
             capabilities.put("apiLimitInterval", apiLimitInterval);
             capabilities.put("apiLimitMax", apiLimitMax);

--- a/test/integration/smoke/test_global_settings.py
+++ b/test/integration/smoke/test_global_settings.py
@@ -70,8 +70,7 @@ class TestUpdateConfigWithScope(cloudstackTestCase):
         @Steps
         Step1: Listing all the Capabilities for a user
         Step2: Verifying the listcapabilities object is not null
-        Step3: Verifying default.page.size is not null
-        Step4: Verifying enable.metrics.ui is not null
+        Step3: Verifying enable.metrics.ui is not null
         """
         # Listing all the Capabilities for a user
 

--- a/test/integration/smoke/test_global_settings.py
+++ b/test/integration/smoke/test_global_settings.py
@@ -63,6 +63,34 @@ class TestUpdateConfigWithScope(cloudstackTestCase):
         self.assertEqual(configParam.value, updateConfigurationResponse.value, "Check if the update API returned \
                          is the same as the one we got in the list API")
 
+    @attr(tags=["devcloud", "basic", "advanced"], required_hardware="false")
+    def test_list_capabilities(self):
+        """
+        @summary: Test List Capabilities
+        @Steps
+        Step1: Listing all the Capabilities for a user
+        Step2: Verifying the listcapabilities object is not null
+        Step3: Verifying default.page.size is not null
+        Step4: Verifying enable.metrics.ui is not null
+        """
+        # Listing all the Capabilities for a user
+
+        listCapabilities = Configurations.listCapabilities(self.apiClient)
+        # Verifying the listcapabilities object is not null
+        self.assertIsNotNone(
+                listCapabilities,
+                "Failed to list Capabilities"
+        )
+
+        # Verifying enable.metrics.ui is not null
+        self.assertIsNotNone(
+                listCapabilities.enablemetricsui,
+                "Failed to fetch enable.metrics.ui"
+        )
+
+        return
+
+
 
     def tearDown(self):
         """

--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -150,8 +150,6 @@
 
                         g_cloudstackversion = json.listcapabilitiesresponse.capability.cloudstackversion;
 
-                        g_defaultpagesize = json.listcapabilitiesresponse.capability.defaultpagesize;
-
                         g_enablemetricsui = json.listcapabilitiesresponse.capability.enablemetricsui;
 
                         if (json.listcapabilitiesresponse.capability.apilimitinterval != null && json.listcapabilitiesresponse.capability.apilimitmax != null) {

--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -150,6 +150,10 @@
 
                         g_cloudstackversion = json.listcapabilitiesresponse.capability.cloudstackversion;
 
+                        g_defaultpagesize = json.listcapabilitiesresponse.capability.defaultpagesize;
+
+                        g_enablemetricsui = json.listcapabilitiesresponse.capability.enablemetricsui;
+
                         if (json.listcapabilitiesresponse.capability.apilimitinterval != null && json.listcapabilitiesresponse.capability.apilimitmax != null) {
                             var intervalLimit = ((json.listcapabilitiesresponse.capability.apilimitinterval * 1000) / json.listcapabilitiesresponse.capability.apilimitmax) * 3; //multiply 3 to be on safe side
                             //intervalLimit = 9999; //this line is for testing only, comment it before check in
@@ -298,6 +302,8 @@
                                 g_userProjectsEnabled = json.listcapabilitiesresponse.capability.allowusercreateprojects;
 
                                 g_cloudstackversion = json.listcapabilitiesresponse.capability.cloudstackversion;
+
+                                g_enablemetricsui = json.listcapabilitiesresponse.capability.enablemetricsui;
 
                                 if (json.listcapabilitiesresponse.capability.apilimitinterval != null && json.listcapabilitiesresponse.capability.apilimitmax != null) {
                                     var intervalLimit = ((json.listcapabilitiesresponse.capability.apilimitinterval * 1000) / json.listcapabilitiesresponse.capability.apilimitmax) * 3; //multiply 3 to be on safe side

--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -277,7 +277,12 @@
                     label: 'label.tag.value'
                 }
             },
-
+            actionPreFilter: function(args){
+                if (g_enablemetricsui)
+                    return ['add', 'snapshot', 'viewMetrics'];
+                else
+                    return ['add', 'snapshot'];
+            },
             // List view actions
             actions: {
                 // Add instance wizard

--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -35,7 +35,6 @@ var g_cloudstackversion = null;
 var g_queryAsyncJobResultInterval = 3000;
 var g_idpList = null;
 var g_appendIdpDomain = false;
-var g_defaultpagesize = 500;
 var g_enablemetricsui = false;
 
 //keyboard keycode

--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -35,6 +35,8 @@ var g_cloudstackversion = null;
 var g_queryAsyncJobResultInterval = 3000;
 var g_idpList = null;
 var g_appendIdpDomain = false;
+var g_defaultpagesize = 500;
+var g_enablemetricsui = false;
 
 //keyboard keycode
 var keycode_Enter = 13;

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -54,6 +54,12 @@
                             label: 'label.vm.display.name'
                         }
                     },
+                    actionPreFilter: function(args){
+                        if (g_enablemetricsui)
+                            return ['add', 'viewMetrics', 'uploadVolume', 'uploadVolumefromLocal'];
+                        else
+                            return ['add', 'uploadVolume', 'uploadVolumefromLocal'];
+                    },
 
                     // List view actions
                     actions: {

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -7851,9 +7851,14 @@
                                             data: zoneObjs
                                         });
                                     }
-                                });
+                               });
                             },
-
+                            actionPreFilter: function(args){
+                                if (g_enablemetricsui)
+                                    return ['add', 'viewMetrics'];
+                                else
+                                    return ['add'];
+                            },
                             actions: {
                                 add: {
                                     label: 'label.add.zone',
@@ -14088,6 +14093,12 @@
                             }
                         });
                     },
+                    actionPreFilter: function(args){
+                        if (g_enablemetricsui)
+                            return ['add', 'viewMetrics'];
+                        else
+                            return ['add'];
+                    },
 
                     actions: {
                         add: {
@@ -15581,7 +15592,12 @@
                             }
                         });
                     },
-
+                    actionPreFilter: function(args){
+                        if (g_enablemetricsui)
+                            return ['add', 'viewMetrics'];
+                        else
+                            return ['add'];
+                    },
                     actions: {
                         add: {
                             label: 'label.add.host',
@@ -17309,7 +17325,12 @@
                             }
                         });
                     },
-
+                    actionPreFilter: function(args){
+                        if (g_enablemetricsui)
+                            return ['add', 'viewMetrics'];
+                        else
+                            return ['add'];
+                    },
                     actions: {
                         add: {
                             label: 'label.add.primary.storage',
@@ -20956,7 +20977,7 @@
         if (l3GatewayServiceUuid != null && l3GatewayServiceUuid.length > 0) {
             array1.push("&l3gatewayserviceuuid=" + todb(args.data.l3gatewayserviceuuid));
         }
-		
+
 		var l2GatewayServiceUuid = args.data.l2gatewayserviceuuid;
         if (l2GatewayServiceUuid != null && l2GatewayServiceUuid.length > 0) {
             array1.push("&l2gatewayserviceuuid=" + todb(args.data.l2gatewayserviceuuid));

--- a/ui/scripts/ui/widgets/listView.js
+++ b/ui/scripts/ui/widgets/listView.js
@@ -1922,7 +1922,14 @@
 
         // List view header actions
         if (listViewData.actions) {
+            // If a preFilter is set, then get the values. Else set this to null
+            var filteredActions = listViewData.actionPreFilter == undefined ?
+                        null : listViewData.actionPreFilter();
             $.each(listViewData.actions, function(actionName, action) {
+                // filter out those actions that shouldn't be shown
+                if (filteredActions != null
+                        && (filteredActions.indexOf(actionName) < 0))
+                    return false;
                 var preFilter = function(extendContext) {
                     var context = $.extend(true, {},
                         $listView.data('view-args').context ? $listView.data('view-args').context : cloudStack.context);


### PR DESCRIPTION
The Metrics view for each type of entity basically fires APIs and calculates required values on the client end. For e.g. to display memory usage etc at the zone level, it will fetch all zones. For each zone it will fetch pods->cluster->host->VMs
For a very large Cloudstack installation this will have a major impact on the performance. 
Ideally, there should be an API which calculates all metrics in the backend and the UI should simply show the values. However, for the time, introduce a global setting called enable.metrics which will be set to false. This will cause the metrics button not to be shown on any of the pages.
If the Admin changes this to true, then the button will be visible and Metrics functionality will work as usual.

In this pull request, have also added JUnit test case for listCapabilities API.

Additionally added a test case in marvin called test_global_settings as part of the smoke tests which test the output of the listCapabilities API and checks if this setting is present or not.

Refer to [CLOUDSTACK-9699](https://issues.apache.org/jira/browse/CLOUDSTACK-9699) for more details.