### PR TITLE
CLOUDSTACK-9939 : Volumes stuck in Creating state while restarting the Management Server when the volume creation is in progress

### DIFF
--- a/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -84,6 +84,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.exception.ExceptionUtil;
 import com.cloud.utils.mgmt.JmxUtil;
 import com.cloud.vm.dao.VMInstanceDao;
+import com.cloud.storage.dao.VolumeDao;
 
 public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager, ClusterManagerListener, Configurable {
     // Advanced
@@ -123,6 +124,8 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
     private VMInstanceDao _vmInstanceDao;
     @Inject
     private VolumeDetailsDao _volumeDetailsDao;
+    @Inject
+    private VolumeDao _volsDao;
 
     private volatile long _executionRunNumber = 1;
 
@@ -1020,6 +1023,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
 
                             try {
                                 _volumeDetailsDao.removeDetail(job.getInstanceId(), "SNAPSHOT_ID");
+                                _volsDao.remove(job.getInstanceId());
                             } catch (Exception e) {
                                 s_logger.error("Unexpected exception while removing concurrent request meta data :" + e.getLocalizedMessage());
                             }


### PR DESCRIPTION
This PR provides solution for the Bug : Volumes stuck in Creating state while restarting the Management Server when the volume creation is in progress