### PR TITLE
CLOUDSTACK-9993: Have basic constraint in CA certificate

### DIFF
--- a/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCACustomTrustManagerTest.java
+++ b/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCACustomTrustManagerTest.java
@@ -56,9 +56,8 @@ public class RootCACustomTrustManagerTest {
         certMap.clear();
         caKeypair = CertUtils.generateRandomKeyPair(1024);
         clientKeypair = CertUtils.generateRandomKeyPair(1024);
-        caCertificate = CertUtils.generateV1Certificate(caKeypair, "CN=ca", "CN=ca", 1,
-                "SHA256withRSA");
-        expiredClientCertificate = CertUtils.generateV3Certificate(caCertificate, caKeypair.getPrivate(), clientKeypair.getPublic(),
+        caCertificate = CertUtils.generateV3Certificate(null, caKeypair, caKeypair.getPublic(), "CN=ca", "SHA256withRSA", 365, null, null);
+        expiredClientCertificate = CertUtils.generateV3Certificate(caCertificate, caKeypair, clientKeypair.getPublic(),
                 "CN=cloudstack.apache.org", "SHA256withRSA", 0, Collections.singletonList("cloudstack.apache.org"), Collections.singletonList(clientIp));
     }
 

--- a/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
+++ b/plugins/ca/root-ca/test/org/apache/cloudstack/ca/provider/RootCAProviderTest.java
@@ -66,7 +66,7 @@ public class RootCAProviderTest {
     @Before
     public void setUp() throws Exception {
         caKeyPair = CertUtils.generateRandomKeyPair(1024);
-        caCertificate = CertUtils.generateV1Certificate(caKeyPair, "CN=ca", "CN=ca", 1, "SHA256withRSA");
+        caCertificate = CertUtils.generateV3Certificate(null, caKeyPair, caKeyPair.getPublic(), "CN=ca", "SHA256withRSA", 365, null, null);
 
         provider = new RootCAProvider();
 

--- a/server/test/org/apache/cloudstack/ca/CABackgroundTaskTest.java
+++ b/server/test/org/apache/cloudstack/ca/CABackgroundTaskTest.java
@@ -68,8 +68,7 @@ public class CABackgroundTaskTest {
         host.setManagementServerId(ManagementServerNode.getManagementServerId());
         task = new CAManagerImpl.CABackgroundTask(caManager, hostDao);
         final KeyPair keypair = CertUtils.generateRandomKeyPair(1024);
-        expiredCertificate = CertUtils.generateV1Certificate(keypair, "CN=ca", "CN=ca", 0,
-                "SHA256withRSA");
+        expiredCertificate = CertUtils.generateV3Certificate(null, keypair, keypair.getPublic(), "CN=ca", "SHA256withRSA", 0, null, null);
 
         Mockito.when(hostDao.findByIp(Mockito.anyString())).thenReturn(host);
         Mockito.when(caManager.getActiveCertificatesMap()).thenReturn(certMap);

--- a/server/test/org/apache/cloudstack/ca/CAManagerImplTest.java
+++ b/server/test/org/apache/cloudstack/ca/CAManagerImplTest.java
@@ -21,6 +21,7 @@ package org.apache.cloudstack.ca;
 
 import java.lang.reflect.Field;
 import java.math.BigInteger;
+import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 
@@ -108,7 +109,8 @@ public class CAManagerImplTest {
     public void testProvisionCertificate() throws Exception {
         final Host host = Mockito.mock(Host.class);
         Mockito.when(host.getPrivateIpAddress()).thenReturn("1.2.3.4");
-        final X509Certificate certificate = CertUtils.generateV1Certificate(CertUtils.generateRandomKeyPair(1024), "CN=ca", "CN=ca", 1, "SHA256withRSA");
+        final KeyPair keyPair = CertUtils.generateRandomKeyPair(1024);
+        final X509Certificate certificate = CertUtils.generateV3Certificate(null, keyPair, keyPair.getPublic(), "CN=ca", "SHA256withRSA", 365, null, null);
         Mockito.when(caProvider.issueCertificate(Mockito.anyString(), Mockito.anyList(), Mockito.anyList(), Mockito.anyInt())).thenReturn(new Certificate(certificate, null, Collections.singletonList(certificate)));
         Mockito.when(agentManager.send(Mockito.anyLong(), Mockito.any(SetupKeyStoreCommand.class))).thenReturn(new SetupKeystoreAnswer("someCsr"));
         Mockito.when(agentManager.reconnect(Mockito.anyLong())).thenReturn(true);

--- a/utils/src/test/java/org/apache/cloudstack/utils/security/CertUtilsTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/security/CertUtilsTest.java
@@ -39,7 +39,7 @@ public class CertUtilsTest {
     @Before
     public void setUp() throws Exception {
         caKeyPair = CertUtils.generateRandomKeyPair(1024);
-        caCertificate = CertUtils.generateV1Certificate(caKeyPair, "CN=test", "CN=test", 1, "SHA256WithRSAEncryption");
+        caCertificate = CertUtils.generateV3Certificate(null, caKeyPair, caKeyPair.getPublic(), "CN=test", "SHA256WithRSAEncryption", 365, null, null);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class CertUtilsTest {
         final List<String> domainNames = Arrays.asList("domain1.com", "www.2.domain2.com", "3.domain3.com");
         final List<String> addressList = Arrays.asList("1.2.3.4", "192.168.1.1", "2a02:120b:2c16:f6d0:d9df:8ebc:e44a:f181");
 
-        final X509Certificate clientCert = CertUtils.generateV3Certificate(caCertificate, caKeyPair.getPrivate(), clientKeyPair.getPublic(),
+        final X509Certificate clientCert = CertUtils.generateV3Certificate(caCertificate, caKeyPair, clientKeyPair.getPublic(),
                 "CN=domain.example", "SHA256WithRSAEncryption", 10, domainNames, addressList);
 
         clientCert.verify(caKeyPair.getPublic());


### PR DESCRIPTION
- Refactors V3 x509 cert generator to put basic constraint and key usage
  extensions when CA cert is created
- Refactors root CA provider to use V3 generator to generate CA cert

Pinging for review - @mlsorensen @nvazquez @borisstoyanov @DaanHoogland  and others

@blueorangutan package