### PR TITLE
[4.9+] CLOUDSTACK-9983: Hide credentials in listClusters response

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/ClusterResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/ClusterResponse.java
@@ -208,6 +208,12 @@ public class ClusterResponse extends BaseResponse {
         if (details == null) {
             return;
         }
-        this.resourceDetails = new HashMap<>(details);
+        resourceDetails = new HashMap<>(details);
+        if (resourceDetails.containsKey("username")) {
+            resourceDetails.remove("username");
+        }
+        if (resourceDetails.containsKey("password")) {
+            resourceDetails.remove("password");
+        }
     }
 }


### PR DESCRIPTION
This removes username and passwords details from the listClusters
response. The details are usually seen in VMware environments only.
With dynamic roles features, the listClusters API may be provided
to a read-only root-admin user role/type which should not be able to get
the credentials.

@blueorangutan package
/cc @borisstoyanov @PaulAngus 