### PR TITLE
CLOUDSTACK-10032 : Database entries for templates created from snapshots disappear after management-server service restart

### DIFF
--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -525,6 +525,8 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                     bufferWriter.write("\n");
                     long size = _storage.getSize(destFileFullPath);
                     bufferWriter.write("size=" + size);
+                    bufferWriter.close();
+                    writer.close();
 
                     /**
                      * Snapshots might be in either QCOW2 or RAW image format


### PR DESCRIPTION
**ISSUE**

**This issue occurs only with KVM hypervisor**. Database entries for templates created from snapshots disappear after management-server service restart

**STEPS TO REPRODUCE**

1. Create a ACS setup and add KVM hypervisor as host.
2. Create snapshot of any disk (root or data disk) of an instance.
3. Create template using disk snapshot.
4. Verify that template got downloaded completely and is in Ready state.
5. Also, verify that entry for this template is present in template_store_ref table in database.
6. Now restart management server.
7. Once management server is restarted completely and web UI is available, check the template status. It will be in Active state instead of downloaded.
8. Also, entry for this template vanishes from template_store_ref table in database.

**Fix for the Issue**

In NfsSecondaryStorageResource.java class, inside method copySnapshotToTemplateFromNfsToNfs() bufferwriter which was created for writing data in template.properties file is not closed and hence few properties were not getting written in template.properties. As few properties were absent in template.properties file, so after management server restart, this template is not loaded and hence it goes into Active state.

**Screenshot of Template.properties before fix :** 

![screenshot before fix](https://user-images.githubusercontent.com/25146827/28970559-98af42d6-7946-11e7-9855-780d0d2cc002.PNG)

**Screenshot of Template.properties after fix :** 

![screenshot after fix](https://user-images.githubusercontent.com/25146827/28970575-a8920cba-7946-11e7-89ee-0895fc60b67f.PNG)

