### PR TITLE
Travis: Fix usage of sudo enable Trusty images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@
 # under the License.
 sudo: required
 dist: trusty
+group: edge
 language: java
 jdk:
-- oraclejdk7
+- openjdk7
 python:
   - "2.7"
 cache:


### PR DESCRIPTION
Adds group to travis yml file based on:
https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2

This can be accepted if Travis passes. Pinging for review - @DaanHoogland @borisstoyanov @wido @karuturi @PaulAngus and others