### PR TITLE
ipv6: Allow all ICMPv6 traffic if -1 is provided as a ICMP type

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -1008,7 +1008,11 @@ def add_network_rules(vm_name, vm_id, vm_ip, vm_ip6, signature, seqno, vmMac, ru
             elif 'icmp' != protocol:
                 execute('ip6tables -I ' + vmchain + ' -p ' + protocol + ' -m ' + protocol + ' --dport ' + range + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
             else:
-                execute('ip6tables -I ' + vmchain + ' -p icmpv6 --icmpv6-type ' + range + ' ' + direction + ' ' + ip + ' -j ' + action)
+                # ip6tables does not allow '--icmpv6-type any', allowing all ICMPv6 is done by not allowing a specific type
+                if range == 'any':
+                    execute('ip6tables -I ' + vmchain + ' -p icmpv6 ' + direction + ' ' + ip + ' -j ' + action)
+                else:
+                    execute('ip6tables -I ' + vmchain + ' -p icmpv6 --icmpv6-type ' + range + ' ' + direction + ' ' + ip + ' -j ' + action)
 
     egress_vmchain = egress_chain_name(vm_name)
     if egressrule_v4 == 0 :


### PR DESCRIPTION
ip6tables no longer takes '--icmpv6-type any' as a argument.

To allow all ICMPv6 traffic with ip6tables it has to be invoked this way:

  $ ip6tables -I i-2-14-VM -p icmpv6 -s ::/0 -j ACCEPT

All ICMPv6 traffic is now allow into the Instance.

Signed-off-by: Wido den Hollander <wido@widodh.nl>