### PR TITLE
CLOUDSTACK-9904: Fix log4j to have @AGENTLOG@ replaced

### DIFF
--- a/plugins/hypervisors/hyperv/pom.xml
+++ b/plugins/hypervisors/hyperv/pom.xml
@@ -96,6 +96,35 @@
             <skipTests>${skipTests}</skipTests>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-resource</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <copy overwrite="true"
+                  todir="${basedir}/target/classes">
+                  <fileset dir="${basedir}/conf">
+                    <include name="*.in"/>
+                  </fileset>
+                  <filterchain>
+                    <filterreader
+                      classname="org.apache.tools.ant.filters.ReplaceTokens">
+                      <param type="propertiesfile"
+                        value="${project.basedir}/../../../${cs.replace.properties}" />
+                    </filterreader>
+                  </filterchain>
+                </copy>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
This fixes log4j xml to have @AGENTLOG@ replaced with values defined
in build/replace.properties.

Without the fix, spurious log files with names such as @AGENTLOG@ are seen.