### PR TITLE
CLOUDSTACK-9979 - Fix test_volumes.py test

### DIFF
--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -245,7 +245,7 @@ class TestCreateVolume(cloudstackTestCase):
             elif list_volume_response[0].hypervisor.lower() == "hyperv":
                 ret = checkVolumeSize(ssh_handle=ssh,volume_name="/dev/sdb",size_to_verify=vol_sz)
             else:
-                ret = checkVolumeSize(ssh_handle=ssh,size_to_verify=vol_sz)
+                ret = checkVolumeSize(ssh_handle=ssh,volume_name="/dev/sdb",size_to_verify=vol_sz)
             self.debug(" Volume Size Expected %s  Actual :%s" %(vol_sz,ret[1]))
             self.virtual_machine.detach_volume(self.apiClient, volume)
             self.assertEqual(ret[0],SUCCESS,"Check if promised disk size actually available")


### PR DESCRIPTION
This is a test fix of the create_volume test. This test was failing was in Trillian.