### PR TITLE
CLOUDSTACK-9925: Quota memory tariff value is for 1MB of RAM used per month (not hour)

### DIFF
--- a/framework/quota/src/org/apache/cloudstack/quota/constant/QuotaTypes.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/constant/QuotaTypes.java
@@ -57,7 +57,7 @@ public class QuotaTypes extends UsageTypes {
         quotaTypeList.put(VM_SNAPSHOT, new QuotaTypes(VM_SNAPSHOT, "VM_SNAPSHOT", "GB-Month", "VM Snapshot storage usage"));
         quotaTypeList.put(CPU_CLOCK_RATE, new QuotaTypes(CPU_CLOCK_RATE, "CPU_CLOCK_RATE", "Compute-Month", "Quota tariff for using 1 CPU of clock rate 100MHz"));
         quotaTypeList.put(CPU_NUMBER, new QuotaTypes(CPU_NUMBER, "CPU_NUMBER", "Compute-Month", "Quota tariff for running VM that has 1vCPU"));
-        quotaTypeList.put(MEMORY, new QuotaTypes(MEMORY, "MEMORY", "Compute-Month", "Quota tariff for using 1MB or RAM for 1 hour"));
+        quotaTypeList.put(MEMORY, new QuotaTypes(MEMORY, "MEMORY", "Compute-Month", "Quota tariff for using 1MB of RAM"));
         quotaTypeMap = Collections.unmodifiableMap(quotaTypeList);
     }
 


### PR DESCRIPTION
The quota memory tariff description in the CloudStack UI is wrong when defines that the value is for "using 1MB or RAM for 1 hour". The quota currency values reflect the value of a resource used per month, not an hour.

Quota divides the tariff value by the number of hours a month has (30 days - 720 hours); then it calculates the credits used by a client based on the amount of resources used per hour. The memory tariff description in the interface is wrong and can guide users to configure values for an hour.