### PR TITLE
CLOUDSTACK-9786:API reference guide entry for associateIpAddress needs additional information

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/address/AssociateIPAddrCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/address/AssociateIPAddrCmd.java
@@ -57,7 +57,7 @@ import com.cloud.offering.NetworkOffering;
 import com.cloud.projects.Project;
 import com.cloud.user.Account;
 
-@APICommand(name = "associateIpAddress", description = "Acquires and associates a public IP to an account.", responseObject = IPAddressResponse.class, responseView = ResponseView.Restricted,
+@APICommand(name = "associateIpAddress", description = "Acquires and associates a public IP to an account. Either of the parameters are required, i.e. either zoneId, or networkId, or vpcId  ", responseObject = IPAddressResponse.class, responseView = ResponseView.Restricted,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
 public class AssociateIPAddrCmd extends BaseAsyncCreateCmd {
     public static final Logger s_logger = Logger.getLogger(AssociateIPAddrCmd.class.getName());


### PR DESCRIPTION
Going through the code & implementation, it seems like either of the parameters are not required while accessing the API : associateIpAddress.
There are 3 cases for which this api works. 1) networkId 2) vpcId 3) zoneId. Either of these can be provided to achieve the same functionality. If neither of them is provided, there is an error text shown.
E.g.
[root@CCP ~]# curl -s 'http://10.66.43.37:8096/client/api?command=associateIpAddress&listall=true' | xmllint --format - -o
```
<?xml version="1.0" encoding="UTF-8"?>
<associateipaddressresponse cloud-stack-version="4.5.1.0">
<errorcode>431</errorcode>
<cserrorcode>4350</cserrorcode>
<errortext>Unable to figure out zone to assign ip to. Please specify either zoneId, or networkId, or vpcId in the call</errortext>
</associateipaddressresponse>
```
Modify the API reference guide entry with this detail in the "description"