### PR TITLE
CLOUDSTACK-10023: Windows VMs with Multiple Nics fail to access internet

### DIFF
--- a/core/src/com/cloud/agent/api/routing/DhcpEntryCommand.java
+++ b/core/src/com/cloud/agent/api/routing/DhcpEntryCommand.java
@@ -34,6 +34,7 @@ public class DhcpEntryCommand extends NetworkElementCommand {
     String ip6Gateway;
     String duid;
     private boolean isDefault;
+    private boolean  isWindows;
     boolean executeInSequence = false;
 
     protected DhcpEntryCommand() {
@@ -142,5 +143,11 @@ public class DhcpEntryCommand extends NetworkElementCommand {
 
     public void setDefault(boolean isDefault) {
         this.isDefault = isDefault;
+    }
+
+    public boolean isWindows() { return isWindows; }
+
+    public void setWindows(boolean windows) {
+        isWindows = windows;
     }
 }

--- a/core/src/com/cloud/agent/resource/virtualnetwork/facade/DhcpEntryConfigItem.java
+++ b/core/src/com/cloud/agent/resource/virtualnetwork/facade/DhcpEntryConfigItem.java
@@ -35,7 +35,7 @@ public class DhcpEntryConfigItem extends AbstractConfigItemFacade {
         final DhcpEntryCommand command = (DhcpEntryCommand) cmd;
 
         final VmDhcpConfig vmDhcpConfig = new VmDhcpConfig(command.getVmName(), command.getVmMac(), command.getVmIpAddress(), command.getVmIp6Address(), command.getDuid(), command.getDefaultDns(),
-                command.getDefaultRouter(), command.getStaticRoutes(), command.isDefault());
+                command.getDefaultRouter(), command.getStaticRoutes(), command.isDefault(),command.isWindows());
 
         return generateConfigItems(vmDhcpConfig);
     }

--- a/core/src/com/cloud/agent/resource/virtualnetwork/model/VmDhcpConfig.java
+++ b/core/src/com/cloud/agent/resource/virtualnetwork/model/VmDhcpConfig.java
@@ -29,13 +29,14 @@ public class VmDhcpConfig extends ConfigBase {
     private String defaultGateway;
     private String staticRoutes;
     private boolean defaultEntry;
+    private boolean windowsEntry;
 
     public VmDhcpConfig() {
         super(VM_DHCP);
     }
 
     public VmDhcpConfig(String hostName, String macAddress, String ipv4Adress, String ipv6Address, String ipv6Duid, String dnsAdresses, String defaultGateway,
-            String staticRoutes, boolean defaultEntry) {
+            String staticRoutes, boolean defaultEntry,boolean windowsEntry) {
         super(VM_DHCP);
         this.hostName = hostName;
         this.macAddress = macAddress;
@@ -46,6 +47,7 @@ public class VmDhcpConfig extends ConfigBase {
         this.defaultGateway = defaultGateway;
         this.staticRoutes = staticRoutes;
         this.defaultEntry = defaultEntry;
+        this.windowsEntry = windowsEntry;
     }
 
     public String getHostName() {
@@ -120,4 +122,7 @@ public class VmDhcpConfig extends ConfigBase {
         this.defaultEntry = defaultEntry;
     }
 
+    public boolean isWindowsEntry() {return windowsEntry;  }
+
+    public void setWindowsEntry(boolean windowsEntry) {this.windowsEntry = windowsEntry;  }
 }

--- a/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
@@ -1584,6 +1584,10 @@ public class HypervDirectConnectResource extends ServerResourceBase implements S
             args += " -N";
         }
 
+        if (cmd.isWindows()) {
+            args += " -W";
+        }
+
         final String command = String.format("%s%s %s", "/root/", VRScripts.DHCP, args);
 
         if (s_logger.isDebugEnabled()) {

--- a/server/src/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/com/cloud/network/router/CommandSetupHelper.java
@@ -109,6 +109,8 @@ import com.cloud.offering.NetworkOffering;
 import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.service.dao.ServiceOfferingDao;
+import com.cloud.storage.GuestOSVO;
+import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.user.Account;
 import com.cloud.uservm.UserVm;
 import com.cloud.utils.Pair;
@@ -173,6 +175,8 @@ public class CommandSetupHelper {
     private VlanDao _vlanDao;
     @Inject
     private IPAddressDao _ipAddressDao;
+    @Inject
+    private GuestOSDao _guestOSDao;
 
     @Inject
     private RouterControlHelper _routerControlHelper;
@@ -216,6 +220,15 @@ public class CommandSetupHelper {
                 _networkModel.getExecuteInSeqNtwkElmtCmd());
 
         String gatewayIp = nic.getIPv4Gateway();
+        if (!nic.isDefaultNic()) {
+            final GuestOSVO guestOS = _guestOSDao.findById(vm.getGuestOSId());
+            if (guestOS == null || !guestOS.getDisplayName().toLowerCase().contains("windows")) {
+                gatewayIp = "0.0.0.0";
+            }
+            else if (guestOS != null && guestOS.getDisplayName().toLowerCase().contains("windows")) {
+                dhcpCommand.setWindows(true);
+            }
+        }
 
         final DataCenterVO dcVo = _dcDao.findById(router.getDataCenterId());
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -130,6 +130,7 @@ class CsDhcp(CsDataBag):
             logging.debug("Hosts file unchanged")
 
     def add(self, entry):
+        windowsInterfaceMetric="1i"
         self.add_host(entry['ipv4_adress'], entry['host_name'])
         # lease time boils down to once a month
         # with a splay of 60 hours to prevent storms
@@ -150,6 +151,9 @@ class CsDhcp(CsDataBag):
             self.dhcp_opts.add("%s,%s" % (tag, 3))
             self.dhcp_opts.add("%s,%s" % (tag, 6))
             self.dhcp_opts.add("%s,%s" % (tag, 15))
+
+        if entry['windows_entry'] == True:
+            self.dhcp_opts.add("%s,%s,%d,%s" % (tag,'vendor:MSFT',3,windowsInterfaceMetric))
 
         i = IPAddress(entry['ipv4_adress'])
         # Calculate the device


### PR DESCRIPTION
REPRO STEPS:
Create a Windows VM with Multiple NICs
Ensure that only one of the NICs can actually access internet (set that as default NIC in ACS)
Try to access internet

EXPECTED BEHAVIOR:
Windows VM should be able to access internet

ACTUAL BEHAVIOR:
Windows VM is not able to access internet


Windows will experience issue if we have multiple default gateway assigned as explained in "Multiple Default Gateways Can Cause Connectivity Problems" (https://support.microsoft.com/en-us/kb/159168).  

You may want to make Windows to select certain gateway always, we can change interface metrics:
 
Go to your Network adapter properties
Select Internet Protocol v4.
Click the Advanced button on General tab.
Uncheck Automatic metric.
Enter a number higher than 10 to the Interface metric field.

The default automatic metric for interfaces is 10. The lower the metric, the higher the preference to use it. So, we have to enter metric higher than 10 for the interfaces you don't want to use. This is because if Windows has multiple interfaces connected to several networks that use DHCP, it installs default gateways for all those interfaces. By default, Windows sets the metric of the default gateways to the same, effectively leading to random selection of default gateway.

Window stand point the above mentioned issue can be resolved by setting metric for NICs inside guest OS

