### PR TITLE
CLOUDSTACK-9795: moved logrotate from cron.daily to cron.hourly for vpcrouter

### DIFF
--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -1110,6 +1110,10 @@ EOF
       echo 0 > /var/cache/cloud/dnsmasq_managed_lease
   fi
   load_modules
+
+  #setup hourly logrotate
+  mv -n /etc/cron.daily/logrotate /etc/cron.hourly 2>&1
+
 }
 
 

--- a/systemvm/patches/debian/config/etc/init.d/cloud-early-config
+++ b/systemvm/patches/debian/config/etc/init.d/cloud-early-config
@@ -1110,10 +1110,6 @@ EOF
       echo 0 > /var/cache/cloud/dnsmasq_managed_lease
   fi
   load_modules
-
-  #setup hourly logrotate
-  mv -n /etc/cron.daily/logrotate /etc/cron.hourly 2>&1
-
 }
 
 


### PR DESCRIPTION
[BACKPORT PR1954]

moved logrotate from cron.daily to cron.hourly for vpcrouter in cloud-early-config. This brings 'vpcrouter' inline with 'router'. We are having issues with cloud.log not rotating fast enough, which filled up /var/log and ultimately caused the VR to stop functioning in such a way that it prevented new VMs from being deployed.