### PR TITLE
CLOUDSTACK-9747: Network Update with new N/W offering retains rules on UI but cleans up on Router.

### DIFF
--- a/api/src/com/cloud/network/Network.java
+++ b/api/src/com/cloud/network/Network.java
@@ -37,13 +37,13 @@ import com.cloud.utils.fsm.StateObject;
  */
 public interface Network extends ControlledEntity, StateObject<Network.State>, InternalIdentity, Identity, Serializable, Displayable {
 
-    public enum GuestType {
+    enum GuestType {
         Shared, Isolated
     }
 
-    public String updatingInSequence ="updatingInSequence";
+    String updatingInSequence ="updatingInSequence";
 
-    public static class Service {
+    class Service {
         private static List<Service> supportedServices = new ArrayList<Service>();
 
         public static final Service Vpn = new Service("Vpn", Capability.SupportedVpnProtocols, Capability.VpnTypes);
@@ -112,7 +112,7 @@ public interface Network extends ControlledEntity, StateObject<Network.State>, I
     /**
      * Provider -> NetworkElement must always be one-to-one mapping. Thus for each NetworkElement we need a separate Provider added in here.
      */
-    public static class Provider {
+    class Provider {
         private static List<Provider> supportedProviders = new ArrayList<Provider>();
 
         public static final Provider VirtualRouter = new Provider("VirtualRouter", false, false);
@@ -186,7 +186,7 @@ public interface Network extends ControlledEntity, StateObject<Network.State>, I
         }
     }
 
-    public static class Capability {
+    class Capability {
 
         private static List<Capability> supportedCapabilities = new ArrayList<Capability>();
 
@@ -244,7 +244,7 @@ public interface Network extends ControlledEntity, StateObject<Network.State>, I
         ImplementNetwork, DestroyNetwork, OperationSucceeded, OperationFailed;
     }
 
-    public enum State {
+    enum State {
 
         Allocated("Indicates the network configuration is in allocated but not setup"), Setup("Indicates the network configuration is setup"), Implementing(
                 "Indicates the network configuration is being implemented"), Implemented("Indicates the network configuration is in use"), Shutdown(
@@ -274,7 +274,7 @@ public interface Network extends ControlledEntity, StateObject<Network.State>, I
         }
     }
 
-    public class IpAddresses {
+    class IpAddresses {
         private String ip4Address;
         private String ip6Address;
 
@@ -350,7 +350,7 @@ public interface Network extends ControlledEntity, StateObject<Network.State>, I
 
     void setPhysicalNetworkId(Long physicalNetworkId);
 
-    public void setTrafficType(TrafficType type);
+    void setTrafficType(TrafficType type);
 
     ACLType getAclType();
 

--- a/api/src/org/apache/cloudstack/api/command/admin/address/AssociateIPAddrCmdByAdmin.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/address/AssociateIPAddrCmdByAdmin.java
@@ -37,7 +37,6 @@ import com.cloud.network.IpAddress;
 public class AssociateIPAddrCmdByAdmin extends AssociateIPAddrCmd {
     public static final Logger s_logger = Logger.getLogger(AssociateIPAddrCmdByAdmin.class.getName());
 
-
     @Override
     public void execute() throws ResourceUnavailableException, ResourceAllocationException,
                                     ConcurrentOperationException, InsufficientCapacityException {
@@ -59,8 +58,4 @@ public class AssociateIPAddrCmdByAdmin extends AssociateIPAddrCmd {
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to assign ip address");
         }
     }
-
-
-
-
 }

--- a/api/src/org/apache/cloudstack/api/command/user/network/UpdateNetworkCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/network/UpdateNetworkCmd.java
@@ -79,8 +79,7 @@ public class UpdateNetworkCmd extends BaseAsyncCustomIdCmd {
     private Boolean updateInSequence;
 
     @Parameter(name = ApiConstants.DISPLAY_NETWORK,
-               type = CommandType.BOOLEAN,
- description = "an optional field, whether to the display the network to the end user or not.", authorized = {RoleType.Admin})
+               type = CommandType.BOOLEAN, description = "an optional field, whether to the display the network to the end user or not.", authorized = {RoleType.Admin})
     private Boolean displayNetwork;
 
     @Parameter(name= ApiConstants.FORCED, type = CommandType.BOOLEAN, description = "Setting this to true will cause a forced network update,", authorized = {RoleType.Admin})

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -1322,19 +1322,19 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
     @Override
     public List<String> getServicesNotSupportedInNewOffering(Network network,long newNetworkOfferingId){
-        NetworkOffering offering =_networkOfferingDao.findById(newNetworkOfferingId);
-        List<String> services=_ntwkOfferingSrvcDao.listServicesForNetworkOffering(offering.getId());
-        List<NetworkServiceMapVO> serviceMap= _ntwkSrvcDao.getServicesInNetwork(network.getId());
-        List<String> servicesNotInNewOffering=new ArrayList<>();
-        for(NetworkServiceMapVO serviceVO :serviceMap){
-            boolean inlist=false;
-            for(String service: services){
-                if(serviceVO.getService().equalsIgnoreCase(service)){
-                    inlist=true;
+        NetworkOffering offering = _networkOfferingDao.findById(newNetworkOfferingId);
+        List<String> services = _ntwkOfferingSrvcDao.listServicesForNetworkOffering(offering.getId());
+        List<NetworkServiceMapVO> serviceMap = _ntwkSrvcDao.getServicesInNetwork(network.getId());
+        List<String> servicesNotInNewOffering = new ArrayList<>();
+        for(NetworkServiceMapVO serviceVO :serviceMap) {
+            boolean inlist = false;
+            for(String service: services) {
+                if(serviceVO.getService().equalsIgnoreCase(service)) {
+                    inlist = true;
                     break;
                 }
             }
-            if(!inlist){
+            if(!inlist) {
                 //ignore Gateway service as this has no effect on the
                 //behaviour of network.
                 if(!serviceVO.getService().equalsIgnoreCase(Service.Gateway.getName()))
@@ -1352,7 +1352,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         //remove all PF/Static Nat rules for the network
         s_logger.info("Services:"+services+" are no longer supported in network:"+network.getUuid()+
                 " after applying new network offering:"+network.getNetworkOfferingId()+" removing the related configuration");
-        if(services.contains(Service.StaticNat.getName())|| services.contains(Service.PortForwarding.getName())) {
+        if(services.contains(Service.StaticNat.getName()) || services.contains(Service.PortForwarding.getName())) {
             try {
                 if (_rulesMgr.revokeAllPFStaticNatRulesForNetwork(networkId, userId, caller)) {
                     s_logger.debug("Successfully cleaned up portForwarding/staticNat rules for network id=" + networkId);

--- a/server/src/com/cloud/network/firewall/FirewallManagerImpl.java
+++ b/server/src/com/cloud/network/firewall/FirewallManagerImpl.java
@@ -832,24 +832,23 @@ public class FirewallManagerImpl extends ManagerBase implements FirewallService,
         Transaction.execute(new TransactionCallbackNoReturn() {
             @Override
             public void doInTransactionWithoutResult(TransactionStatus status) {
-        boolean generateUsageEvent = false;
+                boolean generateUsageEvent = false;
 
-        if (rule.getState() == State.Staged) {
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Found a rule that is still in stage state so just removing it: " + rule);
-            }
-            removeRule(rule);
-            generateUsageEvent = true;
-        } else if (rule.getState() == State.Add || rule.getState() == State.Active) {
-            rule.setState(State.Revoke);
-            _firewallDao.update(rule.getId(), rule);
-            generateUsageEvent = true;
-        }
+                if (rule.getState() == State.Staged) {
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug("Found a rule that is still in stage state so just removing it: " + rule);
+                    }
+                    removeRule(rule);
+                    generateUsageEvent = true;
+                } else if (rule.getState() == State.Add || rule.getState() == State.Active) {
+                    rule.setState(State.Revoke);
+                    _firewallDao.update(rule.getId(), rule);
+                    generateUsageEvent = true;
+                }
 
-        if (generateUsageEvent && needUsageEvent) {
-                    UsageEventUtils.publishUsageEvent(EventTypes.EVENT_NET_RULE_DELETE, rule.getAccountId(), 0, rule.getId(), null, rule.getClass().getName(),
-                        rule.getUuid());
-        }
+                if (generateUsageEvent && needUsageEvent) {
+                    UsageEventUtils.publishUsageEvent(EventTypes.EVENT_NET_RULE_DELETE, rule.getAccountId(), 0, rule.getId(), null, rule.getClass().getName(), rule.getUuid());
+                }
             }
         });
     }


### PR DESCRIPTION
Steps to Reproduce:
===============
1. Create a Network with default N/w offering " Offering for Isolated networks with Source Nat service enabled ".
2. Create PF rules, Firewall Rules on the n/w.
3. Deploy a VM with the above Network.
4. Create a new standalone n/w offering and update the above network with the new offering.

Observations:
==========
Once the N/w update is completed, it's observed that the rules created with default offering still persist on UI but the iptables on VR is cleaned up.

Expected Result:
============

- If the new n/w offering supports the VR service as the old one, rules should be retained on both UI and VR.

or

- Irrespective of new and old n/w offerings supporting or not supporting the VR service, rules on VR and UI to be cleaned up.