### PR TITLE
CLOUDSTACK-10069: Add sha512 suffix to SHA 512 checksum

### DIFF
--- a/tools/build/build_asf.sh
+++ b/tools/build/build_asf.sh
@@ -154,8 +154,8 @@ fi
 echo 'md5'
 gpg -v --print-md MD5 apache-cloudstack-$version-src.tar.bz2 > apache-cloudstack-$version-src.tar.bz2.md5
 
-echo 'sha'
-gpg -v --print-md SHA512 apache-cloudstack-$version-src.tar.bz2 > apache-cloudstack-$version-src.tar.bz2.sha
+echo 'sha512'
+gpg -v --print-md SHA512 apache-cloudstack-$version-src.tar.bz2 > apache-cloudstack-$version-src.tar.bz2.sha512
 
 echo 'verify'
 gpg -v --verify apache-cloudstack-$version-src.tar.bz2.asc apache-cloudstack-$version-src.tar.bz2
@@ -187,11 +187,11 @@ if [ "$committosvn" == "yes" ]; then
   cp $outputdir/apache-cloudstack-$version-src.tar.bz2 .
   cp $outputdir/apache-cloudstack-$version-src.tar.bz2.asc .
   cp $outputdir/apache-cloudstack-$version-src.tar.bz2.md5 .
-  cp $outputdir/apache-cloudstack-$version-src.tar.bz2.sha .
+  cp $outputdir/apache-cloudstack-$version-src.tar.bz2.sha512 .
   svn add apache-cloudstack-$version-src.tar.bz2
   svn add apache-cloudstack-$version-src.tar.bz2.asc
   svn add apache-cloudstack-$version-src.tar.bz2.md5
-  svn add apache-cloudstack-$version-src.tar.bz2.sha
+  svn add apache-cloudstack-$version-src.tar.bz2.sha512
   svn commit -m "Committing release candidate artifacts for $version to dist/dev/cloudstack in preparation for release vote"
 fi
 


### PR DESCRIPTION
Per http://www.apache.org/dev/release-distribution#sigs-and-sums
This will add `.sha512` to the SHA 512 checksum file in the
release/candidate tarball.

Pinging for review @wido @swill @DaanHoogland @karuturi and others.

No trilian tests required, the changes are in build/release scripts.