### PR TITLE
[4.9] CLOUDSTACK-9712: FIX issue on preshared key if we disable/enable remote access vpn

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -659,6 +659,7 @@ class CsRemoteAccessVpn(CsDataBag):
 
 
         secret = CsFile(vpnsecretfilte)
+        secret.empty()
         secret.addeq(": PSK \"%s\"" %psk)
         secret.commit()
 


### PR DESCRIPTION
Way to reproduce the issue
(1) enable remote access vpn
root@r-8349-VM:~# cat /etc/ipsec.d/ipsec.any.secrets
: PSK "mVSx5KDXCPYX7X5DGb2W8yNW"

(2) disable/enable vpn
root@r-8349-VM:~# cat /etc/ipsec.d/ipsec.any.secrets
: PSK "mVSx5KDXCPYX7X5DGb2W8yNW"
: PSK "HeV3dHZpZXt4chhfvhx8D83C"

Expected configuration:
root@r-8349-VM:~# cat /etc/ipsec.d/ipsec.any.secrets
: PSK "HeV3dHZpZXt4chhfvhx8D83C"