### PR TITLE
CLOUDSTACK-9756: Configure to  ignore the ipassoc failure

### DIFF
--- a/engine/components-api/src/com/cloud/network/IpAddressManager.java
+++ b/engine/components-api/src/com/cloud/network/IpAddressManager.java
@@ -43,6 +43,9 @@ public interface IpAddressManager {
         "If true, when account has dedicated public ip range(s), once the ips dedicated to the account have been consumed ips will be acquired from the system pool",
         true, ConfigKey.Scope.Account);
 
+    static final ConfigKey<Boolean> RulesContinueOnError = new ConfigKey<Boolean>("Advanced", Boolean.class, "network.rule.delete.ignoreerror", "true",
+            "When true, ip address delete (ipassoc) failures are  ignored", true);
+
     /**
      * Assigns a new public ip address.
      *

--- a/server/src/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/com/cloud/network/IpAddressManagerImpl.java
@@ -282,6 +282,8 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
     SearchBuilder<IPAddressVO> AssignIpAddressSearch;
     SearchBuilder<IPAddressVO> AssignIpAddressFromPodVlanSearch;
 
+    static Boolean rulesContinueOnErrFlag = true;
+
     @Override
     public boolean configure(String name, Map<String, Object> params) {
         // populate providers
@@ -403,7 +405,11 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
 
         Network.State.getStateMachine().registerListener(new NetworkStateListener(_configDao));
 
-        s_logger.info("Network Manager is configured.");
+        if (RulesContinueOnError.value() != null) {
+            rulesContinueOnErrFlag = RulesContinueOnError.value();
+        }
+
+        s_logger.info("IPAddress Manager is configured.");
 
         return true;
     }
@@ -601,7 +607,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         if (ip.getAssociatedWithNetworkId() != null) {
             Network network = _networksDao.findById(ip.getAssociatedWithNetworkId());
             try {
-                if (!applyIpAssociations(network, true)) {
+                if (!applyIpAssociations(network, rulesContinueOnErrFlag)) {
                     s_logger.warn("Unable to apply ip address associations for " + network);
                     success = false;
                 }
@@ -2026,6 +2032,6 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {UseSystemPublicIps};
+        return new ConfigKey<?>[] {UseSystemPublicIps, RulesContinueOnError};
     }
 }

--- a/server/src/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -2001,7 +2001,10 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
 
     @Override
     public boolean removeAllLoadBalanacersForIp(long ipId, Account caller, long callerUserId) {
-        List<FirewallRuleVO> rules = _firewallDao.listByIpAndPurposeAndNotRevoked(ipId, Purpose.LoadBalancing);
+
+        //Included revoked rules to remove the rules of ips which are in revoke state
+        List<FirewallRuleVO> rules = _firewallDao.listByIpAndPurpose(ipId, Purpose.LoadBalancing);
+
         if (rules != null) {
             s_logger.debug("Found " + rules.size() + " lb rules to cleanup");
             for (FirewallRule rule : rules) {

--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1845,7 +1845,15 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
 
                 if (_networkModel.isProviderSupportServiceInNetwork(guestNetworkId, Service.StaticNat, provider)) {
                     if (ip.isOneToOneNat()) {
-                        final StaticNatImpl staticNat = new StaticNatImpl(ip.getAccountId(), ip.getDomainId(), guestNetworkId, ip.getId(), ip.getVmIp(), false);
+
+                        boolean revoke = false;
+                        if (ip.getState() == IpAddress.State.Releasing ) {
+                            // for ips got struck in releasing state we need to delete the rule not add.
+                            s_logger.debug("Rule revoke set to true for the ip " + ip.getAddress() +" becasue it is in releasing state");
+                            revoke = true;
+                        }
+                        final StaticNatImpl staticNat = new StaticNatImpl(ip.getAccountId(), ip.getDomainId(), guestNetworkId, ip.getId(), ip.getVmIp(), revoke);
+
                         staticNats.add(staticNat);
                     }
                 }

--- a/server/src/com/cloud/network/rules/RulesManagerImpl.java
+++ b/server/src/com/cloud/network/rules/RulesManagerImpl.java
@@ -701,7 +701,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         boolean success = false;
 
         if (apply) {
-            success = applyPortForwardingRules(rule.getSourceIpAddressId(), true, caller);
+            success = applyPortForwardingRules(rule.getSourceIpAddressId(), _ipAddrMgr.RulesContinueOnError.value(), caller);
         } else {
             success = true;
         }
@@ -736,7 +736,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         boolean success = false;
 
         if (apply) {
-            success = applyStaticNatRulesForIp(rule.getSourceIpAddressId(), true, caller, true);
+            success = applyStaticNatRulesForIp(rule.getSourceIpAddressId(),  _ipAddrMgr.RulesContinueOnError.value(), caller, true);
         } else {
             success = true;
         }
@@ -769,7 +769,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         // apply rules for all ip addresses
         for (Long ipId : ipsToReprogram) {
             s_logger.debug("Applying port forwarding rules for ip address id=" + ipId + " as a part of vm expunge");
-            if (!applyPortForwardingRules(ipId, true, _accountMgr.getSystemAccount())) {
+            if (!applyPortForwardingRules(ipId,  _ipAddrMgr.RulesContinueOnError.value(), _accountMgr.getSystemAccount())) {
                 s_logger.warn("Failed to apply port forwarding rules for ip id=" + ipId);
                 success = false;
             }
@@ -1098,10 +1098,10 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         boolean success = true;
 
         // revoke all port forwarding rules
-        success = success && applyPortForwardingRules(ipId, true, caller);
+        success = success && applyPortForwardingRules(ipId,  _ipAddrMgr.RulesContinueOnError.value(), caller);
 
         // revoke all all static nat rules
-        success = success && applyStaticNatRulesForIp(ipId, true, caller, true);
+        success = success && applyStaticNatRulesForIp(ipId,  _ipAddrMgr.RulesContinueOnError.value(), caller, true);
 
         // revoke static nat for the ip address
         success = success && applyStaticNatForIp(ipId, false, caller, true);
@@ -1144,9 +1144,11 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         boolean success = true;
         // revoke all PF rules for the network
         success = success && applyPortForwardingRulesForNetwork(networkId, true, caller);
+        success = success && applyPortForwardingRulesForNetwork(networkId,  _ipAddrMgr.RulesContinueOnError.value(), caller);
 
         // revoke all all static nat rules for the network
         success = success && applyStaticNatRulesForNetwork(networkId, true, caller);
+        success = success && applyStaticNatRulesForNetwork(networkId,  _ipAddrMgr.RulesContinueOnError.value(), caller);
 
         // Now we check again in case more rules have been inserted.
         rules.addAll(_portForwardingDao.listByNetworkAndNotRevoked(networkId));


### PR DESCRIPTION

On failure of ip assoc in back end (In VR), added config option to ignore or not to ignore failure. Using this failures won't be ignored and ip address will not set to free in DB.