### PR TITLE
CLOUDSTACK-9950:listUsageRecords doesnt return required fields

### DIFF
--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3229,7 +3229,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             } else if(svcOffering.getRamSize() != null) {
                 usageRecResponse.setMemory(Integer.toUnsignedLong(svcOffering.getRamSize()));
             }
-            
+
         } else if (usageRecord.getUsageType() == UsageTypes.IP_ADDRESS) {
             //isSourceNAT
             usageRecResponse.setSourceNat((usageRecord.getType().equals("SourceNat")) ? true : false);

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3229,6 +3229,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             } else if(svcOffering.getRamSize() != null) {
                 usageRecResponse.setMemory(Integer.toUnsignedLong(svcOffering.getRamSize()));
             }
+            
         } else if (usageRecord.getUsageType() == UsageTypes.IP_ADDRESS) {
             //isSourceNAT
             usageRecResponse.setSourceNat((usageRecord.getType().equals("SourceNat")) ? true : false);

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3217,17 +3217,17 @@ public class ApiResponseHelper implements ResponseGenerator {
             if(usageRecord.getCpuCores() != null) {
                 usageRecResponse.setCpuNumber(usageRecord.getCpuCores());
             } else if (svcOffering.getCpu() != null){
-                usageRecResponse.setCpuNumber(Integer.toUnsignedLong(svcOffering.getCpu()));
+                usageRecResponse.setCpuNumber(svcOffering.getCpu().longValue());
             }
             if(usageRecord.getCpuSpeed() != null) {
                 usageRecResponse.setCpuSpeed(usageRecord.getCpuSpeed());
             } else if(svcOffering.getSpeed() != null){
-                usageRecResponse.setCpuSpeed(Integer.toUnsignedLong(svcOffering.getSpeed()));
+                usageRecResponse.setCpuSpeed(svcOffering.getSpeed().longValue());
             }
             if(usageRecord.getMemory() != null) {
                 usageRecResponse.setMemory(usageRecord.getMemory());
             } else if(svcOffering.getRamSize() != null) {
-                usageRecResponse.setMemory(Integer.toUnsignedLong(svcOffering.getRamSize()));
+                usageRecResponse.setMemory(svcOffering.getRamSize().longValue());
             }
 
         } else if (usageRecord.getUsageType() == UsageTypes.IP_ADDRESS) {

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3214,10 +3214,21 @@ public class ApiResponseHelper implements ResponseGenerator {
             //Hypervisor Type
             usageRecResponse.setType(usageRecord.getType());
             //Dynamic compute offerings details
-            usageRecResponse.setCpuNumber(usageRecord.getCpuCores());
-            usageRecResponse.setCpuSpeed(usageRecord.getCpuSpeed());
-            usageRecResponse.setMemory(usageRecord.getMemory());
-
+            if(usageRecord.getCpuCores() != null) {
+                usageRecResponse.setCpuNumber(usageRecord.getCpuCores());
+            } else if (svcOffering.getCpu() != null){
+                usageRecResponse.setCpuNumber(Integer.toUnsignedLong(svcOffering.getCpu()));
+            }
+            if(usageRecord.getCpuSpeed() != null) {
+                usageRecResponse.setCpuSpeed(usageRecord.getCpuSpeed());
+            } else if(svcOffering.getSpeed() != null){
+                usageRecResponse.setCpuSpeed(Integer.toUnsignedLong(svcOffering.getSpeed()));
+            }
+            if(usageRecord.getMemory() != null) {
+                usageRecResponse.setMemory(usageRecord.getMemory());
+            } else if(svcOffering.getRamSize() != null) {
+                usageRecResponse.setMemory(Integer.toUnsignedLong(svcOffering.getRamSize()));
+            }
         } else if (usageRecord.getUsageType() == UsageTypes.IP_ADDRESS) {
             //isSourceNAT
             usageRecResponse.setSourceNat((usageRecord.getType().equals("SourceNat")) ? true : false);


### PR DESCRIPTION
There is no cpuspeed, cpunumber or memory details in the listUsageRecords output as documented
In DB (cloud_usage table) we have cpu_speed, cpu_cores and ram fileds, but these are not populated for all the VM's. These fields are only populated for the VM's which are deployed with custom service offerings.