### PR TITLE
Add NULL checks for various objects in SolidFire integration test API

### DIFF
--- a/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/solidfire/SolidFireIntegrationTestManagerImpl.java
+++ b/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/solidfire/SolidFireIntegrationTestManagerImpl.java
@@ -16,21 +16,20 @@
 // under the License.
 package org.apache.cloudstack.solidfire;
 
-import javax.inject.Inject;
-
-import org.apache.cloudstack.storage.datastore.util.SolidFireUtil;
-import org.apache.cloudstack.util.solidfire.SolidFireIntegrationTestUtil;
-import org.springframework.stereotype.Component;
-
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.dc.ClusterDetailsVO;
 import com.cloud.storage.VolumeDetailVO;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.dao.VolumeDetailsDao;
-import com.cloud.user.AccountDetailsDao;
 import com.cloud.user.AccountDetailVO;
+import com.cloud.user.AccountDetailsDao;
 import com.cloud.utils.exception.CloudRuntimeException;
+import org.apache.cloudstack.storage.datastore.util.SolidFireUtil;
+import org.apache.cloudstack.util.solidfire.SolidFireIntegrationTestUtil;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
 
 @Component
 public class SolidFireIntegrationTestManagerImpl implements SolidFireIntegrationTestManager {
@@ -47,6 +46,9 @@ public class SolidFireIntegrationTestManagerImpl implements SolidFireIntegration
         long storagePoolId = util.getStoragePoolIdForStoragePoolUuid(storagePoolUuid);
 
         AccountDetailVO accountDetail = accountDetailsDao.findDetail(csAccountId, SolidFireUtil.getAccountKey(storagePoolId));
+        if (accountDetail == null){
+            throw new CloudRuntimeException("Unable to find SF account for storage " + storagePoolUuid + " for CS account " + csAccountUuid);
+        }
         String sfAccountId = accountDetail.getValue();
 
         return Long.parseLong(sfAccountId);

--- a/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/util/solidfire/SolidFireIntegrationTestUtil.java
+++ b/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/util/solidfire/SolidFireIntegrationTestUtil.java
@@ -16,15 +16,6 @@
 // under the License.
 package org.apache.cloudstack.util.solidfire;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.inject.Inject;
-
-import org.apache.cloudstack.api.response.solidfire.ApiVolumeSnapshotDetailsResponse;
-import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
-import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
-
 import com.cloud.dc.ClusterVO;
 import com.cloud.dc.dao.ClusterDao;
 import com.cloud.storage.SnapshotVO;
@@ -35,6 +26,14 @@ import com.cloud.storage.dao.SnapshotDetailsVO;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.Account;
 import com.cloud.user.dao.AccountDao;
+import com.cloud.utils.exception.CloudRuntimeException;
+import org.apache.cloudstack.api.response.solidfire.ApiVolumeSnapshotDetailsResponse;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SolidFireIntegrationTestUtil {
     @Inject private AccountDao accountDao;
@@ -48,48 +47,70 @@ public class SolidFireIntegrationTestUtil {
 
     public long getAccountIdForAccountUuid(String accountUuid) {
         Account account = accountDao.findByUuid(accountUuid);
-
+        if (account == null){
+            throw new CloudRuntimeException("Unable to find Account for ID: " + accountUuid);
+        }
         return account.getAccountId();
     }
 
     public long getAccountIdForVolumeUuid(String volumeUuid) {
         VolumeVO volume = volumeDao.findByUuid(volumeUuid);
+        if (volume == null){
+            throw new CloudRuntimeException("Unable to find Volume for ID: " + volumeUuid);
+        }
 
         return volume.getAccountId();
     }
 
     public long getAccountIdForSnapshotUuid(String snapshotUuid) {
         SnapshotVO snapshot = snapshotDao.findByUuid(snapshotUuid);
-
+        if (snapshot == null){
+            throw new CloudRuntimeException("Unable to find Volume for ID: " + snapshotUuid);
+        }
         return snapshot.getAccountId();
     }
 
     public long getClusterIdForClusterUuid(String clusterUuid) {
         ClusterVO cluster = clusterDao.findByUuid(clusterUuid);
+        if (cluster == null){
+            throw new CloudRuntimeException("Unable to find Volume for ID: " + clusterUuid);
+        }
 
         return cluster.getId();
     }
 
     public long getStoragePoolIdForStoragePoolUuid(String storagePoolUuid) {
         StoragePoolVO storagePool = storagePoolDao.findByUuid(storagePoolUuid);
+        if (storagePool == null){
+            throw new CloudRuntimeException("Unable to find Volume for ID: " + storagePoolUuid);
+        }
 
         return storagePool.getId();
     }
 
     public String getPathForVolumeUuid(String volumeUuid) {
         VolumeVO volume = volumeDao.findByUuid(volumeUuid);
+        if (volume == null){
+            throw new CloudRuntimeException("Unable to find Volume for ID: " + volumeUuid);
+        }
 
         return volume.getPath();
     }
 
     public String getVolume_iScsiName(String volumeUuid) {
         VolumeVO volume = volumeDao.findByUuid(volumeUuid);
+        if (volume == null){
+            throw new CloudRuntimeException("Unable to find Volume for ID: " + volumeUuid);
+        }
 
         return volume.get_iScsiName();
     }
 
     public List<ApiVolumeSnapshotDetailsResponse> getSnapshotDetails(String snapshotUuid) {
         SnapshotVO snapshot = snapshotDao.findByUuid(snapshotUuid);
+        if (snapshot == null){
+            throw new CloudRuntimeException("Unable to find Volume for ID: " + snapshotUuid);
+        }
 
         List<SnapshotDetailsVO> snapshotDetails = snapshotDetailsDao.listDetails(snapshot.getId());
 


### PR DESCRIPTION
Guard from cases where we pass an invalid `accountID` or `storagePoolID` in the API.

CC: @mike-tutkowski 