### PR TITLE
CLOUDSTACK-9975: Allow customizing system VM templates for SSVM and Console Proxy

### DIFF
--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -263,6 +263,18 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
     private final GlobalLock _allocLock = GlobalLock.getInternLock(getAllocLockName());
 
+    private static final ConfigKey<String> SsvmTemplateXenServer = new ConfigKey<String>("Storage", String.class, "ssvm.template.xenserver", "SystemVM Template (XenServer)",
+            "Name of the SSVM template on Xenserver.", true);
+    private static final ConfigKey<String> SsvmTemplateKVM = new ConfigKey<String>("Storage", String.class, "ssvm.template.kvm", "SystemVM Template (KVM)",
+            "Name of the SSVM template on KVM.", true);
+    private static final ConfigKey<String> SsvmTemplateVMware = new ConfigKey<String>("Storage", String.class, "ssvm.template.vmware", "SystemVM Template (vSphere)",
+            "Name of the SSVM template on VMware.", true);
+    private static final ConfigKey<String> SsvmTemplateHyperV = new ConfigKey<String>("Storage", String.class, "ssvm.template.hyperv", "SystemVM Template (HyperV)",
+            "Name of the SSVM template on Hyperv.", true);
+    private static final ConfigKey<String> SsvmTemplateLxc = new ConfigKey<String>("Storage", String.class, "ssvm.template.lxc", "SystemVM Template (LXC)",
+            "Name of the SSVM template on LXC.", true);
+    private static final ConfigKey<String> SsvmTemplateOvm3 = new ConfigKey<String>("Storage", String.class, "ssvm.template.ovm3", "SystemVM Template (Ovm3)",
+            "Name of the SSVM template on Ovm3.", true);
     static final ConfigKey<String> NTPServerConfig = new ConfigKey<String>(String.class, "ntp.server.list", "Advanced", null,
             "Comma separated list of NTP servers to configure in Secondary storage VM", false, ConfigKey.Scope.Global, null);
 
@@ -642,9 +654,33 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
         VMTemplateVO template = null;
         HypervisorType availableHypervisor = _resourceMgr.getAvailableHypervisor(dataCenterId);
-        template = _templateDao.findSystemVMReadyTemplate(dataCenterId, availableHypervisor);
+
+        String templateName = null;
+        switch (availableHypervisor) {
+        case XenServer:
+            templateName = SsvmTemplateXenServer.value();
+            break;
+        case KVM:
+            templateName = SsvmTemplateKVM.value();
+            break;
+        case VMware:
+            templateName = SsvmTemplateVMware.value();
+            break;
+        case Hyperv:
+            templateName = SsvmTemplateHyperV.value();
+            break;
+        case LXC:
+            templateName = SsvmTemplateLxc.value();
+        case Ovm3:
+            templateName = SsvmTemplateOvm3.value();
+            break;
+        default:
+            break;
+        }
+        template = _templateDao.findRoutingTemplate(availableHypervisor, templateName);
+
         if (template == null) {
-            throw new CloudRuntimeException("Not able to find the System templates or not downloaded in zone " + dataCenterId);
+            throw new CloudRuntimeException("Not able to find the Secondary Storage System template or not downloaded in zone " + dataCenterId);
         }
 
         ServiceOfferingVO serviceOffering = _serviceOffering;
@@ -1510,7 +1546,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {NTPServerConfig};
+        return new ConfigKey<?>[] {NTPServerConfig, SsvmTemplateXenServer, SsvmTemplateKVM, SsvmTemplateVMware, SsvmTemplateHyperV, SsvmTemplateLxc, SsvmTemplateOvm3};
     }
 
 }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

Currently, it is possible to change the template used by virtual routers, but other system VMs do not have the same feature. The virtual router template is configured according to the respective global settings parameters: router.template.hyperv, router.template.kvm, router.template.lxc, router.template.xenserver, router.template.ovm, router.template.vmware.

This PR allows users to configure templates for storage system VMs (SSVMs) and console proxy system VMs with parameters similar with the virtual router template configuration:  ssvm.template.<virtualization-tool> and consoleproxy.template.<virtualization-tool>

If a parameter is null then we use the default system VM.

This feature was useful in a practical scenario where the console proxy system VM template was customized.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
