### PR TITLE
Update hypervisor capabilities for xenserver 7

### DIFF
--- a/setup/db/db/schema-4920to4930.sql
+++ b/setup/db/db/schema-4920to4930.sql
@@ -1,0 +1,22 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.9.2.0 to 4.9.3.0;
+--;
+
+INSERT INTO `cloud`.`hypervisor_capabilities`(uuid, hypervisor_type, hypervisor_version, max_guests_limit, max_data_volumes_limit, storage_motion_supported) values (UUID(), 'XenServer', '7.0.0', 500, 13, 1);


### PR DESCRIPTION
It looks like I missed to add the hypervisor capabilities when changing from master to 4.9. Can this be merged as well? 

@rhtyd @karuturi ?