### PR TITLE
CLOUDSTACK-9650: Allow starting VMs regardless of cpu/memory cluster.…

### DIFF
--- a/api/src/com/cloud/deploy/DeploymentClusterPlanner.java
+++ b/api/src/com/cloud/deploy/DeploymentClusterPlanner.java
@@ -55,7 +55,7 @@ public interface DeploymentClusterPlanner extends DeploymentPlanner {
             "true",
             "Enable/Disable cluster thresholds. If disabled, an instance can start in a cluster even though the threshold may be crossed.",
             false,
-            ConfigKey.Scope.Zone);
+            ConfigKey.Scope.Global);
 
     /**
      * This is called to determine list of possible clusters where a virtual


### PR DESCRIPTION
…disablethreshold setting

Fixed the scope of configuration flag 'cluster.threshold.enabled' introduced as part of PR#1812 to global