### PR TITLE
CLOUDSTACK-9784 : GPU detail not displayed in GPU tab of management server UI.

### DIFF
--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -17228,9 +17228,16 @@
                                                     }
                                                 },
                                                 dataProvider: function (args) {
-                                                    var items = gpugroupObj.vgpu.sort(function(a, b) {
-                                                        return a.maxvgpuperpgpu >= b.maxvgpuperpgpu;
-                                                    });
+                                                    var items;
+
+                                                    if(typeof(gpugroupObj.vgpu) != "undefined") {
+                                                        items = gpugroupObj.vgpu.sort(function(a, b) {
+                                                            return a.maxvgpuperpgpu >= b.maxvgpuperpgpu;
+                                                        });
+                                                    }
+                                                    else {
+                                                        items = gpugroupObj.vgpu;
+                                                    }
                                                     $(items).each(function () {
                                                         this.maxresolution = (this.maxresolutionx == null || this.maxresolutionx == 0
                                                                 || this.maxresolutiony == null || this.maxresolutiony == 0)


### PR DESCRIPTION
ISSUE
==================

When GPU tab of the host is selected on the management server UI, no GPU detail is displayed.

RESOLUTION
==================

In the javascript file "system.js" while fetching the GPU details, sort functionality in dataprovider is returning value as undefined and hence it throwing an exception. So handled the output as undefined gracefully to avoid exception.

**Screenshot before applying fix :**

![screenshot before applying fix](https://cloud.githubusercontent.com/assets/25146827/23017606/f63fe470-f460-11e6-8d26-553e98bb0664.PNG)

**Screenshot after applying fix :**

![screenshot after applying fix](https://cloud.githubusercontent.com/assets/25146827/23017627/07d5a8b4-f461-11e6-814e-3c27b1bbda41.PNG)
