### PR TITLE
CLOUDSTACK-10068 - Fixing test_iso.py assertions are equating srt and…

### DIFF
--- a/test/integration/smoke/test_iso.py
+++ b/test/integration/smoke/test_iso.py
@@ -320,8 +320,8 @@ class TestISO(cloudstackTestCase):
             "Check display text of updated ISO"
         )
         self.assertEqual(
-            iso_response.bootable,
-            self.services["bootable"],
+            str(iso_response.bootable).lower(),
+            str(self.services["bootable"]).lower(),
             "Check if image is bootable of updated ISO"
         )
 
@@ -473,14 +473,14 @@ class TestISO(cloudstackTestCase):
             "Check ISO ID"
         )
         self.assertEqual(
-            iso_response.ispublic,
-            self.services["ispublic"],
+            str(iso_response.ispublic).lower(),
+            str(self.services["ispublic"]).lower(),
             "Check ispublic permission of ISO"
         )
 
         self.assertEqual(
-            iso_response.isfeatured,
-            self.services["isfeatured"],
+            str(iso_response.isfeatured).lower(),
+            str(self.services["isfeatured"]).lower(),
             "Check isfeatured permission of ISO"
         )
         return


### PR DESCRIPTION
… bool instead of the same types

```
2017-09-04 11:23:16,432 - CRITICAL - FAILED: test_02_edit_iso: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python2.7/unittest/case.py", line 369, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_iso.py", line 327, in test_02_edit_iso\n    "Check if image is bootable of updated ISO"\n', '  File "/usr/lib64/python2.7/unittest/case.py", line 553, in assertEqual\n    assertion_func(first, second, msg=msg)\n', '  File "/usr/lib64/python2.7/unittest/case.py", line 546, in _baseAssertEqual\n    raise self.failureException(msg)\n', 'AssertionError: Check if image is bootable of updated ISO\n']
2017-09-04 11:24:56,797 - CRITICAL - FAILED: test_05_iso_permissions: ['Traceback (most recent call last):\n', '  File "/usr/lib64/python2.7/unittest/case.py", line 369, in run\n    testMethod()\n', '  File "/marvin/tests/smoke/test_iso.py", line 480, in test_05_iso_permissions\n    "Check ispublic permission of ISO"\n', '  File "/usr/lib64/python2.7/unittest/case.py", line 553, in assertEqual\n    assertion_func(first, second, msg=msg)\n', '  File "/usr/lib64/python2.7/unittest/case.py", line 546, in _baseAssertEqual\n    raise self.failureException(msg)\n', 'AssertionError: Check ispublic permission of ISO\n']
```

It appears that asserts.equal(boolean.True, str.True) which seems to be causing the issue. Probably related to some api changes in recent PRs. Will fix the equation to str.lower() so it'll pass.

Strangely when running the tests from Pycharm CE they pass, it seems the IDE resolves the type issue during comparison. But when running from command line it failes... 

After fixing this results came back as expected:
```
[root@trl-914-k-cs411-bstoyanov-marvin ~]# cat /marvin//MarvinLogs/test_iso_SIXUJL/results.txt
Test create public & private ISO ... === TestName: test_01_create_iso | Status : SUCCESS ===
ok
Test Edit ISO ... === TestName: test_02_edit_iso | Status : SUCCESS ===
ok
Test delete ISO ... === TestName: test_03_delete_iso | Status : SUCCESS ===
ok
Test for extract ISO ... === TestName: test_04_extract_Iso | Status : SUCCESS ===
ok
Update & Test for ISO permissions ... === TestName: test_05_iso_permissions | Status : SUCCESS ===
ok
Test for copy ISO from one zone to another ... SKIP: Not enough zones available to perform copy template
Test delete ISO ... === TestName: test_07_list_default_iso | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 7 tests in 156.987s

OK (SKIP=1)
```