### PR TITLE
CLOUDSTACK-9842: Unable to map root volume usage to VM

### DIFF
--- a/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -647,7 +647,6 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
             String uuid = srcVol.getUuid();
             Long instanceId = srcVol.getInstanceId();
             srcVol.setUuid(null);
-            srcVol.setInstanceId(null);
             destVol.setUuid(uuid);
             destVol.setInstanceId(instanceId);
             update(srcVolId, srcVol);

--- a/server/src/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/com/cloud/api/query/QueryManagerImpl.java
@@ -1769,6 +1769,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
         sb.and("idIN", sb.entity().getId(), SearchCriteria.Op.IN);
         sb.and("volumeType", sb.entity().getVolumeType(), SearchCriteria.Op.LIKE);
+        sb.and("uuid", sb.entity().getUuid(), SearchCriteria.Op.NNULL);
         sb.and("instanceId", sb.entity().getVmId(), SearchCriteria.Op.EQ);
         sb.and("dataCenterId", sb.entity().getDataCenterId(), SearchCriteria.Op.EQ);
         sb.and("podId", sb.entity().getPodId(), SearchCriteria.Op.EQ);


### PR DESCRIPTION
If a VM is cold migrated the vm_instance_id and uuid of volume is nullified. So there is no link between volume and vm.

With this the ROOT volume usage can not be mapped to a VM.

```
mysql>  select id,name,uuid,created,removed,state from cloud.volumes where name="ROOT-88" ;
+-----+------------+--------------------------------------+---------------------+---------------------+----------+
| id  | name       | uuid                                 | created             | instance_id         | state    |
+-----+------------+--------------------------------------+---------------------+---------------------+----------+
| 89  | ROOT-88   | NULL                                 | 2015-08-31 06:14:01 | NULL                | Expunged |
| 96  | ROOT-88   | a32e70e7-9869-49c8-92fa-5acd45abc94e | 2015-08-31 07:20:41 | 88                 | Expunged |
+-----+------------+--------------------------------------+---------------------+---------------------+----------+
2 rows in set (0.00 sec)

mysql> select * from cloud_usage.usage_volume where id in (89, 96);
+-----+---------+------------+-----------+------------------+-------------+-------------+---------------------+---------------------+
| id  | zone_id | account_id | domain_id | disk_offering_id | template_id | size        | created             | deleted             |
+-----+---------+------------+-----------+------------------+-------------+-------------+---------------------+---------------------+
| 89 |       1 |         55 |        54 |             NULL |        NULL | 16106127360 | 2015-08-31 06:14:01 | 2015-08-31 07:23:32 |
| 96 |       1 |         55 |        54 |               16 |        NULL | 16106127360 | 2015-08-31 07:23:32 | 2015-08-31 08:09:40 |
+-----+---------+------------+-----------+------------------+-------------+-------------+---------------------+---------------------+
2 rows in set (0.00 sec)

mysql> select * from cloud_usage.cloud_usage where usage_id in (89, 96)\G;
*************************** 1. row ***************************
            id: 48042
       zone_id: 1
    account_id: 55
     domain_id: 54
   description: Volume Id: 96 usage time (DiskOffering: 16)
 usage_display: 0.768889 Hrs
    usage_type: 6
     raw_usage: 0.768889188766479
vm_instance_id: NULL
       vm_name: NULL
   offering_id: 16
   template_id: NULL
      usage_id: 96
          type: NULL
          size: 16106127360
    network_id: NULL
    start_date: 2015-08-30 15:00:00
      end_date: 2015-08-31 14:59:59
  virtual_size: NULL
*************************** 2. row ***************************
            id: 48044
       zone_id: 1
    account_id: 55
     domain_id: 54
   description: Volume Id: 89 usage time
 usage_display: 1.158611 Hrs
    usage_type: 6
     raw_usage: 1.15861141681671
vm_instance_id: NULL
       vm_name: NULL
   offering_id: NULL
   template_id: NULL
      usage_id: 89
          type: NULL
          size: 16106127360
    network_id: NULL
    start_date: 2015-08-30 15:00:00
      end_date: 2015-08-31 14:59:59
  virtual_size: NULL
2 rows in set (0.06 sec)

Usage id 48044 is for volume id  89. Volume 89 does not have any instance_id. 
```

Solution:
Removed code which nullifies  vm_instance_id
Also modified QueryManagerImpl to ignore volume which does not have uuid. This is to avoid duplicate volume listing.

