### PR TITLE
CLOUDSTACK-9740 : Search for secondary IP of NIC that is attached to an instance is not working

### DIFF
--- a/api/src/com/cloud/network/NetworkService.java
+++ b/api/src/com/cloud/network/NetworkService.java
@@ -180,4 +180,6 @@ public interface NetworkService {
     IpAddress updateIP(Long id, String customId, Boolean displayIp);
 
     boolean configureNicSecondaryIp(NicSecondaryIp secIp, boolean isZoneSgEnabled);
+
+    List<? extends NicSecondaryIp> listVmNicSecondaryIps(ListNicsCmd listNicsCmd);
 }

--- a/api/src/org/apache/cloudstack/api/command/user/vm/ListNicsCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/ListNicsCmd.java
@@ -18,7 +18,8 @@ package org.apache.cloudstack.api.command.user.vm;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import com.cloud.vm.NicSecondaryIp;
+import org.apache.cloudstack.api.response.NicSecondaryIpResponse;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiCommandJobType;
@@ -122,22 +123,45 @@ public class ListNicsCmd extends BaseListCmd {
     public void execute() throws ResourceUnavailableException, ResourceAllocationException, ConcurrentOperationException, InsufficientCapacityException {
 
         try {
-            List<? extends Nic> results = _networkService.listNics(this);
-            ListResponse<NicResponse> response = new ListResponse<NicResponse>();
-            List<NicResponse> resList = null;
-            if (results != null) {
-                resList = new ArrayList<NicResponse>(results.size());
-                for (Nic r : results) {
-                    NicResponse resp = _responseGenerator.createNicResponse(r);
-                    resp.setObjectName("nic");
-                    resList.add(resp);
-                }
-                response.setResponses(resList);
-            }
-            response.setResponses(resList);
-            response.setResponseName(getCommandName());
-            this.setResponseObject(response);
+            if (this.getKeyword() != null && !this.getKeyword().isEmpty() && this.getNicId() != null) {
+                List<? extends NicSecondaryIp> results = _networkService.listVmNicSecondaryIps(this);
+                ListResponse<NicSecondaryIpResponse> response = new ListResponse<NicSecondaryIpResponse>();
+                List<NicSecondaryIpResponse> resList = new ArrayList<NicSecondaryIpResponse>();
+                NicSecondaryIpResponse res = new NicSecondaryIpResponse();
+                List<NicSecondaryIpResponse> res_List = new ArrayList<NicSecondaryIpResponse>();
+                if (results != null) {
+                    for (NicSecondaryIp r : results) {
+                        NicSecondaryIpResponse ipRes = _responseGenerator.createSecondaryIPToNicResponse(r);
+                        resList.add(ipRes);
+                        res.setSecondaryIpsList(resList);
+                        res.setObjectName("nic");
+                    }
 
+                    res_List.add(res);
+                    response.setResponses(res_List);
+                }
+                response.setResponses(res_List);
+                response.setResponseName(getCommandName());
+                this.setResponseObject(response);
+
+            } else {
+                List<? extends Nic> results = _networkService.listNics(this);
+                ListResponse<NicResponse> response = new ListResponse<NicResponse>();
+                List<NicResponse> resList = null;
+                if (results != null) {
+                    resList = new ArrayList<NicResponse>(results.size());
+                    for (Nic r : results) {
+                        NicResponse resp = _responseGenerator.createNicResponse(r);
+                        resp.setObjectName("nic");
+                        resList.add(resp);
+                    }
+                    response.setResponses(resList);
+                }
+
+                response.setResponses(resList);
+                response.setResponseName(getCommandName());
+                this.setResponseObject(response);
+            }
         } catch (Exception e) {
             s_logger.warn("Failed to list secondary ip address per nic ");
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());

--- a/api/src/org/apache/cloudstack/api/response/NicSecondaryIpResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/NicSecondaryIpResponse.java
@@ -17,7 +17,7 @@
 package org.apache.cloudstack.api.response;
 
 import com.google.gson.annotations.SerializedName;
-
+import java.util.List;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.EntityReference;
@@ -32,6 +32,10 @@ public class NicSecondaryIpResponse extends BaseResponse {
     @SerializedName(ApiConstants.ID)
     @Param(description = "the ID of the secondary private IP addr")
     private String id;
+
+    @SerializedName("secondaryip")
+    @Param(description = "the list of Secondary ipv4 addr of nic")
+    private List<NicSecondaryIpResponse> secondaryIpsList;
 
     @SerializedName(ApiConstants.IP_ADDRESS)
     @Param(description = "Secondary IP address")
@@ -94,4 +98,11 @@ public class NicSecondaryIpResponse extends BaseResponse {
         this.id = id;
     }
 
+    public List<NicSecondaryIpResponse> getSecondaryIpsList() {
+        return secondaryIpsList;
+    }
+
+    public void setSecondaryIpsList(List<NicSecondaryIpResponse> secondaryIpsList) {
+        this.secondaryIpsList = secondaryIpsList;
+    }
 }

--- a/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -213,7 +213,7 @@ public interface NetworkOrchestrationService {
 
     boolean isSecondaryIpSetForNic(long nicId);
 
-    List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId);
+    List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId, String keyword);
 
     Nic savePlaceholderNic(Network network, String ip4Address, String ip6Address, Type vmType);
 

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2894,12 +2894,17 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     }
 
     @Override
-    public List<? extends Nic> listVmNics(final long vmId, final Long nicId, final Long networkId) {
+    public List<? extends Nic> listVmNics(final long vmId, final Long nicId, final Long networkId, String keyword) {
         List<NicVO> result = null;
-        if (nicId == null && networkId == null) {
-            result = _nicDao.listByVmId(vmId);
+
+        if (keyword == null || keyword.isEmpty()) {
+            if (nicId == null && networkId == null) {
+                result = _nicDao.listByVmId(vmId);
+            } else {
+                result = _nicDao.listByVmIdAndNicIdAndNtwkId(vmId, nicId, networkId);
+            }
         } else {
-            result = _nicDao.listByVmIdAndNicIdAndNtwkId(vmId, nicId, networkId);
+            result = _nicDao.listByVmIdAndKeyword(vmId, keyword);
         }
 
         for (final NicVO nic : result) {

--- a/engine/schema/src/com/cloud/vm/dao/NicDao.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicDao.java
@@ -76,4 +76,6 @@ public interface NicDao extends GenericDao<NicVO, Long> {
     int countNicsForStartingVms(long networkId);
 
     NicVO getControlNicForVM(long vmId);
+
+    List<NicVO> listByVmIdAndKeyword(long instanceId, String keyword);
 }

--- a/engine/schema/src/com/cloud/vm/dao/NicDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicDaoImpl.java
@@ -60,7 +60,7 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         AllFieldsSearch.and("network", AllFieldsSearch.entity().getNetworkId(), Op.EQ);
         AllFieldsSearch.and("gateway", AllFieldsSearch.entity().getIPv4Gateway(), Op.EQ);
         AllFieldsSearch.and("vmType", AllFieldsSearch.entity().getVmType(), Op.EQ);
-        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIPv4Address(), Op.EQ);
+        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIPv4Address(), Op.LIKE);
         AllFieldsSearch.and("isDefault", AllFieldsSearch.entity().isDefaultNic(), Op.EQ);
         AllFieldsSearch.and("broadcastUri", AllFieldsSearch.entity().getBroadcastUri(), Op.EQ);
         AllFieldsSearch.and("secondaryip", AllFieldsSearch.entity().getSecondaryIp(), Op.EQ);
@@ -310,5 +310,13 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         sc.setJoinParameters("vm", "state", VirtualMachine.State.Starting);
         List<Integer> results = customSearch(sc, null);
         return results.get(0);
+    }
+
+    @Override
+    public List<NicVO> listByVmIdAndKeyword(long instanceId, String keyword) {
+        SearchCriteria<NicVO> sc = AllFieldsSearch.create();
+        sc.setParameters("instance", instanceId);
+        sc.setParameters("address", "%" + keyword + "%");
+        return listBy(sc);
     }
 }

--- a/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDao.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDao.java
@@ -53,4 +53,6 @@ public interface NicSecondaryIpDao extends GenericDao<NicSecondaryIpVO, Long> {
     List<String> getSecondaryIpAddressesForNic(long nicId);
 
     Long countByNicId(long nicId);
+
+    List<NicSecondaryIpVO> listSecondaryIpUsingKeyword(long nicId, String keyword);
 }

--- a/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/NicSecondaryIpDaoImpl.java
@@ -40,7 +40,7 @@ public class NicSecondaryIpDaoImpl extends GenericDaoBase<NicSecondaryIpVO, Long
         AllFieldsSearch = createSearchBuilder();
         AllFieldsSearch.and("instanceId", AllFieldsSearch.entity().getVmId(), Op.EQ);
         AllFieldsSearch.and("network", AllFieldsSearch.entity().getNetworkId(), Op.EQ);
-        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIp4Address(), Op.EQ);
+        AllFieldsSearch.and("address", AllFieldsSearch.entity().getIp4Address(), Op.LIKE);
         AllFieldsSearch.and("nicId", AllFieldsSearch.entity().getNicId(), Op.EQ);
         AllFieldsSearch.done();
 
@@ -145,5 +145,14 @@ public class NicSecondaryIpDaoImpl extends GenericDaoBase<NicSecondaryIpVO, Long
         SearchCriteria<Long> sc = CountByNicId.create();
         sc.setParameters("nic", nicId);
         return customSearch(sc, null).get(0);
+    }
+
+    @Override
+    public List<NicSecondaryIpVO> listSecondaryIpUsingKeyword(long nicId, String keyword)
+    {
+        SearchCriteria<NicSecondaryIpVO> sc = AllFieldsSearch.create();
+        sc.setParameters("nicId", nicId);
+        sc.setParameters("address", "%" + keyword + "%");
+        return listBy(sc);
     }
 }

--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -4140,6 +4140,7 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
         Account caller = CallContext.current().getCallingAccount();
         Long nicId = cmd.getNicId();
         long vmId = cmd.getVmId();
+        String keyword = cmd.getKeyword();
         Long networkId = cmd.getNetworkId();
         UserVmVO  userVm = _userVmDao.findById(vmId);
 
@@ -4150,7 +4151,26 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
             }
 
         _accountMgr.checkAccess(caller, null, true, userVm);
-        return _networkMgr.listVmNics(vmId, nicId, networkId);
+        return _networkMgr.listVmNics(vmId, nicId, networkId, keyword);
+    }
+
+    @Override
+    public List<? extends NicSecondaryIp> listVmNicSecondaryIps(ListNicsCmd cmd)
+    {
+        Account caller = CallContext.current().getCallingAccount();
+        Long nicId = cmd.getNicId();
+        long vmId = cmd.getVmId();
+        String keyword = cmd.getKeyword();
+        UserVmVO  userVm = _userVmDao.findById(vmId);
+
+        if (userVm == null || (!userVm.isDisplayVm() && caller.getType() == Account.ACCOUNT_TYPE_NORMAL)) {
+            InvalidParameterValueException ex = new InvalidParameterValueException("Virtual mahine id does not exist");
+            ex.addProxyObject(Long.valueOf(vmId).toString(), "vmId");
+            throw ex;
+        }
+
+        _accountMgr.checkAccess(caller, null, true, userVm);
+        return _nicSecondaryIpDao.listSecondaryIpUsingKeyword(nicId, keyword);
     }
 
     public List<NetworkGuru> getNetworkGurus() {

--- a/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/test/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -800,7 +800,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     }
 
     @Override
-    public List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId) {
+    public List<? extends Nic> listVmNics(long vmId, Long nicId, Long networkId, String keyword) {
         // TODO Auto-generated method stub
         return null;
     }
@@ -904,6 +904,11 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     @Override
     public boolean configureNicSecondaryIp(NicSecondaryIp secIp, boolean isZoneSgEnabled) {
         return false;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public List<? extends NicSecondaryIp> listVmNicSecondaryIps(ListNicsCmd listNicsCmd) {
+        return null;
     }
 
 }

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -1710,11 +1710,16 @@
                     dataProvider: function(args) {
                         var data = {};
 
+                        if (args.filterBy.search.value != null) {
+                            data.keyword = args.filterBy.search.value;
+                        }
+
                         $.ajax({
                             url: createURL('listNics'),
                             data: {
                                 nicId: args.context.nics[0].id,
-                                virtualmachineid: args.context.instances[0].id
+                                virtualmachineid: args.context.instances[0].id,
+                                keyword: args.filterBy.search.value
                             },
                             success: function(json) {
                                 var ips = json.listnicsresponse.nic ? json.listnicsresponse.nic[0].secondaryip : [];


### PR DESCRIPTION
Search for secondary IP of NIC that is attached to an instance is not working.

If instance has more than one secondary IP assigned and administrator attempts to search that list, all IPs are displayed instead of being filtered by the search string.
in web UI:
Dashboard -> Instances -> -> NICs -> ”View Secondary IPs” -> Search for a IP, but the search returns all the IPs in the list

**Screenshot before applying fix :**

![screenshot before applying fix](https://cloud.githubusercontent.com/assets/25146827/26343435/9c2d09b4-3fb9-11e7-9497-3213916bd303.PNG)


**Screenshot after applying fix :**

![screenshot after applying fix](https://cloud.githubusercontent.com/assets/25146827/26343442/a14cc0c4-3fb9-11e7-816c-263cdf6aa1fa.PNG)


