### PR TITLE
[CLOUDSTACK-10030] - Make publicips reachable inside VPC

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -886,7 +886,7 @@ class CsForwardingRules(CsDataBag):
         self.fw.append(["filter", "", fw7])
 
     def forward_vpc(self, rule):
-        fw_prerout_rule = "-A PREROUTING -d %s/32 -i %s" % (rule["public_ip"], self.getDeviceByIp(rule['public_ip']))
+        fw_prerout_rule = "-A PREROUTING -d %s/32 " % (rule["public_ip"])
         if not rule["protocol"] == "any":
             fw_prerout_rule += " -m %s -p %s" % (rule["protocol"], rule["protocol"])
         if not rule["public_ports"] == "any":


### PR DESCRIPTION
If a public IP is assigned to a VPC, a VM running inside that VPC cannot ping that public IP. This is due to the IPtables Nat rules set in such a way that drop any requests to the public IP from internal interfaces. I am fixing this so that internal hosts can also reach the public IP.

Reproduction:

Create a VPC
Create a network inside the VPC
Allocate a public IP
Create a VM in the network
Create a port forwarding rule enabling ICMP
ping the public IP inside the VM (this will fail)