### PR TITLE
CLOUDSTACK-9779 : Releasing secondary guest IP fails with error VM nic Ip x.x.x.x is mapped to load balancing rule

### DIFF
--- a/engine/schema/src/com/cloud/network/dao/LoadBalancerDao.java
+++ b/engine/schema/src/com/cloud/network/dao/LoadBalancerDao.java
@@ -29,4 +29,6 @@ public interface LoadBalancerDao extends GenericDao<LoadBalancerVO, Long> {
 
     List<LoadBalancerVO> listInTransitionStateByNetworkIdAndScheme(long networkId, Scheme scheme);
 
+    boolean isLoadBalancerRulesMappedToVmGuestIp(long instanceId, String instanceIp, long networkId);
+
 }

--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -197,6 +197,7 @@ import com.cloud.vm.dao.NicSecondaryIpDao;
 import com.cloud.vm.dao.NicSecondaryIpVO;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
+import com.cloud.network.dao.LoadBalancerDao;
 
 /**
  * NetworkServiceImpl implements NetworkService.
@@ -334,6 +335,9 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
 
     @Inject
     NetworkDetailsDao _networkDetailsDao;
+
+    @Inject
+    LoadBalancerDao _loadBalancerDao;
 
     int _cidrLimit;
     boolean _allowSubdomainNetworkAccess;
@@ -852,7 +856,7 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
                 throw new InvalidParameterValueException("Can' remove the ip " + secondaryIp + "is associate with static NAT rule public IP address id " + publicIpVO.getId());
             }
 
-            if (_lbService.isLbRuleMappedToVmGuestIp(secondaryIp)) {
+            if (_loadBalancerDao.isLoadBalancerRulesMappedToVmGuestIp(vm.getId(), secondaryIp, network.getId())) {
                 s_logger.debug("VM nic IP " + secondaryIp + " is mapped to load balancing rule");
                 throw new InvalidParameterValueException("Can't remove the secondary ip " + secondaryIp + " is mapped to load balancing rule");
             }

--- a/server/test/org/apache/cloudstack/networkoffering/CreateNetworkOfferingTest.java
+++ b/server/test/org/apache/cloudstack/networkoffering/CreateNetworkOfferingTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.cloud.network.dao.LoadBalancerVMMapDao;
 import junit.framework.TestCase;
 
 import org.apache.cloudstack.context.CallContext;
@@ -92,6 +93,9 @@ public class CreateNetworkOfferingTest extends TestCase {
 
     @Inject
     UserIpAddressDetailsDao userIpAddressDetailsDao;
+
+    @Inject
+    LoadBalancerVMMapDao _loadBalancerVMMapDao;
 
     @Override
     @Before

--- a/server/test/resources/createNetworkOffering.xml
+++ b/server/test/resources/createNetworkOffering.xml
@@ -52,5 +52,6 @@
     <bean id="storagePoolTagsDaoImpl" class="com.cloud.storage.dao.StoragePoolTagsDaoImpl" />
     <bean id="primaryDataStoreDaoImpl" class="org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDaoImpl" />
     <bean id="userIpAddressDetailsDao" class="org.apache.cloudstack.resourcedetail.dao.UserIpAddressDetailsDaoImpl" />
+    <bean id="loadBalancerVMMapDaoImpl" class="com.cloud.network.dao.LoadBalancerVMMapDaoImpl" />
     
 </beans>


### PR DESCRIPTION
ISSUE

Releasing secondary guest IP fails with error VM nic Ip x.x.x.x is mapped to load balancing rule

REPRO STEPS

Create two isolated guest networks with same CIDR
Deploy VMs on both networks
Acquire secondary IP on NICs of both VMs and make sure they have the same value, user can input the IP address.
Configure Loadbalancing rule on one of the secondary IP address and try releasing the other secondary IP address.
The operation would fail
EXPECTED BEHAVIOR

Secondary IP address should be released if there are no LB rules associated with it.

ACTUAL BEHAVIOR

Not releasing secondary IP address even if there are no LB rules associated with it.