### PR TITLE
CLOUDSTACK-9992 : Failed to change cluster to managed state

### DIFF
--- a/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
@@ -377,6 +377,11 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         ClustersForHostsNotOwnedByAnyMSSearch.and("resource", ClustersForHostsNotOwnedByAnyMSSearch.entity().getResource(), SearchCriteria.Op.NNULL);
         ClustersForHostsNotOwnedByAnyMSSearch.and("cluster", ClustersForHostsNotOwnedByAnyMSSearch.entity().getClusterId(), SearchCriteria.Op.NNULL);
         ClustersForHostsNotOwnedByAnyMSSearch.and("server", ClustersForHostsNotOwnedByAnyMSSearch.entity().getManagementServerId(), SearchCriteria.Op.NULL);
+
+        ClusterManagedSearch = _clusterDao.createSearchBuilder();
+        ClusterManagedSearch.and("managed", ClusterManagedSearch.entity().getManagedState(), SearchCriteria.Op.EQ);
+        ClustersForHostsNotOwnedByAnyMSSearch.join("ClusterManagedSearch", ClusterManagedSearch, ClusterManagedSearch.entity().getId(), ClustersForHostsNotOwnedByAnyMSSearch.entity().getClusterId(), JoinType.INNER);
+
         ClustersForHostsNotOwnedByAnyMSSearch.done();
 
         AllClustersSearch = _clusterDao.createSearchBuilder(Long.class);
@@ -501,6 +506,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
      */
     private List<Long> findClustersForHostsNotOwnedByAnyManagementServer() {
         SearchCriteria<Long> sc = ClustersForHostsNotOwnedByAnyMSSearch.create();
+        sc.setJoinParameters("ClusterManagedSearch", "managed", Managed.ManagedState.Managed);
 
         List<Long> clusters = customSearch(sc, null);
         return clusters;


### PR DESCRIPTION
ISSUE
============
Failed to change cluster to managed state.

STEPS TO REPRODUCE
==================

1. Create an environment having zone with 2 Clusters and atleast 1 host associated with each cluster.
2. Verify that all clusters are in managed state and all hosts are in up state.
3. Change the value of global setting "direct.agent.load.size" to 1.
4. Restart management server.
5. Check "id" of both clusters.
6. Change state of both the clusters to Unmanaged state.
7. Try to change the cluster which has higher "id" to managed state. Cluster will come to manage state.
8. But host associated with it will never come to UP state, till the time cluster with lower "id" is changed to manage state.

**Screenshot of DB before applying fix :**
![db screenshot before fix](https://user-images.githubusercontent.com/25146827/28068499-7488a2e4-6663-11e7-9b17-eca7bb1e9b6a.PNG)

**Screenshot of DB after applying fix :**
![db screenshot after fix](https://user-images.githubusercontent.com/25146827/28068516-82ab7db0-6663-11e7-92d5-73edba47185c.PNG)
