### PR TITLE
CLOUDSTACK-9908 : Primary Storage allocated capacity goes very high after VM snapshot

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
@@ -1306,11 +1306,12 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
             // get volume's chain size for this VM snapshot; exclude current volume vdisk
             DataStoreTO store = volumeTO.getDataStore();
             ManagedObjectReference morDs = getDatastoreAsManagedObjectReference(baseName, hyperHost, store);
-            long size = getVMSnapshotChainSize(context, hyperHost, baseName + "*.vmdk", morDs, newPath);
+            long size = getVMSnapshotChainSize(context, hyperHost, baseName + ".vmdk", morDs, newPath);
+            size = getVMSnapshotChainSize(context, hyperHost, baseName + "-*.vmdk", morDs, newPath);
 
             if (volumeTO.getVolumeType()== Volume.Type.ROOT) {
                 // add memory snapshot size
-                size += getVMSnapshotChainSize(context, hyperHost, vmName + "*.vmsn", morDs, null);
+                size += getVMSnapshotChainSize(context, hyperHost, vmName + "-*.vmsn", morDs, null);
             }
 
             volumeTO.setSize(size);


### PR DESCRIPTION
Added '-' chracter while reading Filenames so that filename match exactly with VM name.

