### PR TITLE
CLOUDSTACK-10073: KVM host RAM overprovisioning

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -180,3 +180,9 @@ hypervisor.type=kvm
 # router.aggregation.command.each.timeout=600
 # timeout value for aggregation commands send to virtual router
 #
+# host.overcommit.mem.mb = 0
+# allows to increase amount of ram available on host virtually to utilize Zswap, KSM features
+# and modern fast SSD/3D XPoint devices. Specified amount of MBs is added to the memory agent 
+# reports to the Management Server
+# Default: 0
+# 

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -299,6 +299,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
     private long _dom0MinMem;
 
+    private long _dom0OvercommitMem;
+
     protected boolean _disconnected = true;
     protected int _cmdsTimeout;
     protected int _stopTimeout;
@@ -843,6 +845,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         value = (String)params.get("host.reserved.mem.mb");
         // Reserve 1GB unless admin overrides
         _dom0MinMem = NumbersUtil.parseInt(value, 1024) * 1024 * 1024L;
+
+        value = (String)params.get("host.overcommit.mem.mb");
+        // Support overcommit memory for host if host uses ZSWAP, KSM and other memory
+        // compressing technologies
+        _dom0OvercommitMem = NumbersUtil.parseInt(value, 0) * 1024 * 1024L;
 
         value = (String) params.get("kvmclock.disable");
         if (Boolean.parseBoolean(value)) {
@@ -2765,12 +2772,12 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         info.add((int)cpus);
         info.add(speed);
         // Report system's RAM as actual RAM minus host OS reserved RAM
-        ram = ram - _dom0MinMem;
+        ram = ram - _dom0MinMem + _dom0OvercommitMem;
         info.add(ram);
         info.add(cap);
         info.add(_dom0MinMem);
         info.add(cpuSockets);
-        s_logger.debug("cpus=" + cpus + ", speed=" + speed + ", ram=" + ram + ", _dom0MinMem=" + _dom0MinMem + ", cpu sockets=" + cpuSockets);
+        s_logger.debug("cpus=" + cpus + ", speed=" + speed + ", ram=" + ram + ", _dom0MinMem=" + _dom0MinMem + ", _dom0OvercommitMem=" + _dom0OvercommitMem + ", cpu sockets=" + cpuSockets);
 
         return info;
     }


### PR DESCRIPTION
The PR introduces new cloudstack agent KVM property
host.overcommit.mem.mb

which allows increasing KVM host RAM more than physical RAM exists. It is necessary to utilize KSM and ZSwap features which extend RAM with deduplication and compression.