### PR TITLE
CLOUDSTACK-10096 Can't reset integration.api.port and usage.sanity.ch…

### DIFF
--- a/server/src/com/cloud/api/ApiServer.java
+++ b/server/src/com/cloud/api/ApiServer.java
@@ -336,6 +336,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             final ConfigurationVO apiPortConfig = values.get(0);
             if (apiPortConfig.getValue() != null) {
                 apiPort = Integer.parseInt(apiPortConfig.getValue());
+                apiPort = (apiPort <= 0) ? null : apiPort;
             }
         }
 

--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -562,7 +562,7 @@ public enum Config {
             "The interval (in milliseconds) when host stats are retrieved from agents.",
             null),
     HostRetry("Advanced", AgentManager.class, Integer.class, "host.retry", "2", "Number of times to retry hosts for creating a volume", null),
-    IntegrationAPIPort("Advanced", ManagementServer.class, Integer.class, "integration.api.port", null, "Default API port", null),
+    IntegrationAPIPort("Advanced", ManagementServer.class, Integer.class, "integration.api.port", null, "Default API port. To disable set it to 0 or negative.", null),
     InvestigateRetryInterval(
             "Advanced",
             HighAvailabilityManager.class,
@@ -1276,7 +1276,7 @@ public enum Config {
             Integer.class,
             "usage.sanity.check.interval",
             null,
-            "Interval (in days) to check sanity of usage data",
+            "Interval (in days) to check sanity of usage data. To disable set it to 0 or negative.",
             null),
     UsageAggregationTimezone("Usage", ManagementServer.class, String.class, "usage.aggregation.timezone", "GMT", "The timezone to use for usage stats aggregation", null),
     TrafficSentinelIncludeZones(

--- a/setup/db/db/schema-41000to41100.sql
+++ b/setup/db/db/schema-41000to41100.sql
@@ -34,7 +34,7 @@ where
       or service in ('NetworkACL')
     )
   );
-
+ 
 --Alter view template_view
  
 DROP VIEW IF EXISTS `cloud`.`template_view`;

--- a/setup/db/db/schema-41000to41100.sql
+++ b/setup/db/db/schema-41000to41100.sql
@@ -460,7 +460,3 @@ CREATE TABLE `cloud`.`nic_extra_dhcp_options` (
   PRIMARY KEY (`id`),
   CONSTRAINT `fk_nic_extra_dhcp_options_nic_id` FOREIGN KEY (`nic_id`) REFERENCES `nics`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-UPDATE `cloud`.`configuration` SET `description`='Default API port. To disable set it to 0 or negative.' WHERE `name`='integration.api.port';
-
-UPDATE `cloud`.`configuration` SET `description`='Interval (in days) to check sanity of usage data. To disable set it to 0 or negative.' WHERE `name`='usage.sanity.check.interval';

--- a/setup/db/db/schema-41000to41100.sql
+++ b/setup/db/db/schema-41000to41100.sql
@@ -34,7 +34,7 @@ where
       or service in ('NetworkACL')
     )
   );
- 
+  
 --Alter view template_view
  
 DROP VIEW IF EXISTS `cloud`.`template_view`;

--- a/setup/db/db/schema-41000to41100.sql
+++ b/setup/db/db/schema-41000to41100.sql
@@ -34,7 +34,7 @@ where
       or service in ('NetworkACL')
     )
   );
-  
+
 --Alter view template_view
  
 DROP VIEW IF EXISTS `cloud`.`template_view`;
@@ -460,3 +460,7 @@ CREATE TABLE `cloud`.`nic_extra_dhcp_options` (
   PRIMARY KEY (`id`),
   CONSTRAINT `fk_nic_extra_dhcp_options_nic_id` FOREIGN KEY (`nic_id`) REFERENCES `nics`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+UPDATE `cloud`.`configuration` SET `description`='Default API port. To disable set it to 0 or negative.' WHERE `name`='integration.api.port';
+
+UPDATE `cloud`.`configuration` SET `description`='Interval (in days) to check sanity of usage data. To disable set it to 0 or negative.' WHERE `name`='usage.sanity.check.interval';


### PR DESCRIPTION
…eck.interval back to null

Fix for CLOUDSTACK-7931 enforces a valid integer value to be configured for integration.api.port and usage.sanity.check.interval. These global configs can't be reset back to null(default).

While trying to reset following errors is observed. 

![image](https://user-images.githubusercontent.com/12229259/30840938-fd737578-a247-11e7-8585-f46cb38fb153.png)
![image](https://user-images.githubusercontent.com/12229259/30840939-01837b68-a248-11e7-9288-150578f74aa9.png)

But 0 and negative are accepted.

![image](https://user-images.githubusercontent.com/12229259/30840972-26773978-a248-11e7-8205-8dca9624de1a.png)
![image](https://user-images.githubusercontent.com/12229259/30840979-30f1bf54-a248-11e7-9bbf-ee14cd4e0f6c.png)

Add changes to handle 0 and negative values as disabled for api.integration.port.
For usage.sanity.check.interval 0 and negative values are already handled. So no code changes are required. Only updated config description. 
