### PR TITLE
CLOUDSTACK-9828: GetDomRVersionCommand fails to get the correct versi…

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/get_template_version.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/get_template_version.sh
@@ -42,5 +42,6 @@ then
     exit
 fi
 
-echo -n `cat /etc/cloudstack-release`'&'
-cat /var/cache/cloud/cloud-scripts-signature
+release=`cat /etc/cloudstack-release`
+sig=`cat /var/cache/cloud/cloud-scripts-signature`
+echo  "${release}&${sig}"


### PR DESCRIPTION
…on as output

Fix tries to return the output as a single command, instead of appending output from two commands