### PR TITLE
CLOUDSTACK-9873: VR related periodic jobs are scheduled twice and run twice on management servers

### DIFF
--- a/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -591,6 +591,11 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
     }
 
     @Override
+    public boolean start() {
+        return true;
+    }
+
+    @Override
     public boolean startSite2SiteVpn(final Site2SiteVpnConnection conn, final VirtualRouter router) throws ResourceUnavailableException {
         if (router.getState() != State.Running) {
             s_logger.warn("Unable to apply site-to-site VPN configuration, virtual router is not in the right state " + router.getState());


### PR DESCRIPTION
The "start" method of VirtualNetworkApplianceManagerImpl schedules several period checks, including stats updates, alert updates, and VR checks including S2S vpn checks.

VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplianceManagerImpl. Thus when VpcVirtualNetworkApplianceManagerImpl is used, it re-runs the "start" method and once again schedules all the various jobs. Thus all the jobs run twice at each scheduled run. This is easily seen in the mangement-server.log (this is one of the checks that is doubled-up):

`cat /var/log/cloudstack/management/management-server.log | grep "routers to update status"`

Before (runs twice every 30 seconds):
```
2017-04-10 21:48:12,879 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-5f7bc584) (logid:4d5b1031) Found 10 routers to update status.
2017-04-10 21:48:12,932 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-d027ab6f) (logid:1bc50629) Found 10 routers to update status.
2017-04-10 21:48:42,877 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-2c8f4d18) (logid:e9111785) Found 10 routers to update status.
2017-04-10 21:48:42,927 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-1bfd5351) (logid:ad0f95ef) Found 10 routers to update status.
2017-04-10 21:49:12,874 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-ede0d2bb) (logid:6f244423) Found 10 routers to update status.
2017-04-10 21:49:12,928 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-d58842d5) (logid:8442d73c) Found 10 routers to update status.
```
After change (runs once every 30 seconds):
```
2017-04-12 15:19:09,150 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-34e46de7) (logid:280dc634) Found 10 routers to update status.
2017-04-12 15:19:39,150 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-5499a10d) (logid:33ca447b) Found 10 routers to update status.
2017-04-12 15:20:09,155 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-1df751da) (logid:c8d29e06) Found 10 routers to update status.
2017-04-12 15:20:39,152 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-b4cb567a) (logid:a09e1f29) Found 10 routers to update status.
2017-04-12 15:21:09,153 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-ab8e4023) (logid:f329b5ff) Found 10 routers to update status.
2017-04-12 15:21:39,150 DEBUG [c.c.n.r.VirtualNetworkApplianceManagerImpl] (RouterStatusMonitor-1:ctx-04fee930) (logid:32f6619b) Found 10 routers to update status.
```
Exacerbates #2040 