### PR TITLE
CLOUDSTACK-10081: getDevInfo now returns correct value

### DIFF
--- a/python/lib/cloudutils/networkConfig.py
+++ b/python/lib/cloudutils/networkConfig.py
@@ -154,7 +154,7 @@ class networkConfig:
 
         if networkConfig.isBridgePort(dev):
             type = "brport"
-        elif networkConfig.isBridge(dev):
+        elif networkConfig.isBridge(dev) or networkConfig.isOvsBridge(dev):
             type = "bridge"
         else:
             type = "dev"


### PR DESCRIPTION
CloudUtils getDevInfo function will now return "bridge" instead of "dev" when the name of a ovs bridge is passed.

Bug ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-10081