### PR TITLE
Bug-ID: CLOUDSTACK-9734 Destroy VM Fails sometimes

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1703,17 +1703,20 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         deleteVMSnapshots(vm, expunge);
 
-        // reload the vm object from db
-        vm = _vmDao.findByUuid(vmUuid);
-        try {
-            if (!stateTransitTo(vm, VirtualMachine.Event.DestroyRequested, vm.getHostId())) {
-                s_logger.debug("Unable to destroy the vm because it is not in the correct state: " + vm);
-                throw new CloudRuntimeException("Unable to destroy " + vm);
+        Transaction.execute(new TransactionCallbackWithExceptionNoReturn<CloudRuntimeException>() {
+            public void doInTransactionWithoutResult(final TransactionStatus status) throws CloudRuntimeException {
+                VMInstanceVO vm = _vmDao.findByUuid(vmUuid);
+                try {
+                    if (!stateTransitTo(vm, VirtualMachine.Event.DestroyRequested, vm.getHostId())) {
+                        s_logger.debug("Unable to destroy the vm because it is not in the correct state: " + vm);
+                        throw new CloudRuntimeException("Unable to destroy " + vm);
+                    }
+                } catch (final NoTransitionException e) {
+                    s_logger.debug(e.getMessage());
+                    throw new CloudRuntimeException("Unable to destroy " + vm, e);
+                }
             }
-        } catch (final NoTransitionException e) {
-            s_logger.debug(e.getMessage());
-            throw new CloudRuntimeException("Unable to destroy " + vm, e);
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
This is a specific case when vm state gets updated by the vmsync before it can be updated by the api-job-executor thread. 
I could see following logs. 

```
2015-10-28 02:03:21,590 DEBUG [jobs.impl.AsyncJobManagerImpl] (API-Job-Executor-5:ctx-5fe7b795 job-3056226 ctx-49b11835) Sync job-3056236 execution on object VmWorkJobQueue.845336
2015-10-28 02:03:23,563 DEBUG [vm.dao.VMInstanceDaoImpl] (API-Job-Executor-5:ctx-5fe7b795 job-3056226 ctx-49b11835) Unable to update VM[User|i-3702-845336-VM]: DB Data={Host=null; State=Stopped; updated=6; time=Wed Oct 28 02:03:23 PDT 2015} New Data: {Host=null; State=Destroyed; updated=6; time=Wed Oct 28 02:03:23 PDT 2015} Stale Data: {Host=null; State=Stopped; updated=5; time=Wed Oct 28 02:03:18 PDT 2015}
```
I don't see any other traces of sync job queued for the mentioned vm. 
This is an extremely rare scenario and is not reproducible.  

To fix the scenario, I have added 2 retries to trigger DestroyRequested event for the VM.
