### PR TITLE
CLOUDSTACK-9918: Activate NioTest following changes in CLOUDSTACK-9348 PR #1549

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -208,7 +208,6 @@
           <excludes>
             <exclude>com/cloud/utils/testcase/*TestCase*</exclude>
             <exclude>com/cloud/utils/db/*Test*</exclude>
-            <exclude>com/cloud/utils/testcase/NioTest.java</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/utils/src/main/java/com/cloud/utils/nio/NioConnection.java
+++ b/utils/src/main/java/com/cloud/utils/nio/NioConnection.java
@@ -98,10 +98,9 @@ public abstract class NioConnection implements Callable<Boolean> {
         }
         _isStartup = true;
 
-        _threadExecutor = Executors.newSingleThreadExecutor();
-        _futureTask = _threadExecutor.submit(this);
-
+        _threadExecutor = Executors.newSingleThreadExecutor(new NamedThreadFactory(this._name + "-NioConnectionHandler"));
         _isRunning = true;
+        _futureTask = _threadExecutor.submit(this);
     }
 
     public void stop() {


### PR DESCRIPTION
The first PR #1493 re-enabled the NioTest but not the new PR #1549.

@rhtyd the test fails locally on my laptop. Is there any special configuration requirements?