### PR TITLE
CLOUDSTACK-9017 : VPC VR DHCP broken for multihomed guest VMs

### DIFF
--- a/systemvm/patches/debian/config/etc/vpcdnsmasq.conf
+++ b/systemvm/patches/debian/config/etc/vpcdnsmasq.conf
@@ -460,3 +460,5 @@ log-facility=/var/log/dnsmasq.log
 # Include a another lot of configuration options.
 #conf-file=/etc/dnsmasq.more.conf
 conf-dir=/etc/dnsmasq.d
+
+dhcp-optsfile=/etc/dhcpopts.txt

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_dhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_dhcp.py
@@ -21,7 +21,6 @@ from netaddr import *
 
 def merge(dbag, data):
 
-    search(dbag, data['host_name'])
     # A duplicate ip address wil clobber the old value
     # This seems desirable ....
     if "add" in data and data['add'] is False and \
@@ -33,17 +32,3 @@ def merge(dbag, data):
         dbag[data['ipv4_adress']] = data
     return dbag
 
-
-def search(dbag, name):
-    """
-    Dirty hack because CS does not deprovision hosts
-    """
-    hosts = []
-    for o in dbag:
-        if o == 'id':
-            continue
-        print "%s %s" % (dbag[o]['host_name'], name)
-        if dbag[o]['host_name'] == name:
-            hosts.append(o)
-    for o in hosts:
-        del(dbag[o])


### PR DESCRIPTION
REPRO STEPS
==================
1. Deploy a vm to a VPC having more than one tier, selecting one of the tier .
2. Attach the second tier to the VM as second NIC.
3. Stop and start the VM or restart the network service to retrieve the IP addresses from DHCP server.

EXPECTED BEHAVIOR
==================
IP addresses should be assigned to all the tiers even if it is the same VM connected to the tiers of same VPC.

ACTUAL BEHAVIOR
==================
In VMs associated with 2 tiers of the same VPC, one of the NIC can't receive IP address over DHCP

**Screenshot before applying fix :**

![screenshot of before applying fix](https://cloud.githubusercontent.com/assets/25146827/25771124/48dbe380-3266-11e7-9f7b-3fbde0aaa0e3.PNG)

**Screenshot after applying fix :**

![screenshot of after applying fix](https://cloud.githubusercontent.com/assets/25146827/25771128/595e8ba4-3266-11e7-989f-ae4d9e8c7dc1.PNG)
