### PR TITLE
Fix snmptrap alert bug

### DIFF
--- a/plugins/alert-handlers/snmp-alerts/src/org/apache/cloudstack/alert/snmp/SnmpHelper.java
+++ b/plugins/alert-handlers/snmp-alerts/src/org/apache/cloudstack/alert/snmp/SnmpHelper.java
@@ -19,7 +19,6 @@ package org.apache.cloudstack.alert.snmp;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.util.Date;
 
 import org.snmp4j.CommunityTarget;
 import org.snmp4j.PDU;

--- a/plugins/alert-handlers/snmp-alerts/src/org/apache/cloudstack/alert/snmp/SnmpHelper.java
+++ b/plugins/alert-handlers/snmp-alerts/src/org/apache/cloudstack/alert/snmp/SnmpHelper.java
@@ -18,6 +18,7 @@
 package org.apache.cloudstack.alert.snmp;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.util.Date;
 
 import org.snmp4j.CommunityTarget;
@@ -28,6 +29,7 @@ import org.snmp4j.smi.OID;
 import org.snmp4j.smi.OctetString;
 import org.snmp4j.smi.UdpAddress;
 import org.snmp4j.smi.UnsignedInteger32;
+import org.snmp4j.smi.TimeTicks;
 import org.snmp4j.smi.VariableBinding;
 import org.snmp4j.transport.DefaultUdpTransportMapping;
 
@@ -66,7 +68,8 @@ public class SnmpHelper {
 
         int alertType = snmpTrapInfo.getAlertType() + 1;
         if (alertType > 0) {
-            trap.add(new VariableBinding(SnmpConstants.sysUpTime, new OctetString(new Date().toString())));
+            long sysUpTimeTicks = ManagementFactory.getRuntimeMXBean().getUptime() / 10;
+            trap.add(new VariableBinding(SnmpConstants.sysUpTime, new TimeTicks(sysUpTimeTicks)));
             trap.add(new VariableBinding(SnmpConstants.snmpTrapOID, getOID(CsSnmpConstants.TRAPS_PREFIX + alertType)));
             if (snmpTrapInfo.getDataCenterId() != 0) {
                 trap.add(new VariableBinding(getOID(CsSnmpConstants.DATA_CENTER_ID), new UnsignedInteger32(snmpTrapInfo.getDataCenterId())));

--- a/plugins/alert-handlers/snmp-alerts/src/org/apache/cloudstack/alert/snmp/SnmpHelper.java
+++ b/plugins/alert-handlers/snmp-alerts/src/org/apache/cloudstack/alert/snmp/SnmpHelper.java
@@ -18,6 +18,7 @@
 package org.apache.cloudstack.alert.snmp;
 
 import java.io.IOException;
+import java.util.Date;
 
 import org.snmp4j.CommunityTarget;
 import org.snmp4j.PDU;
@@ -65,6 +66,7 @@ public class SnmpHelper {
 
         int alertType = snmpTrapInfo.getAlertType() + 1;
         if (alertType > 0) {
+            trap.add(new VariableBinding(SnmpConstants.sysUpTime, new OctetString(new Date().toString())));
             trap.add(new VariableBinding(SnmpConstants.snmpTrapOID, getOID(CsSnmpConstants.TRAPS_PREFIX + alertType)));
             if (snmpTrapInfo.getDataCenterId() != 0) {
                 trap.add(new VariableBinding(getOID(CsSnmpConstants.DATA_CENTER_ID), new UnsignedInteger32(snmpTrapInfo.getDataCenterId())));


### PR DESCRIPTION
Fix snmptrap alerts info omit to send the field of SnmpConstants.sysUpTime. 

So when standard snmptrapd  receive alerts package the field OID will dislocation