### PR TITLE
CLOUDSTACK-9724: Fixed missing additional public ip on tier network w…

### DIFF
--- a/server/src/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/com/cloud/network/IpAddressManagerImpl.java
@@ -460,6 +460,13 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
                     }
                 } else {
                     if (activeCount != null && activeCount > 0) {
+                        if (network.getVpcId() != null) {
+                            // If there are more than one ip in the vpc tier network and services configured on it.
+                            // restart network with cleanup case, on network reprogramming this needs to be return true
+                            // because on the VR ips has removed. In VPC case restart tier network with cleanup will not
+                            // reboot the VR. So ipassoc is needed.
+                            return true;
+                        }
                         continue;
                     } else if (addCount != null && addCount.longValue() == totalCount.longValue()) {
                         s_logger.trace("All rules are in Add state, have to assiciate IP with the backend");


### PR DESCRIPTION
In VPC tier network acquire an ip and configure the PF service on it. VR now will have the two ip addresses on the interface.
Now restart the VPC tier network with cleanup option. After router comes up the public interface has only one ip (source nat ip)
Fixed the above issue.