### PR TITLE
CLOUDSTACK-9620: Enhancements for managed storage

### DIFF
--- a/api/src/com/cloud/agent/api/to/DiskTO.java
+++ b/api/src/com/cloud/agent/api/to/DiskTO.java
@@ -27,6 +27,7 @@ public class DiskTO {
     public static final String CHAP_INITIATOR_SECRET = "chapInitiatorSecret";
     public static final String CHAP_TARGET_USERNAME = "chapTargetUsername";
     public static final String CHAP_TARGET_SECRET = "chapTargetSecret";
+    public static final String SCSI_NAA_DEVICE_ID = "scsiNaaDeviceId";
     public static final String MANAGED = "managed";
     public static final String IQN = "iqn";
     public static final String STORAGE_HOST = "storageHost";
@@ -36,6 +37,9 @@ public class DiskTO {
     public static final String PROTOCOL_TYPE = "protocoltype";
     public static final String PATH = "path";
     public static final String UUID = "uuid";
+    public static final String VMDK = "vmdk";
+    public static final String EXPAND_DATASTORE = "expandDatastore";
+    public static final String TEMPLATE_RESIGN = "templateResign";
 
     private DataTO data;
     private Long diskSeq;

--- a/api/src/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
@@ -78,6 +78,14 @@ public class ResizeVolumeCmd extends BaseAsyncCmd {
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
 
+    public ResizeVolumeCmd() {}
+
+    public ResizeVolumeCmd(Long id, Long minIops, Long maxIops) {
+        this.id = id;
+        this.minIops = minIops;
+        this.maxIops = maxIops;
+    }
+
     //TODO use the method getId() instead of this one.
     public Long getEntityId() {
         return id;

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1152,6 +1152,21 @@
       </dependencies>
     </profile>
     <profile>
+        <id>vmwaresioc</id>
+        <activation>
+            <property>
+                <name>noredist</name>
+            </property>
+        </activation>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.cloudstack</groupId>
+                <artifactId>cloud-plugin-api-vmware-sioc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </profile>
+    <profile>
       <id>quickcloud</id>
       <activation>
         <property>

--- a/core/src/com/cloud/agent/api/MigrateCommand.java
+++ b/core/src/com/cloud/agent/api/MigrateCommand.java
@@ -53,10 +53,6 @@ public class MigrateCommand extends Command {
         return migrateStorage != null ? new HashMap<>(migrateStorage) : new HashMap<String, MigrateDiskInfo>();
     }
 
-    public boolean isMigrateStorage() {
-        return migrateStorage != null && !migrateStorage.isEmpty();
-    }
-
     public void setAutoConvergence(boolean autoConvergence) {
         this.autoConvergence = autoConvergence;
     }
@@ -100,11 +96,7 @@ public class MigrateCommand extends Command {
 
             @Override
             public String toString() {
-                switch(this) {
-                    case FILE: return "file";
-                    case BLOCK: return "block";
-                    default: throw new IllegalArgumentException();
-                }
+                return name().toLowerCase();
             }
         }
 
@@ -113,11 +105,7 @@ public class MigrateCommand extends Command {
 
             @Override
             public String toString() {
-                switch(this) {
-                    case QCOW2: return "qcow2";
-                    case RAW: return "raw";
-                    default: throw new IllegalArgumentException();
-                }
+                return name().toLowerCase();
             }
         }
 
@@ -126,11 +114,7 @@ public class MigrateCommand extends Command {
 
             @Override
             public String toString() {
-                switch(this) {
-                    case FILE: return "file";
-                    case DEV: return "dev";
-                    default: throw new IllegalArgumentException();
-                }
+                return name().toLowerCase();
             }
         }
 

--- a/core/src/com/cloud/agent/api/MigrateCommand.java
+++ b/core/src/com/cloud/agent/api/MigrateCommand.java
@@ -19,15 +19,20 @@
 
 package com.cloud.agent.api;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.cloud.agent.api.to.VirtualMachineTO;
 
 public class MigrateCommand extends Command {
-    String vmName;
-    String destIp;
-    String hostGuid;
-    boolean isWindows;
-    VirtualMachineTO vmTO;
-    boolean executeInSequence = false;
+    private String vmName;
+    private String destIp;
+    private Map<String, MigrateDiskInfo> migrateStorage;
+    private boolean autoConvergence;
+    private String hostGuid;
+    private boolean isWindows;
+    private VirtualMachineTO vmTO;
+    private boolean executeInSequence = false;
 
     protected MigrateCommand() {
     }
@@ -38,6 +43,26 @@ public class MigrateCommand extends Command {
         this.isWindows = isWindows;
         this.vmTO = vmTO;
         this.executeInSequence = executeInSequence;
+    }
+
+    public void setMigrateStorage(Map<String, MigrateDiskInfo> migrateStorage) {
+        this.migrateStorage = migrateStorage;
+    }
+
+    public Map<String, MigrateDiskInfo> getMigrateStorage() {
+        return migrateStorage != null ? new HashMap<>(migrateStorage) : new HashMap<String, MigrateDiskInfo>();
+    }
+
+    public boolean isMigrateStorage() {
+        return migrateStorage != null && !migrateStorage.isEmpty();
+    }
+
+    public void setAutoConvergence(boolean autoConvergence) {
+        this.autoConvergence = autoConvergence;
+    }
+
+    public boolean isAutoConvergence() {
+        return autoConvergence;
     }
 
     public boolean isWindows() {
@@ -67,5 +92,80 @@ public class MigrateCommand extends Command {
     @Override
     public boolean executeInSequence() {
         return executeInSequence;
+    }
+
+    public static class MigrateDiskInfo {
+        public enum DiskType {
+            FILE, BLOCK;
+
+            @Override
+            public String toString() {
+                switch(this) {
+                    case FILE: return "file";
+                    case BLOCK: return "block";
+                    default: throw new IllegalArgumentException();
+                }
+            }
+        }
+
+        public enum DriverType {
+            QCOW2, RAW;
+
+            @Override
+            public String toString() {
+                switch(this) {
+                    case QCOW2: return "qcow2";
+                    case RAW: return "raw";
+                    default: throw new IllegalArgumentException();
+                }
+            }
+        }
+
+        public enum Source {
+            FILE, DEV;
+
+            @Override
+            public String toString() {
+                switch(this) {
+                    case FILE: return "file";
+                    case DEV: return "dev";
+                    default: throw new IllegalArgumentException();
+                }
+            }
+        }
+
+        private final String serialNumber;
+        private final DiskType diskType;
+        private final DriverType driverType;
+        private final Source source;
+        private final String sourceText;
+
+        public MigrateDiskInfo(final String serialNumber, final DiskType diskType, final DriverType driverType, final Source source, final String sourceText) {
+            this.serialNumber = serialNumber;
+            this.diskType = diskType;
+            this.driverType = driverType;
+            this.source = source;
+            this.sourceText = sourceText;
+        }
+
+        public String getSerialNumber() {
+            return serialNumber;
+        }
+
+        public DiskType getDiskType() {
+            return diskType;
+        }
+
+        public DriverType getDriverType() {
+            return driverType;
+        }
+
+        public Source getSource() {
+            return source;
+        }
+
+        public String getSourceText() {
+            return sourceText;
+        }
     }
 }

--- a/core/src/com/cloud/agent/api/ModifyTargetsAnswer.java
+++ b/core/src/com/cloud/agent/api/ModifyTargetsAnswer.java
@@ -19,5 +19,16 @@
 
 package com.cloud.agent.api;
 
+import java.util.List;
+
 public class ModifyTargetsAnswer extends Answer {
+    private List<String> connectedPaths;
+
+    public void setConnectedPaths(List<String> connectedPaths) {
+        this.connectedPaths = connectedPaths;
+    }
+
+    public List<String> getConnectedPaths() {
+        return connectedPaths;
+    }
 }

--- a/core/src/com/cloud/agent/api/ModifyTargetsCommand.java
+++ b/core/src/com/cloud/agent/api/ModifyTargetsCommand.java
@@ -23,7 +23,11 @@ import java.util.List;
 import java.util.Map;
 
 public class ModifyTargetsCommand extends Command {
+    public enum TargetTypeToRemove { BOTH, NEITHER, STATIC, DYNAMIC }
+
     public static final String IQN = "iqn";
+    public static final String STORAGE_TYPE = "storageType";
+    public static final String STORAGE_UUID = "storageUuid";
     public static final String STORAGE_HOST = "storageHost";
     public static final String STORAGE_PORT = "storagePort";
     public static final String CHAP_NAME = "chapName";
@@ -32,6 +36,9 @@ public class ModifyTargetsCommand extends Command {
     public static final String MUTUAL_CHAP_SECRET = "mutualChapSecret";
 
     private boolean add;
+    private boolean applyToAllHostsInCluster;
+    private TargetTypeToRemove targetTypeToRemove = TargetTypeToRemove.BOTH;
+    private boolean removeAsync;
     private List<Map<String, String>> targets;
 
     public void setAdd(boolean add) {
@@ -40,6 +47,30 @@ public class ModifyTargetsCommand extends Command {
 
     public boolean getAdd() {
         return add;
+    }
+
+    public void setApplyToAllHostsInCluster(boolean applyToAllHostsInCluster) {
+        this.applyToAllHostsInCluster = applyToAllHostsInCluster;
+    }
+
+    public boolean getApplyToAllHostsInCluster() {
+        return applyToAllHostsInCluster;
+    }
+
+    public void setTargetTypeToRemove(TargetTypeToRemove targetTypeToRemove) {
+        this.targetTypeToRemove = targetTypeToRemove;
+    }
+
+    public TargetTypeToRemove getTargetTypeToRemove() {
+        return targetTypeToRemove;
+    }
+
+    public void setRemoveAsync(boolean removeAsync) {
+        this.removeAsync = removeAsync;
+    }
+
+    public boolean isRemoveAsync() {
+        return removeAsync;
     }
 
     public void setTargets(List<Map<String, String>> targets) {

--- a/core/src/com/cloud/agent/api/PrepareForMigrationCommand.java
+++ b/core/src/com/cloud/agent/api/PrepareForMigrationCommand.java
@@ -22,7 +22,8 @@ package com.cloud.agent.api;
 import com.cloud.agent.api.to.VirtualMachineTO;
 
 public class PrepareForMigrationCommand extends Command {
-    VirtualMachineTO vm;
+    private VirtualMachineTO vm;
+    private boolean rollback;
 
     protected PrepareForMigrationCommand() {
     }
@@ -33,6 +34,14 @@ public class PrepareForMigrationCommand extends Command {
 
     public VirtualMachineTO getVirtualMachine() {
         return vm;
+    }
+
+    public void setRollback(boolean rollback) {
+        this.rollback = rollback;
+    }
+
+    public boolean isRollback() {
+        return rollback;
     }
 
     @Override

--- a/core/src/com/cloud/agent/api/StartAnswer.java
+++ b/core/src/com/cloud/agent/api/StartAnswer.java
@@ -29,6 +29,10 @@ public class StartAnswer extends Answer {
 
     VirtualMachineTO vm;
     String hostGuid;
+    // key = an applicable IQN (ex. iqn.1998-01.com.vmware.iscsi:name1)
+    // value = a Map with the following data:
+    //   key = PATH or IMAGE_FORMAT (defined above)
+    //   value = Example if PATH is key: UUID of VDI; Example if IMAGE_FORMAT is key: DiskTO.VHD
     private Map<String, Map<String, String>> _iqnToData;
 
     protected StartAnswer() {

--- a/core/src/com/cloud/agent/api/StartAnswer.java
+++ b/core/src/com/cloud/agent/api/StartAnswer.java
@@ -24,9 +24,12 @@ import java.util.Map;
 import com.cloud.agent.api.to.VirtualMachineTO;
 
 public class StartAnswer extends Answer {
+    public static final String PATH = "path";
+    public static final String IMAGE_FORMAT = "imageFormat";
+
     VirtualMachineTO vm;
     String hostGuid;
-    Map<String, String> _iqnToPath;
+    private Map<String, Map<String, String>> _iqnToData;
 
     protected StartAnswer() {
     }
@@ -61,11 +64,11 @@ public class StartAnswer extends Answer {
         return hostGuid;
     }
 
-    public void setIqnToPath(Map<String, String> iqnToPath) {
-        _iqnToPath = iqnToPath;
+    public void setIqnToData(Map<String, Map<String, String>> iqnToData) {
+        _iqnToData = iqnToData;
     }
 
-    public Map<String, String> getIqnToPath() {
-        return _iqnToPath;
+    public Map<String, Map<String, String>> getIqnToData() {
+        return _iqnToData;
     }
 }

--- a/core/src/com/cloud/agent/api/StopCommand.java
+++ b/core/src/com/cloud/agent/api/StopCommand.java
@@ -22,6 +22,10 @@ package com.cloud.agent.api;
 import com.cloud.agent.api.to.GPUDeviceTO;
 import com.cloud.vm.VirtualMachine;
 
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.List;
+
 public class StopCommand extends RebootCommand {
     private boolean isProxy = false;
     private String urlPort = null;
@@ -30,6 +34,11 @@ public class StopCommand extends RebootCommand {
     boolean checkBeforeCleanup = false;
     String controlIp = null;
     boolean forceStop = false;
+    /**
+     * On KVM when using iSCSI-based managed storage, if the user shuts a VM down from the guest OS (as opposed to doing so from CloudStack),
+     * we need to pass to the KVM agent a list of applicable iSCSI volumes that need to be disconnected.
+     */
+    private List<Map<String, String>> volumesToDisconnect = new ArrayList<>();
 
     protected StopCommand() {
     }
@@ -101,5 +110,13 @@ public class StopCommand extends RebootCommand {
 
     public boolean isForceStop() {
         return forceStop;
+    }
+
+    public void setVolumesToDisconnect(List<Map<String, String>> volumesToDisconnect) {
+        this.volumesToDisconnect = volumesToDisconnect;
+    }
+
+    public List<Map<String, String>> getVolumesToDisconnect() {
+        return volumesToDisconnect;
     }
 }

--- a/core/src/com/cloud/agent/api/storage/CopyVolumeCommand.java
+++ b/core/src/com/cloud/agent/api/storage/CopyVolumeCommand.java
@@ -19,18 +19,22 @@
 
 package com.cloud.agent.api.storage;
 
+import java.util.Map;
+
+import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.storage.StoragePool;
 
 public class CopyVolumeCommand extends StorageNfsVersionCommand {
-
-    long volumeId;
-    String volumePath;
-    StorageFilerTO pool;
-    String secondaryStorageURL;
-    boolean toSecondaryStorage;
-    String vmName;
-    boolean executeInSequence = false;
+    private long volumeId;
+    private String volumePath;
+    private StorageFilerTO pool;
+    private String secondaryStorageURL;
+    private boolean toSecondaryStorage;
+    private String vmName;
+    private DataTO srcData;
+    private Map<String, String> srcDetails;
+    private boolean executeInSequence;
 
     public CopyVolumeCommand() {
     }
@@ -75,4 +79,19 @@ public class CopyVolumeCommand extends StorageNfsVersionCommand {
         return vmName;
     }
 
+    public void setSrcData(DataTO srcData) {
+        this.srcData = srcData;
+    }
+
+    public DataTO getSrcData() {
+        return srcData;
+    }
+
+    public void setSrcDetails(Map<String, String> srcDetails) {
+        this.srcDetails = srcDetails;
+    }
+
+    public Map<String, String> getSrcDetails() {
+        return srcDetails;
+    }
 }

--- a/core/src/com/cloud/agent/api/storage/MigrateVolumeCommand.java
+++ b/core/src/com/cloud/agent/api/storage/MigrateVolumeCommand.java
@@ -19,18 +19,25 @@
 
 package com.cloud.agent.api.storage;
 
+import java.util.Map;
+
 import com.cloud.agent.api.Command;
+import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.StorageFilerTO;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.Volume;
 
 public class MigrateVolumeCommand extends Command {
-
     long volumeId;
     String volumePath;
     StorageFilerTO pool;
     String attachedVmName;
     Volume.Type volumeType;
+
+    private DataTO srcData;
+    private DataTO destData;
+    private Map<String, String> srcDetails;
+    private Map<String, String> destDetails;
 
     public MigrateVolumeCommand(long volumeId, String volumePath, StoragePool pool, int timeout) {
         this.volumeId = volumeId;
@@ -46,6 +53,15 @@ public class MigrateVolumeCommand extends Command {
         this.attachedVmName = attachedVmName;
         this.volumeType = volumeType;
         this.setWait(timeout);
+    }
+
+    public MigrateVolumeCommand(DataTO srcData, DataTO destData, Map<String, String> srcDetails, Map<String, String> destDetails, int timeout) {
+        this.srcData = srcData;
+        this.destData = destData;
+        this.srcDetails = srcDetails;
+        this.destDetails = destDetails;
+
+        setWait(timeout);
     }
 
     @Override
@@ -71,5 +87,25 @@ public class MigrateVolumeCommand extends Command {
 
     public Volume.Type getVolumeType() {
         return volumeType;
+    }
+
+    public DataTO getSrcData() {
+        return srcData;
+    }
+
+    public DataTO getDestData() {
+        return destData;
+    }
+
+    public Map<String, String> getSrcDetails() {
+        return srcDetails;
+    }
+
+    public Map<String, String> getDestDetails() {
+        return destDetails;
+    }
+
+    public int getWaitInMillSeconds() {
+        return getWait() * 1000;
     }
 }

--- a/core/src/com/cloud/storage/template/TemplateLocation.java
+++ b/core/src/com/cloud/storage/template/TemplateLocation.java
@@ -205,6 +205,7 @@ public class TemplateLocation {
         }
 
         _props.setProperty("virtualsize", Long.toString(newInfo.virtualSize));
+        _props.setProperty("size", Long.toString(newInfo.size));
         _formats.add(newInfo);
         return true;
     }

--- a/core/src/org/apache/cloudstack/storage/command/CopyCommand.java
+++ b/core/src/org/apache/cloudstack/storage/command/CopyCommand.java
@@ -29,8 +29,8 @@ public class CopyCommand extends StorageSubSystemCommand {
     private DataTO destTO;
     private DataTO cacheTO;
     private boolean executeInSequence = false;
-    private Map<String, String> options = new HashMap<String, String>();
-    private Map<String, String> options2 = new HashMap<String, String>();
+    private Map<String, String> options = new HashMap<>();
+    private Map<String, String> options2 = new HashMap<>();
 
     public CopyCommand(final DataTO srcData, final DataTO destData, final int timeout, final boolean executeInSequence) {
         super();

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreCapabilities.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/DataStoreCapabilities.java
@@ -36,5 +36,9 @@ public enum DataStoreCapabilities {
     /**
      * indicates that this driver supports the "cloneOfSnapshot" property of cloud.snapshot_details (for creating a volume from a volume)
      */
-    CAN_CREATE_VOLUME_FROM_VOLUME
+    CAN_CREATE_VOLUME_FROM_VOLUME,
+    /**
+     * indicates that this driver supports reverting a volume to a snapshot state
+     */
+    CAN_REVERT_VOLUME_TO_SNAPSHOT
 }

--- a/engine/components-api/src/com/cloud/storage/StorageManager.java
+++ b/engine/components-api/src/com/cloud/storage/StorageManager.java
@@ -44,14 +44,54 @@ import com.cloud.vm.DiskProfile;
 import com.cloud.vm.VMInstanceVO;
 
 public interface StorageManager extends StorageService {
-    static final ConfigKey<Integer> StorageCleanupInterval = new ConfigKey<Integer>(Integer.class, "storage.cleanup.interval", "Advanced", "86400",
-            "The interval (in seconds) to wait before running the storage cleanup thread.", false, ConfigKey.Scope.Global, null);
-    static final ConfigKey<Integer> StorageCleanupDelay = new ConfigKey<Integer>(Integer.class, "storage.cleanup.delay", "Advanced", "86400",
-            "Determines how long (in seconds) to wait before actually expunging destroyed volumes. The default value = the default value of storage.cleanup.interval.", false, ConfigKey.Scope.Global, null);
-    static final ConfigKey<Boolean> StorageCleanupEnabled = new ConfigKey<Boolean>(Boolean.class, "storage.cleanup.enabled", "Advanced", "true",
-            "Enables/disables the storage cleanup thread.", false, ConfigKey.Scope.Global, null);
-    static final ConfigKey<Boolean> TemplateCleanupEnabled = new ConfigKey<Boolean>(Boolean.class, "storage.template.cleanup.enabled", "Storage", "true",
-            "Enable/disable template cleanup activity, only take effect when overall storage cleanup is enabled", false, ConfigKey.Scope.Global, null);
+    ConfigKey<Integer> StorageCleanupInterval = new ConfigKey<>(Integer.class,
+            "storage.cleanup.interval",
+            "Advanced",
+            "86400",
+            "The interval (in seconds) to wait before running the storage cleanup thread.",
+            false,
+            ConfigKey.Scope.Global,
+            null);
+    ConfigKey<Integer> StorageCleanupDelay = new ConfigKey<>(Integer.class,
+            "storage.cleanup.delay",
+            "Advanced",
+            "86400",
+            "Determines how long (in seconds) to wait before actually expunging destroyed volumes. The default value = the default value of storage.cleanup.interval.",
+            false,
+            ConfigKey.Scope.Global,
+            null);
+    ConfigKey<Boolean> StorageCleanupEnabled = new ConfigKey<>(Boolean.class,
+            "storage.cleanup.enabled",
+            "Advanced",
+            "true",
+            "Enables/disables the storage cleanup thread.",
+            false,
+            ConfigKey.Scope.Global,
+            null);
+    ConfigKey<Boolean> TemplateCleanupEnabled = new ConfigKey<>(Boolean.class,
+            "storage.template.cleanup.enabled",
+            "Storage",
+            "true",
+            "Enable/disable template cleanup activity, only take effect when overall storage cleanup is enabled",
+            false,
+            ConfigKey.Scope.Global,
+            null);
+    ConfigKey<Integer> KvmStorageOfflineMigrationWait = new ConfigKey<>(Integer.class,
+            "kvm.storage.offline.migration.wait",
+            "Storage",
+            "10800",
+            "Timeout in seconds for offline (non-live) storage migration to complete on KVM",
+            true,
+            ConfigKey.Scope.Global,
+            null);
+    ConfigKey<Integer> KvmStorageOnlineMigrationWait = new ConfigKey<>(Integer.class,
+            "kvm.storage.online.migration.wait",
+            "Storage",
+            "10800",
+            "Timeout in seconds for online (live) storage migration to complete on KVM (migrateVirtualMachineWithVolume)",
+            true,
+            ConfigKey.Scope.Global,
+            null);
 
     /**
      * Returns a comma separated list of tags for the specified storage pool
@@ -101,6 +141,8 @@ public interface StorageManager extends StorageService {
     StoragePoolVO findLocalStorageOnHost(long hostId);
 
     Host updateSecondaryStorage(long secStorageId, String newUrl);
+
+    void removeStoragePoolFromCluster(long hostId, String iScsiName, StoragePool storagePool);
 
     List<Long> getUpHostsInPool(long poolId);
 

--- a/engine/orchestration/pom.xml
+++ b/engine/orchestration/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>cloud-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -85,6 +85,7 @@ import com.cloud.agent.api.ClusterVMMetaDataSyncAnswer;
 import com.cloud.agent.api.ClusterVMMetaDataSyncCommand;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.MigrateCommand;
+import com.cloud.agent.api.ModifyTargetsCommand;
 import com.cloud.agent.api.PingRoutingCommand;
 import com.cloud.agent.api.PlugNicAnswer;
 import com.cloud.agent.api.PlugNicCommand;
@@ -114,6 +115,7 @@ import com.cloud.agent.manager.Commands;
 import com.cloud.agent.manager.allocator.HostAllocator;
 import com.cloud.alert.AlertManager;
 import com.cloud.capacity.CapacityManager;
+import com.cloud.configuration.Config;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.dc.ClusterDetailsVO;
 import com.cloud.dc.DataCenter;
@@ -536,6 +538,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         final Long hostId = vm.getHostId() != null ? vm.getHostId() : vm.getLastHostId();
 
+        List<Map<String, String>> targets = getTargets(hostId, vm.getId());
+
         if (volumeExpungeCommands != null && volumeExpungeCommands.size() > 0 && hostId != null) {
             final Commands cmds = new Commands(Command.OnError.Stop);
 
@@ -562,6 +566,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         // Clean up volumes based on the vm's instance id
         volumeMgr.cleanupVolumes(vm.getId());
+
+        if (hostId != null && targets != null && targets.size() > 0) {
+            removeDynamicTargets(hostId, targets);
+        }
 
         final VirtualMachineGuru guru = getVmGuru(vm);
         guru.finalizeExpunge(vm);
@@ -597,6 +605,60 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             s_logger.debug("Expunged " + vm);
         }
 
+    }
+
+    private List<Map<String, String>> getTargets(Long hostId, long vmId) {
+        List<Map<String, String>> targets = new ArrayList<>();
+
+        HostVO hostVO = _hostDao.findById(hostId);
+
+        if (hostVO != null && hostVO.getHypervisorType() == HypervisorType.VMware) {
+            List<VolumeVO> volumes = _volsDao.findByInstance(vmId);
+
+            if (volumes != null) {
+                for (VolumeVO volume : volumes) {
+                    StoragePoolVO storagePoolVO = _storagePoolDao.findById(volume.getPoolId());
+
+                    if (storagePoolVO != null && storagePoolVO.isManaged()) {
+                        Map<String, String> target = new HashMap<>();
+
+                        target.put(ModifyTargetsCommand.STORAGE_HOST, storagePoolVO.getHostAddress());
+                        target.put(ModifyTargetsCommand.STORAGE_PORT, String.valueOf(storagePoolVO.getPort()));
+                        target.put(ModifyTargetsCommand.IQN, volume.get_iScsiName());
+
+                        targets.add(target);
+                    }
+                }
+            }
+        }
+
+        return targets;
+    }
+
+    private void removeDynamicTargets(long hostId, List<Map<String, String>> targets) {
+        ModifyTargetsCommand cmd = new ModifyTargetsCommand();
+
+        cmd.setTargets(targets);
+        cmd.setApplyToAllHostsInCluster(true);
+        cmd.setAdd(false);
+        cmd.setTargetTypeToRemove(ModifyTargetsCommand.TargetTypeToRemove.DYNAMIC);
+
+        sendModifyTargetsCommand(cmd, hostId);
+    }
+
+    private void sendModifyTargetsCommand(ModifyTargetsCommand cmd, long hostId) {
+        Answer answer = _agentMgr.easySend(hostId, cmd);
+
+        if (answer == null) {
+            String msg = "Unable to get an answer to the modify targets command";
+
+            s_logger.warn(msg);
+        }
+        else if (!answer.getResult()) {
+            String msg = "Unable to modify target on the following host: " + hostId;
+
+            s_logger.warn(msg);
+        }
     }
 
     @Override
@@ -1073,8 +1135,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
                     startAnswer = cmds.getAnswer(StartAnswer.class);
                     if (startAnswer != null && startAnswer.getResult()) {
-                        handlePath(vmTO.getDisks(), startAnswer.getIqnToPath());
+                        handlePath(vmTO.getDisks(), startAnswer.getIqnToData());
+
                         final String host_guid = startAnswer.getHost_guid();
+
                         if (host_guid != null) {
                             final HostVO finalHost = _resourceMgr.findHostByGuid(host_guid);
                             if (finalHost == null) {
@@ -1254,8 +1318,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     }
 
     // for managed storage on XenServer and VMware, need to update the DB with a path if the VDI/VMDK file was newly created
-    private void handlePath(final DiskTO[] disks, final Map<String, String> iqnToPath) {
-        if (disks != null && iqnToPath != null) {
+    private void handlePath(final DiskTO[] disks, final Map<String, Map<String, String>> iqnToData) {
+        if (disks != null && iqnToData != null) {
             for (final DiskTO disk : disks) {
                 final Map<String, String> details = disk.getDetails();
                 final boolean isManaged = details != null && Boolean.parseBoolean(details.get(DiskTO.MANAGED));
@@ -1264,12 +1328,31 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     final Long volumeId = disk.getData().getId();
                     final VolumeVO volume = _volsDao.findById(volumeId);
                     final String iScsiName = volume.get_iScsiName();
-                    final String path = iqnToPath.get(iScsiName);
 
-                    if (path != null) {
-                        volume.setPath(path);
+                    boolean update = false;
 
-                        _volsDao.update(volumeId, volume);
+                    final Map<String, String> data = iqnToData.get(iScsiName);
+
+                    if (data != null) {
+                        final String path = data.get(StartAnswer.PATH);
+
+                        if (path != null) {
+                            volume.setPath(path);
+
+                            update = true;
+                        }
+
+                        final String imageFormat = data.get(StartAnswer.IMAGE_FORMAT);
+
+                        if (imageFormat != null) {
+                            volume.setFormat(ImageFormat.valueOf(imageFormat));
+
+                            update = true;
+                        }
+
+                        if (update) {
+                            _volsDao.update(volumeId, volume);
+                        }
                     }
                 }
             }
@@ -1331,10 +1414,35 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         }
     }
 
+    private List<Map<String, String>> getVolumesToDisconnect(VirtualMachine vm) {
+        List<Map<String, String>> volumesToDisconnect = new ArrayList<>();
+
+        List<VolumeVO> volumes = _volsDao.findByInstance(vm.getId());
+
+        if (volumes != null) {
+            for (VolumeVO volume : volumes) {
+                StoragePoolVO storagePool = _storagePoolDao.findById(volume.getPoolId());
+
+                if (storagePool != null && storagePool.isManaged()) {
+                    Map<String, String> info = new HashMap<>(3);
+
+                    info.put(DiskTO.STORAGE_HOST, storagePool.getHostAddress());
+                    info.put(DiskTO.STORAGE_PORT, String.valueOf(storagePool.getPort()));
+                    info.put(DiskTO.IQN, volume.get_iScsiName());
+
+                    volumesToDisconnect.add(info);
+                }
+            }
+        }
+
+        return volumesToDisconnect;
+    }
+
     protected boolean sendStop(final VirtualMachineGuru guru, final VirtualMachineProfile profile, final boolean force, final boolean checkBeforeCleanup) {
         final VirtualMachine vm = profile.getVirtualMachine();
         StopCommand stpCmd = new StopCommand(vm, getExecuteInSequence(vm.getHypervisorType()), checkBeforeCleanup);
         stpCmd.setControlIp(getControlNicIpForVM(vm));
+        stpCmd.setVolumesToDisconnect(getVolumesToDisconnect(vm));
         final StopCommand stop = stpCmd;
         try {
             Answer answer = null;
@@ -2103,6 +2211,12 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         try {
             final boolean isWindows = _guestOsCategoryDao.findById(_guestOsDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
             final MigrateCommand mc = new MigrateCommand(vm.getInstanceName(), dest.getHost().getPrivateIpAddress(), isWindows, to, getExecuteInSequence(vm.getHypervisorType()));
+
+            String autoConvergence = _configDao.getValue(Config.KvmAutoConvergence.toString());
+            boolean kvmAutoConvergence = Boolean.parseBoolean(autoConvergence);
+
+            mc.setAutoConvergence(kvmAutoConvergence);
+
             mc.setHostGuid(dest.getHost().getGuid());
 
             try {
@@ -2176,32 +2290,48 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         final Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
 
         for (final VolumeVO volume : allVolumes) {
-            final Long poolId = volumeToPool.get(Long.valueOf(volume.getId()));
+            final Long poolId = volumeToPool.get(volume.getId());
             final StoragePoolVO destPool = _storagePoolDao.findById(poolId);
             final StoragePoolVO currentPool = _storagePoolDao.findById(volume.getPoolId());
             final DiskOfferingVO diskOffering = _diskOfferingDao.findById(volume.getDiskOfferingId());
 
             if (destPool != null) {
-                // Check if pool is accessible from the destination host and disk offering with which the volume was
-                // created is compliant with the pool type.
-                if (_poolHostDao.findByPoolHost(destPool.getId(), host.getId()) == null || destPool.isLocal() != diskOffering.getUseLocalStorage()) {
-                    // Cannot find a pool for the volume. Throw an exception.
-                    throw new CloudRuntimeException("Cannot migrate volume " + volume + " to storage pool " + destPool + " while migrating vm to host " + host +
-                            ". Either the pool is not accessible from the host or because of the offering with which the volume is created it cannot be placed on " +
-                            "the given pool.");
-                } else if (destPool.getId() == currentPool.getId()) {
-                    // If the pool to migrate to is the same as current pool, the volume doesn't need to be migrated.
-                } else {
-                    volumeToPoolObjectMap.put(volume, destPool);
+                if (currentPool.isManaged()) {
+                    if (destPool.getId() == currentPool.getId()) {
+                        volumeToPoolObjectMap.put(volume, currentPool);
+                    }
+                    else {
+                        throw new CloudRuntimeException("Currently, a volume on managed storage can only be 'migrated' to itself.");
+                    }
+                }
+                else {
+                    // Check if pool is accessible from the destination host and disk offering with which the volume was
+                    // created is compliant with the pool type.
+                    if (_poolHostDao.findByPoolHost(destPool.getId(), host.getId()) == null || destPool.isLocal() != diskOffering.getUseLocalStorage()) {
+                        // Cannot find a pool for the volume. Throw an exception.
+                        throw new CloudRuntimeException("Cannot migrate volume " + volume + " to storage pool " + destPool + " while migrating vm to host " + host +
+                                ". Either the pool is not accessible from the host or because of the offering with which the volume is created it cannot be placed on " +
+                                "the given pool.");
+                    } else if (destPool.getId() == currentPool.getId()) {
+                        // If the pool to migrate to is the same as current pool, the volume doesn't need to be migrated.
+                    } else {
+                        volumeToPoolObjectMap.put(volume, destPool);
+                    }
                 }
             } else {
                 if (currentPool.isManaged()) {
-                    volumeToPoolObjectMap.put(volume, currentPool);
+                    if (currentPool.getScope() == ScopeType.ZONE) {
+                        volumeToPoolObjectMap.put(volume, currentPool);
+                    }
+                    else {
+                        throw new CloudRuntimeException("Currently, you can only 'migrate' a volume on managed storage if its storage pool is zone wide.");
+                    }
                 } else {
                     // Find a suitable pool for the volume. Call the storage pool allocator to find the list of pools.
 
                     final DiskProfile diskProfile = new DiskProfile(volume, diskOffering, profile.getHypervisorType());
-                    final DataCenterDeployment plan = new DataCenterDeployment(host.getDataCenterId(), host.getPodId(), host.getClusterId(), host.getId(), null, null);
+                    final DataCenterDeployment plan = new DataCenterDeployment(host.getDataCenterId(), host.getPodId(), host.getClusterId(),
+                            host.getId(), null, null);
 
                     final List<StoragePool> poolList = new ArrayList<>();
                     final ExcludeList avoid = new ExcludeList();
@@ -3588,6 +3718,12 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         try {
             final boolean isWindows = _guestOsCategoryDao.findById(_guestOsDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
             final MigrateCommand mc = new MigrateCommand(vm.getInstanceName(), dest.getHost().getPrivateIpAddress(), isWindows, to, getExecuteInSequence(vm.getHypervisorType()));
+
+            String autoConvergence = _configDao.getValue(Config.KvmAutoConvergence.toString());
+            boolean kvmAutoConvergence = Boolean.parseBoolean(autoConvergence);
+
+            mc.setAutoConvergence(kvmAutoConvergence);
+
             mc.setHostGuid(dest.getHost().getGuid());
 
             try {

--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -19,6 +19,16 @@
 package org.apache.cloudstack.storage.motion;
 
 import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.storage.CopyVolumeAnswer;
+import com.cloud.agent.api.storage.CopyVolumeCommand;
+import com.cloud.agent.api.MigrateAnswer;
+import com.cloud.agent.api.MigrateCommand;
+import com.cloud.agent.api.ModifyTargetsAnswer;
+import com.cloud.agent.api.ModifyTargetsCommand;
+import com.cloud.agent.api.PrepareForMigrationCommand;
+import com.cloud.agent.api.storage.MigrateVolumeAnswer;
+import com.cloud.agent.api.storage.MigrateVolumeCommand;
 import com.cloud.agent.api.to.DataStoreTO;
 import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.DiskTO;
@@ -33,24 +43,35 @@ import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
 import com.cloud.host.dao.HostDetailsDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
-import com.cloud.server.ManagementService;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotVO;
 import com.cloud.storage.Storage.ImageFormat;
+import com.cloud.storage.StorageManager;
+import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.VolumeDetailVO;
+import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.GuestOSCategoryDao;
+import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.storage.dao.SnapshotDetailsDao;
 import com.cloud.storage.dao.SnapshotDetailsVO;
+import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.dao.VolumeDetailsDao;
 import com.cloud.utils.NumbersUtil;
+import com.cloud.utils.db.GlobalLock;
 import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.dao.VMInstanceDao;
+
 import com.google.common.base.Preconditions;
+
 import org.apache.cloudstack.engine.subsystem.api.storage.ChapInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.ClusterScope;
 import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
@@ -81,46 +102,58 @@ import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.ResignatureAnswer;
 import org.apache.cloudstack.storage.command.ResignatureCommand;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.log4j.Logger;
+
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.ExecutionException;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 @Component
 public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
     private static final Logger LOGGER = Logger.getLogger(StorageSystemDataMotionStrategy.class);
     private static final Random RANDOM = new Random(System.nanoTime());
+    private static final int LOCK_TIME_IN_SECONDS = 300;
+    private static final String OPERATION_NOT_SUPPORTED = "This operation is not supported.";
 
     @Inject private AgentManager _agentMgr;
     @Inject private ConfigurationDao _configDao;
     @Inject private DataStoreManager dataStoreMgr;
     @Inject private DiskOfferingDao _diskOfferingDao;
+    @Inject private GuestOSCategoryDao _guestOsCategoryDao;
+    @Inject private GuestOSDao _guestOsDao;
     @Inject private ClusterDao clusterDao;
     @Inject private HostDao _hostDao;
     @Inject private HostDetailsDao hostDetailsDao;
-    @Inject private ManagementService _mgr;
     @Inject private PrimaryDataStoreDao _storagePoolDao;
     @Inject private SnapshotDao _snapshotDao;
+    @Inject private SnapshotDataStoreDao _snapshotDataStoreDao;
     @Inject private SnapshotDetailsDao _snapshotDetailsDao;
+    @Inject private VMInstanceDao _vmDao;
+    @Inject private VMTemplateDao _vmTemplateDao;
     @Inject private VolumeDao _volumeDao;
     @Inject private VolumeDataFactory _volumeDataFactory;
     @Inject private VolumeDetailsDao volumeDetailsDao;
     @Inject private VolumeService _volumeService;
     @Inject private StorageCacheManager cacheMgr;
     @Inject private EndPointSelector selector;
+
     @Override
     public StrategyPriority canHandle(DataObject srcData, DataObject destData) {
         if (srcData instanceof SnapshotInfo) {
@@ -136,9 +169,40 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             return StrategyPriority.HIGHEST;
         }
 
+        if (srcData instanceof VolumeInfo && destData instanceof VolumeInfo) {
+            VolumeInfo srcVolumeInfo = (VolumeInfo)srcData;
+
+            if (isVolumeOnManagedStorage(srcVolumeInfo)) {
+                return StrategyPriority.HIGHEST;
+            }
+
+            VolumeInfo destVolumeInfo = (VolumeInfo)destData;
+
+            if (isVolumeOnManagedStorage(destVolumeInfo)) {
+                return StrategyPriority.HIGHEST;
+            }
+        }
+
+        if (srcData instanceof VolumeInfo && destData instanceof TemplateInfo) {
+            VolumeInfo srcVolumeInfo = (VolumeInfo)srcData;
+
+            if (isVolumeOnManagedStorage(srcVolumeInfo)) {
+                return StrategyPriority.HIGHEST;
+            }
+        }
+
         return StrategyPriority.CANT_HANDLE;
     }
 
+    private boolean isVolumeOnManagedStorage(VolumeInfo volumeInfo) {
+        long storagePooldId = volumeInfo.getDataStore().getId();
+        StoragePoolVO storagePoolVO = _storagePoolDao.findById(storagePooldId);
+
+        return storagePoolVO.isManaged();
+    }
+
+    // canHandle returns true if the storage driver for the DataObject that's passed in can support certain features (what features we
+    // care about during a particular invocation of this method depend on what type of DataObject was passed in (ex. VolumeInfo versus SnapshotInfo)).
     private boolean canHandle(DataObject dataObject) {
         Preconditions.checkArgument(dataObject != null, "Passing 'null' to dataObject of canHandle(DataObject) is not supported.");
 
@@ -151,7 +215,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                 return false;
             }
 
-            if (dataObject instanceof VolumeInfo || dataObject instanceof  SnapshotInfo) {
+            if (dataObject instanceof VolumeInfo || dataObject instanceof SnapshotInfo) {
                 String value = mapCapabilities.get(DataStoreCapabilities.STORAGE_SYSTEM_SNAPSHOT.toString());
                 Boolean supportsStorageSystemSnapshots = Boolean.valueOf(value);
 
@@ -170,7 +234,6 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
                     return true;
                 }
-
             }
         }
 
@@ -179,123 +242,320 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
     @Override
     public StrategyPriority canHandle(Map<VolumeInfo, DataStore> volumeMap, Host srcHost, Host destHost) {
+        if (HypervisorType.KVM.equals(srcHost.getHypervisorType())) {
+            Set<VolumeInfo> volumeInfoSet = volumeMap.keySet();
+
+            for (VolumeInfo volumeInfo : volumeInfoSet) {
+                StoragePoolVO storagePoolVO = _storagePoolDao.findById(volumeInfo.getPoolId());
+
+                if (storagePoolVO.isManaged()) {
+                    return StrategyPriority.HIGHEST;
+                }
+            }
+
+            Collection<DataStore> dataStores = volumeMap.values();
+
+            for (DataStore dataStore : dataStores) {
+                StoragePoolVO storagePoolVO = _storagePoolDao.findById(dataStore.getId());
+
+                if (storagePoolVO.isManaged()) {
+                    return StrategyPriority.HIGHEST;
+                }
+            }
+        }
+
         return StrategyPriority.CANT_HANDLE;
     }
 
     @Override
     public void copyAsync(DataObject srcData, DataObject destData, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
         if (srcData instanceof SnapshotInfo) {
-            SnapshotInfo snapshotInfo = (SnapshotInfo)srcData;
+            SnapshotInfo srcSnapshotInfo = (SnapshotInfo)srcData;
 
-            validate(snapshotInfo);
-
-            boolean canHandleSrc = canHandle(srcData);
-
-            if (canHandleSrc && (destData instanceof TemplateInfo || destData instanceof SnapshotInfo) &&
-                    (destData.getDataStore().getRole() == DataStoreRole.Image || destData.getDataStore().getRole() == DataStoreRole.ImageCache)) {
-                handleCopyDataToSecondaryStorage(snapshotInfo, destData, callback);
-
-                return;
-            }
-
-            if (destData instanceof VolumeInfo) {
-                VolumeInfo volumeInfo = (VolumeInfo)destData;
-
-                boolean canHandleDest = canHandle(destData);
-
-                if (canHandleSrc && canHandleDest) {
-                    if (snapshotInfo.getDataStore().getId() == volumeInfo.getDataStore().getId()) {
-                        handleCreateVolumeFromSnapshotBothOnStorageSystem(snapshotInfo, volumeInfo, callback);
-                        return;
-                    }
-                    else {
-                        String errMsg = "This operation is not supported (DataStoreCapabilities.STORAGE_SYSTEM_SNAPSHOT " +
-                                "not supported by source or destination storage plug-in). " + getSrcDestDataStoreMsg(srcData, destData);
-
-                        LOGGER.warn(errMsg);
-
-                        throw new UnsupportedOperationException(errMsg);
-                    }
-                }
-
-                if (canHandleDest) {
-                    handleCreateVolumeFromSnapshotOnSecondaryStorage(snapshotInfo, volumeInfo, callback);
-
-                    return;
-                }
-
-                if (canHandleSrc) {
-                    String errMsg = "This operation is not supported (DataStoreCapabilities.STORAGE_SYSTEM_SNAPSHOT " +
-                            "not supported by source storage plug-in). " + getSrcDataStoreMsg(srcData);
-
-                    LOGGER.warn(errMsg);
-
-                    throw new UnsupportedOperationException(errMsg);
-                }
-            }
+            handleCopyAsyncForSnapshot(srcSnapshotInfo, destData, callback);
         } else if (srcData instanceof TemplateInfo && destData instanceof VolumeInfo) {
-            boolean canHandleSrc = canHandle(srcData);
+            TemplateInfo srcTemplateInfo = (TemplateInfo)srcData;
+            VolumeInfo destVolumeInfo = (VolumeInfo)destData;
 
-            if (!canHandleSrc) {
-                String errMsg = "This operation is not supported (DataStoreCapabilities.STORAGE_CAN_CREATE_VOLUME_FROM_VOLUME " +
-                        "not supported by destination storage plug-in). " + getDestDataStoreMsg(destData);
+            handleCopyAsyncForTemplateAndVolume(srcTemplateInfo, destVolumeInfo, callback);
+        } else if (srcData instanceof VolumeInfo && destData instanceof VolumeInfo) {
+            VolumeInfo srcVolumeInfo = (VolumeInfo)srcData;
+            VolumeInfo destVolumeInfo = (VolumeInfo)destData;
 
-                LOGGER.warn(errMsg);
+            handleCopyAsyncForVolumes(srcVolumeInfo, destVolumeInfo, callback);
+        } else if (srcData instanceof VolumeInfo && destData instanceof TemplateInfo &&
+                (destData.getDataStore().getRole() == DataStoreRole.Image || destData.getDataStore().getRole() == DataStoreRole.ImageCache)) {
+            VolumeInfo srcVolumeInfo = (VolumeInfo)srcData;
+            TemplateInfo destTemplateInfo = (TemplateInfo)destData;
 
-                throw new UnsupportedOperationException(errMsg);
-            }
+            handleCreateTemplateFromVolume(srcVolumeInfo, destTemplateInfo, callback);
+        }
+        else {
+            handleError(OPERATION_NOT_SUPPORTED, callback);
+        }
+    }
 
-            handleCreateVolumeFromTemplateBothOnStorageSystem((TemplateInfo)srcData, (VolumeInfo)destData, callback);
+    private void handleCopyAsyncForSnapshot(SnapshotInfo srcSnapshotInfo, DataObject destData, AsyncCompletionCallback<CopyCommandResult> callback) {
+        verifyFormat(srcSnapshotInfo);
 
-            return;
+        boolean canHandleSrc = canHandle(srcSnapshotInfo);
+
+        if (canHandleSrc && (destData instanceof TemplateInfo || destData instanceof SnapshotInfo) &&
+                (destData.getDataStore().getRole() == DataStoreRole.Image || destData.getDataStore().getRole() == DataStoreRole.ImageCache)) {
+            handleCopyDataToSecondaryStorage(srcSnapshotInfo, destData, callback);
+        } else if (destData instanceof VolumeInfo) {
+            handleCopyAsyncForSnapshotToVolume(srcSnapshotInfo, (VolumeInfo)destData, callback);
+        } else {
+            handleError(OPERATION_NOT_SUPPORTED, callback);
+        }
+    }
+
+    private void handleCopyAsyncForSnapshotToVolume(SnapshotInfo srcSnapshotInfo, VolumeInfo destVolumeInfo,
+                                                    AsyncCompletionCallback<CopyCommandResult> callback) {
+        boolean canHandleDest = canHandle(destVolumeInfo);
+
+        if (!canHandleDest) {
+            handleError(OPERATION_NOT_SUPPORTED, callback);
         }
 
-        throw new UnsupportedOperationException("This operation is not supported.");
+        boolean canHandleSrc = canHandle(srcSnapshotInfo);
+
+        if (!canHandleSrc) {
+            handleCreateVolumeFromSnapshotOnSecondaryStorage(srcSnapshotInfo, destVolumeInfo, callback);
+        }
+
+        if (srcSnapshotInfo.getDataStore().getId() == destVolumeInfo.getDataStore().getId()) {
+            handleCreateVolumeFromSnapshotBothOnStorageSystem(srcSnapshotInfo, destVolumeInfo, callback);
+        } else {
+            String errMsg = "To perform this operation, the source and destination primary storages must be the same.";
+
+            handleError(errMsg, callback);
+        }
     }
 
-    private String getSrcDestDataStoreMsg(DataObject srcData, DataObject destData) {
-        Preconditions.checkArgument(srcData != null, "Passing 'null' to srcData of getSrcDestDataStoreMsg(DataObject, DataObject) is not supported.");
-        Preconditions.checkArgument(destData != null, "Passing 'null' to destData of getSrcDestDataStoreMsg(DataObject, DataObject) is not supported.");
+    private void handleCopyAsyncForTemplateAndVolume(TemplateInfo srcTemplateInfo, VolumeInfo destVolumeInfo, AsyncCompletionCallback<CopyCommandResult> callback) {
+        boolean canHandleSrc = canHandle(srcTemplateInfo);
 
-        return "Source data store = " + srcData.getDataStore().getName() + "; " + "Destination data store = " + destData.getDataStore().getName() + ".";
+        if (!canHandleSrc) {
+            handleError(OPERATION_NOT_SUPPORTED, callback);
+        }
+
+        handleCreateVolumeFromTemplateBothOnStorageSystem(srcTemplateInfo, destVolumeInfo, callback);
     }
 
-    private String getSrcDataStoreMsg(DataObject srcData) {
-        Preconditions.checkArgument(srcData != null, "Passing 'null' to srcData of getSrcDataStoreMsg(DataObject) is not supported.");
+    private void handleCopyAsyncForVolumes(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo, AsyncCompletionCallback<CopyCommandResult> callback) {
+        if (srcVolumeInfo.getState() == Volume.State.Migrating) {
+            if (isVolumeOnManagedStorage(srcVolumeInfo)) {
+                if (destVolumeInfo.getDataStore().getRole() == DataStoreRole.Image || destVolumeInfo.getDataStore().getRole() == DataStoreRole.ImageCache) {
+                    handleVolumeCopyFromManagedStorageToSecondaryStorage(srcVolumeInfo, destVolumeInfo, callback);
+                } else if (!isVolumeOnManagedStorage(destVolumeInfo)) {
+                    handleVolumeMigrationFromManagedStorageToNonManagedStorage(srcVolumeInfo, destVolumeInfo, callback);
+                } else {
+                    String errMsg = "The source volume to migrate and the destination volume are both on managed storage. " +
+                            "Migration in this case is not yet supported.";
 
-        return "Source data store = " + srcData.getDataStore().getName() + ".";
+                    handleError(errMsg, callback);
+                }
+            } else if (!isVolumeOnManagedStorage(destVolumeInfo)) {
+                String errMsg = "The 'StorageSystemDataMotionStrategy' does not support this migration use case.";
+
+                handleError(errMsg, callback);
+            } else {
+                handleVolumeMigrationFromNonManagedStorageToManagedStorage(srcVolumeInfo, destVolumeInfo, callback);
+            }
+        } else if (srcVolumeInfo.getState() == Volume.State.Uploaded &&
+                (srcVolumeInfo.getDataStore().getRole() == DataStoreRole.Image || srcVolumeInfo.getDataStore().getRole() == DataStoreRole.ImageCache) &&
+                destVolumeInfo.getDataStore().getRole() == DataStoreRole.Primary) {
+            ImageFormat imageFormat = destVolumeInfo.getFormat();
+
+            if (!ImageFormat.QCOW2.equals(imageFormat)) {
+                String errMsg = "The 'StorageSystemDataMotionStrategy' does not support this upload use case (non KVM).";
+
+                handleError(errMsg, callback);
+            }
+
+            handleCreateVolumeFromVolumeOnSecondaryStorage(srcVolumeInfo, destVolumeInfo, destVolumeInfo.getDataCenterId(), HypervisorType.KVM, callback);
+        } else {
+            handleError(OPERATION_NOT_SUPPORTED, callback);
+        }
     }
 
-    private String getDestDataStoreMsg(DataObject destData) {
-        Preconditions.checkArgument(destData != null, "Passing 'null' to destData of getDestDataStoreMsg(DataObject) is not supported.");
+    private void handleError(String errMsg, AsyncCompletionCallback<CopyCommandResult> callback) {
+        LOGGER.warn(errMsg);
 
-        return "Destination data store = " + destData.getDataStore().getName() + ".";
+        invokeCallback(errMsg, callback);
+
+        throw new UnsupportedOperationException(errMsg);
     }
 
-    private void validate(SnapshotInfo snapshotInfo) {
+    private void invokeCallback(String errMsg, AsyncCompletionCallback<CopyCommandResult> callback) {
+        CopyCmdAnswer copyCmdAnswer = new CopyCmdAnswer(errMsg);
+
+        CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+        result.setResult(errMsg);
+
+        callback.complete(result);
+    }
+
+    private void handleVolumeCopyFromManagedStorageToSecondaryStorage(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo,
+                                                                      AsyncCompletionCallback<CopyCommandResult> callback) {
+        String errMsg = null;
+        String volumePath = null;
+
+        try {
+            if (!ImageFormat.QCOW2.equals(srcVolumeInfo.getFormat())) {
+                throw new CloudRuntimeException("Currently, only the KVM hypervisor type is supported for the migration of a volume " +
+                        "from managed storage to non-managed storage.");
+            }
+
+            HypervisorType hypervisorType = HypervisorType.KVM;
+            VirtualMachine vm = srcVolumeInfo.getAttachedVM();
+
+            if (vm != null && vm.getState() != VirtualMachine.State.Stopped) {
+                throw new CloudRuntimeException("Currently, if a volume to copy from managed storage to secondary storage is attached to " +
+                        "a VM, the VM must be in the Stopped state.");
+            }
+
+            long srcStoragePoolId = srcVolumeInfo.getPoolId();
+            StoragePoolVO srcStoragePoolVO = _storagePoolDao.findById(srcStoragePoolId);
+
+            HostVO hostVO;
+
+            if (srcStoragePoolVO.getClusterId() != null) {
+                hostVO = getHostInCluster(srcStoragePoolVO.getClusterId());
+            }
+            else {
+                hostVO = getHost(srcVolumeInfo.getDataCenterId(), hypervisorType, false);
+            }
+
+            volumePath = copyVolumeToSecondaryStorage(srcVolumeInfo, destVolumeInfo, hostVO,
+                    "Unable to copy the volume from managed storage to secondary storage");
+        }
+        catch (Exception ex) {
+            errMsg = "Migration operation failed in 'StorageSystemDataMotionStrategy.handleVolumeCopyFromManagedStorageToSecondaryStorage': " +
+                    ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            CopyCmdAnswer copyCmdAnswer;
+
+            if (errMsg != null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
+            else if (volumePath == null) {
+                copyCmdAnswer = new CopyCmdAnswer("Unable to acquire a volume path");
+            }
+            else {
+                VolumeObjectTO volumeObjectTO = (VolumeObjectTO)destVolumeInfo.getTO();
+
+                volumeObjectTO.setPath(volumePath);
+
+                copyCmdAnswer = new CopyCmdAnswer(volumeObjectTO);
+            }
+
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+            result.setResult(errMsg);
+
+            callback.complete(result);
+        }
+    }
+
+    private void handleVolumeMigrationFromManagedStorageToNonManagedStorage(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo,
+                                                                            AsyncCompletionCallback<CopyCommandResult> callback) {
+        String errMsg = null;
+
+        try {
+            if (!ImageFormat.QCOW2.equals(srcVolumeInfo.getFormat())) {
+                throw new CloudRuntimeException("Currently, only the KVM hypervisor type is supported for the migration of a volume " +
+                        "from managed storage to non-managed storage.");
+            }
+
+            HypervisorType hypervisorType = HypervisorType.KVM;
+            VirtualMachine vm = srcVolumeInfo.getAttachedVM();
+
+            if (vm != null && vm.getState() != VirtualMachine.State.Stopped) {
+                throw new CloudRuntimeException("Currently, if a volume to migrate from managed storage to non-managed storage is attached to " +
+                        "a VM, the VM must be in the Stopped state.");
+            }
+
+            long destStoragePoolId = destVolumeInfo.getPoolId();
+            StoragePoolVO destStoragePoolVO = _storagePoolDao.findById(destStoragePoolId);
+
+            HostVO hostVO;
+
+            if (destStoragePoolVO.getClusterId() != null) {
+                hostVO = getHostInCluster(destStoragePoolVO.getClusterId());
+            }
+            else {
+                hostVO = getHost(destVolumeInfo.getDataCenterId(), hypervisorType, false);
+            }
+
+            setCertainVolumeValuesNull(destVolumeInfo.getId());
+
+            // migrate the volume via the hypervisor
+            String path = migrateVolume(srcVolumeInfo, destVolumeInfo, hostVO, "Unable to migrate the volume from managed storage to non-managed storage");
+
+            updateVolumePath(destVolumeInfo.getId(), path);
+        }
+        catch (Exception ex) {
+            errMsg = "Migration operation failed in 'StorageSystemDataMotionStrategy.handleVolumeMigrationFromManagedStorageToNonManagedStorage': " +
+                    ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            CopyCmdAnswer copyCmdAnswer;
+
+            if (errMsg != null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
+            else {
+                destVolumeInfo = _volumeDataFactory.getVolume(destVolumeInfo.getId(), destVolumeInfo.getDataStore());
+
+                DataTO dataTO = destVolumeInfo.getTO();
+
+                copyCmdAnswer = new CopyCmdAnswer(dataTO);
+            }
+
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+            result.setResult(errMsg);
+
+            callback.complete(result);
+        }
+    }
+
+    private void verifyFormat(ImageFormat imageFormat) {
+        if (imageFormat != ImageFormat.VHD && imageFormat != ImageFormat.OVA && imageFormat != ImageFormat.QCOW2) {
+            throw new CloudRuntimeException("Only the following image types are currently supported: " +
+                    ImageFormat.VHD.toString() + ", " + ImageFormat.OVA.toString() + ", and " + ImageFormat.QCOW2);
+        }
+    }
+
+    private void verifyFormat(SnapshotInfo snapshotInfo) {
         long volumeId = snapshotInfo.getVolumeId();
 
         VolumeVO volumeVO = _volumeDao.findByIdIncludingRemoved(volumeId);
 
-        if (volumeVO.getFormat() != ImageFormat.VHD) {
-            throw new CloudRuntimeException("Only the " + ImageFormat.VHD.toString() + " image type is currently supported.");
-        }
+        verifyFormat(volumeVO.getFormat());
     }
 
     private boolean usingBackendSnapshotFor(SnapshotInfo snapshotInfo) {
-        String property = getProperty(snapshotInfo.getId(), "takeSnapshot");
+        String property = getSnapshotProperty(snapshotInfo.getId(), "takeSnapshot");
 
         return Boolean.parseBoolean(property);
     }
 
-    protected boolean needCacheStorage(DataObject srcData, DataObject destData) {
+    private boolean needCacheStorage(DataObject srcData, DataObject destData) {
         DataTO srcTO = srcData.getTO();
         DataStoreTO srcStoreTO = srcTO.getDataStore();
         DataTO destTO = destData.getTO();
         DataStoreTO destStoreTO = destTO.getDataStore();
 
-        // both snapshot and volume are on primary datastore. No need for a cache storage as
-        // hypervisor will copy directly
+        // both snapshot and volume are on primary datastore - no need for a cache storage as hypervisor will copy directly
         if (srcStoreTO instanceof PrimaryDataStoreTO && destStoreTO instanceof PrimaryDataStoreTO) {
             return false;
         }
@@ -304,14 +564,15 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             return false;
         }
 
-
         if (destStoreTO instanceof NfsTO || destStoreTO.getRole() == DataStoreRole.ImageCache) {
             return false;
         }
+
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("needCacheStorage true, dest at " + destTO.getPath() + " dest role " + destStoreTO.getRole().toString() + srcTO.getPath() + " src role " +
-                srcStoreTO.getRole().toString());
+            LOGGER.debug("needCacheStorage true; dest at " + destTO.getPath() + ", dest role " + destStoreTO.getRole().toString() + "; src at " +
+                    srcTO.getPath() + ", src role " + srcStoreTO.getRole().toString());
         }
+
         return true;
     }
 
@@ -320,6 +581,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         Scope destScope = destData.getDataStore().getScope();
 
         Scope selectedScope = null;
+
         if (srcScope.getScopeId() != null) {
             selectedScope = getZoneScope(srcScope);
         } else if (destScope.getScopeId() != null) {
@@ -327,85 +589,233 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         } else {
             LOGGER.warn("Cannot find a zone-wide scope for movement that needs a cache storage");
         }
+
         return selectedScope;
     }
 
     private Scope getZoneScope(Scope scope) {
         ZoneScope zoneScope;
+
         if (scope instanceof ClusterScope) {
             ClusterScope clusterScope = (ClusterScope)scope;
+
             zoneScope = new ZoneScope(clusterScope.getZoneId());
         } else if (scope instanceof HostScope) {
             HostScope hostScope = (HostScope)scope;
+
             zoneScope = new ZoneScope(hostScope.getZoneId());
         } else {
             zoneScope = (ZoneScope)scope;
         }
+
         return zoneScope;
     }
 
+    private void handleVolumeMigrationFromNonManagedStorageToManagedStorage(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo,
+                                                                            AsyncCompletionCallback<CopyCommandResult> callback) {
+        String errMsg = null;
+
+        try {
+            HypervisorType hypervisorType = srcVolumeInfo.getHypervisorType();
+
+            if (!HypervisorType.KVM.equals(hypervisorType)) {
+                throw new CloudRuntimeException("Currently, only the KVM hypervisor type is supported for the migration of a volume " +
+                        "from non-managed storage to managed storage.");
+            }
+
+            VirtualMachine vm = srcVolumeInfo.getAttachedVM();
+
+            if (vm != null && vm.getState() != VirtualMachine.State.Stopped) {
+                throw new CloudRuntimeException("Currently, if a volume to migrate from non-managed storage to managed storage is attached to " +
+                        "a VM, the VM must be in the Stopped state.");
+            }
+
+            destVolumeInfo.getDataStore().getDriver().createAsync(destVolumeInfo.getDataStore(), destVolumeInfo, null);
+
+            VolumeVO volumeVO = _volumeDao.findById(destVolumeInfo.getId());
+
+            volumeVO.setPath(volumeVO.get_iScsiName());
+
+            _volumeDao.update(volumeVO.getId(), volumeVO);
+
+            destVolumeInfo = _volumeDataFactory.getVolume(destVolumeInfo.getId(), destVolumeInfo.getDataStore());
+
+            long srcStoragePoolId = srcVolumeInfo.getPoolId();
+            StoragePoolVO srcStoragePoolVO = _storagePoolDao.findById(srcStoragePoolId);
+
+            HostVO hostVO;
+
+            if (srcStoragePoolVO.getClusterId() != null) {
+                hostVO = getHostInCluster(srcStoragePoolVO.getClusterId());
+            }
+            else {
+                hostVO = getHost(destVolumeInfo.getDataCenterId(), hypervisorType, false);
+            }
+
+            // migrate the volume via the hypervisor
+            migrateVolume(srcVolumeInfo, destVolumeInfo, hostVO, "Unable to migrate the volume from non-managed storage to managed storage");
+
+            volumeVO = _volumeDao.findById(destVolumeInfo.getId());
+
+            volumeVO.setFormat(ImageFormat.QCOW2);
+
+            _volumeDao.update(volumeVO.getId(), volumeVO);
+        }
+        catch (Exception ex) {
+            errMsg = "Migration operation failed in 'StorageSystemDataMotionStrategy.handleVolumeMigrationFromNonManagedStorageToManagedStorage': " +
+                    ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            CopyCmdAnswer copyCmdAnswer;
+
+            if (errMsg != null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
+            else {
+                destVolumeInfo = _volumeDataFactory.getVolume(destVolumeInfo.getId(), destVolumeInfo.getDataStore());
+
+                DataTO dataTO = destVolumeInfo.getTO();
+
+                copyCmdAnswer = new CopyCmdAnswer(dataTO);
+            }
+
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+            result.setResult(errMsg);
+
+            callback.complete(result);
+        }
+    }
+
     /**
-     * This function is responsible for copying a volume from the managed store to a secondary store. This is used in two cases
+     * This function is responsible for copying a snapshot from managed storage to secondary storage. This is used in the following two cases:
      * 1) When creating a template from a snapshot
      * 2) When createSnapshot is called with location=SECONDARY
      *
-     * @param snapshotInfo Source snapshot
+     * @param snapshotInfo source snapshot
      * @param destData destination (can be template or snapshot)
      * @param callback callback for async
      */
     private void handleCopyDataToSecondaryStorage(SnapshotInfo snapshotInfo, DataObject destData, AsyncCompletionCallback<CopyCommandResult> callback) {
+        String errMsg = null;
+        CopyCmdAnswer copyCmdAnswer = null;
+        boolean usingBackendSnapshot = false;
+
         try {
             snapshotInfo.processEvent(Event.CopyingRequested);
-        }
-        catch (Exception ex) {
-            throw new CloudRuntimeException("This snapshot is not currently in a state where it can be used to create a template.");
-        }
 
-        HostVO hostVO = getHost(snapshotInfo);
+            HostVO hostVO = getHost(snapshotInfo);
 
-        boolean usingBackendSnapshot = usingBackendSnapshotFor(snapshotInfo);
-        boolean computeClusterSupportsResign = clusterDao.getSupportsResigning(hostVO.getClusterId());
-        boolean needCache = needCacheStorage(snapshotInfo, destData);
+            boolean needCache = needCacheStorage(snapshotInfo, destData);
 
-        DataObject destOnStore = destData;
+            DataObject destOnStore = destData;
 
-        if (needCache) {
-            // creates an object in the DB for data to be cached
-            Scope selectedScope = pickCacheScopeForCopy(snapshotInfo, destData);
-            destOnStore = cacheMgr.getCacheObject(snapshotInfo, selectedScope);
-            destOnStore.processEvent(Event.CreateOnlyRequested);
-        }
+            if (needCache) {
+                // creates an object in the DB for data to be cached
+                Scope selectedScope = pickCacheScopeForCopy(snapshotInfo, destData);
 
-        if (usingBackendSnapshot && !computeClusterSupportsResign) {
-            String noSupportForResignErrMsg = "Unable to locate an applicable host with which to perform a resignature operation : Cluster ID = " + hostVO.getClusterId();
+                destOnStore = cacheMgr.getCacheObject(snapshotInfo, selectedScope);
 
-            LOGGER.warn(noSupportForResignErrMsg);
-
-            throw new CloudRuntimeException(noSupportForResignErrMsg);
-        }
-
-        try {
-            if (usingBackendSnapshot) {
-                createVolumeFromSnapshot(hostVO, snapshotInfo, true);
+                destOnStore.processEvent(Event.CreateOnlyRequested);
             }
+
+            usingBackendSnapshot = usingBackendSnapshotFor(snapshotInfo);
+
+            if (usingBackendSnapshot) {
+                final boolean computeClusterSupportsVolumeClone;
+
+                // only XenServer, VMware, and KVM are currently supported
+                if (HypervisorType.XenServer.equals(snapshotInfo.getHypervisorType())) {
+                    computeClusterSupportsVolumeClone = clusterDao.getSupportsResigning(hostVO.getClusterId());
+                }
+                else if (HypervisorType.VMware.equals(snapshotInfo.getHypervisorType()) || HypervisorType.KVM.equals(snapshotInfo.getHypervisorType())) {
+                    computeClusterSupportsVolumeClone = true;
+                }
+                else {
+                    throw new CloudRuntimeException("Unsupported hypervisor type");
+                }
+
+                if (!computeClusterSupportsVolumeClone) {
+                    String noSupportForResignErrMsg = "Unable to locate an applicable host with which to perform a resignature operation : Cluster ID = " +
+                            hostVO.getClusterId();
+
+                    LOGGER.warn(noSupportForResignErrMsg);
+
+                    throw new CloudRuntimeException(noSupportForResignErrMsg);
+                }
+            }
+
+            String vmdk = null;
+            String uuid = null;
+            boolean keepGrantedAccess = false;
 
             DataStore srcDataStore = snapshotInfo.getDataStore();
 
+            if (usingBackendSnapshot) {
+                createVolumeFromSnapshot(snapshotInfo);
+
+                if (HypervisorType.XenServer.equals(snapshotInfo.getHypervisorType()) || HypervisorType.VMware.equals(snapshotInfo.getHypervisorType())) {
+                    keepGrantedAccess = HypervisorType.XenServer.equals(snapshotInfo.getHypervisorType());
+
+                    Map<String, String> extraDetails = null;
+
+                    if (HypervisorType.VMware.equals(snapshotInfo.getHypervisorType())) {
+                        extraDetails = new HashMap<>();
+
+                        String extraDetailsVmdk = getSnapshotProperty(snapshotInfo.getId(), DiskTO.VMDK);
+
+                        extraDetails.put(DiskTO.VMDK, extraDetailsVmdk);
+                        extraDetails.put(DiskTO.TEMPLATE_RESIGN, Boolean.TRUE.toString());
+                    }
+
+                    copyCmdAnswer = performResignature(snapshotInfo, hostVO, extraDetails, keepGrantedAccess);
+
+                    // If using VMware, have the host rescan its software HBA if dynamic discovery is in use.
+                    if (HypervisorType.VMware.equals(snapshotInfo.getHypervisorType())) {
+                        String iqn = getSnapshotProperty(snapshotInfo.getId(), DiskTO.IQN);
+
+                        disconnectHostFromVolume(hostVO, srcDataStore.getId(), iqn);
+                    }
+
+                    if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
+                        if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
+                            throw new CloudRuntimeException(copyCmdAnswer.getDetails());
+                        } else {
+                            throw new CloudRuntimeException("Unable to create volume from snapshot");
+                        }
+                    }
+
+                    vmdk = copyCmdAnswer.getNewData().getPath();
+                    uuid = UUID.randomUUID().toString();
+                }
+            }
+
             String value = _configDao.getValue(Config.PrimaryStorageDownloadWait.toString());
             int primaryStorageDownloadWait = NumbersUtil.parseInt(value, Integer.parseInt(Config.PrimaryStorageDownloadWait.getDefaultValue()));
-            CopyCommand copyCommand = new CopyCommand(snapshotInfo.getTO(), destOnStore.getTO(), primaryStorageDownloadWait, VirtualMachineManager.ExecuteInSequence.value());
-
-            String errMsg = null;
-            CopyCmdAnswer copyCmdAnswer = null;
+            CopyCommand copyCommand = new CopyCommand(snapshotInfo.getTO(), destOnStore.getTO(), primaryStorageDownloadWait,
+                    VirtualMachineManager.ExecuteInSequence.value());
 
             try {
-                // If we are using a back-end snapshot, then we should still have access to it from the hosts in the cluster that hostVO is in
-                // (because we passed in true as the third parameter to createVolumeFromSnapshot above).
-                if (!usingBackendSnapshot) {
+                if (!keepGrantedAccess) {
                     _volumeService.grantAccess(snapshotInfo, hostVO, srcDataStore);
                 }
 
                 Map<String, String> srcDetails = getSnapshotDetails(snapshotInfo);
+
+                if (isForVMware(destData)) {
+                    srcDetails.put(DiskTO.VMDK, vmdk);
+                    srcDetails.put(DiskTO.UUID, uuid);
+
+                    if (destData instanceof TemplateInfo) {
+                        VMTemplateVO templateDataStoreVO = _vmTemplateDao.findById(destData.getId());
+
+                        templateDataStoreVO.setUniqueName(uuid);
+
+                        _vmTemplateDao.update(destData.getId(), templateDataStoreVO);
+                    }
+                }
 
                 copyCommand.setOptions(srcDetails);
 
@@ -423,15 +833,16 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                     // storage), at this point, the data has been copied from the primary
                     // to the NFS cache by the hypervisor. We now invoke another copy
                     // command to copy this data from cache to secondary storage. We
-                    // then cleanup the cache
+                    // then clean up the cache.
 
                     destOnStore.processEvent(Event.OperationSuccessed, copyCmdAnswer);
 
-                    CopyCommand cmd = new CopyCommand(destOnStore.getTO(), destData.getTO(), primaryStorageDownloadWait, VirtualMachineManager.ExecuteInSequence.value());
+                    CopyCommand cmd = new CopyCommand(destOnStore.getTO(), destData.getTO(), primaryStorageDownloadWait,
+                            VirtualMachineManager.ExecuteInSequence.value());
                     EndPoint ep = selector.select(destOnStore, destData);
 
                     if (ep == null) {
-                        errMsg = "No remote endpoint to send command, check if host or ssvm is down?";
+                        errMsg = "No remote endpoint to send command, check if host or SSVM is down";
 
                         LOGGER.error(errMsg);
 
@@ -443,7 +854,6 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                     // clean up snapshot copied to staging
                     cacheMgr.deleteCacheObject(destOnStore);
                 }
-
             } catch (CloudRuntimeException | AgentUnavailableException | OperationTimedoutException ex) {
                 String msg = "Failed to create template from snapshot (Snapshot ID = " + snapshotInfo.getId() + ") : ";
 
@@ -452,6 +862,13 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                 throw new CloudRuntimeException(msg + ex.getMessage());
             } finally {
                 _volumeService.revokeAccess(snapshotInfo, hostVO, srcDataStore);
+
+                // If using VMware, have the host rescan its software HBA if dynamic discovery is in use.
+                if (HypervisorType.VMware.equals(snapshotInfo.getHypervisorType())) {
+                    String iqn = getSnapshotProperty(snapshotInfo.getId(), DiskTO.IQN);
+
+                    disconnectHostFromVolume(hostVO, srcDataStore.getId(), iqn);
+                }
 
                 if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
                     if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
@@ -478,6 +895,20 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
                     LOGGER.warn("Error processing snapshot event: " + ex.getMessage(), ex);
                 }
             }
+        }
+        catch (Exception ex) {
+            errMsg = ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            if (usingBackendSnapshot) {
+                deleteVolumeFromSnapshot(snapshotInfo);
+            }
+
+            if (copyCmdAnswer == null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
 
             CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
 
@@ -485,104 +916,135 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
             callback.complete(result);
         }
-        finally {
-            if (usingBackendSnapshot) {
-                deleteVolumeFromSnapshot(snapshotInfo);
-            }
-        }
     }
 
     /**
      * Creates a volume on the storage from a snapshot that resides on the secondary storage (archived snapshot).
      * @param snapshotInfo snapshot on secondary
      * @param volumeInfo volume to be created on the storage
-     * @param callback  for async
+     * @param callback for async
      */
-    private void handleCreateVolumeFromSnapshotOnSecondaryStorage(SnapshotInfo snapshotInfo, VolumeInfo volumeInfo, AsyncCompletionCallback<CopyCommandResult> callback) {
-        // at this point, the snapshotInfo and volumeInfo should have the same disk offering ID (so either one should be OK to get a DiskOfferingVO instance)
-        DiskOfferingVO diskOffering = _diskOfferingDao.findByIdIncludingRemoved(volumeInfo.getDiskOfferingId());
-        SnapshotVO snapshot = _snapshotDao.findById(snapshotInfo.getId());
-
-        // update the volume's hv_ss_reserve (hypervisor snapshot reserve) from a disk offering (used for managed storage)
-        _volumeService.updateHypervisorSnapshotReserveForVolume(diskOffering, volumeInfo.getId(), snapshot.getHypervisorType());
-
-        CopyCmdAnswer copyCmdAnswer = null;
+    private void handleCreateVolumeFromSnapshotOnSecondaryStorage(SnapshotInfo snapshotInfo, VolumeInfo volumeInfo,
+                                                                  AsyncCompletionCallback<CopyCommandResult> callback) {
         String errMsg = null;
-
-        HostVO hostVO = null;
+        CopyCmdAnswer copyCmdAnswer = null;
 
         try {
+            // at this point, the snapshotInfo and volumeInfo should have the same disk offering ID (so either one should be OK to get a DiskOfferingVO instance)
+            DiskOfferingVO diskOffering = _diskOfferingDao.findByIdIncludingRemoved(volumeInfo.getDiskOfferingId());
+            SnapshotVO snapshot = _snapshotDao.findById(snapshotInfo.getId());
+
+            // update the volume's hv_ss_reserve (hypervisor snapshot reserve) from a disk offering (used for managed storage)
+            _volumeService.updateHypervisorSnapshotReserveForVolume(diskOffering, volumeInfo.getId(), snapshot.getHypervisorType());
+
+            HostVO hostVO;
+
             // create a volume on the storage
             AsyncCallFuture<VolumeApiResult> future = _volumeService.createVolumeAsync(volumeInfo, volumeInfo.getDataStore());
             VolumeApiResult result = future.get();
 
             if (result.isFailed()) {
                 LOGGER.error("Failed to create a volume: " + result.getResult());
+
                 throw new CloudRuntimeException(result.getResult());
             }
 
             volumeInfo = _volumeDataFactory.getVolume(volumeInfo.getId(), volumeInfo.getDataStore());
-
             volumeInfo.processEvent(Event.MigrationRequested);
-
             volumeInfo = _volumeDataFactory.getVolume(volumeInfo.getId(), volumeInfo.getDataStore());
 
-            hostVO = getHost(snapshotInfo.getDataCenterId(), false);
+            hostVO = getHost(snapshotInfo.getDataCenterId(), snapshotInfo.getHypervisorType(), false);
 
             // copy the volume from secondary via the hypervisor
-            copyCmdAnswer = performCopyOfVdi(volumeInfo, snapshotInfo, hostVO);
+            if (HypervisorType.XenServer.equals(snapshotInfo.getHypervisorType())) {
+                copyCmdAnswer = performCopyOfVdi(volumeInfo, snapshotInfo, hostVO);
+            }
+            else {
+                copyCmdAnswer = copyImageToVolume(snapshotInfo, volumeInfo, hostVO);
+            }
 
             if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
                 if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
-                    errMsg = copyCmdAnswer.getDetails();
+                    throw new CloudRuntimeException(copyCmdAnswer.getDetails());
                 }
                 else {
-                    errMsg = "Unable to create volume from snapshot";
+                    throw new CloudRuntimeException("Unable to create volume from snapshot");
                 }
             }
         }
         catch (Exception ex) {
-            errMsg = ex.getMessage() != null ? ex.getMessage() : "Copy operation failed in 'StorageSystemDataMotionStrategy.handleCreateVolumeFromSnapshotBothOnStorageSystem'";
+            errMsg = "Copy operation failed in 'StorageSystemDataMotionStrategy.handleCreateVolumeFromSnapshotOnSecondaryStorage': " +
+                    ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
         }
+        finally {
+            if (copyCmdAnswer == null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
 
-        CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
 
-        result.setResult(errMsg);
+            result.setResult(errMsg);
 
-        callback.complete(result);
+            callback.complete(result);
+        }
     }
 
     /**
      * Clones a template present on the storage to a new volume and resignatures it.
      *
-     * @param templateInfo   source template
-     * @param volumeInfo  destination ROOT volume
-     * @param callback  for async
+     * @param templateInfo source template
+     * @param volumeInfo destination ROOT volume
+     * @param callback for async
      */
     private void handleCreateVolumeFromTemplateBothOnStorageSystem(TemplateInfo templateInfo, VolumeInfo volumeInfo, AsyncCompletionCallback<CopyCommandResult> callback) {
-        Preconditions.checkArgument(templateInfo != null, "Passing 'null' to templateInfo of handleCreateVolumeFromTemplateBothOnStorageSystem is not supported.");
-        Preconditions.checkArgument(volumeInfo != null, "Passing 'null' to volumeInfo of handleCreateVolumeFromTemplateBothOnStorageSystem is not supported.");
-
-        CopyCmdAnswer copyCmdAnswer = null;
         String errMsg = null;
-
-        HostVO hostVO = getHost(volumeInfo.getDataCenterId(), true);
-
-        if (hostVO == null) {
-            throw new CloudRuntimeException("Unable to locate a host capable of resigning in the zone with the following ID: " + volumeInfo.getDataCenterId());
-        }
-
-        boolean computeClusterSupportsResign = clusterDao.getSupportsResigning(hostVO.getClusterId());
-
-        if (!computeClusterSupportsResign) {
-            String noSupportForResignErrMsg = "Unable to locate an applicable host with which to perform a resignature operation : Cluster ID = " + hostVO.getClusterId();
-
-            LOGGER.warn(noSupportForResignErrMsg);
-
-            throw new CloudRuntimeException(noSupportForResignErrMsg);
-        }
+        CopyCmdAnswer copyCmdAnswer = null;
 
         try {
+            Preconditions.checkArgument(templateInfo != null, "Passing 'null' to templateInfo of " +
+                            "handleCreateVolumeFromTemplateBothOnStorageSystem is not supported.");
+            Preconditions.checkArgument(volumeInfo != null, "Passing 'null' to volumeInfo of " +
+                            "handleCreateVolumeFromTemplateBothOnStorageSystem is not supported.");
+
+            verifyFormat(templateInfo.getFormat());
+
+            HostVO hostVO = null;
+
+            final boolean computeClusterSupportsVolumeClone;
+
+            // only XenServer, VMware, and KVM are currently supported
+            // Leave host equal to null for KVM since we don't need to perform a resignature when using that hypervisor type.
+            if (volumeInfo.getFormat() == ImageFormat.VHD) {
+                hostVO = getHost(volumeInfo.getDataCenterId(), HypervisorType.XenServer, true);
+
+                if (hostVO == null) {
+                    throw new CloudRuntimeException("Unable to locate a host capable of resigning in the zone with the following ID: " +
+                            volumeInfo.getDataCenterId());
+                }
+
+                computeClusterSupportsVolumeClone = clusterDao.getSupportsResigning(hostVO.getClusterId());
+
+                if (!computeClusterSupportsVolumeClone) {
+                    String noSupportForResignErrMsg = "Unable to locate an applicable host with which to perform a resignature operation : Cluster ID = " +
+                            hostVO.getClusterId();
+
+                    LOGGER.warn(noSupportForResignErrMsg);
+
+                    throw new CloudRuntimeException(noSupportForResignErrMsg);
+                }
+            }
+            else if (volumeInfo.getFormat() == ImageFormat.OVA) {
+                // all VMware hosts support resigning
+                hostVO = getHost(volumeInfo.getDataCenterId(), HypervisorType.VMware, false);
+
+                if (hostVO == null) {
+                    throw new CloudRuntimeException("Unable to locate a host capable of resigning in the zone with the following ID: " +
+                            volumeInfo.getDataCenterId());
+                }
+            }
+
             VolumeDetailVO volumeDetail = new VolumeDetailVO(volumeInfo.getId(),
                     "cloneOfTemplate",
                     String.valueOf(templateInfo.getId()),
@@ -591,6 +1053,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             volumeDetail = volumeDetailsDao.persist(volumeDetail);
 
             AsyncCallFuture<VolumeApiResult> future = _volumeService.createVolumeAsync(volumeInfo, volumeInfo.getDataStore());
+
             int storagePoolMaxWaitSeconds = NumbersUtil.parseInt(_configDao.getValue(Config.StoragePoolMaxWaitSeconds.key()), 3600);
 
             VolumeApiResult result = future.get(storagePoolMaxWaitSeconds, TimeUnit.SECONDS);
@@ -601,6 +1064,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
             if (result.isFailed()) {
                 LOGGER.warn("Failed to create a volume: " + result.getResult());
+
                 throw new CloudRuntimeException(result.getResult());
             }
 
@@ -608,48 +1072,100 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             volumeInfo.processEvent(Event.MigrationRequested);
             volumeInfo = _volumeDataFactory.getVolume(volumeInfo.getId(), volumeInfo.getDataStore());
 
-            copyCmdAnswer = performResignature(volumeInfo, hostVO);
+            if (hostVO != null) {
+                Map<String, String> extraDetails = null;
 
-            if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
-                if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
-                    throw new CloudRuntimeException(copyCmdAnswer.getDetails());
-                } else {
-                    throw new CloudRuntimeException("Unable to create a volume from a template");
+                if (HypervisorType.VMware.equals(templateInfo.getHypervisorType())) {
+                    extraDetails = new HashMap<>();
+
+                    String extraDetailsVmdk = templateInfo.getUniqueName() + ".vmdk";
+
+                    extraDetails.put(DiskTO.VMDK, extraDetailsVmdk);
+                    extraDetails.put(DiskTO.EXPAND_DATASTORE, Boolean.TRUE.toString());
+                }
+
+                copyCmdAnswer = performResignature(volumeInfo, hostVO, extraDetails);
+
+                if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
+                    if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
+                        throw new CloudRuntimeException(copyCmdAnswer.getDetails());
+                    } else {
+                        throw new CloudRuntimeException("Unable to create a volume from a template");
+                    }
+                }
+
+                // If using VMware, have the host rescan its software HBA if dynamic discovery is in use.
+                if (HypervisorType.VMware.equals(templateInfo.getHypervisorType())) {
+                    disconnectHostFromVolume(hostVO, volumeInfo.getPoolId(), volumeInfo.get_iScsiName());
                 }
             }
-        } catch (InterruptedException | ExecutionException | TimeoutException ex ) {
-            volumeInfo.getDataStore().getDriver().deleteAsync(volumeInfo.getDataStore(), volumeInfo, null);
+            else {
+                VolumeObjectTO newVolume = new VolumeObjectTO();
 
-            throw new CloudRuntimeException("Create volume from template (ID = " + templateInfo.getId() + ") failed " + ex.getMessage());
+                newVolume.setSize(volumeInfo.getSize());
+                newVolume.setPath(volumeInfo.getPath());
+                newVolume.setFormat(volumeInfo.getFormat());
+
+                copyCmdAnswer = new CopyCmdAnswer(newVolume);
+            }
+        } catch (Exception ex) {
+            try {
+                volumeInfo.getDataStore().getDriver().deleteAsync(volumeInfo.getDataStore(), volumeInfo, null);
+            }
+            catch (Exception exc) {
+                LOGGER.warn("Failed to delete volume", exc);
+            }
+
+            if (templateInfo != null) {
+                errMsg = "Create volume from template (ID = " + templateInfo.getId() + ") failed: " + ex.getMessage();
+            }
+            else {
+                errMsg = "Create volume from template failed: " + ex.getMessage();
+            }
+
+            throw new CloudRuntimeException(errMsg);
         }
+        finally {
+            if (copyCmdAnswer == null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
 
-        CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
 
-        result.setResult(errMsg);
+            result.setResult(errMsg);
 
-        callback.complete(result);
+            callback.complete(result);
+        }
     }
 
-    private void handleCreateVolumeFromSnapshotBothOnStorageSystem(SnapshotInfo snapshotInfo, VolumeInfo volumeInfo, AsyncCompletionCallback<CopyCommandResult> callback) {
-        CopyCmdAnswer copyCmdAnswer = null;
+    private void handleCreateVolumeFromSnapshotBothOnStorageSystem(SnapshotInfo snapshotInfo, VolumeInfo volumeInfo,
+                                                                   AsyncCompletionCallback<CopyCommandResult> callback) {
         String errMsg = null;
+        CopyCmdAnswer copyCmdAnswer = null;
 
         try {
+            verifyFormat(snapshotInfo);
+
             HostVO hostVO = getHost(snapshotInfo);
 
             boolean usingBackendSnapshot = usingBackendSnapshotFor(snapshotInfo);
-            boolean computeClusterSupportsResign = clusterDao.getSupportsResigning(hostVO.getClusterId());
+            boolean computeClusterSupportsVolumeClone = true;
 
-            if (usingBackendSnapshot && !computeClusterSupportsResign) {
-                String noSupportForResignErrMsg = "Unable to locate an applicable host with which to perform a resignature operation : Cluster ID = " + hostVO.getClusterId();
+            if (HypervisorType.XenServer.equals(snapshotInfo.getHypervisorType())) {
+                computeClusterSupportsVolumeClone = clusterDao.getSupportsResigning(hostVO.getClusterId());
 
-                LOGGER.warn(noSupportForResignErrMsg);
+                if (usingBackendSnapshot && !computeClusterSupportsVolumeClone) {
+                    String noSupportForResignErrMsg = "Unable to locate an applicable host with which to perform a resignature operation : Cluster ID = " +
+                            hostVO.getClusterId();
 
-                throw new CloudRuntimeException(noSupportForResignErrMsg);
+                    LOGGER.warn(noSupportForResignErrMsg);
+
+                    throw new CloudRuntimeException(noSupportForResignErrMsg);
+                }
             }
 
             boolean canStorageSystemCreateVolumeFromVolume = canStorageSystemCreateVolumeFromVolume(snapshotInfo);
-            boolean useCloning = usingBackendSnapshot || (canStorageSystemCreateVolumeFromVolume && computeClusterSupportsResign);
+            boolean useCloning = usingBackendSnapshot || (canStorageSystemCreateVolumeFromVolume && computeClusterSupportsVolumeClone);
 
             VolumeDetailVO volumeDetail = null;
 
@@ -670,7 +1186,6 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             _volumeService.updateHypervisorSnapshotReserveForVolume(diskOffering, volumeInfo.getId(), snapshot.getHypervisorType());
 
             AsyncCallFuture<VolumeApiResult> future = _volumeService.createVolumeAsync(volumeInfo, volumeInfo.getDataStore());
-
             VolumeApiResult result = future.get();
 
             if (volumeDetail != null) {
@@ -684,40 +1199,154 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             }
 
             volumeInfo = _volumeDataFactory.getVolume(volumeInfo.getId(), volumeInfo.getDataStore());
-
             volumeInfo.processEvent(Event.MigrationRequested);
-
             volumeInfo = _volumeDataFactory.getVolume(volumeInfo.getId(), volumeInfo.getDataStore());
 
-            if (useCloning) {
-                copyCmdAnswer = performResignature(volumeInfo, hostVO);
+            if (HypervisorType.XenServer.equals(snapshotInfo.getHypervisorType()) || HypervisorType.VMware.equals(snapshotInfo.getHypervisorType())) {
+                if (useCloning) {
+                    Map<String, String> extraDetails = null;
+
+                    if (HypervisorType.VMware.equals(snapshotInfo.getHypervisorType())) {
+                        extraDetails = new HashMap<>();
+
+                        String extraDetailsVmdk = getSnapshotProperty(snapshotInfo.getId(), DiskTO.VMDK);
+
+                        extraDetails.put(DiskTO.VMDK, extraDetailsVmdk);
+                    }
+
+                    copyCmdAnswer = performResignature(volumeInfo, hostVO, extraDetails);
+
+                    // If using VMware, have the host rescan its software HBA if dynamic discovery is in use.
+                    if (HypervisorType.VMware.equals(snapshotInfo.getHypervisorType())) {
+                        disconnectHostFromVolume(hostVO, volumeInfo.getPoolId(), volumeInfo.get_iScsiName());
+                    }
+                } else {
+                    // asking for a XenServer host here so we don't always prefer to use XenServer hosts that support resigning
+                    // even when we don't need those hosts to do this kind of copy work
+                    hostVO = getHost(snapshotInfo.getDataCenterId(), snapshotInfo.getHypervisorType(), false);
+
+                    copyCmdAnswer = performCopyOfVdi(volumeInfo, snapshotInfo, hostVO);
+                }
+
+                if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
+                    if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
+                        throw new CloudRuntimeException(copyCmdAnswer.getDetails());
+                    } else {
+                        throw new CloudRuntimeException("Unable to create volume from snapshot");
+                    }
+                }
+            }
+            else if (HypervisorType.KVM.equals(snapshotInfo.getHypervisorType())) {
+                VolumeObjectTO newVolume = new VolumeObjectTO();
+
+                newVolume.setSize(volumeInfo.getSize());
+                newVolume.setPath(volumeInfo.get_iScsiName());
+                newVolume.setFormat(volumeInfo.getFormat());
+
+                copyCmdAnswer = new CopyCmdAnswer(newVolume);
             }
             else {
-                // asking for a XenServer host here so we don't always prefer to use XenServer hosts that support resigning
-                // even when we don't need those hosts to do this kind of copy work
-                hostVO = getHost(snapshotInfo.getDataCenterId(), false);
-
-                copyCmdAnswer = performCopyOfVdi(volumeInfo, snapshotInfo, hostVO);
+                throw new CloudRuntimeException("Unsupported hypervisor type");
             }
+        }
+        catch (Exception ex) {
+            errMsg = "Copy operation failed in 'StorageSystemDataMotionStrategy.handleCreateVolumeFromSnapshotBothOnStorageSystem': " +
+                    ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            if (copyCmdAnswer == null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
+
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+            result.setResult(errMsg);
+
+            callback.complete(result);
+        }
+    }
+
+    private void handleCreateVolumeFromVolumeOnSecondaryStorage(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo,
+                                                                long dataCenterId, HypervisorType hypervisorType,
+                                                                AsyncCompletionCallback<CopyCommandResult> callback) {
+        String errMsg = null;
+        CopyCmdAnswer copyCmdAnswer = null;
+
+        try {
+            // create a volume on the storage
+            destVolumeInfo.getDataStore().getDriver().createAsync(destVolumeInfo.getDataStore(), destVolumeInfo, null);
+
+            destVolumeInfo = _volumeDataFactory.getVolume(destVolumeInfo.getId(), destVolumeInfo.getDataStore());
+
+            HostVO hostVO = getHost(dataCenterId, hypervisorType, false);
+
+            // copy the volume from secondary via the hypervisor
+            copyCmdAnswer = copyImageToVolume(srcVolumeInfo, destVolumeInfo, hostVO);
 
             if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
                 if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
-                    errMsg = copyCmdAnswer.getDetails();
+                    throw new CloudRuntimeException(copyCmdAnswer.getDetails());
                 }
                 else {
-                    errMsg = "Unable to create volume from snapshot";
+                    throw new CloudRuntimeException("Unable to create volume from volume");
                 }
             }
         }
         catch (Exception ex) {
-            errMsg = ex.getMessage() != null ? ex.getMessage() : "Copy operation failed in 'StorageSystemDataMotionStrategy.handleCreateVolumeFromSnapshotBothOnStorageSystem'";
+            errMsg = "Copy operation failed in 'StorageSystemDataMotionStrategy.handleCreateVolumeFromVolumeOnSecondaryStorage': " +
+                    ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            if (copyCmdAnswer == null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
+
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+            result.setResult(errMsg);
+
+            callback.complete(result);
+        }
+    }
+
+    private CopyCmdAnswer copyImageToVolume(DataObject srcDataObject, VolumeInfo destVolumeInfo, HostVO hostVO) {
+        String value = _configDao.getValue(Config.PrimaryStorageDownloadWait.toString());
+        int primaryStorageDownloadWait = NumbersUtil.parseInt(value, Integer.parseInt(Config.PrimaryStorageDownloadWait.getDefaultValue()));
+
+        CopyCommand copyCommand = new CopyCommand(srcDataObject.getTO(), destVolumeInfo.getTO(), primaryStorageDownloadWait,
+                VirtualMachineManager.ExecuteInSequence.value());
+
+        CopyCmdAnswer copyCmdAnswer;
+
+        try {
+            _volumeService.grantAccess(destVolumeInfo, hostVO, destVolumeInfo.getDataStore());
+
+            Map<String, String> destDetails = getVolumeDetails(destVolumeInfo);
+
+            copyCommand.setOptions2(destDetails);
+
+            copyCmdAnswer = (CopyCmdAnswer)_agentMgr.send(hostVO.getId(), copyCommand);
+        }
+        catch (CloudRuntimeException | AgentUnavailableException | OperationTimedoutException ex) {
+            String msg = "Failed to copy image : ";
+
+            LOGGER.warn(msg, ex);
+
+            throw new CloudRuntimeException(msg + ex.getMessage());
+        }
+        finally {
+            _volumeService.revokeAccess(destVolumeInfo, hostVO, destVolumeInfo.getDataStore());
         }
 
-        CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+        VolumeObjectTO volumeObjectTO = (VolumeObjectTO)copyCmdAnswer.getNewData();
 
-        result.setResult(errMsg);
+        volumeObjectTO.setFormat(ImageFormat.QCOW2);
 
-        callback.complete(result);
+        return copyCmdAnswer;
     }
 
     /**
@@ -730,34 +1359,24 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
      * If the storage system is using writable snapshots, then nothing need be done by that storage system here because we can just
      * resign the SR and the VDI that should be inside of the snapshot before copying the VHD file to secondary storage.
      */
-    private void createVolumeFromSnapshot(HostVO hostVO, SnapshotInfo snapshotInfo, boolean keepGrantedAccess) {
-        SnapshotDetailsVO snapshotDetails = handleSnapshotDetails(snapshotInfo.getId(), "tempVolume", "create");
+    private void createVolumeFromSnapshot(SnapshotInfo snapshotInfo) {
+        SnapshotDetailsVO snapshotDetails = handleSnapshotDetails(snapshotInfo.getId(), "create");
 
         try {
             snapshotInfo.getDataStore().getDriver().createAsync(snapshotInfo.getDataStore(), snapshotInfo, null);
         }
         finally {
             _snapshotDetailsDao.remove(snapshotDetails.getId());
-        }
-
-        CopyCmdAnswer copyCmdAnswer = performResignature(snapshotInfo, hostVO, keepGrantedAccess);
-
-        if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
-            if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
-                throw new CloudRuntimeException(copyCmdAnswer.getDetails());
-            } else {
-                throw new CloudRuntimeException("Unable to create volume from snapshot");
-            }
         }
     }
 
     /**
-     * If the underlying storage system needed to create a volume from a snapshot for createVolumeFromSnapshot(HostVO, SnapshotInfo), then
+     * If the underlying storage system needed to create a volume from a snapshot for createVolumeFromSnapshot(SnapshotInfo), then
      * this is its opportunity to delete that temporary volume and restore properties in snapshot_details to the way they were before the
-     * invocation of createVolumeFromSnapshot(HostVO, SnapshotInfo).
+     * invocation of createVolumeFromSnapshot(SnapshotInfo).
      */
     private void deleteVolumeFromSnapshot(SnapshotInfo snapshotInfo) {
-        SnapshotDetailsVO snapshotDetails = handleSnapshotDetails(snapshotInfo.getId(), "tempVolume", "delete");
+        SnapshotDetailsVO snapshotDetails = handleSnapshotDetails(snapshotInfo.getId(), "delete");
 
         try {
             snapshotInfo.getDataStore().getDriver().createAsync(snapshotInfo.getDataStore(), snapshotInfo, null);
@@ -767,12 +1386,332 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         }
     }
 
-    private SnapshotDetailsVO handleSnapshotDetails(long csSnapshotId, String name, String value) {
+    private SnapshotDetailsVO handleSnapshotDetails(long csSnapshotId, String value) {
+        String name = "tempVolume";
+
         _snapshotDetailsDao.removeDetail(csSnapshotId, name);
 
         SnapshotDetailsVO snapshotDetails = new SnapshotDetailsVO(csSnapshotId, name, value, false);
 
         return _snapshotDetailsDao.persist(snapshotDetails);
+    }
+
+    /**
+     * For each disk to migrate:
+     *   Create a volume on the target storage system.
+     *   Make the newly created volume accessible to the target KVM host.
+     *   Send a command to the target KVM host to connect to the newly created volume.
+     * Send a command to the source KVM host to migrate the VM and its storage.
+     */
+    @Override
+    public void copyAsync(Map<VolumeInfo, DataStore> volumeDataStoreMap, VirtualMachineTO vmTO, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
+        String errMsg = null;
+
+        try {
+            if (srcHost.getHypervisorType() != HypervisorType.KVM) {
+                throw new CloudRuntimeException("Invalid hypervisor type (only KVM supported for this operation at the time being)");
+            }
+
+            verifyLiveMigrationMapForKVM(volumeDataStoreMap);
+
+            Map<String, MigrateCommand.MigrateDiskInfo> migrateStorage = new HashMap<>();
+            Map<VolumeInfo, VolumeInfo> srcVolumeInfoToDestVolumeInfo = new HashMap<>();
+
+            for (Map.Entry<VolumeInfo, DataStore> entry : volumeDataStoreMap.entrySet()) {
+                VolumeInfo srcVolumeInfo = entry.getKey();
+                DataStore destDataStore = entry.getValue();
+
+                VolumeVO srcVolume = _volumeDao.findById(srcVolumeInfo.getId());
+                StoragePoolVO destStoragePool = _storagePoolDao.findById(destDataStore.getId());
+
+                VolumeVO destVolume = duplicateVolumeOnAnotherStorage(srcVolume, destStoragePool);
+                VolumeInfo destVolumeInfo = _volumeDataFactory.getVolume(destVolume.getId(), destDataStore);
+
+                // move the volume from Allocated to Creating
+                destVolumeInfo.processEvent(Event.MigrationCopyRequested);
+                // move the volume from Creating to Ready
+                destVolumeInfo.processEvent(Event.MigrationCopySucceeded);
+                // move the volume from Ready to Migrating
+                destVolumeInfo.processEvent(Event.MigrationRequested);
+
+                // create a volume on the destination storage
+                destDataStore.getDriver().createAsync(destDataStore, destVolumeInfo, null);
+
+                destVolume = _volumeDao.findById(destVolume.getId());
+
+                destVolume.setPath(destVolume.get_iScsiName());
+
+                _volumeDao.update(destVolume.getId(), destVolume);
+
+                destVolumeInfo = _volumeDataFactory.getVolume(destVolume.getId(), destDataStore);
+
+                _volumeService.grantAccess(destVolumeInfo, destHost, destDataStore);
+
+                String connectedPath = connectHostToVolume(destHost, destVolumeInfo.getPoolId(), destVolumeInfo.get_iScsiName());
+
+                MigrateCommand.MigrateDiskInfo migrateDiskInfo = new MigrateCommand.MigrateDiskInfo(srcVolumeInfo.getPath(),
+                        MigrateCommand.MigrateDiskInfo.DiskType.BLOCK,
+                        MigrateCommand.MigrateDiskInfo.DriverType.RAW,
+                        MigrateCommand.MigrateDiskInfo.Source.DEV,
+                        connectedPath);
+
+                migrateStorage.put(srcVolumeInfo.getPath(), migrateDiskInfo);
+
+                srcVolumeInfoToDestVolumeInfo.put(srcVolumeInfo, destVolumeInfo);
+            }
+
+            PrepareForMigrationCommand pfmc = new PrepareForMigrationCommand(vmTO);
+
+            try {
+                Answer pfma = _agentMgr.send(destHost.getId(), pfmc);
+
+                if (pfma == null || !pfma.getResult()) {
+                    String details = pfma != null ? pfma.getDetails() : "null answer returned";
+                    String msg = "Unable to prepare for migration due to the following: " + details;
+
+                    throw new AgentUnavailableException(msg, destHost.getId());
+                }
+            }
+            catch (final OperationTimedoutException e) {
+                throw new AgentUnavailableException("Operation timed out", destHost.getId());
+            }
+
+            VMInstanceVO vm = _vmDao.findById(vmTO.getId());
+            boolean isWindows = _guestOsCategoryDao.findById(_guestOsDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
+
+            MigrateCommand migrateCommand = new MigrateCommand(vmTO.getName(), destHost.getPrivateIpAddress(), isWindows, vmTO, true);
+
+            migrateCommand.setWait(StorageManager.KvmStorageOnlineMigrationWait.value());
+
+            migrateCommand.setMigrateStorage(migrateStorage);
+
+            String autoConvergence = _configDao.getValue(Config.KvmAutoConvergence.toString());
+            boolean kvmAutoConvergence = Boolean.parseBoolean(autoConvergence);
+
+            migrateCommand.setAutoConvergence(kvmAutoConvergence);
+
+            MigrateAnswer migrateAnswer = (MigrateAnswer)_agentMgr.send(srcHost.getId(), migrateCommand);
+
+            boolean success = migrateAnswer != null && migrateAnswer.getResult();
+
+            handlePostMigration(success, srcVolumeInfoToDestVolumeInfo, vmTO, destHost);
+
+            if (migrateAnswer == null) {
+                throw new CloudRuntimeException("Unable to get an answer to the migrate command");
+            }
+
+            if (!migrateAnswer.getResult()) {
+                errMsg = migrateAnswer.getDetails();
+
+                throw new CloudRuntimeException(errMsg);
+            }
+        }
+        catch (Exception ex) {
+            errMsg = "Copy operation failed in 'StorageSystemDataMotionStrategy.copyAsync': " + ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            CopyCmdAnswer copyCmdAnswer = new CopyCmdAnswer(errMsg);
+
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+            result.setResult(errMsg);
+
+            callback.complete(result);
+        }
+    }
+
+    private void handlePostMigration(boolean success, Map<VolumeInfo, VolumeInfo> srcVolumeInfoToDestVolumeInfo, VirtualMachineTO vmTO, Host destHost) {
+        if (!success) {
+            try {
+                PrepareForMigrationCommand pfmc = new PrepareForMigrationCommand(vmTO);
+
+                pfmc.setRollback(true);
+
+                Answer pfma = _agentMgr.send(destHost.getId(), pfmc);
+
+                if (pfma == null || !pfma.getResult()) {
+                    String details = pfma != null ? pfma.getDetails() : "null answer returned";
+                    String msg = "Unable to rollback prepare for migration due to the following: " + details;
+
+                    throw new AgentUnavailableException(msg, destHost.getId());
+                }
+            }
+            catch (Exception e) {
+                LOGGER.debug("Failed to disconnect one or more (original) dest volumes", e);
+            }
+        }
+
+        for (Map.Entry<VolumeInfo, VolumeInfo> entry : srcVolumeInfoToDestVolumeInfo.entrySet()) {
+            VolumeInfo srcVolumeInfo = entry.getKey();
+            VolumeInfo destVolumeInfo = entry.getValue();
+
+            if (success) {
+                srcVolumeInfo.processEvent(Event.OperationSuccessed);
+                destVolumeInfo.processEvent(Event.OperationSuccessed);
+
+                _volumeDao.updateUuid(srcVolumeInfo.getId(), destVolumeInfo.getId());
+
+                VolumeVO volumeVO = _volumeDao.findById(destVolumeInfo.getId());
+
+                volumeVO.setFormat(ImageFormat.QCOW2);
+
+                _volumeDao.update(volumeVO.getId(), volumeVO);
+
+                try {
+                    _volumeService.destroyVolume(srcVolumeInfo.getId());
+
+                    srcVolumeInfo = _volumeDataFactory.getVolume(srcVolumeInfo.getId());
+
+                    AsyncCallFuture<VolumeApiResult> destroyFuture = _volumeService.expungeVolumeAsync(srcVolumeInfo);
+
+                    if (destroyFuture.get().isFailed()) {
+                        LOGGER.debug("Failed to clean up source volume on storage");
+                    }
+                } catch (Exception e) {
+                    LOGGER.debug("Failed to clean up source volume on storage", e);
+                }
+
+                // Update the volume ID for snapshots on secondary storage
+                if (!_snapshotDao.listByVolumeId(srcVolumeInfo.getId()).isEmpty()) {
+                    _snapshotDao.updateVolumeIds(srcVolumeInfo.getId(), destVolumeInfo.getId());
+                    _snapshotDataStoreDao.updateVolumeIds(srcVolumeInfo.getId(), destVolumeInfo.getId());
+                }
+            }
+            else {
+                try {
+                    disconnectHostFromVolume(destHost, destVolumeInfo.getPoolId(), destVolumeInfo.get_iScsiName());
+                }
+                catch (Exception e) {
+                    LOGGER.debug("Failed to disconnect (new) dest volume", e);
+                }
+
+                try {
+                    _volumeService.revokeAccess(destVolumeInfo, destHost, destVolumeInfo.getDataStore());
+                }
+                catch (Exception e) {
+                    LOGGER.debug("Failed to revoke access from dest volume", e);
+                }
+
+                destVolumeInfo.processEvent(Event.OperationFailed);
+                srcVolumeInfo.processEvent(Event.OperationFailed);
+
+                try {
+                    _volumeService.destroyVolume(destVolumeInfo.getId());
+
+                    destVolumeInfo = _volumeDataFactory.getVolume(destVolumeInfo.getId());
+
+                    AsyncCallFuture<VolumeApiResult> destroyFuture = _volumeService.expungeVolumeAsync(destVolumeInfo);
+
+                    if (destroyFuture.get().isFailed()) {
+                        LOGGER.debug("Failed to clean up dest volume on storage");
+                    }
+                } catch (Exception e) {
+                    LOGGER.debug("Failed to clean up dest volume on storage", e);
+                }
+            }
+        }
+    }
+
+    private VolumeVO duplicateVolumeOnAnotherStorage(Volume volume, StoragePoolVO storagePoolVO) {
+        Long lastPoolId = volume.getPoolId();
+
+        VolumeVO newVol = new VolumeVO(volume);
+
+        newVol.setInstanceId(null);
+        newVol.setChainInfo(null);
+        newVol.setPath(null);
+        newVol.setFolder(null);
+        newVol.setPodId(storagePoolVO.getPodId());
+        newVol.setPoolId(storagePoolVO.getId());
+        newVol.setLastPoolId(lastPoolId);
+
+        return _volumeDao.persist(newVol);
+    }
+
+    private String connectHostToVolume(Host host, long storagePoolId, String iqn) {
+        ModifyTargetsCommand modifyTargetsCommand = getModifyTargetsCommand(storagePoolId, iqn, true);
+
+        return sendModifyTargetsCommand(modifyTargetsCommand, host.getId()).get(0);
+    }
+
+    private void disconnectHostFromVolume(Host host, long storagePoolId, String iqn) {
+        ModifyTargetsCommand modifyTargetsCommand = getModifyTargetsCommand(storagePoolId, iqn, false);
+
+        sendModifyTargetsCommand(modifyTargetsCommand, host.getId());
+    }
+
+    private ModifyTargetsCommand getModifyTargetsCommand(long storagePoolId, String iqn, boolean add) {
+        StoragePoolVO storagePool = _storagePoolDao.findById(storagePoolId);
+
+        Map<String, String> details = new HashMap<>();
+
+        details.put(ModifyTargetsCommand.IQN, iqn);
+        details.put(ModifyTargetsCommand.STORAGE_TYPE, storagePool.getPoolType().name());
+        details.put(ModifyTargetsCommand.STORAGE_UUID, storagePool.getUuid());
+        details.put(ModifyTargetsCommand.STORAGE_HOST, storagePool.getHostAddress());
+        details.put(ModifyTargetsCommand.STORAGE_PORT, String.valueOf(storagePool.getPort()));
+
+        ModifyTargetsCommand modifyTargetsCommand = new ModifyTargetsCommand();
+
+        List<Map<String, String>> targets = new ArrayList<>();
+
+        targets.add(details);
+
+        modifyTargetsCommand.setTargets(targets);
+        modifyTargetsCommand.setApplyToAllHostsInCluster(true);
+        modifyTargetsCommand.setAdd(add);
+        modifyTargetsCommand.setTargetTypeToRemove(ModifyTargetsCommand.TargetTypeToRemove.DYNAMIC);
+
+        return modifyTargetsCommand;
+    }
+
+    private List<String> sendModifyTargetsCommand(ModifyTargetsCommand cmd, long hostId) {
+        ModifyTargetsAnswer modifyTargetsAnswer = (ModifyTargetsAnswer)_agentMgr.easySend(hostId, cmd);
+
+        if (modifyTargetsAnswer == null) {
+            throw new CloudRuntimeException("Unable to get an answer to the modify targets command");
+        }
+
+        if (!modifyTargetsAnswer.getResult()) {
+            String msg = "Unable to modify targets on the following host: " + hostId;
+
+            throw new CloudRuntimeException(msg);
+        }
+
+        return modifyTargetsAnswer.getConnectedPaths();
+    }
+
+    /*
+    * At a high level: The source storage cannot be managed and the destination storage must be managed.
+    */
+    private void verifyLiveMigrationMapForKVM(Map<VolumeInfo, DataStore> volumeDataStoreMap) {
+        for (Map.Entry<VolumeInfo, DataStore> entry : volumeDataStoreMap.entrySet()) {
+            VolumeInfo volumeInfo = entry.getKey();
+
+            Long storagePoolId = volumeInfo.getPoolId();
+            StoragePoolVO srcStoragePoolVO = _storagePoolDao.findById(storagePoolId);
+
+            if (srcStoragePoolVO == null) {
+                throw new CloudRuntimeException("Volume with ID " + volumeInfo.getId() + " is not associated with a storage pool.");
+            }
+
+            if (srcStoragePoolVO.isManaged()) {
+                throw new CloudRuntimeException("Migrating a volume online with KVM from managed storage is not currently supported.");
+            }
+
+            DataStore dataStore = entry.getValue();
+            StoragePoolVO destStoragePoolVO = _storagePoolDao.findById(dataStore.getId());
+
+            if (destStoragePoolVO == null) {
+                throw new CloudRuntimeException("Destination storage pool with ID " + dataStore.getId() + " was not located.");
+            }
+
+            if (!destStoragePoolVO.isManaged()) {
+                throw new CloudRuntimeException("Migrating a volume online with KVM can currently only be done when moving to managed storage.");
+            }
+        }
     }
 
     private boolean canStorageSystemCreateVolumeFromVolume(SnapshotInfo snapshotInfo) {
@@ -791,7 +1730,17 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         return supportsCloningVolumeFromVolume;
     }
 
-    private String getProperty(long snapshotId, String property) {
+    private String getVolumeProperty(long volumeId, String property) {
+        VolumeDetailVO volumeDetails = volumeDetailsDao.findDetail(volumeId, property);
+
+        if (volumeDetails != null) {
+            return volumeDetails.getValue();
+        }
+
+        return null;
+    }
+
+    private String getSnapshotProperty(long snapshotId, String property) {
         SnapshotDetailsVO snapshotDetails = _snapshotDetailsDao.findDetail(snapshotId, property);
 
         if (snapshotDetails != null) {
@@ -801,17 +1750,123 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         return null;
     }
 
+    private void handleCreateTemplateFromVolume(VolumeInfo volumeInfo, TemplateInfo templateInfo, AsyncCompletionCallback<CopyCommandResult> callback) {
+        boolean srcVolumeDetached = volumeInfo.getAttachedVM() == null;
+
+        String errMsg = null;
+        CopyCmdAnswer copyCmdAnswer = null;
+
+        try {
+            if (!ImageFormat.QCOW2.equals(volumeInfo.getFormat())) {
+                throw new CloudRuntimeException("When using managed storage, you can only create a template from a volume on KVM currently.");
+            }
+
+            volumeInfo.processEvent(Event.MigrationRequested);
+
+            HostVO hostVO = getHost(volumeInfo.getDataCenterId(), HypervisorType.KVM, false);
+            DataStore srcDataStore = volumeInfo.getDataStore();
+
+            String value = _configDao.getValue(Config.PrimaryStorageDownloadWait.toString());
+            int primaryStorageDownloadWait = NumberUtils.toInt(value, Integer.parseInt(Config.PrimaryStorageDownloadWait.getDefaultValue()));
+            CopyCommand copyCommand = new CopyCommand(volumeInfo.getTO(), templateInfo.getTO(), primaryStorageDownloadWait, VirtualMachineManager.ExecuteInSequence.value());
+
+            try {
+                if (srcVolumeDetached) {
+                    _volumeService.grantAccess(volumeInfo, hostVO, srcDataStore);
+                }
+
+                Map<String, String> srcDetails = getVolumeDetails(volumeInfo);
+
+                copyCommand.setOptions(srcDetails);
+
+                copyCmdAnswer = (CopyCmdAnswer)_agentMgr.send(hostVO.getId(), copyCommand);
+
+                if (!copyCmdAnswer.getResult()) {
+                    // We were not able to copy. Handle it.
+                    errMsg = copyCmdAnswer.getDetails();
+                    throw new CloudRuntimeException(errMsg);
+                }
+
+                VMTemplateVO vmTemplateVO = _vmTemplateDao.findById(templateInfo.getId());
+
+                vmTemplateVO.setHypervisorType(HypervisorType.KVM);
+
+                _vmTemplateDao.update(vmTemplateVO.getId(), vmTemplateVO);
+            }
+            catch (CloudRuntimeException | AgentUnavailableException | OperationTimedoutException ex) {
+                String msg = "Failed to create template from volume (Volume ID = " + volumeInfo.getId() + ") : ";
+
+                LOGGER.warn(msg, ex);
+
+                throw new CloudRuntimeException(msg + ex.getMessage());
+            }
+            finally {
+                try {
+                    if (srcVolumeDetached) {
+                        _volumeService.revokeAccess(volumeInfo, hostVO, srcDataStore);
+                    }
+                }
+                catch (Exception ex) {
+                    LOGGER.warn("Error revoking access to volume (Volume ID = " + volumeInfo.getId() + "): " + ex.getMessage(), ex);
+                }
+                if (copyCmdAnswer == null || !copyCmdAnswer.getResult()) {
+                    if (copyCmdAnswer != null && !StringUtils.isEmpty(copyCmdAnswer.getDetails())) {
+                        errMsg = copyCmdAnswer.getDetails();
+                    }
+                    else {
+                        errMsg = "Unable to create template from volume";
+                    }
+                }
+
+                try {
+                    if (StringUtils.isEmpty(errMsg)) {
+                        volumeInfo.processEvent(Event.OperationSuccessed);
+                    }
+                    else {
+                        volumeInfo.processEvent(Event.OperationFailed);
+                    }
+                }
+                catch (Exception ex) {
+                    LOGGER.warn("Error processing snapshot event: " + ex.getMessage(), ex);
+                }
+            }
+        }
+        catch (Exception ex) {
+            errMsg = ex.getMessage();
+
+            throw new CloudRuntimeException(errMsg);
+        }
+        finally {
+            if (copyCmdAnswer == null) {
+                copyCmdAnswer = new CopyCmdAnswer(errMsg);
+            }
+
+            CopyCommandResult result = new CopyCommandResult(null, copyCmdAnswer);
+
+            result.setResult(errMsg);
+
+            callback.complete(result);
+        }
+    }
+
     private Map<String, String> getVolumeDetails(VolumeInfo volumeInfo) {
-        Map<String, String> volumeDetails = new HashMap<String, String>();
+        long storagePoolId = volumeInfo.getPoolId();
+        StoragePoolVO storagePoolVO = _storagePoolDao.findById(storagePoolId);
+
+        if (!storagePoolVO.isManaged()) {
+            return null;
+        }
+
+        Map<String, String> volumeDetails = new HashMap<>();
 
         VolumeVO volumeVO = _volumeDao.findById(volumeInfo.getId());
-
-        long storagePoolId = volumeVO.getPoolId();
-        StoragePoolVO storagePoolVO = _storagePoolDao.findById(storagePoolId);
 
         volumeDetails.put(DiskTO.STORAGE_HOST, storagePoolVO.getHostAddress());
         volumeDetails.put(DiskTO.STORAGE_PORT, String.valueOf(storagePoolVO.getPort()));
         volumeDetails.put(DiskTO.IQN, volumeVO.get_iScsiName());
+
+        volumeDetails.put(DiskTO.VOLUME_SIZE, String.valueOf(volumeVO.getSize()));
+        volumeDetails.put(DiskTO.SCSI_NAA_DEVICE_ID, getVolumeProperty(volumeInfo.getId(), DiskTO.SCSI_NAA_DEVICE_ID));
 
         ChapInfo chapInfo = _volumeService.getChapInfo(volumeInfo, volumeInfo.getDataStore());
 
@@ -836,34 +1891,59 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
         long snapshotId = snapshotInfo.getId();
 
-        snapshotDetails.put(DiskTO.IQN, getProperty(snapshotId, DiskTO.IQN));
+        snapshotDetails.put(DiskTO.IQN, getSnapshotProperty(snapshotId, DiskTO.IQN));
+        snapshotDetails.put(DiskTO.VOLUME_SIZE, String.valueOf(snapshotInfo.getSize()));
+        snapshotDetails.put(DiskTO.SCSI_NAA_DEVICE_ID, getSnapshotProperty(snapshotId, DiskTO.SCSI_NAA_DEVICE_ID));
 
-        snapshotDetails.put(DiskTO.CHAP_INITIATOR_USERNAME, getProperty(snapshotId, DiskTO.CHAP_INITIATOR_USERNAME));
-        snapshotDetails.put(DiskTO.CHAP_INITIATOR_SECRET, getProperty(snapshotId, DiskTO.CHAP_INITIATOR_SECRET));
-        snapshotDetails.put(DiskTO.CHAP_TARGET_USERNAME, getProperty(snapshotId, DiskTO.CHAP_TARGET_USERNAME));
-        snapshotDetails.put(DiskTO.CHAP_TARGET_SECRET, getProperty(snapshotId, DiskTO.CHAP_TARGET_SECRET));
+        snapshotDetails.put(DiskTO.CHAP_INITIATOR_USERNAME, getSnapshotProperty(snapshotId, DiskTO.CHAP_INITIATOR_USERNAME));
+        snapshotDetails.put(DiskTO.CHAP_INITIATOR_SECRET, getSnapshotProperty(snapshotId, DiskTO.CHAP_INITIATOR_SECRET));
+        snapshotDetails.put(DiskTO.CHAP_TARGET_USERNAME, getSnapshotProperty(snapshotId, DiskTO.CHAP_TARGET_USERNAME));
+        snapshotDetails.put(DiskTO.CHAP_TARGET_SECRET, getSnapshotProperty(snapshotId, DiskTO.CHAP_TARGET_SECRET));
 
         return snapshotDetails;
     }
 
     private HostVO getHost(SnapshotInfo snapshotInfo) {
-        HostVO hostVO = getHost(snapshotInfo.getDataCenterId(), true);
+        HypervisorType hypervisorType = snapshotInfo.getHypervisorType();
 
-        if (hostVO == null) {
-            hostVO = getHost(snapshotInfo.getDataCenterId(), false);
+        if (HypervisorType.XenServer.equals(hypervisorType)) {
+            HostVO hostVO = getHost(snapshotInfo.getDataCenterId(), hypervisorType, true);
 
             if (hostVO == null) {
-                throw new CloudRuntimeException("Unable to locate an applicable host in data center with ID = " + snapshotInfo.getDataCenterId());
+                hostVO = getHost(snapshotInfo.getDataCenterId(), hypervisorType, false);
+
+                if (hostVO == null) {
+                    throw new CloudRuntimeException("Unable to locate an applicable host in data center with ID = " + snapshotInfo.getDataCenterId());
+                }
             }
+
+            return hostVO;
         }
 
-        return hostVO;
+        if (HypervisorType.VMware.equals(hypervisorType) || HypervisorType.KVM.equals(hypervisorType)) {
+            return getHost(snapshotInfo.getDataCenterId(), hypervisorType, false);
+        }
+
+        throw new CloudRuntimeException("Unsupported hypervisor type");
     }
 
-    private HostVO getHost(Long zoneId, boolean computeClusterMustSupportResign) {
-        Preconditions.checkArgument(zoneId != null, "Zone ID cannot be null.");
+    private HostVO getHostInCluster(long clusterId) {
+        List<HostVO> hosts = _hostDao.findByClusterId(clusterId);
 
-        List<HostVO> hosts = _hostDao.listByDataCenterIdAndHypervisorType(zoneId, HypervisorType.XenServer);
+        if (hosts != null && hosts.size() > 0) {
+            Collections.shuffle(hosts, RANDOM);
+
+            return hosts.get(0);
+        }
+
+        throw new CloudRuntimeException("Unable to locate a host");
+    }
+
+    private HostVO getHost(Long zoneId, HypervisorType hypervisorType, boolean computeClusterMustSupportResign) {
+        Preconditions.checkArgument(zoneId != null, "Zone ID cannot be null.");
+        Preconditions.checkArgument(hypervisorType != null, "Hypervisor type cannot be null.");
+
+        List<HostVO> hosts = _hostDao.listByDataCenterIdAndHypervisorType(zoneId, hypervisorType);
 
         if (hosts == null) {
             return null;
@@ -896,15 +1976,6 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         return null;
     }
 
-    @Override
-    public void copyAsync(Map<VolumeInfo, DataStore> volumeMap, VirtualMachineTO vmTo, Host srcHost, Host destHost, AsyncCompletionCallback<CopyCommandResult> callback) {
-        CopyCommandResult result = new CopyCommandResult(null, null);
-
-        result.setResult("Unsupported operation requested for copying data.");
-
-        callback.complete(result);
-    }
-
     private Map<String, String> getDetails(DataObject dataObj) {
         if (dataObj instanceof VolumeInfo) {
             return getVolumeDetails((VolumeInfo)dataObj);
@@ -916,19 +1987,45 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         throw new CloudRuntimeException("'dataObj' must be of type 'VolumeInfo' or 'SnapshotInfo'.");
     }
 
-    private CopyCmdAnswer performResignature(DataObject dataObj, HostVO hostVO) {
-        return performResignature(dataObj, hostVO, false);
+    private boolean isForVMware(DataObject dataObj) {
+        if (dataObj instanceof VolumeInfo) {
+            return ImageFormat.OVA.equals(((VolumeInfo)dataObj).getFormat());
+        }
+
+        if (dataObj instanceof SnapshotInfo) {
+            return ImageFormat.OVA.equals(((SnapshotInfo)dataObj).getBaseVolume().getFormat());
+        }
+
+        return dataObj instanceof TemplateInfo && HypervisorType.VMware.equals(((TemplateInfo)dataObj).getHypervisorType());
     }
 
-    private CopyCmdAnswer performResignature(DataObject dataObj, HostVO hostVO, boolean keepGrantedAccess) {
+    private CopyCmdAnswer performResignature(DataObject dataObj, HostVO hostVO, Map<String, String> extraDetails) {
+        return performResignature(dataObj, hostVO, extraDetails, false);
+    }
+
+    private CopyCmdAnswer performResignature(DataObject dataObj, HostVO hostVO, Map<String, String> extraDetails, boolean keepGrantedAccess) {
         long storagePoolId = dataObj.getDataStore().getId();
         DataStore dataStore = dataStoreMgr.getDataStore(storagePoolId, DataStoreRole.Primary);
 
         Map<String, String> details = getDetails(dataObj);
 
+        if (extraDetails != null) {
+            details.putAll(extraDetails);
+        }
+
         ResignatureCommand command = new ResignatureCommand(details);
 
-        ResignatureAnswer answer = null;
+        ResignatureAnswer answer;
+
+        GlobalLock lock = GlobalLock.getInternLock(dataStore.getUuid());
+
+        if (!lock.lock(LOCK_TIME_IN_SECONDS)) {
+            String errMsg = "Couldn't lock the DB (in performResignature) on the following string: " + dataStore.getUuid();
+
+            LOGGER.warn(errMsg);
+
+            throw new CloudRuntimeException(errMsg);
+        }
 
         try {
             _volumeService.grantAccess(dataObj, hostVO, dataStore);
@@ -945,7 +2042,10 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
             throw new CloudRuntimeException(msg + ex.getMessage());
         }
         finally {
-            if (keepGrantedAccess == false) {
+            lock.unlock();
+            lock.releaseRef();
+
+            if (!keepGrantedAccess) {
                 _volumeService.revokeAccess(dataObj, hostVO, dataStore);
             }
         }
@@ -972,17 +2072,146 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         return new CopyCmdAnswer(newVolume);
     }
 
-    protected DataObject cacheSnapshotChain(SnapshotInfo snapshot, Scope scope) {
+    private DataObject cacheSnapshotChain(SnapshotInfo snapshot, Scope scope) {
         DataObject leafData = null;
         DataStore store = cacheMgr.getCacheStorage(snapshot, scope);
+
         while (snapshot != null) {
             DataObject cacheData = cacheMgr.createCacheObject(snapshot, store);
+
             if (leafData == null) {
                 leafData = cacheData;
             }
+
             snapshot = snapshot.getParent();
         }
+
         return leafData;
+    }
+
+    private String migrateVolume(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo, HostVO hostVO, String errMsg) {
+        boolean srcVolumeDetached = srcVolumeInfo.getAttachedVM() == null;
+
+        try {
+            Map<String, String> srcDetails = getVolumeDetails(srcVolumeInfo);
+            Map<String, String> destDetails = getVolumeDetails(destVolumeInfo);
+
+            MigrateVolumeCommand migrateVolumeCommand = new MigrateVolumeCommand(srcVolumeInfo.getTO(), destVolumeInfo.getTO(),
+                    srcDetails, destDetails, StorageManager.KvmStorageOfflineMigrationWait.value());
+
+            if (srcVolumeDetached) {
+                _volumeService.grantAccess(srcVolumeInfo, hostVO, srcVolumeInfo.getDataStore());
+            }
+
+            _volumeService.grantAccess(destVolumeInfo, hostVO, destVolumeInfo.getDataStore());
+
+            MigrateVolumeAnswer migrateVolumeAnswer = (MigrateVolumeAnswer)_agentMgr.send(hostVO.getId(), migrateVolumeCommand);
+
+            if (migrateVolumeAnswer == null || !migrateVolumeAnswer.getResult()) {
+                if (migrateVolumeAnswer != null && !StringUtils.isEmpty(migrateVolumeAnswer.getDetails())) {
+                    throw new CloudRuntimeException(migrateVolumeAnswer.getDetails());
+                }
+                else {
+                    throw new CloudRuntimeException(errMsg);
+                }
+            }
+
+            if (srcVolumeDetached) {
+                _volumeService.revokeAccess(destVolumeInfo, hostVO, destVolumeInfo.getDataStore());
+            }
+
+            try {
+                _volumeService.revokeAccess(srcVolumeInfo, hostVO, srcVolumeInfo.getDataStore());
+            }
+            catch (Exception e) {
+                // This volume should be deleted soon, so just log a warning here.
+                LOGGER.warn(e.getMessage(), e);
+            }
+
+            return migrateVolumeAnswer.getVolumePath();
+        }
+        catch (Exception ex) {
+            try {
+                _volumeService.revokeAccess(destVolumeInfo, hostVO, destVolumeInfo.getDataStore());
+            }
+            catch (Exception e) {
+                // This volume should be deleted soon, so just log a warning here.
+                LOGGER.warn(e.getMessage(), e);
+            }
+
+            if (srcVolumeDetached) {
+                _volumeService.revokeAccess(srcVolumeInfo, hostVO, srcVolumeInfo.getDataStore());
+            }
+
+            String msg = "Failed to perform volume migration : ";
+
+            LOGGER.warn(msg, ex);
+
+            throw new CloudRuntimeException(msg + ex.getMessage());
+        }
+    }
+
+    private String copyVolumeToSecondaryStorage(VolumeInfo srcVolumeInfo, VolumeInfo destVolumeInfo, HostVO hostVO, String errMsg) {
+        boolean srcVolumeDetached = srcVolumeInfo.getAttachedVM() == null;
+
+        try {
+            StoragePoolVO storagePoolVO = _storagePoolDao.findById(srcVolumeInfo.getPoolId());
+            Map<String, String> srcDetails = getVolumeDetails(srcVolumeInfo);
+
+            CopyVolumeCommand copyVolumeCommand = new CopyVolumeCommand(srcVolumeInfo.getId(), destVolumeInfo.getPath(), storagePoolVO,
+                    destVolumeInfo.getDataStore().getUri(), true, StorageManager.KvmStorageOfflineMigrationWait.value(), true);
+
+            copyVolumeCommand.setSrcData(srcVolumeInfo.getTO());
+            copyVolumeCommand.setSrcDetails(srcDetails);
+
+            if (srcVolumeDetached) {
+                _volumeService.grantAccess(srcVolumeInfo, hostVO, srcVolumeInfo.getDataStore());
+            }
+
+            CopyVolumeAnswer copyVolumeAnswer = (CopyVolumeAnswer)_agentMgr.send(hostVO.getId(), copyVolumeCommand);
+
+            if (copyVolumeAnswer == null || !copyVolumeAnswer.getResult()) {
+                if (copyVolumeAnswer != null && !StringUtils.isEmpty(copyVolumeAnswer.getDetails())) {
+                    throw new CloudRuntimeException(copyVolumeAnswer.getDetails());
+                }
+                else {
+                    throw new CloudRuntimeException(errMsg);
+                }
+            }
+
+            return copyVolumeAnswer.getVolumePath();
+        }
+        catch (Exception ex) {
+            String msg = "Failed to perform volume copy to secondary storage : ";
+
+            LOGGER.warn(msg, ex);
+
+            throw new CloudRuntimeException(msg + ex.getMessage());
+        }
+        finally {
+            if (srcVolumeDetached) {
+                _volumeService.revokeAccess(srcVolumeInfo, hostVO, srcVolumeInfo.getDataStore());
+            }
+        }
+    }
+
+    private void setCertainVolumeValuesNull(long volumeId) {
+        VolumeVO volumeVO = _volumeDao.findById(volumeId);
+
+        volumeVO.set_iScsiName(null);
+        volumeVO.setMinIops(null);
+        volumeVO.setMaxIops(null);
+        volumeVO.setHypervisorSnapshotReserve(null);
+
+        _volumeDao.update(volumeId, volumeVO);
+    }
+
+    private void updateVolumePath(long volumeId, String path) {
+        VolumeVO volumeVO = _volumeDao.findById(volumeId);
+
+        volumeVO.setPath(path);
+
+        _volumeDao.update(volumeId, volumeVO);
     }
 
     /**

--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -859,7 +859,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
                 LOGGER.warn(msg, ex);
 
-                throw new CloudRuntimeException(msg + ex.getMessage());
+                throw new CloudRuntimeException(msg + ex.getMessage(), ex);
             } finally {
                 _volumeService.revokeAccess(snapshotInfo, hostVO, srcDataStore);
 
@@ -1336,7 +1336,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
             LOGGER.warn(msg, ex);
 
-            throw new CloudRuntimeException(msg + ex.getMessage());
+            throw new CloudRuntimeException(msg + ex.getMessage(), ex);
         }
         finally {
             _volumeService.revokeAccess(destVolumeInfo, hostVO, destVolumeInfo.getDataStore());
@@ -1798,7 +1798,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
                 LOGGER.warn(msg, ex);
 
-                throw new CloudRuntimeException(msg + ex.getMessage());
+                throw new CloudRuntimeException(msg + ex.getMessage(), ex);
             }
             finally {
                 try {
@@ -2147,7 +2147,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
             LOGGER.warn(msg, ex);
 
-            throw new CloudRuntimeException(msg + ex.getMessage());
+            throw new CloudRuntimeException(msg + ex.getMessage(), ex);
         }
     }
 
@@ -2262,7 +2262,7 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
 
             LOGGER.warn(msg, ex);
 
-            throw new CloudRuntimeException(msg + ex.getMessage());
+            throw new CloudRuntimeException(msg + ex.getMessage(), ex);
         }
         finally {
             if (Snapshot.LocationType.PRIMARY.equals(locationType)) {

--- a/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
+++ b/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeServiceImpl.java
@@ -71,7 +71,9 @@ import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
+import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ModifyTargetsCommand;
 import com.cloud.agent.api.storage.ListVolumeAnswer;
 import com.cloud.agent.api.storage.ListVolumeCommand;
 import com.cloud.agent.api.storage.ResizeVolumeCommand;
@@ -123,6 +125,8 @@ import com.cloud.storage.dao.VolumeDetailsDao;
 @Component
 public class VolumeServiceImpl implements VolumeService {
     private static final Logger s_logger = Logger.getLogger(VolumeServiceImpl.class);
+    @Inject
+    protected AgentManager agentMgr;
     @Inject
     VolumeDao volDao;
     @Inject
@@ -895,12 +899,12 @@ public class VolumeServiceImpl implements VolumeService {
             copyCaller.setCallback(copyCaller.getTarget().copyManagedTemplateCallback(null, null)).setContext(copyContext);
 
             // Populate details which will be later read by the storage subsystem.
-            Map<String, String> details = new HashMap<String, String>();
+            Map<String, String> details = new HashMap<>();
 
             details.put(PrimaryDataStore.MANAGED, Boolean.TRUE.toString());
             details.put(PrimaryDataStore.STORAGE_HOST, destPrimaryDataStore.getHostAddress());
             details.put(PrimaryDataStore.STORAGE_PORT, String.valueOf(destPrimaryDataStore.getPort()));
-            details.put(PrimaryDataStore.MANAGED_STORE_TARGET, ((TemplateObject)templateOnPrimary).getInstallPath());
+            details.put(PrimaryDataStore.MANAGED_STORE_TARGET, templateOnPrimary.getInstallPath());
             details.put(PrimaryDataStore.MANAGED_STORE_TARGET_ROOT_VOLUME, srcTemplateInfo.getUniqueName());
             details.put(PrimaryDataStore.REMOVE_AFTER_COPY, Boolean.TRUE.toString());
             details.put(PrimaryDataStore.VOLUME_SIZE, String.valueOf(templateOnPrimary.getSize()));
@@ -920,7 +924,7 @@ public class VolumeServiceImpl implements VolumeService {
 
             grantAccess(templateOnPrimary, destHost, destPrimaryDataStore);
 
-            VolumeApiResult result = null;
+            VolumeApiResult result;
 
             try {
                 motionSrv.copyAsync(srcTemplateInfo, templateOnPrimary, destHost, copyCaller);
@@ -929,6 +933,16 @@ public class VolumeServiceImpl implements VolumeService {
             }
             finally {
                 revokeAccess(templateOnPrimary, destHost, destPrimaryDataStore);
+
+                if (HypervisorType.VMware.equals(destHost.getHypervisorType())) {
+                    details.put(ModifyTargetsCommand.IQN, templateOnPrimary.getInstallPath());
+
+                    List<Map<String, String>> targets = new ArrayList<>();
+
+                    targets.add(details);
+
+                    removeDynamicTargets(destHost.getId(), targets);
+                }
             }
 
             if (result.isFailed()) {
@@ -948,6 +962,32 @@ public class VolumeServiceImpl implements VolumeService {
         }
         finally {
             _tmpltPoolDao.releaseFromLockTable(templatePoolRefId);
+        }
+    }
+
+    private void removeDynamicTargets(long hostId, List<Map<String, String>> targets) {
+        ModifyTargetsCommand cmd = new ModifyTargetsCommand();
+
+        cmd.setTargets(targets);
+        cmd.setApplyToAllHostsInCluster(true);
+        cmd.setAdd(false);
+        cmd.setTargetTypeToRemove(ModifyTargetsCommand.TargetTypeToRemove.DYNAMIC);
+
+        sendModifyTargetsCommand(cmd, hostId);
+    }
+
+    private void sendModifyTargetsCommand(ModifyTargetsCommand cmd, long hostId) {
+        Answer answer = agentMgr.easySend(hostId, cmd);
+
+        if (answer == null) {
+            String msg = "Unable to get an answer to the modify targets command";
+
+            s_logger.warn(msg);
+        }
+        else if (!answer.getResult()) {
+            String msg = "Unable to modify target on the following host: " + hostId;
+
+            s_logger.warn(msg);
         }
     }
 
@@ -1085,12 +1125,12 @@ public class VolumeServiceImpl implements VolumeService {
                 destPrimaryDataStore.getDriver().getCapabilities().get(DataStoreCapabilities.CAN_CREATE_VOLUME_FROM_VOLUME.toString())
         );
 
-        boolean computeZoneSupportsResign = computeZoneSupportsResign(destHost.getDataCenterId(), destHost.getHypervisorType());
+        boolean computeSupportsVolumeClone = computeSupportsVolumeClone(destHost.getDataCenterId(), destHost.getHypervisorType());
 
         AsyncCallFuture<VolumeApiResult> future = new AsyncCallFuture<>();
 
-        if (storageCanCloneVolume && computeZoneSupportsResign) {
-            s_logger.debug("Storage " + destDataStoreId + " can support cloning using a cached template and host cluster can perform UUID resigning.");
+        if (storageCanCloneVolume && computeSupportsVolumeClone) {
+            s_logger.debug("Storage " + destDataStoreId + " can support cloning using a cached template and compute side is OK with volume cloning.");
 
             TemplateInfo templateOnPrimary = destPrimaryDataStore.getTemplate(srcTemplateInfo.getId());
 
@@ -1118,16 +1158,22 @@ public class VolumeServiceImpl implements VolumeService {
 
             // We have a template on primary storage. Clone it to new volume.
             s_logger.debug("Creating a clone from template on primary storage " + destDataStoreId);
+
             createManagedVolumeCloneTemplateAsync(volumeInfo, templateOnPrimary, destPrimaryDataStore, future);
         } else {
             s_logger.debug("Primary storage does not support cloning or no support for UUID resigning on the host side; copying the template normally");
+
             createManagedVolumeCopyTemplateAsync(volumeInfo, destPrimaryDataStore, srcTemplateInfo, destHost, future);
         }
 
         return future;
     }
 
-    private boolean computeZoneSupportsResign(long zoneId, HypervisorType hypervisorType) {
+    private boolean computeSupportsVolumeClone(long zoneId, HypervisorType hypervisorType) {
+        if (HypervisorType.VMware.equals(hypervisorType) || HypervisorType.KVM.equals(hypervisorType)) {
+            return true;
+        }
+
         return getHost(zoneId, hypervisorType, true) != null;
     }
 
@@ -1757,7 +1803,17 @@ public class VolumeServiceImpl implements VolumeService {
         CreateVolumeContext<VolumeApiResult> context = new CreateVolumeContext<VolumeApiResult>(null, volume, future);
         AsyncCallbackDispatcher<VolumeServiceImpl, CreateCmdResult> caller = AsyncCallbackDispatcher.create(this);
         caller.setCallback(caller.getTarget().resizeVolumeCallback(caller, context)).setContext(context);
-        volume.getDataStore().getDriver().resize(volume, caller);
+
+        try {
+            volume.getDataStore().getDriver().resize(volume, caller);
+        } catch (Exception e) {
+            s_logger.debug("Failed to change state to resize", e);
+
+            result.setResult(e.toString());
+
+            future.complete(result);
+        }
+
         return future;
     }
 

--- a/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/solidfire/SolidFireIntegrationTestManagerImpl.java
+++ b/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/solidfire/SolidFireIntegrationTestManagerImpl.java
@@ -25,6 +25,7 @@ import com.cloud.storage.dao.VolumeDetailsDao;
 import com.cloud.user.AccountDetailVO;
 import com.cloud.user.AccountDetailsDao;
 import com.cloud.utils.exception.CloudRuntimeException;
+
 import org.apache.cloudstack.storage.datastore.util.SolidFireUtil;
 import org.apache.cloudstack.util.solidfire.SolidFireIntegrationTestUtil;
 import org.springframework.stereotype.Component;
@@ -46,9 +47,11 @@ public class SolidFireIntegrationTestManagerImpl implements SolidFireIntegration
         long storagePoolId = util.getStoragePoolIdForStoragePoolUuid(storagePoolUuid);
 
         AccountDetailVO accountDetail = accountDetailsDao.findDetail(csAccountId, SolidFireUtil.getAccountKey(storagePoolId));
+
         if (accountDetail == null){
             throw new CloudRuntimeException("Unable to find SF account for storage " + storagePoolUuid + " for CS account " + csAccountUuid);
         }
+
         String sfAccountId = accountDetail.getValue();
 
         return Long.parseLong(sfAccountId);

--- a/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/util/solidfire/SolidFireIntegrationTestUtil.java
+++ b/plugins/api/solidfire-intg-test/src/org/apache/cloudstack/util/solidfire/SolidFireIntegrationTestUtil.java
@@ -27,13 +27,15 @@ import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.Account;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.exception.CloudRuntimeException;
+
 import org.apache.cloudstack.api.response.solidfire.ApiVolumeSnapshotDetailsResponse;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.inject.Inject;
 
 public class SolidFireIntegrationTestUtil {
     @Inject private AccountDao accountDao;
@@ -47,15 +49,18 @@ public class SolidFireIntegrationTestUtil {
 
     public long getAccountIdForAccountUuid(String accountUuid) {
         Account account = accountDao.findByUuid(accountUuid);
-        if (account == null){
+
+        if (account == null) {
             throw new CloudRuntimeException("Unable to find Account for ID: " + accountUuid);
         }
+
         return account.getAccountId();
     }
 
     public long getAccountIdForVolumeUuid(String volumeUuid) {
         VolumeVO volume = volumeDao.findByUuid(volumeUuid);
-        if (volume == null){
+
+        if (volume == null) {
             throw new CloudRuntimeException("Unable to find Volume for ID: " + volumeUuid);
         }
 
@@ -64,15 +69,18 @@ public class SolidFireIntegrationTestUtil {
 
     public long getAccountIdForSnapshotUuid(String snapshotUuid) {
         SnapshotVO snapshot = snapshotDao.findByUuid(snapshotUuid);
-        if (snapshot == null){
+
+        if (snapshot == null) {
             throw new CloudRuntimeException("Unable to find Volume for ID: " + snapshotUuid);
         }
+
         return snapshot.getAccountId();
     }
 
     public long getClusterIdForClusterUuid(String clusterUuid) {
         ClusterVO cluster = clusterDao.findByUuid(clusterUuid);
-        if (cluster == null){
+
+        if (cluster == null) {
             throw new CloudRuntimeException("Unable to find Volume for ID: " + clusterUuid);
         }
 
@@ -81,7 +89,8 @@ public class SolidFireIntegrationTestUtil {
 
     public long getStoragePoolIdForStoragePoolUuid(String storagePoolUuid) {
         StoragePoolVO storagePool = storagePoolDao.findByUuid(storagePoolUuid);
-        if (storagePool == null){
+
+        if (storagePool == null) {
             throw new CloudRuntimeException("Unable to find Volume for ID: " + storagePoolUuid);
         }
 
@@ -90,7 +99,8 @@ public class SolidFireIntegrationTestUtil {
 
     public String getPathForVolumeUuid(String volumeUuid) {
         VolumeVO volume = volumeDao.findByUuid(volumeUuid);
-        if (volume == null){
+
+        if (volume == null) {
             throw new CloudRuntimeException("Unable to find Volume for ID: " + volumeUuid);
         }
 
@@ -99,7 +109,8 @@ public class SolidFireIntegrationTestUtil {
 
     public String getVolume_iScsiName(String volumeUuid) {
         VolumeVO volume = volumeDao.findByUuid(volumeUuid);
-        if (volume == null){
+
+        if (volume == null) {
             throw new CloudRuntimeException("Unable to find Volume for ID: " + volumeUuid);
         }
 
@@ -108,7 +119,8 @@ public class SolidFireIntegrationTestUtil {
 
     public List<ApiVolumeSnapshotDetailsResponse> getSnapshotDetails(String snapshotUuid) {
         SnapshotVO snapshot = snapshotDao.findByUuid(snapshotUuid);
-        if (snapshot == null){
+
+        if (snapshot == null) {
             throw new CloudRuntimeException("Unable to find Volume for ID: " + snapshotUuid);
         }
 

--- a/plugins/api/vmware-sioc/pom.xml
+++ b/plugins/api/vmware-sioc/pom.xml
@@ -1,0 +1,47 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cloud-plugin-api-vmware-sioc</artifactId>
+  <name>Apache CloudStack Plugin - API VMware SIOC</name>
+  <parent>
+    <groupId>org.apache.cloudstack</groupId>
+    <artifactId>cloudstack-plugins</artifactId>
+    <version>4.11.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+       <artifactId>cloud-plugin-hypervisor-vmware</artifactId>
+       <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xmx1024m</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugins/api/vmware-sioc/resources/META-INF/cloudstack/vmware-sioc/module.properties
+++ b/plugins/api/vmware-sioc/resources/META-INF/cloudstack/vmware-sioc/module.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name=vmware-sioc
+parent=api

--- a/plugins/api/vmware-sioc/resources/META-INF/cloudstack/vmware-sioc/spring-sioc-context.xml
+++ b/plugins/api/vmware-sioc/resources/META-INF/cloudstack/vmware-sioc/spring-sioc-context.xml
@@ -1,0 +1,33 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                      http://www.springframework.org/schema/context
+                      http://www.springframework.org/schema/context/spring-context-3.0.xsd"
+                      >
+
+      <bean id="apiSiocServiceImpl" class="org.apache.cloudstack.api.sioc.ApiSiocServiceImpl"/>
+      <bean id="siocManagerImpl" class="org.apache.cloudstack.sioc.SiocManagerImpl"/>
+
+</beans>

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/command/admin/sioc/UpdateSiocInfoCmd.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/command/admin/sioc/UpdateSiocInfoCmd.java
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.admin.sioc;
+
+import javax.inject.Inject;
+
+import org.apache.log4j.Logger;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.response.StoragePoolResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
+import org.apache.cloudstack.api.response.sioc.ApiUpdateSiocInfoResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.sioc.SiocManager;
+
+import com.cloud.user.Account;
+
+@APICommand(name = UpdateSiocInfoCmd.APINAME, description = "Update SIOC info", responseObject = ApiUpdateSiocInfoResponse.class,
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false,
+        since = "4.11.0",
+        authorized = {RoleType.Admin})
+public class UpdateSiocInfoCmd extends BaseCmd {
+    private static final Logger s_logger = Logger.getLogger(UpdateSiocInfoCmd.class.getName());
+
+    public static final String APINAME = "updateSiocInfo";
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class, description = "Zone ID", required = true)
+    private long zoneId;
+
+    @Parameter(name = ApiConstants.STORAGE_ID, type = CommandType.UUID, entityType = StoragePoolResponse.class, description = "Storage Pool ID", required = true)
+    private long storagePoolId;
+
+    @Parameter(name = "sharespergb", type = CommandType.INTEGER, description = "Shares per GB", required = true)
+    private int sharesPerGB;
+
+    @Parameter(name = "limitiopspergb", type = CommandType.INTEGER, description = "Limit IOPS per GB", required = true)
+    private int limitIopsPerGB;
+
+    @Parameter(name = "iopsnotifythreshold", type = CommandType.INTEGER, description = "Notify if IOPS above this value", required = true)
+    private int iopsNotifyThreshold;
+
+    @Inject private SiocManager manager;
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+    @Override
+    public String getCommandName() {
+        return APINAME.toLowerCase() + BaseCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        Account account = CallContext.current().getCallingAccount();
+
+        if (account != null) {
+            return account.getId();
+        }
+
+        return Account.ACCOUNT_ID_SYSTEM; // no account info given, parent this command to SYSTEM so ERROR events are tracked
+    }
+
+    @Override
+    public void execute() {
+        s_logger.info("'UpdateSiocInfoCmd.execute' method invoked");
+
+        String msg = "Success";
+
+        try {
+            manager.updateSiocInfo(zoneId, storagePoolId, sharesPerGB, limitIopsPerGB, iopsNotifyThreshold);
+        }
+        catch (Exception ex) {
+            msg = ex.getMessage();
+        }
+
+        ApiUpdateSiocInfoResponse response = new ApiUpdateSiocInfoResponse(msg);
+
+        response.setResponseName(getCommandName());
+        response.setObjectName("apiupdatesiocinfo");
+
+        setResponseObject(response);
+    }
+}

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/response/sioc/ApiUpdateSiocInfoResponse.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/response/sioc/ApiUpdateSiocInfoResponse.java
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.response.sioc;
+
+import org.apache.cloudstack.api.BaseResponse;
+
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
+
+public class ApiUpdateSiocInfoResponse extends BaseResponse {
+    @SerializedName("msg")
+    @Param(description = "The return message from the operation ('Success' if successful)")
+    private String _msg;
+
+    public ApiUpdateSiocInfoResponse(String msg) {
+        _msg = msg;
+    }
+}

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/sioc/ApiSiocService.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/sioc/ApiSiocService.java
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.sioc;
+
+import com.cloud.utils.component.PluggableService;
+
+public interface ApiSiocService extends PluggableService {
+}

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/sioc/ApiSiocServiceImpl.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/api/sioc/ApiSiocServiceImpl.java
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.sioc;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.apache.cloudstack.api.command.admin.sioc.UpdateSiocInfoCmd;
+import org.springframework.stereotype.Component;
+
+import com.cloud.utils.component.AdapterBase;
+
+@Component
+public class ApiSiocServiceImpl extends AdapterBase implements ApiSiocService {
+    @Override
+    public List<Class<?>> getCommands() {
+        List<Class<?>> cmdList = new ArrayList<Class<?>>();
+
+        cmdList.add(UpdateSiocInfoCmd.class);
+
+        return cmdList;
+    }
+}

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/sioc/SiocManager.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/sioc/SiocManager.java
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.sioc;
+
+public interface SiocManager {
+    void updateSiocInfo(long zoneId, long storagePoolId, int sharesPerGB, int limitIopsPerGB, int iopsNotifyThreshold) throws Exception;
+}

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/sioc/SiocManagerImpl.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/sioc/SiocManagerImpl.java
@@ -1,0 +1,463 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.sioc;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.cloudstack.util.LoginInfo;
+import org.apache.cloudstack.util.vmware.VMwareUtil;
+import org.apache.cloudstack.utils.volume.VirtualMachineDiskInfo;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.hypervisor.vmware.VmwareDatacenterVO;
+import com.cloud.hypervisor.vmware.VmwareDatacenterZoneMapVO;
+import com.cloud.hypervisor.vmware.dao.VmwareDatacenterDao;
+import com.cloud.hypervisor.vmware.dao.VmwareDatacenterZoneMapDao;
+import com.cloud.hypervisor.vmware.mo.VirtualMachineDiskInfoBuilder;
+import com.cloud.storage.Storage.StoragePoolType;
+import com.cloud.storage.Volume;
+import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.VolumeDao;
+import com.cloud.utils.db.GlobalLock;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.dao.VMInstanceDao;
+
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.SharesInfo;
+import com.vmware.vim25.SharesLevel;
+import com.vmware.vim25.StorageIOAllocationInfo;
+import com.vmware.vim25.VirtualDevice;
+import com.vmware.vim25.VirtualDeviceConfigSpec;
+import com.vmware.vim25.VirtualDeviceConfigSpecOperation;
+import com.vmware.vim25.VirtualDisk;
+import com.vmware.vim25.VirtualDeviceFileBackingInfo;
+import com.vmware.vim25.VirtualMachineConfigInfo;
+import com.vmware.vim25.VirtualMachineConfigSpec;
+
+@Component
+public class SiocManagerImpl implements SiocManager {
+    private static final Logger LOGGER = Logger.getLogger(SiocManagerImpl.class);
+    private static final int LOCK_TIME_IN_SECONDS = 3;
+    private static final int ONE_GB_IN_BYTES = 1000000000;
+    private static final int LOWEST_SHARES_PER_VIRTUAL_DISK = 2000; // We want this to be greater than 1,000, which is the VMware default value.
+    private static final int HIGHEST_SHARES_PER_VIRTUAL_DISK = 4000; // VMware limit
+    private static final int LOWEST_LIMIT_IOPS_PER_VIRTUAL_DISK = 16; // VMware limit
+    private static final int HIGHEST_LIMIT_IOPS_PER_VIRTUAL_DISK = 2147483647; // VMware limit
+
+    @Inject private DataCenterDao zoneDao;
+    @Inject private DiskOfferingDao diskOfferingDao;
+    @Inject private PrimaryDataStoreDao storagePoolDao;
+    @Inject private StoragePoolDetailsDao storagePoolDetailsDao;
+    @Inject private VMInstanceDao vmInstanceDao;
+    @Inject private VmwareDatacenterDao vmwareDcDao;
+    @Inject private VmwareDatacenterZoneMapDao vmwareDcZoneMapDao;
+    @Inject private VolumeDao volumeDao;
+
+    @Override
+    public void updateSiocInfo(long zoneId, long storagePoolId, int sharesPerGB, int limitIopsPerGB, int iopsNotifyThreshold) throws Exception {
+        LOGGER.info("'SiocManagerImpl.updateSiocInfo(long, long, int, int, int)' method invoked");
+
+        DataCenterVO zone = zoneDao.findById(zoneId);
+
+        if (zone == null) {
+            throw new Exception("Error: No zone could be located for the following zone ID: " + zoneId + ".");
+        }
+
+        StoragePoolVO storagePool = storagePoolDao.findById(storagePoolId);
+
+        if (storagePool == null) {
+            throw new Exception("Error: No storage pool could be located for the following pool ID: " + storagePoolId + ".");
+        }
+
+        if (storagePool.getDataCenterId() != zoneId) {
+            throw new Exception("Error: Storage pool '" + storagePool.getName() + "' is not in zone ID " + zoneId + ".");
+        }
+
+        if (!storagePool.getPoolType().equals(StoragePoolType.VMFS)) {
+            throw new Exception("Error: Storage pool '" + storagePool.getName() + "' does not represent a VMFS datastore.");
+        }
+
+        String lockName = zone.getUuid() + "-" + storagePool.getUuid();
+        GlobalLock lock = GlobalLock.getInternLock(lockName);
+
+        if (!lock.lock(LOCK_TIME_IN_SECONDS)) {
+            throw new Exception("Busy: The system is already processing this request.");
+        }
+
+        VMwareUtil.VMwareConnection connection = null;
+
+        try {
+            connection = VMwareUtil.getVMwareConnection(getLoginInfo(zoneId));
+
+            Map<String, ManagedObjectReference> nameToVm = VMwareUtil.getVms(connection);
+
+            List<ManagedObjectReference> allTasks = new ArrayList<>();
+
+            int limitIopsTotal = 0;
+
+            List<VolumeVO> volumes = volumeDao.findByPoolId(storagePoolId, null);
+
+            if (volumes != null && volumes.size() > 0) {
+                Set<Long> instanceIds = new HashSet<>();
+
+                for (VolumeVO volume : volumes) {
+                    Long instanceId = volume.getInstanceId();
+
+                    if (instanceId != null) {
+                        instanceIds.add(instanceId);
+                    }
+                }
+
+                for (Long instanceId : instanceIds) {
+                    ResultWrapper resultWrapper = updateSiocInfo(connection, nameToVm, instanceId, storagePool, sharesPerGB, limitIopsPerGB);
+
+                    limitIopsTotal += resultWrapper.getLimitIopsTotal();
+
+                    allTasks.addAll(resultWrapper.getTasks());
+                }
+            }
+            /*
+            Set<String> vmNames = nameToVm.keySet();
+
+            for (String vmName : vmNames) {
+                // If the VM's name doesn't start with "i-", then it should be a worker VM (which is not stored in the CloudStack datastore).
+                if (!vmName.startsWith("i-")) {
+                    ResultWrapper resultWrapper = updateSiocInfoForWorkerVM(connection, nameToVm.get(vmName),
+                            getDatastoreName(storagePool.getPath()), limitIopsPerGB);
+
+                    limitIopsTotal += resultWrapper.getLimitIopsTotal();
+
+                    allTasks.addAll(resultWrapper.getTasks());
+                }
+            }
+            */
+            for (ManagedObjectReference task : allTasks) {
+                VMwareUtil.waitForTask(connection, task);
+            }
+
+            if (limitIopsTotal > iopsNotifyThreshold) {
+                throw new Exception("Warning: Total number of IOPS: " + limitIopsTotal + "; IOPS notify threshold: " + iopsNotifyThreshold);
+            }
+        }
+        finally {
+            VMwareUtil.closeVMwareConnection(connection);
+
+            lock.unlock();
+            lock.releaseRef();
+        }
+    }
+
+    private ResultWrapper updateSiocInfo(VMwareUtil.VMwareConnection connection, Map<String, ManagedObjectReference> nameToVm, Long instanceId,
+                                         StoragePoolVO storagePool, int sharesPerGB, int limitIopsPerGB) throws Exception {
+        int limitIopsTotal = 0;
+        List<ManagedObjectReference> tasks = new ArrayList<>();
+
+        VMInstanceVO vmInstance = vmInstanceDao.findById(instanceId);
+
+        if (vmInstance == null) {
+            String errMsg = "Error: The VM with ID " + instanceId + " could not be located.";
+
+            throw new Exception(errMsg);
+        }
+
+        String vmName = vmInstance.getInstanceName();
+
+        ManagedObjectReference morVm = nameToVm.get(vmName);
+
+        if (morVm == null) {
+            String errMsg = "Error: The VM with ID " + instanceId + " could not be located (ManagedObjectReference).";
+
+            throw new Exception(errMsg);
+        }
+
+        VirtualMachineConfigInfo vmci = (VirtualMachineConfigInfo)VMwareUtil.getEntityProps(connection, morVm,
+                new String[] { "config" }).get("config");
+        List<VirtualDevice> devices = vmci.getHardware().getDevice();
+
+        for (VirtualDevice device : devices) {
+            if (device instanceof VirtualDisk) {
+                VirtualDisk disk = (VirtualDisk)device;
+
+                VolumeVO volumeVO = getVolumeFromVirtualDisk(vmInstance, storagePool.getId(), devices, disk);
+
+                if (volumeVO != null) {
+                    boolean diskUpdated = false;
+
+                    StorageIOAllocationInfo sioai = disk.getStorageIOAllocation();
+
+                    SharesInfo sharesInfo = sioai.getShares();
+
+                    int currentShares = sharesInfo.getShares();
+                    int newShares = getNewSharesBasedOnVolumeSize(volumeVO, sharesPerGB);
+
+                    if (currentShares != newShares) {
+                        sharesInfo.setLevel(SharesLevel.CUSTOM);
+                        sharesInfo.setShares(newShares);
+
+                        diskUpdated = true;
+                    }
+
+                    long currentLimitIops = sioai.getLimit() !=  null ? sioai.getLimit() : Long.MIN_VALUE;
+                    long newLimitIops = getNewLimitIopsBasedOnVolumeSize(volumeVO, limitIopsPerGB);
+
+                    limitIopsTotal += newLimitIops;
+
+                    if (currentLimitIops != newLimitIops) {
+                        sioai.setLimit(newLimitIops);
+
+                        diskUpdated = true;
+                    }
+
+                    if (diskUpdated) {
+                        VirtualDeviceConfigSpec vdcs = new VirtualDeviceConfigSpec();
+
+                        vdcs.setDevice(disk);
+                        vdcs.setOperation(VirtualDeviceConfigSpecOperation.EDIT);
+
+                        VirtualMachineConfigSpec vmcs = new VirtualMachineConfigSpec();
+
+                        vmcs.getDeviceChange().add(vdcs);
+
+                        try {
+                            ManagedObjectReference task = VMwareUtil.reconfigureVm(connection, morVm, vmcs);
+
+                            tasks.add(task);
+
+                            LOGGER.info(getInfoMsg(volumeVO, newShares, newLimitIops));
+                        } catch (Exception ex) {
+                            throw new Exception("Error: " + ex.getMessage());
+                        }
+                    }
+                }
+            }
+        }
+
+        return new ResultWrapper(limitIopsTotal, tasks);
+    }
+
+    private String getDatastoreName(String path) throws Exception {
+        String searchString = "/";
+
+        int lastIndexOf = path.lastIndexOf(searchString);
+
+        if (lastIndexOf == -1) {
+            throw new Exception("Error: Invalid datastore path");
+        }
+
+        return path.substring(lastIndexOf + searchString.length());
+    }
+
+    private ResultWrapper updateSiocInfoForWorkerVM(VMwareUtil.VMwareConnection connection, ManagedObjectReference morVm, String datastoreName,
+                                                    int limitIopsPerGB) throws Exception {
+        int limitIopsTotal = 0;
+        List<ManagedObjectReference> tasks = new ArrayList<>();
+
+        VirtualMachineConfigInfo vmci = (VirtualMachineConfigInfo)VMwareUtil.getEntityProps(connection, morVm,
+                new String[] { "config" }).get("config");
+        List<VirtualDevice> devices = vmci.getHardware().getDevice();
+
+        for (VirtualDevice device : devices) {
+            if (device instanceof VirtualDisk) {
+                VirtualDisk disk = (VirtualDisk)device;
+
+                if (disk.getBacking() instanceof VirtualDeviceFileBackingInfo) {
+                    VirtualDeviceFileBackingInfo backingInfo = (VirtualDeviceFileBackingInfo)disk.getBacking();
+
+                    if (backingInfo.getFileName().contains(datastoreName)) {
+                        boolean diskUpdated = false;
+
+                        StorageIOAllocationInfo sioai = disk.getStorageIOAllocation();
+
+                        long currentLimitIops = sioai.getLimit() !=  null ? sioai.getLimit() : Long.MIN_VALUE;
+                        long newLimitIops = getNewLimitIopsBasedOnVolumeSize(disk.getCapacityInBytes(), limitIopsPerGB);
+
+                        limitIopsTotal += newLimitIops;
+
+                        if (currentLimitIops != newLimitIops) {
+                            sioai.setLimit(newLimitIops);
+
+                            diskUpdated = true;
+                        }
+
+                        if (diskUpdated) {
+                            VirtualDeviceConfigSpec vdcs = new VirtualDeviceConfigSpec();
+
+                            vdcs.setDevice(disk);
+                            vdcs.setOperation(VirtualDeviceConfigSpecOperation.EDIT);
+
+                            VirtualMachineConfigSpec vmcs = new VirtualMachineConfigSpec();
+
+                            vmcs.getDeviceChange().add(vdcs);
+
+                            try {
+                                ManagedObjectReference task = VMwareUtil.reconfigureVm(connection, morVm, vmcs);
+
+                                tasks.add(task);
+
+                                LOGGER.info(getInfoMsgForWorkerVm(newLimitIops));
+                            } catch (Exception ex) {
+                                throw new Exception("Error: " + ex.getMessage());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return new ResultWrapper(limitIopsTotal, tasks);
+    }
+
+    private String getInfoMsg(Volume volume, Integer newShares, Long newLimitIops) {
+        String msgPrefix = "VMware SIOC: Volume = " + volume.getName();
+
+        String msgNewShares = newShares != null ? "; New Shares = " + newShares : "";
+
+        String msgNewLimitIops = newLimitIops != null ? "; New Limit IOPS = " + newLimitIops : "";
+
+        return msgPrefix + msgNewShares + msgNewLimitIops;
+    }
+
+    private String getInfoMsgForWorkerVm(Long newLimitIops) {
+        return "VMware SIOC: Worker VM's Limit IOPS set to " + newLimitIops;
+    }
+
+    private VolumeVO getVolumeFromVirtualDisk(VMInstanceVO vmInstance, long storagePoolId, List<VirtualDevice> allDevices,
+            VirtualDisk disk) throws Exception {
+        List<VolumeVO> volumes = volumeDao.findByInstance(vmInstance.getId());
+
+        if (volumes == null || volumes.size() == 0) {
+            String errMsg = "Error: The VMware virtual disk '" + disk + "' could not be mapped to a CloudStack volume. " +
+                    "There were no volumes for the VM with the following ID: " + vmInstance.getId() + ".";
+
+            throw new Exception(errMsg);
+        }
+
+        VirtualMachineDiskInfoBuilder diskInfoBuilder = VMwareUtil.getDiskInfoBuilder(allDevices);
+
+        for (VolumeVO volume : volumes) {
+            Long poolId = volume.getPoolId();
+
+            if (poolId != null && poolId == storagePoolId) {
+                StoragePoolVO storagePool = storagePoolDao.findById(poolId);
+                String path = storagePool.getPath();
+                String charToSearchFor = "/";
+                int index = path.lastIndexOf(charToSearchFor) + charToSearchFor.length();
+                String datastoreName = path.substring(index);
+                VirtualMachineDiskInfo diskInfo = diskInfoBuilder.getDiskInfoByBackingFileBaseName(volume.getPath(), datastoreName);
+
+                if (diskInfo != null) {
+                    String deviceBusName = VMwareUtil.getDeviceBusName(allDevices, disk);
+
+                    if (deviceBusName.equals(diskInfo.getDiskDeviceBusName())) {
+                        return volume;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private int getNewSharesBasedOnVolumeSize(VolumeVO volumeVO, int sharesPerGB) {
+        long volumeSizeInBytes = getVolumeSizeInBytes(volumeVO);
+
+        double sizeInGB = volumeSizeInBytes / (double)ONE_GB_IN_BYTES;
+
+        int shares = LOWEST_SHARES_PER_VIRTUAL_DISK + ((int)(sharesPerGB * sizeInGB));
+
+        return getAdjustedShares(shares);
+    }
+
+    private int getAdjustedShares(int shares) {
+        shares = Math.max(shares, LOWEST_SHARES_PER_VIRTUAL_DISK);
+        shares = Math.min(shares, HIGHEST_SHARES_PER_VIRTUAL_DISK);
+
+        return shares;
+    }
+
+    private long getNewLimitIopsBasedOnVolumeSize(VolumeVO volumeVO, int limitIopsPerGB) {
+        long volumeSizeInBytes = getVolumeSizeInBytes(volumeVO);
+
+        return getNewLimitIopsBasedOnVolumeSize(volumeSizeInBytes, limitIopsPerGB);
+    }
+
+    private long getNewLimitIopsBasedOnVolumeSize(Long volumeSizeInBytes, int limitIopsPerGB) {
+        if (volumeSizeInBytes == null) {
+            volumeSizeInBytes = (long)ONE_GB_IN_BYTES;
+        }
+
+        double sizeInGB = volumeSizeInBytes / (double)ONE_GB_IN_BYTES;
+
+        long limitIops = (long)(limitIopsPerGB * sizeInGB);
+
+        return getAdjustedLimitIops(limitIops);
+    }
+
+    private long getAdjustedLimitIops(long limitIops) {
+        limitIops = Math.max(limitIops, LOWEST_LIMIT_IOPS_PER_VIRTUAL_DISK);
+        limitIops = Math.min(limitIops, HIGHEST_LIMIT_IOPS_PER_VIRTUAL_DISK);
+
+        return limitIops;
+    }
+
+    private long getVolumeSizeInBytes(VolumeVO volumeVO) {
+        return volumeVO.getSize() != null && volumeVO.getSize() > ONE_GB_IN_BYTES ? volumeVO.getSize() : ONE_GB_IN_BYTES;
+    }
+
+    private LoginInfo getLoginInfo(long zoneId) {
+        VmwareDatacenterZoneMapVO vmwareDcZoneMap = vmwareDcZoneMapDao.findByZoneId(zoneId);
+        Long associatedVmwareDcId = vmwareDcZoneMap.getVmwareDcId();
+        VmwareDatacenterVO associatedVmwareDc = vmwareDcDao.findById(associatedVmwareDcId);
+
+        String host = associatedVmwareDc.getVcenterHost();
+        String username = associatedVmwareDc.getUser();
+        String password = associatedVmwareDc.getPassword();
+
+        return new LoginInfo(host, username, password);
+    }
+}
+
+class ResultWrapper {
+    private int limitIopsTotal;
+    private List<ManagedObjectReference> tasks;
+
+    ResultWrapper(int limitIopsTotal, List<ManagedObjectReference> tasks) {
+        this.limitIopsTotal = limitIopsTotal;
+        this.tasks = tasks;
+    }
+
+    int getLimitIopsTotal() {
+        return limitIopsTotal;
+    }
+
+    List<ManagedObjectReference> getTasks() {
+        return tasks;
+    }
+}

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/util/LoginInfo.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/util/LoginInfo.java
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.util;
+
+public class LoginInfo {
+    private final String _host;
+    private final String _username;
+    private final String _password;
+
+    public LoginInfo(String host, String username, String password) {
+        _host = host;
+        _username = username;
+        _password = password;
+    }
+
+    public String getHost() {
+        return _host;
+    }
+
+    public String getUsername() {
+        return _username;
+    }
+
+    public String getPassword() {
+        return _password;
+    }
+}

--- a/plugins/api/vmware-sioc/src/org/apache/cloudstack/util/vmware/VMwareUtil.java
+++ b/plugins/api/vmware-sioc/src/org/apache/cloudstack/util/vmware/VMwareUtil.java
@@ -1,0 +1,570 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.util.vmware;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.WebServiceException;
+
+import org.apache.cloudstack.util.LoginInfo;
+import org.apache.log4j.Logger;
+
+import com.cloud.hypervisor.vmware.mo.VirtualMachineDiskInfoBuilder;
+import com.vmware.vim25.DynamicProperty;
+import com.vmware.vim25.InvalidCollectorVersionFaultMsg;
+import com.vmware.vim25.InvalidPropertyFaultMsg;
+import com.vmware.vim25.LocalizedMethodFault;
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.ObjectContent;
+import com.vmware.vim25.ObjectSpec;
+import com.vmware.vim25.ObjectUpdate;
+import com.vmware.vim25.ObjectUpdateKind;
+import com.vmware.vim25.PropertyChange;
+import com.vmware.vim25.PropertyChangeOp;
+import com.vmware.vim25.PropertyFilterSpec;
+import com.vmware.vim25.PropertyFilterUpdate;
+import com.vmware.vim25.PropertySpec;
+import com.vmware.vim25.RetrieveOptions;
+import com.vmware.vim25.RetrieveResult;
+import com.vmware.vim25.RuntimeFaultFaultMsg;
+import com.vmware.vim25.SelectionSpec;
+import com.vmware.vim25.ServiceContent;
+import com.vmware.vim25.TaskInfoState;
+import com.vmware.vim25.TraversalSpec;
+import com.vmware.vim25.UpdateSet;
+import com.vmware.vim25.VimPortType;
+import com.vmware.vim25.VimService;
+import com.vmware.vim25.VirtualDevice;
+import com.vmware.vim25.VirtualDeviceBackingInfo;
+import com.vmware.vim25.VirtualDisk;
+import com.vmware.vim25.VirtualDiskFlatVer2BackingInfo;
+import com.vmware.vim25.VirtualIDEController;
+import com.vmware.vim25.VirtualMachineConfigSpec;
+import com.vmware.vim25.VirtualSCSIController;
+
+public class VMwareUtil {
+    private static final Logger s_logger = Logger.getLogger(VMwareUtil.class);
+
+    private VMwareUtil() {}
+
+    public static class VMwareConnection {
+        private VimPortType _vimPortType;
+        private ServiceContent _serviceContent;
+
+        VMwareConnection(VimPortType vimPortType, ServiceContent serviceContent) {
+            _vimPortType = vimPortType;
+            _serviceContent = serviceContent;
+        }
+
+        VimPortType getVimPortType() {
+            return _vimPortType;
+        }
+
+        ServiceContent getServiceContent() {
+            return _serviceContent;
+        }
+    }
+
+    public static VMwareConnection getVMwareConnection(LoginInfo loginInfo) throws Exception {
+        trustAllHttpsCertificates();
+
+        HostnameVerifier hv = new HostnameVerifier() {
+            @Override
+            public boolean verify(String urlHostName, SSLSession session) {
+                return true;
+            }
+        };
+
+        HttpsURLConnection.setDefaultHostnameVerifier(hv);
+
+        ManagedObjectReference serviceInstanceRef = new ManagedObjectReference();
+
+        final String serviceInstanceName = "ServiceInstance";
+
+        serviceInstanceRef.setType(serviceInstanceName);
+        serviceInstanceRef.setValue(serviceInstanceName);
+
+        VimService vimService = new VimService();
+
+        VimPortType vimPortType = vimService.getVimPort();
+
+        Map<String, Object> ctxt = ((BindingProvider)vimPortType).getRequestContext();
+
+        ctxt.put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, "https://" + loginInfo.getHost() + "/sdk");
+        ctxt.put(BindingProvider.SESSION_MAINTAIN_PROPERTY, true);
+
+        ServiceContent serviceContent = vimPortType.retrieveServiceContent(serviceInstanceRef);
+
+        vimPortType.login(serviceContent.getSessionManager(), loginInfo.getUsername(), loginInfo.getPassword(), null);
+
+        return new VMwareConnection(vimPortType, serviceContent);
+    }
+
+    public static void closeVMwareConnection(VMwareConnection connection) throws Exception {
+        if (connection != null) {
+            connection.getVimPortType().logout(connection.getServiceContent().getSessionManager());
+        }
+    }
+
+    public static Map<String, ManagedObjectReference> getVms(VMwareConnection connection) throws Exception {
+        Map<String, ManagedObjectReference> nameToVm = new HashMap<>();
+
+        ManagedObjectReference rootFolder = connection.getServiceContent().getRootFolder();
+
+        TraversalSpec tSpec = getVMTraversalSpec();
+
+        PropertySpec propertySpec = new PropertySpec();
+
+        propertySpec.setAll(Boolean.FALSE);
+        propertySpec.getPathSet().add("name");
+        propertySpec.setType("VirtualMachine");
+
+        ObjectSpec objectSpec = new ObjectSpec();
+
+        objectSpec.setObj(rootFolder);
+        objectSpec.setSkip(Boolean.TRUE);
+        objectSpec.getSelectSet().add(tSpec);
+
+        PropertyFilterSpec propertyFilterSpec = new PropertyFilterSpec();
+
+        propertyFilterSpec.getPropSet().add(propertySpec);
+        propertyFilterSpec.getObjectSet().add(objectSpec);
+
+        List<PropertyFilterSpec> lstPfs = new ArrayList<>(1);
+
+        lstPfs.add(propertyFilterSpec);
+
+        VimPortType vimPortType = connection.getVimPortType();
+        ManagedObjectReference propertyCollector = connection.getServiceContent().getPropertyCollector();
+
+        List<ObjectContent> lstObjectContent = retrievePropertiesAllObjects(lstPfs, vimPortType, propertyCollector);
+
+        if (lstObjectContent != null) {
+            for (ObjectContent oc : lstObjectContent) {
+                ManagedObjectReference mor = oc.getObj();
+                List<DynamicProperty> dps = oc.getPropSet();
+                String vmName = null;
+
+                if (dps != null) {
+                    for (DynamicProperty dp : dps) {
+                        vmName = (String)dp.getVal();
+                    }
+                }
+
+                if (vmName != null) {
+                    nameToVm.put(vmName, mor);
+                }
+            }
+        }
+
+        return nameToVm;
+    }
+
+    public static Map<String, Object> getEntityProps(VMwareConnection connection, ManagedObjectReference entityMor, String[] props)
+            throws InvalidPropertyFaultMsg, RuntimeFaultFaultMsg {
+        Map<String, Object> retVal = new HashMap<>();
+
+        PropertySpec propertySpec = new PropertySpec();
+
+        propertySpec.setAll(Boolean.FALSE);
+        propertySpec.setType(entityMor.getType());
+        propertySpec.getPathSet().addAll(Arrays.asList(props));
+
+        ObjectSpec objectSpec = new ObjectSpec();
+
+        objectSpec.setObj(entityMor);
+
+        // Create PropertyFilterSpec using the PropertySpec and ObjectPec created above.
+        PropertyFilterSpec propertyFilterSpec = new PropertyFilterSpec();
+
+        propertyFilterSpec.getPropSet().add(propertySpec);
+        propertyFilterSpec.getObjectSet().add(objectSpec);
+
+        List<PropertyFilterSpec> propertyFilterSpecs = new ArrayList<>();
+
+        propertyFilterSpecs.add(propertyFilterSpec);
+
+        RetrieveResult rslts = connection.getVimPortType().retrievePropertiesEx(connection.getServiceContent().getPropertyCollector(),
+                propertyFilterSpecs, new RetrieveOptions());
+        List<ObjectContent> listobjcontent = new ArrayList<>();
+
+        if (rslts != null && rslts.getObjects() != null && !rslts.getObjects().isEmpty()) {
+            listobjcontent.addAll(rslts.getObjects());
+        }
+
+        String token = null;
+
+        if (rslts != null && rslts.getToken() != null) {
+            token = rslts.getToken();
+        }
+
+        while (token != null && !token.isEmpty()) {
+            rslts = connection.getVimPortType().continueRetrievePropertiesEx(connection.getServiceContent().getPropertyCollector(),
+                    token);
+
+            token = null;
+
+            if (rslts != null) {
+                token = rslts.getToken();
+
+                if (rslts.getObjects() != null && !rslts.getObjects().isEmpty()) {
+                    listobjcontent.addAll(rslts.getObjects());
+                }
+            }
+        }
+
+        for (ObjectContent oc : listobjcontent) {
+            List<DynamicProperty> dps = oc.getPropSet();
+
+            if (dps != null) {
+                for (DynamicProperty dp : dps) {
+                    retVal.put(dp.getName(), dp.getVal());
+                }
+            }
+        }
+
+        return retVal;
+    }
+
+    public static ManagedObjectReference reconfigureVm(VMwareConnection connection, ManagedObjectReference morVm,
+            VirtualMachineConfigSpec vmcs) throws Exception {
+        return connection.getVimPortType().reconfigVMTask(morVm, vmcs);
+    }
+
+    public static VirtualMachineDiskInfoBuilder getDiskInfoBuilder(List<VirtualDevice> devices) throws Exception {
+        VirtualMachineDiskInfoBuilder builder = new VirtualMachineDiskInfoBuilder();
+
+        if (devices != null) {
+            for (VirtualDevice device : devices) {
+                if (device instanceof VirtualDisk) {
+                    VirtualDisk virtualDisk = (VirtualDisk)device;
+                    VirtualDeviceBackingInfo backingInfo = virtualDisk.getBacking();
+
+                    if (backingInfo instanceof VirtualDiskFlatVer2BackingInfo) {
+                        VirtualDiskFlatVer2BackingInfo diskBackingInfo = (VirtualDiskFlatVer2BackingInfo)backingInfo;
+
+                        String deviceBusName = VMwareUtil.getDeviceBusName(devices, virtualDisk);
+
+                        while (diskBackingInfo != null) {
+                            builder.addDisk(deviceBusName, diskBackingInfo.getFileName());
+
+                            diskBackingInfo = diskBackingInfo.getParent();
+                        }
+                    }
+                }
+            }
+        }
+
+        return builder;
+    }
+
+    public static String getDeviceBusName(List<VirtualDevice> allDevices, VirtualDisk disk) throws Exception {
+        for (VirtualDevice device : allDevices) {
+            if (device.getKey() == disk.getControllerKey()) {
+                if (device instanceof VirtualIDEController) {
+                    return String.format("ide%d:%d", ((VirtualIDEController)device).getBusNumber(), disk.getUnitNumber());
+                } else if (device instanceof VirtualSCSIController) {
+                    return String.format("scsi%d:%d", ((VirtualSCSIController)device).getBusNumber(), disk.getUnitNumber());
+                } else {
+                    throw new Exception("The device controller is not supported.");
+                }
+            }
+        }
+
+        throw new Exception("The device controller could not be located.");
+    }
+
+    public static boolean waitForTask(VMwareConnection connection, ManagedObjectReference task) throws Exception {
+        try {
+            Object[] result = waitForValues(connection, task, new String[] { "info.state", "info.error" }, new String[] { "state" },
+                    new Object[][] { new Object[] { TaskInfoState.SUCCESS, TaskInfoState.ERROR } });
+
+            if (result[0].equals(TaskInfoState.SUCCESS)) {
+                return true;
+            }
+
+            if (result[1] instanceof LocalizedMethodFault) {
+                throw new Exception(((LocalizedMethodFault)result[1]).getLocalizedMessage());
+            }
+        } catch (WebServiceException we) {
+            s_logger.debug("Cancelling vCenter task because the task failed with the following error: " + we.getLocalizedMessage());
+
+            connection.getVimPortType().cancelTask(task);
+
+            throw new Exception("The vCenter task failed due to the following error: " + we.getLocalizedMessage());
+        }
+
+        return false;
+    }
+
+    private static Object[] waitForValues(VMwareConnection connection, ManagedObjectReference morObj, String[] filterProps,
+            String[] endWaitProps, Object[][] expectedVals) throws InvalidPropertyFaultMsg, RuntimeFaultFaultMsg,
+            InvalidCollectorVersionFaultMsg {
+        String version = "";
+        Object[] endVals = new Object[endWaitProps.length];
+        Object[] filterVals = new Object[filterProps.length];
+
+        PropertyFilterSpec spec = new PropertyFilterSpec();
+
+        ObjectSpec oSpec = new ObjectSpec();
+
+        oSpec.setObj(morObj);
+        oSpec.setSkip(Boolean.FALSE);
+
+        spec.getObjectSet().add(oSpec);
+
+        PropertySpec pSpec = new PropertySpec();
+
+        pSpec.getPathSet().addAll(Arrays.asList(filterProps));
+        pSpec.setType(morObj.getType());
+
+        spec.getPropSet().add(pSpec);
+
+        ManagedObjectReference propertyCollector = connection.getServiceContent().getPropertyCollector();
+        ManagedObjectReference filterSpecRef = connection.getVimPortType().createFilter(propertyCollector, spec, true);
+
+        boolean reached = false;
+
+        UpdateSet updateSet;
+        List<PropertyFilterUpdate> lstPropertyFilterUpdates;
+        List<ObjectUpdate> lstObjectUpdates;
+        List<PropertyChange> lstPropertyChanges;
+
+        while (!reached) {
+            updateSet = connection.getVimPortType().waitForUpdates(propertyCollector, version);
+
+            if (updateSet == null || updateSet.getFilterSet() == null) {
+                continue;
+            }
+
+            version = updateSet.getVersion();
+
+            lstPropertyFilterUpdates = updateSet.getFilterSet();
+
+            for (PropertyFilterUpdate propertyFilterUpdate : lstPropertyFilterUpdates) {
+                lstObjectUpdates = propertyFilterUpdate.getObjectSet();
+
+                for (ObjectUpdate objUpdate : lstObjectUpdates) {
+                    if (objUpdate.getKind() == ObjectUpdateKind.MODIFY || objUpdate.getKind() == ObjectUpdateKind.ENTER ||
+                            objUpdate.getKind() == ObjectUpdateKind.LEAVE) {
+                        lstPropertyChanges = objUpdate.getChangeSet();
+
+                        for (PropertyChange propchg : lstPropertyChanges) {
+                            updateValues(endWaitProps, endVals, propchg);
+                            updateValues(filterProps, filterVals, propchg);
+                        }
+                    }
+                }
+            }
+
+            Object expectedValue;
+
+            // Check if the expected values have been reached and exit the loop if done.
+            // Also, exit the WaitForUpdates loop if this is the case.
+            for (int chgi = 0; chgi < endVals.length && !reached; chgi++) {
+                for (int vali = 0; vali < expectedVals[chgi].length && !reached; vali++) {
+                    expectedValue = expectedVals[chgi][vali];
+
+                    reached = expectedValue.equals(endVals[chgi]) || reached;
+                }
+            }
+        }
+
+        // Destroy the filter when we are done.
+        connection.getVimPortType().destroyPropertyFilter(filterSpecRef);
+
+        return filterVals;
+    }
+
+    private static void updateValues(String[] props, Object[] vals, PropertyChange propertyChange) {
+        for (int findi = 0; findi < props.length; findi++) {
+            if (propertyChange.getName().lastIndexOf(props[findi]) >= 0) {
+                if (propertyChange.getOp() == PropertyChangeOp.REMOVE) {
+                    vals[findi] = "";
+                } else {
+                    vals[findi] = propertyChange.getVal();
+                }
+            }
+        }
+    }
+
+    private static List<ObjectContent> retrievePropertiesAllObjects(List<PropertyFilterSpec> lstPfs,
+            VimPortType vimPortType, ManagedObjectReference propCollectorRef) throws Exception {
+        List<ObjectContent> lstObjectContent = new ArrayList<>();
+
+        RetrieveOptions retrieveOptions = new RetrieveOptions();
+
+        RetrieveResult rslts = vimPortType.retrievePropertiesEx(propCollectorRef, lstPfs, retrieveOptions);
+
+        if (rslts != null && rslts.getObjects() != null && rslts.getObjects().size() > 0) {
+            List<ObjectContent> lstOc = new ArrayList<>();
+
+            for (ObjectContent oc : rslts.getObjects()) {
+                lstOc.add(oc);
+            }
+
+            lstObjectContent.addAll(lstOc);
+        }
+
+        String token = null;
+
+        if (rslts != null && rslts.getToken() != null) {
+            token = rslts.getToken();
+        }
+
+        while (token != null && !token.isEmpty()) {
+            rslts = vimPortType.continueRetrievePropertiesEx(propCollectorRef, token);
+            token = null;
+
+            if (rslts != null) {
+                token = rslts.getToken();
+
+                if (rslts.getObjects() != null && rslts.getObjects().size() > 0) {
+                    List<ObjectContent> lstOc = new ArrayList<>();
+
+                    for (ObjectContent oc : rslts.getObjects()) {
+                        lstOc.add(oc);
+                    }
+
+                    lstObjectContent.addAll(lstOc);
+                }
+            }
+        }
+
+        return lstObjectContent;
+    }
+
+    private static TraversalSpec getVMTraversalSpec() {
+        // Create a TraversalSpec that starts from the 'root' objects
+        // and traverses the inventory tree to get to the VirtualMachines.
+        // Build the traversal specs bottoms up
+
+        // TraversalSpec to get to the VM in a vApp
+        TraversalSpec vAppToVM = new TraversalSpec();
+
+        vAppToVM.setName("vAppToVM");
+        vAppToVM.setType("VirtualApp");
+        vAppToVM.setPath("vm");
+
+        // TraversalSpec for vApp to vApp
+        TraversalSpec vAppToVApp = new TraversalSpec();
+
+        vAppToVApp.setName("vAppToVApp");
+        vAppToVApp.setType("VirtualApp");
+        vAppToVApp.setPath("resourcePool");
+
+        // SelectionSpec for vApp-to-vApp recursion
+        SelectionSpec vAppRecursion = new SelectionSpec();
+
+        vAppRecursion.setName("vAppToVApp");
+
+        // SelectionSpec to get to a VM in the vApp
+        SelectionSpec vmInVApp = new SelectionSpec();
+
+        vmInVApp.setName("vAppToVM");
+
+        // SelectionSpec for both vApp to vApp and vApp to VM
+        List<SelectionSpec> vAppToVMSS = new ArrayList<>();
+
+        vAppToVMSS.add(vAppRecursion);
+        vAppToVMSS.add(vmInVApp);
+
+        vAppToVApp.getSelectSet().addAll(vAppToVMSS);
+
+        // This SelectionSpec is used for recursion for Folder recursion
+        SelectionSpec sSpec = new SelectionSpec();
+
+        sSpec.setName("VisitFolders");
+
+        // Traversal to get to the vmFolder from DataCenter
+        TraversalSpec dataCenterToVMFolder = new TraversalSpec();
+
+        dataCenterToVMFolder.setName("DataCenterToVMFolder");
+        dataCenterToVMFolder.setType("Datacenter");
+        dataCenterToVMFolder.setPath("vmFolder");
+        dataCenterToVMFolder.setSkip(false);
+
+        dataCenterToVMFolder.getSelectSet().add(sSpec);
+
+        // TraversalSpec to get to the DataCenter from rootFolder
+        TraversalSpec traversalSpec = new TraversalSpec();
+
+        traversalSpec.setName("VisitFolders");
+        traversalSpec.setType("Folder");
+        traversalSpec.setPath("childEntity");
+        traversalSpec.setSkip(false);
+
+        List<SelectionSpec> sSpecArr = new ArrayList<>();
+
+        sSpecArr.add(sSpec);
+        sSpecArr.add(dataCenterToVMFolder);
+        sSpecArr.add(vAppToVM);
+        sSpecArr.add(vAppToVApp);
+
+        traversalSpec.getSelectSet().addAll(sSpecArr);
+
+        return traversalSpec;
+    }
+
+    private static void trustAllHttpsCertificates() throws Exception {
+        // Create a trust manager that does not validate certificate chains:
+        TrustManager[] trustAllCerts = new TrustManager[1];
+
+        TrustManager tm = new TrustAllTrustManager();
+
+        trustAllCerts[0] = tm;
+
+        SSLContext sc = SSLContext.getInstance("SSL");
+
+        SSLSessionContext sslsc = sc.getServerSessionContext();
+
+        sslsc.setSessionTimeout(0);
+
+        sc.init(null, trustAllCerts, null);
+
+        HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+     }
+
+    private static class TrustAllTrustManager implements TrustManager, X509TrustManager {
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] certs, String authType) throws CertificateException {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] certs, String authType) throws CertificateException {
+        }
+    }
+}

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2367,6 +2367,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         vm.getDevices().addDevice(getVifDriver(nic.getType(), nic.getName()).plug(nic, vm.getPlatformEmulator(), nicAdapter));
     }
 
+    public boolean cleanupDisk(Map<String, String> volumeToDisconnect) {
+        return _storagePoolMgr.disconnectPhysicalDisk(volumeToDisconnect);
+    }
+
     public boolean cleanupDisk(final DiskDef disk) {
         final String path = disk.getDiskPath();
 

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteStoragePoolCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtDeleteStoragePoolCommandWrapper.java
@@ -30,13 +30,17 @@ import com.cloud.utils.exception.CloudRuntimeException;
 
 @ResourceWrapper(handles =  DeleteStoragePoolCommand.class)
 public final class LibvirtDeleteStoragePoolCommandWrapper extends CommandWrapper<DeleteStoragePoolCommand, Answer, LibvirtComputingResource> {
-
     @Override
     public Answer execute(final DeleteStoragePoolCommand command, final LibvirtComputingResource libvirtComputingResource) {
         try {
-            final StorageFilerTO pool = command.getPool();
-            final KVMStoragePoolManager storagePoolMgr = libvirtComputingResource.getStoragePoolMgr();
-            storagePoolMgr.deleteStoragePool(pool.getType(), pool.getUuid());
+            // if getRemoveDatastore() is true, then we are dealing with managed storage and can skip the delete logic here
+            if (!command.getRemoveDatastore()) {
+                final StorageFilerTO pool = command.getPool();
+                final KVMStoragePoolManager storagePoolMgr = libvirtComputingResource.getStoragePoolMgr();
+
+                storagePoolMgr.deleteStoragePool(pool.getType(), pool.getUuid());
+            }
+
             return new Answer(command);
         } catch (final CloudRuntimeException e) {
             return new Answer(command, false, e.toString());

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -19,7 +19,12 @@
 
 package com.cloud.hypervisor.kvm.resource.wrapper;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -28,11 +33,30 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
+
 import org.libvirt.Connect;
 import org.libvirt.Domain;
 import org.libvirt.DomainInfo.DomainState;
 import org.libvirt.LibvirtException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.MigrateAnswer;
@@ -45,6 +69,7 @@ import com.cloud.hypervisor.kvm.resource.VifDriver;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
 import com.cloud.utils.Ternary;
+import com.cloud.utils.exception.CloudRuntimeException;
 
 @ResourceWrapper(handles =  MigrateCommand.class)
 public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCommand, Answer, LibvirtComputingResource> {
@@ -61,7 +86,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
         String result = null;
 
         List<InterfaceDef> ifaces = null;
-        List<DiskDef> disks = null;
+        List<DiskDef> disks;
 
         Domain dm = null;
         Connect dconn = null;
@@ -69,6 +94,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
         Connect conn = null;
         String xmlDesc = null;
         List<Ternary<String, Boolean, String>> vmsnapshots = null;
+
         try {
             final LibvirtUtilitiesHelper libvirtUtilitiesHelper = libvirtComputingResource.getLibvirtUtilitiesHelper();
 
@@ -79,7 +105,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             /*
                 We replace the private IP address with the address of the destination host.
                 This is because the VNC listens on the private IP address of the hypervisor,
-                but that address is ofcourse different on the target host.
+                but that address is of course different on the target host.
 
                 MigrateCommand.getDestinationIp() returns the private IP address of the target
                 hypervisor. So it's safe to use.
@@ -104,12 +130,17 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             // delete the metadata of vm snapshots before migration
             vmsnapshots = libvirtComputingResource.cleanVMSnapshotMetadata(dm);
 
+            if (command.isMigrateStorage()) {
+                xmlDesc = replaceStorage(xmlDesc, command.getMigrateStorage());
+            }
+
             dconn = libvirtUtilitiesHelper.retrieveQemuConnection("qemu+tcp://" + command.getDestinationIp() + "/system");
 
             //run migration in thread so we can monitor it
             s_logger.info("Live migration of instance " + vmName + " initiated");
             final ExecutorService executor = Executors.newFixedThreadPool(1);
-            final Callable<Domain> worker = new MigrateKVMAsync(libvirtComputingResource, dm, dconn, xmlDesc, vmName, command.getDestinationIp());
+            final Callable<Domain> worker = new MigrateKVMAsync(libvirtComputingResource, dm, dconn, xmlDesc, command.isMigrateStorage(),
+                    command.isAutoConvergence(), vmName, command.getDestinationIp());
             final Future<Domain> migrateThread = executor.submit(worker);
             executor.shutdown();
             long sleeptime = 0;
@@ -166,6 +197,21 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             result = e.getMessage();
         } catch (final TimeoutException e) {
             s_logger.debug("Timed out while migrating domain: " + e.getMessage());
+            result = e.getMessage();
+        } catch (final IOException e) {
+            s_logger.debug("IOException: " + e.getMessage());
+            result = e.getMessage();
+        } catch (final ParserConfigurationException e) {
+            s_logger.debug("ParserConfigurationException: " + e.getMessage());
+            result = e.getMessage();
+        } catch (final SAXException e) {
+            s_logger.debug("SAXException: " + e.getMessage());
+            result = e.getMessage();
+        } catch (final TransformerConfigurationException e) {
+            s_logger.debug("TransformerConfigurationException: " + e.getMessage());
+            result = e.getMessage();
+        } catch (final TransformerException e) {
+            s_logger.debug("TransformerException: " + e.getMessage());
             result = e.getMessage();
         } finally {
             try {
@@ -229,5 +275,139 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             }
         }
         return xmlDesc;
+    }
+
+    // Pass in a list of the disks to update in the XML (xmlDesc). Each disk passed in needs to have a serial number. If any disk's serial number in the
+    // list does not match a disk in the XML, an exception should be thrown.
+    // In addition to the serial number, each disk in the list needs the following info:
+    //   * The value of the 'type' of the disk (ex. file, block)
+    //   * The value of the 'type' of the driver of the disk (ex. qcow2, raw)
+    //   * The source of the disk needs an attribute that is either 'file' or 'dev' as well as its corresponding value.
+    private String replaceStorage(String xmlDesc, Map<String, MigrateCommand.MigrateDiskInfo> migrateStorage)
+            throws IOException, ParserConfigurationException, SAXException, TransformerException {
+        InputStream in = IOUtils.toInputStream(xmlDesc);
+
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        Document doc = docBuilder.parse(in);
+
+        // Get the root element
+        Node domainNode = doc.getFirstChild();
+
+        NodeList domainChildNodes = domainNode.getChildNodes();
+
+        for (int i = 0; i < domainChildNodes.getLength(); i++) {
+            Node domainChildNode = domainChildNodes.item(i);
+
+            if ("devices".equals(domainChildNode.getNodeName())) {
+                NodeList devicesChildNodes = domainChildNode.getChildNodes();
+
+                for (int x = 0; x < devicesChildNodes.getLength(); x++) {
+                    Node deviceChildNode = devicesChildNodes.item(x);
+
+                    if ("disk".equals(deviceChildNode.getNodeName())) {
+                        Node diskNode = deviceChildNode;
+
+                        String sourceFileDevText = getSourceFileDevText(diskNode);
+
+                        String path = getPathFromSourceFileDevText(migrateStorage.keySet(), sourceFileDevText);
+
+                        if (path != null) {
+                            MigrateCommand.MigrateDiskInfo migrateDiskInfo = migrateStorage.remove(path);
+
+                            NamedNodeMap diskNodeAttributes = diskNode.getAttributes();
+                            Node diskNodeAttribute = diskNodeAttributes.getNamedItem("type");
+
+                            diskNodeAttribute.setTextContent(migrateDiskInfo.getDiskType().toString());
+
+                            NodeList diskChildNodes = diskNode.getChildNodes();
+
+                            for (int z = 0; z < diskChildNodes.getLength(); z++) {
+                                Node diskChildNode = diskChildNodes.item(z);
+
+                                if ("driver".equals(diskChildNode.getNodeName())) {
+                                    Node driverNode = diskChildNode;
+
+                                    NamedNodeMap driverNodeAttributes = driverNode.getAttributes();
+                                    Node driverNodeAttribute = driverNodeAttributes.getNamedItem("type");
+
+                                    driverNodeAttribute.setTextContent(migrateDiskInfo.getDriverType().toString());
+                                } else if ("source".equals(diskChildNode.getNodeName())) {
+                                    diskNode.removeChild(diskChildNode);
+
+                                    Element newChildSourceNode = doc.createElement("source");
+
+                                    newChildSourceNode.setAttribute(migrateDiskInfo.getSource().toString(), migrateDiskInfo.getSourceText());
+
+                                    diskNode.appendChild(newChildSourceNode);
+                                } else if ("auth".equals(diskChildNode.getNodeName())) {
+                                    diskNode.removeChild(diskChildNode);
+                                } else if ("iotune".equals(diskChildNode.getNodeName())) {
+                                    diskNode.removeChild(diskChildNode);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!migrateStorage.isEmpty()) {
+            throw new CloudRuntimeException("Disk info was passed into LibvirtMigrateCommandWrapper.replaceStorage that was not used.");
+        }
+
+        return getXml(doc);
+    }
+
+    private String getPathFromSourceFileDevText(Set<String> paths, String sourceFileDevText) {
+        if (paths != null && sourceFileDevText != null) {
+            for (String path : paths) {
+                if (sourceFileDevText.contains(path)) {
+                    return path;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private String getSourceFileDevText(Node diskNode) {
+        NodeList diskChildNodes = diskNode.getChildNodes();
+
+        for (int i = 0; i < diskChildNodes.getLength(); i++) {
+            Node diskChildNode = diskChildNodes.item(i);
+
+            if ("source".equals(diskChildNode.getNodeName())) {
+                NamedNodeMap diskNodeAttributes = diskChildNode.getAttributes();
+
+                Node diskNodeAttribute = diskNodeAttributes.getNamedItem("file");
+
+                if (diskNodeAttribute != null) {
+                    return diskNodeAttribute.getTextContent();
+                }
+
+                diskNodeAttribute = diskNodeAttributes.getNamedItem("dev");
+
+                if (diskNodeAttribute != null) {
+                    return diskNodeAttribute.getTextContent();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private String getXml(Document doc) throws TransformerException {
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+
+        DOMSource source = new DOMSource(doc);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        StreamResult result = new StreamResult(byteArrayOutputStream);
+
+        transformer.transform(source, result);
+
+        return byteArrayOutputStream.toString();
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateVolumeCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateVolumeCommandWrapper.java
@@ -1,0 +1,95 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.storage.MigrateVolumeAnswer;
+import com.cloud.agent.api.storage.MigrateVolumeCommand;
+import com.cloud.agent.api.to.DiskTO;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.hypervisor.kvm.storage.KVMPhysicalDisk;
+import com.cloud.hypervisor.kvm.storage.KVMStoragePool;
+import com.cloud.hypervisor.kvm.storage.KVMStoragePoolManager;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
+import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.apache.log4j.Logger;
+
+@ResourceWrapper(handles =  MigrateVolumeCommand.class)
+public final class LibvirtMigrateVolumeCommandWrapper extends CommandWrapper<MigrateVolumeCommand, Answer, LibvirtComputingResource> {
+    private static final Logger LOGGER = Logger.getLogger(LibvirtMigrateVolumeCommandWrapper.class);
+
+    @Override
+    public Answer execute(final MigrateVolumeCommand command, final LibvirtComputingResource libvirtComputingResource) {
+        KVMStoragePoolManager storagePoolManager = libvirtComputingResource.getStoragePoolMgr();
+
+        VolumeObjectTO srcVolumeObjectTO = (VolumeObjectTO)command.getSrcData();
+        PrimaryDataStoreTO srcPrimaryDataStore = (PrimaryDataStoreTO)srcVolumeObjectTO.getDataStore();
+
+        Map<String, String> srcDetails = command.getSrcDetails();
+
+        String srcPath = srcDetails != null ? srcDetails.get(DiskTO.IQN) : srcVolumeObjectTO.getPath();
+
+        VolumeObjectTO destVolumeObjectTO = (VolumeObjectTO)command.getDestData();
+        PrimaryDataStoreTO destPrimaryDataStore = (PrimaryDataStoreTO)destVolumeObjectTO.getDataStore();
+
+        Map<String, String> destDetails = command.getDestDetails();
+
+        String destPath = destDetails != null && destDetails.get(DiskTO.IQN) != null ? destDetails.get(DiskTO.IQN) :
+                (destVolumeObjectTO.getPath() != null ? destVolumeObjectTO.getPath() : UUID.randomUUID().toString());
+
+        try {
+            storagePoolManager.connectPhysicalDisk(srcPrimaryDataStore.getPoolType(), srcPrimaryDataStore.getUuid(), srcPath, srcDetails);
+
+            KVMPhysicalDisk srcPhysicalDisk = storagePoolManager.getPhysicalDisk(srcPrimaryDataStore.getPoolType(), srcPrimaryDataStore.getUuid(), srcPath);
+
+            KVMStoragePool destPrimaryStorage = storagePoolManager.getStoragePool(destPrimaryDataStore.getPoolType(), destPrimaryDataStore.getUuid());
+
+            storagePoolManager.connectPhysicalDisk(destPrimaryDataStore.getPoolType(), destPrimaryDataStore.getUuid(), destPath, destDetails);
+
+            storagePoolManager.copyPhysicalDisk(srcPhysicalDisk, destPath, destPrimaryStorage, command.getWaitInMillSeconds());
+        }
+        catch (Exception ex) {
+            return new MigrateVolumeAnswer(command, false, ex.getMessage(), null);
+        }
+        finally {
+            try {
+                storagePoolManager.disconnectPhysicalDisk(destPrimaryDataStore.getPoolType(), destPrimaryDataStore.getUuid(), destPath);
+            }
+            catch (Exception e) {
+                LOGGER.warn("Unable to disconnect from the destination device.", e);
+            }
+
+            try {
+                storagePoolManager.disconnectPhysicalDisk(srcPrimaryDataStore.getPoolType(), srcPrimaryDataStore.getUuid(), srcPath);
+            }
+            catch (Exception e) {
+                LOGGER.warn("Unable to disconnect from the source device.", e);
+            }
+        }
+
+        return new MigrateVolumeAnswer(command, true, null, destPath);
+    }
+}

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtModifyTargetsCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtModifyTargetsCommandWrapper.java
@@ -1,0 +1,80 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ModifyTargetsAnswer;
+import com.cloud.agent.api.ModifyTargetsCommand;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.hypervisor.kvm.storage.KVMPhysicalDisk;
+import com.cloud.hypervisor.kvm.storage.KVMStoragePoolManager;
+import com.cloud.storage.Storage.StoragePoolType;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+import com.cloud.utils.exception.CloudRuntimeException;
+
+@ResourceWrapper(handles =  ModifyTargetsCommand.class)
+public final class LibvirtModifyTargetsCommandWrapper extends CommandWrapper<ModifyTargetsCommand, Answer, LibvirtComputingResource> {
+    private static final Logger s_logger = Logger.getLogger(LibvirtMigrateCommandWrapper.class);
+
+    @Override
+    public Answer execute(final ModifyTargetsCommand command, final LibvirtComputingResource libvirtComputingResource) {
+        KVMStoragePoolManager storagePoolMgr = libvirtComputingResource.getStoragePoolMgr();
+
+        List<Map<String, String>> targets = command.getTargets();
+
+        // When attempting to connect to one or more targets, place the successfully connected path into this List.
+        List<String> connectedPaths = new ArrayList<>(targets.size());
+
+        for (Map<String, String> target : targets) {
+            StoragePoolType storagePoolType = StoragePoolType.valueOf(target.get(ModifyTargetsCommand.STORAGE_TYPE));
+            String storageUuid = target.get(ModifyTargetsCommand.STORAGE_UUID);
+            String path = target.get(ModifyTargetsCommand.IQN);
+
+            if (command.getAdd()) {
+                if (storagePoolMgr.connectPhysicalDisk(storagePoolType, storageUuid, path, target)) {
+                    KVMPhysicalDisk kvmPhysicalDisk = storagePoolMgr.getPhysicalDisk(storagePoolType, storageUuid, path);
+
+                    connectedPaths.add(kvmPhysicalDisk.getPath());
+                }
+                else {
+                    throw new CloudRuntimeException("Unable to connect to the following target: " + path);
+                }
+            }
+            else {
+                if (!storagePoolMgr.disconnectPhysicalDisk(storagePoolType, storageUuid, path)) {
+                    throw new CloudRuntimeException("Unable to disconnect from the following target: " + path);
+                }
+            }
+        }
+
+        ModifyTargetsAnswer modifyTargetsAnswer =  new ModifyTargetsAnswer();
+
+        modifyTargetsAnswer.setConnectedPaths(connectedPaths);
+
+        return modifyTargetsAnswer;
+    }
+}

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
@@ -20,12 +20,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.cloud.storage.Storage;
+import org.apache.cloudstack.utils.qemu.QemuImg;
+import org.apache.cloudstack.utils.qemu.QemuImgException;
+import org.apache.cloudstack.utils.qemu.QemuImgFile;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.utils.qemu.QemuImg.PhysicalDiskFormat;
 
 import com.cloud.agent.api.to.DiskTO;
+import com.cloud.storage.Storage;
 import com.cloud.storage.Storage.ProvisioningType;
 import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.utils.StringUtils;
@@ -37,7 +40,7 @@ import com.cloud.utils.script.Script;
 public class IscsiAdmStorageAdaptor implements StorageAdaptor {
     private static final Logger s_logger = Logger.getLogger(IscsiAdmStorageAdaptor.class);
 
-    private static final Map<String, KVMStoragePool> MapStorageUuidToStoragePool = new HashMap<String, KVMStoragePool>();
+    private static final Map<String, KVMStoragePool> MapStorageUuidToStoragePool = new HashMap<>();
 
     @Override
     public KVMStoragePool createStoragePool(String uuid, String host, int port, String path, String userInfo, StoragePoolType storagePoolType) {
@@ -115,7 +118,7 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
             }
         }
 
-        // ex. sudo iscsiadm -m node -T iqn.2012-03.com.test:volume1 -p 192.168.233.10 --login
+        // ex. sudo iscsiadm -m node -T iqn.2012-03.com.test:volume1 -p 192.168.233.10:3260 --login
         iScsiAdmCmd = new Script(true, "iscsiadm", 0, s_logger);
 
         iScsiAdmCmd.add("-m", "node");
@@ -165,6 +168,23 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
         }
     }
 
+    private void waitForDiskToBecomeUnavailable(String host, int port, String iqn, String lun) {
+        int numberOfTries = 10;
+        int timeBetweenTries = 1000;
+
+        String deviceByPath = getByPath(host, port, "/" + iqn + "/" + lun);
+
+        while (getDeviceSize(deviceByPath) > 0 && numberOfTries > 0) {
+            numberOfTries--;
+
+            try {
+                Thread.sleep(timeBetweenTries);
+            } catch (Exception ex) {
+                // don't do anything
+            }
+        }
+    }
+
     private void executeChapCommand(String path, KVMStoragePool pool, String nParameter, String vParameter, String detail) throws Exception {
         Script iScsiAdmCmd = new Script(true, "iscsiadm", 0, s_logger);
 
@@ -193,13 +213,13 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
     }
 
     // example by-path: /dev/disk/by-path/ip-192.168.233.10:3260-iscsi-iqn.2012-03.com.solidfire:storagepool2-lun-0
-    private String getByPath(String host, String path) {
-        return "/dev/disk/by-path/ip-" + host + "-iscsi-" + getIqn(path) + "-lun-" + getLun(path);
+    private static String getByPath(String host, int port, String path) {
+        return "/dev/disk/by-path/ip-" + host + ":" + port + "-iscsi-" + getIqn(path) + "-lun-" + getLun(path);
     }
 
     @Override
     public KVMPhysicalDisk getPhysicalDisk(String volumeUuid, KVMStoragePool pool) {
-        String deviceByPath = getByPath(pool.getSourceHost() + ":" + pool.getSourcePort(), volumeUuid);
+        String deviceByPath = getByPath(pool.getSourceHost(), pool.getSourcePort(), volumeUuid);
         KVMPhysicalDisk physicalDisk = new KVMPhysicalDisk(deviceByPath, volumeUuid, pool);
 
         physicalDisk.setFormat(PhysicalDiskFormat.RAW);
@@ -225,6 +245,9 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
             s_logger.warn("Unable to retrieve the size of device " + deviceByPath);
 
             return 0;
+        }
+        else {
+            s_logger.info("Successfully retrieved the size of device " + deviceByPath);
         }
 
         return Long.parseLong(parser.getLine());
@@ -252,10 +275,10 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
         return tmp[index].trim();
     }
 
-    public boolean disconnectPhysicalDisk(String host, int port, String iqn, String lun) {
+    private boolean disconnectPhysicalDisk(String host, int port, String iqn, String lun) {
         // use iscsiadm to log out of the iSCSI target and un-discover it
 
-        // ex. sudo iscsiadm -m node -T iqn.2012-03.com.test:volume1 -p 192.168.233.10 --logout
+        // ex. sudo iscsiadm -m node -T iqn.2012-03.com.test:volume1 -p 192.168.233.10:3260 --logout
         Script iScsiAdmCmd = new Script(true, "iscsiadm", 0, s_logger);
 
         iScsiAdmCmd.add("-m", "node");
@@ -295,6 +318,8 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
             System.out.println("Removed iSCSI target /" + iqn + "/" + lun);
         }
 
+        waitForDiskToBecomeUnavailable(host, port, iqn, lun);
+
         return true;
     }
 
@@ -304,13 +329,26 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
     }
 
     @Override
+    public boolean disconnectPhysicalDisk(Map<String, String> volumeToDisconnect) {
+        String host = volumeToDisconnect.get(DiskTO.STORAGE_HOST);
+        String port = volumeToDisconnect.get(DiskTO.STORAGE_PORT);
+        String path = volumeToDisconnect.get(DiskTO.IQN);
+
+        if (host != null && port != null && path != null) {
+            return disconnectPhysicalDisk(host, Integer.parseInt(port), getIqn(path), getLun(path));
+        }
+
+        return false;
+    }
+
+    @Override
     public boolean disconnectPhysicalDiskByPath(String localPath) {
         String search1 = "/dev/disk/by-path/ip-";
         String search2 = ":";
         String search3 = "-iscsi-";
         String search4 = "-lun-";
 
-        if (localPath.indexOf(search3) == -1) {
+        if (!localPath.contains(search3)) {
             // this volume doesn't below to this adaptor, so just return true
             return true;
         }
@@ -356,8 +394,37 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
     }
 
     @Override
-    public KVMPhysicalDisk copyPhysicalDisk(KVMPhysicalDisk disk, String name, KVMStoragePool destPool, int timeout) {
-        throw new UnsupportedOperationException("Copying a disk is not supported in this configuration.");
+    public KVMPhysicalDisk copyPhysicalDisk(KVMPhysicalDisk srcDisk, String destVolumeUuid, KVMStoragePool destPool, int timeout) {
+        QemuImg q = new QemuImg(timeout);
+
+        QemuImgFile srcFile;
+
+        KVMStoragePool srcPool = srcDisk.getPool();
+
+        if (srcPool.getType() == StoragePoolType.RBD) {
+            srcFile = new QemuImgFile(KVMPhysicalDisk.RBDStringBuilder(srcPool.getSourceHost(), srcPool.getSourcePort(),
+                                                                       srcPool.getAuthUserName(), srcPool.getAuthSecret(),
+                                                                       srcDisk.getPath()),srcDisk.getFormat());
+        } else {
+            srcFile = new QemuImgFile(srcDisk.getPath(), srcDisk.getFormat());
+        }
+
+        KVMPhysicalDisk destDisk = destPool.getPhysicalDisk(destVolumeUuid);
+
+        QemuImgFile destFile = new QemuImgFile(destDisk.getPath(), destDisk.getFormat());
+
+        try {
+            q.convert(srcFile, destFile);
+        } catch (QemuImgException ex) {
+            String msg = "Failed to copy data from " + srcDisk.getPath() + " to " +
+                    destDisk.getPath() + ". The error was the following: " + ex.getMessage();
+
+            s_logger.error(msg);
+
+            throw new CloudRuntimeException(msg);
+        }
+
+        return destPool.getPhysicalDisk(destVolumeUuid);
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
@@ -158,6 +158,18 @@ public class KVMStoragePoolManager {
         return result;
     }
 
+    public boolean disconnectPhysicalDisk(Map<String, String> volumeToDisconnect) {
+        for (Map.Entry<String, StorageAdaptor> set : _storageMapper.entrySet()) {
+            StorageAdaptor adaptor = set.getValue();
+
+            if (adaptor.disconnectPhysicalDisk(volumeToDisconnect)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public boolean disconnectPhysicalDiskByPath(String path) {
         for (Map.Entry<String, StorageAdaptor> set : _storageMapper.entrySet()) {
             StorageAdaptor adaptor = set.getValue();

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -237,8 +237,17 @@ public class KVMStorageProcessor implements StorageProcessor {
                 }
                 primaryVol = storagePoolMgr.copyPhysicalDisk(tmplVol, volume.getUuid(), primaryPool, cmd.getWaitInMillSeconds());
             } else if (destData instanceof TemplateObjectTO) {
-                final TemplateObjectTO destTempl = (TemplateObjectTO)destData;
-                primaryVol = storagePoolMgr.copyPhysicalDisk(tmplVol, destTempl.getUuid(), primaryPool, cmd.getWaitInMillSeconds());
+                TemplateObjectTO destTempl = (TemplateObjectTO)destData;
+
+                Map<String, String> details = primaryStore.getDetails();
+
+                String path = details != null ? details.get("managedStoreTarget") : null;
+
+                storagePoolMgr.connectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), path, details);
+
+                primaryVol = storagePoolMgr.copyPhysicalDisk(tmplVol, path != null ? path : destTempl.getUuid(), primaryPool, cmd.getWaitInMillSeconds());
+
+                storagePoolMgr.disconnectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), path);
             } else {
                 primaryVol = storagePoolMgr.copyPhysicalDisk(tmplVol, UUID.randomUUID().toString(), primaryPool, cmd.getWaitInMillSeconds());
             }
@@ -422,24 +431,41 @@ public class KVMStorageProcessor implements StorageProcessor {
                 }
             }
 
+            Map<String, String> details = cmd.getOptions2();
+
+            String path = details != null ? details.get(DiskTO.IQN) : null;
+
+            storagePoolMgr.connectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), path, details);
+
             final String volumeName = UUID.randomUUID().toString();
 
             final int index = srcVolumePath.lastIndexOf(File.separator);
             final String volumeDir = srcVolumePath.substring(0, index);
             String srcVolumeName = srcVolumePath.substring(index + 1);
+
             secondaryStoragePool = storagePoolMgr.getStoragePoolByURI(secondaryStorageUrl + File.separator + volumeDir);
+
             if (!srcVolumeName.endsWith(".qcow2") && srcFormat == ImageFormat.QCOW2) {
                 srcVolumeName = srcVolumeName + ".qcow2";
             }
+
             final KVMPhysicalDisk volume = secondaryStoragePool.getPhysicalDisk(srcVolumeName);
+
             volume.setFormat(PhysicalDiskFormat.valueOf(srcFormat.toString()));
-            final KVMPhysicalDisk newDisk = storagePoolMgr.copyPhysicalDisk(volume, volumeName, primaryPool, cmd.getWaitInMillSeconds());
+
+            final KVMPhysicalDisk newDisk = storagePoolMgr.copyPhysicalDisk(volume, path != null ? path : volumeName, primaryPool, cmd.getWaitInMillSeconds());
+
+            storagePoolMgr.disconnectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), path);
+
             final VolumeObjectTO newVol = new VolumeObjectTO();
+
             newVol.setFormat(ImageFormat.valueOf(newDisk.getFormat().toString().toUpperCase()));
-            newVol.setPath(volumeName);
+            newVol.setPath(path != null ? path : volumeName);
+
             return new CopyCmdAnswer(newVol);
         } catch (final CloudRuntimeException e) {
-            s_logger.debug("Failed to ccopyVolumeFromImageCacheToPrimary: ", e);
+            s_logger.debug("Failed to copyVolumeFromImageCacheToPrimary: ", e);
+
             return new CopyCmdAnswer(e.toString());
         } finally {
             if (secondaryStoragePool != null) {
@@ -496,6 +522,13 @@ public class KVMStorageProcessor implements StorageProcessor {
 
     @Override
     public Answer createTemplateFromVolume(final CopyCommand cmd) {
+        Map<String, String> details = cmd.getOptions();
+
+        if (details != null && details.get(DiskTO.IQN) != null) {
+            // use the managed-storage approach
+            return createTemplateFromVolumeOrSnapshot(cmd);
+        }
+
         final DataTO srcData = cmd.getSrcTO();
         final DataTO destData = cmd.getDestTO();
         final int wait = cmd.getWaitInMillSeconds();
@@ -510,7 +543,8 @@ public class KVMStorageProcessor implements StorageProcessor {
         final NfsTO nfsImageStore = (NfsTO)imageStore;
 
         KVMStoragePool secondaryStorage = null;
-        KVMStoragePool primary = null;
+        KVMStoragePool primary;
+
         try {
             final String templateFolder = template.getPath();
 
@@ -614,8 +648,139 @@ public class KVMStorageProcessor implements StorageProcessor {
     }
 
     @Override
-    public Answer createTemplateFromSnapshot(final CopyCommand cmd) {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    public Answer createTemplateFromSnapshot(CopyCommand cmd) {
+        Map<String, String> details = cmd.getOptions();
+
+        if (details != null && details.get(DiskTO.IQN) != null) {
+            // use the managed-storage approach
+            return createTemplateFromVolumeOrSnapshot(cmd);
+        }
+
+        return new CopyCmdAnswer("operation not supported");
+    }
+
+    private Answer createTemplateFromVolumeOrSnapshot(CopyCommand cmd) {
+        DataTO srcData = cmd.getSrcTO();
+
+        final boolean isVolume;
+
+        if (srcData instanceof VolumeObjectTO) {
+            isVolume = true;
+        }
+        else if (srcData instanceof SnapshotObjectTO) {
+            isVolume = false;
+        }
+        else {
+            return new CopyCmdAnswer("unsupported object type");
+        }
+
+        PrimaryDataStoreTO primaryStore = (PrimaryDataStoreTO)srcData.getDataStore();
+
+        DataTO destData = cmd.getDestTO();
+        TemplateObjectTO template = (TemplateObjectTO)destData;
+        DataStoreTO imageStore = template.getDataStore();
+
+        if (!(imageStore instanceof NfsTO)) {
+            return new CopyCmdAnswer("unsupported protocol");
+        }
+
+        NfsTO nfsImageStore = (NfsTO)imageStore;
+
+        KVMStoragePool secondaryStorage = null;
+
+        try {
+            Map<String, String> details = cmd.getOptions();
+
+            String path = details != null ? details.get(DiskTO.IQN) : null;
+
+            if (path == null) {
+                new CloudRuntimeException("The 'path' field must be specified.");
+            }
+
+            storagePoolMgr.connectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), path, details);
+
+            KVMPhysicalDisk srcDisk = storagePoolMgr.getPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), path);
+
+            secondaryStorage = storagePoolMgr.getStoragePoolByURI(nfsImageStore.getUrl());
+
+            String templateFolder = template.getPath();
+            String tmpltPath = secondaryStorage.getLocalPath() + File.separator + templateFolder;
+
+            storageLayer.mkdirs(tmpltPath);
+
+            String templateName = UUID.randomUUID().toString();
+
+            s_logger.debug("Converting " + srcDisk.getFormat().toString() + " disk " + srcDisk.getPath() + " into template " + templateName);
+
+            String destName = templateFolder + "/" + templateName + ".qcow2";
+
+            storagePoolMgr.copyPhysicalDisk(srcDisk, destName, secondaryStorage, cmd.getWaitInMillSeconds());
+
+            File templateProp = new File(tmpltPath + "/template.properties");
+
+            if (!templateProp.exists()) {
+                templateProp.createNewFile();
+            }
+
+            String templateContent = "filename=" + templateName + ".qcow2" + System.getProperty("line.separator");
+
+            DateFormat dateFormat = new SimpleDateFormat("MM_dd_yyyy");
+            Date date = new Date();
+
+            if (isVolume) {
+                templateContent += "volume.name=" + dateFormat.format(date) + System.getProperty("line.separator");
+            }
+            else {
+                templateContent += "snapshot.name=" + dateFormat.format(date) + System.getProperty("line.separator");
+            }
+
+            FileOutputStream templFo = new FileOutputStream(templateProp);
+
+            templFo.write(templateContent.getBytes());
+            templFo.flush();
+            templFo.close();
+
+            Map<String, Object> params = new HashMap<>();
+
+            params.put(StorageLayer.InstanceConfigKey, storageLayer);
+
+            Processor qcow2Processor = new QCOW2Processor();
+
+            qcow2Processor.configure("QCOW2 Processor", params);
+
+            FormatInfo info = qcow2Processor.process(tmpltPath, null, templateName);
+
+            TemplateLocation loc = new TemplateLocation(storageLayer, tmpltPath);
+
+            loc.create(1, true, templateName);
+            loc.addFormat(info);
+            loc.save();
+
+            storagePoolMgr.disconnectPhysicalDisk(primaryStore.getPoolType(), primaryStore.getUuid(), path);
+
+            TemplateObjectTO newTemplate = new TemplateObjectTO();
+
+            newTemplate.setPath(templateFolder + File.separator + templateName + ".qcow2");
+            newTemplate.setSize(info.virtualSize);
+            newTemplate.setPhysicalSize(info.size);
+            newTemplate.setFormat(ImageFormat.QCOW2);
+            newTemplate.setName(templateName);
+
+            return new CopyCmdAnswer(newTemplate);
+        } catch (Exception ex) {
+            if (isVolume) {
+                s_logger.debug("Failed to create template from volume: ", ex);
+            }
+            else {
+                s_logger.debug("Failed to create template from snapshot: ", ex);
+            }
+
+            return new CopyCmdAnswer(ex.toString());
+        } finally {
+            if (secondaryStorage != null) {
+                secondaryStorage.delete();
+            }
+        }
     }
 
     protected String copyToS3(final File srcFile, final S3TO destStore, final String destPath) throws InterruptedException {
@@ -1327,7 +1492,17 @@ public class KVMStorageProcessor implements StorageProcessor {
             final String primaryUuid = pool.getUuid();
             final KVMStoragePool primaryPool = storagePoolMgr.getStoragePool(pool.getPoolType(), primaryUuid);
             final String volUuid = UUID.randomUUID().toString();
-            final KVMPhysicalDisk disk = storagePoolMgr.copyPhysicalDisk(snapshotDisk, volUuid, primaryPool, cmd.getWaitInMillSeconds());
+
+            Map<String, String> details = cmd.getOptions2();
+
+            String path = details != null ? details.get(DiskTO.IQN) : null;
+
+            storagePoolMgr.connectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path, details);
+
+            KVMPhysicalDisk disk = storagePoolMgr.copyPhysicalDisk(snapshotDisk, path != null ? path : volUuid, primaryPool, cmd.getWaitInMillSeconds());
+
+            storagePoolMgr.disconnectPhysicalDisk(pool.getPoolType(), pool.getUuid(), path);
+
             final VolumeObjectTO newVol = new VolumeObjectTO();
             newVol.setPath(disk.getName());
             newVol.setSize(disk.getVirtualSize());

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -761,6 +761,12 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
     }
 
     @Override
+    public boolean disconnectPhysicalDisk(Map<String, String> volumeToDisconnect) {
+        // this is for managed storage that needs to cleanup disks after use
+        return false;
+    }
+
+    @Override
     public boolean disconnectPhysicalDiskByPath(String localPath) {
         // we've only ever cleaned up ISOs that are NFS mounted
         String poolUuid = null;

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/ManagedNfsStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/ManagedNfsStorageAdaptor.java
@@ -261,6 +261,11 @@ public class ManagedNfsStorageAdaptor implements StorageAdaptor {
     }
 
     @Override
+    public boolean disconnectPhysicalDisk(Map<String, String> volumeToDisconnect) {
+        return false;
+    }
+
+    @Override
     public boolean disconnectPhysicalDiskByPath(String localPath) {
         return false;
     }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/StorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/StorageAdaptor.java
@@ -48,6 +48,8 @@ public interface StorageAdaptor {
     // given disk path (per database) and pool, clean up disk on host
     public boolean disconnectPhysicalDisk(String volumePath, KVMStoragePool pool);
 
+    public boolean disconnectPhysicalDisk(Map<String, String> volumeToDisconnect);
+
     // given local path to file/device (per Libvirt XML), 1) check that device is
     // handled by your adaptor, return false if not. 2) clean up device, return true
     public boolean disconnectPhysicalDiskByPath(String localPath);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -2459,12 +2459,12 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         return sr;
     }
 
-    private String resignatureIscsiSr(Connection conn, Host host, Map<String, String> deviceConfig, String srNameLabel, Map<String, String> smConfig) throws XmlRpcException, XenAPIException {
-
+    private String resignatureIscsiSr(Connection conn, Host host, Map<String, String> deviceConfig, String srNameLabel, Map<String, String> smConfig)
+            throws XmlRpcException, XenAPIException {
         String pooluuid;
+
         try {
-            SR.create(conn, host, deviceConfig, new Long(0), srNameLabel, srNameLabel, SRType.RELVMOISCSI.toString(),
-                        "user", true, smConfig);
+            SR.create(conn, host, deviceConfig, new Long(0), srNameLabel, srNameLabel, SRType.RELVMOISCSI.toString(), "user", true, smConfig);
 
             // The successful outcome of SR.create (right above) is to throw an exception of type XenAPIException (with expected
             // toString() text) after resigning the metadata (we indicated to perform a resign by passing in SRType.RELVMOISCSI.toString()).
@@ -2492,6 +2492,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
                 throw new CloudRuntimeException("Non-existent or invalid SR UUID");
             }
         }
+
         return pooluuid;
     }
 

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServerStorageProcessor.java
@@ -298,7 +298,7 @@ public class XenServerStorageProcessor implements StorageProcessor {
                 return new AttachAnswer(disk);
             }
 
-            VDI vdi = null;
+            VDI vdi;
 
             if (isManaged) {
                 vdi = hypervisorResource.prepareManagedStorage(conn, details, data.getPath(), vdiNameLabel);
@@ -320,10 +320,13 @@ public class XenServerStorageProcessor implements StorageProcessor {
             vbdr.VDI = vdi;
             vbdr.bootable = false;
             vbdr.userdevice = "autodetect";
+
             final Long deviceId = disk.getDiskSeq();
+
             if (deviceId != null && !hypervisorResource.isDeviceUsed(conn, vm, deviceId)) {
                 vbdr.userdevice = deviceId.toString();
             }
+
             vbdr.mode = Types.VbdMode.RW;
             vbdr.type = Types.VbdType.DISK;
             vbdr.unpluggable = true;
@@ -337,6 +340,7 @@ public class XenServerStorageProcessor implements StorageProcessor {
                 vbd.destroy(conn);
                 throw e;
             }
+
             // Update the VDI's label to include the VM name
             vdi.setNameLabel(conn, vdiNameLabel);
 
@@ -345,7 +349,9 @@ public class XenServerStorageProcessor implements StorageProcessor {
             return new AttachAnswer(newDisk);
         } catch (final Exception e) {
             final String msg = "Failed to attach volume for uuid: " + data.getPath() + " due to "  + e.toString();
+
             s_logger.warn(msg, e);
+
             return new AttachAnswer(msg);
         }
     }

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625StorageProcessor.java
@@ -1079,7 +1079,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
         }
     }
 
-    public Answer createTemplateFromSnapshot2(final CopyCommand cmd) {
+    private Answer createTemplateFromSnapshot2(final CopyCommand cmd) {
         final Connection conn = hypervisorResource.getConnection();
 
         final SnapshotObjectTO snapshotObjTO = (SnapshotObjectTO) cmd.getSrcTO();
@@ -1089,13 +1089,11 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             return null;
         }
 
-        NfsTO destStore = null;
-        PrimaryDataStoreTO srcStore = null;
-        URI destUri = null;
+        NfsTO destStore;
+        URI destUri;
 
         try {
-            srcStore = (PrimaryDataStoreTO) snapshotObjTO.getDataStore();
-            destStore = (NfsTO) templateObjTO.getDataStore();
+            destStore = (NfsTO)templateObjTO.getDataStore();
             destUri = new URI(destStore.getUrl());
         } catch (final Exception ex) {
             s_logger.debug("Invalid URI", ex);
@@ -1118,7 +1116,7 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             final String storageHost = srcDetails.get(DiskTO.STORAGE_HOST);
             final String chapInitiatorUsername = srcDetails.get(DiskTO.CHAP_INITIATOR_USERNAME);
             final String chapInitiatorSecret = srcDetails.get(DiskTO.CHAP_INITIATOR_SECRET);
-            String srType = null;
+            String srType;
 
             srType = CitrixResourceBase.SRType.LVMOISCSI.toString();
 
@@ -1173,13 +1171,6 @@ public class Xenserver625StorageProcessor extends XenServerStorageProcessor {
             result = true;
 
             return new CopyCmdAnswer(newTemplate);
-            // } catch (Exception ex) {
-            // s_logger.error("Failed to create a template from a snapshot",
-            // ex);
-            //
-            // return new
-            // CopyCmdAnswer("Failed to create a template from a snapshot: " +
-            // ex.toString());
         } catch (final BadServerResponse e) {
             s_logger.error("Failed to create a template from a snapshot due to incomprehensible server response", e);
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -188,6 +188,17 @@
       </modules>
     </profile>
     <profile>
+      <id>vmware-sioc</id>
+      <activation>
+        <property>
+          <name>noredist</name>
+        </property>
+      </activation>
+      <modules>
+        <module>api/vmware-sioc</module>
+      </modules>
+    </profile>
+    <profile>
       <id>mysqlha</id>
       <activation>
         <property>

--- a/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/lifecycle/SolidFirePrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/solidfire/src/org/apache/cloudstack/storage/datastore/lifecycle/SolidFirePrimaryDataStoreLifeCycle.java
@@ -30,6 +30,7 @@ import org.apache.log4j.Logger;
 import org.apache.cloudstack.engine.subsystem.api.storage.ClusterScope;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.HostScope;
+import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreInfo;
 import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreLifeCycle;
 import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStoreParameters;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
@@ -41,7 +42,10 @@ import org.apache.cloudstack.storage.volume.datastore.PrimaryDataStoreHelper;
 
 import com.cloud.agent.api.StoragePoolInfo;
 import com.cloud.capacity.CapacityManager;
+import com.cloud.dc.ClusterVO;
+import com.cloud.dc.dao.ClusterDao;
 import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.resource.ResourceManager;
@@ -57,10 +61,13 @@ import com.cloud.storage.StoragePoolAutomation;
 import com.cloud.storage.VMTemplateStoragePoolVO;
 import com.cloud.utils.exception.CloudRuntimeException;
 
+import com.google.common.base.Preconditions;
+
 public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeCycle {
     private static final Logger s_logger = Logger.getLogger(SolidFirePrimaryDataStoreLifeCycle.class);
 
     @Inject private CapacityManager _capacityMgr;
+    @Inject private ClusterDao _clusterDao;
     @Inject private DataCenterDao _zoneDao;
     @Inject private PrimaryDataStoreDao _storagePoolDao;
     @Inject private PrimaryDataStoreHelper _dataStoreHelper;
@@ -77,6 +84,8 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
     public DataStore initialize(Map<String, Object> dsInfos) {
         String url = (String)dsInfos.get("url");
         Long zoneId = (Long)dsInfos.get("zoneId");
+        Long podId = (Long)dsInfos.get("podId");
+        Long clusterId = (Long)dsInfos.get("clusterId");
         String storagePoolName = (String)dsInfos.get("name");
         String providerName = (String)dsInfos.get("providerName");
         Long capacityBytes = (Long)dsInfos.get("capacityBytes");
@@ -84,6 +93,14 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
         String tags = (String)dsInfos.get("tags");
         @SuppressWarnings("unchecked")
         Map<String, String> details = (Map<String, String>)dsInfos.get("details");
+
+        if (podId != null && clusterId == null) {
+            throw new CloudRuntimeException("If the Pod ID is specified, the Cluster ID must also be specified.");
+        }
+
+        if (podId == null && clusterId != null) {
+            throw new CloudRuntimeException("If the Pod ID is not specified, the Cluster ID must also not be specified.");
+        }
 
         String storageVip = SolidFireUtil.getStorageVip(url);
         int storagePort = SolidFireUtil.getStoragePort(url);
@@ -104,13 +121,26 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
         parameters.setType(StoragePoolType.Iscsi);
         parameters.setUuid(UUID.randomUUID().toString());
         parameters.setZoneId(zoneId);
+        parameters.setPodId(podId);
+        parameters.setClusterId(clusterId);
         parameters.setName(storagePoolName);
         parameters.setProviderName(providerName);
         parameters.setManaged(true);
         parameters.setCapacityBytes(capacityBytes);
         parameters.setUsedBytes(0);
         parameters.setCapacityIops(capacityIops);
-        parameters.setHypervisorType(HypervisorType.Any);
+
+        if (clusterId != null) {
+            ClusterVO clusterVO = _clusterDao.findById(clusterId);
+
+            Preconditions.checkNotNull(clusterVO, "Unable to locate the specified cluster");
+
+            parameters.setHypervisorType(clusterVO.getHypervisorType());
+        }
+        else {
+            parameters.setHypervisorType(HypervisorType.Any);
+        }
+
         parameters.setTags(tags);
         parameters.setDetails(details);
 
@@ -166,9 +196,24 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
                           ". Exception: " + ex);
         }
 
+        if (lClusterDefaultMinIops < SolidFireUtil.MIN_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MIN_IOPS + "' must be greater than or equal to " +
+                SolidFireUtil.MIN_IOPS_PER_VOLUME + ".");
+        }
+
+        if (lClusterDefaultMinIops > SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MIN_IOPS + "' must be less than or equal to " +
+                SolidFireUtil.MAX_MIN_IOPS_PER_VOLUME + ".");
+        }
+
         if (lClusterDefaultMinIops > lClusterDefaultMaxIops) {
             throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MIN_IOPS + "' must be less than or equal to the parameter '" +
                 SolidFireUtil.CLUSTER_DEFAULT_MAX_IOPS + "'.");
+        }
+
+        if (lClusterDefaultMaxIops > SolidFireUtil.MAX_IOPS_PER_VOLUME) {
+            throw new CloudRuntimeException("The parameter '" + SolidFireUtil.CLUSTER_DEFAULT_MAX_IOPS + "' must be less than or equal to " +
+                SolidFireUtil.MAX_IOPS_PER_VOLUME + ".");
         }
 
         if (Float.compare(fClusterDefaultBurstIopsPercentOfMaxIops, 1.0f) < 0) {
@@ -186,23 +231,35 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
     // do not implement this method for SolidFire's plug-in
     @Override
     public boolean attachHost(DataStore store, HostScope scope, StoragePoolInfo existingInfo) {
-        return true; // should be ignored for zone-wide-only plug-ins like SolidFire's
+        return true;
     }
 
-    // do not implement this method for SolidFire's plug-in
     @Override
-    public boolean attachCluster(DataStore store, ClusterScope scope) {
-        return true; // should be ignored for zone-wide-only plug-ins like SolidFire's
+    public boolean attachCluster(DataStore dataStore, ClusterScope scope) {
+        PrimaryDataStoreInfo primarystore = (PrimaryDataStoreInfo)dataStore;
+
+        List<HostVO> hosts =
+                _resourceMgr.listAllUpAndEnabledHosts(Host.Type.Routing, primarystore.getClusterId(), primarystore.getPodId(), primarystore.getDataCenterId());
+
+        for (HostVO host : hosts) {
+            try {
+                _storageMgr.connectHostToSharedPool(host.getId(), dataStore.getId());
+            } catch (Exception e) {
+                s_logger.warn("Unable to establish a connection between " + host + " and " + dataStore, e);
+            }
+        }
+
+        _dataStoreHelper.attachCluster(dataStore);
+
+        return true;
     }
 
     @Override
     public boolean attachZone(DataStore dataStore, ZoneScope scope, HypervisorType hypervisorType) {
-        _dataStoreHelper.attachZone(dataStore);
-
         List<HostVO> xenServerHosts = _resourceMgr.listAllUpAndEnabledHostsInOneZoneByHypervisor(HypervisorType.XenServer, scope.getScopeId());
         List<HostVO> vmWareServerHosts = _resourceMgr.listAllUpAndEnabledHostsInOneZoneByHypervisor(HypervisorType.VMware, scope.getScopeId());
         List<HostVO> kvmHosts = _resourceMgr.listAllUpAndEnabledHostsInOneZoneByHypervisor(HypervisorType.KVM, scope.getScopeId());
-        List<HostVO> hosts = new ArrayList<HostVO>();
+        List<HostVO> hosts = new ArrayList<>();
 
         hosts.addAll(xenServerHosts);
         hosts.addAll(vmWareServerHosts);
@@ -215,6 +272,8 @@ public class SolidFirePrimaryDataStoreLifeCycle implements PrimaryDataStoreLifeC
                 s_logger.warn("Unable to establish a connection between " + host + " and " + dataStore, e);
             }
         }
+
+        _dataStoreHelper.attachZone(dataStore);
 
         return true;
     }

--- a/server/src/com/cloud/api/query/ViewResponseHelper.java
+++ b/server/src/com/cloud/api/query/ViewResponseHelper.java
@@ -293,7 +293,9 @@ public class ViewResponseHelper {
                     vs = ApiDBUtils.getVolumeStatistics(vrData.getPath());
                 }
                 else if (vr.getFormat() == ImageFormat.OVA){
-                    vs = ApiDBUtils.getVolumeStatistics(vrData.getChainInfo());
+                    if (vrData.getChainInfo() != null) {
+                        vs = ApiDBUtils.getVolumeStatistics(vrData.getChainInfo());
+                    }
                 }
                 if (vs != null){
                     long vsz = vs.getVirtualSize();

--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -899,7 +899,14 @@ public enum Config {
             "0",
             "Default disk I/O writerate in bytes per second allowed in User vm's disk.",
             null),
-
+    KvmAutoConvergence(
+            "Advanced",
+            ManagementServer.class,
+            Boolean.class,
+            "kvm.auto.convergence",
+            "false",
+            "Setting this to 'true' allows KVM to use auto convergence to complete VM migration (libvirt version 1.2.3+ and QEMU version 1.6+)",
+            null),
     ControlCidr(
             "Advanced",
             ManagementServer.class,

--- a/server/src/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/com/cloud/storage/VolumeApiServiceImpl.java
@@ -18,6 +18,7 @@ package com.cloud.storage;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.ModifyTargetsCommand;
 import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.DiskTO;
 import com.cloud.api.ApiDBUtils;
@@ -475,7 +476,17 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     }
                 } else {
                     volume.setDiskOfferingId(diskOfferingId);
+
+                    DiskOfferingVO diskOfferingVO = _diskOfferingDao.findById(diskOfferingId);
+
+                    Boolean isCustomizedIops = diskOfferingVO != null && diskOfferingVO.isCustomizedIops() != null ? diskOfferingVO.isCustomizedIops() : false;
+
+                    if (isCustomizedIops == null || !isCustomizedIops) {
+                        volume.setMinIops(diskOfferingVO.getMinIops());
+                        volume.setMaxIops(diskOfferingVO.getMaxIops());
+                    }
                 }
+
                 // volume.setSize(size);
                 volume.setInstanceId(null);
                 volume.setUpdated(new Date());
@@ -916,7 +927,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             newMinIops = cmd.getMinIops();
 
             if (newMinIops != null) {
-                if (diskOffering.isCustomizedIops() == null || !diskOffering.isCustomizedIops()) {
+                if (!volume.getVolumeType().equals(Volume.Type.ROOT) && (diskOffering.isCustomizedIops() == null || !diskOffering.isCustomizedIops())) {
                     throw new InvalidParameterValueException("The current disk offering does not support customization of the 'Min IOPS' parameter.");
                 }
             }
@@ -928,7 +939,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             newMaxIops = cmd.getMaxIops();
 
             if (newMaxIops != null) {
-                if (diskOffering.isCustomizedIops() == null || !diskOffering.isCustomizedIops()) {
+                if (!volume.getVolumeType().equals(Volume.Type.ROOT) && (diskOffering.isCustomizedIops() == null || !diskOffering.isCustomizedIops())) {
                     throw new InvalidParameterValueException("The current disk offering does not support customization of the 'Max IOPS' parameter.");
                 }
             }
@@ -967,7 +978,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     throw new InvalidParameterValueException("The new disk offering requires that a size be specified.");
                 }
 
-                // convert from bytes to GiB
+                // convert from GiB to bytes
                 newSize = newSize << 30;
             } else {
                 newSize = newDiskOffering.getDiskSize();
@@ -998,6 +1009,24 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (currentSize != newSize) {
             if (!validateVolumeSizeRange(newSize)) {
                 throw new InvalidParameterValueException("Requested size out of range");
+            }
+
+            Long storagePoolId = volume.getPoolId();
+
+            if (storagePoolId != null) {
+                StoragePoolVO storagePoolVO = _storagePoolDao.findById(storagePoolId);
+
+                if (storagePoolVO.isManaged()) {
+                    Long instanceId = volume.getInstanceId();
+
+                    if (instanceId != null) {
+                        VMInstanceVO vmInstanceVO = _vmInstanceDao.findById(instanceId);
+
+                        if (vmInstanceVO.getHypervisorType() == HypervisorType.KVM && vmInstanceVO.getState() != State.Stopped) {
+                            throw new CloudRuntimeException("This kind of KVM disk cannot be resized while it is connected to a VM that's not in the Stopped state.");
+                        }
+                    }
+                }
             }
 
             /*
@@ -1161,25 +1190,11 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
             // this call to resize has a different impact depending on whether the
             // underlying primary storage is managed or not
-            // if managed, this is the chance for the plug-in to change IOPS value, if applicable
+            // if managed, this is the chance for the plug-in to change the size and/or IOPS values
             // if not managed, this is the chance for the plug-in to talk to the hypervisor layer
             // to change the size of the disk
             AsyncCallFuture<VolumeApiResult> future = volService.resize(vol);
             VolumeApiResult result = future.get();
-
-            // managed storage is designed in such a way that the storage plug-in does not
-            // talk to the hypervisor layer; as such, if the storage is managed and the
-            // current and new sizes are different, then CloudStack (i.e. not a storage plug-in)
-            // needs to tell the hypervisor to resize the disk
-            if (storagePool.isManaged() && currentSize != newSize) {
-                if (hosts != null && hosts.length > 0) {
-                    volService.resizeVolumeOnHypervisor(volumeId, newSize, hosts[0], instanceName);
-                }
-
-                volume.setSize(newSize);
-
-                _volsDao.update(volume.getId(), volume);
-            }
 
             if (result.isFailed()) {
                 s_logger.warn("Failed to resize the volume " + volume);
@@ -1190,11 +1205,30 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 throw new CloudRuntimeException(details);
             }
 
+            // managed storage is designed in such a way that the storage plug-in does not
+            // talk to the hypervisor layer; as such, if the storage is managed and the
+            // current and new sizes are different, then CloudStack (i.e. not a storage plug-in)
+            // needs to tell the hypervisor to resize the disk
+            if (storagePool.isManaged() && currentSize != newSize) {
+                if (hosts != null && hosts.length > 0) {
+                    HostVO hostVO = _hostDao.findById(hosts[0]);
+
+                    if (hostVO.getHypervisorType() != HypervisorType.KVM) {
+                        volService.resizeVolumeOnHypervisor(volumeId, newSize, hosts[0], instanceName);
+                    }
+                }
+
+                volume.setSize(newSize);
+
+                _volsDao.update(volume.getId(), volume);
+            }
+
             volume = _volsDao.findById(volume.getId());
 
             if (newDiskOfferingId != null) {
                 volume.setDiskOfferingId(newDiskOfferingId);
             }
+
             if (currentSize != newSize) {
                 volume.setSize(newSize);
             }
@@ -1851,6 +1885,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
             volService.revokeAccess(volFactory.getVolume(volume.getId()), host, dataStore);
 
+            handleTargetsForVMware(hostId, volumePool.getHostAddress(), volumePool.getPort(), volume.get_iScsiName());
+
             return _volsDao.findById(volumeId);
         } else {
 
@@ -1882,6 +1918,46 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
         } catch (JsonParseException e) {
             s_logger.debug("Error parsing chain info json: " + e.getMessage());
+        }
+    }
+
+    private void handleTargetsForVMware(long hostId, String storageAddress, int storagePort, String iScsiName) {
+        HostVO host = _hostDao.findById(hostId);
+
+        if (host.getHypervisorType() == HypervisorType.VMware) {
+            ModifyTargetsCommand cmd = new ModifyTargetsCommand();
+
+            List<Map<String, String>> targets = new ArrayList<>();
+
+            Map<String, String> target = new HashMap<>();
+
+            target.put(ModifyTargetsCommand.STORAGE_HOST, storageAddress);
+            target.put(ModifyTargetsCommand.STORAGE_PORT, String.valueOf(storagePort));
+            target.put(ModifyTargetsCommand.IQN, iScsiName);
+
+            targets.add(target);
+
+            cmd.setTargets(targets);
+            cmd.setApplyToAllHostsInCluster(true);
+            cmd.setAdd(false);
+            cmd.setTargetTypeToRemove(ModifyTargetsCommand.TargetTypeToRemove.DYNAMIC);
+
+            sendModifyTargetsCommand(cmd, hostId);
+        }
+    }
+
+    private void sendModifyTargetsCommand(ModifyTargetsCommand cmd, long hostId) {
+        Answer answer = _agentMgr.easySend(hostId, cmd);
+
+        if (answer == null) {
+            String msg = "Unable to get an answer to the modify targets command";
+
+            s_logger.warn(msg);
+        }
+        else if (!answer.getResult()) {
+            String msg = "Unable to modify target on the following host: " + hostId;
+
+            s_logger.warn(msg);
         }
     }
 
@@ -2088,6 +2164,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         StoragePoolVO storagePoolVO = _storagePoolDao.findById(volume.getPoolId());
+
         if (storagePoolVO.isManaged() && locationType == null) {
             locationType = Snapshot.LocationType.PRIMARY;
         }
@@ -2206,6 +2283,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         StoragePoolVO storagePoolVO = _storagePoolDao.findById(volume.getPoolId());
+
         if (!storagePoolVO.isManaged() && locationType != null) {
             throw new InvalidParameterValueException("VolumeId: " + volumeId + " LocationType is supported only for managed storage");
         }
@@ -2295,7 +2373,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new InvalidParameterValueException("Please specify a valid zone.");
         }
         if (volume.getPoolId() == null) {
-            throw new InvalidParameterValueException("The volume doesnt belong to a storage pool so cant extract it");
+            throw new InvalidParameterValueException("The volume doesn't belong to a storage pool so can't extract it");
         }
         // Extract activity only for detached volumes or for volumes whose
         // instance is stopped
@@ -2419,9 +2497,15 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         String extractUrl = secStore.createEntityExtractUrl(vol.getPath(), vol.getFormat(), vol);
         VolumeDataStoreVO volumeStoreRef = _volumeStoreDao.findByVolume(volumeId);
+
         volumeStoreRef.setExtractUrl(extractUrl);
         volumeStoreRef.setExtractUrlCreated(DateUtil.now());
+        volumeStoreRef.setDownloadState(VMTemplateStorageResourceAssoc.Status.DOWNLOADED);
+        volumeStoreRef.setDownloadPercent(100);
+        volumeStoreRef.setZoneId(zoneId);
+
         _volumeStoreDao.update(volumeStoreRef.getId(), volumeStoreRef);
+
         return extractUrl;
     }
 
@@ -2630,6 +2714,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 // Mark the volume as attached
                 if (sendCommand) {
                     DiskTO disk = answer.getDisk();
+
                     _volsDao.attachVolume(volumeToAttach.getId(), vm.getId(), disk.getDiskSeq());
 
                     volumeToAttach = _volsDao.findById(volumeToAttach.getId());
@@ -2643,6 +2728,14 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     deviceId = getDeviceId(vm, deviceId);
 
                     _volsDao.attachVolume(volumeToAttach.getId(), vm.getId(), deviceId);
+
+                    volumeToAttach = _volsDao.findById(volumeToAttach.getId());
+
+                    if (vm.getHypervisorType() == HypervisorType.KVM && volumeToAttachStoragePool.isManaged() && volumeToAttach.getPath() == null) {
+                        volumeToAttach.setPath(volumeToAttach.get_iScsiName());
+
+                        _volsDao.update(volumeToAttach.getId(), volumeToAttach);
+                    }
                 }
 
                 // insert record for disk I/O statistics

--- a/server/src/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/com/cloud/storage/VolumeApiServiceImpl.java
@@ -974,6 +974,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 // convert from GiB to bytes
                 newSize = newSize << 30;
             } else {
+                if (cmd.getSize() != null) {
+                    throw new InvalidParameterValueException("You cannnot pass in a custom disk size to a non-custom disk offering.");
+                }
+
                 newSize = newDiskOffering.getDiskSize();
             }
 

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -70,6 +70,7 @@ import org.apache.cloudstack.api.command.user.vm.UpdateVmNicIpCmd;
 import org.apache.cloudstack.api.command.user.vm.UpgradeVMCmd;
 import org.apache.cloudstack.api.command.user.vmgroup.CreateVMGroupCmd;
 import org.apache.cloudstack.api.command.user.vmgroup.DeleteVMGroupCmd;
+import org.apache.cloudstack.api.command.user.volume.ResizeVolumeCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.cloud.entity.api.VirtualMachineEntity;
 import org.apache.cloudstack.engine.cloud.entity.api.db.dao.VMNetworkMapDao;
@@ -109,6 +110,7 @@ import com.cloud.agent.api.GetVmStatsAnswer;
 import com.cloud.agent.api.GetVmStatsCommand;
 import com.cloud.agent.api.GetVolumeStatsAnswer;
 import com.cloud.agent.api.GetVolumeStatsCommand;
+import com.cloud.agent.api.ModifyTargetsCommand;
 import com.cloud.agent.api.PvlanSetupCommand;
 import com.cloud.agent.api.RestoreVMSnapshotAnswer;
 import com.cloud.agent.api.RestoreVMSnapshotCommand;
@@ -1115,6 +1117,20 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         // Check that the specified service offering ID is valid
         _itMgr.checkIfCanUpgrade(vmInstance, newServiceOffering);
+
+        DiskOfferingVO newROOTDiskOffering = _diskOfferingDao.findById(newServiceOffering.getId());
+
+        List<VolumeVO> vols = _volsDao.findReadyRootVolumesByInstance(vmInstance.getId());
+
+        for (final VolumeVO rootVolumeOfVm : vols) {
+            rootVolumeOfVm.setDiskOfferingId(newROOTDiskOffering.getId());
+
+            _volsDao.update(rootVolumeOfVm.getId(), rootVolumeOfVm);
+
+            ResizeVolumeCmd resizeVolumeCmd = new ResizeVolumeCmd(rootVolumeOfVm.getId(), newROOTDiskOffering.getMinIops(), newROOTDiskOffering.getMaxIops());
+
+            _volumeService.resizeVolume(resizeVolumeCmd);
+        }
 
         // Check if the new service offering can be applied to vm instance
         ServiceOffering newSvcOffering = _offeringDao.findById(svcOffId);
@@ -4955,7 +4971,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         List<VolumeVO> vols = _volsDao.findByInstance(vm.getId());
         if (vols.size() > 1) {
-            throw new InvalidParameterValueException("Data disks attached to the vm, can not migrate. Need to dettach data disks at first");
+            throw new InvalidParameterValueException("Data disks attached to the vm, can not migrate. Need to detach data disks first");
         }
 
         // Check that Vm does not have VM Snapshots
@@ -4969,7 +4985,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 destPool.getClusterId()).getHypervisorType();
         }
 
-        if (vm.getHypervisorType() != destHypervisorType) {
+        if (vm.getHypervisorType() != destHypervisorType && destHypervisorType != HypervisorType.Any) {
             throw new InvalidParameterValueException("hypervisor is not compatible: dest: " + destHypervisorType.toString() + ", vm: " + vm.getHypervisorType().toString());
         }
         _itMgr.storageMigration(vm.getUuid(), destPool);
@@ -5384,13 +5400,47 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         }
 
         // Check if the source and destination hosts are of the same type and support storage motion.
-        if (!(srcHost.getHypervisorType().equals(destinationHost.getHypervisorType()))) {
-            throw new CloudRuntimeException("The source and destination hosts are not of the same type. " + "Source hypervisor type and version: "
-                    + srcHost.getHypervisorType().toString() + " " + srcHost.getHypervisorVersion() + ", Destination hypervisor type and version: "
-                    + destinationHost.getHypervisorType().toString() + " " + destinationHost.getHypervisorVersion());
+        if (!srcHost.getHypervisorType().equals(destinationHost.getHypervisorType())) {
+            throw new CloudRuntimeException("The source and destination hosts are not of the same type and version. Source hypervisor type and version: " +
+                    srcHost.getHypervisorType().toString() + " " + srcHost.getHypervisorVersion() + ", Destination hypervisor type and version: " +
+                    destinationHost.getHypervisorType().toString() + " " + destinationHost.getHypervisorVersion());
+        }
+
+        String srcHostVersion = srcHost.getHypervisorVersion();
+        String destinationHostVersion = destinationHost.getHypervisorVersion();
+
+        if (HypervisorType.KVM.equals(srcHost.getHypervisorType())) {
+            if (srcHostVersion == null) {
+                srcHostVersion = "";
+            }
+
+            if (destinationHostVersion == null) {
+                destinationHostVersion = "";
+            }
+        }
+
+        if (!srcHostVersion.equals(destinationHostVersion)) {
+            throw new CloudRuntimeException("The source and destination hosts are not of the same type and version. Source hypervisor type and version: " +
+                    srcHost.getHypervisorType().toString() + " " + srcHost.getHypervisorVersion() + ", Destination hypervisor type and version: " +
+                    destinationHost.getHypervisorType().toString() + " " + destinationHost.getHypervisorVersion());
         }
 
         HypervisorCapabilitiesVO capabilities = _hypervisorCapabilitiesDao.findByHypervisorTypeAndVersion(srcHost.getHypervisorType(), srcHost.getHypervisorVersion());
+
+        if (capabilities == null && HypervisorType.KVM.equals(srcHost.getHypervisorType())) {
+            List<HypervisorCapabilitiesVO> lstHypervisorCapabilities = _hypervisorCapabilitiesDao.listAllByHypervisorType(HypervisorType.KVM);
+
+            if (lstHypervisorCapabilities != null) {
+                for (HypervisorCapabilitiesVO hypervisorCapabilities : lstHypervisorCapabilities) {
+                    if (hypervisorCapabilities.isStorageMotionSupported()) {
+                        capabilities = hypervisorCapabilities;
+
+                        break;
+                    }
+                }
+            }
+        }
+
         if (!capabilities.isStorageMotionSupported()) {
             throw new CloudRuntimeException("Migration with storage isn't supported on hypervisor " + srcHost.getHypervisorType() + " of version " + srcHost.getHypervisorVersion());
         }
@@ -6168,9 +6218,10 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     }
 
     private void handleManagedStorage(UserVmVO vm, VolumeVO root) {
-        if ( Volume.State.Allocated.equals(root.getState()) ){
+        if (Volume.State.Allocated.equals(root.getState())) {
             return;
         }
+
         StoragePoolVO storagePool = _storagePoolDao.findById(root.getPoolId());
 
         if (storagePool != null && storagePool.isManaged()) {
@@ -6203,7 +6254,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     Map<String, String> details = primaryDataStore.getDetails();
 
                     if (details == null) {
-                        details = new HashMap<String, String>();
+                        details = new HashMap<>();
 
                         primaryDataStore.setDetails(details);
                     }
@@ -6212,35 +6263,84 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
                     cmd = new DeleteCommand(volumeInfo.getTO());
                 }
+                else if (host.getHypervisorType() == HypervisorType.KVM) {
+                    cmd = null;
+                }
                 else {
                     throw new CloudRuntimeException("This hypervisor type is not supported on managed storage for this command.");
                 }
 
-                Commands cmds = new Commands(Command.OnError.Stop);
+                if (cmd != null) {
+                    Commands cmds = new Commands(Command.OnError.Stop);
 
-                cmds.addCommand(cmd);
+                    cmds.addCommand(cmd);
 
-                try {
-                    _agentMgr.send(hostId, cmds);
-                }
-                catch (Exception ex) {
-                    throw new CloudRuntimeException(ex.getMessage());
-                }
+                    try {
+                        _agentMgr.send(hostId, cmds);
+                    } catch (Exception ex) {
+                        throw new CloudRuntimeException(ex.getMessage());
+                    }
 
-                if (!cmds.isSuccessful()) {
-                    for (Answer answer : cmds.getAnswers()) {
-                        if (!answer.getResult()) {
-                            s_logger.warn("Failed to reset vm due to: " + answer.getDetails());
+                    if (!cmds.isSuccessful()) {
+                        for (Answer answer : cmds.getAnswers()) {
+                            if (!answer.getResult()) {
+                                s_logger.warn("Failed to reset vm due to: " + answer.getDetails());
 
-                            throw new CloudRuntimeException("Unable to reset " + vm + " due to " + answer.getDetails());
+                                throw new CloudRuntimeException("Unable to reset " + vm + " due to " + answer.getDetails());
+                            }
                         }
                     }
                 }
 
                 // root.getPoolId() should be null if the VM we are detaching the disk from has never been started before
                 DataStore dataStore = root.getPoolId() != null ? _dataStoreMgr.getDataStore(root.getPoolId(), DataStoreRole.Primary) : null;
+
                 volumeMgr.revokeAccess(volFactory.getVolume(root.getId()), host, dataStore);
+
+                if (dataStore != null) {
+                    handleTargetsForVMware(host.getId(), storagePool.getHostAddress(), storagePool.getPort(), root.get_iScsiName());
+                }
             }
+        }
+    }
+
+    private void handleTargetsForVMware(long hostId, String storageAddress, int storagePort, String iScsiName) {
+        HostVO host = _hostDao.findById(hostId);
+
+        if (host.getHypervisorType() == HypervisorType.VMware) {
+            ModifyTargetsCommand cmd = new ModifyTargetsCommand();
+
+            List<Map<String, String>> targets = new ArrayList<>();
+
+            Map<String, String> target = new HashMap<>();
+
+            target.put(ModifyTargetsCommand.STORAGE_HOST, storageAddress);
+            target.put(ModifyTargetsCommand.STORAGE_PORT, String.valueOf(storagePort));
+            target.put(ModifyTargetsCommand.IQN, iScsiName);
+
+            targets.add(target);
+
+            cmd.setTargets(targets);
+            cmd.setApplyToAllHostsInCluster(true);
+            cmd.setAdd(false);
+            cmd.setTargetTypeToRemove(ModifyTargetsCommand.TargetTypeToRemove.DYNAMIC);
+
+            sendModifyTargetsCommand(cmd, hostId);
+        }
+    }
+
+    private void sendModifyTargetsCommand(ModifyTargetsCommand cmd, long hostId) {
+        Answer answer = _agentMgr.easySend(hostId, cmd);
+
+        if (answer == null) {
+            String msg = "Unable to get an answer to the modify targets command";
+
+            s_logger.warn(msg);
+        }
+        else if (!answer.getResult()) {
+            String msg = "Unable to modify target on the following host: " + hostId;
+
+            s_logger.warn(msg);
         }
     }
 

--- a/server/test/com/cloud/storage/snapshot/SnapshotManagerTest.java
+++ b/server/test/com/cloud/storage/snapshot/SnapshotManagerTest.java
@@ -16,12 +16,6 @@
 // under the License.
 package com.cloud.storage.snapshot;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -79,6 +73,11 @@ import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
 import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotService;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SnapshotManagerTest {
     @Spy
@@ -126,7 +125,7 @@ public class SnapshotManagerTest {
     @Mock
     DataStore storeMock;
     @Mock
-    SnapshotDataStoreDao _snapshotStoreDao;
+    SnapshotDataStoreDao snapshotStoreDao;
     @Mock
     SnapshotDataStoreVO snapshotStoreMock;
     @Mock
@@ -153,7 +152,7 @@ public class SnapshotManagerTest {
         _snapshotMgr._storagePoolDao = _storagePoolDao;
         _snapshotMgr._resourceMgr = _resourceMgr;
         _snapshotMgr._vmSnapshotDao = _vmSnapshotDao;
-        _snapshotMgr._snapshotStoreDao = _snapshotStoreDao;
+        _snapshotMgr._snapshotStoreDao = snapshotStoreDao;
 
         when(_snapshotDao.findById(anyLong())).thenReturn(snapshotMock);
         when(snapshotMock.getVolumeId()).thenReturn(TEST_VOLUME_ID);
@@ -260,6 +259,7 @@ public class SnapshotManagerTest {
         when(snapshotMock.getState()).thenReturn(Snapshot.State.Destroyed);
         when(snapshotMock.getAccountId()).thenReturn(2L);
         when(snapshotMock.getDataCenterId()).thenReturn(2L);
+
         _snapshotMgr.deleteSnapshot(TEST_SNAPSHOT_ID);
     }
 
@@ -311,14 +311,14 @@ public class SnapshotManagerTest {
         when(_vmDao.findById(anyLong())).thenReturn(vmMock);
         when(vmMock.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
         when(_vmSnapshotDao.findById(anyLong())).thenReturn(vmSnapshotMock);
-        when(_snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(null);
+        when(snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(null);
         when(snapshotFactory.getSnapshot(anyLong(), Mockito.any(DataStore.class))).thenReturn(snapshotInfoMock);
         when(storeMock.create(snapshotInfoMock)).thenReturn(snapshotInfoMock);
-        when(_snapshotStoreDao.findBySnapshot(anyLong(), any(DataStoreRole.class))).thenReturn(snapshotStoreMock);
-        when(_snapshotStoreDao.update(anyLong(), any(SnapshotDataStoreVO.class))).thenReturn(true);
+        when(snapshotStoreDao.findBySnapshot(anyLong(), any(DataStoreRole.class))).thenReturn(snapshotStoreMock);
+        when(snapshotStoreDao.update(anyLong(), any(SnapshotDataStoreVO.class))).thenReturn(true);
         when(_snapshotDao.update(anyLong(), any(SnapshotVO.class))).thenReturn(true);
         when(vmMock.getAccountId()).thenReturn(2L);
-        when(snapshotStrategy.backupSnapshot(any(SnapshotInfo.class))).thenReturn(snapshotInfoMock);;;
+        when(snapshotStrategy.backupSnapshot(any(SnapshotInfo.class))).thenReturn(snapshotInfoMock);
 
         Snapshot snapshot = _snapshotMgr.backupSnapshotFromVmSnapshot(TEST_SNAPSHOT_ID, TEST_VM_ID, TEST_VOLUME_ID, TEST_VM_SNAPSHOT_ID);
         Assert.assertNotNull(snapshot);
@@ -330,7 +330,7 @@ public class SnapshotManagerTest {
         when(_vmDao.findById(anyLong())).thenReturn(vmMock);
         when(vmMock.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
         when(_vmSnapshotDao.findById(anyLong())).thenReturn(vmSnapshotMock);
-        when(_snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(snapshotStoreMock);
+        when(snapshotStoreDao.findParent(any(DataStoreRole.class), anyLong(), anyLong())).thenReturn(snapshotStoreMock);
         when(snapshotStoreMock.getInstallPath()).thenReturn("VM_SNAPSHOT_NAME");
         when(vmSnapshotMock.getName()).thenReturn("VM_SNAPSHOT_NAME");
         Snapshot snapshot = _snapshotMgr.backupSnapshotFromVmSnapshot(TEST_SNAPSHOT_ID, TEST_VM_ID, TEST_VOLUME_ID, TEST_VM_SNAPSHOT_ID);

--- a/test/integration/plugins/solidfire/TestAddRemoveHosts.py
+++ b/test/integration/plugins/solidfire/TestAddRemoveHosts.py
@@ -51,6 +51,9 @@ from marvin.lib.utils import cleanup_resources
 #  Check that ip_address_of_new_xenserver_host / ip_address_of_new_kvm_host is correct.
 #  If using XenServer, verify the "xen_server_master_hostname" variable is correct.
 #  If using KVM, verify the "kvm_1_ip_address" variable is correct.
+#
+# Note:
+#  If you do have more than one cluster, you might need to change this line: cls.cluster = list_clusters(cls.apiClient)[0]
 
 
 class TestData:
@@ -92,18 +95,18 @@ class TestData:
     # modify to control which hypervisor type to test
     hypervisor_type = xenServer
     xen_server_master_hostname = "XenServer-6.5-1"
-    kvm_1_ip_address = "192.168.129.84"
-    ip_address_of_new_xenserver_host = "192.168.129.243"
-    ip_address_of_new_kvm_host = "192.168.129.3"
+    kvm_1_ip_address = "10.117.40.112"
+    ip_address_of_new_xenserver_host = "10.117.40.107"
+    ip_address_of_new_kvm_host = "10.117.40.116"
 
     def __init__(self):
         self.testdata = {
             TestData.solidFire: {
-                TestData.mvip: "192.168.139.112",
+                TestData.mvip: "10.117.40.120",
                 TestData.username: "admin",
                 TestData.password: "admin",
                 TestData.port: 443,
-                TestData.url: "https://192.168.139.112:443"
+                TestData.url: "https://10.117.40.120:443"
             },
             TestData.kvm: {
                 TestData.username: "root",
@@ -144,7 +147,7 @@ class TestData:
             TestData.primaryStorage: {
                 TestData.name: "SolidFire-%d" % random.randint(0, 100),
                 TestData.scope: "ZONE",
-                TestData.url: "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                TestData.url: "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                        "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
                        "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",
@@ -157,7 +160,7 @@ class TestData:
             TestData.primaryStorage2: {
                 TestData.name: "SolidFireShared-%d" % random.randint(0, 100),
                 TestData.scope: "CLUSTER",
-                TestData.url: "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                TestData.url: "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                        "minIops=5000;maxIops=50000;burstIops=75000",
                 TestData.provider: "SolidFireShared",
@@ -191,7 +194,7 @@ class TestData:
             TestData.zoneId: 1,
             TestData.clusterId: 1,
             TestData.domainId: 1,
-            TestData.url: "192.168.129.50"
+            TestData.url: "10.117.40.114"
         }
 
 
@@ -223,7 +226,7 @@ class TestAddRemoveHosts(cloudstackTestCase):
         # Get Resources from Cloud Infrastructure
         cls.zone = get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId])
         cls.cluster = list_clusters(cls.apiClient)[0]
-        cls.template = get_template(cls.apiClient, cls.zone.id, cls.configData["ostype"])
+        cls.template = get_template(cls.apiClient, cls.zone.id, hypervisor=TestData.hypervisor_type)
         cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
 
         # Create test account
@@ -753,7 +756,7 @@ class TestAddRemoveHosts(cloudstackTestCase):
 
         searchFor = "InitiatorName="
 
-        stdin, stdout, stderr = ssh_connection.exec_command("sudo grep " + searchFor + " /etc/iscsi/initiatorname.iscsi")
+        stdout = ssh_connection.exec_command("sudo grep " + searchFor + " /etc/iscsi/initiatorname.iscsi")[1]
 
         result = stdout.read()
 

--- a/test/integration/plugins/solidfire/TestManagedSystemVMs.py
+++ b/test/integration/plugins/solidfire/TestManagedSystemVMs.py
@@ -93,17 +93,17 @@ class TestData():
     zoneId = "zoneid"
 
     # modify to control which hypervisor type to test
-    hypervisor_type = kvm
+    hypervisor_type = xenServer
     xen_server_hostname = "XenServer-6.5-1"
 
     def __init__(self):
         self.testdata = {
             TestData.solidFire: {
-                TestData.mvip: "192.168.139.112",
+                TestData.mvip: "10.117.40.120",
                 TestData.username: "admin",
                 TestData.password: "admin",
                 TestData.port: 443,
-                TestData.url: "https://192.168.139.112:443"
+                TestData.url: "https://10.117.40.120:443"
             },
             TestData.kvm: {
                 TestData.username: "root",
@@ -130,7 +130,7 @@ class TestData():
             TestData.primaryStorage: {
                 TestData.name: TestData.get_name_for_solidfire_storage(),
                 TestData.scope: "ZONE",
-                TestData.url: "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                TestData.url: "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                        "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
                        "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",
@@ -184,7 +184,7 @@ class TestData():
             TestData.zoneId: 1,
             TestData.clusterId: 1,
             TestData.domainId: 1,
-            TestData.url: "192.168.129.50"
+            TestData.url: "10.117.40.114"
         }
 
     @staticmethod
@@ -225,7 +225,7 @@ class TestManagedSystemVMs(cloudstackTestCase):
         # Get Resources from Cloud Infrastructure
         cls.zone = Zone(get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId]).__dict__)
         cls.cluster = list_clusters(cls.apiClient)[0]
-        cls.template = get_template(cls.apiClient, cls.zone.id, cls.configData["ostype"])
+        cls.template = get_template(cls.apiClient, cls.zone.id, hypervisor=TestData.hypervisor_type)
         cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
 
         # Create test account

--- a/test/integration/plugins/solidfire/TestUploadDownload.py
+++ b/test/integration/plugins/solidfire/TestUploadDownload.py
@@ -1,0 +1,516 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import random
+import SignedAPICall
+import urllib2
+
+from solidfire.factory import ElementFactory
+
+from util import sf_util
+
+# All tests inherit from cloudstackTestCase
+from marvin.cloudstackTestCase import cloudstackTestCase
+
+# Import Integration Libraries
+
+# base - contains all resources as entities and defines create, delete, list operations on them
+from marvin.lib.base import Account, DiskOffering, ServiceOffering, StoragePool, User, VirtualMachine, Volume
+
+# common - commonly used methods for all tests are listed here
+from marvin.lib.common import get_domain, get_template, get_zone, list_clusters, list_volumes
+
+# utils - utility classes for common cleanup, external library wrappers, etc.
+from marvin.lib.utils import cleanup_resources, wait_until
+
+# Prerequisites:
+#  Only one zone
+#  Only one pod
+#  Only one cluster
+
+# Note:
+#  If you do have more than one cluster, you might need to change this line: cls.cluster = list_clusters(cls.apiClient)[0]
+#  Set extract.url.cleanup.interval to 240.
+#  Set extract.url.expiration.interval to 120.
+
+
+class TestData:
+    account = "account"
+    capacityBytes = "capacitybytes"
+    capacityIops = "capacityiops"
+    clusterId = "clusterId"
+    computeOffering = "computeoffering"
+    diskOffering = "diskoffering"
+    domainId = "domainId"
+    hypervisor = "hypervisor"
+    kvm = "kvm"
+    login = "login"
+    mvip = "mvip"
+    password = "password"
+    port = "port"
+    primaryStorage = "primarystorage"
+    provider = "provider"
+    scope = "scope"
+    solidFire = "solidfire"
+    storageTag = "SolidFire_SAN_1"
+    tags = "tags"
+    url = "url"
+    user = "user"
+    username = "username"
+    virtualMachine = "virtualmachine"
+    volume_1 = "volume_1"
+    xenServer = "xenserver"
+    zoneId = "zoneId"
+
+    # modify to control which hypervisor type to test
+    hypervisor_type = kvm
+    volume_url = "http://10.117.40.114/tiny-centos-63.qcow2"
+    file_type = "QCOW2"
+    properties_file = "volume.properties"
+    install_path_index = 14
+    secondary_storage_server = "10.117.40.114"
+    secondary_storage_server_root = "/export/secondary/"
+    secondary_storage_server_username = "cloudstack"
+    secondary_storage_server_password = "solidfire"
+    # "HTTP_DOWNLOAD" and "FTP_UPLOAD" are valid for download_mode, but they lead to the same behavior
+    download_mode = "HTTP_DOWNLOAD"
+
+    def __init__(self):
+        self.testdata = {
+            TestData.solidFire: {
+                TestData.mvip: "10.117.40.120",
+                TestData.username: "admin",
+                TestData.password: "admin",
+                TestData.port: 443,
+                TestData.url: "https://10.117.40.120:443"
+            },
+            TestData.account: {
+                "email": "test@test.com",
+                "firstname": "John",
+                "lastname": "Doe",
+                TestData.username: "test",
+                TestData.password: "test"
+            },
+            TestData.user: {
+                "email": "user@test.com",
+                "firstname": "Jane",
+                "lastname": "Doe",
+                TestData.username: "testuser",
+                TestData.password: "password"
+            },
+            TestData.primaryStorage: {
+                "name": "SolidFire-%d" % random.randint(0, 100),
+                TestData.scope: "ZONE",
+                "url": "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
+                       "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
+                       "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
+                       "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",
+                TestData.provider: "SolidFire",
+                TestData.tags: TestData.storageTag,
+                TestData.capacityIops: 4500000,
+                TestData.capacityBytes: 2251799813685248,
+                TestData.hypervisor: "Any"
+            },
+            TestData.virtualMachine: {
+                "name": "TestVM",
+                "displayname": "Test VM"
+            },
+            TestData.computeOffering: {
+                "name": "SF_CO_1",
+                "displaytext": "SF_CO_1 (Min IOPS = 10,000; Max IOPS = 15,000)",
+                "cpunumber": 1,
+                "cpuspeed": 100,
+                "memory": 128,
+                "storagetype": "shared",
+                "customizediops": False,
+                "miniops": "10000",
+                "maxiops": "15000",
+                "hypervisorsnapshotreserve": 200,
+                TestData.tags: TestData.storageTag
+            },
+            TestData.diskOffering: {
+                "name": "SF_DO_1",
+                "displaytext": "SF_DO_1 Custom Size",
+                "customizediops": False,
+                "miniops": 5000,
+                "maxiops": 10000,
+                TestData.tags: TestData.storageTag,
+                "storagetype": "shared"
+            },
+            TestData.volume_1: {
+                "diskname": "testvolume",
+            },
+            TestData.zoneId: 1,
+            TestData.clusterId: 1,
+            TestData.domainId: 1,
+            TestData.url: "10.117.40.114"
+        }
+
+
+class TestUploadDownload(cloudstackTestCase):
+    errorText = "should be either detached or the VM should be in stopped state"
+    assertText = "The length of the response for the 'volume_store_ref' result should be equal to 1."
+    assertText2 = "The length of the response for the 'volume_store_ref' result should be equal to 0."
+
+    @classmethod
+    def setUpClass(cls):
+        # Set up API client
+        testclient = super(TestUploadDownload, cls).getClsTestClient()
+
+        cls.apiClient = testclient.getApiClient()
+        cls.configData = testclient.getParsedTestDataConfig()
+        cls.dbConnection = testclient.getDbConnection()
+
+        cls.testdata = TestData().testdata
+
+        # Set up SolidFire connection
+        solidfire = cls.testdata[TestData.solidFire]
+
+        cls.sfe = ElementFactory.create(solidfire[TestData.mvip], solidfire[TestData.username], solidfire[TestData.password])
+
+        # Get Resources from Cloud Infrastructure
+        cls.zone = get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId])
+        cls.cluster = list_clusters(cls.apiClient)[1]
+        cls.template = get_template(cls.apiClient, cls.zone.id, hypervisor=TestData.hypervisor_type)
+        cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
+
+        # Create test account
+        cls.account = Account.create(
+            cls.apiClient,
+            cls.testdata[TestData.account],
+            admin=1
+        )
+
+        # Set up connection to make customized API calls
+        user = User.create(
+            cls.apiClient,
+            cls.testdata[TestData.user],
+            account=cls.account.name,
+            domainid=cls.domain.id
+        )
+
+        url = cls.testdata[TestData.url]
+
+        api_url = "http://" + url + ":8080/client/api"
+        userkeys = User.registerUserKeys(cls.apiClient, user.id)
+
+        cls.cs_api = SignedAPICall.CloudStack(api_url, userkeys.apikey, userkeys.secretkey)
+
+        primarystorage = cls.testdata[TestData.primaryStorage]
+
+        cls.primary_storage = StoragePool.create(
+            cls.apiClient,
+            primarystorage,
+            scope=primarystorage[TestData.scope],
+            zoneid=cls.zone.id,
+            provider=primarystorage[TestData.provider],
+            tags=primarystorage[TestData.tags],
+            capacityiops=primarystorage[TestData.capacityIops],
+            capacitybytes=primarystorage[TestData.capacityBytes],
+            hypervisor=primarystorage[TestData.hypervisor]
+        )
+
+        compute_offering = ServiceOffering.create(
+            cls.apiClient,
+            cls.testdata[TestData.computeOffering]
+        )
+
+        cls.disk_offering = DiskOffering.create(
+            cls.apiClient,
+            cls.testdata[TestData.diskOffering],
+            custom=True
+        )
+
+        # Create VM and volume for tests
+        cls.virtual_machine = VirtualMachine.create(
+            cls.apiClient,
+            cls.testdata[TestData.virtualMachine],
+            accountid=cls.account.name,
+            zoneid=cls.zone.id,
+            serviceofferingid=compute_offering.id,
+            templateid=cls.template.id,
+            domainid=cls.domain.id,
+            startvm=True
+        )
+
+        cls._cleanup = [
+            compute_offering,
+            cls.disk_offering,
+            user,
+            cls.account
+        ]
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.virtual_machine.delete(cls.apiClient, True)
+
+            cleanup_resources(cls.apiClient, cls._cleanup)
+
+            cls.primary_storage.delete(cls.apiClient)
+
+            sf_util.purge_solidfire_volumes(cls.sfe)
+        except Exception as e:
+            logging.debug("Exception in tearDownClass(cls): %s" % e)
+
+    def setUp(self):
+        self.cleanup = []
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiClient, self.cleanup)
+        except Exception as e:
+            logging.debug("Exception in tearDown(self): %s" % e)
+
+    def test_01_upload_and_download_snapshot(self):
+        list_volumes_response = list_volumes(
+            self.apiClient,
+            virtualmachineid=self.virtual_machine.id,
+            listall=True
+        )
+
+        sf_util.check_list(list_volumes_response, 1, self, "There should only be one volume in this list.")
+
+        vm_root_volume = list_volumes_response[0]
+
+        ### Perform tests related to uploading a QCOW2 file to secondary storage and then moving it to managed storage
+
+        volume_name = "Volume-A"
+        services = {"format": TestData.file_type, "diskname": volume_name}
+
+        uploaded_volume = Volume.upload(self.apiClient, services, self.zone.id,
+                                        account=self.account.name, domainid=self.account.domainid,
+                                        url=TestData.volume_url, diskofferingid=self.disk_offering.id)
+
+        self._wait_for_volume_state(uploaded_volume.id, "Uploaded")
+
+        uploaded_volume_id = sf_util.get_cs_volume_db_id(self.dbConnection, uploaded_volume)
+
+        result = self._get_volume_store_ref_row(uploaded_volume_id)
+
+        self.assertEqual(
+            len(result),
+            1,
+            TestUploadDownload.assertText
+        )
+
+        install_path = self._get_install_path(result[0][TestData.install_path_index])
+
+        self._verify_uploaded_volume_present(install_path)
+
+        uploaded_volume = self.virtual_machine.attach_volume(
+            self.apiClient,
+            uploaded_volume
+        )
+
+        uploaded_volume = sf_util.check_and_get_cs_volume(self, uploaded_volume.id, volume_name, self)
+
+        sf_account_id = sf_util.get_sf_account_id(self.cs_api, self.account.id, self.primary_storage.id, self, "The SolidFire account ID should be a non-zero integer.")
+
+        sf_volumes = sf_util.get_active_sf_volumes(self.sfe, sf_account_id)
+
+        self.assertNotEqual(
+            len(sf_volumes),
+            0,
+            "The length of the response for the SolidFire-volume query should not be zero."
+        )
+
+        sf_volume = sf_util.check_and_get_sf_volume(sf_volumes, uploaded_volume.name, self)
+
+        sf_volume_size = sf_util.get_volume_size_with_hsr(self.cs_api, uploaded_volume, self)
+
+        sf_util.check_size_and_iops(sf_volume, uploaded_volume, sf_volume_size, self)
+
+        sf_vag_id = sf_util.get_vag_id(self.cs_api, self.cluster.id, self.primary_storage.id, self)
+
+        sf_util.check_vag(sf_volume, sf_vag_id, self)
+
+        result = self._get_volume_store_ref_row(uploaded_volume_id)
+
+        self.assertEqual(
+            len(result),
+            0,
+            TestUploadDownload.assertText2
+        )
+
+        self._verify_uploaded_volume_not_present(install_path)
+
+        ### Perform tests related to extracting the contents of a volume on managed storage to a QCOW2 file
+        ### and downloading the file
+
+        try:
+            # for data disk
+            Volume.extract(self.apiClient, uploaded_volume.id, self.zone.id, TestData.download_mode)
+
+            raise Exception("The volume extraction (for the data disk) did not fail (as expected).")
+        except Exception as e:
+            if TestUploadDownload.errorText in str(e):
+                pass
+            else:
+                raise
+
+        vm_root_volume_id = sf_util.get_cs_volume_db_id(self.dbConnection, vm_root_volume)
+
+        try:
+            # for root disk
+            Volume.extract(self.apiClient, vm_root_volume.id, self.zone.id, TestData.download_mode)
+
+            raise Exception("The volume extraction (for the root disk) did not fail (as expected).")
+        except Exception as e:
+            if TestUploadDownload.errorText in str(e):
+                pass
+            else:
+                raise
+
+        self.virtual_machine.stop(self.apiClient)
+
+        self._extract_volume_and_verify(uploaded_volume_id, "Unable to locate the extracted file for the data disk (attached)")
+
+        result = self._get_volume_store_ref_row(vm_root_volume_id)
+
+        self.assertEqual(
+            len(result),
+            0,
+            TestUploadDownload.assertText2
+        )
+
+        self._extract_volume_and_verify(vm_root_volume_id, "Unable to locate the extracted file for the root disk")
+
+        uploaded_volume = self.virtual_machine.detach_volume(
+            self.apiClient,
+            uploaded_volume
+        )
+
+        self._extract_volume_and_verify(uploaded_volume_id, "Unable to locate the extracted file for the data disk (detached)")
+
+        uploaded_volume = Volume(uploaded_volume.__dict__)
+
+        uploaded_volume.delete(self.apiClient)
+
+        # self.virtual_machine.start(self.apiClient)
+
+    def _verify_uploaded_volume_present(self, install_path, verify_properties_file=True):
+        result, result2 = self._get_results(install_path)
+
+        self.assertFalse(result is None or len(result.strip()) == 0, "Unable to find the QCOW2 file")
+
+        if verify_properties_file:
+            self.assertFalse(result2 is None or len(result2.strip()) == 0, "Unable to find the " + TestData.properties_file + " file")
+
+    def _verify_uploaded_volume_not_present(self, install_path):
+        result, result2 = self._get_results(install_path)
+
+        self.assertTrue(result is None or len(result.strip()) == 0, "QCOW2 file present, but should not be")
+        self.assertTrue(result2 is None or len(result2.strip()) == 0, TestData.properties_file + " file present, but should not be")
+
+    def _get_results(self, install_path):
+        ssh_connection = sf_util.get_ssh_connection(TestData.secondary_storage_server,
+                                                    TestData.secondary_storage_server_username,
+                                                    TestData.secondary_storage_server_password)
+
+        stdout = ssh_connection.exec_command("ls -l " + TestData.secondary_storage_server_root +
+                                                            install_path + " | grep qcow2")[1]
+
+        result = stdout.read()
+
+        stdout = ssh_connection.exec_command("ls -l " + TestData.secondary_storage_server_root +
+                                                            install_path + " | grep " + TestData.properties_file)[1]
+
+        result2 = stdout.read()
+
+        ssh_connection.close()
+
+        return result, result2
+
+    def _get_install_path(self, install_path):
+        index = install_path.rfind('/')
+
+        return install_path[:index]
+
+    def _get_volume_store_ref_row(self, volume_id):
+        sql_query = "Select * From volume_store_ref Where volume_id = '" + str(volume_id) + "'"
+
+        # make sure you can connect to MySQL: https://teamtreehouse.com/community/cant-connect-remotely-to-mysql-server-with-mysql-workbench
+        sql_result = self.dbConnection.execute(sql_query)
+
+        return sql_result
+
+    def _extract_volume_and_verify(self, volume_id, error_msg):
+        extract_result = Volume.extract(self.apiClient, volume_id, self.zone.id, TestData.download_mode)
+
+        result = self._get_volume_store_ref_row(volume_id)
+
+        self.assertEqual(
+            len(result),
+            1,
+            TestUploadDownload.assertText
+        )
+
+        install_path = self._get_install_path(result[0][TestData.install_path_index])
+
+        self._verify_uploaded_volume_present(install_path, False)
+
+        url_response = urllib2.urlopen(extract_result.url)
+
+        if url_response.code != 200:
+            raise Exception(error_msg)
+
+        self._wait_for_removal_of_extracted_volume(volume_id, extract_result.url)
+
+    def _wait_for_removal_of_extracted_volume(self, volume_id, extract_result_url):
+        retry_interval = 60
+        num_tries = 10
+
+        wait_result, return_val = wait_until(retry_interval, num_tries, self._check_removal_of_extracted_volume_state, volume_id, extract_result_url)
+
+        if not wait_result:
+            raise Exception(return_val)
+
+    def _check_removal_of_extracted_volume_state(self, volume_id, extract_result_url):
+        result = self._get_volume_store_ref_row(volume_id)
+
+        if len(result) == 0:
+            try:
+                urllib2.urlopen(extract_result_url)
+            except Exception as e:
+                if "404" in str(e):
+                    return True, ""
+
+        return False, "The extracted volume has not been removed."
+
+    def _wait_for_volume_state(self, volume_id, volume_state):
+        retry_interval = 30
+        num_tries = 10
+
+        wait_result, return_val = wait_until(retry_interval, num_tries, TestUploadDownload._check_volume_state, self.apiClient, volume_id, volume_state)
+
+        if not wait_result:
+            raise Exception(return_val)
+
+    @staticmethod
+    def _check_volume_state(api_client, volume_id, volume_state):
+        volume = list_volumes(
+            api_client,
+            id=volume_id,
+            listall=True
+        )[0]
+
+        if str(volume.state).lower() == volume_state.lower():
+            return True, ""
+
+        return False, "The volume is not in the '" + volume_state + "' state. State = " + str(volume.state)

--- a/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
+++ b/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
@@ -84,11 +84,11 @@ class TestData():
     def __init__(self):
         self.testdata = {
             TestData.solidFire: {
-                TestData.mvip: "192.168.139.112",
+                TestData.mvip: "10.117.40.120",
                 TestData.username: "admin",
                 TestData.password: "admin",
                 TestData.port: 443,
-                TestData.url: "https://192.168.139.112:443"
+                TestData.url: "https://10.117.40.120:443"
             },
             TestData.xenServer: {
                 TestData.username: "root",
@@ -118,7 +118,7 @@ class TestData():
             TestData.primaryStorage: {
                 TestData.name: "SolidFire-%d" % random.randint(0, 100),
                 TestData.scope: "ZONE",
-                TestData.url: "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                TestData.url: "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                        "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
                        "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",
@@ -132,7 +132,7 @@ class TestData():
             TestData.primaryStorage2: {
                 TestData.name: "SolidFireShared-%d" % random.randint(0, 100),
                 TestData.scope: "CLUSTER",
-                TestData.url: "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                TestData.url: "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
                         "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                         "minIops=5000;maxIops=50000;burstIops=75000",
                 TestData.provider: "SolidFireShared",
@@ -211,7 +211,7 @@ class TestData():
             TestData.clusterId1: 1,
             TestData.clusterId2: 2,
             TestData.domainId: 1,
-            TestData.url: "192.168.129.50"
+            TestData.url: "10.117.40.114"
         }
 
 

--- a/test/integration/plugins/solidfire/TestVMSnapshots.py
+++ b/test/integration/plugins/solidfire/TestVMSnapshots.py
@@ -18,6 +18,7 @@
 import logging
 import random
 import SignedAPICall
+import time
 import XenAPI
 
 from solidfire.factory import ElementFactory
@@ -71,14 +72,17 @@ class TestData:
     xenServer = "xenserver"
     zoneId = "zoneId"
 
+    # modify to control which hypervisor type to test
+    hypervisor_type = xenServer
+
     def __init__(self):
         self.testdata = {
             TestData.solidFire: {
-                TestData.mvip: "192.168.139.112",
+                TestData.mvip: "10.117.40.120",
                 TestData.username: "admin",
                 TestData.password: "admin",
                 TestData.port: 443,
-                TestData.url: "https://192.168.139.112:443"
+                TestData.url: "https://10.117.40.120:443"
             },
             TestData.xenServer: {
                 TestData.username: "root",
@@ -101,7 +105,7 @@ class TestData:
             TestData.primaryStorage: {
                 "name": "SolidFire-%d" % random.randint(0, 100),
                 TestData.scope: "ZONE",
-                "url": "MVIP=192.168.139.112;SVIP=10.10.8.112;" +
+                "url": "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                        "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
                        "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",
@@ -145,7 +149,7 @@ class TestData:
             TestData.zoneId: 1,
             TestData.clusterId: 1,
             TestData.domainId: 1,
-            TestData.url: "192.168.129.50"
+            TestData.url: "10.117.40.114"
         }
 
 
@@ -190,7 +194,7 @@ class TestVMSnapshots(cloudstackTestCase):
 
         # Get Resources from Cloud Infrastructure
         cls.zone = get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId])
-        template = get_template(cls.apiClient, cls.zone.id, cls.configData["ostype"])
+        template = get_template(cls.apiClient, cls.zone.id, hypervisor=TestData.hypervisor_type)
         cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
 
         # Create test account
@@ -252,7 +256,6 @@ class TestVMSnapshots(cloudstackTestCase):
         )
 
         cls._cleanup = [
-            cls.virtual_machine,
             compute_offering,
             cls.disk_offering,
             user,
@@ -262,6 +265,10 @@ class TestVMSnapshots(cloudstackTestCase):
     @classmethod
     def tearDownClass(cls):
         try:
+            time.sleep(60)
+
+            cls.virtual_machine.delete(cls.apiClient, True)
+
             cleanup_resources(cls.apiClient, cls._cleanup)
 
             cls.primary_storage.delete(cls.apiClient)

--- a/tools/apidoc/gen_toc.py
+++ b/tools/apidoc/gen_toc.py
@@ -189,7 +189,8 @@ known_categories = {
     'removeAnnotation' : 'Annotations',
     'CA': 'Certificate',
     'listElastistorInterface': 'Misc',
-    'cloudian': 'Cloudian'
+    'cloudian': 'Cloudian',
+    'Sioc' : 'Sioc'
     }
 
 

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -18016,6 +18016,10 @@
                                                     id: "gluster",
                                                     description: "Gluster"
                                                 });
+                                                items.push({
+                                                    id: "custom",
+                                                    description: "custom"
+                                                });
                                                 args.response.success({
                                                     data: items
                                                 });

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/DatastoreMO.java
@@ -57,7 +57,7 @@ public class DatastoreMO extends BaseMO {
     @Override
     public String getName() throws Exception {
         if (_name == null)
-            _name = (String)_context.getVimClient().getDynamicProperty(_mor, "name");
+            _name = _context.getVimClient().getDynamicProperty(_mor, "name");
 
         return _name;
     }
@@ -109,7 +109,7 @@ public class DatastoreMO extends BaseMO {
         PropertyFilterSpec pfSpec = new PropertyFilterSpec();
         pfSpec.getPropSet().add(pSpec);
         pfSpec.getObjectSet().add(oSpec);
-        List<PropertyFilterSpec> pfSpecArr = new ArrayList<PropertyFilterSpec>();
+        List<PropertyFilterSpec> pfSpecArr = new ArrayList<>();
         pfSpecArr.add(pfSpec);
 
         List<ObjectContent> ocs = _context.getService().retrieveProperties(_context.getPropertyCollector(), pfSpecArr);
@@ -118,8 +118,12 @@ public class DatastoreMO extends BaseMO {
         assert (ocs.get(0).getObj() != null);
         assert (ocs.get(0).getPropSet() != null);
         String dcName = ocs.get(0).getPropSet().get(0).getVal().toString();
-        _ownerDc = new Pair<DatacenterMO, String>(new DatacenterMO(_context, ocs.get(0).getObj()), dcName);
+        _ownerDc = new Pair<>(new DatacenterMO(_context, ocs.get(0).getObj()), dcName);
         return _ownerDc;
+    }
+
+    public void renameDatastore(String newDatastoreName) throws Exception {
+        _context.getService().renameDatastore(_mor, newDatastoreName);
     }
 
     public void makeDirectory(String path, ManagedObjectReference morDc) throws Exception {
@@ -133,7 +137,7 @@ public class DatastoreMO extends BaseMO {
         _context.getService().makeDirectory(morFileManager, fullPath, morDc, true);
     }
 
-    public String getDatastoreRootPath() throws Exception {
+    String getDatastoreRootPath() throws Exception {
         return String.format("[%s]", getName());
     }
 
@@ -210,7 +214,7 @@ public class DatastoreMO extends BaseMO {
         return false;
     }
 
-    public boolean copyDatastoreFile(String srcFilePath, ManagedObjectReference morSrcDc, ManagedObjectReference morDestDs, String destFilePath,
+    boolean copyDatastoreFile(String srcFilePath, ManagedObjectReference morSrcDc, ManagedObjectReference morDestDs, String destFilePath,
             ManagedObjectReference morDestDc, boolean forceOverwrite) throws Exception {
 
         String srcDsName = getName();
@@ -269,7 +273,7 @@ public class DatastoreMO extends BaseMO {
     public String[] getVmdkFileChain(String rootVmdkDatastoreFullPath) throws Exception {
         Pair<DatacenterMO, String> dcPair = getOwnerDatacenter();
 
-        List<String> files = new ArrayList<String>();
+        List<String> files = new ArrayList<>();
         files.add(rootVmdkDatastoreFullPath);
 
         String currentVmdkFullPath = rootVmdkDatastoreFullPath;
@@ -399,7 +403,7 @@ public class DatastoreMO extends BaseMO {
             return rootDirectoryFilePath;
         }
 
-        String parentFolderPath = null;
+        String parentFolderPath;
         String absoluteFileName = null;
         s_logger.info("Searching file " + fileName + " in " + datastorePath);
 

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/HostStorageSystemMO.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/HostStorageSystemMO.java
@@ -52,4 +52,12 @@ public class HostStorageSystemMO extends BaseMO {
     public void rescanVmfs() throws Exception {
         _context.getService().rescanVmfs(_mor);
     }
+
+    public void mountVmfsVolume(String datastoreUuid) throws Exception {
+        _context.getService().mountVmfsVolume(_mor, datastoreUuid);
+    }
+
+    public void unmountVmfsVolume(String datastoreUuid) throws Exception {
+        _context.getService().unmountVmfsVolume(_mor, datastoreUuid);
+    }
 }

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineDiskInfoBuilder.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/VirtualMachineDiskInfoBuilder.java
@@ -89,8 +89,9 @@ public class VirtualMachineDiskInfoBuilder {
     private static boolean chainContains(List<String> chain, String diskBackingFileBaseName, String dataStoreName) {
         for (String backing : chain) {
             DatastoreFile file = new DatastoreFile(backing);
+
             // Ensure matching disk exists in the right datastore
-            if (file.getFileBaseName().equals(diskBackingFileBaseName) && backing.contains(dataStoreName))
+            if (file.getFileBaseName().equals(diskBackingFileBaseName) && file.getDatastoreName().equals(dataStoreName))
                 return true;
         }
 


### PR DESCRIPTION
Allowed zone-wide primary storage based on a custom plug-in to be added via the GUI in a KVM-only environment (previously this only worked for XenServer and VMware)

Added support for root disks on managed storage with KVM

Added support for volume snapshots with managed storage on KVM

Enabled creating a template directly from a volume (i.e. without having to go through a volume snapshot) on KVM with managed storage

Only allowed the resizing of a volume for managed storage on KVM if the volume in question is either not attached to a VM or is attached to a VM in the Stopped state

Included support for Reinstall VM on KVM with managed storage

Enabled offline migration on KVM from non-managed storage to managed storage and vice versa

Included support for online storage migration on KVM with managed storage (NFS and Ceph to managed storage)

Added support to download (extract) a managed-storage volume to a QCOW2 file

When uploading a file from outside of CloudStack to CloudStack, set the min and max IOPS, if applicable.

Included support for the KVM auto-convergence feature

The compression flag was actually added in version 1.0.3 (1000003) as opposed to version 1.3.0 (1003000) (changed this to reflect the correct version)

On KVM when using iSCSI-based managed storage, if the user shuts a VM down from the guest OS (as opposed to doing so from CloudStack), we need to pass to the KVM agent a list of applicable iSCSI volumes that need to be disconnected.

Added a new Global Setting: kvm.storage.live.migration.wait

For XenServer, added a check to enforce that only volumes from zone-wide managed storage can be storage motioned from a host in one cluster to a host in another cluster (cannot do so at the time being with volumes from cluster-scoped managed storage)

Don’t allow Storage XenMotion on a VM that has any managed-storage volume with one or more snapshots.

Enabled for managed storage with VMware: Template caching, create snapshot, delete snapshot, create volume from snapshot, and create template from snapshot

Added an SIOC API plug-in to support VMware SIOC

When starting a VM that uses managed storage in a cluster other than the one it last was running in, we need to remove the reference to the iSCSI volume from the original cluster.

Added the ability to revert a volume to a snapshot

Enabled cluster-scoped managed storage

Added support for VMware dynamic discovery
  