### PR TITLE
Agent logrotation fixes

### DIFF
--- a/agent/conf/cloudstack-agent.logrotate
+++ b/agent/conf/cloudstack-agent.logrotate
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-/var/log/cloudstack/agent/cloudstack-agent.out
-/var/log/cloudstack/agent/cloudstack-agent.err
+@AGENTLOG@
 {
     copytruncate
     daily

--- a/agent/conf/cloudstack-agent.logrotate
+++ b/agent/conf/cloudstack-agent.logrotate
@@ -16,6 +16,7 @@
 # under the License.
 
 @AGENTLOG@
+/var/log/cloudstack/agent/security_group.log
 {
     copytruncate
     daily

--- a/debian/rules
+++ b/debian/rules
@@ -51,10 +51,11 @@ override_dh_auto_install:
 	install -m0644 packaging/systemd/$(PACKAGE)-agent.service debian/$(PACKAGE)-agent/lib/systemd/system/$(PACKAGE)-agent.service
 	install -m0644 packaging/systemd/$(PACKAGE)-agent.default $(DESTDIR)/$(SYSCONFDIR)/default/$(PACKAGE)-agent
 
+	install -D -m0644 agent/target/transformed/cloudstack-agent.logrotate $(DESTDIR)/$(SYSCONFDIR)/logrotate.d/cloudstack-agent
+
 	install -D agent/target/transformed/cloud-setup-agent $(DESTDIR)/usr/bin/cloudstack-setup-agent
 	install -D agent/target/transformed/cloud-ssh $(DESTDIR)/usr/bin/cloudstack-ssh
 	install -D agent/target/transformed/cloudstack-agent-profile.sh $(DESTDIR)/$(SYSCONFDIR)/profile.d/cloudstack-agent-profile.sh
-	install -D agent/target/transformed/cloudstack-agent.logrotate $(DESTDIR)/$(SYSCONFDIR)/logrotate.d/cloudstack-agent
 	install -D agent/target/transformed/cloudstack-agent-upgrade $(DESTDIR)/usr/bin/cloudstack-agent-upgrade
 	install -D agent/target/transformed/libvirtqemuhook $(DESTDIR)/usr/share/$(PACKAGE)-agent/lib/
 	install -D agent/target/transformed/* $(DESTDIR)/$(SYSCONFDIR)/$(PACKAGE)/agent


### PR DESCRIPTION
The logrotation configuration file doesn't work for a variety of reasons, security_group logs aren't considered at all.

This PR should fix those issues