### PR TITLE
CLOUDSTACK-9339: Send correct network type to router config

### DIFF
--- a/core/src/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
+++ b/core/src/com/cloud/agent/resource/virtualnetwork/facade/IpAssociationConfigItem.java
@@ -41,7 +41,7 @@ public class IpAssociationConfigItem extends AbstractConfigItemFacade {
 
         for (final IpAddressTO ip : command.getIpAddresses()) {
             final IpAddress ipAddress = new IpAddress(ip.getPublicIp(), ip.isSourceNat(), ip.isAdd(), ip.isOneToOneNat(), ip.isFirstIP(), ip.getVlanGateway(), ip.getVlanNetmask(),
-                    ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString());
+                    ip.getVifMacAddress(), ip.getNicDevId(), ip.isNewNic(), ip.getTrafficType().toString().toLowerCase());
             ips.add(ipAddress);
         }
 


### PR DESCRIPTION
This forces the network type (nw_type) of the IP address being sent into router configuration scripts to be lowercase. All of the Python config scripts on the router explicitly look for network type "public" with a lowercase P. Sending "Public" with an uppercase P can cause important iptables rules to not be created, meaning that public networking won't work.

We discovered this while applying the other fix for CLOUDSTACK-9339 to our own 4.7 branch, and then checked master and saw that it hadn't been changed yet. The fix is very simple: force the network type to lowercase when creating IpAssoc config items. Without this fix, iptables rules for public IPs that are added in `CsAddress.py` would get skipped, and traffic into instances on interfaces other than eth2 would not work.