### PR TITLE
CLOUDSTACK-9977: Enhance SSL protocol used by Console Proxy

### DIFF
--- a/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxySecureServerFactoryImpl.java
+++ b/services/console-proxy/server/src/com/cloud/consoleproxy/ConsoleProxySecureServerFactoryImpl.java
@@ -91,6 +91,8 @@ public class ConsoleProxySecureServerFactoryImpl implements ConsoleProxyServerFa
                     SSLParameters sslparams = c.getDefaultSSLParameters();
 
                     params.setSSLParameters(sslparams);
+                    params.setProtocols(SSLUtils.getRecommendedProtocols());
+                    params.setCipherSuites(SSLUtils.getRecommendedCiphers());
                     // statement above could throw IAE if any params invalid.
                     // eg. if app has a UI and parameters supplied by a user.
                 }
@@ -110,7 +112,8 @@ public class ConsoleProxySecureServerFactoryImpl implements ConsoleProxyServerFa
             SSLServerSocket srvSock = null;
             SSLServerSocketFactory ssf = sslContext.getServerSocketFactory();
             srvSock = (SSLServerSocket)ssf.createServerSocket(port);
-            srvSock.setEnabledProtocols(SSLUtils.getSupportedProtocols(srvSock.getEnabledProtocols()));
+            srvSock.setEnabledProtocols(SSLUtils.getRecommendedProtocols());
+            srvSock.setEnabledCipherSuites(SSLUtils.getRecommendedCiphers());
 
             s_logger.info("create SSL server socket on port: " + port);
             return srvSock;

--- a/systemvm/scripts/_run.sh
+++ b/systemvm/scripts/_run.sh
@@ -68,4 +68,4 @@ if [ "$(uname -m | grep '64')" == "" ]; then
   fi
 fi
 
-java -Djavax.net.ssl.trustStore=./certs/realhostip.keystore -Djsse.enableSNIExtension=false -Dlog.home=$LOGHOME -mx${maxmem}m -cp $CP com.cloud.agent.AgentShell $keyvalues $@
+java -Djavax.net.ssl.trustStore=./certs/realhostip.keystore -Djdk.tls.ephemeralDHKeySize=2048 -Djsse.enableSNIExtension=false -Dlog.home=$LOGHOME -mx${maxmem}m -cp $CP com.cloud.agent.AgentShell $keyvalues $@

--- a/utils/src/main/java/org/apache/cloudstack/utils/security/SSLUtils.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/security/SSLUtils.java
@@ -39,7 +39,24 @@ public class SSLUtils {
             }
             set.add(s);
         }
-        return (String[]) set.toArray(new String[set.size()]);
+        return set.toArray(new String[set.size()]);
+    }
+
+    /**
+     * It returns recommended protocols that are considered secure.
+     */
+    public static String[] getRecommendedProtocols() {
+        return new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+    }
+
+    /**
+     * It returns recommended ciphers that are considered secure.
+     */
+    public static String[] getRecommendedCiphers() {
+        return new String[] { "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384" };
     }
 
     public static String[] getSupportedCiphers() throws NoSuchAlgorithmException {
@@ -49,10 +66,10 @@ public class SSLUtils {
     }
 
     public static SSLContext getSSLContext() throws NoSuchAlgorithmException {
-        return SSLContext.getInstance("TLSv1");
+        return SSLContext.getInstance("TLSv1.2");
     }
 
     public static SSLContext getSSLContext(String provider) throws NoSuchAlgorithmException, NoSuchProviderException {
-        return SSLContext.getInstance("TLSv1", provider);
+        return SSLContext.getInstance("TLSv1.2", provider);
     }
 }

--- a/utils/src/test/java/com/cloud/utils/security/SSLUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/security/SSLUtilsTest.java
@@ -1,0 +1,79 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.utils.security;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.apache.cloudstack.utils.security.SSLUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SSLUtilsTest {
+
+    @Spy
+    private SSLUtils spySSLUtils;
+
+    @Test
+    public void getRecommendedProtocolsTest() {
+        ArrayList<String> protocolsList = new ArrayList<>(Arrays.asList(spySSLUtils.getRecommendedProtocols()));
+        verifyProtocols(protocolsList);
+    }
+
+    @Test
+    public void getRecommendedCiphers() {
+        String[] expectedCiphers = { "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                "TLS_RSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                "TLS_DHE_RSA_WITH_AES_256_CBC_SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384" };
+        Assert.assertArrayEquals(expectedCiphers, spySSLUtils.getRecommendedCiphers());
+    }
+
+    @Test
+    public void getSSLContextTest() throws NoSuchAlgorithmException {
+        Assert.assertEquals("TLSv1.2", spySSLUtils.getSSLContext().getProtocol());
+    }
+
+    @Test
+    public void getSSLContextTestStringAsParameter() throws NoSuchAlgorithmException, NoSuchProviderException {
+        Assert.assertEquals("TLSv1.2", spySSLUtils.getSSLContext("SunJSSE").getProtocol());
+    }
+
+    @Test
+    public void getSupportedProtocolsTest() {
+        ArrayList<String> protocolsList = new ArrayList<>(Arrays.asList(spySSLUtils.getSupportedProtocols(new String[] { "TLSv1", "TLSv1.1", "TLSv1.2", "SSLv3", "SSLv2Hello" })));
+        verifyProtocols(protocolsList);
+    }
+
+    private void verifyProtocols(ArrayList<String> protocolsList) {
+        Assert.assertTrue(protocolsList.contains("TLSv1"));
+        Assert.assertTrue(protocolsList.contains("TLSv1.1"));
+        Assert.assertTrue(protocolsList.contains("TLSv1.2"));
+        Assert.assertFalse(protocolsList.contains("SSLv3"));
+        Assert.assertFalse(protocolsList.contains("SSLv2Hello"));
+    }
+
+}


### PR DESCRIPTION
Current SSL protocol and ciphers used in SystemVMs are not the recommended. One can verify this with tests such as the one from SSL Labs (https://www.ssllabs.com/ssltest/). The grade was capped to C because of SSL ciphers and protocol. The grade was capped to B because it was allowed to use Diffie-Hellman keys with size lesser than 2048 bits. This commit changes the grade from C to A-.

The following image shows the test result before any changes.
![sslreportc](https://user-images.githubusercontent.com/5025148/28134712-2aed18d8-671a-11e7-9184-bc788d9cf89c.png)

After including the changes from this commit the test result was A-.
![sslreporta](https://user-images.githubusercontent.com/5025148/28134719-2d199bd6-671a-11e7-9fe3-ad64c20fdc3f.png)

