### PR TITLE
CLOUDSTACK-10090:createPortForwardingRule api call accepts 'halt' as …

### DIFF
--- a/server/src/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VirtualRouterElement.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
+
+import com.cloud.utils.net.NetUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import com.cloud.network.router.NetworkHelper;
@@ -568,7 +570,10 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
         capabilities.put(Service.SourceNat, sourceNatCapabilities);
 
         capabilities.put(Service.StaticNat, null);
-        capabilities.put(Service.PortForwarding, null);
+
+        final Map<Capability, String> portForwardingCapabilities = new HashMap<Capability, String>();
+        portForwardingCapabilities.put(Capability.SupportedProtocols, NetUtils.TCP_PROTO + "," + NetUtils.UDP_PROTO);
+        capabilities.put(Service.PortForwarding, portForwardingCapabilities);
 
         return capabilities;
     }


### PR DESCRIPTION
…Protocol which Stops VR

When we run the createPortForwardingRule API with input as Protocol as halt the PF rule is added however Halt is executed on VR. Hence the VR is stopped.

Following entry added to Firewall_Rules table and VirtualRouter went to halt(stopped)
mysql> select * from firewall_rules where id = 7 

*************************** 1. row ***************************
id: 7
uuid: XXXXXXXXXXXXXXXXXXXXXXXXXXX
ip_address_id: 13
start_port: 222
end_port: 222
state: Revoke
protocol: `halt`
purpose: PortForwarding
account_id: 2
domain_id: 1
network_id: 208
xid: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
created: 2017-09-04 04:48:16
icmp_code: NULL
icmp_type: NULL
related: NULL
type: User
vpc_id: NULL
traffic_type