### PR TITLE
CLOUDSTACK-10036: Decreasing timeout of failing unit test

### DIFF
--- a/utils/src/test/java/org/apache/cloudstack/utils/hypervisor/HypervisorUtilsTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/hypervisor/HypervisorUtilsTest.java
@@ -58,7 +58,7 @@ public class HypervisorUtilsTest {
         System.out.print("Testing block on modified files - ");
         String filePath = "./testfileinactive";
         int timeoutSeconds = 8;
-        long thresholdMilliseconds = 2000;
+        long thresholdMilliseconds = 1000;
         File file = new File(filePath);
 
         long startTime = setupcheckVolumeFileForActivityFile(file, _minFileSize);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CLOUDSTACK-10036

This test occasionally fails on CentOS6 environments by failing to meet the 2000 milliseconds threshold. Usually it ends up executing the method for ~1100. So decreasing the timeout to 1000 would prevent it from failing.