### PR TITLE
CLOUDSTACK-9807/CLOUDSTACK-9808 - Added upgrade changes for 4.10 system vm template

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
@@ -23,15 +23,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.apache.log4j.Logger;
 
-import com.cloud.hypervisor.Hypervisor;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
 
@@ -65,7 +60,6 @@ public class Upgrade452to460 implements DbUpgrade {
 
     @Override
     public void performDataMigration(final Connection conn) {
-        updateSystemVmTemplates(conn);
         updateVMInstanceUserId(conn);
         addIndexForVMInstance(conn);
     }
@@ -169,175 +163,5 @@ public class Upgrade452to460 implements DbUpgrade {
         }
 
         return new File[] { new File(script) };
-    }
-
-    @SuppressWarnings("serial")
-    private void updateSystemVmTemplates(final Connection conn) {
-        s_logger.debug("Updating System Vm template IDs");
-        // Get all hypervisors in use
-        final Set<Hypervisor.HypervisorType> hypervisorsListInUse = new HashSet<Hypervisor.HypervisorType>();
-        try (PreparedStatement pstmt = conn.prepareStatement("select distinct(hypervisor_type) from `cloud`.`cluster` where removed is null"); ResultSet rs = pstmt.executeQuery()) {
-            while (rs.next()) {
-                switch (Hypervisor.HypervisorType.getType(rs.getString(1))) {
-                case XenServer:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.XenServer);
-                    break;
-                case KVM:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.KVM);
-                    break;
-                case VMware:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.VMware);
-                    break;
-                case Hyperv:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.Hyperv);
-                    break;
-                case LXC:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.LXC);
-                    break;
-                case Ovm3:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.Ovm3);
-                    break;
-                default: // no action on cases Any, BareMetal, None, Ovm,
-                    // Parralels, Simulator and VirtualBox:
-                    break;
-                }
-            }
-        } catch (final SQLException e) {
-            s_logger.error("updateSystemVmTemplates:Exception while getting hypervisor types from clusters: " + e.getMessage());
-            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting hypervisor types from clusters", e);
-        }
-
-        final Map<Hypervisor.HypervisorType, String> NewTemplateNameList = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "systemvm-xenserver-4.6");
-                put(Hypervisor.HypervisorType.VMware, "systemvm-vmware-4.6");
-                put(Hypervisor.HypervisorType.KVM, "systemvm-kvm-4.6");
-                put(Hypervisor.HypervisorType.LXC, "systemvm-lxc-4.6");
-                put(Hypervisor.HypervisorType.Hyperv, "systemvm-hyperv-4.6");
-                put(Hypervisor.HypervisorType.Ovm3, "systemvm-ovm3-4.6");
-            }
-        };
-
-        final Map<Hypervisor.HypervisorType, String> routerTemplateConfigurationNames = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "router.template.xenserver");
-                put(Hypervisor.HypervisorType.VMware, "router.template.vmware");
-                put(Hypervisor.HypervisorType.KVM, "router.template.kvm");
-                put(Hypervisor.HypervisorType.LXC, "router.template.lxc");
-                put(Hypervisor.HypervisorType.Hyperv, "router.template.hyperv");
-                put(Hypervisor.HypervisorType.Ovm3, "router.template.ovm3");
-            }
-        };
-
-        final Map<Hypervisor.HypervisorType, String> newTemplateUrl = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-xen.vhd.bz2");
-                put(Hypervisor.HypervisorType.VMware, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-vmware.ova");
-                put(Hypervisor.HypervisorType.KVM, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-kvm.qcow2.bz2");
-                put(Hypervisor.HypervisorType.LXC, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-kvm.qcow2.bz2");
-                put(Hypervisor.HypervisorType.Hyperv, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-hyperv.vhd.zip");
-                put(Hypervisor.HypervisorType.Ovm3, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-ovm.raw.bz2");
-            }
-        };
-
-        final Map<Hypervisor.HypervisorType, String> newTemplateChecksum = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "8886f554a499ec5405b6f203d9d36460");
-                put(Hypervisor.HypervisorType.VMware, "4b415224fe00b258f66cad9fce9f73fc");
-                put(Hypervisor.HypervisorType.KVM, "c059b0d051e0cd6fbe9d5d4fc40c7e5d");
-                put(Hypervisor.HypervisorType.LXC, "c059b0d051e0cd6fbe9d5d4fc40c7e5d");
-                put(Hypervisor.HypervisorType.Hyperv, "53e24bddfa56ea3139ed37af4b519013");
-                put(Hypervisor.HypervisorType.Ovm3, "c8577d27b2daafb2d9a4ed307ce2f00f");
-            }
-        };
-
-        for (final Map.Entry<Hypervisor.HypervisorType, String> hypervisorAndTemplateName : NewTemplateNameList.entrySet()) {
-            s_logger.debug("Updating " + hypervisorAndTemplateName.getKey() + " System Vms");
-            try (PreparedStatement pstmt = conn.prepareStatement("select id from `cloud`.`vm_template` where name = ? and removed is null order by id desc limit 1")) {
-                // Get 4.6.0 system Vm template Id for corresponding hypervisor
-                long templateId = -1;
-                pstmt.setString(1, hypervisorAndTemplateName.getValue());
-                try (ResultSet rs = pstmt.executeQuery()) {
-                    if (rs.next()) {
-                        templateId = rs.getLong(1);
-                    }
-                } catch (final SQLException e) {
-                    s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
-                    throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
-                }
-
-                // change template type to SYSTEM
-                if (templateId != -1) {
-                    try (PreparedStatement templ_type_pstmt = conn.prepareStatement("update `cloud`.`vm_template` set type='SYSTEM' where id = ?");) {
-                        templ_type_pstmt.setLong(1, templateId);
-                        templ_type_pstmt.executeUpdate();
-                    } catch (final SQLException e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system': " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system'", e);
-                    }
-                    // update template ID of system Vms
-                    try (PreparedStatement update_templ_id_pstmt = conn
-                            .prepareStatement("update `cloud`.`vm_instance` set vm_template_id = ? where type <> 'User' and hypervisor_type = ?");) {
-                        update_templ_id_pstmt.setLong(1, templateId);
-                        update_templ_id_pstmt.setString(2, hypervisorAndTemplateName.getKey().toString());
-                        update_templ_id_pstmt.executeUpdate();
-                    } catch (final Exception e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to " + templateId
-                                + ": " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to "
-                                + templateId, e);
-                    }
-
-                    // Change value of global configuration parameter
-                    // router.template.* for the corresponding hypervisor
-                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
-                        update_pstmt.setString(1, hypervisorAndTemplateName.getValue());
-                        update_pstmt.setString(2, routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()));
-                        update_pstmt.executeUpdate();
-                    } catch (final SQLException e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting " + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to "
-                                + hypervisorAndTemplateName.getValue() + ": " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting "
-                                + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to " + hypervisorAndTemplateName.getValue(), e);
-                    }
-
-                    // Change value of global configuration parameter
-                    // minreq.sysvmtemplate.version for the ACS version
-                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
-                        update_pstmt.setString(1, getUpgradedVersion());
-                        update_pstmt.setString(2, "minreq.sysvmtemplate.version");
-                        update_pstmt.executeUpdate();
-                    } catch (final SQLException e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.6.0: " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.6.0", e);
-                    }
-                } else {
-                    if (hypervisorsListInUse.contains(hypervisorAndTemplateName.getKey())) {
-                        throw new CloudRuntimeException(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. Cannot upgrade system Vms");
-                    } else {
-                        s_logger.warn(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. " + hypervisorAndTemplateName.getKey()
-                                + " hypervisor is not used, so not failing upgrade");
-                        // Update the latest template URLs for corresponding
-                        // hypervisor
-                        try (PreparedStatement update_templ_url_pstmt = conn
-                                .prepareStatement("UPDATE `cloud`.`vm_template` SET url = ? , checksum = ? WHERE hypervisor_type = ? AND type = 'SYSTEM' AND removed is null order by id desc limit 1");) {
-                            update_templ_url_pstmt.setString(1, newTemplateUrl.get(hypervisorAndTemplateName.getKey()));
-                            update_templ_url_pstmt.setString(2, newTemplateChecksum.get(hypervisorAndTemplateName.getKey()));
-                            update_templ_url_pstmt.setString(3, hypervisorAndTemplateName.getKey().toString());
-                            update_templ_url_pstmt.executeUpdate();
-                        } catch (final SQLException e) {
-                            s_logger.error("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
-                                    + hypervisorAndTemplateName.getKey().toString() + ": " + e.getMessage());
-                            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
-                                    + hypervisorAndTemplateName.getKey().toString(), e);
-                        }
-                    }
-                }
-            } catch (final SQLException e) {
-                s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
-                throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
-            }
-        }
-        s_logger.debug("Updating System Vm Template IDs Complete");
     }
 }

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
@@ -17,12 +17,20 @@
 
 package com.cloud.upgrade.dao;
 
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
 import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class Upgrade4920to41000 implements DbUpgrade {
     final static Logger LOG = Logger.getLogger(Upgrade4920to41000.class);
@@ -53,7 +61,165 @@ public class Upgrade4920to41000 implements DbUpgrade {
 
     @Override
     public void performDataMigration(Connection conn) {
+        updateSystemVmTemplates(conn);
     }
+
+    @SuppressWarnings("serial")
+    private void updateSystemVmTemplates(final Connection conn) {
+        LOG.debug("Updating System Vm template IDs");
+        // Get all hypervisors in use
+        final Set<Hypervisor.HypervisorType> hypervisorsListInUse = new HashSet<Hypervisor.HypervisorType>();
+        try (PreparedStatement pstmt = conn.prepareStatement("select distinct(hypervisor_type) from `cloud`.`cluster` where removed is null"); ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                switch (Hypervisor.HypervisorType.getType(rs.getString(1))) {
+                    case XenServer:
+                        hypervisorsListInUse.add(Hypervisor.HypervisorType.XenServer);
+                        break;
+                    case KVM:
+                        hypervisorsListInUse.add(Hypervisor.HypervisorType.KVM);
+                        break;
+                    case VMware:
+                        hypervisorsListInUse.add(Hypervisor.HypervisorType.VMware);
+                        break;
+                    case Hyperv:
+                        hypervisorsListInUse.add(Hypervisor.HypervisorType.Hyperv);
+                        break;
+                    default: // no action on cases Any, BareMetal, None, Ovm,
+                        // Parralels, Simulator and VirtualBox:
+                        break;
+                }
+            }
+        } catch (final SQLException e) {
+            LOG.error("updateSystemVmTemplates:Exception while getting hypervisor types from clusters: " + e.getMessage());
+            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting hypervisor types from clusters", e);
+        }
+
+        final Map<Hypervisor.HypervisorType, String> NewTemplateNameList = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(Hypervisor.HypervisorType.XenServer, "systemvm-xenserver-4.10");
+                put(Hypervisor.HypervisorType.VMware, "systemvm-vmware-4.10");
+                put(Hypervisor.HypervisorType.KVM, "systemvm-kvm-4.10");
+                put(Hypervisor.HypervisorType.Hyperv, "systemvm-hyperv-4.10");
+            }
+        };
+
+        final Map<Hypervisor.HypervisorType, String> routerTemplateConfigurationNames = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(Hypervisor.HypervisorType.XenServer, "router.template.xenserver");
+                put(Hypervisor.HypervisorType.VMware, "router.template.vmware");
+                put(Hypervisor.HypervisorType.KVM, "router.template.kvm");
+                put(Hypervisor.HypervisorType.Hyperv, "router.template.hyperv");
+            }
+        };
+
+        final Map<Hypervisor.HypervisorType, String> newTemplateUrl = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(Hypervisor.HypervisorType.XenServer, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-xen.vhd.bz2");
+                put(Hypervisor.HypervisorType.VMware, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-vmware.ova");
+                put(Hypervisor.HypervisorType.KVM, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-kvm.qcow2.bz2");
+                put(Hypervisor.HypervisorType.Hyperv, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-hyperv.vhd.zip");
+            }
+        };
+
+        final Map<Hypervisor.HypervisorType, String> newTemplateChecksum = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(Hypervisor.HypervisorType.XenServer, "908c28a8d4c232f960e0f84af7f86c80");
+                put(Hypervisor.HypervisorType.VMware, "970bfb070a80bd74820881d8149643c1");
+                put(Hypervisor.HypervisorType.KVM, "bc2eac46f16a2ece6c19d4b89db41de3");
+                put(Hypervisor.HypervisorType.Hyperv, "0adb35bd9f92e80d3fc63fcdd9bb55e5");
+            }
+        };
+
+        for (final Map.Entry<Hypervisor.HypervisorType, String> hypervisorAndTemplateName : NewTemplateNameList.entrySet()) {
+            LOG.debug("Updating " + hypervisorAndTemplateName.getKey() + " System Vms");
+            try (PreparedStatement pstmt = conn.prepareStatement("select id from `cloud`.`vm_template` where name = ? and removed is null order by id desc limit 1")) {
+                // Get 4.10.0 system Vm template Id for corresponding hypervisor
+                long templateId = -1;
+                pstmt.setString(1, hypervisorAndTemplateName.getValue());
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    if (rs.next()) {
+                        templateId = rs.getLong(1);
+                    }
+                } catch (final SQLException e) {
+                    LOG.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
+                    throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
+                }
+
+                // change template type to SYSTEM
+                if (templateId != -1) {
+                    try (PreparedStatement templ_type_pstmt = conn.prepareStatement("update `cloud`.`vm_template` set type='SYSTEM' where id = ?");) {
+                        templ_type_pstmt.setLong(1, templateId);
+                        templ_type_pstmt.executeUpdate();
+                    } catch (final SQLException e) {
+                        LOG.error("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system': " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system'", e);
+                    }
+                    // update template ID of system Vms
+                    try (PreparedStatement update_templ_id_pstmt = conn
+                            .prepareStatement("update `cloud`.`vm_instance` set vm_template_id = ? where type <> 'User' and hypervisor_type = ?");) {
+                        update_templ_id_pstmt.setLong(1, templateId);
+                        update_templ_id_pstmt.setString(2, hypervisorAndTemplateName.getKey().toString());
+                        update_templ_id_pstmt.executeUpdate();
+                    } catch (final Exception e) {
+                        LOG.error("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to " + templateId
+                                + ": " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to "
+                                + templateId, e);
+                    }
+
+                    // Change value of global configuration parameter
+                    // router.template.* for the corresponding hypervisor
+                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
+                        update_pstmt.setString(1, hypervisorAndTemplateName.getValue());
+                        update_pstmt.setString(2, routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()));
+                        update_pstmt.executeUpdate();
+                    } catch (final SQLException e) {
+                        LOG.error("updateSystemVmTemplates:Exception while setting " + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to "
+                                + hypervisorAndTemplateName.getValue() + ": " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting "
+                                + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to " + hypervisorAndTemplateName.getValue(), e);
+                    }
+
+                    // Change value of global configuration parameter
+                    // minreq.sysvmtemplate.version for the ACS version
+                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
+                        update_pstmt.setString(1, getUpgradedVersion());
+                        update_pstmt.setString(2, "minreq.sysvmtemplate.version");
+                        update_pstmt.executeUpdate();
+                    } catch (final SQLException e) {
+                        LOG.error("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.10.0: " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.10.0", e);
+                    }
+                } else {
+                    if (hypervisorsListInUse.contains(hypervisorAndTemplateName.getKey())) {
+                        throw new CloudRuntimeException(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. Cannot upgrade system Vms");
+                    } else {
+                        LOG.warn(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. " + hypervisorAndTemplateName.getKey()
+                                + " hypervisor is not used, so not failing upgrade");
+                        // Update the latest template URLs for corresponding
+                        // hypervisor
+                        try (PreparedStatement update_templ_url_pstmt = conn
+                                .prepareStatement("UPDATE `cloud`.`vm_template` SET url = ? , checksum = ? WHERE hypervisor_type = ? AND type = 'SYSTEM' AND removed is null order by id desc limit 1");) {
+                            update_templ_url_pstmt.setString(1, newTemplateUrl.get(hypervisorAndTemplateName.getKey()));
+                            update_templ_url_pstmt.setString(2, newTemplateChecksum.get(hypervisorAndTemplateName.getKey()));
+                            update_templ_url_pstmt.setString(3, hypervisorAndTemplateName.getKey().toString());
+                            update_templ_url_pstmt.executeUpdate();
+                        } catch (final SQLException e) {
+                            LOG.error("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
+                                    + hypervisorAndTemplateName.getKey().toString() + ": " + e.getMessage());
+                            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
+                                    + hypervisorAndTemplateName.getKey().toString(), e);
+                        }
+                    }
+                }
+            } catch (final SQLException e) {
+                LOG.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
+                throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
+            }
+        }
+        LOG.debug("Updating System Vm Template IDs Complete");
+    }
+
 
     @Override
     public File[] getCleanupScripts() {


### PR DESCRIPTION
Removed systemvm template upgrade code in 4.6 upgrade. Added 4.10 system vm template upgrade changes with new urls and md5sum

Manual testing results:
Updated min req version:
mysql> select name, value from configuration where name = 'minreq.sysvmtemplate.version';
+------------------------------+----------+
| name                         | value    |
+------------------------------+----------+
| minreq.sysvmtemplate.version | 4.10.0.0 |
+------------------------------+----------+
1 row in set (0.00 sec)

Update template for KVM:
mysql> select * from vm_template where name = 'systemvm-kvm-4.10'\G
*************************** 1. row ***************************
                  id: 201
         unique_name: 201-2-badc363a-507d-3802-942f-205d35c3b575
                name: systemvm-kvm-4.10
                uuid: 3526258d-d9a4-4c3d-8f15-3137eb5d7ab8
              public: 0
            featured: 0
                type: SYSTEM
                 hvm: 1
                bits: 64
                 url: http://packages.shapeblue.com/systemvmtemplate/4.10/systemvm64template-4.10-kvm.qcow2.bz2
              format: QCOW2
             created: 2017-03-02 11:35:06
             removed: NULL
          account_id: 2
            checksum: NULL
        display_text: systemvm-kvm-4.10
     enable_password: 0
       enable_sshkey: 0
         guest_os_id: 184
            bootable: 1
         prepopulate: 0
         cross_zones: 1
         extractable: 0
     hypervisor_type: KVM
  source_template_id: NULL
        template_tag: NULL
            sort_key: 0
                size: 5242880
               state: Active
        update_count: 0
             updated: NULL
dynamically_scalable: 0
1 row in set (0.00 sec)

