### PR TITLE
CLOUDSTACK-10058: Error while opening the Settings tab in Secondary storage

### DIFF
--- a/framework/config/src/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -140,7 +140,8 @@ public class ConfigKey<T> {
     public T value() {
         if (_value == null || isDynamic()) {
             ConfigurationVO vo = s_depot != null ? s_depot.global().findById(key()) : null;
-            _value = valueOf((vo != null && vo.getValue() != null) ? vo.getValue() : defaultValue());
+            final String value = (vo != null && vo.getValue() != null) ? vo.getValue() : defaultValue();
+            _value = ((value == null) ? (T)defaultValue() : valueOf(value));
         }
 
         return _value;

--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1754,7 +1754,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
                 if (configVo != null) {
                     final ConfigKey<?> key = _configDepot.get(param.getName());
                     if (key != null) {
-                        configVo.setValue(key.valueIn(id).toString());
+                        configVo.setValue(key.valueIn(id) == null ? null : key.valueIn(id).toString());
                         configVOList.add(configVo);
                     } else {
                         s_logger.warn("ConfigDepot could not find parameter " + param.getName() + " for scope " + scope);


### PR DESCRIPTION
Issue Description:
=============
https://issues.apache.org/jira/browse/CLOUDSTACK-10058

Root Cause:
=========
Some global parameters contains NULL value, where the code doesn't handle NULL check.
So it fails with an exception. Hence nothing appears on the field(ERROR).

Solution:
=======
Added required NULL check.

Snapshots:
========
Before
![before](https://user-images.githubusercontent.com/12583725/29914910-c38e578c-8e57-11e7-8dd2-2620542b3881.png)

After
![after](https://user-images.githubusercontent.com/12583725/29914916-c9954cbc-8e57-11e7-965c-3f15c17c3cd0.png)
