### PR TITLE
CLOUDSTACK-9986: Consider overcommit ratios with total/threshold values

### DIFF
--- a/plugins/metrics/src/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -316,9 +316,6 @@ public class MetricsServiceImpl extends ComponentLifecycleBase implements Metric
             final Float cpuDisableThreshold = DeploymentClusterPlanner.ClusterCPUCapacityDisableThreshold.valueIn(clusterId);
             final Float memoryDisableThreshold = DeploymentClusterPlanner.ClusterMemoryCapacityDisableThreshold.valueIn(clusterId);
 
-            final Double cpuOvercommitRatio = findRatioValue(ApiDBUtils.findClusterDetails(clusterId, "cpuOvercommitRatio"));
-            final Double memoryOvercommitRatio = findRatioValue(ApiDBUtils.findClusterDetails(clusterId, "memoryOvercommitRatio"));
-
             // CPU and memory capacities
             final CapacityDaoImpl.SummedCapacity cpuCapacity = getCapacity((int) Capacity.CAPACITY_TYPE_CPU, null, clusterId);
             final CapacityDaoImpl.SummedCapacity memoryCapacity = getCapacity((int) Capacity.CAPACITY_TYPE_MEMORY, null, clusterId);
@@ -351,13 +348,13 @@ public class MetricsServiceImpl extends ComponentLifecycleBase implements Metric
             // CPU thresholds
             metricsResponse.setCpuUsageThreshold(metrics.getCpuUsedPercentage(), metrics.getTotalHosts(), cpuThreshold);
             metricsResponse.setCpuUsageDisableThreshold(metrics.getCpuUsedPercentage(), metrics.getTotalHosts(), cpuDisableThreshold);
-            metricsResponse.setCpuAllocatedThreshold(metrics.getCpuAllocated(), metrics.getTotalCpu(), cpuOvercommitRatio, cpuThreshold);
-            metricsResponse.setCpuAllocatedDisableThreshold(metrics.getCpuAllocated(), metrics.getTotalCpu(), cpuOvercommitRatio, cpuDisableThreshold);
+            metricsResponse.setCpuAllocatedThreshold(metrics.getCpuAllocated(), metrics.getTotalCpu(), cpuThreshold);
+            metricsResponse.setCpuAllocatedDisableThreshold(metrics.getCpuAllocated(), metrics.getTotalCpu(), cpuDisableThreshold);
             // Memory thresholds
             metricsResponse.setMemoryUsageThreshold(metrics.getMemoryUsed(), metrics.getTotalMemory(), memoryThreshold);
             metricsResponse.setMemoryUsageDisableThreshold(metrics.getMemoryUsed(), metrics.getTotalMemory(), memoryDisableThreshold);
-            metricsResponse.setMemoryAllocatedThreshold(metrics.getMemoryAllocated(), metrics.getTotalMemory(), memoryOvercommitRatio, memoryThreshold);
-            metricsResponse.setMemoryAllocatedDisableThreshold(metrics.getMemoryAllocated(), metrics.getTotalMemory(), memoryOvercommitRatio, memoryDisableThreshold);
+            metricsResponse.setMemoryAllocatedThreshold(metrics.getMemoryAllocated(), metrics.getTotalMemory(), memoryThreshold);
+            metricsResponse.setMemoryAllocatedDisableThreshold(metrics.getMemoryAllocated(), metrics.getTotalMemory(), memoryDisableThreshold);
 
             metricsResponses.add(metricsResponse);
         }

--- a/plugins/metrics/src/org/apache/cloudstack/response/ClusterMetricsResponse.java
+++ b/plugins/metrics/src/org/apache/cloudstack/response/ClusterMetricsResponse.java
@@ -172,15 +172,15 @@ public class ClusterMetricsResponse extends ClusterResponse {
         }
     }
 
-    public void setCpuAllocatedThreshold(final Long cpuAllocated, final Long cpuUsed, final Double overCommitRatio, final Double threshold) {
-        if (cpuAllocated != null && cpuUsed != null && overCommitRatio != null && threshold != null && cpuUsed != 0) {
-            this.cpuAllocatedThresholdExceeded = (1.0 * cpuAllocated * overCommitRatio / cpuUsed) > threshold;
+    public void setCpuAllocatedThreshold(final Long cpuAllocated, final Long cpuTotal, final Double threshold) {
+        if (cpuAllocated != null && cpuTotal != null && threshold != null && cpuTotal != 0) {
+            this.cpuAllocatedThresholdExceeded = (1.0 * cpuAllocated / cpuTotal) > threshold;
         }
     }
 
-    public void setCpuAllocatedDisableThreshold(final Long cpuAllocated, final Long cpuUsed, final Double overCommitRatio, final Float threshold) {
-        if (cpuAllocated != null && cpuUsed != null && overCommitRatio != null && threshold != null && cpuUsed != 0) {
-            this.cpuAllocatedDisableThresholdExceeded = (1.0 * cpuAllocated * overCommitRatio / cpuUsed) > threshold;
+    public void setCpuAllocatedDisableThreshold(final Long cpuAllocated, final Long cpuTotal, final Float threshold) {
+        if (cpuAllocated != null && cpuTotal != null && threshold != null && cpuTotal != 0) {
+            this.cpuAllocatedDisableThresholdExceeded = (1.0 * cpuAllocated / cpuTotal) > threshold;
         }
     }
 
@@ -197,15 +197,15 @@ public class ClusterMetricsResponse extends ClusterResponse {
     }
 
 
-    public void setMemoryAllocatedThreshold(final Long memAllocated, final Long memTotal, final Double overCommitRatio, final Double threshold) {
-        if (memAllocated != null && memTotal != null && overCommitRatio != null && threshold != null && memTotal != 0) {
-            this.memoryAllocatedThresholdExceeded = (1.0 * memAllocated * overCommitRatio / memTotal) > threshold;
+    public void setMemoryAllocatedThreshold(final Long memAllocated, final Long memTotal, final Double threshold) {
+        if (memAllocated != null && memTotal != null && threshold != null && memTotal != 0) {
+            this.memoryAllocatedThresholdExceeded = (1.0 * memAllocated / memTotal) > threshold;
         }
     }
 
-    public void setMemoryAllocatedDisableThreshold(final Long memAllocated, final Long memTotal, final Double overCommitRatio, final Float threshold) {
-        if (memAllocated != null && memTotal != null && overCommitRatio != null && threshold != null && memTotal != 0) {
-            this.memoryAllocatedDisableThresholdExceeded = (1.0 * memAllocated * overCommitRatio / memTotal) > threshold;
+    public void setMemoryAllocatedDisableThreshold(final Long memAllocated, final Long memTotal, final Float threshold) {
+        if (memAllocated != null && memTotal != null && threshold != null && memTotal != 0) {
+            this.memoryAllocatedDisableThresholdExceeded = (1.0 * memAllocated / memTotal) > threshold;
         }
     }
 }

--- a/plugins/metrics/src/org/apache/cloudstack/response/HostMetricsResponse.java
+++ b/plugins/metrics/src/org/apache/cloudstack/response/HostMetricsResponse.java
@@ -167,13 +167,13 @@ public class HostMetricsResponse extends HostResponse {
 
     public void setCpuAllocatedThreshold(final String cpuAllocated, final Double overCommitRatio, final Double threshold) {
         if (cpuAllocated != null && overCommitRatio != null && threshold != null) {
-            this.cpuAllocatedThresholdExceeded = (Double.valueOf(cpuAllocated.replace("%", "")) * overCommitRatio) > (100.0 * threshold);
+            this.cpuAllocatedThresholdExceeded = Double.valueOf(cpuAllocated.replace("%", "")) > (100.0 * threshold * overCommitRatio);
         }
     }
 
     public void setCpuAllocatedDisableThreshold(final String cpuAllocated, final Double overCommitRatio, final Float threshold) {
         if (cpuAllocated != null && overCommitRatio != null && threshold != null) {
-            this.cpuAllocatedDisableThresholdExceeded = (Double.valueOf(cpuAllocated.replace("%", "")) * overCommitRatio) > (100.0 * threshold);
+            this.cpuAllocatedDisableThresholdExceeded = Double.valueOf(cpuAllocated.replace("%", "")) > (100.0 * threshold * overCommitRatio);
         }
     }
 
@@ -191,13 +191,13 @@ public class HostMetricsResponse extends HostResponse {
 
     public void setMemoryAllocatedThreshold(final Long memAllocated, final Long memTotal, final Double overCommitRatio, final Double threshold) {
         if (memAllocated != null && memTotal != null && overCommitRatio != null && threshold != null) {
-            this.memoryAllocatedThresholdExceeded = (memAllocated * overCommitRatio) > (memTotal * threshold);
+            this.memoryAllocatedThresholdExceeded = memAllocated > (memTotal * threshold * overCommitRatio);
         }
     }
 
     public void setMemoryAllocatedDisableThreshold(final Long memAllocated, final Long memTotal, final Double overCommitRatio, final Float threshold) {
         if (memAllocated != null && memTotal != null && overCommitRatio != null && threshold != null) {
-            this.memoryAllocatedDisableThresholdExceeded = (memAllocated * overCommitRatio) > (memTotal * threshold);
+            this.memoryAllocatedDisableThresholdExceeded = memAllocated > (memTotal * threshold * overCommitRatio);
         }
     }
 


### PR DESCRIPTION
Consider the CPU and memory overcommit ratios with total cpu/ram values
or thresholds for host and cluster metrics. This will fix incorrect
notification (cells turning yellow/red) in the metrics view.

Pinging for review - @borisstoyanov @DaanHoogland and others.