### PR TITLE
Revert "CLOUDSTACK-9708: Router deployment failed due to two threads …

### DIFF
--- a/engine/schema/src/com/cloud/vm/dao/UserVmDaoImpl.java
+++ b/engine/schema/src/com/cloud/vm/dao/UserVmDaoImpl.java
@@ -192,18 +192,6 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
                 JoinBuilder.JoinType.INNER);
         AccountDataCenterVirtualSearch.done();
 
-        SearchBuilder<NicVO> nicSearchByNetwork = _nicDao.createSearchBuilder();
-        nicSearchByNetwork.and("networkId", nicSearchByNetwork.entity().getNetworkId(), SearchCriteria.Op.EQ);
-        nicSearchByNetwork.and("removed", nicSearchByNetwork.entity().getRemoved(), SearchCriteria.Op.NULL);
-        nicSearchByNetwork.and().op("ip4Address", nicSearchByNetwork.entity().getIPv4Address(), SearchCriteria.Op.NNULL);
-        nicSearchByNetwork.or("ip6Address", nicSearchByNetwork.entity().getIPv6Address(), SearchCriteria.Op.NNULL);
-        nicSearchByNetwork.cp();
-
-        UserVmSearch = createSearchBuilder();
-        UserVmSearch.and("states", UserVmSearch.entity().getState(), SearchCriteria.Op.IN);
-        UserVmSearch.join("nicSearchByNetwork", nicSearchByNetwork, UserVmSearch.entity().getId(), nicSearchByNetwork.entity().getInstanceId(), JoinBuilder.JoinType.INNER);
-        UserVmSearch.done();
-
         UserVmByIsoSearch = createSearchBuilder();
         UserVmByIsoSearch.and("isoId", UserVmByIsoSearch.entity().getIsoId(), SearchCriteria.Op.EQ);
         UserVmByIsoSearch.done();
@@ -313,11 +301,25 @@ public class UserVmDaoImpl extends GenericDaoBase<UserVmVO, Long> implements Use
 
     @Override
     public List<UserVmVO> listByNetworkIdAndStates(long networkId, State... states) {
+        if (UserVmSearch == null) {
+            SearchBuilder<NicVO> nicSearch = _nicDao.createSearchBuilder();
+            nicSearch.and("networkId", nicSearch.entity().getNetworkId(), SearchCriteria.Op.EQ);
+            nicSearch.and("removed", nicSearch.entity().getRemoved(), SearchCriteria.Op.NULL);
+            nicSearch.and().op("ip4Address", nicSearch.entity().getIPv4Address(), SearchCriteria.Op.NNULL);
+            nicSearch.or("ip6Address", nicSearch.entity().getIPv6Address(), SearchCriteria.Op.NNULL);
+            nicSearch.cp();
+
+            UserVmSearch = createSearchBuilder();
+            UserVmSearch.and("states", UserVmSearch.entity().getState(), SearchCriteria.Op.IN);
+            UserVmSearch.join("nicSearch", nicSearch, UserVmSearch.entity().getId(), nicSearch.entity().getInstanceId(), JoinBuilder.JoinType.INNER);
+            UserVmSearch.done();
+        }
+
         SearchCriteria<UserVmVO> sc = UserVmSearch.create();
         if (states != null && states.length != 0) {
             sc.setParameters("states", (Object[])states);
         }
-        sc.setJoinParameters("nicSearchByNetwork", "networkId", networkId);
+        sc.setJoinParameters("nicSearch", "networkId", networkId);
 
         return listBy(sc);
     }


### PR DESCRIPTION
…start VR simultaneously."

This reverts commit 42e60ebac6f067e003598447ef75d914b7916734.
This reverts commit 9e20525e08d8dae7bcf3d568c5a1ccdb793eeb9d.

We're seeing some new errors, the PR was merged without trillian tests: https://github.com/apache/cloudstack/pull/1870