### PR TITLE
CLOUDSTACK-9993: With auth strictness stop SSL handshake for rogue clients

### DIFF
--- a/plugins/ca/root-ca/src/org/apache/cloudstack/ca/provider/RootCAProvider.java
+++ b/plugins/ca/root-ca/src/org/apache/cloudstack/ca/provider/RootCAProvider.java
@@ -249,7 +249,7 @@ public final class RootCAProvider extends AdapterBase implements CAProvider, Con
         TrustManager[] tms = new TrustManager[]{new RootCACustomTrustManager(remoteAddress, authStrictness, allowExpiredCertificate, certMap, caCertificate, crlDao)};
         sslContext.init(kmf.getKeyManagers(), tms, new SecureRandom());
         final SSLEngine sslEngine = sslContext.createSSLEngine();
-        sslEngine.setWantClientAuth(authStrictness);
+        sslEngine.setNeedClientAuth(authStrictness);
         return sslEngine;
     }
 

--- a/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
+++ b/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
@@ -136,7 +136,7 @@ public class RootCAProviderTest {
         overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "false");
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
         Assert.assertFalse(e.getUseClientMode());
-        Assert.assertFalse(e.getWantClientAuth());
+        Assert.assertFalse(e.getNeedClientAuth());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class RootCAProviderTest {
         overrideDefaultConfigValue(RootCAProvider.rootCAAuthStrictness, "_defaultValue", "true");
         final SSLEngine e = provider.createSSLEngine(SSLUtils.getSSLContext(), "/1.2.3.4:5678", null);
         Assert.assertFalse(e.getUseClientMode());
-        Assert.assertTrue(e.getWantClientAuth());
+        Assert.assertTrue(e.getNeedClientAuth());
     }
 
     @Test

--- a/systemvm/patches/debian/config/opt/cloud/bin/patchsystemvm.sh
+++ b/systemvm/patches/debian/config/opt/cloud/bin/patchsystemvm.sh
@@ -21,10 +21,21 @@ logfile="/var/log/patchsystemvm.log"
 # To use existing console proxy .zip-based package file
 patch_console_proxy() {
    local patchfile=$1
+   local backupfolder="/tmp/.conf.backup"
+   if [ -f /usr/local/cloud/systemvm/conf/cloud.jks ]; then
+      rm -fr $backupfolder
+      mkdir -p $backupfolder
+      cp -r /usr/local/cloud/systemvm/conf/* $backupfolder/
+   fi
    rm /usr/local/cloud/systemvm -rf
    mkdir -p /usr/local/cloud/systemvm
    echo "All" | unzip $patchfile -d /usr/local/cloud/systemvm >$logfile 2>&1
    find /usr/local/cloud/systemvm/ -name \*.sh | xargs chmod 555
+   if [ -f $backupfolder/cloud.jks ]; then
+      cp -r $backupfolder/* /usr/local/cloud/systemvm/conf/
+      echo "Restored keystore file and certs using backup" >> $logfile
+   fi
+   rm -fr $backupfolder
    return 0
 }
 


### PR DESCRIPTION
When auth strictness is set to true, terminate SSH handshake for clients
that do not present valid or any certificates.

This uses the `setNeedClientAuth`, where if the option is set and the
client chooses not to provide authentication information about itself,
the negotiations will stop and the engine will begin its closure
procedure:
https://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLEngine.html#setNeedClientAuth(boolean)

Signed-off-by: Rohit Yadav <rohit.yadav@shapeblue.com>

Pinging for review - @DaanHoogland @nvazquez @borisstoyanov @wido @mlsorensen and others