### PR TITLE
CLOUDSTACK-9832: Do not assign public IP NIC to the VPC VR when the VPC offering does not contain VpcVirtualRouter as a SourceNat provider

### DIFF
--- a/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -180,6 +180,11 @@ public interface NetworkOrchestrationService {
         throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException, ConcurrentOperationException, InsufficientCapacityException,
         ResourceUnavailableException;
 
+    /**
+     * Removes the provided nic from the given vm
+     * @param vm
+     * @param nic
+     */
     void removeNic(VirtualMachineProfile vm, Nic nic);
 
     /**

--- a/engine/components-api/src/com/cloud/network/vpc/VpcManager.java
+++ b/engine/components-api/src/com/cloud/network/vpc/VpcManager.java
@@ -165,4 +165,11 @@ public interface VpcManager {
         validateNtwkOffForNtwkInVpc(Long networkId, long newNtwkOffId, String newCidr, String newNetworkDomain, Vpc vpc, String gateway, Account networkOwner, Long aclId);
 
     List<PrivateGateway> getVpcPrivateGateways(long vpcId);
+
+    /**
+     * Checks if the specified offering needs a public src nat ip or not.
+     * @param vpcOfferingId
+     * @return
+     */
+    boolean isSrcNatIpRequired(long vpcOfferingId);
 }

--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -43,14 +43,12 @@ import org.apache.cloudstack.api.command.user.vpc.ListPrivateGatewaysCmd;
 import org.apache.cloudstack.api.command.user.vpc.ListStaticRoutesCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.cloudstack.framework.config.ConfigDepot;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
-import com.cloud.configuration.ConfigurationManager;
 import com.cloud.configuration.Resource.ResourceType;
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenterVO;
@@ -88,8 +86,6 @@ import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
-import com.cloud.network.dao.PhysicalNetworkDao;
-import com.cloud.network.dao.Site2SiteVpnGatewayDao;
 import com.cloud.network.element.NetworkElement;
 import com.cloud.network.element.StaticNatServiceProvider;
 import com.cloud.network.element.VpcProvider;
@@ -108,7 +104,6 @@ import com.cloud.offerings.NetworkOfferingServiceMapVO;
 import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
 import com.cloud.org.Grouping;
 import com.cloud.projects.Project.ListProjectResourcesCriteria;
-import com.cloud.server.ConfigurationServer;
 import com.cloud.server.ResourceTag.ResourceObjectType;
 import com.cloud.tags.ResourceTagVO;
 import com.cloud.tags.dao.ResourceTagDao;
@@ -140,7 +135,6 @@ import com.cloud.utils.exception.ExceptionUtil;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.ReservationContextImpl;
-import com.cloud.vm.dao.DomainRouterDao;
 
 public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvisioningService, VpcService {
     private static final Logger s_logger = Logger.getLogger(VpcManagerImpl.class);
@@ -162,8 +156,6 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @Inject
     ConfigurationDao _configDao;
     @Inject
-    ConfigurationManager _configMgr;
-    @Inject
     AccountManager _accountMgr;
     @Inject
     NetworkDao _ntwkDao;
@@ -176,8 +168,6 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @Inject
     IPAddressDao _ipAddressDao;
     @Inject
-    DomainRouterDao _routerDao;
-    @Inject
     VpcGatewayDao _vpcGatewayDao;
     @Inject
     PrivateIpDao _privateIpDao;
@@ -188,13 +178,9 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @Inject
     VpcOfferingServiceMapDao _vpcOffServiceDao;
     @Inject
-    PhysicalNetworkDao _pNtwkDao;
-    @Inject
     ResourceTagDao _resourceTagDao;
     @Inject
     FirewallRulesDao _firewallDao;
-    @Inject
-    Site2SiteVpnGatewayDao _vpnGatewayDao;
     @Inject
     Site2SiteVpnManager _s2sVpnMgr;
     @Inject
@@ -206,17 +192,11 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @Inject
     DataCenterDao _dcDao;
     @Inject
-    ConfigurationServer _configServer;
-    @Inject
     NetworkACLDao _networkAclDao;
-    @Inject
-    NetworkACLItemDao _networkACLItemDao;
     @Inject
     NetworkACLManager _networkAclMgr;
     @Inject
     IpAddressManager _ipAddrMgr;
-    @Inject
-    ConfigDepot _configDepot;
 
     @Inject
     private VpcPrivateGatewayTransactionCallable vpcTxCallable;
@@ -2266,14 +2246,9 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         // check permissions
         _accountMgr.checkAccess(caller, null, true, owner, vpc);
 
-        boolean isSourceNat = false;
-        if (getExistingSourceNatInVpc(owner.getId(), vpcId) == null) {
-            isSourceNat = true;
-        }
-
         s_logger.debug("Associating ip " + ipToAssoc + " to vpc " + vpc);
 
-        final boolean isSourceNatFinal = isSourceNat;
+        final boolean isSourceNatFinal = isSrcNatIpRequired(vpc.getVpcOfferingId()) && getExistingSourceNatInVpc(owner.getId(), vpcId) == null;
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) {
@@ -2448,5 +2423,11 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     public boolean applyStaticRoute(final long routeId) throws ResourceUnavailableException {
         final StaticRoute route = _staticRouteDao.findById(routeId);
         return applyStaticRoutesForVpc(route.getVpcId());
+    }
+
+    @Override
+    public boolean isSrcNatIpRequired(long vpcOfferingId) {
+        final Map<Network.Service, Set<Network.Provider>> vpcOffSvcProvidersMap = getVpcOffSvcProvidersMap(vpcOfferingId);
+        return vpcOffSvcProvidersMap.get(Network.Service.SourceNat).contains(Network.Provider.VPCVirtualRouter);
     }
 }

--- a/server/src/org/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
+++ b/server/src/org/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
@@ -73,11 +73,6 @@ public class VpcRouterDeploymentDefinition extends RouterDeploymentDefinition {
     }
 
     @Override
-    public boolean isPublicNetwork() {
-        return true;
-    }
-
-    @Override
     protected void lock() {
         final Vpc vpcLock = vpcDao.acquireInLockTable(vpc.getId());
         if (vpcLock == null) {
@@ -115,12 +110,19 @@ public class VpcRouterDeploymentDefinition extends RouterDeploymentDefinition {
      */
     @Override
     protected boolean prepareDeployment() {
+        //Check if the VR is the src NAT provider...
+        isPublicNetwork = vpcMgr.isSrcNatIpRequired(vpc.getVpcOfferingId());
+
+        // Check if public network has to be set on VR
         return true;
     }
 
     @Override
     protected void findSourceNatIP() throws InsufficientAddressCapacityException, ConcurrentOperationException {
-        sourceNatIp = vpcMgr.assignSourceNatIpAddressToVpc(owner, vpc);
+        sourceNatIp = null;
+        if (isPublicNetwork) {
+            sourceNatIp = vpcMgr.assignSourceNatIpAddressToVpc(owner, vpc);
+        }
     }
 
     @Override

--- a/server/test/org/cloud/network/router/deployment/VpcRouterDeploymentDefinitionTest.java
+++ b/server/test/org/cloud/network/router/deployment/VpcRouterDeploymentDefinitionTest.java
@@ -168,9 +168,30 @@ public class VpcRouterDeploymentDefinitionTest extends RouterDeploymentDefinitio
         assertEquals("If there is already a router found, there is no need to deploy more", 0, deployment.getNumberOfRoutersToDeploy());
     }
 
+    protected void driveTestPrepareDeployment(final boolean isRedundant, final boolean isPublicNw) {
+        // Prepare
+        when(vpcMgr.isSrcNatIpRequired(mockVpc.getVpcOfferingId())).thenReturn(isPublicNw);
+
+        // Execute
+        final boolean canProceedDeployment = deployment.prepareDeployment();
+        // Assert
+        assertTrue("There are no preconditions for Vpc Deployment, thus it should always pass", canProceedDeployment);
+        assertEquals(isPublicNw, deployment.isPublicNetwork());
+    }
+
     @Test
-    public void testPrepareDeployment() {
-        assertTrue("There are no preconditions for Vpc Deployment, thus it should always pass", deployment.prepareDeployment());
+    public void testPrepareDeploymentPublicNw() {
+        driveTestPrepareDeployment(true, true);
+    }
+
+    @Test
+    public void testPrepareDeploymentNonRedundant() {
+        driveTestPrepareDeployment(false, true);
+    }
+
+    @Test
+    public void testPrepareDeploymentRedundantNonPublicNw() {
+        driveTestPrepareDeployment(true, false);
     }
 
     @Test
@@ -246,6 +267,7 @@ public class VpcRouterDeploymentDefinitionTest extends RouterDeploymentDefinitio
         // Prepare
         final PublicIp publicIp = mock(PublicIp.class);
         when(vpcMgr.assignSourceNatIpAddressToVpc(mockOwner, mockVpc)).thenReturn(publicIp);
+        deployment.isPublicNetwork = true;
 
         // Execute
         deployment.findSourceNatIP();

--- a/test/integration/plugins/nuagevsp/nuageTestCase.py
+++ b/test/integration/plugins/nuagevsp/nuageTestCase.py
@@ -848,6 +848,34 @@ class nuageTestCase(cloudstackTestCase):
         self.debug("Successfully validated the assignment and state of public "
                    "IP address - %s" % public_ip.ipaddress.ipaddress)
 
+    # verify_VRWithoutPublicIPNIC - Verifies that the given Virtual Router has
+    # no public IP and NIC
+    def verify_VRWithoutPublicIPNIC(self, vr):
+        """Verifies VR without Public IP and NIC"""
+        self.debug("Verifies that there is no public IP and NIC in Virtual "
+                   "Router - %s" % vr.name)
+        self.assertEqual(vr.publicip, None,
+                         "Virtual router has public IP"
+                         )
+        for nic in vr.nic:
+            self.assertNotEqual(nic.traffictype, "Public",
+                                "Virtual router has public NIC"
+                                )
+        self.debug("Successfully verified that there is no public IP and NIC "
+                   "in Virtual Router - %s" % vr.name)
+
+    def verify_vpc_has_no_src_nat(self, vpc, account=None):
+        if not account:
+            account = self.account
+        self.debug("Verify that there is no src NAT ip address "
+                   "allocated for the vpc")
+        src_nat_ip = PublicIPAddress.list(
+            self.api_client,
+            vpcid=vpc.id,
+            issourcenat=True,
+            account=account.name)
+        self.assertEqual(src_nat_ip, None, "VPC has a source NAT ip!")
+
     # VSD verifications; VSD is a programmable policy and analytics engine of
     # Nuage VSP SDN platform
 
@@ -984,10 +1012,10 @@ class nuageTestCase(cloudstackTestCase):
         expected_status = cs_object.state.upper() if not stopped \
             else "DELETE_PENDING"
         tries = 0
-        while (vsd_object.status != expected_status) and (tries < 10):
+        while (vsd_object.status != expected_status) and (tries < 120):
             self.debug("Waiting for the CloudStack object " + cs_object.name +
                        " to be fully resolved in VSD...")
-            time.sleep(30)
+            time.sleep(5)
             self.debug("Rechecking the CloudStack object " + cs_object.name +
                        " status in VSD...")
             vsd_object = self.vsd.get_vm(

--- a/test/integration/plugins/nuagevsp/test_nuage_static_nat.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_static_nat.py
@@ -26,8 +26,11 @@ from marvin.lib.base import (Account,
 from marvin.cloudstackAPI import (enableNuageUnderlayVlanIpRange,
                                   disableNuageUnderlayVlanIpRange,
                                   listNuageUnderlayVlanIpRanges)
+from marvin.lib.common import list_virtual_machines
+
 # Import System Modules
 from nose.plugins.attrib import attr
+import threading
 import copy
 import time
 
@@ -150,7 +153,7 @@ class TestNuageStaticNat(nuageTestCase):
 
         # wget from VM
         tries = 0
-        max_tries = 3 if non_default_nic else 10
+        max_tries = 3 if non_default_nic else 120
         filename = None
         headers = None
         while tries < max_tries:
@@ -162,7 +165,7 @@ class TestNuageStaticNat(nuageTestCase):
             except Exception as e:
                 self.debug("Failed to wget from VM - %s" % e)
                 self.debug("Retrying wget from VM after some time...")
-                time.sleep(60)
+                time.sleep(5)
                 tries += 1
 
         if not filename and not headers:
@@ -292,6 +295,17 @@ class TestNuageStaticNat(nuageTestCase):
                 self.debug("Skipped Static NAT Internet traffic "
                            "(wget www.google.com) test from VM as there is no "
                            "Internet connectivity in the data center")
+
+    # enable_staticNat_on_a_starting_vm - Enables Static Nat on a starting VM
+    # in the given network with the given public IP.
+    def enable_staticNat_on_a_starting_vm(self):
+        self.debug("Enables Static Nat on a starting VM in the network - %s "
+                   "with the given public IP - %s" %
+                   (self.network, self.public_ip))
+        time.sleep(15)
+        vm_list = list_virtual_machines(self.api_client, listall=True)
+        self.create_StaticNatRule_For_VM(
+            vm_list[0], self.public_ip, self.network)
 
     @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
     def test_01_nuage_StaticNAT_public_ip_range(self):
@@ -2086,3 +2100,74 @@ class TestNuageStaticNat(nuageTestCase):
         # from the deployed VM
         self.verify_StaticNAT_Internet_traffic(
             vpc_vm, vpc_tier, public_ip_2, vpc=vpc)
+
+    # Bug CLOUDSTACK-9751
+    @attr(tags=["advanced", "nuagevsp"], required_hardware="true")
+    def test_11_nuage_enable_staticNat_when_vr_is_in_starting_state(self):
+        """Test Nuage VSP Static NAT functionality by enabling Static Nat when
+        VR is in starting state
+        """
+
+        # 1. Create a Nuage VSP Isolated network offering.
+        # 2. Create an Isolated network with above created offering.
+        # 3. Deploy a VM in the above created Isolated network,
+        #    which starts a VR.
+        # 4. While VR is in the starting state, acquire a public IP and enable
+        #    static nat in another thread.
+        # 5. Verify that Static NAT is successfully enabled in both CloudStack
+        #    and VSD.
+        # 6. Delete all the created objects (cleanup).
+
+        # Creating network offering
+        self.debug("Creating Nuage VSP Isolated Network offering with Static "
+                   "NAT service provider as NuageVsp...")
+        net_off = self.create_NetworkOffering(
+            self.test_data["nuagevsp"]["isolated_network_offering"])
+        self.validate_NetworkOffering(net_off, state="Enabled")
+
+        # Creating an Isolated network
+        self.debug("Creating an Isolated network with Static NAT service...")
+        self.network = self.create_Network(net_off, gateway='10.1.1.1')
+        self.validate_Network(self.network, state="Allocated")
+
+        # Acquiring a Public IP
+        self.debug("Acquiring a Public IP in the created Isolated network...")
+        self.public_ip = self.acquire_PublicIPAddress(self.network)
+        self.validate_PublicIPAddress(self.public_ip, self.network)
+
+        # Enabling Static NAT on a starting VM
+        self.debug("Creating a thread for enabling Static Nat on a starting "
+                   "VM...")
+        static_nat_thread = threading.Thread(
+            name='enable_static_nat',
+            target=self.enable_staticNat_on_a_starting_vm)
+        static_nat_thread.start()
+
+        vm = self.create_VM(self.network)
+
+        # Check the status of Static Nat thread and if it is not finished then
+        # below command will wait for it to finish
+        self.debug("Waiting for for enabling Static Nat on a starting VM "
+                   "thread to finish...")
+        static_nat_thread.join()
+
+        # CloudStack verification for the implemented Isolated Network
+        self.validate_Network(self.network, state="Implemented")
+        vr = self.get_Router(self.network)
+        self.check_Router_state(vr, state="Running")
+        self.check_VM_state(vm, state="Running")
+
+        # VSD verification for the implemented Isolated Network
+        self.verify_vsd_network(self.domain.id, self.network)
+        self.verify_vsd_router(vr)
+        self.verify_vsd_vm(vm)
+
+        # CloudStack verification for Static NAT functionality
+        self.validate_PublicIPAddress(
+            self.public_ip, self.network, static_nat=True, vm=vm)
+
+        # VSD verification for Static NAT functionality
+        self.verify_vsd_floating_ip(self.network, vm, self.public_ip.ipaddress)
+
+        # Verifying Static NAT traffic
+        self.verify_StaticNAT_traffic(self.network, self.public_ip)

--- a/test/integration/plugins/nuagevsp/test_nuage_vpc_internal_lb.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vpc_internal_lb.py
@@ -1428,6 +1428,7 @@ class TestNuageInternalLb(nuageTestCase):
             http_rule["publicport"])
 
         # Verifying Internal LB (wget) traffic tests
+        # Bug CLOUDSTACK-9749
         self.verify_lb_wget_file(
             wget_file_1, [internal_vm_1, internal_vm_1_1, internal_vm_1_2])
         self.verify_lb_wget_file(
@@ -1908,9 +1909,17 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(
-            ssh_client, int_lb_rule_1.sourceipaddress,
-            self.test_data["http_rule"]["publicport"])
+        tries = 0
+        while tries < 120:
+            wget_file = self.wget_from_vm_cmd(
+                ssh_client, int_lb_rule_1.sourceipaddress,
+                self.test_data["http_rule"]["publicport"])
+            if wget_file != "":
+                break
+            self.debug("Waiting for the InternalLbVm in the Internal tier to "
+                       "be fully resolved for (wget) traffic test...")
+            time.sleep(5)
+            tries += 1
 
         # Verifying Internal LB (wget) traffic test
         self.verify_lb_wget_file(
@@ -1954,9 +1963,17 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(
-            ssh_client, int_lb_rule_1.sourceipaddress,
-            self.test_data["http_rule"]["publicport"])
+        tries = 0
+        while tries < 120:
+            wget_file = self.wget_from_vm_cmd(
+                ssh_client, int_lb_rule_1.sourceipaddress,
+                self.test_data["http_rule"]["publicport"])
+            if wget_file != "":
+                break
+            self.debug("Waiting for the InternalLbVm in the Internal tier to "
+                       "be fully resolved for (wget) traffic test...")
+            time.sleep(5)
+            tries += 1
 
         # Verifying Internal LB (wget) traffic test
         self.verify_lb_wget_file(
@@ -2128,16 +2145,15 @@ class TestNuageInternalLb(nuageTestCase):
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
         tries = 0
-        while tries < 25:
+        while tries < 120:
             wget_file = self.wget_from_vm_cmd(
                 ssh_client, int_lb_rule_1.sourceipaddress,
                 self.test_data["http_rule"]["publicport"])
             if wget_file != "":
                 break
-            self.debug("Waiting for the InternalLbVm and all the VMs in the "
-                       "Internal tier to be fully resolved for (wget) traffic "
-                       "test...")
-            time.sleep(60)
+            self.debug("Waiting for the InternalLbVm in the Internal tier to "
+                       "be fully resolved for (wget) traffic test...")
+            time.sleep(5)
             tries += 1
 
         # Verifying Internal LB (wget) traffic test
@@ -2489,11 +2505,20 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(
-            ssh_client, int_lb_rule_1.sourceipaddress,
-            self.test_data["http_rule"]["publicport"])
+        tries = 0
+        while tries < 120:
+            wget_file = self.wget_from_vm_cmd(
+                ssh_client, int_lb_rule_1.sourceipaddress,
+                self.test_data["http_rule"]["publicport"])
+            if wget_file != "":
+                break
+            self.debug("Waiting for the InternalLbVm in the Internal tier to "
+                       "be fully resolved for (wget) traffic test...")
+            time.sleep(5)
+            tries += 1
 
         # Verifying Internal LB (wget) traffic test
+        # Bug CLOUDSTACK-9837
         self.verify_lb_wget_file(
             wget_file, [internal_vm, internal_vm_1, internal_vm_2])
 
@@ -2556,9 +2581,17 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(
-            ssh_client, int_lb_rule_1.sourceipaddress,
-            self.test_data["http_rule"]["publicport"])
+        tries = 0
+        while tries < 120:
+            wget_file = self.wget_from_vm_cmd(
+                ssh_client, int_lb_rule_1.sourceipaddress,
+                self.test_data["http_rule"]["publicport"])
+            if wget_file != "":
+                break
+            self.debug("Waiting for the InternalLbVm in the Internal tier to "
+                       "be fully resolved for (wget) traffic test...")
+            time.sleep(5)
+            tries += 1
 
         # Verifying Internal LB (wget) traffic test
         self.verify_lb_wget_file(
@@ -2611,9 +2644,17 @@ class TestNuageInternalLb(nuageTestCase):
 
         # Internal LB (wget) traffic test
         ssh_client = self.ssh_into_VM(public_vm, public_ip)
-        wget_file = self.wget_from_vm_cmd(
-            ssh_client, int_lb_rule_1.sourceipaddress,
-            self.test_data["http_rule"]["publicport"])
+        tries = 0
+        while tries < 120:
+            wget_file = self.wget_from_vm_cmd(
+                ssh_client, int_lb_rule_1.sourceipaddress,
+                self.test_data["http_rule"]["publicport"])
+            if wget_file != "":
+                break
+            self.debug("Waiting for the InternalLbVm in the Internal tier to "
+                       "be fully resolved for (wget) traffic test...")
+            time.sleep(5)
+            tries += 1
 
         # Verifying Internal LB (wget) traffic test
         self.verify_lb_wget_file(

--- a/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
@@ -59,11 +59,13 @@ class TestNuageVpcNetwork(nuageTestCase):
         # 5. Create a VPC Network with Nuage VSP VPC Network offering and the
         #    created ACL list, check if it is successfully created, is in the
         #    "Implemented" state, and is added to the VPC VR.
-        # 6. Deploy a VM in the created VPC network, check if the VM is
+        # 6. Verify that the VPC VR has no Public IP and NIC as it is not the
+        #    Source NAT service provider.
+        # 7. Deploy a VM in the created VPC network, check if the VM is
         #    successfully deployed and is in the "Running" state.
-        # 7. Verify that the created ACL item is successfully implemented in
+        # 8. Verify that the created ACL item is successfully implemented in
         #    Nuage VSP.
-        # 8. Delete all the created objects (cleanup).
+        # 9. Delete all the created objects (cleanup).
 
         # Creating a VPC offering
         self.debug("Creating Nuage VSP VPC offering...")
@@ -98,6 +100,11 @@ class TestNuageVpcNetwork(nuageTestCase):
         self.validate_Network(vpc_network, state="Implemented")
         vr = self.get_Router(vpc_network)
         self.check_Router_state(vr, state="Running")
+
+        # Verifying that the VPC VR has no public IP and NIC
+        self.verify_VRWithoutPublicIPNIC(vr)
+        # Verifying that the VPC has no src NAT ip
+        self.verify_vpc_has_no_src_nat(vpc)
 
         # Deploying a VM in the VPC network
         vm = self.create_VM(vpc_network)

--- a/test/integration/plugins/nuagevsp/test_nuage_vsp.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vsp.py
@@ -173,11 +173,13 @@ class TestNuageVsp(nuageTestCase):
         # 4. Deploy a VM in the created Isolated network, check if the Isolated
         #    network state is changed to "Implemented", and both the VM & VR
         #    are successfully deployed and are in the "Running" state.
-        # 5. Deploy one more VM in the created Isolated network, check if the
+        # 5. Verify that the VPC VR has no Public IP and NIC as it is not the
+        #    Source NAT service provider.
+        # 6. Deploy one more VM in the created Isolated network, check if the
         #    VM is successfully deployed and is in the "Running" state.
-        # 6. Delete the created Isolated Network after destroying its VMs,
+        # 7. Delete the created Isolated Network after destroying its VMs,
         #    check if the Isolated network is successfully deleted.
-        # 7. Delete all the created objects (cleanup).
+        # 8. Delete all the created objects (cleanup).
 
         for zone in self.zones:
             self.debug("Zone - %s" % zone.name)
@@ -205,6 +207,9 @@ class TestNuageVsp(nuageTestCase):
             vr = self.get_Router(network)
             self.check_Router_state(vr, state="Running")
             self.check_VM_state(vm_1, state="Running")
+
+            # Verifying that the VR has no public IP and NIC
+            self.verify_VRWithoutPublicIPNIC(vr)
 
             # VSD verification
             self.verify_vsd_network(self.domain.id, network)


### PR DESCRIPTION
Detail:
When the VPC offering does not contain VpcVirtualRouter as a SourceNat provider,
then we will not add the interface in the public network to the VpcVR. Thus, conserving Public IPs.

Co-Authored-By: Prashanth Manthena prashanth.manthena@nuagenetworks.net