### PR TITLE
CLOUDSTACK-9935 : Search in VPN Customer Gateway not working

### DIFF
--- a/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
+++ b/server/src/com/cloud/network/vpn/Site2SiteVpnManagerImpl.java
@@ -586,6 +586,7 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         boolean listAll = cmd.listAll();
         long startIndex = cmd.getStartIndex();
         long pageSizeVal = cmd.getPageSizeVal();
+        String keyword = cmd.getKeyword();
 
         Account caller = CallContext.current().getCallingAccount();
         List<Long> permittedAccounts = new ArrayList<Long>();
@@ -602,12 +603,17 @@ public class Site2SiteVpnManagerImpl extends ManagerBase implements Site2SiteVpn
         _accountMgr.buildACLSearchBuilder(sb, domainId, isRecursive, permittedAccounts, listProjectResourcesCriteria);
 
         sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
+        sb.and("name", sb.entity().getName(), SearchCriteria.Op.LIKE);
 
         SearchCriteria<Site2SiteCustomerGatewayVO> sc = sb.create();
         _accountMgr.buildACLSearchCriteria(sc, domainId, isRecursive, permittedAccounts, listProjectResourcesCriteria);
 
         if (id != null) {
-            sc.addAnd("id", SearchCriteria.Op.EQ, id);
+            sc.setParameters("id", id);
+        }
+        if(keyword != null && !keyword.isEmpty())
+        {
+            sc.setParameters("name", "%" + keyword + "%");
         }
 
         Pair<List<Site2SiteCustomerGatewayVO>, Integer> result = _customerGatewayDao.searchAndCount(sc, searchFilter);


### PR DESCRIPTION
ISSUE
============
Using the search field in Network - VPN Customer Gateway results in all VPN customer gateways being listed. Results are not narrowed down to what you searched.

REPRO STEPS
==================
Created two VPN customer gateways named Test1 and Test2 and try to  search for Test1. Both VPN customer gateways were displayed after hitting the search button.

EXPECTED BEHAVIOR
==================
Searching should narrow down the results.

ACTUAL BEHAVIOR
==================
All VPN customer gateways are listed after searching.


**Screenshot before applying fix :**
![screenshot before adding fix](https://cloud.githubusercontent.com/assets/25146827/26632662/75eb7dfa-462e-11e7-8498-05a3698e3b71.png)


**Screenshot after applying fix :**
![screenshot after adding fix](https://cloud.githubusercontent.com/assets/25146827/26632689/8e906f78-462e-11e7-9a53-fd5a84e44430.png)
