### PR TITLE
CLOUDSTACK-10009: fix test_data.py remove item "templateregister", and fix tests to use default template

### DIFF
--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -936,13 +936,6 @@ test_data = {
         "format": "OVA",
         "ostype": "Red Hat Enterprise Linux 6.0 (64-bit)"
     },
-    "templateregister": {
-        "displaytext": "xs",
-        "name": "xs",
-        "passwordenabled": False,
-        "url": "http://people.apache.org/~sanjeev/ttylinux_pv.vhd.bz2",
-        "format": "VHD"
-    },
     "security_group": {"name": "custom_Sec_Grp"},
     "ingress_rule": {
         "protocol": "TCP",


### PR DESCRIPTION
…ng attribute
Due to using default template and removing management restart 5 mins sleep current execution time has been reduced to 5mins
=== TestName: test_00_deploy_vm_root_resize | Status : SUCCESS ===
=== TestName: test_01_deploy_vm_root_resize | Status : SUCCESS ===
=== TestName: test_02_deploy_vm_root_resize | Status : SUCCESS ===
![screen shot 2017-07-21 at 4 18 24 pm](https://user-images.githubusercontent.com/13551960/28465100-458d5d34-6e30-11e7-8923-00268277f831.png)