### PR TITLE
CLOUDSTACK-9888: Duplicate usage while processing usage events 

### DIFF
--- a/test/integration/smoke/test_usage.py
+++ b/test/integration/smoke/test_usage.py
@@ -1821,3 +1821,13 @@ class TestVpnUsage(cloudstackTestCase):
             "Check VPN.USER.ADD in events table"
         )
         return
+
+    def test_duplicate_usage(self):
+        """
+            Create duplicate entries in usage_event Table
+            Run the Usage server
+            check the usage_job  table there should not be any duplicate entries
+        """
+
+        self.dbclient.execute("insert into cloud.usage_event (uuid, role_id, rule, permission, sort_order) values (UUID(), %d, '%s', '%s', %d)" % (roleId, rule, perm.upper(), sortOrder))
+        self.dbclient.execute("insert into cloud.usage_event (uuid, role_id, rule, permission, sort_order) values (UUID(), %d, '%s', '%s', %d)" % (roleId, rule, perm.upper(), sortOrder))


### PR DESCRIPTION
Usage server is generating duplicate usage if usage server skips event due to any exception

Usage server start processing events from current date or last unprocessed event date.
There are two major parts of usage server
1 process the events and generates helper records
2 generate the usage from helper records

currently assumption in usage generation is that events are sequential processed and it has to generate usage from the date of last unprocessed event.

In case of exception, exception is suppressed in the current implementation and usage server process rest of the events.
when usage server starts again it picks the unprocessed event (due to exception) and reports the usage from unprocessed event date.

To avoid duplication usage, server should stop processing the events  when there is an exception.
For the same exceptions are not suppressed as part of the fix.

In the code for only EVENT_VM_START, EVENT_VM_CREATE  events have try catch blocks rest of the events don't have, so removing try catch blocks

Business justification : In correct usage or incomplete usage results in discrepancies in billing, payment . also impacts customer relationships, fixing all dependent systems is time consuming and complicated so better to handle this in cloudstack and let admin fix the wrong event and then generate the usage.