### PR TITLE
CLOUDSTACK-9748:VPN Users search functionality broken

### DIFF
--- a/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -582,6 +582,7 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
     public Pair<List<? extends VpnUser>, Integer> searchForVpnUsers(ListVpnUsersCmd cmd) {
         String username = cmd.getUsername();
         Long id = cmd.getId();
+        String keyword = cmd.getKeyword();
         Account caller = CallContext.current().getCallingAccount();
         List<Long> permittedAccounts = new ArrayList<Long>();
 
@@ -596,7 +597,7 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
 
 
         sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
-        sb.and("username", sb.entity().getUsername(), SearchCriteria.Op.EQ);
+        sb.and("username", sb.entity().getUsername(), SearchCriteria.Op.LIKE);
         sb.and("state", sb.entity().getState(), Op.IN);
 
         SearchCriteria<VpnUserVO> sc = sb.create();
@@ -611,6 +612,10 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
 
         if (username != null) {
             sc.setParameters("username", username);
+        }
+
+        if (keyword!= null) {
+            sc.setParameters("username",  "%" + keyword + "%");
         }
 
         Pair<List<VpnUserVO>, Integer> result = _vpnUsersDao.searchAndCount(sc, searchFilter);


### PR DESCRIPTION
VPN Users search functionality broken 
If you try to search VPN users with it’s user name, you will not be able to search.

Fixed the same.