### PR TITLE
CLOUDSTACK-9781:ACS records ID in events tables instead of UUID.

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/router/CreateVirtualRouterElementCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/router/CreateVirtualRouterElementCmd.java
@@ -106,7 +106,7 @@ public class CreateVirtualRouterElementCmd extends BaseAsyncCreateCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Virtual router element Id: " + getEntityId());
+        CallContext.current().setEventDetails("Virtual router element Id: " + getEntityUuid());
         VirtualRouterProvider result = _service.get(0).getCreatedElement(getEntityId());
         if (result != null) {
             VirtualRouterProviderResponse response = _responseGenerator.createVirtualRouterProviderResponse(result);
@@ -137,6 +137,6 @@ public class CreateVirtualRouterElementCmd extends BaseAsyncCreateCmd {
 
     @Override
     public String getEventDescription() {
-        return "Adding physical network ServiceProvider Virtual Router: " + getEntityId();
+        return "Adding physical network ServiceProvider Virtual Router: " + getEntityUuid();
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/router/DestroyRouterCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/router/DestroyRouterCmd.java
@@ -82,7 +82,7 @@ public class DestroyRouterCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "destroying router: " + getId();
+        return "destroying router: " + this._uuidMgr.getUuid(VirtualMachine.class,getId());
     }
 
     @Override
@@ -98,7 +98,7 @@ public class DestroyRouterCmd extends BaseAsyncCmd {
     @Override
     public void execute() throws ConcurrentOperationException, ResourceUnavailableException {
         CallContext ctx = CallContext.current();
-        ctx.setEventDetails("Router Id: " + getId());
+        ctx.setEventDetails("Router Id: " + this._uuidMgr.getUuid(VirtualMachine.class,getId()));
 
         VirtualRouter result = _routerService.destroyRouter(getId(), ctx.getCallingAccount(), ctx.getCallingUserId());
         if (result != null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/router/RebootRouterCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/router/RebootRouterCmd.java
@@ -83,7 +83,7 @@ public class RebootRouterCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "rebooting router: " + getId();
+        return "rebooting router: " + this._uuidMgr.getUuid(VirtualMachine.class,getId());
     }
 
     @Override
@@ -98,7 +98,7 @@ public class RebootRouterCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
-        CallContext.current().setEventDetails("Router Id: " + getId());
+        CallContext.current().setEventDetails("Router Id: " + this._uuidMgr.getUuid(VirtualMachine.class,getId()));
         VirtualRouter result = _routerService.rebootRouter(getId(), true);
         if (result != null) {
             DomainRouterResponse response = _responseGenerator.createDomainRouterResponse(result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/router/StartRouterCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/router/StartRouterCmd.java
@@ -89,7 +89,7 @@ public class StartRouterCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "starting router: " + getId();
+        return "starting router: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -104,7 +104,7 @@ public class StartRouterCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException {
-        CallContext.current().setEventDetails("Router Id: " + getId());
+        CallContext.current().setEventDetails("Router Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         VirtualRouter result = null;
         VirtualRouter router = _routerService.findRouter(getId());
         if (router == null || router.getRole() != Role.VIRTUAL_ROUTER) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/router/StopRouterCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/router/StopRouterCmd.java
@@ -87,7 +87,7 @@ public class StopRouterCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "stopping router: " + getId();
+        return "Stopping router: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -106,7 +106,7 @@ public class StopRouterCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ConcurrentOperationException, ResourceUnavailableException {
-        CallContext.current().setEventDetails("Router Id: " + getId());
+        CallContext.current().setEventDetails("Router Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         VirtualRouter result = null;
         VirtualRouter router = _routerService.findRouter(getId());
         if (router == null || router.getRole() != Role.VIRTUAL_ROUTER) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/DestroySystemVmCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/DestroySystemVmCmd.java
@@ -84,7 +84,7 @@ public class DestroySystemVmCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "destroying system vm: " + getId();
+        return "destroying system vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -99,7 +99,7 @@ public class DestroySystemVmCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         VirtualMachine instance = _mgr.destroySystemVM(this);
         if (instance != null) {
             SystemVmResponse response = _responseGenerator.createSystemVmResponse(instance);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/MigrateSystemVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/MigrateSystemVMCmd.java
@@ -104,7 +104,7 @@ public class MigrateSystemVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Attempting to migrate VM Id: " + getVirtualMachineId() + " to host Id: " + getHostId();
+        return "Attempting to migrate VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) + " to host Id: " + this._uuidMgr.getUuid(Host.class, getHostId());
     }
 
     @Override
@@ -115,7 +115,7 @@ public class MigrateSystemVMCmd extends BaseAsyncCmd {
             throw new InvalidParameterValueException("Unable to find the host to migrate the VM, host id=" + getHostId());
         }
         try {
-            CallContext.current().setEventDetails("VM Id: " + getVirtualMachineId() + " to host Id: " + getHostId());
+            CallContext.current().setEventDetails("VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) + " to host Id: " + this._uuidMgr.getUuid(Host.class, getHostId()));
             //FIXME : Should not be calling UserVmService to migrate all types of VMs - need a generic VM layer
             VirtualMachine migratedVm = _userVmService.migrateVirtualMachine(getVirtualMachineId(), destinationHost);
             if (migratedVm != null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/RebootSystemVmCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/RebootSystemVmCmd.java
@@ -91,7 +91,7 @@ public class RebootSystemVmCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "rebooting system vm: " + getId();
+        return "rebooting system vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -106,7 +106,7 @@ public class RebootSystemVmCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         VirtualMachine result = _mgr.rebootSystemVM(this);
         if (result != null) {
             SystemVmResponse response = _responseGenerator.createSystemVmResponse(result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/ScaleSystemVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/ScaleSystemVMCmd.java
@@ -101,7 +101,7 @@ public class ScaleSystemVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("SystemVm Id: " + getId());
+        CallContext.current().setEventDetails("SystemVm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
 
         ServiceOffering serviceOffering = _entityMgr.findById(ServiceOffering.class, serviceOfferingId);
         if (serviceOffering == null) {
@@ -140,6 +140,6 @@ public class ScaleSystemVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Upgrading system vm: " + getId() + " to service offering: " + getServiceOfferingId();
+        return "Upgrading system vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()) + " to service offering: " + this._uuidMgr.getUuid(ServiceOffering.class, getServiceOfferingId());
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/StartSystemVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/StartSystemVMCmd.java
@@ -95,7 +95,7 @@ public class StartSystemVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "starting system vm: " + getId();
+        return "starting system vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -110,7 +110,7 @@ public class StartSystemVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         VirtualMachine instance = _mgr.startSystemVM(getId());
         if (instance != null) {
             SystemVmResponse response = _responseGenerator.createSystemVmResponse(instance);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/StopSystemVmCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/StopSystemVmCmd.java
@@ -97,7 +97,7 @@ public class StopSystemVmCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "stopping system vm: " + getId();
+        return "stopping system vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -116,7 +116,7 @@ public class StopSystemVmCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, ConcurrentOperationException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         VirtualMachine result = _mgr.stopSystemVM(this);
         if (result != null) {
             SystemVmResponse response = _responseGenerator.createSystemVmResponse(result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/UpgradeSystemVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/systemvm/UpgradeSystemVMCmd.java
@@ -96,7 +96,7 @@ public class UpgradeSystemVMCmd extends BaseCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
 
         ServiceOffering serviceOffering = _entityMgr.findById(ServiceOffering.class, serviceOfferingId);
         if (serviceOffering == null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/template/CreateTemplateCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/template/CreateTemplateCmdByAdmin.java
@@ -18,6 +18,8 @@ package org.apache.cloudstack.api.command.admin.template;
 
 import java.util.List;
 
+import com.cloud.storage.Snapshot;
+import com.cloud.storage.Volume;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -38,7 +40,7 @@ public class CreateTemplateCmdByAdmin extends CreateTemplateCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Template Id: "+getEntityId()+((getSnapshotId() == null) ? " from volume Id: " + getVolumeId() : " from snapshot Id: " + getSnapshotId()));
+        CallContext.current().setEventDetails("Template Id: " + getEntityUuid()+((getSnapshotId() == null) ? " from volume Id: " + this._uuidMgr.getUuid(Volume.class, getVolumeId()) : " from snapshot Id: " + this._uuidMgr.getUuid(Snapshot.class, getSnapshotId())));
         VirtualMachineTemplate template = null;
         template = _templateService.createPrivateTemplate(this);
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/AddNicToVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/AddNicToVMCmdByAdmin.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.admin.vm;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import com.cloud.network.Network;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -41,7 +42,7 @@ public class AddNicToVMCmdByAdmin extends AddNicToVMCmd {
 
     @Override
     public void execute(){
-        CallContext.current().setEventDetails("Vm Id: " + getVmId() + " Network Id: " + getNetworkId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId()) + " Network Id: " + this._uuidMgr.getUuid(Network.class, getNetworkId()));
         UserVm result = _userVmService.addNicToVirtualMachine(this);
         ArrayList<VMDetails> dc = new ArrayList<VMDetails>();
         dc.add(VMDetails.valueOf("nics"));

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/DeployVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/DeployVMCmdByAdmin.java
@@ -46,7 +46,7 @@ public class DeployVMCmdByAdmin extends DeployVMCmd {
 
         if (getStartVm()) {
             try {
-                CallContext.current().setEventDetails("Vm Id: "+getEntityId());
+                CallContext.current().setEventDetails("Vm Id: " + getEntityUuid());
                 result = _userVmService.startVirtualMachine(this);
             } catch (ResourceUnavailableException ex) {
                 s_logger.warn("Exception: ", ex);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/DestroyVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/DestroyVMCmdByAdmin.java
@@ -42,7 +42,7 @@ public class DestroyVMCmdByAdmin extends DestroyVMCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, ConcurrentOperationException{
-        CallContext.current().setEventDetails("Vm Id: "+getId());
+        CallContext.current().setEventDetails("Vm Id: "+this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result = _userVmService.destroyVm(this);
 
         UserVmResponse response = new UserVmResponse();

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ExpungeVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/ExpungeVMCmd.java
@@ -89,7 +89,7 @@ public class ExpungeVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Expunging vm: " + getId();
+        return "Expunging vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -104,7 +104,7 @@ public class ExpungeVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, ConcurrentOperationException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         try {
             UserVm result = _userVmService.expungeVm(this.getId());
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/MigrateVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/MigrateVMCmd.java
@@ -119,7 +119,13 @@ public class MigrateVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Attempting to migrate VM Id: " + getVirtualMachineId() + " to host Id: " + getHostId();
+        if (getHostId() != null) {
+            return "Attempting to migrate VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) + " to host Id: " + this._uuidMgr.getUuid(Host.class, getHostId());
+        } else if (getStoragePoolId() != null) {
+            return "Attempting to migrate VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) + " to storage pool Id: " + this._uuidMgr.getUuid(StoragePool.class, getStoragePoolId());
+        } else {
+            return "Attempting to migrate VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId());
+        }
     }
 
     @Override
@@ -146,7 +152,7 @@ public class MigrateVMCmd extends BaseAsyncCmd {
             if (destinationHost.getType() != Host.Type.Routing) {
                 throw new InvalidParameterValueException("The specified host(" + destinationHost.getName() + ") is not suitable to migrate the VM, please specify another one");
             }
-            CallContext.current().setEventDetails("VM Id: " + getVirtualMachineId() + " to host Id: " + getHostId());
+            CallContext.current().setEventDetails("VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) + ((getHostId() != null) ?  " to host Id: " + this._uuidMgr.getUuid(Host.class, getHostId()) : "" ));
         }
 
         StoragePool destStoragePool = null;
@@ -155,7 +161,7 @@ public class MigrateVMCmd extends BaseAsyncCmd {
             if (destStoragePool == null) {
                 throw new InvalidParameterValueException("Unable to find the storage pool to migrate the VM");
             }
-            CallContext.current().setEventDetails("VM Id: " + getVirtualMachineId() + " to storage pool Id: " + getStoragePoolId());
+            CallContext.current().setEventDetails("VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) + " to storage pool Id: " + this._uuidMgr.getUuid(StoragePool.class, getStoragePoolId()));
         }
 
         try {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/MigrateVirtualMachineWithVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/MigrateVirtualMachineWithVolumeCmd.java
@@ -136,7 +136,7 @@ public class MigrateVirtualMachineWithVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Attempting to migrate VM Id: " + getVirtualMachineId() + " to host Id: " + getHostId();
+        return "Attempting to migrate VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) + " to host Id: " + this._uuidMgr.getUuid(Host.class, getHostId());
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/RebootVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/RebootVMCmdByAdmin.java
@@ -38,7 +38,7 @@ public class RebootVMCmdByAdmin extends RebootVMCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException{
-        CallContext.current().setEventDetails("Vm Id: "+getId());
+        CallContext.current().setEventDetails("Vm Id: "+this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result;
         result = _userVmService.rebootVirtualMachine(this);
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/RemoveNicFromVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/RemoveNicFromVMCmdByAdmin.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.admin.vm;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import com.cloud.vm.Nic;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -40,7 +41,7 @@ public class RemoveNicFromVMCmdByAdmin extends RemoveNicFromVMCmd {
 
     @Override
     public void execute(){
-        CallContext.current().setEventDetails("Vm Id: "+getVmId() + " Nic Id: " + getNicId());
+        CallContext.current().setEventDetails("Vm Id: "+this._uuidMgr.getUuid(VirtualMachine.class, getVmId()) + " Nic Id: " + this._uuidMgr.getUuid(Nic.class, getNicId()));
         UserVm result = _userVmService.removeNicFromVirtualMachine(this);
         ArrayList<VMDetails> dc = new ArrayList<VMDetails>();
         dc.add(VMDetails.valueOf("nics"));

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/RestoreVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/RestoreVMCmdByAdmin.java
@@ -43,7 +43,7 @@ public class RestoreVMCmdByAdmin extends RestoreVMCmd {
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException,
             ResourceAllocationException {
         UserVm result;
-        CallContext.current().setEventDetails("Vm Id: " + getVmId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId()));
         result = _userVmService.restoreVM(this);
         if (result != null) {
             UserVmResponse response = _responseGenerator.createUserVmResponse(ResponseView.Full, "virtualmachine", result).get(0);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/StartVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/StartVMCmdByAdmin.java
@@ -45,7 +45,7 @@ public class StartVMCmdByAdmin extends StartVMCmd {
     @Override
     public void execute() throws ResourceUnavailableException, ResourceAllocationException {
         try {
-            CallContext.current().setEventDetails("Vm Id: " + getId());
+            CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
 
             UserVm result ;
             result = _userVmService.startVirtualMachine(this);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/StopVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/StopVMCmdByAdmin.java
@@ -39,7 +39,7 @@ public class StopVMCmdByAdmin extends StopVMCmd {
 
     @Override
     public void execute() throws ServerApiException, ConcurrentOperationException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result;
 
         result = _userVmService.stopVirtualMachine(getId(), isForced());

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpdateDefaultNicForVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpdateDefaultNicForVMCmdByAdmin.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.admin.vm;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import com.cloud.vm.Nic;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -41,7 +42,7 @@ public class UpdateDefaultNicForVMCmdByAdmin extends UpdateDefaultNicForVMCmd {
 
     @Override
     public void execute(){
-        CallContext.current().setEventDetails("Vm Id: "+getVmId() + " Nic Id: " + getNicId());
+        CallContext.current().setEventDetails("Vm Id: "+this._uuidMgr.getUuid(VirtualMachine.class, getVmId()) + " Nic Id: " + this._uuidMgr.getUuid(Nic.class, getNicId()));
         UserVm result = _userVmService.updateDefaultNicForVirtualMachine(this);
         ArrayList<VMDetails> dc = new ArrayList<VMDetails>();
         dc.add(VMDetails.valueOf("nics"));

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpdateVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpdateVMCmdByAdmin.java
@@ -42,7 +42,7 @@ public class UpdateVMCmdByAdmin extends UpdateVMCmd {
     @Override
     public void execute() throws ResourceUnavailableException,
             InsufficientCapacityException, ServerApiException {
-        CallContext.current().setEventDetails("Vm Id: "+getId());
+        CallContext.current().setEventDetails("Vm Id: "+this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result = _userVmService.updateVirtualMachine(this);
         if (result != null){
             UserVmResponse response = _responseGenerator.createUserVmResponse(ResponseView.Full, "virtualmachine", result).get(0);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpgradeVMCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vm/UpgradeVMCmdByAdmin.java
@@ -42,7 +42,7 @@ public class UpgradeVMCmdByAdmin extends UpgradeVMCmd {
 
     @Override
     public void execute() throws ResourceAllocationException{
-        CallContext.current().setEventDetails("Vm Id: "+getId());
+        CallContext.current().setEventDetails("Vm Id: "+this._uuidMgr.getUuid(VirtualMachine.class, getId()));
 
         ServiceOffering serviceOffering = _entityMgr.findById(ServiceOffering.class, serviceOfferingId);
         if (serviceOffering == null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vmsnapshot/RevertToVMSnapshotCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vmsnapshot/RevertToVMSnapshotCmdByAdmin.java
@@ -18,6 +18,7 @@ package org.apache.cloudstack.api.command.admin.vmsnapshot;
 
 import java.util.logging.Logger;
 
+import com.cloud.vm.snapshot.VMSnapshot;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
@@ -42,7 +43,7 @@ public class RevertToVMSnapshotCmdByAdmin extends RevertToVMSnapshotCmd {
     @Override
     public void execute() throws  ResourceUnavailableException, InsufficientCapacityException, ResourceAllocationException, ConcurrentOperationException {
         CallContext.current().setEventDetails(
-                "vmsnapshot id: " + getVmSnapShotId());
+                "vmsnapshot id: " + this._uuidMgr.getUuid(VMSnapshot.class, getVmSnapShotId()));
         UserVm result = _vmSnapshotService.revertToSnapshot(getVmSnapShotId());
         if (result != null) {
             UserVmResponse response = _responseGenerator.createUserVmResponse(ResponseView.Full,

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/AttachVolumeCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/AttachVolumeCmdByAdmin.java
@@ -36,7 +36,7 @@ public class AttachVolumeCmdByAdmin extends AttachVolumeCmd {
 
     @Override
     public void execute(){
-        CallContext.current().setEventDetails("Volume Id: "+getId()+" VmId: "+getVirtualMachineId());
+        CallContext.current().setEventDetails("Volume Id: "+this._uuidMgr.getUuid(Volume.class, getId())+" VmId: "+this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()));
         Volume result = _volumeService.attachVolumeToVM(this);
         if (result != null) {
             VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Full, result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/CreateVolumeCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/CreateVolumeCmdByAdmin.java
@@ -38,7 +38,7 @@ public class CreateVolumeCmdByAdmin extends CreateVolumeCmd {
 
     @Override
     public void execute(){
-        CallContext.current().setEventDetails("Volume Id: "+getEntityId()+((getSnapshotId() == null) ? "" : " from snapshot: " + getSnapshotId()));
+        CallContext.current().setEventDetails("Volume Id: "+ getEntityUuid() + ((getSnapshotId() == null) ? "" : " from snapshot: " + this._uuidMgr.getUuid(Snapshot.class, getSnapshotId())));
         Volume volume = _volumeService.createVolume(this);
         if (volume != null) {
             VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Full, volume);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/DetachVolumeCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/DetachVolumeCmdByAdmin.java
@@ -37,7 +37,7 @@ public class DetachVolumeCmdByAdmin extends DetachVolumeCmd {
 
     @Override
     public void execute(){
-        CallContext.current().setEventDetails("Volume Id: "+getId()+" VmId: "+getVirtualMachineId());
+        CallContext.current().setEventDetails(getEventDescription());
         Volume result = _volumeService.detachVolumeFromVM(this);
         if (result != null){
             VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Full, result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/ResizeVolumeCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/ResizeVolumeCmdByAdmin.java
@@ -37,7 +37,7 @@ public class ResizeVolumeCmdByAdmin extends ResizeVolumeCmd {
     public void execute() throws ResourceAllocationException{
         Volume volume = null;
         try {
-            CallContext.current().setEventDetails("Volume Id: " + getEntityId() + " to size " + getSize() + "G");
+            CallContext.current().setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, getEntityId()) + " to size " + getSize() + "G");
             volume = _volumeService.resizeVolume(this);
         } catch (InvalidParameterValueException ex) {
             s_logger.info(ex.getMessage());

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/UpdateVolumeCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/volume/UpdateVolumeCmdByAdmin.java
@@ -32,7 +32,7 @@ public class UpdateVolumeCmdByAdmin extends UpdateVolumeCmd {
 
     @Override
     public void execute(){
-        CallContext.current().setEventDetails("Volume Id: "+getId());
+        CallContext.current().setEventDetails("Volume Id: "+this._uuidMgr.getUuid(Volume.class, getId()));
         Volume result = _volumeService.updateVolume(getId(), getPath(), getState(), getStorageId(), getDisplayVolume(),
                 getCustomId(), getEntityOwnerId(), getChainInfo());
         if (result != null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/CreateSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/CreateSnapshotCmd.java
@@ -112,14 +112,6 @@ public class CreateSnapshotCmd extends BaseAsyncCreateCmd {
         return snapshotName;
     }
 
-    public String getVolumeUuid() {
-        Volume volume = _entityMgr.findById(Volume.class, getVolumeId());
-        if (volume == null) {
-            throw new InvalidParameterValueException("Unable to find volume's UUID");
-        }
-        return volume.getUuid();
-    }
-
     public Long getPolicyId() {
         if (policyId != null) {
             return policyId;
@@ -179,7 +171,7 @@ public class CreateSnapshotCmd extends BaseAsyncCreateCmd {
 
     @Override
     public String getEventDescription() {
-        return "creating snapshot for volume: " + getVolumeUuid();
+        return "creating snapshot for volume: " + this._uuidMgr.getUuid(Volume.class, getVolumeId());
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/CreateSnapshotFromVMSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/CreateSnapshotFromVMSnapshotCmd.java
@@ -151,7 +151,7 @@ public class CreateSnapshotFromVMSnapshotCmd extends BaseAsyncCreateCmd {
 
     @Override
     public String getEventDescription() {
-        return "creating snapshot from vm snapshot : " + getVMSnapshotId();
+        return "creating snapshot from vm snapshot : " + this._uuidMgr.getUuid(VMSnapshot.class, getVMSnapshotId());
     }
 
     @Override
@@ -173,7 +173,7 @@ public class CreateSnapshotFromVMSnapshotCmd extends BaseAsyncCreateCmd {
     @Override
     public void execute() {
         s_logger.info("CreateSnapshotFromVMSnapshotCmd with vm snapshot id:" + getVMSnapshotId() + " and snapshot id:" + getEntityId() + " starts:" + System.currentTimeMillis());
-        CallContext.current().setEventDetails("Vm Snapshot Id: "+ getVMSnapshotId());
+        CallContext.current().setEventDetails("Vm Snapshot Id: "+ this._uuidMgr.getUuid(VMSnapshot.class, getVMSnapshotId()));
         Snapshot snapshot = null;
         try {
             snapshot = _snapshotService.backupSnapshotFromVmSnapshot(getEntityId(), getVmId(), getVolumeId(), getVMSnapshotId());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/DeleteSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/DeleteSnapshotCmd.java
@@ -84,7 +84,7 @@ public class DeleteSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "deleting snapshot: " + getId();
+        return  "deleting snapshot: " + this._uuidMgr.getUuid(Snapshot.class, getId());
     }
 
     @Override
@@ -99,7 +99,7 @@ public class DeleteSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Snapshot Id: " + getId());
+        CallContext.current().setEventDetails("Snapshot Id: " + this._uuidMgr.getUuid(Snapshot.class, getId()));
         boolean result = _snapshotService.deleteSnapshot(getId());
         if (result) {
             SuccessResponse response = new SuccessResponse(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/RevertSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/RevertSnapshotCmd.java
@@ -82,7 +82,7 @@ public class RevertSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "revert snapshot: " + getId();
+        return  "revert snapshot: " + this._uuidMgr.getUuid(Snapshot.class, getId());
     }
 
     @Override
@@ -97,7 +97,7 @@ public class RevertSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Snapshot Id: " + getId());
+        CallContext.current().setEventDetails("Snapshot Id: " + this._uuidMgr.getUuid(Snapshot.class, getId()));
         Snapshot snapshot = _snapshotService.revertSnapshot(getId());
         if (snapshot != null) {
             SnapshotResponse response = _responseGenerator.createSnapshotResponse(snapshot);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/CopyTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/CopyTemplateCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.user.template;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.cloud.dc.DataCenter;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -94,6 +95,10 @@ public class CopyTemplateCmd extends BaseAsyncCmd {
         return null;
     }
 
+    public Long getDestinationZoneId() {
+        return destZoneId;
+    }
+
     public Long getId() {
         return id;
     }
@@ -133,8 +138,19 @@ public class CopyTemplateCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "copying template: " + getId() + " from zone: " + getSourceZoneId()
-                + " to zone: " + getDestinationZoneIds();
+        StringBuilder descBuilder = new StringBuilder();
+        if (getDestinationZoneIds() != null) {
+
+            for (Long destId : getDestinationZoneIds()) {
+                descBuilder.append(", ");
+                descBuilder.append(this._uuidMgr.getUuid(DataCenter.class, destId));
+            }
+            if (descBuilder.length() > 0) {
+                descBuilder.deleteCharAt(0);
+            }
+        }
+
+        return  "copying template: " + this._uuidMgr.getUuid(VirtualMachineTemplate.class, getId()) +((getSourceZoneId() != null) ? " from zone: " + this._uuidMgr.getUuid(DataCenter.class, getSourceZoneId()) : "") + ((descBuilder.length() > 0) ? " to zones: " + descBuilder.toString() : "");
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/CreateTemplateCmd.java
@@ -293,7 +293,7 @@ public class CreateTemplateCmd extends BaseAsyncCreateCmd {
     @Override
     public void execute() {
         CallContext.current().setEventDetails(
-            "Template Id: " + getEntityId() + ((getSnapshotId() == null) ? " from volume Id: " + getVolumeId() : " from snapshot Id: " + getSnapshotId()));
+            "Template Id: " + getEntityUuid() + ((getSnapshotId() == null) ? " from volume Id: " + this._uuidMgr.getUuid(Volume.class, getVolumeId()) : " from snapshot Id: " + this._uuidMgr.getUuid(Snapshot.class, getSnapshotId())));
         VirtualMachineTemplate template = null;
         template = _templateService.createPrivateTemplate(this);
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/DeleteTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/DeleteTemplateCmd.java
@@ -100,7 +100,7 @@ public class DeleteTemplateCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Deleting template " + getId();
+        return "Deleting template " + this._uuidMgr.getUuid(VirtualMachineTemplate.class, getId());
     }
 
     @Override
@@ -115,7 +115,7 @@ public class DeleteTemplateCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Template Id: " + getId());
+        CallContext.current().setEventDetails("Template Id: " + this._uuidMgr.getUuid(VirtualMachineTemplate.class, getId()));
         boolean result = _templateService.deleteTemplate(this);
         if (result) {
             SuccessResponse response = new SuccessResponse(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/template/ExtractTemplateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/template/ExtractTemplateCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.template;
 
+import com.cloud.dc.DataCenter;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -113,7 +114,7 @@ public class ExtractTemplateCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "extracting template: " + getId() + " from zone: " + getZoneId();
+     return "extracting template: " + this._uuidMgr.getUuid(VirtualMachineTemplate.class, getId()) + ((getZoneId() != null) ? " from zone: " + this._uuidMgr.getUuid(DataCenter.class, getZoneId()) : "");
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/AddIpToVmNicCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/AddIpToVmNicCmd.java
@@ -105,7 +105,7 @@ public class AddIpToVmNicCmd extends BaseAsyncCreateCmd {
 
     @Override
     public String getEventDescription() {
-        return "associating ip to nic id=" + getNicId() + " belonging to network id=" + getNetworkId();
+        return "associating ip to nic id=" + this._uuidMgr.getUuid(Nic.class, getNicId()) + " belonging to network id=" + this._uuidMgr.getUuid(Network.class, getNetworkId());
     }
 
     /////////////////////////////////////////////////////
@@ -124,11 +124,11 @@ public class AddIpToVmNicCmd extends BaseAsyncCreateCmd {
     @Override
     public void execute() throws ResourceUnavailableException, ResourceAllocationException, ConcurrentOperationException, InsufficientCapacityException {
 
-        CallContext.current().setEventDetails("Nic Id: " + getNicId());
+        CallContext.current().setEventDetails("Nic Id: " + this._uuidMgr.getUuid(Nic.class, getNicId()));
         NicSecondaryIp result = _entityMgr.findById(NicSecondaryIp.class, getEntityId());
 
         if (result != null) {
-            CallContext.current().setEventDetails("secondary Ip Id: " + getEntityId());
+            CallContext.current().setEventDetails("secondary Ip Id: " + getEntityUuid());
             boolean success = false;
             success = _networkService.configureNicSecondaryIp(result, isZoneSGEnabled());
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/AddNicToVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/AddNicToVMCmd.java
@@ -22,6 +22,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.cloud.network.Network;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -121,7 +122,7 @@ public class AddNicToVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "Adding network " + getNetworkId() + " to user vm: " + getVmId();
+        return  "Adding network " + this._uuidMgr.getUuid(Network.class, getNetworkId()) + " to user vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId());
     }
 
     @Override
@@ -157,7 +158,7 @@ public class AddNicToVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Vm Id: " + getVmId() + " Network Id: " + getNetworkId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId()) + " Network Id: " + this._uuidMgr.getUuid(Network.class, getNetworkId()));
         UserVm result = _userVmService.addNicToVirtualMachine(this);
         ArrayList<VMDetails> dc = new ArrayList<VMDetails>();
         dc.add(VMDetails.valueOf("nics"));

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -522,7 +522,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
 
     @Override
     public String getEventDescription() {
-        return "starting Vm. Vm Id: " + getEntityId();
+        return "starting Vm. Vm Id: " + getEntityUuid();
     }
 
     @Override
@@ -536,7 +536,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
 
         if (getStartVm()) {
             try {
-                CallContext.current().setEventDetails("Vm Id: " + getEntityId());
+                CallContext.current().setEventDetails("Vm Id: " + getEntityUuid());
                 result = _userVmService.startVirtualMachine(this);
             } catch (ResourceUnavailableException ex) {
                 s_logger.warn("Exception: ", ex);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DestroyVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DestroyVMCmd.java
@@ -104,7 +104,7 @@ public class DestroyVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "destroying vm: " + getId();
+        return  "destroying vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -119,7 +119,7 @@ public class DestroyVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, ConcurrentOperationException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result = _userVmService.destroyVm(this);
 
         UserVmResponse response = new UserVmResponse();

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/RebootVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/RebootVMCmd.java
@@ -86,7 +86,7 @@ public class RebootVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "rebooting user vm: " + getId();
+        return  "rebooting user vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -101,7 +101,7 @@ public class RebootVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result;
         result = _userVmService.rebootVirtualMachine(this);
         if (result !=null){

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/RemoveNicFromVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/RemoveNicFromVMCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.user.vm;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import com.cloud.vm.Nic;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -89,7 +90,7 @@ public class RemoveNicFromVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "Removing NIC " + getNicId() + " from user vm: " + getVmId();
+        return  "Removing NIC " + this._uuidMgr.getUuid(Nic.class, getNicId()) + " from user vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId());
     }
 
     @Override
@@ -103,7 +104,7 @@ public class RemoveNicFromVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Vm Id: " + getVmId() + " Nic Id: " + getNicId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId()) + " Nic Id: " + this._uuidMgr.getUuid(Nic.class, getNicId()));
         UserVm result = _userVmService.removeNicFromVirtualMachine(this);
         ArrayList<VMDetails> dc = new ArrayList<VMDetails>();
         dc.add(VMDetails.valueOf("nics"));

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/RestoreVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/RestoreVMCmd.java
@@ -72,7 +72,7 @@ public class RestoreVMCmd extends BaseAsyncCmd {
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException,
             ResourceAllocationException {
         UserVm result;
-        CallContext.current().setEventDetails("Vm Id: " + getVmId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId()));
         result = _userVmService.restoreVM(this);
         if (result != null) {
             UserVmResponse response = _responseGenerator.createUserVmResponse(ResponseView.Restricted, "virtualmachine", result).get(0);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/ScaleVMCmd.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.offering.ServiceOffering;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -129,7 +130,7 @@ public class ScaleVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "upgrading vm: " + getId() + " to service offering: " + getServiceOfferingId();
+        return  "upgrading vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()) + " to service offering: " + this._uuidMgr.getUuid(ServiceOffering.class, getServiceOfferingId());
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/StartVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/StartVMCmd.java
@@ -117,7 +117,7 @@ public class StartVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "starting user vm: " + getId();
+        return "starting user vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -133,7 +133,7 @@ public class StartVMCmd extends BaseAsyncCmd {
     @Override
     public void execute() throws ResourceUnavailableException, ResourceAllocationException {
         try {
-            CallContext.current().setEventDetails("Vm Id: " + getId());
+            CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
 
             UserVm result;
             result = _userVmService.startVirtualMachine(this);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/StopVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/StopVMCmd.java
@@ -96,7 +96,7 @@ public class StopVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "stopping user vm: " + getId();
+        return "stopping user vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getId());
     }
 
     @Override
@@ -115,7 +115,7 @@ public class StopVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws ServerApiException, ConcurrentOperationException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result;
 
         result = _userVmService.stopVirtualMachine(getId(), isForced());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateDefaultNicForVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateDefaultNicForVMCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.user.vm;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+import com.cloud.vm.Nic;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
@@ -90,7 +91,7 @@ public class UpdateDefaultNicForVMCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "Updating NIC " + getNicId() + " on user vm: " + getVmId();
+        return  "Updating NIC " + this._uuidMgr.getUuid(Nic.class, getNicId()) + " on user vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId());
     }
 
     @Override
@@ -104,7 +105,7 @@ public class UpdateDefaultNicForVMCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Vm Id: " + getVmId() + " Nic Id: " + getNicId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId()) + " Nic Id: " + this._uuidMgr.getUuid(Nic.class, getNicId()));
         UserVm result = _userVmService.updateDefaultNicForVirtualMachine(this);
         ArrayList<VMDetails> dc = new ArrayList<VMDetails>();
         dc.add(VMDetails.valueOf("nics"));

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateVMCmd.java
@@ -250,7 +250,7 @@ public class UpdateVMCmd extends BaseCustomIdCmd implements SecurityGroupAction 
 
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
         UserVm result = _userVmService.updateVirtualMachine(this);
         if (result != null){
             UserVmResponse response = _responseGenerator.createUserVmResponse(ResponseView.Restricted, "virtualmachine", result).get(0);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateVmNicIpCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpdateVmNicIpCmd.java
@@ -126,7 +126,7 @@ public class UpdateVmNicIpCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "associating ip to nic id: " + getNetworkId() + " in zone " + getZoneId();
+        return  "associating ip to nic id: " + this._uuidMgr.getUuid(Network.class, getNetworkId()) + " in zone " + this._uuidMgr.getUuid(DataCenter.class, getZoneId());
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/UpgradeVMCmd.java
@@ -119,7 +119,7 @@ public class UpgradeVMCmd extends BaseCmd {
 
     @Override
     public void execute() throws ResourceAllocationException {
-        CallContext.current().setEventDetails("Vm Id: " + getId());
+        CallContext.current().setEventDetails("Vm Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getId()));
 
         ServiceOffering serviceOffering = _entityMgr.findById(ServiceOffering.class, serviceOfferingId);
         if (serviceOffering == null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/CreateVMSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/CreateVMSnapshotCmd.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.api.command.user.vmsnapshot;
 
 import java.util.logging.Logger;
 
+import com.cloud.vm.VirtualMachine;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.APICommand;
@@ -99,7 +100,7 @@ public class CreateVMSnapshotCmd extends BaseAsyncCreateCmd {
 
     @Override
     public String getEventDescription() {
-        return "creating snapshot for VM: " + getVmId();
+        return "creating snapshot for VM: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId());
     }
 
     @Override
@@ -109,7 +110,7 @@ public class CreateVMSnapshotCmd extends BaseAsyncCreateCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("VM Id: " + getVmId());
+        CallContext.current().setEventDetails("VM Id: " + this._uuidMgr.getUuid(VirtualMachine.class, getVmId()));
         VMSnapshot result = _vmSnapshotService.createVMSnapshot(getVmId(), getEntityId(), getQuiescevm());
         if (result != null) {
             VMSnapshotResponse response = _responseGenerator.createVMSnapshotResponse(result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/DeleteVMSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/DeleteVMSnapshotCmd.java
@@ -69,7 +69,7 @@ public class DeleteVMSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("vmsnapshot id: " + getId());
+        CallContext.current().setEventDetails("vmsnapshot id: " + this._uuidMgr.getUuid(VMSnapshot.class, getId()));
         boolean result = _vmSnapshotService.deleteVMSnapshot(getId());
         if (result) {
             SuccessResponse response = new SuccessResponse(getCommandName());
@@ -81,7 +81,7 @@ public class DeleteVMSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Delete VM snapshot: " + getId();
+        return "Delete VM snapshot: " + this._uuidMgr.getUuid(VMSnapshot.class, getId());
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/RevertToVMSnapshotCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vmsnapshot/RevertToVMSnapshotCmd.java
@@ -74,7 +74,7 @@ public class RevertToVMSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() throws  ResourceUnavailableException, InsufficientCapacityException, ResourceAllocationException, ConcurrentOperationException {
-        CallContext.current().setEventDetails("vmsnapshot id: " + getVmSnapShotId());
+        CallContext.current().setEventDetails("vmsnapshot id: " + this._uuidMgr.getUuid(VMSnapshot.class, getVmSnapShotId()));
         UserVm result = _vmSnapshotService.revertToSnapshot(getVmSnapShotId());
         if (result != null) {
             UserVmResponse response = _responseGenerator.createUserVmResponse(ResponseView.Restricted,
@@ -88,7 +88,7 @@ public class RevertToVMSnapshotCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Revert from VM snapshot: " + getVmSnapShotId();
+        return "Revert from VM snapshot: " + this._uuidMgr.getUuid(VMSnapshot.class, getVmSnapShotId());
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/AttachVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/AttachVolumeCmd.java
@@ -111,12 +111,12 @@ public class AttachVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "attaching volume: " + getId() + " to vm: " + getVirtualMachineId();
+        return  "attaching volume: " + this._uuidMgr.getUuid(Volume.class, getId()) + " to vm: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId());
     }
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Volume Id: " + getId() + " VmId: " + getVirtualMachineId());
+        CallContext.current().setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, getId()) + " VmId: " + this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()));
         Volume result = _volumeService.attachVolumeToVM(this);
         if (result != null) {
             VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Restricted, result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/CreateVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/CreateVolumeCmd.java
@@ -203,7 +203,7 @@ public class CreateVolumeCmd extends BaseAsyncCreateCustomIdCmd {
 
     @Override
     public String getEventDescription() {
-        return  "creating volume: " + getVolumeName() + ((getSnapshotId() == null) ? "" : " from snapshot: " + getSnapshotId());
+        return  "creating volume: " + getVolumeName() + ((getSnapshotId() == null) ? "" : " from snapshot: " + this._uuidMgr.getUuid(Snapshot.class, getSnapshotId()));
     }
 
     @Override
@@ -220,7 +220,7 @@ public class CreateVolumeCmd extends BaseAsyncCreateCustomIdCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Volume Id: " + getEntityId() + ((getSnapshotId() == null) ? "" : " from snapshot: " + getSnapshotId()));
+        CallContext.current().setEventDetails("Volume Id: " + getEntityUuid() + ((getSnapshotId() == null) ? "" : " from snapshot: " + this._uuidMgr.getUuid(Snapshot.class, getSnapshotId())));
         Volume volume = _volumeService.createVolume(this);
         if (volume != null) {
             VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Restricted, volume);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/DeleteVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/DeleteVolumeCmd.java
@@ -81,7 +81,7 @@ public class DeleteVolumeCmd extends BaseCmd {
 
     @Override
     public void execute() throws ConcurrentOperationException {
-        CallContext.current().setEventDetails("Volume Id: " + getId());
+        CallContext.current().setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, getId()));
         boolean result = _volumeService.deleteVolume(id, CallContext.current().getCallingAccount());
         if (result) {
             SuccessResponse response = new SuccessResponse(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/DetachVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/DetachVolumeCmd.java
@@ -129,9 +129,9 @@ public class DetachVolumeCmd extends BaseAsyncCmd {
     public String getEventDescription() {
         StringBuilder sb = new StringBuilder();
         if (id != null) {
-            sb.append(": " + id);
+            sb.append(": " + this._uuidMgr.getUuid(Volume.class, id));
         } else if ((deviceId != null) && (virtualMachineId != null)) {
-            sb.append(" with device id: " + deviceId + " from vm: " + virtualMachineId);
+            sb.append(" with device id: " + deviceId + " from vm: " + ((getVirtualMachineId() != null) ? this._uuidMgr.getUuid(VirtualMachine.class, getVirtualMachineId()) : "" ));
         } else {
             sb.append(" <error:  either volume id or deviceId/vmId need to be specified>");
         }
@@ -140,7 +140,7 @@ public class DetachVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Volume Id: " + getId() + " VmId: " + getVirtualMachineId());
+        CallContext.current().setEventDetails(getEventDescription());
         Volume result = _volumeService.detachVolumeFromVM(this);
         if (result != null){
             VolumeResponse response = _responseGenerator.createVolumeResponse(ResponseView.Restricted, result);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ExtractVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ExtractVolumeCmd.java
@@ -133,7 +133,7 @@ public class ExtractVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Volume Id: " + getId());
+        CallContext.current().setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, getId()));
         String uploadUrl = _volumeService.extractVolume(this);
         if (uploadUrl != null) {
             ExtractResponse response = new ExtractResponse();

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/MigrateVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/MigrateVolumeCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.volume;
 
+import com.cloud.storage.StoragePool;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -102,7 +103,7 @@ public class MigrateVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Attempting to migrate volume Id: " + getVolumeId() + " to storage pool Id: " + getStoragePoolId();
+        return "Attempting to migrate volume Id: " + this._uuidMgr.getUuid(Volume.class, getVolumeId()) + " to storage pool Id: " + this._uuidMgr.getUuid(StoragePool.class, getStoragePoolId());
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
@@ -163,14 +163,14 @@ public class ResizeVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return "Volume Id: " + getEntityId() + " to size " + getSize() + "G";
+        return "Volume Id: " + this._uuidMgr.getUuid(Volume.class, getEntityId()) + " to size " + getSize() + "G";
     }
 
     @Override
     public void execute() throws ResourceAllocationException {
         Volume volume = null;
         try {
-            CallContext.current().setEventDetails("Volume Id: " + getEntityId() + " to size " + getSize() + "G");
+            CallContext.current().setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, getEntityId()) + " to size " + getSize() + "G");
             volume = _volumeService.resizeVolume(this);
         } catch (InvalidParameterValueException ex) {
             s_logger.info(ex.getMessage());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/UpdateVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/UpdateVolumeCmd.java
@@ -154,7 +154,7 @@ public class UpdateVolumeCmd extends BaseAsyncCustomIdCmd {
 
     @Override
     public void execute() {
-        CallContext.current().setEventDetails("Volume Id: " + getId());
+        CallContext.current().setEventDetails("Volume Id: " + this._uuidMgr.getUuid(Volume.class, getId()));
         Volume result = _volumeService.updateVolume(getId(), getPath(), getState(), getStorageId(), getDisplayVolume(),
                 getCustomId(), getEntityOwnerId(), getChainInfo());
         if (result != null) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/UploadVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/UploadVolumeCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.volume;
 
+import com.cloud.dc.DataCenter;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -169,7 +170,7 @@ public class UploadVolumeCmd extends BaseAsyncCmd {
 
     @Override
     public String getEventDescription() {
-        return  "uploading volume: " + getVolumeName() + " in the zone " + getZoneId();
+        return  "uploading volume: " + getVolumeName() + " in the zone " + this._uuidMgr.getUuid(DataCenter.class, getZoneId());
     }
 
     @Override

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -493,7 +493,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 volume.setDomainId((owner == null) ? Domain.ROOT_DOMAIN : owner.getDomainId());
                 volume.setFormat(ImageFormat.valueOf(format));
                 volume = _volsDao.persist(volume);
-                CallContext.current().setEventDetails("Volume Id: " + volume.getId());
+                CallContext.current().setEventDetails("Volume Id: " + volume.getUuid());
 
                 // Increment resource count during allocation; if actual creation fails,
                 // decrement it
@@ -764,7 +764,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                             diskOfferingId, null, size, Volume.class.getName(), volume.getUuid(), displayVolume);
                 }
 
-                CallContext.current().setEventDetails("Volume Id: " + volume.getId());
+                CallContext.current().setEventDetails("Volume Id: " + volume.getUuid());
 
                 // Increment resource count during allocation; if actual creation fails,
                 // decrement it

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1128,7 +1128,7 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         if (isoId == null) {
             throw new InvalidParameterValueException("The specified VM has no ISO attached to it.");
         }
-        CallContext.current().setEventDetails("Vm Id: " + vmId + " ISO Id: " + isoId);
+        CallContext.current().setEventDetails("Vm Id: " + userVM.getUuid() + " ISO Id: " + isoId);
 
         State vmState = userVM.getState();
         if (vmState != State.Running && vmState != State.Stopped) {

--- a/server/src/main/java/com/cloud/uuididentity/UUIDManagerImpl.java
+++ b/server/src/main/java/com/cloud/uuididentity/UUIDManagerImpl.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
+import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.context.CallContext;
 
 import com.cloud.exception.InvalidParameterValueException;
@@ -109,6 +110,19 @@ public class UUIDManagerImpl implements UUIDManager {
             checkUuid(customId, entityType);
             return customId;
         }
+    }
+
+    @Override
+    public <T> String getUuid(Class<T> entityType, Long customId) {
+        if (customId == null) {
+            return null;
+        }
+        Identity identity = (Identity) this._entityMgr.findById(entityType, customId);
+        if (identity == null) {
+            throw new InvalidParameterValueException("Unable to find UUID for id " + customId);
+        }
+        return identity.getUuid();
+
     }
 
 }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1626,7 +1626,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         Long vmId = cmd.getId();
         Long newServiceOfferingId = cmd.getServiceOfferingId();
-        CallContext.current().setEventDetails("Vm Id: " + vmId);
+        VirtualMachine vm = (VirtualMachine) this._entityMgr.findById(VirtualMachine.class, vmId);
+        if (vm == null) {
+            throw new InvalidParameterValueException("Unable to find VM's UUID");
+        }
+        CallContext.current().setEventDetails("Vm Id: " + vm.getUuid());
 
         boolean result = upgradeVirtualMachine(vmId, newServiceOfferingId, cmd.getDetails());
         if (result) {
@@ -3812,7 +3816,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Successfully allocated DB entry for " + vm);
                 }
-                CallContext.current().setEventDetails("Vm Id: " + vm.getId());
+                CallContext.current().setEventDetails("Vm Id: " + vm.getUuid());
 
                 if (!offering.isDynamic()) {
                     UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VM_CREATE, accountId, zone.getId(), vm.getId(), vm.getHostName(), offering.getId(), template.getId(),

--- a/utils/src/main/java/com/cloud/utils/db/UUIDManager.java
+++ b/utils/src/main/java/com/cloud/utils/db/UUIDManager.java
@@ -45,4 +45,6 @@ public interface UUIDManager {
      * .
      */
     <T> void checkUuidSimple(String uuid, Class<T> entityType);
+
+    public <T> String getUuid(Class<T> entityType, Long customId);
 }


### PR DESCRIPTION
ISSUE
=====
Wrong presentation of volume id in ACS events.
While creating a snapshot, only volume ID is mentioned in the events. For example, “Scheduled async job for creating snapshot for volume Id:270". On looking into the notification, user is not able to identify the volume. So modified event description with UUID.

Please see screenshots.
**Before modification:**
![before](https://cloud.githubusercontent.com/assets/12637540/23013215/bd8dd6b6-f44f-11e6-92bd-f097ad1213b8.PNG)

**After modification:**

![after](https://cloud.githubusercontent.com/assets/12637540/23013214/bd8c7da2-f44f-11e6-9ec7-1f0105196970.PNG)