### PR TITLE
[4.9+][network blocker] CLOUDSTACK-9838: Allow ingress traffic between guest VMs via snat IPs

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -140,7 +140,7 @@ class CsAcl(CsDataBag):
                                     " -s %s " % cidr +
                                     " -p %s " % rule['protocol'] +
                                     " -m %s " % rule['protocol'] +
-                                    "  %s -j RETURN" % rnge])
+                                    "  %s -j %s" % (rnge, self.rule['action'])])
 
             logging.debug("Current ACL IP direction is ==> %s", self.direction)
             if self.direction == 'egress':

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -380,7 +380,7 @@ class CsIP:
             self.fw.append(["mangle", "",
                             "-A FIREWALL_%s DROP" % self.address['public_ip']])
             self.fw.append(["mangle", "",
-                            "-A VPN_%s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.address['public_ip']])
+                            "-I VPN_%s -m state --state RELATED,ESTABLISHED -j ACCEPT" % self.address['public_ip']])
             self.fw.append(["mangle", "",
                             "-A VPN_%s -j RETURN" % self.address['public_ip']])
             self.fw.append(["nat", "",

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
@@ -63,7 +63,7 @@ class CsRoute:
         table = self.get_tablename(dev)
         logging.info("Adding route: dev " + dev + " table: " +
                      table + " network: " + address + " if not present")
-        cmd = "dev %s table %s %s" % (dev, table, address)
+        cmd = "dev %s table %s throw %s proto static" % (dev, table, address)
         self.set_route(cmd)
 
     def set_route(self, cmd, method="add"):


### PR DESCRIPTION
This enables the firewall/mangle tables rules to ACCEPT instead of RETURN, which
is the same behaviour as observed in ACS 4.5. By accepting the traffic, guest
VMs will be able to communicate tcp traffic between each other over snat public
IPs.

This is a regression from ACS 4.5, observed in ACS 4.9.2.0.
Pinging for review - @PaulAngus @borisstoyanov @DagSonsteboSB @abhinandanprateek @DaanHoogland and others

@blueorangutan package