### PR TITLE
python-version: Use default to system provided version

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-cloudstack
+system


### PR DESCRIPTION
This aims at fixing recent Travis failures

Pinging - @DaanHoogland @borisstoyanov @wido and others

Refer:
https://travis-ci.org/apache/cloudstack/builds
Most failures due to failing apidocs build:
```
[[1;34mINFO[m] [1mBuilding Apache CloudStack apidocs 4.11.0.0-SNAPSHOT[m
log4j:WARN No appenders could be found for logger (org.reflections.Reflections).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
pyenv: version `cloudstack' is not installed (set by /home/travis/build/apache/cloudstack/.python-version)
...
[[1;34mINFO[m] Apache CloudStack apidocs .......................... [1;31mFAILURE[m [  9.127 s]
```