### PR TITLE
CLOUDSTACK-9990 : Account name is giving null in event tab after successful creation of account

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/account/CreateAccountCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/account/CreateAccountCmd.java
@@ -184,7 +184,7 @@ public class CreateAccountCmd extends BaseCmd {
     @Override
     public void execute() {
         validateParams();
-        CallContext.current().setEventDetails("Account Name: " + getAccountName() + ", Domain Id:" + getDomainId());
+        CallContext.current().setEventDetails("Account Name: " + getUsername() + ", Domain Id:" + getDomainId());
         UserAccount userAccount =
             _accountService.createUserAccount(getUsername(), getPassword(), getFirstName(), getLastName(), getEmail(), getTimeZone(), getAccountName(), getAccountType(), getRoleId(),
                 getDomainId(), getNetworkDomain(), getDetails(), getAccountUUID(), getUserUUID());


### PR DESCRIPTION
This PR provide fix for the issue: 
Account name is giving null in event tab after successful creation of account. 

Earlier AccountName was used for populating event description. Replaced with UserName for constructing event description.