### PR TITLE
[4.10-blocker] Fix error in restart network in 4.10.0.0 RC

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade4920to41000.java
@@ -183,7 +183,7 @@ public class Upgrade4920to41000 implements DbUpgrade {
                     // Change value of global configuration parameter
                     // minreq.sysvmtemplate.version for the ACS version
                     try (PreparedStatement update_pstmt = conn.prepareStatement("UPDATE `cloud`.`configuration` SET value = ? WHERE name = ?");) {
-                        update_pstmt.setString(1, getUpgradedVersion());
+                        update_pstmt.setString(1, "4.10.0");
                         update_pstmt.setString(2, "minreq.sysvmtemplate.version");
                         update_pstmt.executeUpdate();
                     } catch (final SQLException e) {


### PR DESCRIPTION
The PR fixes the error in restart network:
2017-04-04 10:27:39,217 DEBUG [c.c.n.r.NetworkHelperImpl] (API-Job-Executor-2:ctx-08904854 job-29417 ctx-3405d3f2) (logid:19bbd6e6) Router requires upgrade. Unable to send command to router:9784, router template version : Cloudstack Release 4.10.0 Wed Feb 15 05:42:18 UTC 2017, minimal required version : 4.10.0.0

It works after changing minreq.sysvmtemplate.version from 4.10.0.0 to 4.10.0