### PR TITLE
CLOUDSTACK-10060:ListUsage API always displays the Virtual size as '0' for Usage type=9 (snapshot)

### DIFF
--- a/usage/src/com/cloud/usage/parser/StorageUsageParser.java
+++ b/usage/src/com/cloud/usage/parser/StorageUsageParser.java
@@ -181,8 +181,11 @@ public class StorageUsageParser {
                 usageDesc += "Snapshot ";
                 break;
         }
-        // Create the usage record
-        usageDesc += "Id:" + storageId + " Size:" + size + "VirtualSize:" + virtualSize;
+        //Create the usage record
+        usageDesc += "Id:" + storageId + " Size:" + size;
+        if (type != StorageTypes.SNAPSHOT) {
+            usageDesc += " VirtualSize:" + virtualSize;
+        }
 
         //ToDo: get zone id
         UsageVO usageRecord =


### PR DESCRIPTION
**Bug Description:**
In the listUsage API, the Virtual Size of Snapshot is always displayed as '0'.

**Root Cause:**
In case of snapshots, the usage is accounted for depending on the value of the global parameter, 'usage.snapshot.virtualsize.select'. If set to 'true', the usage calculation is done based on the Virtual Size, and if set to false, it is done based on the Physical size. In the Usage API, this value, (i.e. virtual or physical) is displayed as 'Size' field correctly, but the field 'VirtualSize' is always displayed as 0. This is misleading.

**Expected Output:**
Since this is a Usage API, ideally only that size should be displayed which is used for billing, depending on the value of 'usage.snapshot.virtualsize.select'.
There is another API - the ListSnapshot API that displays both, the physical as well as Virtual size and can be used to know both the sizes.

**Fix Implemented:**
Skipped showing the 'VirtualSize' Field for type=snapshot
