### PR TITLE
CLOUDSTACK-9875: Unable to re-apply Explicit dedication to VM

### DIFF
--- a/server/src/org/apache/cloudstack/affinity/AffinityGroupServiceImpl.java
+++ b/server/src/org/apache/cloudstack/affinity/AffinityGroupServiceImpl.java
@@ -432,12 +432,23 @@ public class AffinityGroupServiceImpl extends ManagerBase implements AffinityGro
                 throw new InvalidParameterValueException("Unable to find affinity group by id " + affinityGroupId);
             } else {
                 // verify permissions
-                _accountMgr.checkAccess(caller, null, true, owner, ag);
-                // Root admin has access to both VM and AG by default, but make sure the
-                // owner of these entities is same
-                if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
-                    if (ag.getAccountId() != owner.getAccountId()) {
-                        throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's account");
+                if (ag.getAclType() == ACLType.Domain) {
+                    _accountMgr.checkAccess(caller, null, false, owner, ag);
+                    // make sure the affinity group is available in that domain
+                    if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
+                        if (!isAffinityGroupAvailableInDomain(ag.getId(), owner.getDomainId())) {
+                            throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's domain");
+                        }
+                    }
+                } else {
+                    _accountMgr.checkAccess(caller, null, true, owner, ag);
+                    // Root admin has access to both VM and AG by default,
+                    // but
+                    // make sure the owner of these entities is same
+                    if (caller.getId() == Account.ACCOUNT_ID_SYSTEM || _accountMgr.isRootAdmin(caller.getId())) {
+                        if (ag.getAccountId() != owner.getAccountId()) {
+                            throw new PermissionDeniedException("Affinity Group " + ag + " does not belong to the VM's account");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Problem:
When a VM is deployed with in an Affinity group which has the cluster dedicated to a subdomain (zone is dedicated to parent domain) it is getting successful. We can also stop the vm and remove the affinity group, but if you want to add back the affinity it is failing.

Following are the steps to reproduce

1. I had created a Domain (Glass SA Parent Domain) and under it a subdomain (Glass SA Subdomain) and created an account to it.
2. Apply dedication to the zone for primary domain (Glass SA Parent Domain)
3. Apply dedication to the cluster for sub domain (Glass SA Subdomain)
4. Logged in with the Account of Subdomain.
5. Created an instance with the affinity (DedicatedGrp-domain-Glass SA Subdomain) - the dedication set with the cluster for the subdomain.
6. Powered off the VM, removed the affinity.
7. Tried adding back (the cluster affinity subdomain) - gives the error "Entity affinity Group () and entity Acct () belong to different accounts" 

Root cause:
During VM deployment there is clear check on affinity type (account/domain). Here since the acl_type is "domain" it does not expect to be same owner for entities.
But during update of affinity to VM there is no specific check for acl_type "domain".

Solution:
Fix is to make the access check similar to VM deployment where it does not expect to be same owner for entities if the acl_type is "domain".