### PR TITLE
Dockerfile: Upgrade base distro to Ubuntu 16.04, fix support for JDK8

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,16 +17,18 @@
 #
 # CloudStack-simulator build
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
 LABEL Vendor="Apache.org" License="ApacheV2" Version="4.10.0.0-SNAPSHOT"
 
-RUN add-apt-repository -y ppa:openjdk-r/ppa && apt-get -y update && apt-get install -y \
+RUN apt-get -y update && apt-get install -y \
     genisoimage \
     libffi-dev \
     libssl-dev \
     git \
+    sudo \
+    ipmitool \
     maven \
     openjdk-8-jdk \
     python-dev \
@@ -39,8 +41,11 @@ RUN echo 'mysql-server mysql-server/root_password password root' |  debconf-set-
     echo 'mysql-server mysql-server/root_password_again password root' |  debconf-set-selections;
 
 RUN apt-get install -qqy mysql-server && \
-    apt-get clean all
+    apt-get clean all && \
+    mkdir /var/run/mysqld; \
+    chown mysql /var/run/mysqld
 
+RUN echo '''sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"''' >> /etc/mysql/mysql.conf.d/mysqld.cnf
 RUN (/usr/bin/mysqld_safe &); sleep 5; mysqladmin -u root -proot password ''
 
 #RUN pip install --allow-external mysql-connector-python mysql-connector-python


### PR DESCRIPTION
Fix current broken build introduce with JDK upgrade from #1888 of docker simulator because of missing dependencies and JDK8. This PR upgrade the distro to Ubuntu 16.04 and use default jdk version 8.

I've quickly test the build locally, no error in the UI and logs.