### PR TITLE
CLOUDSTACK-9902: add consoleproxy.sslEnable toggle

### DIFF
--- a/setup/db/db/schema-41000to41100.sql
+++ b/setup/db/db/schema-41000to41100.sql
@@ -244,3 +244,7 @@ CREATE VIEW `cloud`.`host_view` AS
 
 -- Out-of-band management driver for nested-cloudstack
 ALTER TABLE `cloud`.`oobm` MODIFY COLUMN port VARCHAR(255);
+
+
+-- CLOUDSTACK-9902: Console proxy SSL toggle
+INSERT IGNORE INTO `cloud`.`configuration` (`category`, `instance`, `component`, `name`, `value`, `description`, `default_value`, `is_dynamic`) VALUES ('Console Proxy', 'DEFAULT', 'AgentManager', 'consoleproxy.sslEnabled', 'false', 'Enable SSL for console proxy', 'false', 0);


### PR DESCRIPTION
This adds the missing global configuration parameter consoleproxy.sslEnable required for enabling SSL on the console proxy VM.