### PR TITLE
CLOUDSTACK-9999: vpc tiers do not work if vpc has more than 8 tiers

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -151,7 +151,7 @@ class updateDataBag:
         dp['add'] = d['add']
         dp['one_to_one_nat'] = False
         dp['gateway'] = d['router_guest_gateway']
-        dp['nic_dev_id'] = d['device'][3]
+        dp['nic_dev_id'] = d['device'][3:]
         dp['nw_type'] = 'guest'
         dp = PrivateGatewayHack.update_network_type_for_privategateway(dbag, dp)
         qf = QueueFile()


### PR DESCRIPTION
In the VR, deviceid of eth1X should be 1X (eth10->10, eth11->11), not 1.

