### PR TITLE
CLOUDSTACK-9743 - ODL plugin responds to deleteHost causing other plugin in the chain to be ignored 

### DIFF
--- a/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightElement.java
+++ b/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightElement.java
@@ -19,19 +19,6 @@
 
 package org.apache.cloudstack.network.opendaylight;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
-import org.apache.cloudstack.network.opendaylight.agent.commands.StartupOpenDaylightControllerCommand;
-
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.deploy.DeployDestination;
 import com.cloud.exception.ConcurrentOperationException;
@@ -55,6 +42,16 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VirtualMachineProfile;
+import org.apache.cloudstack.network.opendaylight.agent.commands.StartupOpenDaylightControllerCommand;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Component
 public class OpendaylightElement extends AdapterBase implements ConnectivityProvider, ResourceStateAdapter {
@@ -156,7 +153,7 @@ public class OpendaylightElement extends AdapterBase implements ConnectivityProv
 
     @Override
     public DeleteHostAnswer deleteHost(HostVO host, boolean isForced, boolean isForceDeleteStorage) throws UnableDeleteHostException {
-        return new DeleteHostAnswer(true);
+        return null;
     }
 
     private static Map<Service, Map<Capability, String>> setCapabilities() {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


I found this bug when writing a plugin for Baremetal. What happens is that when a host is deleted, it goes through a list of all registered plugins and calls the deleteHost for each plugin. See `ResourceManagerImpl.java:dispatchToStateAdapters` and it stops as soon as someone returns a deleteAnswer. 

Now in case of ODL, it returns a valid answer irrespective of any condition. This causes the other plugins which are supposed to handle this delete request to be skipped. I am returning `null` here so that Cloudstack will continue further and keep calling other agents which can correctly handle the delete request. 