### PR TITLE
CLOUDSTACK-9740 : Search for secondary IP of NIC that is attached to …

### DIFF
--- a/api/src/com/cloud/network/NetworkService.java
+++ b/api/src/com/cloud/network/NetworkService.java
@@ -175,6 +175,8 @@ public interface NetworkService {
     /* lists the nic informaton */
     List<? extends Nic> listNics(ListNicsCmd listNicsCmd);
 
+    List<? extends NicSecondaryIp> listSecondaryNics(ListNicsCmd listNicsCmd);
+
     Map<Network.Capability, String> getNetworkOfferingServiceCapabilities(NetworkOffering offering, Service service);
 
     IpAddress updateIP(Long id, String customId, Boolean displayIp);

--- a/api/src/org/apache/cloudstack/api/ApiServerService.java
+++ b/api/src/org/apache/cloudstack/api/ApiServerService.java
@@ -43,7 +43,4 @@ public interface ApiServerService {
 
     public Class<?> getCmdClass(String cmdName);
 
-    public String getJSONContentType();
-
-    public boolean isSecureSessionCookieEnabled();
 }

--- a/api/src/org/apache/cloudstack/api/response/NicSecondaryIpResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/NicSecondaryIpResponse.java
@@ -25,6 +25,8 @@ import org.apache.cloudstack.api.EntityReference;
 import com.cloud.serializer.Param;
 import com.cloud.vm.NicSecondaryIp;
 
+import java.util.List;
+
 @EntityReference(value = NicSecondaryIp.class)
 @SuppressWarnings("unused")
 public class NicSecondaryIpResponse extends BaseResponse {
@@ -32,6 +34,10 @@ public class NicSecondaryIpResponse extends BaseResponse {
     @SerializedName(ApiConstants.ID)
     @Param(description = "the ID of the secondary private IP addr")
     private String id;
+
+    @SerializedName("secondaryip")
+    @Param(description = "the Secondary ipv4 addr of nic")
+    private List<NicSecondaryIpResponse> secondaryIpsList;
 
     @SerializedName(ApiConstants.IP_ADDRESS)
     @Param(description = "Secondary IP address")
@@ -64,6 +70,14 @@ public class NicSecondaryIpResponse extends BaseResponse {
 
     public void setIpAddr(String ipAddr) {
         this.ipAddr = ipAddr;
+    }
+
+    public List<NicSecondaryIpResponse> getSecondaryIpsList() {
+        return secondaryIpsList;
+    }
+
+    public void setSecondaryIpsList(List<NicSecondaryIpResponse> secondaryIpsList) {
+        this.secondaryIpsList = secondaryIpsList;
     }
 
     public String getNicId() {

--- a/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -213,7 +213,7 @@ public interface NetworkOrchestrationService {
 
     boolean isSecondaryIpSetForNic(long nicId);
 
-    List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId);
+    List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId, String keyword);
 
     Nic savePlaceholderNic(Network network, String ip4Address, String ip6Address, Type vmType);
 
@@ -227,7 +227,7 @@ public interface NetworkOrchestrationService {
 
     void prepareAllNicsForMigration(VirtualMachineProfile vm, DeployDestination dest);
 
-    boolean canUpdateInSequence(Network network, boolean forced);
+    boolean canUpdateInSequence(Network network);
 
     List<String> getServicesNotSupportedInNewOffering(Network network, long newNetworkOfferingId);
 
@@ -236,6 +236,4 @@ public interface NetworkOrchestrationService {
     void configureUpdateInSequence(Network network);
 
     int getResourceCount(Network network);
-
-    void finalizeUpdateInSequence(Network network, boolean success);
 }

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -40,8 +40,6 @@ import com.cloud.network.dao.RemoteAccessVpnDao;
 import com.cloud.network.dao.RemoteAccessVpnVO;
 import com.cloud.network.dao.VpnUserDao;
 import com.cloud.network.element.RedundantResource;
-import com.cloud.network.router.VirtualRouter;
-import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.dao.DomainRouterDao;
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
@@ -1300,22 +1298,13 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     }
 
     @Override
-    public boolean canUpdateInSequence(Network network, boolean forced){
+    public boolean canUpdateInSequence(Network network){
         List<Provider> providers = getNetworkProviders(network.getId());
 
         //check if the there are no service provider other than virtualrouter.
         for(Provider provider :providers){
             if(provider!=Provider.VirtualRouter)
                 throw new UnsupportedOperationException("Cannot update the network resources in sequence when providers other than virtualrouter are used");
-        }
-        //check if routers are in correct state before proceeding with the update
-        List<DomainRouterVO> routers=_rotuerDao.listByNetworkAndRole(network.getId(), VirtualRouter.Role.VIRTUAL_ROUTER);
-        for(DomainRouterVO router :routers){
-            if(router.getRedundantState()== VirtualRouter.RedundantState.UNKNOWN){
-                if(!forced){
-                    throw new CloudRuntimeException("Domain router: "+router.getInstanceName()+" is in unknown state, Cannot update network. set parameter forced to true for forcing an update");
-                }
-            }
         }
         return true;
     }
@@ -1452,20 +1441,6 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             }
         return resourceCount;
         }
-
-    @Override
-    public void finalizeUpdateInSequence(Network network, boolean success) {
-        List<Provider> providers = getNetworkProviders(network.getId());
-        for (NetworkElement element : networkElements) {
-            if (providers.contains(element.getProvider())) {
-                //currently only one element implements the redundant resource interface
-                if (element instanceof RedundantResource) {
-                    ((RedundantResource) element).finalize(network,success);
-                    break;
-                }
-            }
-        }
-    }
 
 
     @DB
@@ -2894,12 +2869,17 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     }
 
     @Override
-    public List<? extends Nic> listVmNics(final long vmId, final Long nicId, final Long networkId) {
+    public List<? extends Nic> listVmNics(final long vmId, final Long nicId, final Long networkId, String keyword) {
         List<NicVO> result = null;
-        if (nicId == null && networkId == null) {
-            result = _nicDao.listByVmId(vmId);
+
+        if (keyword == null || keyword.isEmpty()) {
+            if (nicId == null && networkId == null) {
+                result = _nicDao.listByVmId(vmId);
+            } else {
+                result = _nicDao.listByVmIdAndNicIdAndNtwkId(vmId, nicId, networkId);
+            }
         } else {
-            result = _nicDao.listByVmIdAndNicIdAndNtwkId(vmId, nicId, networkId);
+            result = _nicDao.listByVmIdAndKeyword(vmId, keyword);
         }
 
         for (final NicVO nic : result) {

--- a/engine/schema/src/com/cloud/vm/dao/NicDao.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicDao.java
@@ -26,6 +26,8 @@ import com.cloud.vm.VirtualMachine;
 public interface NicDao extends GenericDao<NicVO, Long> {
     List<NicVO> listByVmId(long instanceId);
 
+    List<NicVO> listByVmIdAndKeyword(long instanceId, String keyword);
+
     List<String> listIpAddressInNetwork(long networkConfigId);
 
     List<NicVO> listByVmIdIncludingRemoved(long instanceId);

--- a/engine/schema/src/com/cloud/vm/dao/NicDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicDaoImpl.java
@@ -60,7 +60,7 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         AllFieldsSearch.and("network", AllFieldsSearch.entity().getNetworkId(), Op.EQ);
         AllFieldsSearch.and("gateway", AllFieldsSearch.entity().getIPv4Gateway(), Op.EQ);
         AllFieldsSearch.and("vmType", AllFieldsSearch.entity().getVmType(), Op.EQ);
-        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIPv4Address(), Op.EQ);
+        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIPv4Address(), Op.LIKE);
         AllFieldsSearch.and("isDefault", AllFieldsSearch.entity().isDefaultNic(), Op.EQ);
         AllFieldsSearch.and("broadcastUri", AllFieldsSearch.entity().getBroadcastUri(), Op.EQ);
         AllFieldsSearch.and("secondaryip", AllFieldsSearch.entity().getSecondaryIp(), Op.EQ);
@@ -106,6 +106,14 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
     public List<NicVO> listByVmId(long instanceId) {
         SearchCriteria<NicVO> sc = AllFieldsSearch.create();
         sc.setParameters("instance", instanceId);
+        return listBy(sc);
+    }
+
+    @Override
+    public List<NicVO> listByVmIdAndKeyword(long instanceId, String keyword) {
+        SearchCriteria<NicVO> sc = AllFieldsSearch.create();
+        sc.setParameters("instance", instanceId);
+        sc.setParameters("address", "%" + keyword + "%");
         return listBy(sc);
     }
 

--- a/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDao.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDao.java
@@ -53,4 +53,6 @@ public interface NicSecondaryIpDao extends GenericDao<NicSecondaryIpVO, Long> {
     List<String> getSecondaryIpAddressesForNic(long nicId);
 
     Long countByNicId(long nicId);
+
+    List<NicSecondaryIpVO> listSecondaryIpUsingKeyword(long nicId, String keyword);
 }

--- a/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDaoImpl.java
@@ -40,7 +40,7 @@ public class NicSecondaryIpDaoImpl extends GenericDaoBase<NicSecondaryIpVO, Long
         AllFieldsSearch = createSearchBuilder();
         AllFieldsSearch.and("instanceId", AllFieldsSearch.entity().getVmId(), Op.EQ);
         AllFieldsSearch.and("network", AllFieldsSearch.entity().getNetworkId(), Op.EQ);
-        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIp4Address(), Op.EQ);
+        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIp4Address(), Op.LIKE);
         AllFieldsSearch.and("nicId", AllFieldsSearch.entity().getNicId(), Op.EQ);
         AllFieldsSearch.done();
 
@@ -145,5 +145,14 @@ public class NicSecondaryIpDaoImpl extends GenericDaoBase<NicSecondaryIpVO, Long
         SearchCriteria<Long> sc = CountByNicId.create();
         sc.setParameters("nic", nicId);
         return customSearch(sc, null).get(0);
+    }
+
+    @Override
+    public List<NicSecondaryIpVO> listSecondaryIpUsingKeyword(long nicId, String keyword)
+    {
+        SearchCriteria<NicSecondaryIpVO> sc = AllFieldsSearch.create();
+        sc.setParameters("nicId", nicId);
+        sc.setParameters("address", "%" + keyword + "%");
+        return listBy(sc);
     }
 }

--- a/server/src/com/cloud/api/ApiServlet.java
+++ b/server/src/com/cloud/api/ApiServlet.java
@@ -158,7 +158,7 @@ public class ApiServlet extends HttpServlet {
         try {
 
             if (HttpUtils.RESPONSE_TYPE_JSON.equalsIgnoreCase(responseType)) {
-                resp.setContentType(apiServer.getJSONContentType());
+                resp.setContentType(ApiServer.JSONcontentType.value());
             } else if (HttpUtils.RESPONSE_TYPE_XML.equalsIgnoreCase(responseType)){
                 resp.setContentType(HttpUtils.XML_CONTENT_TYPE);
             }
@@ -189,12 +189,10 @@ public class ApiServlet extends HttpServlet {
                             }
                         }
                         session = req.getSession(true);
-                        if (apiServer.isSecureSessionCookieEnabled()) {
+                        if (ApiServer.EnableSecureSessionCookie.value()) {
                             resp.setHeader("SET-COOKIE", String.format("JSESSIONID=%s;Secure;HttpOnly;Path=/client", session.getId()));
                             if (s_logger.isDebugEnabled()) {
-                                if (s_logger.isDebugEnabled()) {
-                                    s_logger.debug("Session cookie is marked secure!");
-                                }
+                                s_logger.debug("Session cookie is marked secure!");
                             }
                         }
                     }
@@ -231,7 +229,7 @@ public class ApiServlet extends HttpServlet {
                         sessionKeyCookie.setMaxAge(0);
                         resp.addCookie(sessionKeyCookie);
                     }
-                    HttpUtils.writeHttpResponse(resp, responseString, httpResponseCode, responseType, apiServer.getJSONContentType());
+                    HttpUtils.writeHttpResponse(resp, responseString, httpResponseCode, responseType, ApiServer.JSONcontentType.value());
                     return;
                 }
             }
@@ -256,7 +254,7 @@ public class ApiServlet extends HttpServlet {
                     auditTrailSb.append(" " + HttpServletResponse.SC_UNAUTHORIZED + " " + "unable to verify user credentials");
                     final String serializedResponse =
                             apiServer.getSerializedApiError(HttpServletResponse.SC_UNAUTHORIZED, "unable to verify user credentials", params, responseType);
-                    HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_UNAUTHORIZED, responseType, apiServer.getJSONContentType());
+                    HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_UNAUTHORIZED, responseType, ApiServer.JSONcontentType.value());
                     return;
                 }
 
@@ -267,7 +265,7 @@ public class ApiServlet extends HttpServlet {
                         s_logger.info("missing command, ignoring request...");
                         auditTrailSb.append(" " + HttpServletResponse.SC_BAD_REQUEST + " " + "no command specified");
                         final String serializedResponse = apiServer.getSerializedApiError(HttpServletResponse.SC_BAD_REQUEST, "no command specified", params, responseType);
-                        HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_BAD_REQUEST, responseType, apiServer.getJSONContentType());
+                        HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_BAD_REQUEST, responseType, ApiServer.JSONcontentType.value());
                         return;
                     }
                     final User user = entityMgr.findById(User.class, userId);
@@ -283,7 +281,7 @@ public class ApiServlet extends HttpServlet {
                     auditTrailSb.append(" " + HttpServletResponse.SC_UNAUTHORIZED + " " + "unable to verify user credentials");
                     final String serializedResponse =
                             apiServer.getSerializedApiError(HttpServletResponse.SC_UNAUTHORIZED, "unable to verify user credentials", params, responseType);
-                    HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_UNAUTHORIZED, responseType, apiServer.getJSONContentType());
+                    HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_UNAUTHORIZED, responseType, ApiServer.JSONcontentType.value());
                     return;
                 }
             } else {
@@ -297,7 +295,7 @@ public class ApiServlet extends HttpServlet {
                 // Add the HTTP method (GET/POST/PUT/DELETE) as well into the params map.
                 params.put("httpmethod", new String[] {req.getMethod()});
                 final String response = apiServer.handleRequest(params, responseType, auditTrailSb);
-                HttpUtils.writeHttpResponse(resp, response != null ? response : "", HttpServletResponse.SC_OK, responseType, apiServer.getJSONContentType());
+                HttpUtils.writeHttpResponse(resp, response != null ? response : "", HttpServletResponse.SC_OK, responseType, ApiServer.JSONcontentType.value());
             } else {
                 if (session != null) {
                     try {
@@ -310,13 +308,13 @@ public class ApiServlet extends HttpServlet {
                 final String serializedResponse =
                         apiServer.getSerializedApiError(HttpServletResponse.SC_UNAUTHORIZED, "unable to verify user credentials and/or request signature", params,
                                 responseType);
-                HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_UNAUTHORIZED, responseType, apiServer.getJSONContentType());
+                HttpUtils.writeHttpResponse(resp, serializedResponse, HttpServletResponse.SC_UNAUTHORIZED, responseType, ApiServer.JSONcontentType.value());
 
             }
         } catch (final ServerApiException se) {
             final String serializedResponseText = apiServer.getSerializedApiError(se, params, responseType);
             resp.setHeader("X-Description", se.getDescription());
-            HttpUtils.writeHttpResponse(resp, serializedResponseText, se.getErrorCode().getHttpCode(), responseType, apiServer.getJSONContentType());
+            HttpUtils.writeHttpResponse(resp, serializedResponseText, se.getErrorCode().getHttpCode(), responseType, ApiServer.JSONcontentType.value());
             auditTrailSb.append(" " + se.getErrorCode() + " " + se.getDescription());
         } catch (final Exception ex) {
             s_logger.error("unknown exception writing api response", ex);

--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -489,10 +489,7 @@ public enum Config {
             null),
 
     // Snapshots
-    SnapshotHourlyMax("Snapshots", SnapshotManager.class, Integer.class, "snapshot.max.hourly", "8", "Maximum hourly snapshots for a volume", null),
-    SnapshotDailyMax("Snapshots", SnapshotManager.class, Integer.class, "snapshot.max.daily", "8", "Maximum daily snapshots for a volume", null),
-    SnapshotWeeklyMax("Snapshots", SnapshotManager.class, Integer.class, "snapshot.max.weekly", "8", "Maximum weekly snapshots for a volume", null),
-    SnapshotMonthlyMax("Snapshots", SnapshotManager.class, Integer.class, "snapshot.max.monthly", "8", "Maximum monthly snapshots for a volume", null),
+
     SnapshotPollInterval(
             "Snapshots",
             SnapshotManager.class,
@@ -1498,24 +1495,6 @@ public enum Config {
             "agent.load.threshold",
             "0.7",
             "Percentage (as a value between 0 and 1) of connected agents after which agent load balancing will start happening",
-            null),
-
-    JSONDefaultContentType(
-            "Advanced",
-            ManagementServer.class,
-            String.class,
-            "json.content.type",
-            "application/json; charset=UTF-8",
-            "Http response content type for JSON",
-            null),
-
-    EnableSecureSessionCookie(
-            "Advanced",
-            ManagementServer.class,
-            Boolean.class,
-            "enable.secure.session.cookie",
-            "false",
-            "Session cookie's secure flag is enabled if true. Use this only when using HTTPS",
             null),
 
     DefaultMaxDomainUserVms("Domain Defaults", ManagementServer.class, Long.class, "max.domain.user.vms", "40", "The default maximum number of user VMs that can be deployed for a domain", null),

--- a/server/src/com/cloud/storage/snapshot/SnapshotManager.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManager.java
@@ -25,18 +25,23 @@ import com.cloud.exception.ResourceAllocationException;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotVO;
 import com.cloud.storage.Volume;
+import org.apache.cloudstack.framework.config.ConfigKey;
 
 /**
  *
  *
  */
 public interface SnapshotManager {
-
-    public static final int HOURLYMAX = 8;
-    public static final int DAILYMAX = 8;
-    public static final int WEEKLYMAX = 8;
-    public static final int MONTHLYMAX = 12;
     public static final int DELTAMAX = 16;
+
+    static final ConfigKey<Integer> SnapshotHourlyMax = new ConfigKey<Integer>(Integer.class, "snapshot.max.hourly", "Snapshots", "8",
+            "Maximum recurring hourly snapshots to be retained for a volume. If the limit is reached, early snapshots from the start of the hour are deleted so that newer ones can be saved. This limit does not apply to manual snapshots. If set to 0, recurring hourly snapshots can not be scheduled.", false, ConfigKey.Scope.Global, null);
+    static final ConfigKey<Integer> SnapshotDailyMax = new ConfigKey<Integer>(Integer.class, "snapshot.max.daily", "Snapshots", "8",
+            "Maximum recurring daily snapshots to be retained for a volume. If the limit is reached, snapshots from the start of the day are deleted so that newer ones can be saved. This limit does not apply to manual snapshots. If set to 0, recurring daily snapshots can not be scheduled.", false, ConfigKey.Scope.Global, null);
+    static final ConfigKey<Integer> SnapshotWeeklyMax = new ConfigKey<Integer>(Integer.class, "snapshot.max.weekly", "Snapshots", "8",
+            "Maximum recurring weekly snapshots to be retained for a volume. If the limit is reached, snapshots from the beginning of the week are deleted so that newer ones can be saved. This limit does not apply to manual snapshots. If set to 0, recurring weekly snapshots can not be scheduled.", false, ConfigKey.Scope.Global, null);
+    static final ConfigKey<Integer> SnapshotMonthlyMax = new ConfigKey<Integer>(Integer.class, "snapshot.max.monthly", "Snapshots", "8",
+            "Maximum recurring monthly snapshots to be retained for a volume. If the limit is reached, snapshots from the beginning of the month are deleted so that newer ones can be saved. This limit does not apply to manual snapshots. If set to 0, recurring monthly snapshots can not be scheduled.", false, ConfigKey.Scope.Global, null);
 
     void deletePoliciesForVolume(Long volumeId);
 

--- a/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -111,6 +111,8 @@ import org.apache.cloudstack.engine.subsystem.api.storage.StorageStrategyFactory
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
@@ -128,7 +130,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 @Component
-public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implements SnapshotManager, SnapshotApiService {
+public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implements SnapshotManager, SnapshotApiService, Configurable {
     private static final Logger s_logger = Logger.getLogger(SnapshotManagerImpl.class);
     @Inject
     VMTemplateDao _templateDao;
@@ -1176,10 +1178,10 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
 
         String value = _configDao.getValue(Config.BackupSnapshotWait.toString());
 
-        Type.HOURLY.setMax(NumbersUtil.parseInt(_configDao.getValue("snapshot.max.hourly"), HOURLYMAX));
-        Type.DAILY.setMax(NumbersUtil.parseInt(_configDao.getValue("snapshot.max.daily"), DAILYMAX));
-        Type.WEEKLY.setMax(NumbersUtil.parseInt(_configDao.getValue("snapshot.max.weekly"), WEEKLYMAX));
-        Type.MONTHLY.setMax(NumbersUtil.parseInt(_configDao.getValue("snapshot.max.monthly"), MONTHLYMAX));
+        Type.HOURLY.setMax(SnapshotHourlyMax.value());
+        Type.DAILY.setMax(SnapshotDailyMax.value());
+        Type.WEEKLY.setMax(SnapshotWeeklyMax.value());
+        Type.MONTHLY.setMax(SnapshotMonthlyMax.value());
         _totalRetries = NumbersUtil.parseInt(_configDao.getValue("total.retries"), 4);
         _pauseInterval = 2 * NumbersUtil.parseInt(_configDao.getValue("ping.interval"), 60);
 
@@ -1319,5 +1321,12 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
     }
 
 
+    @Override
+    public String getConfigComponentName() {
+        return SnapshotManager.class.getSimpleName();
+    }
 
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] { SnapshotHourlyMax, SnapshotDailyMax, SnapshotMonthlyMax, SnapshotWeeklyMax}; }
 }

--- a/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -800,7 +800,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     }
 
     @Override
-    public List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId) {
+    public List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId, String keyword) {
         // TODO Auto-generated method stub
         return null;
     }
@@ -808,6 +808,11 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     @Override
     public List<? extends Nic> listNics(ListNicsCmd listNicsCmd) {
         // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public List<? extends NicSecondaryIp> listSecondaryNics(ListNicsCmd listNicsCmd) {
         return null;
     }
 
@@ -848,7 +853,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     }
 
     @Override
-    public boolean canUpdateInSequence(Network network, boolean forced) {
+    public boolean canUpdateInSequence(Network network) {
         return false;
     }
 
@@ -870,11 +875,6 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     @Override
     public int getResourceCount(Network network) {
         return 0;
-    }
-
-    @Override
-    public void finalizeUpdateInSequence(Network network, boolean success) {
-        return;
     }
 
     @Override

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1710,11 +1710,16 @@
                     dataProvider: function(args) {
                         var data = {};
 
+                        if (args.filterBy.search.value != null) {
+                            data.keyword = args.filterBy.search.value;
+                        }
+
                         $.ajax({
                             url: createURL('listNics'),
                             data: {
                                 nicId: args.context.nics[0].id,
-                                virtualmachineid: args.context.instances[0].id
+                                virtualmachineid: args.context.instances[0].id,
+                                keyword: args.filterBy.search.value
                             },
                             success: function(json) {
                                 var ips = json.listnicsresponse.nic ? json.listnicsresponse.nic[0].secondaryip : [];

--- a/utils/src/main/java/com/cloud/utils/HttpUtils.java
+++ b/utils/src/main/java/com/cloud/utils/HttpUtils.java
@@ -50,6 +50,17 @@ public class HttpUtils {
         else {
             resp.addHeader("X-XSS-Protection", "1;mode=block");
         }
+
+        if (resp.containsHeader("content-security-policy")) {
+            resp.setIntHeader("content-security-policy", 1);
+        }else {
+            resp.addIntHeader("content-security-policy", 1);
+        }
+        resp.addHeader("content-security-policy","default-src=none");
+        resp.addHeader("content-security-policy","script-src=self");
+        resp.addHeader("content-security-policy","connect-src=self");
+        resp.addHeader("content-security-policy","img-src=self");
+        resp.addHeader("content-security-policy","style-src=self");
     }
 
     public static void writeHttpResponse(final HttpServletResponse resp, final String response,


### PR DESCRIPTION
Search for secondary IP of NIC that is attached to an instance is not working.

If instance has more than one secondary IP assigned and administrator attempts to search that list, all IPs are displayed instead of being filtered by the search string.
in web UI:
CCP dashboard -> Instances -> <Instance name> -> NICs -> ”View Secondary IPs” -> Search for a IP, but the search returns all the IPs in the list

**Screenshot before applying fix :** 

![screenshot before applying fix](https://cloud.githubusercontent.com/assets/25146827/23013581/40b9b4b4-f451-11e6-849a-89bbe5c9bd54.PNG)

**Screenshot after applying fix :**

![screenshot after applying fix](https://cloud.githubusercontent.com/assets/25146827/23013593/5039b042-f451-11e6-963b-7e0f3d9e6c77.PNG)

