### PR TITLE
vRouters fixes & performance improvement

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsConfig.py
@@ -26,7 +26,7 @@ class CsConfig(object):
     A class to cache all the stuff that the other classes need
     """
     __LOG_FILE = "/var/log/cloud.log"
-    __LOG_LEVEL = "DEBUG"
+    __LOG_LEVEL = "INFO"
     __LOG_FORMAT = "%(asctime)s %(levelname)-8s %(message)s"
     cl = None
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -47,28 +47,29 @@ class DataBag:
         data = self.bdata
         if not os.path.exists(self.DPATH):
             os.makedirs(self.DPATH)
-        self.fpath = self.DPATH + '/' + self.key + '.json'
+        self.fpath = os.path.join(self.DPATH, self.key + '.json')
+
         try:
-            handle = open(self.fpath)
+            with open(self.fpath, 'r') as _fh:
+                logging.debug("Loading data bag type %s", self.key)
+                data = json.load(_fh)
         except IOError:
             logging.debug("Creating data bag type %s", self.key)
             data.update({"id": self.key})
-        else:
-            logging.debug("Loading data bag type %s",  self.key)
-            data = json.load(handle)
-            handle.close()
-        self.dbag = data
+        finally:
+            self.dbag = data
 
     def save(self, dbag):
         try:
-            handle = open(self.fpath, 'w')
+            with open(self.fpath, 'w') as _fh:
+                logging.debug("Writing data bag type %s", self.key)
+                json.dump(
+                    dbag, _fh,
+                    sort_keys=True,
+                    indent=2
+                )
         except IOError:
             logging.error("Could not write data bag %s", self.key)
-        else:
-            logging.debug("Writing data bag type %s", self.key)
-            logging.debug(dbag)
-        jsono = json.dumps(dbag, indent=4, sort_keys=True)
-        handle.write(jsono)
 
     def getDataBag(self):
         return self.dbag

--- a/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
@@ -52,15 +52,16 @@ def process(do_merge=True):
     qf.setFile(sys.argv[1])
     qf.do_merge = do_merge
     qf.load(None)
-
     return qf
 
 
 def process_file():
     print "[INFO] process_file"
     qf = process()
-    # Converge
-    finish_config()
+    # These can be safely deferred, dramatically speeding up loading times
+    if not (os.environ.get('DEFER_CONFIG', False) and sys.argv[1] in ('vm_dhcp_entry.json', 'vm_metadata.json')):
+        # Converge
+        finish_config()
 
 
 def process_vmpasswd():

--- a/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/update_config.py
@@ -27,7 +27,7 @@ import configure
 import json
 from cs.CsVmPassword import *
 
-logging.basicConfig(filename='/var/log/cloud.log', level=logging.DEBUG, format='%(asctime)s  %(filename)s %(funcName)s:%(lineno)d %(message)s')
+logging.basicConfig(filename='/var/log/cloud.log', level=logging.INFO, format='%(asctime)s  %(filename)s %(funcName)s:%(lineno)d %(message)s')
 
 # first commandline argument should be the file to process
 if (len(sys.argv) != 2):

--- a/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
@@ -90,8 +90,8 @@ do
     fi
 done < $cfg
 
-#remove the configuration file, log file should have all the records as well
-rm -f $cfg
+# archive the configuration file
+mv $cfg /var/cache/cloud/processed/
 
 # Flush kernel conntrack table
 log_it "VR config: Flushing conntrack table"

--- a/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
@@ -27,39 +27,28 @@ log_it() {
     echo "$(date) : $*" >> $log
 }
 
-while getopts 'c:' OPTION
-do
-  case $OPTION in
-      c) cfg="$OPTARG"
-          ;;
-  esac
-done
+while getopts 'c:' OPTION; do
+    case $OPTION in
+        c) cfg="$OPTARG" ;;
+esac; done
 
-while read line
-do
+while read line; do
     #comment
-    if [[ $line == \#* ]]
-    then
-	    continue
-    fi
+    if [[ $line == \#* ]]; then
+        continue
 
-    if [ "$line" == "<version>" ]
-    then
+    elif [ "$line" == "<version>" ]; then
         read line
         version=$line
         log_it "VR config: configuation format version $version"
         #skip </version>
         read line
-        continue
-    fi
 
-    if [ "$line" == "<script>" ]
-    then
+    elif [ "$line" == "<script>" ]; then
         read line
         log_it "VR config: executing: $line"
         eval $line >> $log 2>&1
-        if [ $? -ne 0 ]
-        then
+        if [ $? -ne 0 ]; then
             log_it "VR config: executing failed: $line"
             # expose error info to mgmt server
             echo "VR config: execution failed: \"$line\", check $log in VR for details " 1>&2
@@ -68,26 +57,22 @@ do
         #skip </script>
         read line
         log_it "VR config: execution success "
-        continue
-    fi
 
-    if [ "$line" == "<file>" ]
-    then
+    elif [ "$line" == "<file>" ]; then
         read line
         file=$line
         log_it "VR config: creating file: $file"
         rm -f $file
-        while read -r line
-        do
-            if [ "$line" == "</file>" ]
-            then
+        while read -r line; do
+            if [ "$line" == "</file>" ]; then
                 break
             fi
             echo $line >> $file
         done
         log_it "VR config: create file success"
-        continue
+
     fi
+
 done < $cfg
 
 # archive the configuration file

--- a/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/vr_cfg.sh
@@ -32,6 +32,7 @@ while getopts 'c:' OPTION; do
         c) cfg="$OPTARG" ;;
 esac; done
 
+export DEFER_CONFIG=true
 while read line; do
     #comment
     if [[ $line == \#* ]]; then
@@ -77,6 +78,10 @@ done < $cfg
 
 # archive the configuration file
 mv $cfg /var/cache/cloud/processed/
+
+unset DEFER_CONFIG
+# trigger finish_config()
+/opt/cloud/bin/configure.py
 
 # Flush kernel conntrack table
 log_it "VR config: Flushing conntrack table"


### PR DESCRIPTION
This PR:
* lowers logging on the vRouters; specifically by not dumping the full databag every time it is loaded and saved; this helps with log partitions filling up like there's no tomorrow
* defers configuring the daemons (Apache, DNSmasq et al) until after vr_cfg has parsed through the entire config. 

Without these patches, the VR in a pod containing 5 instances in a zone with 2.000 will load in ~8.002.000 config entries in about 8.000 restarts/reloads of dnsmasq and apache.
This takes hours, hitting several timeout and other bugs along the way.

This PR, combined with @wido 's PR's, brings that down to 5 config entries and 1 restart/reload.
In aforementioned scenario our VR's loading times were brought down from 3+ hours to 3+ minutes.

# References
https://github.com/apache/cloudstack/pull/1451
https://github.com/apache/cloudstack/pull/1856
https://github.com/apache/cloudstack/pull/2077
