### PR TITLE
CLOUDSTACK-10042: Properly show ICMP SecGroup Rules

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -26,11 +26,19 @@
             tags: elem.tags
         };
 
+        if (typeof elem.icmptype != 'undefined') {
+             var icmptype = elem.icmptype.toString()
+        }
+
+        if (typeof elem.icmpcode != 'undefined') {
+             var icmpcode = elem.icmpcode.toString()
+        }
+
         if (elemData.startport == 0 && elemData.endport) {
             elemData.startport = '0';
-        } else if (elem.icmptype && elem.icmpcode) {
-            elemData.startport = elem.icmptype;
-            elemData.endport = elem.icmpcode;
+        } else if (icmptype && icmpcode) {
+            elemData.startport = icmptype;
+            elemData.endport = icmpcode;
         }
 
         return elemData;


### PR DESCRIPTION
A simple if-statement would fail if either the type or code were 0
as that if-statement failed them.

By checking if they are defined and casting them to a String afterwards
this makes the if-statement properly resolve and show the rule as it should.

Signed-off-by: Wido den Hollander <wido@widodh.nl>