### PR TITLE
[CLOUDSTACK-9910] API: display zone capacity data only to admin

### DIFF
--- a/server/src/com/cloud/api/query/dao/DataCenterJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/DataCenterJoinDaoImpl.java
@@ -76,10 +76,10 @@ public class DataCenterJoinDaoImpl extends GenericDaoBase<DataCenterJoinVO, Long
             zoneResponse.setInternalDns2(dataCenter.getInternalDns2());
             // FIXME zoneResponse.setVlan(dataCenter.get.getVnet());
             zoneResponse.setGuestCidrAddress(dataCenter.getGuestNetworkCidr());
-        }
 
-        if (showCapacities != null && showCapacities) {
-            zoneResponse.setCapacitites(ApiResponseHelper.getDataCenterCapacityResponse(dataCenter.getId()));
+            if (showCapacities != null && showCapacities) {
+                zoneResponse.setCapacitites(ApiResponseHelper.getDataCenterCapacityResponse(dataCenter.getId()));
+            }
         }
 
         // set network domain info


### PR DESCRIPTION
Currently any user with an access to the API can read the full capacities but that information should not be disclosed to normal user.