### PR TITLE
CLOUDSTACK-9937 : dedicateCluster API response does not return correct detail in response

### DIFF
--- a/plugins/dedicated-resources/src/org/apache/cloudstack/api/commands/DedicateClusterCmd.java
+++ b/plugins/dedicated-resources/src/org/apache/cloudstack/api/commands/DedicateClusterCmd.java
@@ -105,14 +105,12 @@ public class DedicateClusterCmd extends BaseAsyncCmd {
         List<? extends DedicatedResources> result = dedicatedService.dedicateCluster(getClusterId(), getDomainId(), getAccountName());
         ListResponse<DedicateClusterResponse> response = new ListResponse<DedicateClusterResponse>();
         List<DedicateClusterResponse> clusterResponseList = new ArrayList<DedicateClusterResponse>();
-        if (result != null) {
-            for (DedicatedResources resource : result) {
-                DedicateClusterResponse clusterResponse = dedicatedService.createDedicateClusterResponse(resource);
-                clusterResponseList.add(clusterResponse);
-            }
-            response.setResponses(clusterResponseList);
-            response.setResponseName(getCommandName());
-            this.setResponseObject(response);
+
+        // List of result should always contain single element as only one cluster will be associated with each cluster ID.
+        if (result != null && result.size() == 1) {
+            DedicateClusterResponse clusterResponse = dedicatedService.createDedicateClusterResponse(result.get(0));
+            clusterResponse.setResponseName(getCommandName());
+            this.setResponseObject(clusterResponse);
         } else {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to dedicate cluster");
         }


### PR DESCRIPTION
ISSUE
==================
1. dedicateCluster API did not return correct details in response when executed although API itself worked fine.
2. As per documentation, response for dedicateCluster API should have affinity group id, cluster id, cluster name, etc. but none of those were included response.

**Screenshot before applying fix :**

![screenshot before adding fix - 1](https://cloud.githubusercontent.com/assets/25146827/26671513/68760b0e-46d3-11e7-9f5a-ae7ebd4c2df5.png)

![screenshot before adding fix - 2](https://cloud.githubusercontent.com/assets/25146827/26671528/71ce0abc-46d3-11e7-8a5f-540b78c0dd97.png)



**Screenshot after applying fix :**

![screenshot after adding fix - 1](https://cloud.githubusercontent.com/assets/25146827/26671547/80c43776-46d3-11e7-9637-d03eef0b1980.png)

![screenshot after adding fix - 2](https://cloud.githubusercontent.com/assets/25146827/26671552/8908d356-46d3-11e7-8070-01a17da3eb59.png)
