### PR TITLE
CLOUDSTACK-10099

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -1540,6 +1540,7 @@
                                                                 id: this.id,
                                                                 availableHostName: this.name,
                                                                 availableHostSuitability: suitability,
+                                                                requiresStorageMotion: this.requiresStorageMotion,
                                                                 cpuused: this.cpuused,
                                                                 memoryused: (parseFloat(this.memoryused)/(1024.0*1024.0*1024.0)).toFixed(2) + ' GB'
                                                             });


### PR DESCRIPTION
Fix for CLOUDSTACK-10099, which concerns the GUI not invoking the migrateVirtualMachineWithVolume API command when it should.