### PR TITLE
 CLOUDSTACK-9162: Handled vpn user add when vpn is not enabled on the…

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vpn/AddVpnUserCmd.java
@@ -124,7 +124,7 @@ public class AddVpnUserCmd extends BaseAsyncCreateCmd {
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to add vpn user");
             }
         }catch (Exception ex) {
-            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to add vpn user due to resource unavailable");
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, ex.getMessage());
         }
 
         VpnUsersResponse vpnResponse = new VpnUsersResponse();

--- a/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/RemoteAccessVpnManagerImpl.java
@@ -90,6 +90,7 @@ import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionCallbackWithException;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.net.NetUtils;
+import org.apache.commons.collections.CollectionUtils;
 
 public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAccessVpnService, Configurable {
     private final static Logger s_logger = Logger.getLogger(RemoteAccessVpnManagerImpl.class);
@@ -508,6 +509,12 @@ public class RemoteAccessVpnManagerImpl extends ManagerBase implements RemoteAcc
 
         s_logger.debug("Applying vpn users for " + owner);
         List<RemoteAccessVpnVO> vpns = _remoteAccessVpnDao.findByAccount(vpnOwnerId);
+
+        if (CollectionUtils.isEmpty(vpns)) {
+            s_logger.debug("There are no remote access vpns configured on this account  " + owner +" to apply vpn user, failing add vpn user ");
+            return false;
+        }
+
         RemoteAccessVpnVO vpnTemp  = null;
 
         List<VpnUserVO> users = _vpnUsersDao.listByAccount(vpnOwnerId);


### PR DESCRIPTION
… account
When API called without account id or calling api without enabling the API throwing the exception.
http://1<MSIP>:8096/client/api?command=addVpnUser&password=password111&username=api123

This closes the PR #1241 