### PR TITLE
CLOUDSTACK-9909: Logrotate config for tomcat needs to be updated for …

### DIFF
--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -291,7 +291,7 @@ install -D packaging/systemd/cloudstack-management.service ${RPM_BUILD_ROOT}%{_u
 install -D packaging/systemd/cloudstack-management.default ${RPM_BUILD_ROOT}%{_sysconfdir}/default/%{name}-management
 install -D server/target/conf/cloudstack-sudoers ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 touch ${RPM_BUILD_ROOT}%{_localstatedir}/run/%{name}-management.pid
-install -D server/target/conf/cloudstack-catalina.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-catalina
+install -D server/target/conf/cloudstack-catalina7.logrotate ${RPM_BUILD_ROOT}%{_sysconfdir}/logrotate.d/%{name}-catalina
 
 chmod 440 ${RPM_BUILD_ROOT}%{_sysconfdir}/sudoers.d/%{name}-management
 chmod 770 ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/Catalina

--- a/server/conf/cloudstack-catalina7.logrotate
+++ b/server/conf/cloudstack-catalina7.logrotate
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+/var/log/cloudstack/management/catalina.out {
+    copytruncate
+    daily
+    rotate 14
+    compress
+    missingok
+    create 0644 cloud cloud
+    su cloud cloud
+}


### PR DESCRIPTION
 logrotate 3.8  config changes as per below link
https://github.com/logrotate/logrotate/blob/r3-8-0/CHANGES#L6-L8

Changes:

New file  cloudstack-catalina7.logrotate  for centos7 logrotate config
cloud.spec file has changed to include new file 
