### PR TITLE
[CLOUDSTACK-10008] Check for host before adding it to storagepaths

### DIFF
--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/provider/SolidFireHostListener.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/provider/SolidFireHostListener.java
@@ -195,7 +195,7 @@ public class SolidFireHostListener implements HypervisorHostListener {
                     if (hostIdForVm != null) {
                         HostVO hostForVm = _hostDao.findById(hostIdForVm);
 
-                        if (hostForVm.getClusterId().equals(clusterId)) {
+                        if (hostForVm != null && hostForVm.getClusterId().equals(clusterId)) {
                             storagePaths.add(volume.get_iScsiName());
                         }
                     }


### PR DESCRIPTION
This happens when you have a stopped VM which has a managed volume attached to it. The host that the VM was originally running on was removed. So, the `last_host_id` of the instance is set to a non-existing host which causes an NPE here. 

cc: @mike-tutkowski 