### PR TITLE
[4.9+] CLOUDSTACK-9900: Fix high CPU deviation issues seen in metrics view

### DIFF
--- a/plugins/metrics/src/org/apache/cloudstack/response/ClusterMetricsResponse.java
+++ b/plugins/metrics/src/org/apache/cloudstack/response/ClusterMetricsResponse.java
@@ -128,10 +128,10 @@ public class ClusterMetricsResponse extends ClusterResponse {
         }
     }
 
-    public void setCpuMaxDeviation(final Double maxCpuDeviation, final Double totalCpuUsed, final Long totalHosts) {
-        if (maxCpuDeviation != null && totalCpuUsed != null && totalHosts != null && totalHosts != 0) {
-            final Double averageCpuUsage = totalCpuUsed / totalHosts;
-            this.cpuMaxDeviation = String.format("%.2f%%", (maxCpuDeviation - averageCpuUsage) * 100.0 / averageCpuUsage);
+    public void setCpuMaxDeviation(final Double maxCpuUsagePercentage, final Double totalCpuUsedPercentage, final Long totalHosts) {
+        if (maxCpuUsagePercentage != null && totalCpuUsedPercentage != null && totalHosts != null && totalHosts != 0) {
+            final Double averageCpuUsagePercentage = totalCpuUsedPercentage / totalHosts;
+            this.cpuMaxDeviation = String.format("%.2f%%", (maxCpuUsagePercentage - averageCpuUsagePercentage) / averageCpuUsagePercentage);
         }
     }
 

--- a/plugins/metrics/src/org/apache/cloudstack/response/ZoneMetricsResponse.java
+++ b/plugins/metrics/src/org/apache/cloudstack/response/ZoneMetricsResponse.java
@@ -123,10 +123,10 @@ public class ZoneMetricsResponse extends ZoneResponse {
         }
     }
 
-    public void setCpuMaxDeviation(final Double maxCpuDeviation, final Double totalCpuUsed, final Long totalHosts) {
-        if (maxCpuDeviation != null && totalCpuUsed != null && totalHosts != null && totalHosts != 0) {
-            final Double averageCpuUsage = totalCpuUsed / totalHosts;
-            this.cpuMaxDeviation = String.format("%.2f%%", (maxCpuDeviation - averageCpuUsage) * 100.0 / averageCpuUsage);
+    public void setCpuMaxDeviation(final Double maxCpuUsagePercentage, final Double totalCpuUsedPercentage, final Long totalHosts) {
+        if (maxCpuUsagePercentage != null && totalCpuUsedPercentage != null && totalHosts != null && totalHosts != 0) {
+            final Double averageCpuUsagePercentage = totalCpuUsedPercentage / totalHosts;
+            this.cpuMaxDeviation = String.format("%.2f%%", (maxCpuUsagePercentage - averageCpuUsagePercentage) / averageCpuUsagePercentage);
         }
     }
 


### PR DESCRIPTION
HostStats returns cpu usage in percentage while memory usage in bytes.
This fixes a regression in maximum CPU usage deviation that did not
assume the values to be in percentage and multiple the final ratios
with 100 which leads to 100x the actual deviation value.

Pinging for review - @karuturi @DaanHoogland @abhinandanprateek @borisstoyanov @rashmidixit 
@blueorangutan package