### PR TITLE
CLOUDSTACK-9887 ignore bogus default gateway

### DIFF
--- a/server/src/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/com/cloud/network/router/CommandSetupHelper.java
@@ -108,8 +108,6 @@ import com.cloud.offering.NetworkOffering;
 import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.service.dao.ServiceOfferingDao;
-import com.cloud.storage.GuestOSVO;
-import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.user.Account;
 import com.cloud.uservm.UserVm;
 import com.cloud.utils.Pair;
@@ -174,8 +172,6 @@ public class CommandSetupHelper {
     private VlanDao _vlanDao;
     @Inject
     private IPAddressDao _ipAddressDao;
-    @Inject
-    private GuestOSDao _guestOSDao;
 
     @Inject
     private RouterControlHelper _routerControlHelper;
@@ -221,12 +217,6 @@ public class CommandSetupHelper {
                 _networkModel.getExecuteInSeqNtwkElmtCmd());
 
         String gatewayIp = nic.getIPv4Gateway();
-        if (!nic.isDefaultNic()) {
-            final GuestOSVO guestOS = _guestOSDao.findById(vm.getGuestOSId());
-            if (guestOS == null || !guestOS.getDisplayName().toLowerCase().contains("windows")) {
-                gatewayIp = "0.0.0.0";
-            }
-        }
 
         final DataCenterVO dcVo = _dcDao.findById(router.getDataCenterId());
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -89,9 +89,10 @@ class CsDhcp(CsDataBag):
                 gateway = gn.get_gateway()
             else:
                 gateway = i['gateway']
-            sline = "dhcp-option=tag:interface-%s-%s,3," % (device, idx)
-            line = "dhcp-option=tag:interface-%s-%s,3,%s" % (device, idx, gateway)
-            self.conf.search(sline, line)
+            if gateway != '0.0.0.0':
+                sline = "dhcp-option=tag:interface-%s-%s,3," % (device, idx)
+                line = "dhcp-option=tag:interface-%s-%s,3,%s" % (device, idx, gateway)
+                self.conf.search(sline, line)
             # Netmask
             netmask = ''
             if self.config.is_vpc():


### PR DESCRIPTION
  when a shared network is secondary the default gateway gets overwritten by a bogus one
  dnsmasq does the right thing and replaces it with its own default which is not good for us
  so check for '0.0.0.0'