### PR TITLE
python-version: use system default python version

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-cloudstack
+system


### PR DESCRIPTION
By default use system default for Travis to pass

This tests fix from 4.9 based PR: https://github.com/apache/cloudstack/pull/2195
If this succeeds, we can fwd merge.