### PR TITLE
CLOUDSTACK-9729: Use latest Nuage client.

### DIFF
--- a/plugins/network-elements/nuage-vsp/pom.xml
+++ b/plugins/network-elements/nuage-vsp/pom.xml
@@ -34,11 +34,14 @@
       <url>http://cs.mv.nuagenetworks.net/releases/</url>
     </repository>
   </repositories>
+  <properties>
+      <nuage.vsp.client.version>1.0.1</nuage.vsp.client.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>net.nuagenetworks.vsp</groupId>
       <artifactId>nuage-vsp-acs-client</artifactId>
-      <version>1.0.0</version>
+      <version>${nuage.vsp.client.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/test/integration/plugins/nuagevsp/nuageTestCase.py
+++ b/test/integration/plugins/nuagevsp/nuageTestCase.py
@@ -186,9 +186,12 @@ class nuageTestCase(cloudstackTestCase):
         cls.https_proxy = None
         zone = next(zone for zone in cls.config.zones
                     if zone.name == cls.zone.name)
-        if zone.dcInternetConnectivityInfo.available:
-            cls.isInternetConnectivityAvailable = \
-                zone.dcInternetConnectivityInfo.available == "true"
+
+        cls.isInternetConnectivityAvailable = \
+            hasattr(zone, "dcInternetConnectivityInfo") \
+            and hasattr(zone.dcInternetConnectivityInfo, "available") \
+            and zone.dcInternetConnectivityInfo.available == "true"
+
         if cls.isInternetConnectivityAvailable:
             if zone.dcInternetConnectivityInfo.httpProxy:
                 cls.http_proxy = zone.dcInternetConnectivityInfo.httpProxy

--- a/test/integration/plugins/nuagevsp/test_nuage_internal_dns.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_internal_dns.py
@@ -342,11 +342,6 @@ class TestNuageInternalDns(nuageTestCase):
         except Exception as e:
             self.fail("Failed to stop the virtual instances, %s" % e)
 
-        try:
-            vm_1.start(self.apiclient)
-        except Exception as e:
-            self.fail("Failed to start the virtual instances, %s" % e)
-
         self.test_data["virtual_machine"]["displayname"] = "vm2"
         self.test_data["virtual_machine"]["name"] = "vm2"
         vm_2 = self.create_VM(network_1)
@@ -358,6 +353,11 @@ class TestNuageInternalDns(nuageTestCase):
             self.verify_vsd_dhcp_option(
                 self.DOMAINNAME, "update.com", nic, True)
             self.verify_vsd_dhcp_option(self.HOSTNAME, "vm2", nic, True)
+
+        try:
+            vm_1.start(self.apiclient)
+        except Exception as e:
+            self.fail("Failed to start the virtual instances, %s" % e)
 
         public_ip_1 = self.acquire_PublicIPAddress(network_1)
         self.create_and_verify_fw(vm_1, public_ip_1, network_1)

--- a/test/integration/plugins/nuagevsp/test_nuage_static_nat.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_static_nat.py
@@ -503,7 +503,7 @@ class TestNuageStaticNat(nuageTestCase):
             self.validate_PublicIPAddress(public_ip, network_1)
         self.debug("Acquired public IP in the created Isolated network "
                    "successfully released in CloudStack")
-
+        self.delete_VM(vm_1)
         # Bug CLOUDSTACK-9398
         """
         self.debug("Creating a persistent Isolated network with Static NAT "
@@ -559,6 +559,7 @@ class TestNuageStaticNat(nuageTestCase):
             self.validate_PublicIPAddress(public_ip, network_2)
         self.debug("Acquired public IP in the created Isolated network "
                    "successfully released in CloudStack")
+        self.delete_VM(vm_2)
         """
 
         self.debug("Creating an Isolated network with Static NAT service and "
@@ -613,6 +614,7 @@ class TestNuageStaticNat(nuageTestCase):
             self.validate_PublicIPAddress(public_ip, network_3)
         self.debug("Acquired public IP in the created Isolated network "
                    "successfully released in CloudStack")
+        self.delete_VM(vm_3)
 
         self.debug("Creating an Isolated network with Static NAT service "
                    "provider as VirtualRouter...")
@@ -663,6 +665,7 @@ class TestNuageStaticNat(nuageTestCase):
             self.validate_PublicIPAddress(public_ip, network_4)
         self.debug("Acquired public IP in the created Isolated network "
                    "successfully released in CloudStack")
+        self.delete_VM(vm_4)
 
         self.debug("Creating an Isolated network with no Static NAT "
                    "service...")
@@ -699,6 +702,7 @@ class TestNuageStaticNat(nuageTestCase):
             self.validate_PublicIPAddress(public_ip, network_5)
         self.debug("Acquired public IP in the created Isolated network "
                    "successfully released in CloudStack")
+        self.delete_VM(vm_5)
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_04_nuage_StaticNAT_vpc_networks(self):


### PR DESCRIPTION
CloudStack root pom change to use Amazon WS 11.1.16
caused our client to fail, as it was depending on classes,
which are not not present anymore.
Latest client version uses Gson instead.

BUG-ID: CLOUDSTACK-9729
Bugfix-for: master