### PR TITLE
CLOUDSTACK-10014: Fix test accounts remove secret key check

### DIFF
--- a/test/integration/component/test_accounts.py
+++ b/test/integration/component/test_accounts.py
@@ -20,6 +20,7 @@
 from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.lib.utils import (random_gen,
                               cleanup_resources)
+from marvin.cloudstackAPI import *
 from marvin.lib.base import (Domain,
                              Account,
                              ServiceOffering,
@@ -42,6 +43,8 @@ from marvin.lib.common import (get_domain,
 from nose.plugins.attrib import attr
 from marvin.cloudstackException import CloudstackAPIException
 import time
+
+from pyVmomi.VmomiSupport import GetVersionFromVersionUri
 
 
 class Services:
@@ -1649,6 +1652,11 @@ class TestUserAPIKeys(cloudstackTestCase):
             user.apikey,
             userkeys.apikey,
             "Check User api key")
+        user.secretkey = self.get_secret_key(user.id)
+        self.assertEqual(
+            user.secretkey,
+            userkeys.secretkey,
+            "Check User having secret key")
 
         self.debug("Get test client with user keys")
         cs_api = self.testClient.getUserApiClient(
@@ -1660,6 +1668,17 @@ class TestUserAPIKeys(cloudstackTestCase):
             userkeys.apikey,
             new_keys.apikey,
             "Check API key is different")
+        new_keys.secretkey = self.get_secret_key(user_1.id)
+        self.assertNotEqual(
+            userkeys.secretkey,
+            new_keys.secretkey,
+            "Check secret key is different")
+
+    def get_secret_key(self, id):
+        cmd = getUserKeys.getUserKeysCmd()
+        cmd.id = id
+        keypair = self.apiclient.getUserKeys(cmd)
+        return keypair.secretkey
 
     @attr(tags=[
         "role",
@@ -2058,3 +2077,4 @@ class TestDomainForceRemove(cloudstackTestCase):
         with self.assertRaises(Exception):
             domain.delete(self.apiclient, cleanup=False)
         return
+

--- a/test/integration/component/test_accounts.py
+++ b/test/integration/component/test_accounts.py
@@ -1649,10 +1649,6 @@ class TestUserAPIKeys(cloudstackTestCase):
             user.apikey,
             userkeys.apikey,
             "Check User api key")
-        self.assertEqual(
-            user.secretkey,
-            userkeys.secretkey,
-            "Check User having secret key")
 
         self.debug("Get test client with user keys")
         cs_api = self.testClient.getUserApiClient(
@@ -1664,10 +1660,6 @@ class TestUserAPIKeys(cloudstackTestCase):
             userkeys.apikey,
             new_keys.apikey,
             "Check API key is different")
-        self.assertNotEqual(
-            userkeys.secretkey,
-            new_keys.secretkey,
-            "Check secret key is different")
 
     @attr(tags=[
         "role",


### PR DESCRIPTION
…_same_account: remove secret key checks since it was removed from the API response
Removing secret key as it's not part of the api response any more. The changed test is passing:

<img width="1046" alt="screen shot 2017-07-24 at 4 58 25 pm" src="https://user-images.githubusercontent.com/13551960/28526822-5db1d9a4-7091-11e7-89fe-7d540befb1bb.png">

Ping @rhtyd @DaanHoogland @PaulAngus @jayapalu for review