### PR TITLE
CLOUDSTACK-9914: update Quota plugin to support currency values up to 5 decimal places

### DIFF
--- a/setup/db/db/schema-41000to41100-cleanup.sql
+++ b/setup/db/db/schema-41000to41100-cleanup.sql
@@ -18,3 +18,6 @@
 --;
 -- Schema upgrade cleanup from 4.10.0.0 to 4.11.0.0
 --;
+
+-- CLOUDSTACK-9914: Alter quota_tariff to support currency values up to 5 decimal places
+ALTER TABLE `cloud_usage`.`quota_tariff` MODIFY `currency_value` DECIMAL(15,5) not null


### PR DESCRIPTION
**Summary:** this commit alters column currency_value from table cloud_usage.quota_tariff to support values up to 5 decimal places. The current implementation allows up to 2 decimal places.

**Issue:** need to use more than 2 decimal places to define resources values in Quota tariff.

**Solution:** modify column currency_value from table cloud_usage.quota_tariff to support values up to 5 decimal places. Values with more than 5 decimal places will be displayed with scientific notation in the user interface.

**SQL command:** "ALTER TABLE cloud_usage.quota_tariff MODIFY currency_value DECIMAL(15,5) not null"