### PR TITLE
CLOUDSTACK-8886: Limitations is listUsageRecords output, listUsageRec…

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/UsageRecordResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/UsageRecordResponse.java
@@ -253,4 +253,8 @@ public class UsageRecordResponse extends BaseResponse implements ControlledEntit
     public void setMemory(Long memory) {
         this.memory = memory;
     }
+
+    public String getDomainName(){
+        return domainName;
+    }
 }

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3173,6 +3173,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         Domain domain = ApiDBUtils.findDomainById(usageRecord.getDomainId());
         if (domain != null) {
             usageRecResponse.setDomainId(domain.getUuid());
+            usageRecResponse.setDomainName(domain.getName());
         }
 
         if (usageRecord.getZoneId() != null) {

--- a/server/test/com/cloud/api/ApiResponseHelperTest.java
+++ b/server/test/com/cloud/api/ApiResponseHelperTest.java
@@ -16,21 +16,32 @@
 // under the License.
 package com.cloud.api;
 
-import java.lang.reflect.Field;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
-
+import com.cloud.domain.DomainVO;
+import com.cloud.usage.UsageVO;
+import com.cloud.user.AccountVO;
+import org.apache.cloudstack.api.response.UsageRecordResponse;
 import org.apache.cloudstack.usage.UsageService;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+import java.lang.reflect.Field;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ApiDBUtils.class)
 public class ApiResponseHelperTest {
 
     @Mock
@@ -54,15 +65,48 @@ public class ApiResponseHelperTest {
     public void getDateStringInternal() throws ParseException {
         Mockito.when(usageService.getUsageTimezone()).thenReturn(
                 TimeZone.getTimeZone("UTC"));
-        Assert.assertEquals("2014-06-29'T'23:45:00+00:00", helper
+        assertEquals("2014-06-29'T'23:45:00+00:00", helper
                 .getDateStringInternal(dateFormat.parse("2014-06-29 23:45:00 UTC")));
-        Assert.assertEquals("2014-06-29'T'23:45:01+00:00", helper
+        assertEquals("2014-06-29'T'23:45:01+00:00", helper
                 .getDateStringInternal(dateFormat.parse("2014-06-29 23:45:01 UTC")));
-        Assert.assertEquals("2014-06-29'T'23:45:11+00:00", helper
+        assertEquals("2014-06-29'T'23:45:11+00:00", helper
                 .getDateStringInternal(dateFormat.parse("2014-06-29 23:45:11 UTC")));
-        Assert.assertEquals("2014-06-29'T'23:05:11+00:00", helper
+        assertEquals("2014-06-29'T'23:05:11+00:00", helper
                 .getDateStringInternal(dateFormat.parse("2014-06-29 23:05:11 UTC")));
-        Assert.assertEquals("2014-05-29'T'08:45:11+00:00", helper
+        assertEquals("2014-05-29'T'08:45:11+00:00", helper
                 .getDateStringInternal(dateFormat.parse("2014-05-29 08:45:11 UTC")));
+    }
+
+    @Test
+    public void testUsageRecordResponse(){
+        //Creating the usageVO object to be passed to the createUsageResponse.
+        Long zoneId = null;
+        Long accountId = null;
+        Long domainId = null;
+        String Description = "Test Object";
+        String usageDisplay = " ";
+        int usageType = -1;
+        Double rawUsage = null;
+        Long vmId = null;
+        String vmName = " ";
+        Long offeringId = null;
+        Long templateId = null;
+        Long usageId = null;
+        Date startDate = null;
+        Date endDate = null;
+        String type = " ";
+        UsageVO usage = new UsageVO(zoneId,accountId,domainId,Description,usageDisplay,usageType,rawUsage,vmId,vmName,offeringId,templateId,usageId,startDate,endDate,type);
+
+        DomainVO domain = new DomainVO();
+        domain.setName("DomainName");
+
+        AccountVO account = new AccountVO();
+
+        PowerMockito.mockStatic(ApiDBUtils.class);
+        when(ApiDBUtils.findAccountById(anyLong())).thenReturn(account);
+        when(ApiDBUtils.findDomainById(anyLong())).thenReturn(domain);
+
+        UsageRecordResponse MockResponse = helper.createUsageResponse(usage);
+        assertEquals("DomainName",MockResponse.getDomainName());
     }
 }


### PR DESCRIPTION
As @kansal  is inactive created new branch and raised the PR. This is continuation of PR #858
This closes #858

Problem: Only domainid is returned by usageReports API call. In cloudstack documention it mentions "domain" as being in the usage response. The API should really be returning the domain as account information has both account and accountid.

Fix: Missing setDomainName at the time of creating response.