### PR TITLE
CLOUDSTACK-9600: listVirtualMachines: add VPC ID to response

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -144,6 +144,10 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     @Param(description = "the ID of the service offering of the virtual machine")
     private String serviceOfferingId;
 
+    @SerializedName(ApiConstants.VPC_ID)
+    @Param(description = "the ID of the VPC the virtual machine belongs to", since = "4.11")
+    private String vpcId;
+
     @SerializedName("serviceofferingname")
     @Param(description = "the name of the service offering of the virtual machine")
     private String serviceOfferingName;
@@ -708,6 +712,7 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     public void setVgpu(String vgpu) {
         this.vgpu = vgpu;
     }
+
     public void setCpuUsed(String cpuUsed) {
         this.cpuUsed = cpuUsed;
     }
@@ -812,5 +817,9 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
 
     public void setOsTypeId(Long osTypeId) {
         this.osTypeId = osTypeId;
+    }
+
+    public void setVpcId(String vpcId) {
+        this.vpcId = vpcId;
     }
 }

--- a/server/src/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -192,6 +192,10 @@ public class UserVmJoinDaoImpl extends GenericDaoBaseWithTagInformation<UserVmJo
         userVmResponse.setKeyPairName(userVm.getKeypairName());
         userVmResponse.setOsTypeId(userVm.getGuestOsId());
 
+        if (userVm.getVpcUuid() != null) {
+            userVmResponse.setVpcId(userVm.getVpcUuid());
+        }
+
         if (details.contains(VMDetails.all) || details.contains(VMDetails.stats)) {
             // stats calculation
             VmStats vmStats = ApiDBUtils.getVmStatistics(userVm.getId());

--- a/server/src/com/cloud/api/query/vo/UserVmJoinVO.java
+++ b/server/src/com/cloud/api/query/vo/UserVmJoinVO.java
@@ -370,7 +370,6 @@ public class UserVmJoinVO extends BaseViewWithTagInformationVO implements Contro
     @Column(name = "dynamically_scalable")
     private boolean isDynamicallyScalable;
 
-
     public UserVmJoinVO() {
     }
 
@@ -826,7 +825,6 @@ public class UserVmJoinVO extends BaseViewWithTagInformationVO implements Contro
     public Boolean isDynamicallyScalable() {
         return isDynamicallyScalable;
     }
-
 
     @Override
     public Class<?> getEntityType() {


### PR DESCRIPTION
Currently, the listVirtualMachines takes the vpcid as a param but does not return it in a response. It also solves expensive operation for finding out if a VM is in a VPC.