### PR TITLE
CLOUDSTACK-9851 travis CI build failure after merge of PR#1953 & CLOUDSTACK-9850

### DIFF
--- a/server/src/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1433,7 +1433,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         // that supported by hypervisor
         if (deviceId == null || deviceId.longValue() != 0) {
             List<VolumeVO> existingDataVolumes = _volsDao.findByInstanceAndType(vmId, Volume.Type.DATADISK);
-            int maxAttachableDataVolumesSupported = getMaxDataVolumesSupported(vm) - 2; //IDs: 0 (ROOT) and 3 (CD-ROM) are reserved
+            int maxAttachableDataVolumesSupported = getMaxDataVolumesSupported(vm);
             if (existingDataVolumes.size() >= maxAttachableDataVolumesSupported) {
                 throw new InvalidParameterValueException("The specified VM already has the maximum number of data disks (" + maxAttachableDataVolumesSupported + ") attached. Please specify another VM.");
             }
@@ -2634,11 +2634,12 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     private Long getDeviceId(UserVmVO vm, Long deviceId) {
         // allocate deviceId
-        int maxDeviceId = getMaxDataVolumesSupported(vm) - 1;
+        int maxDevices = getMaxDataVolumesSupported(vm) + 2; // add 2 to consider devices root volume and cdrom
+        int maxDeviceId = maxDevices - 1;
         List<VolumeVO> vols = _volsDao.findByInstance(vm.getId());
         if (deviceId != null) {
-            if (deviceId.longValue() <= 0 || deviceId.longValue() > maxDeviceId || deviceId.longValue() == 3) {
-                throw new RuntimeException("deviceId should be 1,2,4-" + maxDeviceId);
+            if (deviceId.longValue() < 0 || deviceId.longValue() > maxDeviceId  || deviceId.longValue() == 3) {
+                throw new RuntimeException("deviceId should be 0,1,2,4-" + maxDeviceId);
             }
             for (VolumeVO vol : vols) {
                 if (vol.getDeviceId().equals(deviceId)) {


### PR DESCRIPTION
Fixed travis CI failures happening after merge of PR#1953.
Also fixed root volume detach that was broken after merge of PR#1953.
I found following logs with root volume attach. 

`
2017-03-24 23:19:48,380 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl] (API-Job-Executor-27:ctx-7c53d1bc job-44) (logid:f3b54257) Executing AsyncJobVO {id:44, userId: 2, accountId: 2, instanceType: Volume, instanceId: 3, cmd: org.apache.cloudstack.api.command.admin.volume.AttachVolumeCmdByAdmin, cmdInfo: {"apiKey":"PYHMg5HhOkmTQvlmZSe1dIDfTxl8uwreeFoqfj0a4zPCC-1XTuwH7H5I8Ac9fyvPbtNO1eN9THi72q8ATfs8hg","signature":"DD+ljbVWpWQw6FCl1tCDSYe5Ui0\u003d","httpmethod":"GET","deviceid":"0","ctxAccountId":"2","uuid":"2db57cd8-c96c-48f9-83c5-b9a79c852cc5","cmdEventType":"VOLUME.ATTACH","virtualmachineid":"9cb6a944-8775-4e11-961b-0e8dbdebf5a7","response":"json","ctxUserId":"2","ctxStartEventId":"117","id":"2db57cd8-c96c-48f9-83c5-b9a79c852cc5","ctxDetails":"{\"interface com.cloud.vm.VirtualMachine\":\"9cb6a944-8775-4e11-961b-0e8dbdebf5a7\",\"interface com.cloud.storage.Volume\":\"2db57cd8-c96c-48f9-83c5-b9a79c852cc5\"}"}, cmdVersion: 0, status: IN_PROGRESS, processStatus: 0, resultCode: 0, result: null, initMsid: 4278190080, completeMsid: null, lastUpdated: null, lastPolled: null, created: null }
2017-03-24 23:19:50,160 ERROR [c.c.v.VmWorkJobHandlerProxy] (Work-Job-Executor-15:ctx-489eb1dd job-44/job-45 ctx-cce17070) (logid:f3b54257) Invocation exception, caused by: java.lang.RuntimeException: deviceId should be 1,2,4-5
`
