### PR TITLE
CLOUDSTACK-10087 Template registration errors out when template URL i…

### DIFF
--- a/systemvm/debian/opt/cloud/bin/setup/secstorage.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/secstorage.sh
@@ -80,6 +80,17 @@ CORS
   rm -f /etc/logrotate.d/cloud
 }
 
+import_jvm_cacerts(){
+ log_it "importing jvm keystore to realhostip keystore"
+ keyStore=/usr/local/cloud/systemvm/certs/realhostip.keystore
+ storepass="vmops.com"
+ java_home=$(readlink -f $(which java) | sed "s:/bin/java::")
+ java_keystore=$java_home/jre/lib/security/cacerts
+ java_store_pass="changeit"
+ keytool -importkeystore -srckeystore $java_keystore -srcstorepass $java_store_pass -destkeystore $keyStore -deststorepass $storepass -noprompt
+ log_it "import of jvm keystore to realhostip keystore completed"
+}
+
 secstorage_svcs
 if [ $? -gt 0 ]
 then
@@ -87,3 +98,4 @@ then
   exit 1
 fi
 setup_secstorage
+import_jvm_cacerts


### PR DESCRIPTION
…s https

ca certificates were missing in realhostip.keystore.

Before adding the fix while registering the template, it raises an exception "unable to find valid certification path to requested target".

![image](https://user-images.githubusercontent.com/12229259/30679204-da21685e-9e65-11e7-87c3-8515523b7b3d.png)

After the fix register template works fine.

![image](https://user-images.githubusercontent.com/12229259/30679212-e5a53714-9e65-11e7-94c2-4147b30be0ba.png)
