### PR TITLE
CLOUDSTACK-9981 : Regression occurs after upgrading to 4.10 while registering a template.

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/template/RegisterTemplateCmd.java
@@ -148,7 +148,6 @@ public class RegisterTemplateCmd extends BaseCmd {
             collectionType = CommandType.UUID,
             entityType = ZoneResponse.class,
             required=false,
-            since="4.10.0.0",
             description="A list of zone ids where the template will be hosted. Use this parameter if the template needs " +
                     "to be registered to multiple zones in one go. Use zoneid if the template " +
                     "needs to be registered to only one zone." +


### PR DESCRIPTION
When an environment is upgraded to 4.10, then while registering template for a zone from cloudstack UI will fail if it is created in older version(before 3.x). 

This bug got introduced with the PR#1894 for CLOUDSTACK-9700. In this PR a new parameter ‘zoneIds’ was added to the registerTemplate api and is marked with the ‘since’ attribute as ‘4.10.0.0’. since attribute is suppose to provide version for the containing data, not about when parameter was introduced. Although the parameter was introduced in 4.10, but it can contain the information from earlier version, thus it is wrongly marked here as ‘4.10.0.0’.  

This issue occurs because zones from older version have UUID parameter value as Integer, whereas higher version zones have fixed format. So while fetching the ZoneIds for installing templates, parsing for UUID with integer value fails and hence template is not installed.

Fix :

For the sake of backward compatibility, along with UUID, integer is also being parsed while retrieving ZoneId for the installing templates. Integer value of UUID cannot be converted into the fixed format because this value is used as a hard coded value in few automation scripts which runs locally for some customers. Hence, "since" attribute should be removed from a parameter command for ZoneIds. 

**Screenshot before applying fix :**
![screenshot before fix](https://user-images.githubusercontent.com/25146827/27779107-3fda7e36-5fde-11e7-8502-2d62a32368dd.png)

**Screenshot after applying fix :**
![screenshot after fix](https://user-images.githubusercontent.com/25146827/27779117-4cc9ee60-5fde-11e7-8df7-320bbb9ea879.png)
