### PR TITLE
CLOUDSTACK-9853: Add support for Secondary IPv6 Addresses and Subnets

### DIFF
--- a/api/src/com/cloud/vm/NicSecondaryIp.java
+++ b/api/src/com/cloud/vm/NicSecondaryIp.java
@@ -34,6 +34,8 @@ public interface NicSecondaryIp extends ControlledEntity, Identity, InternalIden
 
     String getIp4Address();
 
+    String getIp6Address();
+
     long getNetworkId();
 
     long getVmId();

--- a/core/src/com/cloud/agent/api/SecurityGroupRulesCmd.java
+++ b/core/src/com/cloud/agent/api/SecurityGroupRulesCmd.java
@@ -35,7 +35,7 @@ import com.cloud.utils.net.NetUtils;
 public class SecurityGroupRulesCmd extends Command {
     private static final String CIDR_LENGTH_SEPARATOR = "/";
     private static final char RULE_TARGET_SEPARATOR = ',';
-    private static final char RULE_COMMAND_SEPARATOR = ':';
+    private static final char RULE_COMMAND_SEPARATOR = ';';
     protected static final String EGRESS_RULE = "E:";
     protected static final String INGRESS_RULE = "I:";
     private static final Logger LOGGER = Logger.getLogger(SecurityGroupRulesCmd.class);

--- a/core/test/com/cloud/agent/api/SecurityGroupRulesCmdTest.java
+++ b/core/test/com/cloud/agent/api/SecurityGroupRulesCmdTest.java
@@ -86,7 +86,7 @@ public class SecurityGroupRulesCmdTest {
      */
     @Test
     public void testCompressStringifiedRules() throws Exception {
-        final String compressed = "eJzztEpMSrYytDKyMtQz0jPWM9E31THTM9ez0LPUN9Dxc40IUXAlrAQAPdoP3Q==";
+        final String compressed = "eJzztEpMSrY2tDayNtQz0jPWM9E31THTM9ez0LPUN9Dxc40IUXAlrAQAPusP4w==";
         final String a = securityGroupRulesCmd.compressStringifiedRules();
         assertTrue(compressed.equals(a));
     }

--- a/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDaoImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
+import com.cloud.utils.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.GenericDaoBase;
@@ -106,7 +107,13 @@ public class NicSecondaryIpDaoImpl extends GenericDaoBase<NicSecondaryIpVO, Long
         List<NicSecondaryIpVO> results = search(sc, null);
         List<String> ips = new ArrayList<String>(results.size());
         for (NicSecondaryIpVO result : results) {
-            ips.add(result.getIp4Address());
+            if (StringUtils.isNotBlank(result.getIp4Address())) {
+                ips.add(result.getIp4Address());
+            }
+
+            if (StringUtils.isNotBlank(result.getIp6Address())) {
+                ips.add(result.getIp6Address());
+            }
         }
         return ips;
     }

--- a/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpVO.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpVO.java
@@ -42,6 +42,16 @@ public class NicSecondaryIpVO implements NicSecondaryIp {
         this.networkId = networkId;
     }
 
+    public NicSecondaryIpVO(long nicId, String ip4Address, String ip6Address, long vmId, long accountId, long domainId, long networkId) {
+        this.nicId = nicId;
+        this.vmId = vmId;
+        this.ip4Address = ip4Address;
+        this.ip6Address = ip6Address;
+        this.accountId = accountId;
+        this.domainId = domainId;
+        this.networkId = networkId;
+    }
+
     protected NicSecondaryIpVO() {
     }
 

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
@@ -102,11 +102,11 @@ public final class LibvirtStartCommandWrapper extends CommandWrapper<StartComman
                         final StringBuilder sb = new StringBuilder();
                         if (nicSecIps != null) {
                             for (final String ip : nicSecIps) {
-                                sb.append(ip).append(":");
+                                sb.append(ip).append(";");
                             }
                             secIpsStr = sb.toString();
                         } else {
-                            secIpsStr = "0:";
+                            secIpsStr = "0;";
                         }
                         libvirtComputingResource.defaultNetworkRules(conn, vmName, nic, vmSpec.getId(), secIpsStr);
                     }

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
@@ -179,11 +179,11 @@ public final class CitrixStartCommandWrapper extends CommandWrapper<StartCommand
                             final StringBuilder sb = new StringBuilder();
                             if (nicSecIps != null) {
                                 for (final String ip : nicSecIps) {
-                                    sb.append(ip).append(":");
+                                    sb.append(ip).append(";");
                                 }
                                 secIpsStr = sb.toString();
                             } else {
-                                secIpsStr = "0:";
+                                secIpsStr = "0;";
                             }
                             result = citrixResourceBase.callHostPlugin(conn, "vmops", "default_network_rules", "vmName", vmName, "vmIP", nic.getIp(), "vmMAC", nic.getMac(),
                                     "vmID", Long.toString(vmSpec.getId()), "secIps", secIpsStr);

--- a/scripts/vm/hypervisor/xenserver/vmops
+++ b/scripts/vm/hypervisor/xenserver/vmops
@@ -802,7 +802,7 @@ def default_network_rules(session, args):
 
     #add secodnary nic ips to ipset
     secIpSet = "1"
-    ips = sec_ips.split(':')
+    ips = sec_ips.split(';')
     ips.pop()
     if ips[0] == "0":
         secIpSet = "0";

--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -481,7 +481,7 @@ def default_network_rules(vm_name, vm_id, vm_ip, vm_ip6, vm_mac, vif, brname, se
 
     #add secodnary nic ips to ipset
     secIpSet = "1"
-    ips = sec_ips.split(':')
+    ips = sec_ips.split(';')
     ips.pop()
     if ips[0] == "0":
         secIpSet = "0";


### PR DESCRIPTION
This commit adds support for passing IPv6 Addresses and/or Subnets as
Secondary IPs.

This is groundwork for CLOUDSTACK-9853 where IPv6 Subnets have to be
allowed in the Security Groups of Instances to we can add DHCPv6
Prefix Delegation.

Use ; instead of : for separating addresses, otherwise it would cause
problems with IPv6 Addresses.

Signed-off-by: Wido den Hollander <wido@widodh.nl>