### PR TITLE
CLOUDSTACK-10067: Fix a case where a user 'ro' or 'roo' exists on the system

### DIFF
--- a/setup/bindir/cloud-set-guest-sshkey-configdrive.in
+++ b/setup/bindir/cloud-set-guest-sshkey-configdrive.in
@@ -84,7 +84,7 @@ else
     exit 1
 fi
 
-homedir=$(grep ^$user /etc/passwd|awk -F ":" '{print $6}')
+homedir=$(getent passwd $user|awk -F ":" '{print $6}')
 sshdir=$homedir/.ssh
 authorized=$sshdir/authorized_keys
 

--- a/setup/bindir/cloud-set-guest-sshkey.in
+++ b/setup/bindir/cloud-set-guest-sshkey.in
@@ -49,7 +49,7 @@ if [ -z "$SSHKEY_SERVER_IP" ]; then
      logger -t "cloud" "Unable to determine the password server, falling back to data-server"
      SSHKEY_SERVER_IP=data-server
 fi
- 
+
 logger -t "cloud" "Sending request to ssh key server at $SSHKEY_SERVER_IP"
 publickey=$(wget -q -t 3 -T 20 -O - http://$SSHKEY_SERVER_IP/latest/public-keys)
 if [ $? -eq 0 ]; then
@@ -67,7 +67,7 @@ if [ -z "$publickey" ]; then
     exit 1
 fi
 
-homedir=$(grep ^$user /etc/passwd|awk -F ":" '{print $6}')
+homedir=$(getent passwd $user|awk -F ":" '{print $6}')
 sshdir=$homedir/.ssh
 authorized=$sshdir/authorized_keys
 


### PR DESCRIPTION
Fix a case where a user 'ro' or 'roo' exists on the system or other variants, like 'cen' and 'centos'.
If one sets user=roo, this will return two directories (/root /home/roo) and then it will fail.

Also, if user 'ro' or 'roo' does not exist, this will happily put the sshkey to the authorized_keys of the root account, which is not the intended place.

As another slightly less improbable example, if we have two users in our company named lars, then we could end up with lars's sshkey in larsb's authorized_keys.

The binary getent should be available on most Linux platforms, including ones using uClibc.