### PR TITLE
CLOUDSTACK-9861: Expire VM snapshots after configured duration

### DIFF
--- a/engine/components-api/src/com/cloud/vm/snapshot/VMSnapshotManager.java
+++ b/engine/components-api/src/com/cloud/vm/snapshot/VMSnapshotManager.java
@@ -19,12 +19,18 @@ package com.cloud.vm.snapshot;
 
 import java.util.List;
 
+import org.apache.cloudstack.framework.config.ConfigKey;
+
 import com.cloud.agent.api.RestoreVMSnapshotCommand;
 import com.cloud.utils.component.Manager;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VMInstanceVO;
 
 public interface VMSnapshotManager extends VMSnapshotService, Manager {
+
+    static final ConfigKey<Integer> VMSnapshotExpireInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vmsnapshot.expire.interval", "-1",
+            "VM Snapshot expire interval in hours", true, ConfigKey.Scope.Account);
+
     public static final int VMSNAPSHOTMAX = 10;
 
     /**

--- a/server/src/com/cloud/storage/snapshot/SnapshotManager.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManager.java
@@ -32,6 +32,10 @@ import org.apache.cloudstack.framework.config.ConfigKey;
  *
  */
 public interface SnapshotManager {
+    public static final int HOURLYMAX = 8;
+    public static final int DAILYMAX = 8;
+    public static final int WEEKLYMAX = 8;
+    public static final int MONTHLYMAX = 12;
     public static final int DELTAMAX = 16;
 
     static final ConfigKey<Integer> SnapshotHourlyMax = new ConfigKey<Integer>(Integer.class, "snapshot.max.hourly", "Snapshots", "8",

--- a/server/src/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
+++ b/server/src/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
@@ -36,6 +36,7 @@ import org.apache.cloudstack.engine.subsystem.api.storage.VMSnapshotStrategy;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
 import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.jobs.AsyncJob;
 import org.apache.cloudstack.framework.jobs.AsyncJobExecutionContext;
@@ -118,7 +119,7 @@ import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 import com.cloud.vm.snapshot.dao.VMSnapshotDetailsDao;
 
 @Component
-public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase implements VMSnapshotManager, VMSnapshotService, VmWorkJobHandler {
+public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase implements VMSnapshotManager, VMSnapshotService, VmWorkJobHandler, Configurable {
     private static final Logger s_logger = Logger.getLogger(VMSnapshotManagerImpl.class);
 
     public static final String VM_WORK_JOB_HANDLER = VMSnapshotManagerImpl.class.getSimpleName();
@@ -1296,5 +1297,15 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
             }
         }
         return true;
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return VMSnapshotManager.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {VMSnapshotExpireInterval};
     }
 }


### PR DESCRIPTION
Default value of the account level global config vmsnapshot.expire.interval is -1 that conforms to legacy behaviour
A positive value will expire the VM snapshots for the respective account in that many hours