### PR TITLE
[4.10/blocker] Upgrade4920to41000: Migrate systemvmtemplate for 4.10

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade452to460.java
@@ -17,23 +17,17 @@
 
 package com.cloud.upgrade.dao;
 
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+import org.apache.log4j.Logger;
+
 import java.io.File;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.log4j.Logger;
-
-import com.cloud.hypervisor.Hypervisor;
-import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.script.Script;
 
 public class Upgrade452to460 implements DbUpgrade {
     final static Logger s_logger = Logger.getLogger(Upgrade452to460.class);
@@ -65,7 +59,6 @@ public class Upgrade452to460 implements DbUpgrade {
 
     @Override
     public void performDataMigration(final Connection conn) {
-        updateSystemVmTemplates(conn);
         updateVMInstanceUserId(conn);
         addIndexForVMInstance(conn);
     }
@@ -169,175 +162,5 @@ public class Upgrade452to460 implements DbUpgrade {
         }
 
         return new File[] { new File(script) };
-    }
-
-    @SuppressWarnings("serial")
-    private void updateSystemVmTemplates(final Connection conn) {
-        s_logger.debug("Updating System Vm template IDs");
-        // Get all hypervisors in use
-        final Set<Hypervisor.HypervisorType> hypervisorsListInUse = new HashSet<Hypervisor.HypervisorType>();
-        try (PreparedStatement pstmt = conn.prepareStatement("select distinct(hypervisor_type) from `cloud`.`cluster` where removed is null"); ResultSet rs = pstmt.executeQuery()) {
-            while (rs.next()) {
-                switch (Hypervisor.HypervisorType.getType(rs.getString(1))) {
-                case XenServer:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.XenServer);
-                    break;
-                case KVM:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.KVM);
-                    break;
-                case VMware:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.VMware);
-                    break;
-                case Hyperv:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.Hyperv);
-                    break;
-                case LXC:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.LXC);
-                    break;
-                case Ovm3:
-                    hypervisorsListInUse.add(Hypervisor.HypervisorType.Ovm3);
-                    break;
-                default: // no action on cases Any, BareMetal, None, Ovm,
-                    // Parralels, Simulator and VirtualBox:
-                    break;
-                }
-            }
-        } catch (final SQLException e) {
-            s_logger.error("updateSystemVmTemplates:Exception while getting hypervisor types from clusters: " + e.getMessage());
-            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting hypervisor types from clusters", e);
-        }
-
-        final Map<Hypervisor.HypervisorType, String> NewTemplateNameList = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "systemvm-xenserver-4.6");
-                put(Hypervisor.HypervisorType.VMware, "systemvm-vmware-4.6");
-                put(Hypervisor.HypervisorType.KVM, "systemvm-kvm-4.6");
-                put(Hypervisor.HypervisorType.LXC, "systemvm-lxc-4.6");
-                put(Hypervisor.HypervisorType.Hyperv, "systemvm-hyperv-4.6");
-                put(Hypervisor.HypervisorType.Ovm3, "systemvm-ovm3-4.6");
-            }
-        };
-
-        final Map<Hypervisor.HypervisorType, String> routerTemplateConfigurationNames = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "router.template.xenserver");
-                put(Hypervisor.HypervisorType.VMware, "router.template.vmware");
-                put(Hypervisor.HypervisorType.KVM, "router.template.kvm");
-                put(Hypervisor.HypervisorType.LXC, "router.template.lxc");
-                put(Hypervisor.HypervisorType.Hyperv, "router.template.hyperv");
-                put(Hypervisor.HypervisorType.Ovm3, "router.template.ovm3");
-            }
-        };
-
-        final Map<Hypervisor.HypervisorType, String> newTemplateUrl = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-xen.vhd.bz2");
-                put(Hypervisor.HypervisorType.VMware, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-vmware.ova");
-                put(Hypervisor.HypervisorType.KVM, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-kvm.qcow2.bz2");
-                put(Hypervisor.HypervisorType.LXC, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-kvm.qcow2.bz2");
-                put(Hypervisor.HypervisorType.Hyperv, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-hyperv.vhd.zip");
-                put(Hypervisor.HypervisorType.Ovm3, "http://cloudstack.apt-get.eu/systemvm/4.6/systemvm64template-4.6.0-ovm.raw.bz2");
-            }
-        };
-
-        final Map<Hypervisor.HypervisorType, String> newTemplateChecksum = new HashMap<Hypervisor.HypervisorType, String>() {
-            {
-                put(Hypervisor.HypervisorType.XenServer, "8886f554a499ec5405b6f203d9d36460");
-                put(Hypervisor.HypervisorType.VMware, "4b415224fe00b258f66cad9fce9f73fc");
-                put(Hypervisor.HypervisorType.KVM, "c059b0d051e0cd6fbe9d5d4fc40c7e5d");
-                put(Hypervisor.HypervisorType.LXC, "c059b0d051e0cd6fbe9d5d4fc40c7e5d");
-                put(Hypervisor.HypervisorType.Hyperv, "53e24bddfa56ea3139ed37af4b519013");
-                put(Hypervisor.HypervisorType.Ovm3, "c8577d27b2daafb2d9a4ed307ce2f00f");
-            }
-        };
-
-        for (final Map.Entry<Hypervisor.HypervisorType, String> hypervisorAndTemplateName : NewTemplateNameList.entrySet()) {
-            s_logger.debug("Updating " + hypervisorAndTemplateName.getKey() + " System Vms");
-            try (PreparedStatement pstmt = conn.prepareStatement("select id from `cloud`.`vm_template` where name = ? and removed is null order by id desc limit 1")) {
-                // Get 4.6.0 system Vm template Id for corresponding hypervisor
-                long templateId = -1;
-                pstmt.setString(1, hypervisorAndTemplateName.getValue());
-                try (ResultSet rs = pstmt.executeQuery()) {
-                    if (rs.next()) {
-                        templateId = rs.getLong(1);
-                    }
-                } catch (final SQLException e) {
-                    s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
-                    throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
-                }
-
-                // change template type to SYSTEM
-                if (templateId != -1) {
-                    try (PreparedStatement templ_type_pstmt = conn.prepareStatement("update `cloud`.`vm_template` set type='SYSTEM' where id = ?");) {
-                        templ_type_pstmt.setLong(1, templateId);
-                        templ_type_pstmt.executeUpdate();
-                    } catch (final SQLException e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system': " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system'", e);
-                    }
-                    // update template ID of system Vms
-                    try (PreparedStatement update_templ_id_pstmt = conn
-                            .prepareStatement("update `cloud`.`vm_instance` set vm_template_id = ? where type <> 'User' and hypervisor_type = ?");) {
-                        update_templ_id_pstmt.setLong(1, templateId);
-                        update_templ_id_pstmt.setString(2, hypervisorAndTemplateName.getKey().toString());
-                        update_templ_id_pstmt.executeUpdate();
-                    } catch (final Exception e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to " + templateId
-                                + ": " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to "
-                                + templateId, e);
-                    }
-
-                    // Change value of global configuration parameter
-                    // router.template.* for the corresponding hypervisor
-                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
-                        update_pstmt.setString(1, hypervisorAndTemplateName.getValue());
-                        update_pstmt.setString(2, routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()));
-                        update_pstmt.executeUpdate();
-                    } catch (final SQLException e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting " + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to "
-                                + hypervisorAndTemplateName.getValue() + ": " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting "
-                                + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to " + hypervisorAndTemplateName.getValue(), e);
-                    }
-
-                    // Change value of global configuration parameter
-                    // minreq.sysvmtemplate.version for the ACS version
-                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
-                        update_pstmt.setString(1, getUpgradedVersion());
-                        update_pstmt.setString(2, "minreq.sysvmtemplate.version");
-                        update_pstmt.executeUpdate();
-                    } catch (final SQLException e) {
-                        s_logger.error("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.6.0: " + e.getMessage());
-                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.6.0", e);
-                    }
-                } else {
-                    if (hypervisorsListInUse.contains(hypervisorAndTemplateName.getKey())) {
-                        throw new CloudRuntimeException(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. Cannot upgrade system Vms");
-                    } else {
-                        s_logger.warn(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. " + hypervisorAndTemplateName.getKey()
-                                + " hypervisor is not used, so not failing upgrade");
-                        // Update the latest template URLs for corresponding
-                        // hypervisor
-                        try (PreparedStatement update_templ_url_pstmt = conn
-                                .prepareStatement("UPDATE `cloud`.`vm_template` SET url = ? , checksum = ? WHERE hypervisor_type = ? AND type = 'SYSTEM' AND removed is null order by id desc limit 1");) {
-                            update_templ_url_pstmt.setString(1, newTemplateUrl.get(hypervisorAndTemplateName.getKey()));
-                            update_templ_url_pstmt.setString(2, newTemplateChecksum.get(hypervisorAndTemplateName.getKey()));
-                            update_templ_url_pstmt.setString(3, hypervisorAndTemplateName.getKey().toString());
-                            update_templ_url_pstmt.executeUpdate();
-                        } catch (final SQLException e) {
-                            s_logger.error("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
-                                    + hypervisorAndTemplateName.getKey().toString() + ": " + e.getMessage());
-                            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
-                                    + hypervisorAndTemplateName.getKey().toString(), e);
-                        }
-                    }
-                }
-            } catch (final SQLException e) {
-                s_logger.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
-                throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
-            }
-        }
-        s_logger.debug("Updating System Vm Template IDs Complete");
     }
 }

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
@@ -17,12 +17,29 @@
 
 package com.cloud.upgrade.dao;
 
+import com.cloud.hypervisor.Hypervisor;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.script.Script;
 import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.cloud.hypervisor.Hypervisor.HypervisorType.Hyperv;
+import static com.cloud.hypervisor.Hypervisor.HypervisorType.KVM;
+import static com.cloud.hypervisor.Hypervisor.HypervisorType.LXC;
+import static com.cloud.hypervisor.Hypervisor.HypervisorType.Ovm3;
+import static com.cloud.hypervisor.Hypervisor.HypervisorType.VMware;
+import static com.cloud.hypervisor.Hypervisor.HypervisorType.XenServer;
 
 public class Upgrade4920to41000 implements DbUpgrade {
     final static Logger LOG = Logger.getLogger(Upgrade4920to41000.class);
@@ -53,6 +70,7 @@ public class Upgrade4920to41000 implements DbUpgrade {
 
     @Override
     public void performDataMigration(Connection conn) {
+        updateSystemVmTemplates(conn);
     }
 
     @Override
@@ -62,5 +80,156 @@ public class Upgrade4920to41000 implements DbUpgrade {
             throw new CloudRuntimeException("Unable to find db/schema-4920to41000-cleanup.sql");
         }
         return new File[] {new File(script)};
+    }
+
+    private void updateSystemVmTemplates(final Connection conn) {
+        LOG.debug("Updating System Vm template IDs");
+        // Get all hypervisors in use
+        final Set<Hypervisor.HypervisorType> hypervisorsListInUse = new HashSet<Hypervisor.HypervisorType>();
+        try (PreparedStatement pstmt = conn.prepareStatement("select distinct(hypervisor_type) from `cloud`.`cluster` where removed is null"); ResultSet rs = pstmt.executeQuery()) {
+            final List<Hypervisor.HypervisorType> allowedHypervisorTypes = Arrays.asList(XenServer, KVM, VMware, Hyperv, LXC, Ovm3);
+            final Hypervisor.HypervisorType currentHypervisorType = Hypervisor.HypervisorType.getType(rs.getString(1));
+            for (final Hypervisor.HypervisorType hypervisorType : allowedHypervisorTypes) {
+                if (hypervisorType == currentHypervisorType) {
+                    hypervisorsListInUse.add(hypervisorType);
+                }
+            }
+        } catch (final SQLException e) {
+            LOG.error("updateSystemVmTemplates:Exception while getting hypervisor types from clusters: " + e.getMessage());
+            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting hypervisor types from clusters", e);
+        }
+
+        final Map<Hypervisor.HypervisorType, String> NewTemplateNameList = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(XenServer, "systemvm-xenserver-4.10");
+                put(VMware, "systemvm-vmware-4.10");
+                put(KVM, "systemvm-kvm-4.10");
+                put(LXC, "systemvm-lxc-4.10");
+                put(Hyperv, "systemvm-hyperv-4.10");
+                put(Ovm3, "systemvm-ovm3-4.10");
+            }
+        };
+
+        final Map<Hypervisor.HypervisorType, String> routerTemplateConfigurationNames = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(XenServer, "router.template.xenserver");
+                put(VMware, "router.template.vmware");
+                put(KVM, "router.template.kvm");
+                put(LXC, "router.template.lxc");
+                put(Hyperv, "router.template.hyperv");
+                put(Ovm3, "router.template.ovm3");
+            }
+        };
+
+        final Map<Hypervisor.HypervisorType, String> newTemplateUrl = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(XenServer, "http://packages.shapeblue.com/systemvmtemplate/4.10/systemvm64template-4.10-xen.vhd.bz2");
+                put(VMware, "http://packages.shapeblue.com/systemvmtemplate/4.10/systemvm64template-4.10-vmware.ova");
+                put(KVM, "http://packages.shapeblue.com/systemvmtemplate/4.10/systemvm64template-4.10-kvm.qcow2.bz2");
+                put(LXC, "http://packages.shapeblue.com/systemvmtemplate/4.10/systemvm64template-4.10-kvm.qcow2.bz2");
+                put(Hyperv, "http://packages.shapeblue.com/systemvmtemplate/4.10/systemvm64template-4.10-hyperv.vhd.zip");
+                put(Ovm3, "http://packages.shapeblue.com/systemvmtemplate/4.10/systemvm64template-4.10-ovm.raw.bz2");
+            }
+        };
+
+        final Map<Hypervisor.HypervisorType, String> newTemplateChecksum = new HashMap<Hypervisor.HypervisorType, String>() {
+            {
+                put(XenServer, "d70d61594475b7fc3b3e9694306d6ffe");
+                put(VMware, "b19325c5605f740574d2ee3c63a91795");
+                put(KVM, "c2d27ea0edf9e7d9574a1c7650fc324e");
+                put(LXC, "c2d27ea0edf9e7d9574a1c7650fc324e");
+                put(Hyperv, "a76fb79e1a4f2f7df072c20bff79832f");
+                put(Ovm3, "e8af7993ff43cc7f7ed938a97e9ac952");
+            }
+        };
+
+        for (final Map.Entry<Hypervisor.HypervisorType, String> hypervisorAndTemplateName : NewTemplateNameList.entrySet()) {
+            LOG.debug("Updating " + hypervisorAndTemplateName.getKey() + " System Vms");
+            try (PreparedStatement pstmt = conn.prepareStatement("select id from `cloud`.`vm_template` where name = ? and removed is null order by id desc limit 1")) {
+                // Get 4.10 system Vm template Id for corresponding hypervisor
+                long templateId = -1;
+                pstmt.setString(1, hypervisorAndTemplateName.getValue());
+                try (ResultSet rs = pstmt.executeQuery()) {
+                    if (rs.next()) {
+                        templateId = rs.getLong(1);
+                    }
+                } catch (final SQLException e) {
+                    LOG.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
+                    throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
+                }
+
+                // change template type to SYSTEM
+                if (templateId != -1) {
+                    try (PreparedStatement templ_type_pstmt = conn.prepareStatement("update `cloud`.`vm_template` set type='SYSTEM' where id = ?");) {
+                        templ_type_pstmt.setLong(1, templateId);
+                        templ_type_pstmt.executeUpdate();
+                    } catch (final SQLException e) {
+                        LOG.error("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system': " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating template with id " + templateId + " to be marked as 'system'", e);
+                    }
+                    // update template ID of system Vms
+                    try (PreparedStatement update_templ_id_pstmt = conn
+                            .prepareStatement("update `cloud`.`vm_instance` set vm_template_id = ? where type <> 'User' and hypervisor_type = ?");) {
+                        update_templ_id_pstmt.setLong(1, templateId);
+                        update_templ_id_pstmt.setString(2, hypervisorAndTemplateName.getKey().toString());
+                        update_templ_id_pstmt.executeUpdate();
+                    } catch (final Exception e) {
+                        LOG.error("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to " + templateId
+                                + ": " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting template for " + hypervisorAndTemplateName.getKey().toString() + " to "
+                                + templateId, e);
+                    }
+
+                    // Change value of global configuration parameter
+                    // router.template.* for the corresponding hypervisor
+                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
+                        update_pstmt.setString(1, hypervisorAndTemplateName.getValue());
+                        update_pstmt.setString(2, routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()));
+                        update_pstmt.executeUpdate();
+                    } catch (final SQLException e) {
+                        LOG.error("updateSystemVmTemplates:Exception while setting " + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to "
+                                + hypervisorAndTemplateName.getValue() + ": " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting "
+                                + routerTemplateConfigurationNames.get(hypervisorAndTemplateName.getKey()) + " to " + hypervisorAndTemplateName.getValue(), e);
+                    }
+
+                    // Change value of global configuration parameter
+                    // minreq.sysvmtemplate.version for the ACS version
+                    try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
+                        update_pstmt.setString(1, "4.10.0");
+                        update_pstmt.setString(2, "minreq.sysvmtemplate.version");
+                        update_pstmt.executeUpdate();
+                    } catch (final SQLException e) {
+                        LOG.error("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.10.0: " + e.getMessage());
+                        throw new CloudRuntimeException("updateSystemVmTemplates:Exception while setting 'minreq.sysvmtemplate.version' to 4.10.0", e);
+                    }
+                } else {
+                    if (hypervisorsListInUse.contains(hypervisorAndTemplateName.getKey())) {
+                        throw new CloudRuntimeException(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. Cannot upgrade system Vms");
+                    } else {
+                        LOG.warn(getUpgradedVersion() + hypervisorAndTemplateName.getKey() + " SystemVm template not found. " + hypervisorAndTemplateName.getKey()
+                                + " hypervisor is not used, so not failing upgrade");
+                        // Update the latest template URLs for corresponding
+                        // hypervisor
+                        try (PreparedStatement update_templ_url_pstmt = conn
+                                .prepareStatement("UPDATE `cloud`.`vm_template` SET url = ? , checksum = ? WHERE hypervisor_type = ? AND type = 'SYSTEM' AND removed is null order by id desc limit 1");) {
+                            update_templ_url_pstmt.setString(1, newTemplateUrl.get(hypervisorAndTemplateName.getKey()));
+                            update_templ_url_pstmt.setString(2, newTemplateChecksum.get(hypervisorAndTemplateName.getKey()));
+                            update_templ_url_pstmt.setString(3, hypervisorAndTemplateName.getKey().toString());
+                            update_templ_url_pstmt.executeUpdate();
+                        } catch (final SQLException e) {
+                            LOG.error("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
+                                    + hypervisorAndTemplateName.getKey().toString() + ": " + e.getMessage());
+                            throw new CloudRuntimeException("updateSystemVmTemplates:Exception while updating 'url' and 'checksum' for hypervisor type "
+                                    + hypervisorAndTemplateName.getKey().toString(), e);
+                        }
+                    }
+                }
+            } catch (final SQLException e) {
+                LOG.error("updateSystemVmTemplates:Exception while getting ids of templates: " + e.getMessage());
+                throw new CloudRuntimeException("updateSystemVmTemplates:Exception while getting ids of templates", e);
+            }
+        }
+        LOG.debug("Updating System Vm Template IDs Complete");
     }
 }


### PR DESCRIPTION
- Adds systemvm migration for upgrading to 4.10
- Remove systemvm migration block for upgrading from 4.5 or below, this
  ensures that pre 4.6 users are not required to seed 4.6 systemvmtemplate
  to upgrade to 4.10, but can directly seed a 4.10 systemvmtemplate

Pinging for review - @karuturi @PaulAngus @abhinandanprateek @DaanHoogland @koushik-das @borisstoyanov @wido and others.

Note: for the 4.10 release systemvmtemplates are not available on http://cloudstack.apt-get.eu/systemvm yet so I've used URLs from packages.shapeblue.com.