### PR TITLE
[CLOUDSTACK-10029] All private, public, and guest interfaceses are marked as untagged ca…

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1695,8 +1695,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 if (nic.getBrName().equalsIgnoreCase(_linkLocalBridgeName)) {
                     broadcastUriAllocatedToVM.put("LinkLocal", nicPos);
                 } else {
-                    if (nic.getBrName().equalsIgnoreCase(_publicBridgeName) || nic.getBrName().equalsIgnoreCase(_privBridgeName) ||
-                            nic.getBrName().equalsIgnoreCase(_guestBridgeName)) {
+                    if (nic.getBrName() == null) {
                         broadcastUriAllocatedToVM.put(BroadcastDomainType.Vlan.toUri(Vlan.UNTAGGED).toString(), nicPos);
                     } else {
                         final String broadcastUri = getBroadcastUriFromBridge(nic.getBrName());
@@ -1749,8 +1748,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 if (nic.getBrName().equalsIgnoreCase(_linkLocalBridgeName)) {
                     broadcastUriAllocatedToVM.put("LinkLocal", nicPos);
                 } else {
-                    if (nic.getBrName().equalsIgnoreCase(_publicBridgeName) || nic.getBrName().equalsIgnoreCase(_privBridgeName) ||
-                            nic.getBrName().equalsIgnoreCase(_guestBridgeName)) {
+                    if (nic.getBrName() == null) {
                         broadcastUriAllocatedToVM.put(BroadcastDomainType.Vlan.toUri(Vlan.UNTAGGED).toString(), nicPos);
                     } else {
                         final String broadcastUri = getBroadcastUriFromBridge(nic.getBrName());


### PR DESCRIPTION
…using constant Vif creation in Virtual Router VM

When adding static nat eth interfaces are being added constantly to Virtual Route VM till they reach PCI slot limit. This is caused by public, prrivate and guest interfaces being marked as untagged and in HashMap values are overwritten and cleanupNetworkElementCommand dosn't know nic number in VR VM and constantly adds eth interfaces.

2017-07-25 10:47:21,054 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) Exexutiong cleanupNetworkElementCommand
2017-07-25 10:47:21,054 DEBUG [kvm.resource.LibvirtConnection] (agentRequest-Handler-2:null) (logid:57628c13) Looking for libvirtd connection at: qemu:///system
2017-07-25 10:47:21,057 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) HASH MAP DUMP: {vlan://untagged=0}
2017-07-25 10:47:21,057 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) HASH MAP DUMP: {LinkLocal=1, vlan://untagged=0}
2017-07-25 10:47:21,057 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) HASH MAP DUMP: {LinkLocal=1, vlan://untagged=2}
2017-07-25 10:47:21,057 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) HASH MAP DUMP: {LinkLocal=1, vlan://untagged=3}
2017-07-25 10:47:21,058 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) HASH MAP DUMP: {LinkLocal=1, vlan://untagged=4}
2017-07-25 10:47:21,058 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) NIC pos 5
2017-07-25 10:47:21,058 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) HASH MAP DUMP: {LinkLocal=1, vlan://untagged=4}
2017-07-25 10:47:21,058 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) Lokking for BroadcastUri vlan://261
2017-07-25 10:47:21,058 ERROR [kvm.resource.LibvirtComputingResource] (agentRequest-Handler-2:null) (logid:57628c13) Plugging in VIF with MAC 1e:00:07:00:02:c8