### PR TITLE
CLOUDSTACK-9768: Time displayed for events in UI is incorrect

### DIFF
--- a/api/src/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/org/apache/cloudstack/api/ApiConstants.java
@@ -263,6 +263,7 @@ public class ApiConstants {
     public static final String ISO_ID = "isoid";
     public static final String TIMEOUT = "timeout";
     public static final String TIMEZONE = "timezone";
+    public static final String TIMEZONEOFFSET = "timezoneoffset";
     public static final String TYPE = "type";
     public static final String TRUST_STORE = "truststore";
     public static final String TRUST_STORE_PASSWORD = "truststorepass";

--- a/api/src/org/apache/cloudstack/api/response/LoginCmdResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/LoginCmdResponse.java
@@ -58,6 +58,10 @@ public class LoginCmdResponse extends AuthenticationCmdResponse {
     @Param(description = "user time zone")
     private String timeZone;
 
+    @SerializedName(value = ApiConstants.TIMEZONEOFFSET)
+    @Param(description = "user time zoneoffset")
+    private String timeZoneOffset;
+
     @SerializedName(value = ApiConstants.REGISTERED)
     @Param(description = "Is user registered")
     private String registered;
@@ -137,6 +141,12 @@ public class LoginCmdResponse extends AuthenticationCmdResponse {
     public void setTimeZone(String timeZone) {
         this.timeZone = timeZone;
     }
+
+    public String getTimeZoneOffset() {
+        return timeZoneOffset;
+    }
+
+    public void setTimeZoneOffset(String timeZoneOffset) { this.timeZoneOffset = timeZoneOffset; }
 
     public String getRegistered() {
         return registered;

--- a/server/src/com/cloud/api/ApiServer.java
+++ b/server/src/com/cloud/api/ApiServer.java
@@ -987,6 +987,9 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
                 if (ApiConstants.TIMEZONE.equalsIgnoreCase(attrName)) {
                     response.setTimeZone(attrObj.toString());
                 }
+                if (ApiConstants.TIMEZONEOFFSET.equalsIgnoreCase(attrName)) {
+                    response.setTimeZoneOffset(attrObj.toString());
+                }
                 if (ApiConstants.REGISTERED.equalsIgnoreCase(attrName)) {
                     response.setRegistered(attrObj.toString());
                 }

--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -120,6 +120,7 @@
                     g_username = unBoxCookieValue('username');
                     g_userfullname = unBoxCookieValue('userfullname');
                     g_timezone = unBoxCookieValue('timezone');
+                    g_timezoneoffset = unBoxCookieValue('timezoneoffset');
                 } else { //single-sign-on (bypass login screen)
                     g_sessionKey = encodeURIComponent(g_loginResponse.sessionkey);
                     g_role = g_loginResponse.type;
@@ -129,6 +130,7 @@
                     g_domainid = g_loginResponse.domainid;
                     g_userfullname = g_loginResponse.firstname + ' ' + g_loginResponse.lastname;
                     g_timezone = g_loginResponse.timezone;
+                    g_timezoneoffset = g_loginResponse.timezoneoffset;
                 }
 
                 var userValid = false;
@@ -258,6 +260,7 @@
                         g_account = loginresponse.account;
                         g_domainid = loginresponse.domainid;
                         g_timezone = loginresponse.timezone;
+                        g_timezoneoffset = loginresponse.timezoneoffset;
                         g_userfullname = loginresponse.firstname + ' ' + loginresponse.lastname;
 
                         $.cookie('username', g_username, {
@@ -273,6 +276,9 @@
                             expires: 1
                         });
                         $.cookie('timezone', g_timezone, {
+                            expires: 1
+                        });
+                        $.cookie('timezoneoffset', g_timezoneoffset, {
                             expires: 1
                         });
                         $.cookie('userfullname', g_userfullname, {


### PR DESCRIPTION
Time displayed for events in UI is incorrect. Let's say, when we login using Japanese language the time displayed in the events is GMT instead of JST. However with English language the time is JST, as expected.
Example: 
Time is displayed in the event is 10:40, if you are logged in using English language. 
Whereas, time in the event shows 19:40 If you login with Japanese language.