### PR TITLE
CLOUDSTACK-10108:ConfigKey based approach for reading 'ping' configua…

### DIFF
--- a/engine/orchestration/resources/META-INF/cloudstack/core/spring-engine-orchestration-core-context.xml
+++ b/engine/orchestration/resources/META-INF/cloudstack/core/spring-engine-orchestration-core-context.xml
@@ -59,6 +59,7 @@
     </bean>
 
     <bean id="clusteredAgentManagerImpl" class="com.cloud.agent.manager.ClusteredAgentManagerImpl" />
+    <bean id="managementServiceConfigurationImpl" class="com.cloud.configuration.ManagementServiceConfigurationImpl" />
 
     <bean id="cloudOrchestrator"
         class="org.apache.cloudstack.engine.orchestration.CloudOrchestrator" />

--- a/engine/orchestration/src/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/ClusteredAgentManagerImpl.java
@@ -198,7 +198,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
         }
 
         // for agents that are self-managed, threshold to be considered as disconnected after pingtimeout
-        final long cutSeconds = (System.currentTimeMillis() >> 10) - getTimeout();
+        final long cutSeconds = (System.currentTimeMillis() >> 10) - mgmtServiceConf.getTimeout();
         final List<HostVO> hosts = _hostDao.findAndUpdateDirectAgentToLoad(cutSeconds, LoadSize.value().longValue(), _nodeId);
         final List<HostVO> appliances = _hostDao.findAndUpdateApplianceToLoad(cutSeconds, _nodeId);
 
@@ -747,7 +747,7 @@ public class ClusteredAgentManagerImpl extends AgentManagerImpl implements Clust
     public void onManagementNodeLeft(final List<? extends ManagementServerHost> nodeList, final long selfNodeId) {
         for (final ManagementServerHost vo : nodeList) {
             s_logger.info("Marking hosts as disconnected on Management server" + vo.getMsid());
-            final long lastPing = (System.currentTimeMillis() >> 10) - getTimeout();
+            final long lastPing = (System.currentTimeMillis() >> 10) - mgmtServiceConf.getTimeout();
             _hostDao.markHostsAsDisconnected(vo.getMsid(), lastPing);
             outOfBandManagementDao.expireServerOwnership(vo.getMsid());
             haConfigDao.expireServerOwnership(vo.getMsid());

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.apache.log4j.Logger;
-import org.apache.cloudstack.framework.config.ConfigKey;
+import com.cloud.configuration.ManagementServiceConfiguration;
 import org.apache.cloudstack.framework.messagebus.MessageBus;
 import org.apache.cloudstack.framework.messagebus.PublishScope;
 
@@ -39,9 +39,7 @@ public class VirtualMachinePowerStateSyncImpl implements VirtualMachinePowerStat
     @Inject MessageBus _messageBus;
     @Inject VMInstanceDao _instanceDao;
     @Inject VirtualMachineManager _vmMgr;
-
-    protected final ConfigKey<Integer> PingInterval = new ConfigKey<Integer>(Integer.class, "ping.interval", "Advanced", "60",
-            "Interval to send application level pings to make sure the connection is still working", false);
+    @Inject ManagementServiceConfiguration mgmtServiceConf;
 
     public VirtualMachinePowerStateSyncImpl() {
     }
@@ -107,7 +105,7 @@ public class VirtualMachinePowerStateSyncImpl implements VirtualMachinePowerStat
                 s_logger.debug("Run missing VM report. current time: " + currentTime.getTime());
 
             // 2 times of sync-update interval for graceful period
-            long milliSecondsGracefullPeriod = PingInterval.value() * 2000L;
+            long milliSecondsGracefullPeriod = mgmtServiceConf.getPingInterval() * 2000L;
 
             for (VMInstanceVO instance : vmsThatAreMissingReport) {
 

--- a/engine/schema/src/com/cloud/configuration/ManagementServiceConfiguration.java
+++ b/engine/schema/src/com/cloud/configuration/ManagementServiceConfiguration.java
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.configuration;
+
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
+
+public interface ManagementServiceConfiguration extends Configurable {
+    ConfigKey<Integer> PingInterval = new ConfigKey<Integer>("Advanced", Integer.class, "ping.interval", "60",
+            "Interval to send application level pings to make sure the connection is still working", false);
+    ConfigKey<Float> PingTimeout = new ConfigKey<Float>("Advanced", Float.class, "ping.timeout", "2.5",
+            "Multiplier to ping.interval before announcing an agent has timed out", true);
+    public int getPingInterval();
+    public float getPingTimeout();
+    public long getTimeout();
+}

--- a/engine/schema/src/com/cloud/configuration/ManagementServiceConfigurationImpl.java
+++ b/engine/schema/src/com/cloud/configuration/ManagementServiceConfigurationImpl.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.configuration;
+
+import org.apache.cloudstack.framework.config.ConfigKey;
+
+public class ManagementServiceConfigurationImpl implements ManagementServiceConfiguration {
+    @Override
+    public String getConfigComponentName() {
+        return ManagementServiceConfiguration.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {PingInterval, PingTimeout};
+    }
+
+    @Override
+    public int getPingInterval() {
+        return ManagementServiceConfiguration.PingInterval.value();
+    }
+
+    @Override
+    public float getPingTimeout() {
+        return ManagementServiceConfiguration.PingTimeout.value();
+    }
+
+    @Override
+    public long getTimeout() {
+        return (long) (PingTimeout.value() * PingInterval.value());
+    }
+}

--- a/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
@@ -30,8 +30,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.persistence.TableGenerator;
 
-import com.cloud.utils.NumbersUtil;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import com.cloud.configuration.ManagementServiceConfiguration;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -78,6 +77,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
     private static final Logger state_logger = Logger.getLogger(ResourceState.class);
 
     private static final String LIST_CLUSTERID_FOR_HOST_TAG = "select distinct cluster_id from host join host_tags on host.id = host_tags.host_id and host_tags.tag = ?";
+
 
     protected SearchBuilder<HostVO> TypePodDcStatusSearch;
 
@@ -145,7 +145,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
     @Inject
     protected ClusterDao _clusterDao;
     @Inject
-    private ConfigurationDao _configDao;
+    ManagementServiceConfiguration mgmtServiceConf;
 
     public HostDaoImpl() {
         super();
@@ -993,9 +993,7 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
             }
         }
         if (event.equals(Event.ManagementServerDown)) {
-            Float pingTimeout = NumbersUtil.parseFloat(_configDao.getValue("ping.timeout"), 2.5f);
-            Integer pingInterval = NumbersUtil.parseInt(_configDao.getValue("ping.interval"), 60);
-            ub.set(host, _pingTimeAttr, ((System.currentTimeMillis() >> 10) - (long)(pingTimeout * pingInterval)));
+            ub.set(host, _pingTimeAttr, ((System.currentTimeMillis() >> 10) - mgmtServiceConf.getTimeout()));
         }
         int result = update(ub, sc, null);
         assert result <= 1 : "How can this update " + result + " rows? ";

--- a/server/test/resources/createNetworkOffering.xml
+++ b/server/test/resources/createNetworkOffering.xml
@@ -41,7 +41,7 @@
     <bean id="ConfigurationManager" class="com.cloud.configuration.ConfigurationManagerImpl">
         <property name="name" value="ConfigurationManager"/>
     </bean>
-
+    <bean id="managementServiceConfigurationImpl" class="com.cloud.configuration.ManagementServiceConfigurationImpl" />
     <bean class="org.apache.cloudstack.networkoffering.ChildTestConfiguration" />
     <bean id="UservmDetailsDaoImpl" class="com.cloud.vm.dao.UserVmDetailsDaoImpl" />
     <bean id="hostGpuGroupsDaoImpl" class="com.cloud.gpu.dao.HostGpuGroupsDaoImpl" />

--- a/test/integration/component/test_host.py
+++ b/test/integration/component/test_host.py
@@ -98,9 +98,6 @@ class TestHostHA(cloudstackTestCase):
 
         return
     
-
-
-    
     def checkHostDown(self, fromHostIp, testHostIp):
         try:
             ssh = SshClient(fromHostIp, 22, "root", "password") 
@@ -165,9 +162,9 @@ class TestHostHA(cloudstackTestCase):
         """ Restart management
         server and usage server """
         sshClient = SshClient(self.mgtSvrDetails["mgtSvrIp"],
-                    22,
-                    self.mgtSvrDetails["user"],
-                    self.mgtSvrDetails["passwd"]
+            22,
+            self.mgtSvrDetails["user"],
+            self.mgtSvrDetails["passwd"]
         )
         command = "service cloudstack-management restart"
         sshClient.execute(command)
@@ -197,8 +194,7 @@ class TestHostHA(cloudstackTestCase):
             
 
         hostToTest = listHost[0]
-        hostUpInCloudstack = wait_until(10, 10, self.checkHostUp, hostToTest.ipaddress, hostToTest.ipaddress)
-        #hostUpInCloudstack = wait_until(40, 10, self.checkHostStateInCloudstack, "Up", hostToTest.id)
+        hostUpInCloudstack = wait_until(40, 10, self.checkHostStateInCloudstack, "Up", hostToTest.id)
 
         if not(hostUpInCloudstack): 
             raise self.fail("Host is not up %s, in cloudstack so failing test " % (hostToTest.ipaddress))


### PR DESCRIPTION
In CLOUDSTACK-9886, we are reading ping.interval and ping.timeout using configdao which involves direct reading of DB. So, replaced it with ConfigKey based approach