### PR TITLE
CLOUDSTACK-9834: prepareTemplate API call doesn't work well with XenServer & Local SR (Db_exn.Uniqueness_constraint_violation)

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -99,7 +99,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
         PBD pbd = null;
 
         try {
-            final String srname = hypervisorResource.getHost().getUuid() + path.trim();
+            final String srname = path.trim();
             synchronized (srname.intern()) {
                 final Set<SR> srs = SR.getByNameLabel(conn, srname);
                 if (srs != null && !srs.isEmpty()) {


### PR DESCRIPTION
removed the host uuid from SR label so that any host which has access to
the SR(all the hosts in the same pool) can reuse the same SR