### PR TITLE
CLOUDSTACK-10101: Present the full domain name when listing user's domains in SAML2 plugin

### DIFF
--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/ListAndSwitchSAMLAccountCmd.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/command/ListAndSwitchSAMLAccountCmd.java
@@ -172,6 +172,7 @@ public class ListAndSwitchSAMLAccountCmd extends BaseCmd implements APIAuthentic
                     accountResponse.setUserName(user.getUsername());
                     accountResponse.setDomainId(domain.getUuid());
                     accountResponse.setDomainName(domain.getName());
+                    accountResponse.setDomainPath(domain.getPath());
                     accountResponse.setAccountName(userAccount.getAccountName());
                     accountResponse.setIdpId(user.getExternalEntity());
                     accountResponses.add(accountResponse);

--- a/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/response/SamlUserAccountResponse.java
+++ b/plugins/user-authenticators/saml2/src/org/apache/cloudstack/api/response/SamlUserAccountResponse.java
@@ -44,6 +44,10 @@ public class SamlUserAccountResponse extends AuthenticationCmdResponse {
     @Param(description = "The IDP ID")
     private String idpId;
 
+    @SerializedName("domainPath")
+    @Param(description = "The full qualified domain path")
+    private String domainPath;
+
     public SamlUserAccountResponse() {
         super();
         setObjectName("samluseraccount");
@@ -96,4 +100,13 @@ public class SamlUserAccountResponse extends AuthenticationCmdResponse {
     public void setIdpId(String idpId) {
         this.idpId = idpId;
     }
+
+    public String getDomainPath() {
+        return domainPath;
+    }
+
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
+    }
+
 }

--- a/ui/scripts/ui-custom/saml.js
+++ b/ui/scripts/ui-custom/saml.js
@@ -81,7 +81,10 @@
                     option.data("userId", accounts[i].userId);
                     option.data("domainId", accounts[i].domainId);
                     option.val(accounts[i].userId + '/' + accounts[i].domainId);
-                    option.html(accounts[i].accountName + "/" + accounts[i].domainName);
+                    option.html(accounts[i].accountName + accounts[i].domainPath);
+					if (accounts[i].domainName == 'ROOT') {
+						option.append('ROOT');
+					}
                     option.appendTo($domainSelect);
                 }
                 var currentAccountDomain = g_userid + '/' + g_domainid;


### PR DESCRIPTION
This PR is related to the Saml2 user authentication plugin.

The user can list its domains. His/Her domains are presented as the following example:
username/subdomainA
username/subdomainB

However, if a user has two subdomains of the same name (**Dom1/subdomainA** and **Dom2/subdomainA**) the list is presented as follows:
username/subdomainA
username/subdomainA

The proposed change allows showing the full domain name to avoid such cases. Thus, the domains will be presented as follows:
username/Dom1/subdomainA
username/Dom2/subdomainA