### PR TITLE
CLOUDSTACK-9831: Previous pod_id still remains in the vm_instance table

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2287,8 +2287,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         work.setResourceId(destHostId);
         work = _workDao.persist(work);
 
+
         // Put the vm in migrating state.
         vm.setLastHostId(srcHostId);
+        vm.setPodIdToDeployIn(destHost.getPodId());
         moveVmToMigratingState(vm, destHostId, work);
 
         boolean migrated = false;
@@ -2365,6 +2367,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                         "Migrate Command failed.  Please check logs.");
                 try {
                     _agentMgr.send(destHostId, new Commands(cleanup(vm.getInstanceName())), null);
+                    vm.setPodIdToDeployIn(srcHost.getPodId());
                     stateTransitTo(vm, Event.OperationFailed, srcHostId);
                 } catch (final AgentUnavailableException e) {
                     s_logger.warn("Looks like the destination Host is unavailable for cleanup.", e);


### PR DESCRIPTION
Previous pod_id still remains in the vm_instance table after VM migration with migrateVirtualMachineWithVolume

```

Previous pod_id still remains in the vm_instance table after VM migration with migrateVirtualMachineWithVolume

Before migrateVirtualMachineWithVolume
mysql> select v.id,v.instance_name,h.name,v.pod_id as pod_id_from_instance_tb,h.pod_id as pod_id_from_host_tb from vm_instance v, host h where v.host_id=h.id and v.id=2;
------------------------------------------------------------------------------------------------------
id 	instance_name 	name 	pod_id_from_instance_tb 	pod_id_from_host_tb

------------------------------------------------------------------------------------------------------
2 	i-2-2-VM 	testVM 	1 	1

------------------------------------------------------------------------------------------------------
1 row in set (0.00 sec)

After migrateVirtualMachineWithVolume
mysql> select v.id,v.instance_name,h.name,v.pod_id as pod_id_from_instance_tb,h.pod_id as pod_id_from_host_tb from vm_instance v, host h where v.host_id=h.id and v.id=3;
-----------------------------------------------------------------------------------------------------
id 	instance_name 	name 	pod_id_from_instance_tb 	pod_id_from_host_tb

-----------------------------------------------------------------------------------------------------
3 	i-2-3-VM 	testVm1 	1 	2

-----------------------------------------------------------------------------------------------------
1 row in set (0.00 sec)

```