### PR TITLE
do not take down the VPN on public IP config changes

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -629,7 +629,6 @@ class CsRemoteAccessVpn(CsDataBag):
                 self.remoteaccessvpn_iptables(public_ip, self.dbag[public_ip])
 
                 CsHelper.execute("ipsec auto --rereadall")
-                CsHelper.execute("service xl2tpd stop")
                 CsHelper.execute("service xl2tpd start")
                 CsHelper.execute("ipsec auto --rereadsecrets")
                 CsHelper.execute("ipsec auto --replace L2TP-PSK")


### PR DESCRIPTION
This fix is similar to the 4.10 fix found here: https://github.com/apache/cloudstack/pull/2062

**NOTE:** I have not tested this fix since I do not have a 4.9 environment.  We need confirmation from the people who raised the concern that this does in-fact fix their issue before this is merged.

@borisstoyanov can you run trillian tests against this please?