### PR TITLE
CLOUDSTACK-9746 system-vm: logrotate config causes critical failures

### DIFF
--- a/systemvm/patches/debian/config/etc/logrotate.d/apache2
+++ b/systemvm/patches/debian/config/etc/logrotate.d/apache2
@@ -4,6 +4,6 @@
        rotate 3
        compress
        dateext
-       size 10M
+       maxsize 10M
        notifempty
 }

--- a/systemvm/patches/debian/config/etc/logrotate.d/cloud
+++ b/systemvm/patches/debian/config/etc/logrotate.d/cloud
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 /var/log/cloud.log {
-        rotate 4
+        rotate 10
         daily
-        size 10M
+        maxsize 10M
         missingok
         notifempty
         compress

--- a/systemvm/patches/debian/config/etc/logrotate.d/conntrackd
+++ b/systemvm/patches/debian/config/etc/logrotate.d/conntrackd
@@ -1,6 +1,6 @@
 /var/log/conntrackd-stats.log {
     daily
-    size 10M
+    maxsize 10M
     rotate 2
     missingok
     compress

--- a/systemvm/patches/debian/config/etc/logrotate.d/dnsmasq
+++ b/systemvm/patches/debian/config/etc/logrotate.d/dnsmasq
@@ -1,6 +1,6 @@
 /var/log/dnsmasq.log {
     daily
-    size 10M
+    maxsize 10M
     missingok
     rotate 5
     notifempty

--- a/systemvm/patches/debian/config/etc/logrotate.d/haproxy
+++ b/systemvm/patches/debian/config/etc/logrotate.d/haproxy
@@ -3,7 +3,7 @@
     rotate 5
     missingok
     notifempty
-    size 10M
+    maxsize 10M
     postrotate  
       /bin/kill -HUP `cat /var/run/rsyslog.pid 2> /dev/null` 2> /dev/null || true
     endscript

--- a/systemvm/patches/debian/config/etc/logrotate.d/ppp
+++ b/systemvm/patches/debian/config/etc/logrotate.d/ppp
@@ -1,6 +1,6 @@
 /var/log/ppp-connect-errors {
 	daily
-	size 10M
+	maxsize 10M
 	rotate 5
 	missingok
 	notifempty

--- a/systemvm/patches/debian/config/etc/logrotate.d/rsyslog
+++ b/systemvm/patches/debian/config/etc/logrotate.d/rsyslog
@@ -2,10 +2,9 @@
 {
 	rotate 7
 	daily
-	size 50M
+	maxsize 10M
 	missingok
 	notifempty
-	delaycompress
 	compress
 	postrotate
 		/usr/sbin/invoke-rc.d rsyslog rotate > /dev/null
@@ -27,11 +26,10 @@
 {
 	rotate 10
 	daily
-	size 50M
+	maxsize 10M
 	missingok
 	notifempty
 	compress
-	delaycompress
 	sharedscripts
 	postrotate
 		/usr/sbin/invoke-rc.d rsyslog rotate > /dev/null


### PR DESCRIPTION
* rotate both daily and by size by using maxsize in stead of size
* decrease the max size to 10M for rsyslog files
* remove delaycompress for rsyslog files
* increase rotate to 10 for cloud.log
