### PR TITLE
CLOUDSTACK-9905:VPN Gateway with Public Subnet

### DIFF
--- a/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -438,8 +438,8 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
             name = "VPN-" + gatewayIp;
         }
         String guestCidrList = cmd.getGuestCidrList();
-        if (!NetUtils.validateGuestCidrList(guestCidrList)) {
-            throw new InvalidParameterValueException("The customer gateway guest cidr list " + guestCidrList + " contains invalid guest cidr!");
+        if (!NetUtils.isValidCidrList(guestCidrList)) {
+            throw new InvalidParameterValueException("The customer gateway peer cidr list " + guestCidrList + " contains an invalid cidr!");
         }
         String ipsecPsk = cmd.getIpsecPsk();
         String ikePolicy = cmd.getIkePolicy();


### PR DESCRIPTION
CLOUDSTACK-9905 : VPN Gateway with Public Subnet

When we attempt to use a /24 subnet with a public IP ranges, for example,153.97.140.0/24. VPN Customer Gateways can be created with this type of CIDR, but cannot be updated, for example to 153.97.181.0/24 . Attempting to do so produces the error "The customer gateway cidr list 153.97.181.0/24 contains invalid guest cidr!"

REPRO STEPS

Created a new VPN Customer Gateway
Attempted to change the CIDR list entry from 153.97.180.0/24 to 153.97.181.0/24
The UI became unresponsive
The Management-server log shows the following:
2017-03-31 17:10:42,471 WARN [c.c.u.n.NetUtils] (API-Job-Executor-9:ctx-ed9b5816 job-172 ctx-32369258) (logid:3a16f24b) cidr 153.97.181.0/24 is not RFC 1918 compliant
153.97.181.0/24

### EXPECTED BEHAVIOR
==================
Users should be able to update existing VPN Customer Gateway CIDR list as needed
Resolution

Removed RFC 1918 compliant check during updation of VPN Customer Gateway CIDR