### PR TITLE
BUG-ID: CLOUDSTACK-9808 Added system Vm upgrade path for LXC and OVM

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
@@ -84,6 +84,12 @@ public class Upgrade4920to41000 implements DbUpgrade {
                     case Hyperv:
                         hypervisorsListInUse.add(Hypervisor.HypervisorType.Hyperv);
                         break;
+                    case LXC:
+                        hypervisorsListInUse.add(Hypervisor.HypervisorType.LXC);
+                        break;
+                    case Ovm3:
+                        hypervisorsListInUse.add(Hypervisor.HypervisorType.Ovm3);
+                        break;
                     default: // no action on cases Any, BareMetal, None, Ovm,
                         // Parralels, Simulator and VirtualBox:
                         break;
@@ -100,6 +106,8 @@ public class Upgrade4920to41000 implements DbUpgrade {
                 put(Hypervisor.HypervisorType.VMware, "systemvm-vmware-4.10");
                 put(Hypervisor.HypervisorType.KVM, "systemvm-kvm-4.10");
                 put(Hypervisor.HypervisorType.Hyperv, "systemvm-hyperv-4.10");
+                put(Hypervisor.HypervisorType.LXC, "systemvm-lxc-4.10");
+                put(Hypervisor.HypervisorType.Ovm3, "systemvm-ovm3-4.10");
             }
         };
 
@@ -109,6 +117,8 @@ public class Upgrade4920to41000 implements DbUpgrade {
                 put(Hypervisor.HypervisorType.VMware, "router.template.vmware");
                 put(Hypervisor.HypervisorType.KVM, "router.template.kvm");
                 put(Hypervisor.HypervisorType.Hyperv, "router.template.hyperv");
+                put(Hypervisor.HypervisorType.LXC, "router.template.lxc");
+                put(Hypervisor.HypervisorType.Ovm3, "router.template.ovm3");
             }
         };
 
@@ -118,6 +128,8 @@ public class Upgrade4920to41000 implements DbUpgrade {
                 put(Hypervisor.HypervisorType.VMware, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-vmware.ova");
                 put(Hypervisor.HypervisorType.KVM, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-kvm.qcow2.bz2");
                 put(Hypervisor.HypervisorType.Hyperv, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-hyperv.vhd.zip");
+                put(Hypervisor.HypervisorType.LXC, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-kvm.qcow2.bz2");
+                put(Hypervisor.HypervisorType.Ovm3, "https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-ovm.raw.bz2");
             }
         };
 
@@ -127,6 +139,8 @@ public class Upgrade4920to41000 implements DbUpgrade {
                 put(Hypervisor.HypervisorType.VMware, "970bfb070a80bd74820881d8149643c1");
                 put(Hypervisor.HypervisorType.KVM, "bc2eac46f16a2ece6c19d4b89db41de3");
                 put(Hypervisor.HypervisorType.Hyperv, "0adb35bd9f92e80d3fc63fcdd9bb55e5");
+                put(Hypervisor.HypervisorType.LXC, "bc2eac46f16a2ece6c19d4b89db41de3");
+                put(Hypervisor.HypervisorType.Ovm3, "94a41f0a5361933813bb34a51df56f56");
             }
         };
 


### PR DESCRIPTION
`

> mysql> select id,unique_name,name,type,url,updated,created from vm_template where type='SYSTEM';
> +----+-------------+-------------------------------+--------+-----------------------------------------------------------------------------------------------+---------+---------------------+
> | id | unique_name | name                          | type   | url                                                                                           | updated | created             |
> +----+-------------+-------------------------------+--------+-----------------------------------------------------------------------------------------------+---------+---------------------+
> |  1 | routing-1   | SystemVM Template (XenServer) | SYSTEM | https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-xen.vhd.bz2    | NULL    | 2017-03-30 15:53:00 |
> |  3 | routing-3   | SystemVM Template (KVM)       | SYSTEM | https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-kvm.qcow2.bz2  | NULL    | 2017-03-30 15:53:00 |
> |  8 | routing-8   | SystemVM Template (vSphere)   | SYSTEM | https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-vmware.ova     | NULL    | 2017-03-30 15:53:00 |
> |  9 | routing-9   | SystemVM Template (HyperV)    | SYSTEM | https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-hyperv.vhd.zip | NULL    | 2017-03-30 15:53:00 |
> | 10 | routing-10  | SystemVM Template (LXC)       | SYSTEM | https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-kvm.qcow2.bz2  | NULL    | 2017-03-30 15:54:13 |
> | 12 | routing-12  | SystemVM Template (Ovm3)      | SYSTEM | https://download.cloudstack.org/systemvm/4.10/systemvm64template-master-4.10.0-ovm.raw.bz2    | NULL    | 2017-03-30 15:55:58 |
> +----+-------------+-------------------------------+--------+-----------------------------------------------------------------------------------------------+---------+---------------------+
> 6 rows in set (0.00 sec)

`