### PR TITLE
KVM host memory overprovision parameter

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -156,3 +156,7 @@ hypervisor.type=kvm
 #router.aggregation.command.each.timeout=600
 #timeout value for aggregation commands send to virtual router
 #
+# host.overcommit.mem.mb = 0
+# allows to increase amount of ram available on host virtually to utilize Zswap, KSM features
+# and modern fast SSD/3D XPoint devices
+# 

--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -18,8 +18,8 @@
 [Unit]
 Description=CloudStack Agent
 Documentation=http://www.cloudstack.org/
-Requires=libvirtd.service
-After=libvirtd.service
+Requires=libvirt-bin.service
+After=libvirt-bin.service
 
 [Service]
 Type=simple

--- a/plugins/database/quota/src/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
+++ b/plugins/database/quota/src/org/apache/cloudstack/api/response/QuotaResponseBuilderImpl.java
@@ -523,14 +523,7 @@ public class QuotaResponseBuilderImpl implements QuotaResponseBuilder {
 
     @Override
     public Date startOfNextDay() {
-        Calendar c = Calendar.getInstance();
-        c.setTime(new Date());
-        c.add(Calendar.DATE, 1);
-        c.set(Calendar.HOUR, 0);
-        c.set(Calendar.MINUTE, 0);
-        c.set(Calendar.SECOND, 0);
-        c.set(Calendar.MILLISECOND, 0);
-        return c.getTime();
+        return startOfNextDay(new Date());
     }
 
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -270,6 +270,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     private long _dom0MinMem;
 
+    private long _dom0OvercommitMem;
+
     protected boolean _disconnected = true;
     protected int _cmdsTimeout;
     protected int _stopTimeout;
@@ -798,6 +800,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         value = (String)params.get("host.reserved.mem.mb");
         // Reserve 1GB unless admin overrides
         _dom0MinMem = NumbersUtil.parseInt(value, 1024) * 1024 * 1024L;
+
+        value = (String)params.get("host.overcommit.mem.mb");
+        // Support overcommit memory for host if host uses ZSWAP, KSM and other memory
+        // compressing technologies
+        _dom0OvercommitMem = NumbersUtil.parseInt(value, 1024) * 1024 * 1024L;
 
         value = (String) params.get("kvmclock.disable");
         if (Boolean.parseBoolean(value)) {
@@ -2658,12 +2665,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         info.add((int)cpus);
         info.add(speed);
         // Report system's RAM as actual RAM minus host OS reserved RAM
-        ram = ram - _dom0MinMem;
+        ram = ram - _dom0MinMem + _dom0OvercommitMem;
         info.add(ram);
         info.add(cap);
         info.add(_dom0MinMem);
         info.add(cpuSockets);
-        s_logger.debug("cpus=" + cpus + ", speed=" + speed + ", ram=" + ram + ", _dom0MinMem=" + _dom0MinMem + ", cpu sockets=" + cpuSockets);
+        s_logger.debug("cpus=" + cpus + ", speed=" + speed + ", ram=" + ram + ", _dom0MinMem=" + _dom0MinMem + ", _dom0OvercommitMem=" + _dom0OvercommitMem + ", cpu sockets=" + cpuSockets);
 
         return info;
     }


### PR DESCRIPTION
Commit enables a new feature for KVM hypervisor which purpose is to increase virtually amount of RAM available beyond the actual limit.

There is a new parameter in agent.properties: host.overcommit.mem.mb which enables adding specified amount of RAM to actually available.

Also, there is a small refactoring for QuotaResponseBuilderImpl class which deduplicates the code.