### PR TITLE
CLOUDSTACK-10054:Volume download times out in 3600 seconds

### DIFF
--- a/core/src/main/java/com/cloud/storage/template/IsoProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/IsoProcessor.java
@@ -36,6 +36,11 @@ public class IsoProcessor extends AdapterBase implements Processor {
     StorageLayer _storage;
 
     @Override
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) {
+      return process(templatePath, format, templateName);
+    }
+
+   @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
         if (format != null) {
             s_logger.debug("We don't handle conversion from " + format + " to ISO.");

--- a/core/src/main/java/com/cloud/storage/template/IsoProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/IsoProcessor.java
@@ -36,12 +36,12 @@ public class IsoProcessor extends AdapterBase implements Processor {
     StorageLayer _storage;
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) {
-      return process(templatePath, format, templateName);
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
+      return process(templatePath, format, templateName, 0);
     }
 
    @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) {
         if (format != null) {
             s_logger.debug("We don't handle conversion from " + format + " to ISO.");
             return null;

--- a/core/src/main/java/com/cloud/storage/template/OVAProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/OVAProcessor.java
@@ -42,11 +42,15 @@ import com.cloud.utils.script.Script;
 
 public class OVAProcessor extends AdapterBase implements Processor {
     private static final Logger s_logger = Logger.getLogger(OVAProcessor.class);
-
     StorageLayer _storage;
 
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+        return process(templatePath, format, templateName, 0);
+    }
+
+    @Override
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
         if (format != null) {
             if (s_logger.isInfoEnabled()) {
                 s_logger.info("We currently don't handle conversion from " + format + " to OVA.");
@@ -66,8 +70,7 @@ public class OVAProcessor extends AdapterBase implements Processor {
         s_logger.info("Template processing - untar OVA package. templatePath: " + templatePath + ", templateName: " + templateName);
         String templateFileFullPath = templatePath + File.separator + templateName + "." + ImageFormat.OVA.getFileExtension();
         File templateFile = new File(templateFileFullPath);
-
-        Script command = new Script("tar", 0, s_logger);
+        Script command = new Script("tar", processTimeout, s_logger);
         command.add("--no-same-owner");
         command.add("--no-same-permissions");
         command.add("-xf", templateFileFullPath);

--- a/core/src/main/java/com/cloud/storage/template/Processor.java
+++ b/core/src/main/java/com/cloud/storage/template/Processor.java
@@ -44,6 +44,8 @@ public interface Processor extends Adapter {
      */
     FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException;
 
+    FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException;
+
     public static class FormatInfo {
         public ImageFormat format;
         public long size;

--- a/core/src/main/java/com/cloud/storage/template/QCOW2Processor.java
+++ b/core/src/main/java/com/cloud/storage/template/QCOW2Processor.java
@@ -40,6 +40,11 @@ public class QCOW2Processor extends AdapterBase implements Processor {
 
     private StorageLayer _storage;
 
+   @Override
+   public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException  {
+     return process(templatePath, format, templateName);
+   }
+
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
         if (format != null) {

--- a/core/src/main/java/com/cloud/storage/template/QCOW2Processor.java
+++ b/core/src/main/java/com/cloud/storage/template/QCOW2Processor.java
@@ -41,12 +41,12 @@ public class QCOW2Processor extends AdapterBase implements Processor {
     private StorageLayer _storage;
 
    @Override
-   public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException  {
-     return process(templatePath, format, templateName);
+   public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException  {
+     return process(templatePath, format, templateName, 0);
    }
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
         if (format != null) {
             s_logger.debug("We currently don't handle conversion from " + format + " to QCOW2.");
             return null;

--- a/core/src/main/java/com/cloud/storage/template/RawImageProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/RawImageProcessor.java
@@ -45,6 +45,11 @@ public class RawImageProcessor extends AdapterBase implements Processor {
         return true;
     }
 
+   @Override
+   public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
+      return process(templatePath, format, templateName);
+   }
+
     @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
         if (format != null) {

--- a/core/src/main/java/com/cloud/storage/template/RawImageProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/RawImageProcessor.java
@@ -46,12 +46,12 @@ public class RawImageProcessor extends AdapterBase implements Processor {
     }
 
    @Override
-   public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
-      return process(templatePath, format, templateName);
+   public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+      return process(templatePath, format, templateName, 0);
    }
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
         if (format != null) {
             s_logger.debug("We currently don't handle conversion from " + format + " to raw image.");
             return null;

--- a/core/src/main/java/com/cloud/storage/template/TARProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/TARProcessor.java
@@ -34,6 +34,11 @@ public class TARProcessor extends AdapterBase implements Processor {
     private StorageLayer _storage;
 
     @Override
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) {
+       return process(templatePath, format, templateName);
+    }
+
+    @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
         if (format != null) {
             s_logger.debug("We currently don't handle conversion from " + format + " to TAR.");

--- a/core/src/main/java/com/cloud/storage/template/TARProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/TARProcessor.java
@@ -34,12 +34,12 @@ public class TARProcessor extends AdapterBase implements Processor {
     private StorageLayer _storage;
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) {
-       return process(templatePath, format, templateName);
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
+       return process(templatePath, format, templateName, 0);
     }
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName) {
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) {
         if (format != null) {
             s_logger.debug("We currently don't handle conversion from " + format + " to TAR.");
             return null;

--- a/core/src/main/java/com/cloud/storage/template/VhdProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/VhdProcessor.java
@@ -57,12 +57,12 @@ public class VhdProcessor extends AdapterBase implements Processor {
     private String vhdIdentifierCookie = "conectix";
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
-     return process(templatePath, format, templateName);
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+     return process(templatePath, format, templateName, 0);
     }
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
         if (format != null) {
             s_logger.debug("We currently don't handle conversion from " + format + " to VHD.");
             return null;

--- a/core/src/main/java/com/cloud/storage/template/VhdProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/VhdProcessor.java
@@ -57,6 +57,11 @@ public class VhdProcessor extends AdapterBase implements Processor {
     private String vhdIdentifierCookie = "conectix";
 
     @Override
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
+     return process(templatePath, format, templateName);
+    }
+
+    @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
         if (format != null) {
             s_logger.debug("We currently don't handle conversion from " + format + " to VHD.");

--- a/core/src/main/java/com/cloud/storage/template/VmdkProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/VmdkProcessor.java
@@ -43,6 +43,11 @@ public class VmdkProcessor extends AdapterBase implements Processor {
     StorageLayer _storage;
 
     @Override
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
+     return process(templatePath, format, templateName);
+    }
+
+    @Override
     public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
         if (format != null) {
             if (s_logger.isInfoEnabled()) {

--- a/core/src/main/java/com/cloud/storage/template/VmdkProcessor.java
+++ b/core/src/main/java/com/cloud/storage/template/VmdkProcessor.java
@@ -43,12 +43,12 @@ public class VmdkProcessor extends AdapterBase implements Processor {
     StorageLayer _storage;
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
-     return process(templatePath, format, templateName);
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+     return process(templatePath, format, templateName, 0);
     }
 
     @Override
-    public FormatInfo process(String templatePath, ImageFormat format, String templateName) throws InternalErrorException {
+    public FormatInfo process(String templatePath, ImageFormat format, String templateName, long processTimeout) throws InternalErrorException {
         if (format != null) {
             if (s_logger.isInfoEnabled()) {
                 s_logger.info("We currently don't handle conversion from " + format + " to VMDK.");

--- a/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/command/TemplateOrVolumePostUploadCommand.java
@@ -51,6 +51,8 @@ public class TemplateOrVolumePostUploadCommand {
 
     private String defaultMaxAccountSecondaryStorage;
 
+    private long processTimeout;
+
     private long accountId;
 
     private Integer nfsVersion;
@@ -205,5 +207,13 @@ public class TemplateOrVolumePostUploadCommand {
 
     public void setNfsVersion(Integer nfsVersion) {
         this.nfsVersion = nfsVersion;
+    }
+
+    public void setProcessTimeout(long processTimeout) {
+        this.processTimeout = processTimeout;
+    }
+
+    public long getProcessTimeout() {
+        return processTimeout;
     }
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManager.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManager.java
@@ -42,6 +42,9 @@ public interface VmwareManager {
     static final ConfigKey<String> s_vmwareSearchExcludeFolder = new ConfigKey<String>("Advanced", String.class, "vmware.search.exclude.folders", null,
             "Comma seperated list of Datastore Folders to exclude from VMWare search", true, ConfigKey.Scope.Global);
 
+    static final ConfigKey<Integer> s_vmwareOVAPackageTimeout = new ConfigKey<Integer>(Integer.class, "vmware.package.ova.timeout", "Advanced", "3600",
+            "Vmware script timeout for ova packaging process", true, ConfigKey.Scope.Global, 1000);
+
     String composeWorkerName();
 
     String getSystemVMIsoFileNameOnDatastore();

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareManagerImpl.java
@@ -136,6 +136,7 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
     private static final Logger s_logger = Logger.getLogger(VmwareManagerImpl.class);
 
     private static final long SECONDS_PER_MINUTE = 60;
+
     private int _timeout;
 
     private String _instance;
@@ -204,7 +205,6 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
     private int _additionalPortRangeSize;
     private int _routerExtraPublicNics = 2;
     private int _vCenterSessionTimeout = 1200000; // Timeout in milliseconds
-
     private String _rootDiskController = DiskControllerType.ide.toString();
 
     private final String _dataDiskController = DiskControllerType.osdefault.toString();
@@ -229,9 +229,8 @@ public class VmwareManagerImpl extends ManagerBase implements VmwareManager, Vmw
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {s_vmwareNicHotplugWaitTimeout, s_vmwareCleanOldWorderVMs, templateCleanupInterval, s_vmwareSearchExcludeFolder};
+        return new ConfigKey<?>[] {s_vmwareNicHotplugWaitTimeout, s_vmwareCleanOldWorderVMs, templateCleanupInterval, s_vmwareSearchExcludeFolder, s_vmwareOVAPackageTimeout};
     }
-
     @Override
     public boolean configure(String name, Map<String, Object> params) throws ConfigurationException {
         s_logger.info("Configure VmwareManagerImpl, manager name: " + name);

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManager.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/manager/VmwareStorageManager.java
@@ -51,7 +51,7 @@ public interface VmwareStorageManager {
 
     boolean execute(VmwareHostService hostService, CreateEntityDownloadURLCommand cmd);
 
-    public void createOva(String path, String name);
+    public void createOva(String path, String name, int archiveTimeout);
 
-    public String createOvaForTemplate(TemplateObjectTO template);
+    public String createOvaForTemplate(TemplateObjectTO template, int archiveTimeout);
 }

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareSecondaryStorageResourceHandler.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareSecondaryStorageResourceHandler.java
@@ -145,8 +145,11 @@ public class VmwareSecondaryStorageResourceHandler implements SecondaryStorageRe
     }
 
     protected Answer execute(CreateEntityDownloadURLCommand cmd) {
-        _storageMgr.execute(this, cmd);
-        return _resource.defaultAction(cmd);
+        boolean success = _storageMgr.execute(this, cmd);
+        if (success) {
+            return _resource.defaultAction(cmd);
+        }
+        return new Answer(cmd, false, "Failed to download");
     }
 
     private Answer execute(PrimaryStorageDownloadCommand cmd) {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -367,6 +367,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                                                           dataObject.getDataStore().getRole().toString());
                 command.setLocalPath(volumeStore.getLocalDownloadPath());
                 //using the existing max upload size configuration
+                command.setProcessTimeout(NumbersUtil.parseLong(_configDao.getValue("vmware.package.ova.timeout"), 3600));
                 command.setMaxUploadSize(_configDao.getValue(Config.MaxUploadVolumeSize.key()));
                 command.setDefaultMaxAccountSecondaryStorage(_configDao.getValue(Config.DefaultMaxAccountSecondaryStorage.key()));
                 command.setAccountId(vol.getAccountId());

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -90,7 +90,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     private String _name;
     StorageLayer _storage;
     public Map<String, Processor> _processors;
-
+    private long _processTimeout;
     private Integer _nfsVersion;
 
     public class Completion implements DownloadCompleteCallback {
@@ -459,7 +459,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
             FormatInfo info = null;
             try {
-                info = processor.process(resourcePath, null, templateName);
+                info = processor.process(resourcePath, null, templateName, this._processTimeout);
             } catch (InternalErrorException e) {
                 s_logger.error("Template process exception ", e);
                 return e.toString();
@@ -677,6 +677,8 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
     @Override
     public DownloadAnswer handleDownloadCommand(SecondaryStorageResource resource, DownloadCommand cmd) {
+        int timeout = NumbersUtil.parseInt(cmd.getContextParam("vmware.package.ova.timeout"), 3600000);
+        this._processTimeout = timeout;
         ResourceType resourceType = cmd.getResourceType();
         if (cmd instanceof DownloadProgressCommand) {
             return handleDownloadProgressCmd(resource, (DownloadProgressCommand)cmd);

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadEntity.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/UploadEntity.java
@@ -34,6 +34,7 @@ public class UploadEntity {
     private int maxSizeInGB;
     private String description;
     private long contentLength;
+    private long processTimeout;
 
     public static enum ResourceType {
         VOLUME, TEMPLATE
@@ -58,6 +59,14 @@ public class UploadEntity {
         this.filename=filename;
         this.installPathPrefix = installPathPrefix;
         this.entityId=entityId;
+    }
+
+    public void setProcessTimeout(long processTimeout) {
+        this.processTimeout = processTimeout;
+    }
+
+    public long getProcessTimeout() {
+        return processTimeout;
     }
 
     public UploadEntity(){


### PR DESCRIPTION
Problem Statement -
When tried to download a volume of type Vmware with large size, it fails in an hour before generating the URL.
It can be seen in the ssvm logs that ova generation tar command fails/timed out in an hour. The volume is of 800GB and we should be able to increase the timeout. Unfortunately there is not method to do that. There is no global parameter to update the timeout for this operation.
Solution
Add a global parameter 'vmware.package.ova.timeout' for all the tar commands(commands taking long time)