### PR TITLE
CLOUDSTACK-9748:VPN Users search functionality broken

### DIFF
--- a/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -590,6 +590,7 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
     public Pair<List<? extends VpnUser>, Integer> searchForVpnUsers(ListVpnUsersCmd cmd) {
         String username = cmd.getUsername();
         Long id = cmd.getId();
+        String keyword = cmd.getKeyword();
         Account caller = CallContext.current().getCallingAccount();
         List<Long> permittedAccounts = new ArrayList<Long>();
 
@@ -605,6 +606,7 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
 
         sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
         sb.and("username", sb.entity().getUsername(), SearchCriteria.Op.EQ);
+        sb.and("keyword", sb.entity().getUsername(), SearchCriteria.Op.LIKE);
         sb.and("state", sb.entity().getState(), Op.IN);
 
         SearchCriteria<VpnUserVO> sc = sb.create();
@@ -612,6 +614,10 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
 
         //list only active users
         sc.setParameters("state", State.Active, State.Add);
+
+        if(keyword != null){
+            sc.setParameters("keyword", "%" + keyword + "%");
+        }
 
         if (id != null) {
             sc.setParameters("id", id);


### PR DESCRIPTION
VPN Users search functionality broken
If you try to search VPN users with it’s user name, you will not be able to search.

Fixed the same.

Parent PR : https://github.com/apache/cloudstack/pull/1910