### PR TITLE
CLOUDSTACK-9951: Add support for batch/bulk VM deployment option in CS

### DIFF
--- a/api/src/com/cloud/vm/UserVmService.java
+++ b/api/src/com/cloud/vm/UserVmService.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.cloudstack.api.BaseCmd.HTTPMethod;
 import org.apache.cloudstack.api.command.admin.vm.AssignVMCmd;
+import org.apache.cloudstack.api.command.admin.vm.BulkDeployVMCmd;
 import org.apache.cloudstack.api.command.admin.vm.RecoverVMCmd;
 import org.apache.cloudstack.api.command.user.vm.AddNicToVMCmd;
 import org.apache.cloudstack.api.command.user.vm.DeployVMCmd;
@@ -482,4 +483,5 @@ public interface UserVmService {
      */
     public boolean isDisplayResourceEnabled(Long vmId);
 
+    List<Long> bulkDeployVirtualMachine(BulkDeployVMCmd cmd) throws ResourceAllocationException;
 }

--- a/api/src/org/apache/cloudstack/api/ResponseGenerator.java
+++ b/api/src/org/apache/cloudstack/api/ResponseGenerator.java
@@ -455,4 +455,6 @@ public interface ResponseGenerator {
     ListResponse<UpgradeRouterTemplateResponse> createUpgradeRouterTemplateResponse(List<Long> jobIds);
 
     SSHKeyPairResponse createSSHKeyPairResponse(SSHKeyPair sshkeyPair, boolean privatekey);
+
+    List<AsyncJobResponse> createAsyncJobResponse(List<Long> jobIds);
 }

--- a/api/src/org/apache/cloudstack/api/command/admin/vm/BulkDeployVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/vm/BulkDeployVMCmd.java
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.admin.vm;
+
+import java.util.List;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.affinity.AffinityGroupResponse;
+import org.apache.cloudstack.api.ACL;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.response.AsyncJobResponse;
+import org.apache.cloudstack.api.response.ClusterResponse;
+import org.apache.cloudstack.api.response.DiskOfferingResponse;
+import org.apache.cloudstack.api.response.DomainResponse;
+import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.api.response.NetworkResponse;
+import org.apache.cloudstack.api.response.PodResponse;
+import org.apache.cloudstack.api.response.SecurityGroupResponse;
+import org.apache.cloudstack.api.response.ServiceOfferingResponse;
+import org.apache.cloudstack.api.response.TemplateResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.log4j.Logger;
+
+import com.cloud.dc.DataCenter;
+import com.cloud.dc.DataCenter.NetworkType;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.offering.DiskOffering;
+import com.cloud.offering.ServiceOffering;
+
+@APICommand(name = "bulkDeployVirtualMachine", description = "Creates and automatically start multiple virtual machines of similar configuration based on virtualmachinecount.", responseObject = AsyncJobResponse.class,
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false,
+        authorized = { RoleType.Admin }, since = "4.11")
+public class BulkDeployVMCmd extends BaseCmd {
+    public static final Logger s_logger = Logger.getLogger(BulkDeployVMCmd.class.getName());
+    private static final String s_name = "bulkdeployvirtualmachineresponse";
+
+    @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class, required = true, description = "availability zone for the virtual machine")
+    private Long zoneId;
+
+    @ACL
+    @Parameter(name = ApiConstants.SERVICE_OFFERING_ID, type = CommandType.UUID, entityType = ServiceOfferingResponse.class, required = true, description = "the ID of the service offering for the virtual machine")
+    private Long serviceOfferingId;
+
+    @ACL
+    @Parameter(name = ApiConstants.TEMPLATE_ID, type = CommandType.UUID, entityType = TemplateResponse.class, required = true, description = "the ID of the template for the virtual machine")
+    private Long templateId;
+
+    @Parameter(name = ApiConstants.VIRTUAL_MACHINE_COUNT, type = CommandType.INTEGER, required = true, description = "number of virtual machines to be deployed")
+    private Integer count;
+
+    @Parameter(name = ApiConstants.POD_ID, type = CommandType.UUID, entityType = PodResponse.class, description = "optional pod ID for placing the virtual machine, mutually exclusive with cluster ID")
+    private Long podId;
+
+    @Parameter(name = ApiConstants.CLUSTER_ID, type = CommandType.UUID, entityType = ClusterResponse.class, description = "optional cluster ID for placing the virtual machine, mutually exclusive with pod ID")
+    private Long clusterId;
+
+    @Parameter(name = ApiConstants.HYPERVISOR, type = CommandType.STRING, description = "hypervisor type on which to deploy the virtual machine. "
+            + "The parameter is required and respected only when hypervisor info is not set on the ISO/Template passed to the call")
+    private String hypervisor;
+
+    @Parameter(name = ApiConstants.USER_DATA, type = CommandType.STRING, description = "an optional binary data that can be sent to the virtual machine upon a successful deployment. "
+            + "This binary data must be base64 encoded before adding it to the request. Using HTTP GET (via querystring), you can send up to 2KB of data after base64 encoding. "
+            + "Using HTTP POST (via POST body), you can send up to 32K of data after base64 encoding.", length = 32768)
+    private String userData;
+
+    @Parameter(name = ApiConstants.SSH_KEYPAIR, type = CommandType.STRING, description = "name of the ssh key pair used to login to the virtual machine")
+    private String sshKeyPairName;
+
+    @Parameter(name = ApiConstants.NETWORK_IDS, type = CommandType.LIST, collectionType = CommandType.UUID, entityType = NetworkResponse.class,
+            description = "comma separated list of network IDs used by the virtual machine")
+    private List<Long> networkIds;
+
+    @ACL
+    @Parameter(name = ApiConstants.DISK_OFFERING_ID, type = CommandType.UUID, entityType = DiskOfferingResponse.class,
+            description = "the ID of the disk offering for the virtual machine. If the template is of ISO format, the diskOfferingId is for the root disk volume. "
+            + "Otherwise this parameter is used to indicate the offering for the data disk volume.")
+    private Long diskOfferingId;
+
+    @ACL
+    @Parameter(name = ApiConstants.SECURITY_GROUP_IDS, type = CommandType.LIST, collectionType = CommandType.UUID, entityType = SecurityGroupResponse.class,
+            description = "comma separated list of security group IDs that are going to be applied to the virtual machine. "
+            + "Should be passed only when VM is created from a zone with Basic Network support. Mutually exclusive with securitygroupnames parameter")
+    private List<Long> securityGroupIds;
+
+    @ACL
+    @Parameter(name = ApiConstants.SECURITY_GROUP_NAMES, type = CommandType.LIST, collectionType = CommandType.STRING, entityType = SecurityGroupResponse.class,
+            description = "comma separated list of security group names that are going to be applied to the virtual machine. "
+            + "Should be passed only when VM is created from a zone with Basic Network support. Mutually exclusive with securitygroupids parameter")
+    private List<String> securityGroupNames;
+
+    @ACL
+    @Parameter(name = ApiConstants.AFFINITY_GROUP_IDS, type = CommandType.LIST, collectionType = CommandType.UUID, entityType = AffinityGroupResponse.class,
+            description = "comma separated list of affinity groups IDs that are going to be applied to the virtual machine. "
+            + "Mutually exclusive with affinitygroupnames parameter")
+    private List<Long> affinityGroupIds;
+
+    @ACL
+    @Parameter(name = ApiConstants.AFFINITY_GROUP_NAMES, type = CommandType.LIST, collectionType = CommandType.STRING, entityType = AffinityGroupResponse.class,
+            description = "comma separated list of affinity groups names that are going to be applied to the virtual machine. "
+            + "Mutually exclusive with affinitygroupids parameter")
+    private List<String> affinityGroupNames;
+
+    @Parameter(name = ApiConstants.ACCOUNT, type = CommandType.STRING, description = "an optional account for the virtual machine. Must be used with domainId.")
+    private String accountName;
+
+    @Parameter(name = ApiConstants.DOMAIN_ID, type = CommandType.UUID, entityType = DomainResponse.class, description = "an optional domainId for the virtual machine. If the account parameter is used, domainId must also be used.")
+    private Long domainId;
+
+    public Long getZoneId() {
+        return zoneId;
+    }
+
+    public Long getPodId() {
+        return podId;
+    }
+
+    public Long getClusterId() {
+        return clusterId;
+    }
+
+    public Long getServiceOfferingId() {
+        return serviceOfferingId;
+    }
+
+    public Long getTemplateId() {
+        return templateId;
+    }
+
+    public String getHypervisor() {
+        return hypervisor;
+    }
+
+    public List<Long> getNetworkIds() {
+        return networkIds;
+    }
+
+    public Long getDiskOfferingId() {
+        return diskOfferingId;
+    }
+
+    public List<Long> getSecurityGroupIds() {
+        return securityGroupIds;
+    }
+
+    public List<String> getSecurityGroupNames() {
+        return securityGroupNames;
+    }
+
+    public String getUserData() {
+        return userData;
+    }
+
+    public String getSshKeyPairName() {
+        return sshKeyPairName;
+    }
+
+    public List<Long> getAffinityGroupIds() {
+        return affinityGroupIds;
+    }
+
+    public List<String> getAffinityGroupNames() {
+        return affinityGroupNames;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public Long getDomainId() {
+        return domainId;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    private void verifyInputs() {
+        if (count == null || count <= 0) {
+            throw new InvalidParameterValueException("Invalid value for 'virtualmachinecount' parameter, it should be a positive number");
+        }
+        if (podId != null && clusterId != null) {
+            throw new InvalidParameterValueException("'podid' parameter is mutually exclusive with 'clusterid' parameter");
+        }
+        if (securityGroupIds != null && securityGroupNames != null) {
+            throw new InvalidParameterValueException("'securitygroupids' parameter is mutually exclusive with 'securitygroupnames' parameter");
+        }
+        if (affinityGroupIds != null && affinityGroupNames != null) {
+            throw new InvalidParameterValueException("'affinitygroupids' parameter is mutually exclusive with 'affinitygroupnames' parameter");
+        }
+
+        DataCenter zone = _entityMgr.findById(DataCenter.class, zoneId);
+        ServiceOffering serviceOffering = _entityMgr.findById(ServiceOffering.class, serviceOfferingId);
+        if (!zone.isLocalStorageEnabled() && serviceOffering.getUseLocalStorage()) {
+            throw new InvalidParameterValueException("Zone " + zone.getName() + " is not configured to use local storage but service offering " + serviceOffering.getName() + " uses it");
+        }
+        if (serviceOffering.isDynamic()) {
+            throw new InvalidParameterValueException("Service offering " + serviceOffering.getName() + " is a custom one and not supported for bulk VM deployments");
+        }
+        if (diskOfferingId != null) {
+            DiskOffering diskOffering = _entityMgr.findById(DiskOffering.class, diskOfferingId);
+            if (!zone.isLocalStorageEnabled() && diskOffering.getUseLocalStorage()) {
+                throw new InvalidParameterValueException("Zone " + zone.getName() + " is not configured to use local storage but disk offering " + diskOffering.getName() + " uses it");
+            }
+            if (diskOffering.isCustomized()) {
+                throw new InvalidParameterValueException("Disk offering " + diskOffering.getName() + " is a custom one and not supported for bulk VM deployments");
+            }
+        }
+        if (zone.getNetworkType() == NetworkType.Basic) {
+            if (CollectionUtils.isNotEmpty(getNetworkIds())) {
+                throw new InvalidParameterValueException("Can't specify 'networkids' parameter in basic zone " + zone.getName());
+            }
+        } else {
+            if (!zone.isSecurityGroupEnabled()) {
+                if (CollectionUtils.isNotEmpty(getSecurityGroupIds()) || CollectionUtils.isNotEmpty(getSecurityGroupNames())) {
+                    throw new InvalidParameterValueException("Can't create VM with security groups; security group feature is not enabled for zone " + zone.getName());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void execute() throws ResourceAllocationException {
+        verifyInputs();
+        List<Long> jobIds = _userVmService.bulkDeployVirtualMachine(this);
+        List<AsyncJobResponse> jobs = _responseGenerator.createAsyncJobResponse(jobIds);
+        ListResponse<AsyncJobResponse> response = new ListResponse<AsyncJobResponse>();
+        response.setResponses(jobs, jobs.size());
+        response.setResponseName(getCommandName());
+        this.setResponseObject(response);
+    }
+
+    @Override
+    public String getCommandName() {
+        return s_name;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        Long accountId = _accountService.finalyzeAccountId(accountName, domainId, null, true);
+        if (accountId == null) {
+            return CallContext.current().getCallingAccount().getId();
+        }
+
+        return accountId;
+    }
+
+
+}

--- a/api/src/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -184,9 +184,17 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = ApiConstants.DEPLOYMENT_PLANNER, type = CommandType.STRING, description = "Deployment planner to use for vm allocation. Available to ROOT admin only", since = "4.4", authorized = { RoleType.Admin })
     private String deploymentPlanner;
 
+    protected Long podId = null;
+    protected Long clusterId = null;
+    protected List<Long> vmIds = new ArrayList<Long>();
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
+
+    public List<Long> getVmIds() {
+        return vmIds;
+    }
 
     public String getAccountName() {
         if (accountName == null) {
@@ -252,10 +260,12 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
             return displayVm;
     }
 
+    @Override
     public List<String> getSecurityGroupNameList() {
         return securityGroupNameList;
     }
 
+    @Override
     public List<Long> getSecurityGroupIdList() {
         return securityGroupIdList;
     }
@@ -278,6 +288,14 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
 
     public Long getZoneId() {
         return zoneId;
+    }
+
+    public Long getPodId() {
+        return podId;
+    }
+
+    public Long getClusterId() {
+        return clusterId;
     }
 
     public List<Long> getNetworkIds() {

--- a/engine/api/src/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntity.java
+++ b/engine/api/src/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntity.java
@@ -106,7 +106,7 @@ public interface VirtualMachineEntity extends CloudStackEntity {
      * @param reservationId reservation id from reserve call.
      *
      */
-    void deploy(String reservationId, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean deployOnGivenHost)
+    void deploy(String reservationId, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean retry)
             throws InsufficientCapacityException, ResourceUnavailableException;
 
     /**

--- a/engine/orchestration/src/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManager.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManager.java
@@ -39,7 +39,7 @@ public interface VMEntityManager {
     String reserveVirtualMachine(VMEntityVO vmEntityVO, DeploymentPlanner plannerToUse, DeploymentPlan plan, ExcludeList exclude) throws InsufficientCapacityException,
         ResourceUnavailableException;
 
-    void deployVirtualMachine(String reservationId, VMEntityVO vmEntityVO, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean deployOnGivenHost)
+    void deployVirtualMachine(String reservationId, VMEntityVO vmEntityVO, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean retry)
         throws InsufficientCapacityException, ResourceUnavailableException;
 
     boolean stopvirtualmachine(VMEntityVO vmEntityVO, String caller) throws ResourceUnavailableException;

--- a/engine/orchestration/src/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/cloud/entity/api/VMEntityManagerImpl.java
@@ -218,7 +218,7 @@ public class VMEntityManagerImpl implements VMEntityManager {
     }
 
     @Override
-    public void deployVirtualMachine(String reservationId, VMEntityVO vmEntityVO, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean deployOnGivenHost)
+    public void deployVirtualMachine(String reservationId, VMEntityVO vmEntityVO, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean retry)
         throws InsufficientCapacityException, ResourceUnavailableException {
         //grab the VM Id and destination using the reservationId.
 
@@ -233,9 +233,9 @@ public class VMEntityManagerImpl implements VMEntityManager {
                 _itMgr.start(vm.getUuid(), params, reservedPlan, _planningMgr.getDeploymentPlannerByName(vmReservation.getDeploymentPlanner()));
             } catch (Exception ex) {
                 // Retry the deployment without using the reservation plan
-                // Retry is only done if host id is not passed in deploy virtual machine api. Otherwise
-                // the instance may be started on another host instead of the intended one.
-                if (!deployOnGivenHost) {
+                // Retry is only done if host/cluster/pod id is not exlicitly passed, otherwise
+                // the instance may be started on another host/cluster/pod instead of the intended one
+                if (retry) {
                     DataCenterDeployment plan = new DataCenterDeployment(0, null, null, null, null, null);
 
                     if (reservedPlan.getAvoids() != null) {

--- a/engine/orchestration/src/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntityImpl.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/cloud/entity/api/VirtualMachineEntityImpl.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Component;
 import org.apache.cloudstack.engine.cloud.entity.api.db.VMEntityVO;
+import org.springframework.stereotype.Component;
 
 import com.cloud.deploy.DeploymentPlan;
 import com.cloud.deploy.DeploymentPlanner;
@@ -52,7 +52,7 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
     }
 
     public void init(String vmId, String owner, String hostName, String displayName, int cpu, int speed, long memory, List<String> computeTags,
-        List<String> rootDiskTags, List<String> networks) {
+            List<String> rootDiskTags, List<String> networks) {
         init(vmId);
         this.vmEntityVO.setOwner(owner);
         this.vmEntityVO.setHostname(hostName);
@@ -94,13 +94,11 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
 
     @Override
     public String getCurrentState() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public String getDesiredState() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -116,7 +114,6 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
 
     @Override
     public String getOwner() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -132,66 +129,53 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
 
     @Override
     public void delDetail(String name, String value) {
-        // TODO Auto-generated method stub
     }
 
     @Override
     public void updateDetail(String name, String value) {
-        // TODO Auto-generated method stub
     }
 
     @Override
     public List<Method> getApplicableActions() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public List<String> listVolumeIds() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public List<VolumeEntity> listVolumes() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public List<String> listNicUuids() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public List<NicEntity> listNics() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public TemplateEntity getTemplate() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public List<String> listTags() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void addTag() {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
     public void delTag() {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
@@ -202,14 +186,12 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
 
     @Override
     public void migrateTo(String reservationId, String caller) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
-    public void deploy(String reservationId, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean deployOnGivenHost) throws InsufficientCapacityException,
+    public void deploy(String reservationId, String caller, Map<VirtualMachineProfile.Param, Object> params, boolean retry) throws InsufficientCapacityException,
         ResourceUnavailableException {
-        manager.deployVirtualMachine(reservationId, this.vmEntityVO, caller, params, deployOnGivenHost);
+        manager.deployVirtualMachine(reservationId, this.vmEntityVO, caller, params, retry);
     }
 
     @Override
@@ -224,8 +206,6 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
 
     @Override
     public void cleanup() {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
@@ -235,38 +215,28 @@ public class VirtualMachineEntityImpl implements VirtualMachineEntity {
 
     @Override
     public VirtualMachineEntity duplicate(String externalId) {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public SnapshotEntity takeSnapshotOf() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void attach(VolumeEntity volume, short deviceId) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
     public void detach(VolumeEntity volume) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
     public void connectTo(NetworkEntity network, short nicId) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
     public void disconnectFrom(NetworkEntity netowrk, short nicId) {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -99,23 +99,26 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
 
     protected Attribute _updateTimeAttr;
 
-    private static final String ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART1 = "SELECT host.cluster_id, SUM(IF(vm.state='Running' AND vm.account_id = ?, 1, 0)) " +
-        "FROM `cloud`.`host` host LEFT JOIN `cloud`.`vm_instance` vm ON host.id = vm.host_id WHERE ";
-    private static final String ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2 = " AND host.type = 'Routing' AND host.removed is null GROUP BY host.cluster_id " +
-        "ORDER BY 2 ASC ";
+    private static final String ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART0 = "SELECT cluster_id, SUM(vm_count) FROM (";
+    private static final String ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART1 = "SELECT host.cluster_id AS cluster_id, SUM(IF(vm.state in ('Running', 'Starting') AND vm.account_id = ?, 1, 0)) AS vm_count " +
+            "FROM `cloud`.`host` host LEFT JOIN `cloud`.`vm_instance` vm ON host.id = vm.host_id WHERE ";
+    private static final String ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2 = " AND host.type = 'Routing' AND host.removed is null GROUP BY cluster_id UNION ALL " +
+            "SELECT rsv.cluster_id AS cluster_id, COUNT(rsv.cluster_id) AS vm_count FROM `cloud`.`vm_reservation` rsv LEFT JOIN `cloud`.`vm_instance` vm ON rsv.vm_id = vm.id WHERE vm.state in ('Stopped') AND vm.account_id = ? AND ";
+    private static final String ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART3 = " GROUP BY cluster_id) t GROUP BY cluster_id ORDER BY 2 ASC ";
 
-    private static final String ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT = "SELECT pod.id, SUM(IF(vm.state='Running' AND vm.account_id = ?, 1, 0)) FROM `cloud`.`" +
-        "host_pod_ref` pod LEFT JOIN `cloud`.`vm_instance` vm ON pod.id = vm.pod_id WHERE pod.data_center_id = ? AND pod.removed is null "
-        + " GROUP BY pod.id ORDER BY 2 ASC ";
+    private static final String ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT = "SELECT pod_id, SUM(vm_count) FROM (SELECT pod.id AS pod_id, SUM(IF(vm.state in ('Running', 'Starting') AND vm.account_id = ?, 1, 0)) AS vm_count " +
+            "FROM `cloud`.`host_pod_ref` pod LEFT JOIN `cloud`.`vm_instance` vm ON pod.id = vm.pod_id WHERE pod.data_center_id = ? AND pod.removed is null GROUP BY pod_id UNION ALL " +
+            "SELECT rsv.pod_id AS pod_id, COUNT(rsv.pod_id) AS vm_count FROM `cloud`.`vm_reservation` rsv LEFT JOIN `cloud`.`vm_instance` vm ON rsv.vm_id = vm.id WHERE vm.state in ('Stopped') AND vm.account_id = ? AND " +
+            "rsv.data_center_id = ? GROUP BY pod_id) t GROUP BY pod_id ORDER BY 2 ASC ";
 
-    private static final String ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT =
-        "SELECT host.id, SUM(IF(vm.state='Running' AND vm.account_id = ?, 1, 0)) FROM `cloud`.`host` host LEFT JOIN `cloud`.`vm_instance` vm ON host.id = vm.host_id " +
-            "WHERE host.data_center_id = ? AND host.type = 'Routing' AND host.removed is null ";
-
-    private static final String ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2 = " GROUP BY host.id ORDER BY 2 ASC ";
+    private static final String ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT = "SELECT host_id, SUM(vm_count) FROM (SELECT host.id AS host_id, SUM(IF(vm.state in ('Running', 'Starting') AND vm.account_id = ?, 1, 0)) AS vm_count " +
+            "FROM `cloud`.`host` host LEFT JOIN `cloud`.`vm_instance` vm ON host.id = vm.host_id WHERE host.data_center_id = ? AND host.type = 'Routing' AND host.removed is null ";
+    private static final String ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2 = " GROUP BY host_id UNION ALL SELECT rsv.host_id AS host_id, COUNT(rsv.host_id) AS vm_count " +
+            "FROM `cloud`.`vm_reservation` rsv LEFT JOIN `cloud`.`vm_instance` vm ON rsv.vm_id = vm.id WHERE vm.state in ('Stopped') AND vm.account_id = ? AND rsv.data_center_id = ? ";
+    private static final String ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT_PART3 = " GROUP BY host_id) t GROUP BY host_id ORDER BY 2 ASC ";
 
     private static final String COUNT_VMS_BASED_ON_VGPU_TYPES1 =
-            "SELECT pci, type, SUM(vmcount) FROM (SELECT MAX(IF(offering.name = 'pciDevice',value,'')) AS pci, MAX(IF(offering.name = 'vgpuType', value,'')) " +
+            "SELECT pci, type, SUM(vmcount) FROM (SELECT MAX(IF(offering.name = 'pciDevice', value, '')) AS pci, MAX(IF(offering.name = 'vgpuType', value, '')) " +
             "AS type, COUNT(DISTINCT vm.id) AS vmcount FROM service_offering_details offering INNER JOIN vm_instance vm ON offering.service_offering_id = vm.service_offering_id " +
             "INNER JOIN `cloud`.`host` ON vm.host_id = host.id WHERE vm.state = 'Running' AND host.data_center_id = ? ";
     private static final String COUNT_VMS_BASED_ON_VGPU_TYPES2 =
@@ -554,13 +557,18 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         List<Long> result = new ArrayList<Long>();
         Map<Long, Double> clusterVmCountMap = new HashMap<Long, Double>();
 
-        StringBuilder sql = new StringBuilder(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART1);
+        StringBuilder sql = new StringBuilder(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART0);
+        sql.append(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART1);
         sql.append("host.data_center_id = ?");
         sql.append(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2);
+        sql.append("rsv.data_center_id = ?");
+        sql.append(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART3);
         try {
             pstmt = txn.prepareAutoCloseStatement(sql.toString());
             pstmt.setLong(1, accountId);
             pstmt.setLong(2, zoneId);
+            pstmt.setLong(3, accountId);
+            pstmt.setLong(4, zoneId);
 
             ResultSet rs = pstmt.executeQuery();
             while (rs.next()) {
@@ -583,13 +591,18 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         List<Long> result = new ArrayList<Long>();
         Map<Long, Double> clusterVmCountMap = new HashMap<Long, Double>();
 
-        StringBuilder sql = new StringBuilder(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART1);
+        StringBuilder sql = new StringBuilder(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART0);
+        sql.append(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART1);
         sql.append("host.pod_id = ?");
         sql.append(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2);
+        sql.append("rsv.pod_id = ?");
+        sql.append(ORDER_CLUSTERS_NUMBER_OF_VMS_FOR_ACCOUNT_PART3);
         try {
             pstmt = txn.prepareAutoCloseStatement(sql.toString());
             pstmt.setLong(1, accountId);
             pstmt.setLong(2, podId);
+            pstmt.setLong(3, accountId);
+            pstmt.setLong(4, podId);
 
             ResultSet rs = pstmt.executeQuery();
             while (rs.next()) {
@@ -612,11 +625,13 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         PreparedStatement pstmt = null;
         List<Long> result = new ArrayList<Long>();
         Map<Long, Double> podVmCountMap = new HashMap<Long, Double>();
+        String sql = ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT;
         try {
-            String sql = ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT;
             pstmt = txn.prepareAutoCloseStatement(sql);
             pstmt.setLong(1, accountId);
             pstmt.setLong(2, dataCenterId);
+            pstmt.setLong(3, accountId);
+            pstmt.setLong(4, dataCenterId);
 
             ResultSet rs = pstmt.executeQuery();
             while (rs.next()) {
@@ -626,9 +641,9 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
             }
             return new Pair<List<Long>, Map<Long, Double>>(result, podVmCountMap);
         } catch (SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT, e);
+            throw new CloudRuntimeException("DB Exception on: " + sql, e);
         } catch (Throwable e) {
-            throw new CloudRuntimeException("Caught: " + ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT, e);
+            throw new CloudRuntimeException("Caught: " + sql, e);
         }
     }
 
@@ -637,26 +652,40 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<Long> result = new ArrayList<Long>();
+
+        StringBuilder sql = new StringBuilder(ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT);
+        if (podId != null) {
+            sql.append(" AND host.pod_id = ? ");
+        }
+        if (clusterId != null) {
+            sql.append(" AND host.cluster_id = ? ");
+        }
+        sql.append(ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2);
+        if (podId != null) {
+            sql.append(" AND rsv.pod_id = ? ");
+        }
+        if (clusterId != null) {
+            sql.append(" AND rsv.cluster_id = ? ");
+        }
+        sql.append(ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT_PART3);
         try {
-            String sql = ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT;
+            pstmt = txn.prepareAutoCloseStatement(sql.toString());
+            int position = 1;
+            pstmt.setLong(position, accountId);
+            pstmt.setLong(++position, dcId);
             if (podId != null) {
-                sql = sql + " AND host.pod_id = ? ";
-            }
-
-            if (clusterId != null) {
-                sql = sql + " AND host.cluster_id = ? ";
-            }
-
-            sql = sql + ORDER_HOSTS_NUMBER_OF_VMS_FOR_ACCOUNT_PART2;
-
-            pstmt = txn.prepareAutoCloseStatement(sql);
-            pstmt.setLong(1, accountId);
-            pstmt.setLong(2, dcId);
-            if (podId != null) {
-                pstmt.setLong(3, podId);
+                pstmt.setLong(++position, podId);
             }
             if (clusterId != null) {
-                pstmt.setLong(4, clusterId);
+                pstmt.setLong(++position, clusterId);
+            }
+            pstmt.setLong(++position, accountId);
+            pstmt.setLong(++position, dcId);
+            if (podId != null) {
+                pstmt.setLong(++position, podId);
+            }
+            if (clusterId != null) {
+                pstmt.setLong(++position, clusterId);
             }
 
             ResultSet rs = pstmt.executeQuery();
@@ -665,28 +694,25 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
             }
             return result;
         } catch (SQLException e) {
-            throw new CloudRuntimeException("DB Exception on: " + ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT, e);
+            throw new CloudRuntimeException("DB Exception on: " + sql, e);
         } catch (Throwable e) {
-            throw new CloudRuntimeException("Caught: " + ORDER_PODS_NUMBER_OF_VMS_FOR_ACCOUNT, e);
+            throw new CloudRuntimeException("Caught: " + sql, e);
         }
     }
 
     @Override
     public HashMap<String, Long> countVgpuVMs(Long dcId, Long podId, Long clusterId) {
-        StringBuilder finalQuery = new StringBuilder();
         TransactionLegacy txn = TransactionLegacy.currentTxn();
         PreparedStatement pstmt = null;
         List<Long> resourceIdList = new ArrayList<Long>();
         HashMap<String, Long> result = new HashMap<String, Long>();
 
         resourceIdList.add(dcId);
-        finalQuery.append(COUNT_VMS_BASED_ON_VGPU_TYPES1);
-
+        StringBuilder finalQuery = new StringBuilder(COUNT_VMS_BASED_ON_VGPU_TYPES1);
         if (podId != null) {
             finalQuery.append("AND host.pod_id = ? ");
             resourceIdList.add(podId);
         }
-
         if (clusterId != null) {
             finalQuery.append("AND host.cluster_id = ? ");
             resourceIdList.add(clusterId);

--- a/server/src/com/cloud/api/ApiDBUtils.java
+++ b/server/src/com/cloud/api/ApiDBUtils.java
@@ -184,6 +184,7 @@ import com.cloud.network.dao.AccountGuestVlanMapDao;
 import com.cloud.network.dao.AccountGuestVlanMapVO;
 import com.cloud.network.dao.FirewallRulesCidrsDao;
 import com.cloud.network.dao.FirewallRulesDao;
+import com.cloud.network.dao.FirewallRulesDcidrsDao;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.LoadBalancerDao;
@@ -275,6 +276,7 @@ import com.cloud.template.TemplateManager;
 import com.cloud.template.VirtualMachineTemplate;
 import com.cloud.user.Account;
 import com.cloud.user.AccountDetailsDao;
+import com.cloud.user.AccountManager;
 import com.cloud.user.AccountService;
 import com.cloud.user.AccountVO;
 import com.cloud.user.ResourceLimitService;
@@ -310,8 +312,6 @@ import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
 import com.cloud.vm.snapshot.VMSnapshot;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
-import com.cloud.user.AccountManager;
-import com.cloud.network.dao.FirewallRulesDcidrsDao;
 
 public class ApiDBUtils {
     private static ManagementServer s_ms;
@@ -1882,8 +1882,12 @@ public class ApiDBUtils {
         return s_jobJoinDao.newAsyncJobResponse(ve);
     }
 
-    public static AsyncJobJoinVO newAsyncJobView(AsyncJob e) {
-        return s_jobJoinDao.newAsyncJobView(e);
+    public static AsyncJobJoinVO newAsyncJobView(AsyncJob job) {
+        return newAsyncJobView(job.getId());
+    }
+
+    public static AsyncJobJoinVO newAsyncJobView(long jobId) {
+        return s_jobJoinDao.newAsyncJobView(jobId);
     }
 
     public static DiskOfferingResponse newDiskOfferingResponse(DiskOfferingJoinVO offering) {

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3799,4 +3799,15 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setDomainName(domain.getName());
         return response;
     }
+
+    @Override
+    public List<AsyncJobResponse> createAsyncJobResponse(List<Long> jobIds) {
+        List<AsyncJobResponse> respList = new ArrayList<AsyncJobResponse>();
+        for (Long jobId : jobIds) {
+            AsyncJobJoinVO job = ApiDBUtils.newAsyncJobView(jobId.longValue());
+            respList.add(ApiDBUtils.newAsyncJobResponse(job));
+        }
+        return respList;
+    }
+
 }

--- a/server/src/com/cloud/api/query/dao/AsyncJobJoinDao.java
+++ b/server/src/com/cloud/api/query/dao/AsyncJobJoinDao.java
@@ -17,15 +17,14 @@
 package com.cloud.api.query.dao;
 
 import org.apache.cloudstack.api.response.AsyncJobResponse;
-import org.apache.cloudstack.framework.jobs.AsyncJob;
 
 import com.cloud.api.query.vo.AsyncJobJoinVO;
 import com.cloud.utils.db.GenericDao;
 
 public interface AsyncJobJoinDao extends GenericDao<AsyncJobJoinVO, Long> {
 
-    AsyncJobResponse newAsyncJobResponse(AsyncJobJoinVO vol);
+    AsyncJobResponse newAsyncJobResponse(AsyncJobJoinVO job);
 
-    AsyncJobJoinVO newAsyncJobView(AsyncJob vol);
+    AsyncJobJoinVO newAsyncJobView(long jobId);
 
 }

--- a/server/src/com/cloud/api/query/dao/AsyncJobJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/AsyncJobJoinDaoImpl.java
@@ -19,13 +19,10 @@ package com.cloud.api.query.dao;
 import java.util.Date;
 import java.util.List;
 
-
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
 import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.response.AsyncJobResponse;
-import org.apache.cloudstack.framework.jobs.AsyncJob;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.api.ApiSerializerHelper;
 import com.cloud.api.SerializationContext;
@@ -89,13 +86,12 @@ public class AsyncJobJoinDaoImpl extends GenericDaoBase<AsyncJobJoinVO, Long> im
     }
 
     @Override
-    public AsyncJobJoinVO newAsyncJobView(AsyncJob job) {
+    public AsyncJobJoinVO newAsyncJobView(long jobId) {
         SearchCriteria<AsyncJobJoinVO> sc = jobIdSearch.create();
-        sc.setParameters("id", job.getId());
-        List<AsyncJobJoinVO> accounts = searchIncludingRemoved(sc, null, null, false);
-        assert accounts != null && accounts.size() == 1 : "No async job found for job id " + job.getId();
-        return accounts.get(0);
-
+        sc.setParameters("id", jobId);
+        List<AsyncJobJoinVO> jobs = searchIncludingRemoved(sc, null, null, false);
+        assert jobs != null && jobs.size() == 1 : "No async job found for job id " + jobId;
+        return jobs.get(0);
     }
 
 }

--- a/server/src/com/cloud/network/as/AutoScaleManagerImpl.java
+++ b/server/src/com/cloud/network/as/AutoScaleManagerImpl.java
@@ -1372,7 +1372,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
     private boolean startNewVM(long vmId) {
         try {
             CallContext.current().setEventDetails("Vm Id: " + vmId);
-            _userVmManager.startVirtualMachine(vmId, null, null, null);
+            _userVmManager.startVirtualMachine(vmId, null, null, null, null, null, null);
         } catch (final ResourceUnavailableException ex) {
             s_logger.warn("Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.RESOURCE_UNAVAILABLE_ERROR, ex.getMessage());

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -232,6 +232,7 @@ import org.apache.cloudstack.api.command.admin.vlan.ListVlanIpRangesCmd;
 import org.apache.cloudstack.api.command.admin.vlan.ReleasePublicIpRangeCmd;
 import org.apache.cloudstack.api.command.admin.vm.AddNicToVMCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.vm.AssignVMCmd;
+import org.apache.cloudstack.api.command.admin.vm.BulkDeployVMCmd;
 import org.apache.cloudstack.api.command.admin.vm.DeployVMCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.vm.DestroyVMCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.vm.ExpungeVMCmd;
@@ -2822,6 +2823,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(UpdateTemplatePermissionsCmd.class);
         cmdList.add(AddNicToVMCmd.class);
         cmdList.add(DeployVMCmd.class);
+        cmdList.add(BulkDeployVMCmd.class);
         cmdList.add(DestroyVMCmd.class);
         cmdList.add(ExpungeVMCmd.class);
         cmdList.add(GetVMPasswordCmd.class);

--- a/server/src/com/cloud/vm/UserVmManager.java
+++ b/server/src/com/cloud/vm/UserVmManager.java
@@ -91,19 +91,20 @@ public interface UserVmManager extends UserVmService {
 
     boolean expunge(UserVmVO vm, long callerUserId, Account caller);
 
-    Pair<UserVmVO, Map<VirtualMachineProfile.Param, Object>> startVirtualMachine(long vmId, Long hostId, Map<VirtualMachineProfile.Param, Object> additionalParams, String deploymentPlannerToUse)
-        throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException;
+    Pair<UserVmVO, Map<VirtualMachineProfile.Param, Object>> startVirtualMachine(long vmId, Long hostId, Map<VirtualMachineProfile.Param, Object> additionalParams,
+            String deploymentPlannerToUse, Long podId, Long clusterId, List<Long> vmIds)
+            throws ConcurrentOperationException, ResourceUnavailableException, InsufficientCapacityException;
 
-    boolean upgradeVirtualMachine(Long id, Long serviceOfferingId, Map<String, String> customParameters) throws ResourceUnavailableException,
-        ConcurrentOperationException, ManagementServerException,
-        VirtualMachineMigrationException;
+    boolean upgradeVirtualMachine(Long id, Long serviceOfferingId, Map<String, String> customParameters)
+            throws ResourceUnavailableException, ConcurrentOperationException, ManagementServerException, VirtualMachineMigrationException;
 
     boolean setupVmForPvlan(boolean add, Long hostId, NicProfile nic);
 
     void collectVmDiskStatistics(UserVmVO userVm);
 
     UserVm updateVirtualMachine(long id, String displayName, String group, Boolean ha, Boolean isDisplayVmEnabled, Long osTypeId, String userData,
-                                Boolean isDynamicallyScalable, HTTPMethod httpMethod, String customId, String hostName, String instanceName, List<Long> securityGroupIdList) throws ResourceUnavailableException, InsufficientCapacityException;
+            Boolean isDynamicallyScalable, HTTPMethod httpMethod, String customId, String hostName, String instanceName, List<Long> securityGroupIdList)
+            throws ResourceUnavailableException, InsufficientCapacityException;
 
     //the validateCustomParameters, save and remove CustomOfferingDetils functions can be removed from the interface once we can
     //find a common place for all the scaling and upgrading code of both user and systemvms.

--- a/test/integration/smoke/misc/test_bulk_deploy_vm.py
+++ b/test/integration/smoke/misc/test_bulk_deploy_vm.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# All tests inherit from cloudstackTestCase
+from marvin.cloudstackTestCase import cloudstackTestCase
+
+# Import Integration Libraries
+from marvin.cloudstackAPI import (bulkDeployVirtualMachine,
+                                  queryAsyncJobResult)
+from marvin.codes import (FAILED, JOB_FAILED,
+                          JOB_CANCELLED, JOB_SUCCEEDED)
+# base - contains all resources as entities and defines create, delete, list operations on them
+from marvin.lib.base import (Account, Cluster, Host, Pod,
+                             ServiceOffering, VirtualMachine)
+# utils - utility classes for common cleanup, external library wrappers etc
+from marvin.lib.utils import cleanup_resources
+# common - commonly used methods for all tests are listed here
+from marvin.lib.common import get_zone, get_domain, get_template
+
+from nose.plugins.attrib import attr
+import time
+
+
+class TestBulkDeployVM(cloudstackTestCase):
+    """Test bulk VM deploy into user account
+    """
+
+    def setUp(self):
+        self.testdata = self.testClient.getParsedTestDataConfig()
+        self.apiclient = self.testClient.getApiClient()
+
+        # Get zone, domain and default built-in template
+        self.domain = get_domain(self.apiclient)
+        self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
+        self.testdata["mode"] = self.zone.networktype
+        self.template = get_template(self.apiclient, self.zone.id, self.testdata["ostype"])
+
+        # create a user account
+        self.account = Account.create(
+            self.apiclient,
+            self.testdata["account"],
+            domainid=self.domain.id
+        )
+        # create a service offering
+        self.testdata["service_offerings"]["tiny"]["deploymentplanner"] = "UserDispersingPlanner"
+        self.service_offering = ServiceOffering.create(
+            self.apiclient,
+            self.testdata["service_offerings"]["tiny"]
+        )
+        # build cleanup list
+        self.cleanup = [
+            self.service_offering,
+            self.account
+        ]
+
+    def query_async_job(self, jobid):
+        """Query the status for Async Job"""
+        try:
+            async_timeout = 300
+            cmd = queryAsyncJobResult.queryAsyncJobResultCmd()
+            cmd.jobid = jobid
+            timeout = async_timeout
+            async_response = FAILED
+            while timeout > 0:
+                async_response = self.apiclient.queryAsyncJobResult(cmd)
+                if async_response != FAILED:
+                    job_status = async_response.jobstatus
+                    if job_status in [JOB_CANCELLED, JOB_SUCCEEDED]:
+                        break
+                    elif job_status == JOB_FAILED:
+                        raise Exception("Job failed: %s" % async_response)
+                time.sleep(5)
+                timeout -= 5
+            return async_response
+        except Exception as e:
+            return FAILED
+
+    def bulk_deploy_vm(self, clusters, clusterid=None, podid=None):
+        """Test bulk deploy of VM
+        """
+
+        self.assertTrue(isinstance(clusters, list) and len(clusters) > 0, msg="No clusters present")
+
+        vm_count = len(clusters) * 2 - 1
+        avg_vm_count_per_cluster = (vm_count + 1)/(len(clusters))
+
+        cmd = bulkDeployVirtualMachine.bulkDeployVirtualMachineCmd()
+        cmd.serviceofferingid = self.service_offering.id
+        cmd.templateid = self.template.id
+        cmd.virtualmachinecount = vm_count
+        cmd.zoneid = self.zone.id
+        cmd.account = self.account.name
+        cmd.domainid = self.account.domainid
+        if clusterid is not None:
+            cmd.clusterid = clusterid
+        if podid is not None:
+            cmd.podid = podid
+
+        jobs = self.apiclient.bulkDeployVirtualMachine(cmd)
+        self.assertTrue(isinstance(jobs, list) and len(jobs) > 0, msg="Bulk VM deploy response is empty")
+        self.assertEqual(len(jobs), vm_count, msg="Required number of VM creation jobs not scheduled")
+        for job in jobs:
+            self.query_async_job(job.jobid)
+
+        for cluster in clusters:
+            cluster_vm_count = 0
+            hosts = Host.list(self.apiclient,
+                              clusterid=cluster.id)
+            for host in hosts:
+                vms = VirtualMachine.list(self.apiclient,
+                                          account=self.account.name,
+                                          domainid=self.account.domainid,
+                                          hostid=host.id)
+                if isinstance(vms, list):
+                    cluster_vm_count += len(vms)
+            self.assertTrue(avg_vm_count_per_cluster-1 <= cluster_vm_count <= avg_vm_count_per_cluster+1,
+                            "VM distribution is not proper")
+
+    @attr(tags=['advanced', 'basic'], required_hardware="false")
+    def test_bulk_deploy_vm(self):
+        """Test bulk deploy of VM
+        """
+
+        clusters = Cluster.list(self.apiclient)
+        self.bulk_deploy_vm(clusters)
+
+    @attr(tags=['advanced', 'basic'], required_hardware="false")
+    def test_bulk_deploy_vm_with_cluster(self):
+        """Test bulk deploy of VM in specific cluster
+        """
+
+        clusters = Cluster.list(self.apiclient)
+        self.assertTrue(isinstance(clusters, list) and len(clusters) > 0, msg="No clusters present")
+        cluster = clusters[0]
+        self.bulk_deploy_vm([cluster], clusterid=cluster.id)
+
+    def test_bulk_deploy_vm_with_pod(self):
+        """Test bulk deploy of VM in specific pod
+        """
+
+        pods = Pod.list(self.apiclient)
+        self.assertTrue(isinstance(pods, list) and len(pods) > 0, msg="No pods present")
+        pod = pods[0]
+        clusters = Cluster.list(self.apiclient, podid=pod.id)
+        self.bulk_deploy_vm(clusters, clusterid=None, podid=pod.id)
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)


### PR DESCRIPTION
Added a new API to support bulk deployment of VMs. There is also an option to specify pod or cluster to deploy the VMs.
VMs will be appropriately placed based on selected deployment planner and the existing VM distribution based on count.
For details refer the FS @ https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=70258861