### PR TITLE
CLOUDSTACK-9955 : Featured Templates/Iso's created by Root/admin user are not visible to Domain Admin users

### DIFF
--- a/server/src/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/com/cloud/api/query/QueryManagerImpl.java
@@ -3147,13 +3147,13 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 ex.addProxyObject(template.getUuid(), "templateId");
                 throw ex;
             }
-            if (caller.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN) {
+            if (!template.isPublicTemplate() && caller.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN) {
                 Account template_acc = _accountMgr.getAccount(template.getAccountId());
                 DomainVO domain = _domainDao.findById(template_acc.getDomainId());
                 _accountMgr.checkAccess(caller, domain);
+            }
 
-
-            }// if template is not public, perform permission check here
+            // if template is not public, perform permission check here
             else if (!template.isPublicTemplate() && caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
                 _accountMgr.checkAccess(caller, null, false, template);
             }


### PR DESCRIPTION
ISSUE
============
Featured Templates/Iso's created by Root/admin user are not visible to Domain Admin users.

STEPS TO REPRODUCE
==================
Mark a template as featured and try to view it from a domain admin user
The issue occurs for both templates and iso's registered before and after upgrade
Templates,ISO's whose owner is ROOT admin, public: Yes, featured: Yes
Log in to UI (as a domain admin, such as an admin of “TEST/TEST1” domain)
Choose “Templates”.
Error message will be shown on UI

**Screenshot before applying fix :**
![screenshot before fix](https://user-images.githubusercontent.com/25146827/27066446-ea820736-5021-11e7-860a-2d7af3cb1add.png)

**Screenshot after applying fix :**
![screenshot after fix](https://user-images.githubusercontent.com/25146827/27066455-f8126738-5021-11e7-98e9-1023449a18e7.png)
