### PR TITLE
ipv6: Set IPv6 CIDR and Gateway in 'nic' profile

### DIFF
--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -1523,6 +1523,8 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             nic.setIPv4Address(profile.getIPv4Address());
             nic.setAddressFormat(profile.getFormat());
             nic.setIPv6Address(profile.getIPv6Address());
+            nic.setIPv6Cidr(profile.getIPv6Cidr());
+            nic.setIPv6Gateway(profile.getIPv6Gateway());
             nic.setMacAddress(profile.getMacAddress());
             nic.setIsolationUri(profile.getIsolationUri());
             nic.setBroadcastUri(profile.getBroadCastUri());


### PR DESCRIPTION
Without this information a NPE might be triggered when starting a VR, SSVM or CP
as this information is read from the 'nics' table and causes a NPE.

During deployment we should set the IPv6 Gateway and CIDR for the NIC object so that
it is persisted to the database.

Signed-off-by: Wido den Hollander <wido@widodh.nl>