### PR TITLE
CLOUDSTACK-10120 : Allow migration of VM's from Cloudstack UI between the hosts with different version

### DIFF
--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -1432,7 +1432,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         sb.and("clusterId", sb.entity().getClusterId(), SearchCriteria.Op.EQ);
         sb.and("resourceState", sb.entity().getResourceState(), SearchCriteria.Op.EQ);
         sb.and("hypervisorType", sb.entity().getHypervisorType(), SearchCriteria.Op.EQ);
-        sb.and("hypervisorVersion", sb.entity().getHypervisorVersion(), SearchCriteria.Op.EQ);
+        sb.and("hypervisorVersion", sb.entity().getHypervisorVersion(), SearchCriteria.Op.GTEQ);
 
         final String haTag = _haMgr.getHaTag();
         SearchBuilder<HostTagVO> hostTagSearch = null;


### PR DESCRIPTION
**ISSUE**

Currently Cloudstack doesn't allow to migrate the VM's between the hosts with different versions of Hypervisors from UI, whereas using API it is possible. Hypervisor itself allows migration of VM's between different versions, like VMware allows migration of VM's from 5.1 ESXi to 5.5 ESXi. Similarly XenServer allows migration from 6.2 to 6.5.

**STEPS TO REPRODUCE**

- Create Cloudstack setup with more than one hosts of different version.
- Try to migrate a VM from lower version host to higher version host.
- On UI, it will not list the hosts with different version. Whereas using API migrateVirtualMachineWithVolume, VM from lower version of host can be migrated to higher version host.

**FIX**

Added a fix, to list hosts of same and higher version on UI while listing hosts that are available for migration.