### PR TITLE
CLOUDSTACK-9780: Fixed the default JAVA_HOME value to be Java8 if not set

### DIFF
--- a/client/tomcatconf/classpath.conf.in
+++ b/client/tomcatconf/classpath.conf.in
@@ -34,8 +34,8 @@ for vendorconf in "@MSCONF@"/vendor/* ; do
 	CLASSPATH=$vendorconf:$CLASSPATH
 done
 export CLASSPATH
-if ([ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]) && [ -d /usr/lib/jvm/jre-1.7.0 ]; then
-     export JAVA_HOME=/usr/lib/jvm/jre-1.7.0
+if ([ -z "$JAVA_HOME" ] || [ ! -d "$JAVA_HOME" ]) && [ -d /usr/lib/jvm/jre-1.8.0 ]; then
+     export JAVA_HOME=/usr/lib/jvm/jre-1.8.0
 fi
 PATH=$JAVA_HOME/bin:/sbin:/usr/sbin:$PATH
 export PATH


### PR DESCRIPTION
Now that PR-1888 is merged, Java8 is required.  Unfortunately, the file pushed to `/etc/cloudstack/management/classpath.conf` on ACS install will default the version to Java7 instead of Java8 if JAVA_HOME is unset.  This fix sets the default to Java8 if JAVA_HOME is not set.