### PR TITLE
CLOUDSTACK-9964 : Snapahots are not getting deleted properly, if VM is assigned to another user

### DIFF
--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -289,6 +289,7 @@ import com.cloud.vm.dao.VMInstanceDao;
 import com.cloud.vm.snapshot.VMSnapshotManager;
 import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
+import com.cloud.storage.snapshot.SnapshotApiService;
 
 public class UserVmManagerImpl extends ManagerBase implements UserVmManager, VirtualMachineGuru, UserVmService, Configurable {
     private static final Logger s_logger = Logger.getLogger(UserVmManagerImpl.class);
@@ -475,6 +476,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     protected VMNetworkMapDao _vmNetworkMapDao;
     @Inject
     protected IpAddressManager _ipAddrMgr;
+    @Inject
+    private SnapshotApiService _snapshotService;
 
     protected ScheduledExecutorService _executor = null;
     protected ScheduledExecutorService _vmIpFetchExecutor = null;
@@ -5234,7 +5237,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             //snapshots: mark these removed in db
             List<SnapshotVO> snapshots = _snapshotDao.listByVolumeIdIncludingRemoved(volume.getId());
             for (SnapshotVO snapshot : snapshots) {
-                _snapshotDao.remove(snapshot.getId());
+                    boolean result = _snapshotService.deleteSnapshot(snapshot.getId());
+                    if (result) {
+                        s_logger.info("Snapshot id: " + snapshot.getId() + " delete successfully ");
+                    } else {
+                        s_logger.error("Unable to delete Snapshot id: " + snapshot.getId());
+                    }
             }
         }
 


### PR DESCRIPTION
When VM is assigned to another account , snapshots related to VM were deleted(soft delete) in db but not in physical storage.It will be no use of the untracked files in file storage if the snapshot is deleted in cloud stack db. 

This PR provide solution for removing the snapshot permanently in db as well as from storage whenever a VM is assigned to another user. 