### PR TITLE
Change the README link for event page to the current ACS CCCs website

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ developer [page](http://cloudstack.apache.org/developers.html) for contributing 
 
 * [Blog](https://blogs.apache.org/cloudstack)
 * [Twitter](https://twitter.com/cloudstack)
-* [Planet CloudStack](http://planet.apache.org/cloudstack)
-* [Events and meetup](http://lanyrd.com/topics/apache-cloudstack)
+* [Events and meetup](http://cloudstackcollab.org/)
 
 ## Reporting Security Vulnerabilities
 


### PR DESCRIPTION
While reading the README file of Apache CloudStack repository on Github I noticed that we have a section called “News and Events”. This section was pointing to a website for conferences, which was not updated in years. I changed the link to send the users to http://cloudstackcollab.org/ hot site.

Moreover, I removed the reference for http://planet.apache.org/cloudstack; this system was shut down and is no longer available (http://markmail.org/message/wcdqncr6vr4lk6a7?q=planet%2Eapache%2Eorg#query:planet.apache.org+page:1+mid:6g76gvitxhlyee4n+state:results).