### PR TITLE
systemvm: fix pep8 errors

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py
@@ -1,19 +1,19 @@
-#Licensed to the Apache Software Foundation (ASF) under one
-#or more contributor license agreements.  See the NOTICE file
-#distributed with this work for additional information
-#regarding copyright ownership.  The ASF licenses this file
-#to you under the Apache License, Version 2.0 (the
-#"License"); you may not use this file except in compliance
-#with the License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
-#Unless required by applicable law or agreed to in writing,
-#software distributed under the License is distributed on an
-#"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-#KIND, either express or implied.  See the License for the
-#specific language governing permissions and limitations
-#under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 __author__ = 'frank'
 
@@ -36,6 +36,7 @@ hdlr.setFormatter(formatter)
 logger.addHandler(hdlr)
 logger.setLevel(logging.WARNING)
 
+
 class ShellCmd(object):
     '''
     classdocs
@@ -46,7 +47,15 @@ class ShellCmd(object):
         '''
         self.cmd = cmd
         if pipe:
-            self.process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, executable='/bin/sh', cwd=workdir)
+            self.process = subprocess.Popen(
+                cmd,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                executable='/bin/sh',
+                cwd=workdir
+            )
         else:
             self.process = subprocess.Popen(cmd, shell=True, executable='/bin/sh', cwd=workdir)
 
@@ -67,12 +76,15 @@ class ShellCmd(object):
         self.return_code = self.process.returncode
         return self.stdout
 
+
 def shell(cmd):
     return ShellCmd(cmd)()
 
 
 class Server(object):
+
     CMDLINE = '/var/cache/cloud/cmdline'
+
     def __init__(self):
         self.apikey = None
         self.secretkey = None
@@ -140,11 +152,19 @@ class Server(object):
 
     def notify_provisioning_done(self, mac):
         sig = self._make_sign(mac)
-        cmd = 'http://%s:%s/client/api?command=notifyBaremetalProvisionDone&mac=%s&apiKey=%s&signature=%s' % (self._get_mgmt_ip(), self._get_mgmt_port(), mac, self.apikey, sig)
+        cmd = 'http://%s:%s/client/api?command=notifyBaremetalProvisionDone&mac=%s&apiKey=%s&signature=%s' % (
+            self._get_mgmt_ip(),
+            self._get_mgmt_port(),
+            mac,
+            self.apikey,
+            sig
+        )
         shell("curl -X GET '%s'" % cmd)
         return ''
 
+
 server = None
+
 
 @app.route('/baremetal/provisiondone/<mac>', methods=['GET'])
 def notify_provisioning_done(mac):
@@ -157,5 +177,8 @@ def notify_provisioning_done(mac):
 
 if __name__ == '__main__':
     server = Server()
-    shell("iptables-save | grep -- '-A INPUT -i eth0 -p tcp -m tcp --dport 10086 -j ACCEPT' > /dev/null || iptables -I INPUT -i eth0 -p tcp -m tcp --dport 10086 -j ACCEPT")
+    shell(
+        "iptables-save | grep -- '-A INPUT -i eth0 -p tcp -m tcp --dport 10086 -j ACCEPT' > /dev/null || " +
+        "iptables -I INPUT -i eth0 -p tcp -m tcp --dport 10086 -j ACCEPT"
+    )
     app.run(host='0.0.0.0', port=10086, debug=True)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -27,6 +27,7 @@ from CsRule import CsRule
 
 VRRP_TYPES = ['guest']
 
+
 class CsAddress(CsDataBag):
 
     def compare(self):
@@ -359,7 +360,6 @@ class CsIP:
         self.fw.append(["filter", "", "-P INPUT DROP"])
         self.fw.append(["filter", "", "-P FORWARD DROP"])
 
-
     def fw_router(self):
         if self.config.is_vpc():
             return
@@ -441,7 +441,7 @@ class CsIP:
 
         if self.get_type() in ["guest"]:
             self.fw.append(["mangle", "front", "-A PREROUTING " +
-                            " -i %s -m state --state RELATED,ESTABLISHED "  % self.dev +
+                            " -i %s -m state --state RELATED,ESTABLISHED " % self.dev +
                             "-j CONNMARK --restore-mark --nfmask 0xffffffff --ctmask 0xffffffff"])
             guestNetworkCidr = self.address['network']
             self.fw.append(["filter", "", "-A FORWARD -d %s -o %s -j ACL_INBOUND_%s" %
@@ -573,7 +573,7 @@ class CsIP:
         cmdline = self.config.cmdline()
         # If redundant then this is dealt with by the master backup functions
         if self.get_type() in ["guest"] and not cmdline.is_redundant():
-            pwdsvc = CsPasswdSvc(self.address['public_ip']).start()
+            CsPasswdSvc(self.address['public_ip']).start()
 
         if self.get_type() == "public" and self.config.is_vpc() and method == "add":
             if self.address["source_nat"]:
@@ -723,4 +723,3 @@ class CsRpsrfs:
         if count < 2:
             logging.debug("Single CPU machine")
         return count
-

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsApp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsApp.py
@@ -19,7 +19,6 @@ import os
 import CsHelper
 from CsFile import CsFile
 from CsProcess import CsProcess
-import CsHelper
 
 
 class CsApp:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
@@ -18,7 +18,6 @@
 
 from CsDatabag import CsCmdLine
 from CsAddress import CsAddress
-import logging
 
 
 class CsConfig(object):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py
@@ -136,8 +136,8 @@ class CsCmdLine(CsDataBag):
         This is slightly difficult to happen, but if it does, destroy the router with the password generated with the
         code below and restart the VPC with out the clean up option.
         '''
-        if(self.get_type()=='router'):
-            passwd="%s-%s" % (self.get_eth2_ip(), self.get_router_id())
+        if self.get_type() == 'router':
+            passwd = "%s-%s" % (self.get_eth2_ip(), self.get_router_id())
         else:
             passwd = "%s-%s" % (self.get_vpccidr(), self.get_router_id())
         md5 = hashlib.md5()

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -16,7 +16,7 @@
 # under the License.
 import CsHelper
 import logging
-from netaddr import *
+from netaddr import IPAddress
 from random import randint
 from CsGuestNetwork import CsGuestNetwork
 from cs.CsDatabag import CsDataBag
@@ -134,13 +134,13 @@ class CsDhcp(CsDataBag):
         # with a splay of 60 hours to prevent storms
         lease = randint(700, 760)
 
-        if entry['default_entry'] == True:
+        if entry['default_entry'] is True:
             self.cloud.add("%s,%s,%s,%sh" % (entry['mac_address'],
                                              entry['ipv4_adress'],
                                              entry['host_name'],
                                              lease))
         else:
-            tag = entry['ipv4_adress'].replace(".","_")
+            tag = entry['ipv4_adress'].replace(".", "_")
             self.cloud.add("%s,set:%s,%s,%s,%sh" % (entry['mac_address'],
                                                     tag,
                                                     entry['ipv4_adress'],
@@ -157,7 +157,6 @@ class CsDhcp(CsDataBag):
                 v['dnsmasq'] = True
                 # Virtual Router
                 v['gateway'] = entry['default_gateway']
-
 
     def add_host(self, ip, hosts):
         self.hosts[ip] = hosts

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py
@@ -17,7 +17,6 @@
 # under the License.
 import logging
 import re
-import copy
 
 
 class CsFile:
@@ -66,7 +65,6 @@ class CsFile:
         logging.info("Wrote edited file %s" % self.filename)
         self.config = list(self.new_config)
         logging.info("Updated file in-cache configuration")
-
 
     def dump(self):
         for line in self.new_config:
@@ -134,13 +132,12 @@ class CsFile:
             return True
         return False
 
-
     def searchString(self, search, ignoreLinesStartWith):
         found = False
         logging.debug("Searching for %s string " % search)
 
         for index, line in enumerate(self.new_config):
-            print ' line = ' +line
+            print ' line = ' + line
             if line.lstrip().startswith(ignoreLinesStartWith):
                 continue
             if search in line:
@@ -149,9 +146,7 @@ class CsFile:
 
         return found
 
-
     def deleteLine(self, search):
-        found = False
         logging.debug("Searching for %s to remove the line " % search)
         temp_config = []
         for index, line in enumerate(self.new_config):
@@ -161,7 +156,6 @@ class CsFile:
                 temp_config.append(line)
 
         self.new_config = list(temp_config)
-
 
     def compare(self, o):
         result = (isinstance(o, self.__class__) and set(self.config) == set(o.config))

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsGuestNetwork.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsGuestNetwork.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 from merge import DataBag
-import CsHelper
 
 
 class CsGuestNetwork:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -24,13 +24,16 @@ import logging
 import os.path
 import re
 import shutil
-from netaddr import *
-from pprint import pprint
+import sys
+from netaddr import IPNetwork
 
-PUBLIC_INTERFACES = {"router" : "eth2", "vpcrouter" : "eth1"}
+PUBLIC_INTERFACES = {"router": "eth2", "vpcrouter": "eth1"}
 
-STATE_COMMANDS = {"router" : "ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo \"MASTER\"; else echo \"BACKUP\"; fi'",
-                  "vpcrouter" : "ip addr | grep eth1 | grep state | awk '{print $9;}' | xargs bash -c 'if [ $0 == \"UP\" ]; then echo \"MASTER\"; else echo \"BACKUP\"; fi'"}
+STATE_COMMANDS = {
+    "router": "ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo \"MASTER\"; else echo \"BACKUP\"; fi'",
+    "vpcrouter": "ip addr | grep eth1 | grep state | awk '{print $9;}' | xargs bash -c 'if [ $0 == \"UP\" ]; then echo \"MASTER\"; else echo \"BACKUP\"; fi'"
+}
+
 
 def reconfigure_interfaces(router_config, interfaces):
     for interface in interfaces:
@@ -51,6 +54,7 @@ def reconfigure_interfaces(router_config, interfaces):
                         execute(cmd)
                 else:
                     execute(cmd)
+
 
 def is_mounted(name):
     for i in execute("mount"):
@@ -238,6 +242,7 @@ def copy_if_needed(src, dest):
     if os.path.isfile(dest):
         return
     copy(src, dest)
+
 
 def copy(src, dest):
     """

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import logging
-import os.path
-import re
 from cs.CsDatabag import CsDataBag
 from CsProcess import CsProcess
 from CsFile import CsFile

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsMonitor.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsMonitor.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import logging
 from cs.CsDatabag import CsDataBag
 from CsFile import CsFile
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
@@ -16,8 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import CsHelper
-from pprint import pprint
-from CsDatabag import CsDataBag, CsCmdLine
+from CsDatabag import CsCmdLine
 import logging
 
 
@@ -144,7 +143,7 @@ class CsNetfilters(object):
         # PASS 2: Create rules
         for fw in list:
             tupledFw = tuple(fw)
-            if tupledFw in ruleSet :
+            if tupledFw in ruleSet:
                 logging.debug("Already processed : %s", tupledFw)
                 continue
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsProcess.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsProcess.py
@@ -42,7 +42,7 @@ class CsProcess(object):
         self.pid = []
         for i in CsHelper.execute("ps aux"):
             items = len(self.search)
-            proc = re.split("\s+", i)[items*-1:]
+            proc = re.split("\s+", i)[items * -1:]
             matches = len([m for m in proc if m in self.search])
             if matches == items:
                 self.pid.append(re.split("\s+", i)[1])

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -42,6 +42,7 @@ from CsStaticRoutes import CsStaticRoutes
 import socket
 from time import sleep
 
+
 class CsRedundant(object):
 
     CS_RAMDISK_DIR = "/ramdisk"
@@ -103,7 +104,7 @@ class CsRedundant(object):
                 if devUp:
                     logging.info("Device %s is present, let's start keepalive now." % dev)
                     isDeviceReady = True
-        
+
         if not isDeviceReady:
             logging.info("Guest network not configured yet, let's stop router redundancy for now.")
             CsHelper.service("conntrackd", "stop")
@@ -150,18 +151,19 @@ class CsRedundant(object):
         # conntrackd configuration
         conntrackd_template_conf = "%s/%s" % (self.CS_TEMPLATES_DIR, "conntrackd.conf.templ")
         conntrackd_temp_bkp = "%s/%s" % (self.CS_TEMPLATES_DIR, "conntrackd.conf.templ.bkp")
-        
+
         CsHelper.copy(conntrackd_template_conf, conntrackd_temp_bkp)
 
         conntrackd_tmpl = CsFile(conntrackd_template_conf)
         conntrackd_tmpl.section("Multicast {", "}", [
-                      "IPv4_address 225.0.0.50\n",
-                      "Group 3780\n",
-                      "IPv4_interface %s\n" % guest.get_ip(),
-                      "Interface %s\n" % guest.get_device(),
-                      "SndSocketBuffer 1249280\n",
-                      "RcvSocketBuffer 1249280\n",
-                      "Checksum on\n"])
+            "IPv4_address 225.0.0.50\n",
+            "Group 3780\n",
+            "IPv4_interface %s\n" % guest.get_ip(),
+            "Interface %s\n" % guest.get_device(),
+            "SndSocketBuffer 1249280\n",
+            "RcvSocketBuffer 1249280\n",
+            "Checksum on\n"
+        ])
         conntrackd_tmpl.section("Address Ignore {", "}", self._collect_ignore_ips())
         conntrackd_tmpl.commit()
 
@@ -371,10 +373,10 @@ class CsRedundant(object):
         lines = []
         for interface in self.address.get_interfaces():
             if interface.needs_vrrp():
-                cmdline=self.config.get_cmdline_instance()
+                cmdline = self.config.get_cmdline_instance()
                 if not interface.is_added():
                     continue
-                if(cmdline.get_type()=='router'):
+                if cmdline.get_type() == 'router':
                     str = "        %s brd %s dev %s\n" % (cmdline.get_guest_gw(), interface.get_broadcast(), interface.get_device())
                 else:
                     str = "        %s brd %s dev %s\n" % (interface.get_gateway_cidr(), interface.get_broadcast(), interface.get_device())

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py
@@ -37,11 +37,11 @@ class CsRoute:
         logging.info(
             "Adding route table: " + str + " to " + filename + " if not present ")
         if not CsHelper.definedinfile(filename, str):
-             CsHelper.execute("sudo echo " + str + " >> /etc/iproute2/rt_tables")
+            CsHelper.execute("sudo echo " + str + " >> /etc/iproute2/rt_tables")
         # remove "from all table tablename" if exists, else it will interfer with
         # routing of unintended traffic
         if self.findRule("from all lookup " + tablename):
-             CsHelper.execute("sudo ip rule delete from all table " + tablename)
+            CsHelper.execute("sudo ip rule delete from all table " + tablename)
 
     def flush_table(self, tablename):
         CsHelper.execute("ip route flush table %s" % (tablename))

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRule.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRule.py
@@ -49,7 +49,7 @@ class CsRule:
             logging.info("Added fwmark rule for %s" % (self.table))
 
     def delMark(self):
-        if  self.findMark():
+        if self.findMark():
             cmd = "ip rule delete fwmark %s table %s" % (self.tableNo, self.table)
             CsHelper.execute(cmd)
             logging.info("Deleting fwmark rule for %s" % (self.table))

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
@@ -18,7 +18,8 @@
 # under the License.
 
 from CsDatabag import CsDataBag
-from CsRedundant import *
+import logging
+import CsHelper
 
 
 class CsStaticRoutes(CsDataBag):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_cmdline.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_cmdline.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-
 
 def merge(dbag, cmdline):
     if 'redundant_router' in cmdline['cmd_line']:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_dhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_dhcp.py
@@ -15,9 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-from netaddr import *
-
 
 def merge(dbag, data):
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_firewallrules.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_firewallrules.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from pprint import pprint
 import copy
 
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_forwardingrules.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_forwardingrules.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-
 
 def merge(dbag, rules):
     for rule in rules["rules"]:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_guestnetwork.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_guestnetwork.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-
 keys = ['eth1', 'eth2', 'eth3', 'eth4', 'eth5', 'eth6', 'eth7', 'eth8', 'eth9']
 
 
@@ -29,7 +27,7 @@ def merge(dbag, gn):
             device_to_die = dbag[device][0]
             try:
                 dbag[device].remove(device_to_die)
-            except ValueError, e:
+            except ValueError:
                 print "[WARN] cs_guestnetwork.py :: Error occurred removing item from databag. => %s" % device_to_die
                 del(dbag[device])
         else:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py
@@ -15,8 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from netaddr import IPNetwork
 
-from netaddr import *
 
 def merge(dbag, ip):
     nic_dev_id = None
@@ -31,7 +31,7 @@ def merge(dbag, ip):
 
     ipo = IPNetwork(ip['public_ip'] + '/' + ip['netmask'])
     if 'nic_dev_id' in ip:
-         nic_dev_id = ip['nic_dev_id']
+        nic_dev_id = ip['nic_dev_id']
     ip['device'] = 'eth' + str(nic_dev_id)
     ip['broadcast'] = str(ipo.broadcast)
     ip['cidr'] = str(ipo.ip) + '/' + str(ipo.prefixlen)
@@ -45,7 +45,7 @@ def merge(dbag, ip):
         dbag[ip['device']] = [ip]
     else:
         if 'source_nat' in ip and ip['source_nat'] and ip['device'] in dbag and len(dbag[ip['device']]) > 0:
-            dbag[ip['device']].insert(0, ip) # make sure the source_nat ip is first (primary) on the device
+            dbag[ip['device']].insert(0, ip)  # make sure the source_nat ip is first (primary) on the device
         else:
             dbag.setdefault(ip['device'], []).append(ip)
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_loadbalancer.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_loadbalancer.py
@@ -15,9 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-import copy
-
 
 def merge(dbag, data):
     """ Simply overwrite the existsing bag as, the whole configuration is sent every time """

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_monitorservice.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_monitorservice.py
@@ -15,12 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-from netaddr import *
-
 
 def merge(dbag, data):
-
     if "config" in data:
         dbag['config'] = data["config"]
     return dbag

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_network_acl.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_network_acl.py
@@ -15,9 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-from netaddr import *
-
 
 def merge(dbag, data):
     dbag[data['device']] = data

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_remoteaccessvpn.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_remoteaccessvpn.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from pprint import pprint
 
 
 def merge(dbag, vpn):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_site2sitevpn.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_site2sitevpn.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from pprint import pprint
 
 
 def merge(dbag, vpn):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from pprint import pprint
 
 
 def merge(dbag, staticroutes):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_vmdata.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_vmdata.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-
 
 def merge(dbag, metadata):
     dbag[metadata["vm_ip_address"]] = metadata["vm_metadata"]

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_vmp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_vmp.py
@@ -15,9 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pprint import pprint
-from netaddr import *
-
 
 def merge(dbag, data):
     """

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_vpnusers.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_vpnusers.py
@@ -15,8 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from pprint import pprint
-
 import copy
 
 
@@ -38,8 +36,8 @@ def merge(dbag, data):
             del(dbagc[user])
 
     for user in data['vpn_users']:
-        username=user['user']
-        add=user['add']
+        username = user['user']
+        add = user['add']
         if username not in dbagc.keys():
             dbagc[username] = user
         elif username in dbagc.keys() and not add:

--- a/systemvm/patches/debian/config/opt/cloud/bin/line_edit.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/line_edit.py
@@ -193,6 +193,7 @@ class LineEditingFile(object):
                 os.unlink(changed_filename)
         return changes
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     import doctest

--- a/systemvm/patches/debian/config/opt/cloud/bin/master.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/master.py
@@ -19,7 +19,6 @@
 
 from cs.CsRedundant import CsRedundant
 from cs.CsDatabag import CsCmdLine
-from cs.CsAddress import CsAddress
 from cs.CsConfig import CsConfig
 import logging
 from optparse import OptionParser
@@ -42,7 +41,7 @@ logging.basicConfig(filename=config.get_logger(),
                     format=config.get_format())
 config.cmdline()
 cl = CsCmdLine("cmdline", config)
-#Update the configuration to set state as backup and let keepalived decide who the real Master is!
+# Update the configuration to set state as backup and let keepalived decide who the real Master is!
 cl.set_master_state(False)
 cl.save()
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -36,8 +36,6 @@ import cs_remoteaccessvpn
 import cs_vpnusers
 import cs_staticroutes
 
-from pprint import pprint
-
 
 class DataBag:
 
@@ -57,7 +55,7 @@ class DataBag:
             logging.debug("Creating data bag type %s", self.key)
             data.update({"id": self.key})
         else:
-            logging.debug("Loading data bag type %s",  self.key)
+            logging.debug("Loading data bag type %s", self.key)
             data = json.load(handle)
             handle.close()
         self.dbag = data
@@ -270,6 +268,7 @@ class updateDataBag:
             dbag = cs_ip.merge(dbag, ip)
         return dbag
 
+
 class QueueFile:
 
     fileName = ''
@@ -281,7 +280,7 @@ class QueueFile:
         if data is not None:
             self.data = data
             self.type = self.data["type"]
-            proc = updateDataBag(self)
+            updateDataBag(self)
             return
         fn = self.configCache + '/' + self.fileName
         try:
@@ -296,7 +295,7 @@ class QueueFile:
                 self.__moveFile(fn, self.configCache + "/processed")
             else:
                 os.remove(fn)
-            proc = updateDataBag(self)
+            updateDataBag(self)
 
     def setFile(self, name):
         self.fileName = name
@@ -319,7 +318,6 @@ class QueueFile:
 
 class PrivateGatewayHack:
 
-
     @classmethod
     def update_network_type_for_privategateway(cls, dbag, data):
         ip = data['router_guest_ip'] if 'router_guest_ip' in data.keys() else data['public_ip']
@@ -332,14 +330,15 @@ class PrivateGatewayHack:
             data['nw_type'] = "public"
             logging.debug("Updating nw_type for ip %s" % ip)
         else:
-            logging.debug("Not updating nw_type for ip %s because has_private_gw_ip = %s and private_gw_matches = %s " % (ip, has_private_gw_ip, private_gw_matches))
+            logging.debug(
+                "Not updating nw_type for ip %s because has_private_gw_ip = %s and private_gw_matches = %s " %
+                (ip, has_private_gw_ip, private_gw_matches)
+            )
         return data
-
 
     @classmethod
     def if_config_has_privategateway(cls, dbag):
         return 'privategateway' in dbag['config'].keys() and dbag['config']['privategateway'] != "None"
-
 
     @classmethod
     def ip_matches_private_gateway_ip(cls, ip, private_gateway_ip):
@@ -347,7 +346,6 @@ class PrivateGatewayHack:
         if ip == private_gateway_ip:
             new_ip_matches_private_gateway_ip = True
         return new_ip_matches_private_gateway_ip
-
 
     @classmethod
     def load_inital_data(cls):

--- a/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
@@ -19,8 +19,6 @@
 import sys
 from merge import QueueFile
 import logging
-import subprocess
-from subprocess import PIPE, STDOUT
 import os
 import os.path
 import configure
@@ -57,7 +55,6 @@ def process_file():
 def is_guestnet_configured(guestnet_dict, keys):
 
     existing_keys = []
-    new_eth_key = None
 
     for k1, v1 in guestnet_dict.iteritems():
         if k1 in keys and len(v1) > 0:
@@ -108,6 +105,7 @@ def is_guestnet_configured(guestnet_dict, keys):
             break
 
     return exists
+
 
 if not (os.path.isfile(jsonCmdConfigPath) and os.access(jsonCmdConfigPath, os.R_OK)):
     print "[ERROR] update_config.py :: You are telling me to process %s, but i can't access it" % jsonCmdConfigPath

--- a/systemvm/patches/debian/config/opt/cloud/bin/vmdata.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/vmdata.py
@@ -130,7 +130,7 @@ def createfile(ip, folder, file, data):
 def htaccess(ip, folder, file):
     entry = "Options -Indexes\nOrder Deny,Allow\nDeny from all\nAllow from " + ip
     htaccessFolder = "/var/www/html/" + folder + "/" + ip
-    htaccessFile = htaccessFolder+"/.htaccess"
+    htaccessFile = htaccessFolder + "/.htaccess"
 
     try:
         os.makedirs(htaccessFolder, 0755)
@@ -159,10 +159,11 @@ def exflock(file):
 def unflock(file):
     try:
         flock(file, LOCK_UN)
-    except IOError:
+    except IOError as e:
         print "failed to unlock file" + file.name + " due to : " + e.strerror
         sys.exit(1)
     return True
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
fixed pep8 errors. in `baremetal-vr.py` also replaced "windows carriage return" to "unix carriage return".

Before:
~~~
 $ pep8 --max-line-length=160 systemvm/patches/debian/config/opt/cloud/bin/**/*.py
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:1:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:2:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:3:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:4:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:5:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:6:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:7:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:11:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:12:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:13:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:14:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:15:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:16:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:20:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:21:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:22:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:23:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:24:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:25:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:26:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:28:1: E402 module level import not at top of file
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:39:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:49:161: E501 line too long (166 > 160 characters)
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:70:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:76:5: E301 expected 1 blank line, found 0
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:143:161: E501 line too long (176 > 160 characters)
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:147:1: E305 expected 2 blank lines after class or function definition, found 1
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:149:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/baremetal-vr.py:160:161: E501 line too long (172 > 160 characters)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:50:15: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:73:17: E122 continuation line missing indentation or outdented
systemvm/patches/debian/config/opt/cloud/bin/configure.py:125:44: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:323:25: E221 multiple spaces before operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:503:18: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:503:48: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:504:18: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:504:48: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:506:12: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:508:16: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:531:25: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:555:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/configure.py:556:13: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:563:23: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:573:40: E228 missing whitespace around modulo operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:573:46: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:574:37: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:574:42: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:575:45: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:586:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:589:34: E228 missing whitespace around modulo operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:589:40: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:608:47: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:613:65: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:618:1: E303 too many blank lines (3)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:628:22: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:630:13: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/configure.py:632:65: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:645:17: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/configure.py:650:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:651:21: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:652:23: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:653:23: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:654:25: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:657:16: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:658:18: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:659:20: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:660:16: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:661:12: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:663:9: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/configure.py:668:9: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:670:38: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:674:43: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:675:43: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:678:21: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:679:53: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:683:18: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:684:18: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:685:17: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:688:9: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:695:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:696:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:697:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:698:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:699:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:699:71: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:700:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:700:78: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:701:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:703:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:704:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:705:35: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:708:9: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:708:31: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:709:31: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:710:34: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:715:37: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:715:53: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/configure.py:716:37: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:717:37: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:718:37: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:719:37: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:734:5: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/configure.py:780:9: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/configure.py:895:109: E502 the backslash is redundant between brackets
systemvm/patches/debian/config/opt/cloud/bin/configure.py:898:137: E502 the backslash is redundant between brackets
systemvm/patches/debian/config/opt/cloud/bin/configure.py:909:9: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/configure.py:913:144: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/configure.py:913:161: E501 line too long (185 > 160 characters)
systemvm/patches/debian/config/opt/cloud/bin/configure.py:1035:1: E305 expected 2 blank lines after class or function definition, found 1
systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py:30:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py:363:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py:444:75: E221 multiple spaces before operator
systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py:726:1: W391 blank line at end of file
systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py:139:27: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/cs/CsDatabag.py:140:19: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py:137:35: E712 comparison to True should be 'if cond is True:' or 'if cond:'
systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py:143:51: E231 missing whitespace after ','
systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py:162:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py:71:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py:138:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py:143:31: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py:153:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/cs/CsFile.py:166:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:30:30: E203 whitespace before ':'
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:30:52: E203 whitespace before ':'
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:32:27: E203 whitespace before ':'
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:33:30: E203 whitespace before ':'
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:33:161: E501 line too long (173 > 160 characters)
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:35:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:55:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py:242:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py:147:35: E203 whitespace before ':'
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py:45:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py:106:1: W293 blank line contains whitespace
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py:153:1: W293 blank line contains whitespace
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py:374:24: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py:377:38: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py:40:14: E111 indentation is not a multiple of four
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py:44:14: E111 indentation is not a multiple of four
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRoute.py:118:21: W292 no newline at end of file
systemvm/patches/debian/config/opt/cloud/bin/cs/CsRule.py:52:11: E271 multiple spaces after keyword
systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py:42:48: W292 no newline at end of file
systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py:21:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py:34:10: E111 indentation is not a multiple of four
systemvm/patches/debian/config/opt/cloud/bin/cs_ip.py:48:45: E261 at least two spaces before inline comment
systemvm/patches/debian/config/opt/cloud/bin/cs_vpnusers.py:41:17: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/cs_vpnusers.py:42:12: E225 missing whitespace around operator
systemvm/patches/debian/config/opt/cloud/bin/line_edit.py:196:1: E305 expected 2 blank lines after class or function definition, found 1
systemvm/patches/debian/config/opt/cloud/bin/master.py:45:1: E265 block comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/merge.py:273:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/merge.py:323:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/merge.py:335:161: E501 line too long (165 > 160 characters)
systemvm/patches/debian/config/opt/cloud/bin/merge.py:339:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/merge.py:344:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/merge.py:352:5: E303 too many blank lines (2)
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:36:20: E272 multiple spaces before keyword
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:37:18: E272 multiple spaces before keyword
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:37:44: E261 at least two spaces before inline comment
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:37:45: E262 inline comment should start with '# '
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:45:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:48:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:51:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:61:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:64:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:68:35: E701 multiple statements on one line (colon)
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:74:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:84:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:87:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:93:1: E302 expected 2 blank lines, found 1
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:106:5: E301 expected 1 blank line, found 0
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:136:46: E231 missing whitespace after ':'
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:137:44: E231 missing whitespace after ':'
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:138:21: E124 closing bracket does not match visual indentation
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:169:23: E251 unexpected spaces around keyword / parameter equals
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:169:25: E251 unexpected spaces around keyword / parameter equals
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:170:22: E251 unexpected spaces around keyword / parameter equals
systemvm/patches/debian/config/opt/cloud/bin/passwd_server_ip.py:170:24: E251 unexpected spaces around keyword / parameter equals
systemvm/patches/debian/config/opt/cloud/bin/update_config.py:112:1: E305 expected 2 blank lines after class or function definition, found 1
systemvm/patches/debian/config/opt/cloud/bin/vmdata.py:167:1: E305 expected 2 blank lines after class or function definition, found 1
~~~
