### PR TITLE
CLOUDSTACK-9369 Fixed Ldap regression

### DIFF
--- a/server/src/com/cloud/api/auth/DefaultLoginAPIAuthenticatorCmd.java
+++ b/server/src/com/cloud/api/auth/DefaultLoginAPIAuthenticatorCmd.java
@@ -166,7 +166,7 @@ public class DefaultLoginAPIAuthenticatorCmd extends BaseCmd implements APIAuthe
                     throw new CloudAuthenticationException("Unable to find the domain from the path " + domain);
                 }
                 final UserAccount userAccount = _accountService.getActiveUserAccount(username[0], domainId);
-                if (userAccount == null || !(User.Source.UNKNOWN.equals(userAccount.getSource()) || User.Source.LDAP.equals(userAccount.getSource()))) {
+                if (userAccount != null && User.Source.SAML2 == userAccount.getSource()) {
                     throw new CloudAuthenticationException("User is not allowed CloudStack login");
                 }
                 return ApiResponseSerializer.toSerializedString(_apiServer.loginUser(session, username[0], pwd, domainId, domain, remoteAddress, params),


### PR DESCRIPTION
Ldap auto creation of accounts is broken due to the security fix for
CLOUDSTACK-9369.
There was an explicit check to not allow login incase the
user doesnt exist.  removed the same.