### PR TITLE
CLOUDSTACK-10059: Dashboard ignores resource value that is less than 1%

### DIFF
--- a/ui/scripts/dashboard.js
+++ b/ui/scripts/dashboard.js
@@ -267,7 +267,7 @@
                                             zoneID: capacity.zoneid, // Temporary fix for dashboard
                                             zoneName: capacity.zonename,
                                             type: cloudStack.converters.toCapacityCountType(capacity.type),
-                                            percent: parseInt(capacity.percentused),
+                                            percent: capacity.percentused,
                                             used: cloudStack.converters.convertByType(capacity.type, capacity.capacityused),
                                             total: cloudStack.converters.convertByType(capacity.type, capacity.capacitytotal)
                                         };


### PR DESCRIPTION
Description:
=========
https://issues.apache.org/jira/browse/CLOUDSTACK-10059

Root Cause:
=========
The API returns the percentage value as floating point number but In UI it is converted to floor value of that number.
Hence for values less than 1%, the value is being converted to 0% and it doesn't show the value in the UI.

Solution:
=======
Removed the conversion, now it represents as it is(Floating point value).

Snapshots:
========
Before
![before](https://user-images.githubusercontent.com/12583725/29915971-07bdfa2c-8e5b-11e7-84eb-84285547954c.png)

After
<img width="875" alt="after" src="https://user-images.githubusercontent.com/12583725/29915981-0ee7d43a-8e5b-11e7-9aca-c748aa819bf8.png">
