### PR TITLE
CLOUDSTACK-10016: VPC VR doesn't respond to DNS requests from remote access vpn clients

### DIFF
--- a/systemvm/patches/debian/config/etc/vpcdnsmasq.conf
+++ b/systemvm/patches/debian/config/etc/vpcdnsmasq.conf
@@ -90,7 +90,7 @@ except-interface=lo
 # want dnsmasq to really bind only the interfaces it is listening on,
 # uncomment this option. About the only time you may need this is when
 # running another nameserver on the same machine.
-bind-interfaces
+#bind-interfaces
 
 # If you don't want dnsmasq to read /etc/hosts, uncomment the
 # following line.


### PR DESCRIPTION
When enabling remote access VPN, a new interface is created upon client connecting via VPN. The DNS service (dnsmasq) is set only to listen on interfaces that are active when it starts. Thus VPN users are provided the VR's IP address for DNS resolution, but it is not actually listening for DNS requests.