### PR TITLE
CLOUDSTACK-9907 Physical size of snapshot is considered for usage

### DIFF
--- a/server/src/com/cloud/storage/snapshot/SnapshotManager.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManager.java
@@ -42,7 +42,8 @@ public interface SnapshotManager {
             "Maximum recurring weekly snapshots to be retained for a volume. If the limit is reached, snapshots from the beginning of the week are deleted so that newer ones can be saved. This limit does not apply to manual snapshots. If set to 0, recurring weekly snapshots can not be scheduled.", false, ConfigKey.Scope.Global, null);
     static final ConfigKey<Integer> SnapshotMonthlyMax = new ConfigKey<Integer>(Integer.class, "snapshot.max.monthly", "Snapshots", "8",
             "Maximum recurring monthly snapshots to be retained for a volume. If the limit is reached, snapshots from the beginning of the month are deleted so that newer ones can be saved. This limit does not apply to manual snapshots. If set to 0, recurring monthly snapshots can not be scheduled.", false, ConfigKey.Scope.Global, null);
-
+    static final ConfigKey<Boolean> usageSnapshotSelection = new ConfigKey<Boolean>("Usage", Boolean.class, "usage.snapshot.virtualsize.select", "false",
+            "Set the value to true if snapshot usage need to consider virtual size, else physical size is considered ", false);
     void deletePoliciesForVolume(Long volumeId);
 
     /**

--- a/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -1328,5 +1328,5 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] { SnapshotHourlyMax, SnapshotDailyMax, SnapshotMonthlyMax, SnapshotWeeklyMax}; }
+        return new ConfigKey<?>[] { SnapshotHourlyMax, SnapshotDailyMax, SnapshotMonthlyMax, SnapshotWeeklyMax, usageSnapshotSelection}; }
 }

--- a/usage/src/com/cloud/usage/UsageManagerImpl.java
+++ b/usage/src/com/cloud/usage/UsageManagerImpl.java
@@ -169,6 +169,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
     private Future _scheduledFuture = null;
     private Future _heartbeat = null;
     private Future _sanity = null;
+    private boolean  usageSnapshotSelection = false;
 
     public UsageManagerImpl() {
     }
@@ -208,6 +209,7 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
         String sanityCheckInterval = configs.get("usage.sanity.check.interval");
         String quotaEnable = configs.get("quota.enable.service");
         _runQuota = Boolean.valueOf(quotaEnable == null ? "false" : quotaEnable );
+        usageSnapshotSelection  = Boolean.valueOf(configs.get("usage.snapshot.virtualsize.select"));
         if (sanityCheckInterval != null) {
             _sanityCheckInterval = Integer.parseInt(sanityCheckInterval);
         }
@@ -1535,7 +1537,11 @@ public class UsageManagerImpl extends ManagerBase implements UsageManager, Runna
 
         long snapId = event.getResourceId();
         if (EventTypes.EVENT_SNAPSHOT_CREATE.equals(event.getType())) {
-            snapSize = event.getSize();
+            if (usageSnapshotSelection){
+                snapSize =  event.getVirtualSize();
+            }else {
+                snapSize = event.getSize();
+            }
             zoneId = event.getZoneId();
         }
 


### PR DESCRIPTION
Physical size of the snapshot is considered for the usage generation. This will have a huge impact on customer billiing after the  FIX(https://issues.apache.org/jira/browse/CLOUDSTACK-7825).
As part of the above fix size column now has the physical size of the snapshot and the virtual_size column has the virtual size of the volume. 
Now when the usage is processed it is taking the size ( which is physical size of the snapshot). But It should take Virtual size for existing customers.
So as part of fix providing option for customers to choose between virtual and physical size.
