### PR TITLE
CLOUDSTACK-9749: Disable password service on ilb systemvm

### DIFF
--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -1084,6 +1084,7 @@ EOF
   enable_irqbalance 1
   enable_vpc_rpsrfs 1
   enable_svc cloud 0
+  enable_svc cloud-passwd-srvr 1
   disable_rpfilter
   enable_fwding 1
   cp /etc/iptables/iptables-vpcrouter /etc/iptables/rules.v4

--- a/systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip
+++ b/systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip
@@ -18,7 +18,6 @@
 
 . /etc/default/cloud-passwd-srvr
 addr=$1;
-ENABLED=1
 while [ "$ENABLED" == "1" ]
 do
     python /opt/cloud/bin/passwd_server_ip.py $addr >/dev/null 2>/dev/null


### PR DESCRIPTION
Fix cloud-password-srvr correctly.
Made sure it runs on VPC VR, but not on Internal LB