### PR TITLE
[CLOUDSTACK-9840] Fix datetime format of snapshots events

### DIFF
--- a/server/src/com/cloud/storage/listener/SnapshotStateListener.java
+++ b/server/src/com/cloud/storage/listener/SnapshotStateListener.java
@@ -101,7 +101,7 @@ public class SnapshotStateListener implements StateListener<State, Event, Snapsh
         eventDescription.put("old-state", oldState.name());
         eventDescription.put("new-state", newState.name());
 
-        String eventDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date());
+        String eventDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").format(new Date());
         eventDescription.put("eventDateTime", eventDate);
 
         eventMsg.setDescription(eventDescription);


### PR DESCRIPTION
Include the timezone in datetime format of snapshot events, to be consistent with every other events.
"eventDateTime" was added by @chipchilders in commit 14ee684ce3 and was updated the same day to add the timezone (commit bf967eb622f) except for Snapshots.