### PR TITLE
CLOUDSTACK-10002: Restart network with cleanup spawns Redundant Routers(In Default Network Offering)

### DIFF
--- a/engine/schema/src/com/cloud/network/dao/NetworkVO.java
+++ b/engine/schema/src/com/cloud/network/dao/NetworkVO.java
@@ -67,7 +67,7 @@ public class NetworkVO implements Network {
     String name;
 
     @Column(name = "display_text")
-    String displayText;;
+    String displayText;
 
     @Column(name = "broadcast_uri")
     URI broadcastUri;
@@ -299,14 +299,18 @@ public class NetworkVO implements Network {
         return state;
     }
 
+    // don't use this directly when possible, use Network state machine instead
+    public void setState(State state) {
+        this.state = state;
+    }
+
     @Override
     public boolean isRedundant() {
         return this.redundant;
     }
 
-    // don't use this directly when possible, use Network state machine instead
-    public void setState(State state) {
-        this.state = state;
+    public void setRedundant(boolean redundant) {
+        this.redundant = redundant;
     }
 
     @Override
@@ -630,9 +634,4 @@ public class NetworkVO implements Network {
     public void setVpcId(Long vpcId) {
         this.vpcId = vpcId;
     }
-
-    public void setIsReduntant(boolean reduntant) {
-        this.redundant = reduntant;
-    }
-
 }

--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -2121,7 +2121,7 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
                 networkOfferingChanged = true;
 
                 //Setting the new network's isReduntant to the new network offering's RedundantRouter.
-                network.setIsReduntant(_networkOfferingDao.findById(networkOfferingId).getRedundantRouter());
+                network.setRedundant(_networkOfferingDao.findById(networkOfferingId).getRedundantRouter());
             }
         }
 


### PR DESCRIPTION
Reproduction Steps:
===============
Create a network with redundant router capability.
Create instances with the above network.
Update the network to Default Offering(DefaultIsolatedNetworkOfferingWithSourceNAT).
After successful update, one router is created which is as expected.
Try to restart the network with cleanup=true.


Observation:
=========
Two routers are created with redundant state UNKNOWN.
Note: - The similar behavior is seen when we update RVR to default.


Expectation:
=========
After successful restart, only one router should be created.


FS:
==
https://cwiki.apache.org/confluence/display/CLOUDSTACK/Persistent+Configuration+for+Virtual+Routers


Resolution:
========
The setter name is different from what it should be used by update call.


JIRA Ticket:
=========
https://issues.apache.org/jira/browse/CLOUDSTACK-10002