### PR TITLE
CLOUDSTACK-9824:Resource count for Primary storage is considered twice - while creating and while attaching the disk

### DIFF
--- a/server/src/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1465,11 +1465,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         Account owner = _accountDao.findById(volumeToAttach.getAccountId());
 
-        try {
-            _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, volumeToAttach.getSize());
-        } catch (ResourceAllocationException e) {
-            s_logger.error("primary storage resource limit check failed", e);
-            throw new InvalidParameterValueException(e.getMessage());
+        if(!(volumeToAttach.getState() == Volume.State.Allocated || volumeToAttach.getState() == Volume.State.Ready)){
+            try {
+                _resourceLimitMgr.checkResourceLimit(owner, ResourceType.primary_storage, volumeToAttach.getSize());
+            } catch (ResourceAllocationException e) {
+                s_logger.error("primary storage resource limit check failed", e);
+                throw new InvalidParameterValueException(e.getMessage());
+            }
         }
 
         HypervisorType rootDiskHyperType = vm.getHypervisorType();


### PR DESCRIPTION
The Primary Storage resource counts is considered twice: Once while creating the volume and next while attaching it. This results in failure while Attaching the volume, if the primary storage resource limit is set.

**Following are the steps to reproduce the issue:**
1. Create a Domain
2. Create an Account.
3. Allocate 11 GB Primary storage limit to the domain.
4. Deploy a VM sized 8GB (Primary storage resource count is now 8GB )
5. Create a 2GB custom disk by using the option 'Add Volume' link.(Primary storage resource count is now 10GB). The Volume state is 'Allocated'
6. Now try to Attach the data-disk created above to a VM. At this point the resource count limit is again checked, and the attachment fails, because it is expected to be 12GB, but, which exceeds the limit of 11GB.
7. This issue is also observed for volumes which are 'Detached'. On detaching an attached volume, the state is still seen as 'Ready'. When such a 
volume is tried to attach again, it will fail as the resource limit will be checked again.

**Fix implemented:**
1. When a volume is ‘Added’, its state is seen as ‘Allocated’ and it utilizes the primary storage resource. When the Volume in ‘Allocated’ state is attached to a VM, its state changes to ‘Ready’.
2. When the volume is detached from the VM, its state is still seen as ‘Ready’. When the volume is detached, the resources (primary storage) are not released, because the volume is still in primary storage. 
3. The fix is to skip checking the resource limit when the volume state is either 'Allocated' or 'Ready'. Because the volume state being 'Allocated' or 'Ready' implies that it is already on the Primary storage and hence the limit should not be checked again.

**Test Results:**
1. Set a limit of 42 GB primary storage to a new domain 
2. Deployed a 30GB VM in it. 
3. Created a 10 GB disk and could attach and detach it multiple times without any error of resource limit.