### PR TITLE
CLOUDSTACK-10022: Allow domain admin to create and delete subdomains

### DIFF
--- a/api/src/org/apache/cloudstack/api/command/admin/domain/CreateDomainCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/domain/CreateDomainCmd.java
@@ -17,7 +17,7 @@
 package org.apache.cloudstack.api.command.admin.domain;
 
 import org.apache.log4j.Logger;
-
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -31,7 +31,8 @@ import com.cloud.domain.Domain;
 import com.cloud.user.Account;
 
 @APICommand(name = "createDomain", description = "Creates a domain", responseObject = DomainResponse.class,
-        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+ requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {
+        RoleType.Admin, RoleType.DomainAdmin })
 public class CreateDomainCmd extends BaseCmd {
     public static final Logger s_logger = Logger.getLogger(CreateDomainCmd.class.getName());
 
@@ -45,9 +46,9 @@ public class CreateDomainCmd extends BaseCmd {
     private String domainName;
 
     @Parameter(name = ApiConstants.PARENT_DOMAIN_ID,
-               type = CommandType.UUID,
-               entityType = DomainResponse.class,
-               description = "assigns new domain a parent domain by domain ID of the parent.  If no parent domain is specied, the ROOT domain is assumed.")
+            type = CommandType.UUID,
+            entityType = DomainResponse.class,
+            description = "assigns new domain a parent domain by domain ID of the parent.  If no parent domain is specied, the ROOT domain is assumed.")
     private Long parentDomainId;
 
     @Parameter(name = ApiConstants.NETWORK_DOMAIN, type = CommandType.STRING, description = "Network domain for networks in the domain")

--- a/api/src/org/apache/cloudstack/api/command/admin/domain/DeleteDomainCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/domain/DeleteDomainCmd.java
@@ -18,8 +18,7 @@ package org.apache.cloudstack.api.command.admin.domain;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
-
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -30,13 +29,15 @@ import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.region.RegionService;
+import org.apache.log4j.Logger;
 
 import com.cloud.domain.Domain;
 import com.cloud.event.EventTypes;
 import com.cloud.user.Account;
 
 @APICommand(name = "deleteDomain", description = "Deletes a specified domain", responseObject = SuccessResponse.class,
-        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+requestHasSensitiveInfo = false, responseHasSensitiveInfo = false, authorized = {
+        RoleType.Admin, RoleType.DomainAdmin })
 public class DeleteDomainCmd extends BaseAsyncCmd {
     public static final Logger s_logger = Logger.getLogger(DeleteDomainCmd.class.getName());
     private static final String s_name = "deletedomainresponse";
@@ -49,8 +50,8 @@ public class DeleteDomainCmd extends BaseAsyncCmd {
     private Long id;
 
     @Parameter(name = ApiConstants.CLEANUP,
-               type = CommandType.BOOLEAN,
-               description = "true if all domain resources (child domains, accounts) have to be cleaned up, false otherwise")
+            type = CommandType.BOOLEAN,
+            description = "true if all domain resources (child domains, accounts) have to be cleaned up, false otherwise")
     private Boolean cleanup;
 
     @Inject

--- a/ui/scripts/domains.js
+++ b/ui/scripts/domains.js
@@ -771,7 +771,9 @@
         } else if (isDomainAdmin()) {
             if (args.context.domains[0].id != g_domainid) {
                 allowedActions.push("edit"); //merge updateResourceLimit into edit
+                allowedActions.push("delete");
             }
+            allowedActions.push("create");
         }
         allowedActions.push("updateResourceCount");
         return allowedActions;


### PR DESCRIPTION
This change allows a domain admin to create and delete subdomains; the domain admin cannot delete its own domain.

To do that, two files have been changed:
(i) _schema-41000to41100.sql:_ two rows were added in table _role_permissions_, allowing the Domain Admin role (id: 3) to execute API commands 'createDomain' and 'deleteDomain';
(ii) _domains.js:_ enable buttons for creating and deleting domain in the CloudStack UI.