### PR TITLE
CLOUDSTACK-9843 : Performance improvement of SSHHelper

### DIFF
--- a/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
+++ b/utils/src/main/java/com/cloud/utils/ssh/SshHelper.java
@@ -39,12 +39,6 @@ public class SshHelper {
     private static final int DEFAULT_CONNECT_TIMEOUT = 180000;
     private static final int DEFAULT_KEX_TIMEOUT = 60000;
 
-    /**
-     * Waiting time to check if the SSH session was successfully opened. This value (of 1000
-     * milliseconds) represents one (1) second.
-     */
-    private static final long WAITING_OPEN_SSH_SESSION = 1000;
-
     private static final Logger s_logger = Logger.getLogger(SshHelper.class);
 
     public static Pair<Boolean, String> sshExecute(String host, int port, String user, File pemKeyFile, String password, String command) throws Exception {
@@ -236,14 +230,9 @@ public class SshHelper {
         }
     }
 
-    /**
-     * It gets a {@link Session} from the given {@link Connection}; then, it waits
-     * {@value #WAITING_OPEN_SSH_SESSION} milliseconds before returning the session, given a time to
-     * ensure that the connection is open before proceeding the execution.
-     */
+
     protected static Session openConnectionSession(Connection conn) throws IOException, InterruptedException {
         Session sess = conn.openSession();
-        Thread.sleep(WAITING_OPEN_SSH_SESSION);
         return sess;
     }
 

--- a/utils/src/test/java/com/cloud/utils/ssh/SshHelperTest.java
+++ b/utils/src/test/java/com/cloud/utils/ssh/SshHelperTest.java
@@ -146,6 +146,6 @@ public class SshHelperTest {
         Mockito.verify(conn).openSession();
 
         PowerMockito.verifyStatic();
-        Thread.sleep(Mockito.anyLong());
+
     }
 }


### PR DESCRIPTION
A delay of 1 sec has been introduced in SSHHelper Class. This is a fail safe code. Removing this will improves the performance of deployVm by 4 sec, createFirewallRule by 1 sec and createPortForwardingRule by 1 sec.

We have not faced any issues after removing the delay. This was introduced when we were using older version of Trilead library. 