### PR TITLE
CLOUDSTACK-10085 : Upload volume from local fails when global config max.account.seconday.storage is set to -1

### DIFF
--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -35,9 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import javax.naming.ConfigurationException;
-
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.CheckHealthAnswer;
@@ -76,6 +74,7 @@ import com.cloud.exception.InternalErrorException;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.host.Host;
 import com.cloud.host.Host.Type;
+import com.cloud.configuration.Resource;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.resource.ServerResourceBase;
 import com.cloud.storage.DataStoreRole;
@@ -2809,7 +2808,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         int accountDirSizeInGB = getSizeInGB(accountTemplateDirSize + accountSnapshotDirSize + accountVolumeDirSize);
         int defaultMaxAccountSecondaryStorageInGB = Integer.parseInt(cmd.getDefaultMaxAccountSecondaryStorage());
 
-        if ((accountDirSizeInGB + contentLengthInGB) > defaultMaxAccountSecondaryStorageInGB) {
+        if (defaultMaxAccountSecondaryStorageInGB != Resource.RESOURCE_UNLIMITED && (accountDirSizeInGB + contentLengthInGB) > defaultMaxAccountSecondaryStorageInGB) {
             s_logger.error("accountDirSizeInGb: " + accountDirSizeInGB + " defaultMaxAccountSecondaryStorageInGB: " + defaultMaxAccountSecondaryStorageInGB + " contentLengthInGB:"
                     + contentLengthInGB);
             String errorMessage = "Maximum number of resources of type secondary_storage for account has exceeded";


### PR DESCRIPTION
**ISSUE**

Upload volume from local fails when global config max.account.seconday.storage is set to -1

**STEPS TO REPRODUCE**

1. Download any volume on your local machine.
2. Change value of global configuration max.account.seconday.storage to -1.
3. Restart Management server.
4. Try to upload a volume from UI using "Upload from Local" option. Upload will fail.

**FIX**

Implementation of -1 option for unlimited secondary storage usage, which is absent in current code.