### PR TITLE
CLOUDSTACK-9801: IPSec VPN does not work after vRouter reboot or recreate

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -623,6 +623,12 @@ class CsRemoteAccessVpn(CsDataBag):
             #Enable remote access vpn
             if vpnconfig['create']:
                 logging.debug("Enabling  remote access vpn  on "+ public_ip)
+
+                dev = CsHelper.get_device(public_ip)
+                if dev == "":
+                        logging.error("Request for ipsec to %s not possible because ip is not configured", public_ip)
+                        continue
+
                 CsHelper.start_if_stopped("ipsec")
                 self.configure_l2tpIpsec(public_ip, self.dbag[public_ip])
                 logging.debug("Remote accessvpn  data bag %s",  self.dbag)


### PR DESCRIPTION
After a vRouter is recreated  (e.g. reboot via CloudStack UI) and Remote Access VPN enabled, VPN won't work anymore. Here is the abbreviated output of "ipsec auto -status" while we were having the issue:

```
root@r-10-VM:~# ipsec auto --status
000 using kernel interface: netkey
000 interface lo/lo 127.0.0.1
000 interface lo/lo 127.0.0.1
000 interface eth0/eth0 169.254.1.45
000 interface eth0/eth0 169.254.1.45
000 %myid = (none)
```

After this commit, the following occurs and VPNs work:
```

root@r-10-VM:~# ipsec auto --status
000 using kernel interface: netkey
000 interface lo/lo 127.0.0.1
000 interface lo/lo 127.0.0.1
000 interface eth0/eth0 169.254.1.45
000 interface eth0/eth0 169.254.1.45
000 interface eth1/eth1 xxx.xxx.xxx.172
000 interface eth1/eth1 xxx.xxx.xxx.172
000 interface eth2/eth2 192.168.1.1
000 interface eth2/eth2 192.168.1.1
000 %myid = (none)

```
eth1 interface IP is masked, but now ipsec sees all the interfaces and VPN works.

Looks like this bug was introduced by Pull Request #1423

It added code to start ipsec (cloudstack/systemvm/patches/debian/config/opt/cloud/bin/configure.py)

```
if vpnconfig['create']:
    logging.debug("Enabling remote access vpn on "+ public_ip)
    CsHelper.start_if_stopped("ipsec")
```