### PR TITLE
CLOUDSTACK-10007 Isolation method claim

### DIFF
--- a/server/src/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/DirectNetworkGuru.java
@@ -35,6 +35,8 @@ import com.cloud.exception.InsufficientAddressCapacityException;
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.InsufficientVirtualNetworkCapacityException;
 import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.network.dao.PhysicalNetworkDao;
+import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.network.IpAddressManager;
 import com.cloud.network.Ipv6AddressManager;
 import com.cloud.network.Network;
@@ -46,6 +48,8 @@ import com.cloud.network.NetworkProfile;
 import com.cloud.network.Networks.BroadcastDomainType;
 import com.cloud.network.Networks.Mode;
 import com.cloud.network.Networks.TrafficType;
+import com.cloud.network.PhysicalNetwork;
+import com.cloud.network.PhysicalNetwork.IsolationMethod;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkVO;
@@ -99,8 +103,11 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
     IpAddressManager _ipAddrMgr;
     @Inject
     NetworkOfferingServiceMapDao _ntwkOfferingSrvcDao;
+    @Inject
+    PhysicalNetworkDao _physicalNetworkDao;
 
     private static final TrafficType[] TrafficTypes = {TrafficType.Guest};
+    protected IsolationMethod[] _isolationMethods;
 
     @Override
     public boolean isMyTrafficType(TrafficType type) {
@@ -112,14 +119,23 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
         return false;
     }
 
+    protected boolean isMyIsolationMethod(PhysicalNetwork physicalNetwork) {
+        for (IsolationMethod m : _isolationMethods) {
+            if (physicalNetwork.getIsolationMethods().contains(m.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public TrafficType[] getSupportedTrafficType() {
         return TrafficTypes;
     }
 
-    protected boolean canHandle(NetworkOffering offering, DataCenter dc) {
+    protected boolean canHandle(NetworkOffering offering, DataCenter dc, PhysicalNetwork physnet) {
         // this guru handles only Guest networks in Advance zone with source nat service disabled
-        if (dc.getNetworkType() == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && offering.getGuestType() == GuestType.Shared
+        if (dc.getNetworkType() == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && isMyIsolationMethod(physnet) && offering.getGuestType() == GuestType.Shared
                 && !_ntwkOfferingSrvcDao.isProviderForNetworkOffering(offering.getId(), Network.Provider.NuageVsp)
                 && !_ntwkOfferingSrvcDao.isProviderForNetworkOffering(offering.getId(), Network.Provider.NiciraNvp)) {
             return true;
@@ -132,8 +148,9 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
     @Override
     public Network design(NetworkOffering offering, DeploymentPlan plan, Network userSpecified, Account owner) {
         DataCenter dc = _dcDao.findById(plan.getDataCenterId());
+        PhysicalNetworkVO physnet = _physicalNetworkDao.findById(plan.getPhysicalNetworkId());
 
-        if (!canHandle(offering, dc)) {
+        if (!canHandle(offering, dc, physnet)) {
             return null;
         }
 
@@ -190,6 +207,7 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
 
     protected DirectNetworkGuru() {
         super();
+        _isolationMethods = new IsolationMethod[] { new IsolationMethod("VLAN") };
     }
 
     @Override

--- a/server/src/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/DirectNetworkGuru.java
@@ -135,9 +135,8 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
 
     protected boolean canHandle(NetworkOffering offering, DataCenter dc, PhysicalNetwork physnet) {
         // this guru handles only Guest networks in Advance zone with source nat service disabled
-        if (dc.getNetworkType() == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && isMyIsolationMethod(physnet) && offering.getGuestType() == GuestType.Shared
-                && !_ntwkOfferingSrvcDao.isProviderForNetworkOffering(offering.getId(), Network.Provider.NuageVsp)
-                && !_ntwkOfferingSrvcDao.isProviderForNetworkOffering(offering.getId(), Network.Provider.NiciraNvp)) {
+        if (dc.getNetworkType() == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && offering.getGuestType() == GuestType.Shared &&
+            isMyIsolationMethod(physnet)) {
             return true;
         } else {
             s_logger.trace("We only take care of Guest networks of type " + GuestType.Shared);

--- a/server/src/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/DirectNetworkGuru.java
@@ -135,8 +135,9 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
 
     protected boolean canHandle(NetworkOffering offering, DataCenter dc, PhysicalNetwork physnet) {
         // this guru handles only Guest networks in Advance zone with source nat service disabled
-        if (dc.getNetworkType() == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && offering.getGuestType() == GuestType.Shared &&
-            isMyIsolationMethod(physnet)) {
+        if (dc.getNetworkType() == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && isMyIsolationMethod(physnet) && offering.getGuestType() == GuestType.Shared
+                && !_ntwkOfferingSrvcDao.isProviderForNetworkOffering(offering.getId(), Network.Provider.NuageVsp)
+                && !_ntwkOfferingSrvcDao.isProviderForNetworkOffering(offering.getId(), Network.Provider.NiciraNvp)) {
             return true;
         } else {
             s_logger.trace("We only take care of Guest networks of type " + GuestType.Shared);

--- a/server/src/com/cloud/network/guru/DirectPodBasedNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/DirectPodBasedNetworkGuru.java
@@ -47,6 +47,7 @@ import com.cloud.network.Networks.IsolationType;
 import com.cloud.network.addr.PublicIp;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
+import com.cloud.network.PhysicalNetwork;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.utils.db.DB;
@@ -83,9 +84,9 @@ public class DirectPodBasedNetworkGuru extends DirectNetworkGuru {
     IpAddressManager _ipAddrMgr;
 
     @Override
-    protected boolean canHandle(NetworkOffering offering, DataCenter dc) {
+    protected boolean canHandle(NetworkOffering offering, DataCenter dc, PhysicalNetwork physnet) {
         // this guru handles system Direct pod based network
-        if (dc.getNetworkType() == NetworkType.Basic && isMyTrafficType(offering.getTrafficType())) {
+        if (dc.getNetworkType() == NetworkType.Basic && isMyTrafficType(offering.getTrafficType()) && isMyIsolationMethod(physnet)) {
             return true;
         } else {
             s_logger.trace("We only take care of Guest Direct Pod based networks");


### PR DESCRIPTION
This will prevent DirectNetworkGuru from designing and implementing a network it is not supposed to but, as discussed with @fmaximus, the  commit "remove hardcoded exemptions on directnetworkguru" will still allow it to implement a network if it supports one of the services from the offering so several gurus can still end up implementing a single network.
Solutions could include:
- only canHandle() if all required services are supported
- link a guru to a physical network and not ask for any guru if they canHandle()
- retrospecively check what guru implements the best set of services.