### PR TITLE
CLOUDSTACK-9956 File search on the vmware datastore may select wrong file if there are multiple files with same name.

### DIFF
--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -531,6 +531,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
                 // FIXME: Fix                    long checkPointId2 = _checkPointMgr.pushCheckPoint(new VmwareCleanupMaid(hostDetails.get("guid"), workerName2));
                 cmd.setContextParam("worker2", workerName2);
                 cmd.setContextParam("checkpoint2", String.valueOf(checkPointId2));
+                cmd.setContextParam("searchexludefolders", _vmwareMgr.s_vmwareSearchExcludeFolder.value());
             }
 
             return new Pair<Boolean, Long>(Boolean.TRUE, cmdTarget.first().getId());

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManager.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManager.java
@@ -39,6 +39,9 @@ public interface VmwareManager {
     public static final ConfigKey<Boolean> s_vmwareCleanOldWorderVMs = new ConfigKey<Boolean>("Advanced", Boolean.class, "vmware.clean.old.worker.vms", "false",
             "If a worker vm is older then twice the 'job.expire.minutes' + 'job.cancel.threshold.minutes' , remove it.", true, ConfigKey.Scope.Global);
 
+    static final ConfigKey<String> s_vmwareSearchExcludeFolder = new ConfigKey<String>("Advanced", String.class, "vmware.search.exclude.folders", null,
+            "Comma seperated list of Datastore Folders to exclude from VMWare search", true, ConfigKey.Scope.Global);
+
     String composeWorkerName();
 
     String getSystemVMIsoFileNameOnDatastore();

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -229,7 +229,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {s_vmwareNicHotplugWaitTimeout, s_vmwareCleanOldWorderVMs, templateCleanupInterval};
+        return new ConfigKey<?>[] {s_vmwareNicHotplugWaitTimeout, s_vmwareCleanOldWorderVMs, templateCleanupInterval, s_vmwareSearchExcludeFolder};
     }
 
     @Override

--- a/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/com/cloud/hypervisor/vmware/manager/VmwareStorageManagerImpl.java
@@ -307,6 +307,7 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
         String snapshotUuid = cmd.getSnapshotUuid(); // not null: Precondition.
         String prevSnapshotUuid = cmd.getPrevSnapshotUuid();
         String prevBackupUuid = cmd.getPrevBackupUuid();
+        String searchExcludedFolders = cmd.getContextParam("searchexludefolders");
         VirtualMachineMO workerVm = null;
         String workerVMName = null;
         String volumePath = cmd.getVolumePath();
@@ -344,7 +345,7 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
                         workerVm = vmMo;
 
                         // attach volume to worker VM
-                        String datastoreVolumePath = getVolumePathInDatastore(dsMo, volumePath + ".vmdk");
+                        String datastoreVolumePath = getVolumePathInDatastore(dsMo, volumePath + ".vmdk", searchExcludedFolders);
                         vmMo.attachDisk(new String[] {datastoreVolumePath}, morDs);
                     }
                 }
@@ -986,6 +987,8 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
         VirtualMachineMO workerVm = null;
         VirtualMachineMO vmMo = null;
         String exportName = UUID.randomUUID().toString();
+        String searchExcludedFolders = cmd.getContextParam("searchexludefolders");
+
 
         try {
             ManagedObjectReference morDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, poolId);
@@ -1009,7 +1012,7 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
                 }
 
                 //attach volume to worker VM
-                String datastoreVolumePath = getVolumePathInDatastore(dsMo, volumePath + ".vmdk");
+                String datastoreVolumePath = getVolumePathInDatastore(dsMo, volumePath + ".vmdk", searchExcludedFolders);
                 workerVm.attachDisk(new String[] {datastoreVolumePath}, morDs);
                 vmMo = workerVm;
             }
@@ -1030,8 +1033,8 @@ public class VmwareStorageManagerImpl implements VmwareStorageManager {
         }
     }
 
-    private String getVolumePathInDatastore(DatastoreMO dsMo, String volumeFileName) throws Exception {
-        String datastoreVolumePath = dsMo.searchFileInSubFolders(volumeFileName, true);
+    private String getVolumePathInDatastore(DatastoreMO dsMo, String volumeFileName, String searchExcludeFolders) throws Exception {
+        String datastoreVolumePath = dsMo.searchFileInSubFolders(volumeFileName, true, searchExcludeFolders);
         if (datastoreVolumePath == null) {
             throw new CloudRuntimeException("Unable to find file " + volumeFileName + " in datastore " + dsMo.getName());
         }

--- a/vmware-base/test/com/cloud/hypervisor/vmware/mo/DatastoreMOTest.java
+++ b/vmware-base/test/com/cloud/hypervisor/vmware/mo/DatastoreMOTest.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.cloud.hypervisor.vmware.mo;
+
+import com.cloud.hypervisor.vmware.util.VmwareClient;
+import com.cloud.hypervisor.vmware.util.VmwareContext;
+import com.vmware.vim25.FileInfo;
+import com.vmware.vim25.HostDatastoreBrowserSearchResults;
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.VimPortType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by sudharma_jain on 6/13/17.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(DatastoreMO.class)
+public class DatastoreMOTest {
+    @Mock
+    VmwareContext _context ;
+    @Mock
+    VmwareClient _client;
+    @Mock
+    ManagedObjectReference _mor;
+    @Mock
+    HostDatastoreBrowserMO browserMo;
+    @Mock
+    VimPortType vimPortType;
+
+    DatastoreMO datastoreMO ;
+    String fileName = "ROOT-5.vmdk";
+
+
+    @Before
+    public void setUp() throws Exception {
+
+        datastoreMO = new DatastoreMO(_context, _mor);
+        PowerMockito.whenNew(HostDatastoreBrowserMO.class).withAnyArguments().thenReturn(browserMo);
+        when(_context.getVimClient()).thenReturn(_client);
+        when(_client.getDynamicProperty(any(ManagedObjectReference.class), eq("name"))).thenReturn("252d36c96cfb32f48ce7756ccb79ae37");
+
+        ArrayList<HostDatastoreBrowserSearchResults> results = new ArrayList<>();
+
+        HostDatastoreBrowserSearchResults r1 =  new HostDatastoreBrowserSearchResults();
+        FileInfo f1 = new FileInfo();
+        f1.setPath(fileName);
+        r1.getFile().add(f1);
+        r1.setFolderPath("[252d36c96cfb32f48ce7756ccb79ae37] .snapshot/hourly.2017-02-23_1705/i-2-5-VM/");
+
+        HostDatastoreBrowserSearchResults r2 =  new HostDatastoreBrowserSearchResults();
+        FileInfo f2 = new FileInfo();
+        f2.setPath(fileName);
+        r2.getFile().add(f2);
+        r2.setFolderPath("[252d36c96cfb32f48ce7756ccb79ae37] .snapshot/hourly.2017-02-23_1605/i-2-5-VM/");
+
+        HostDatastoreBrowserSearchResults r3 =  new HostDatastoreBrowserSearchResults();
+        FileInfo f3 = new FileInfo();
+        f3.setPath(fileName);
+        r3.getFile().add(f3);
+        r3.setFolderPath("[252d36c96cfb32f48ce7756ccb79ae37] i-2-5-VM/");
+
+        results.add(r1);
+        results.add(r2);
+        results.add(r3);
+
+        when(browserMo.searchDatastore(any(String.class), any(String.class), eq(true))).thenReturn(null);
+        when(browserMo.searchDatastoreSubFolders(any(String.class),any(String.class), any(Boolean.class) )).thenReturn(results);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void testSearchFileInSubFolders() throws Exception {
+        assertEquals("Unexpected Behavior: search should exclude .snapshot folder", "[252d36c96cfb32f48ce7756ccb79ae37] i-2-5-VM/ROOT-5.vmdk", datastoreMO.searchFileInSubFolders(fileName, false, ".snapshot") );
+    }
+
+    @Test
+    public void testSearchFileInSubFoldersWithExcludeMultipleFolders() throws Exception {
+        assertEquals("Unexpected Behavior: search should exclude folders", datastoreMO.searchFileInSubFolders(fileName, false, "i-2-5-VM, .snapshot/hourly.2017-02-23_1705"), "[252d36c96cfb32f48ce7756ccb79ae37] .snapshot/hourly.2017-02-23_1605/i-2-5-VM/ROOT-5.vmdk" );
+    }
+
+}


### PR DESCRIPTION
if there are multiple files with the same name on vmware datastore, search operation may select any one file during volume related operations. This involves volume attach/detach, volume download, volume snapshot etc.

While using NetApp as the backup solution. This has .snapshot folder on the datastore and sometimes files from this folder gets selected during volume operations and the operation fails. Because of wrong selection of file following exception can be observed while volume deletion. 

2017-02-23 19:39:05,750 ERROR [c.c.s.r.VmwareStorageProcessor] (DirectAgent-304:ctx-a1dbf5d8 ac.local) delete volume failed due to Exception: java.lang.RuntimeException
Message: Cannot delete file [4cbcd46d44c53f5c8244c0aad26a97e1] .snapshot/hourly.2017-02-23_1605/r-97-VM/ROOT-97.vmdk

 To fix this behavior I have added a global configuration by name vmware.search.exclude.folders which can be comma separated list of folder paths.  

I have also added a unit test to test the new method.
