### PR TITLE
[CLOUDSTACK-9858] Retirement of midonet plugin (build disabling)

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -79,7 +79,6 @@
     <module>network-elements/nuage-vsp</module>
     <module>network-elements/bigswitch</module>
     <module>network-elements/brocade-vcs</module>
-    <module>network-elements/midonet</module>
     <module>network-elements/stratosphere-ssp</module>
     <module>network-elements/opendaylight</module>
     <module>outofbandmanagement-drivers/ipmitool</module>
@@ -204,6 +203,12 @@
       </activation>
       <modules>
         <module>hypervisors/simulator</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>midonet</id>
+      <modules>
+        <module>network-elements/midonet</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
Recently there have been two threads asking and discussing the “midonet” integration with Apache CloudStack (ACS) [1-2].

After quite some discussions, we noticed that despite having some people willing to use it, the plugin has never been fully developed by its vendor (Midokura). Further, nobody else has put the effort on fully testing and finishing its implementation. It seems that the plugin was incorporated into our code base without being fully finished. Moreover, I have asked around at the Midonet community, and the java client they use has changed quite a bit from the one we use.

It begs the question if it does not work, why do we advertise such integration? [3]. 
Following the component retirement process defined in [4], a vote thread was started in [5]. The community decided to retire this Midonet plugin. This task represents the first step of the retirement, which is the disabling of the plugin in CloudStack`s build process.
 
[1] http://cloudstack.markmail.org/thread/qyedle5jb2c34gsc#query:+page:1+mid:xn2zq2v3eim5vl2q+state:results
[2] http://cloudstack.markmail.org/message/rewzk4v7dgzpsxkm?q=midonet+order:date-backward&page=1#query:midonet%20order%3Adate-backward+page:1+mid:i563khxlginf6smg+state:results
[3] http://docs.cloudstack.apache.org/en/latest/networking/midonet.html
[4] https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=68720798
[5] http://markmail.org/message/qigrtfirwnmct4hr