### PR TITLE
deb: Only build binary packages

### DIFF
--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -58,6 +58,6 @@ dch -b -v "${VERSION}~${DISTCODE}" -u low -m "Apache CloudStack Release ${VERSIO
 sed -i '0,/ UNRELEASED;/s// unstable;/g' debian/changelog
 
 dpkg-checkbuilddeps
-dpkg-buildpackage -uc -us
+dpkg-buildpackage -uc -us -b
 
 /bin/mv /tmp/changelog.orig debian/changelog


### PR DESCRIPTION
We do not need to build a tarball before building the DEB packages

Saves a few minutes on building DEB packages

Signed-off-by: Wido den Hollander <wido@widodh.nl>