### PR TITLE
CLOUDSTACK-9885: VPCVR: Updated to the private the traffic_type

### DIFF
--- a/api/src/com/cloud/network/Networks.java
+++ b/api/src/com/cloud/network/Networks.java
@@ -270,7 +270,7 @@ public class Networks {
      * Different types of network traffic in the data center.
      */
     public enum TrafficType {
-        None, Public, Guest, Storage, Management, Control, Vpn;
+        None, Public, Guest, Storage, Management, PrivateGw, Control, Vpn;
 
         public static boolean isSystemNetwork(TrafficType trafficType) {
             if (Storage.equals(trafficType) || Management.equals(trafficType) || Control.equals(trafficType)) {
@@ -292,6 +292,8 @@ public class Networks {
                 return Control;
             } else if ("Vpn".equals(type)) {
                 return Vpn;
+            } else if ("PrivateGw".equals(type)) {
+                return PrivateGw;
             } else {
                 return None;
             }

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2021,7 +2021,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
         final NetworkOfferingVO ntwkOff = _networkOfferingDao.findById(networkOfferingId);
         // this method supports only guest network creation
-        if (ntwkOff.getTrafficType() != TrafficType.Guest) {
+        if (!(ntwkOff.getTrafficType() == TrafficType.Guest || ntwkOff.getTrafficType() == TrafficType.PrivateGw)) {
             s_logger.warn("Only guest networks can be created using this method");
             return null;
         }

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -2787,7 +2787,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             return getNetworkByName(conn, name);
         }
 
-        if (type == TrafficType.Guest) {
+        if (type == TrafficType.Guest || type == TrafficType.PrivateGw) {
             return new XsLocalNetwork(this, Network.getByUuid(conn, _host.getGuestNetwork()), null, PIF.getByUuid(conn, _host.getGuestPif()), null);
         } else if (type == TrafficType.Control) {
             setupLinkLocalNetwork(conn);

--- a/server/src/com/cloud/network/guru/PrivateNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/PrivateNetworkGuru.java
@@ -64,7 +64,7 @@ public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
     @Inject
     EntityManager _entityMgr;
 
-    private static final TrafficType[] TrafficTypes = {TrafficType.Guest};
+    private static final TrafficType[] TrafficTypes = {TrafficType.PrivateGw};
 
     protected PrivateNetworkGuru() {
         super();

--- a/setup/db/db/schema-4930to41000.sql
+++ b/setup/db/db/schema-4930to41000.sql
@@ -246,3 +246,4 @@ CREATE TABLE `cloud`.`guest_os_details` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `user_ip_address` ADD COLUMN `rule_state` VARCHAR(32) COMMENT 'static  rule state while removing';
+UPDATE  TABLE network_offerings set traffic_type='PrivateGw' where id=5;


### PR DESCRIPTION
Updated the traffic_type to PrivateGw to avoid configuring keepalied on the private gateway interface.
For more details about the bug please see CLOUDSTACK-9885