### PR TITLE
CLOUDSTACK-9805: Display VR list in network details

### DIFF
--- a/ui/index.jsp
+++ b/ui/index.jsp
@@ -1818,7 +1818,6 @@
         <script type="text/javascript" src="scripts/ui-custom/securityRules.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/vpc.js"></script>
         <script type="text/javascript" src="scripts/vpc.js"></script>
-        <script type="text/javascript" src="scripts/network.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/recurringSnapshots.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/uploadVolume.js"></script>
         <script type="text/javascript" src="scripts/storage.js"></script>
@@ -1833,6 +1832,7 @@
         <script type="text/javascript" src="scripts/ui-custom/physicalResources.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/zoneWizard.js"></script>
         <script type="text/javascript" src="scripts/system.js"></script>
+        <script type="text/javascript" src="scripts/network.js"></script>
         <script type="text/javascript" src="scripts/domains.js"></script>
         <script type="text/javascript" src="scripts/docs.js"></script>
         <script type="text/javascript" src="scripts/vm_snapshots.js"></script>

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1194,6 +1194,10 @@
                                 hiddenTabs.push('egressRules');
                             }
 
+                            if (!isAdmin()) {
+                                hiddenTabs.push("virtualRouters");
+                            }
+
                             return hiddenTabs;
                         },
 
@@ -1892,6 +1896,11 @@
                                         }
                                     });
                                 }
+                            },
+
+                            virtualRouters: {
+                                title: "label.virtual.appliances",
+                                listView: cloudStack.sections.system.subsections.virtualRouters.sections.routerNoGroup.listView
                             }
                         }
                     }
@@ -5738,8 +5747,10 @@
                         tabFilter: function(args) {
                             var hiddenTabs = [];
                             var isRouterOwner = isAdmin();
-                            if (!isRouterOwner)
+                            if (!isRouterOwner) {
                                 hiddenTabs.push("router");
+                                hiddenTabs.push("virtualRouters");
+                            }
                             return hiddenTabs;
                         },
 
@@ -5905,6 +5916,10 @@
                                         }
                                     });
                                 }
+                            },
+                            virtualRouters: {
+                                title: "label.virtual.routers",
+                                listView: cloudStack.sections.system.subsections.virtualRouters.sections.routerNoGroup.listView
                             }
                         }
                     }

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -9769,6 +9769,16 @@
                                              domainid: args.context.routerGroupByAccount[0].domainid
                                         })
                                     }
+                                    if ("networks" in args.context) {
+                                       $.extend(data2, {
+                                             networkid: args.context.networks[0].id
+                                       })
+                                    }
+                                    if ("vpc" in args.context) {
+                                       $.extend(data2, {
+                                             vpcid: args.context.vpc[0].id
+                                       })
+                                    }
                                 }
 
                                 var routers =[];


### PR DESCRIPTION
![screenshot from 2017-03-01 14-52-26](https://cloud.githubusercontent.com/assets/95203/23453709/64f31f8a-fe8f-11e6-8281-a06e27bf3a14.png)

Displays a VR tab that lists VRs for the network in the detail views. This has come up several times, and useful for admins when they want to reboot/destroy or view VR associated with a network.

Pinging for review - @abhinandanprateek @borisstoyanov @DaanHoogland @PaulAngus @karuturi @koushik-das 