### PR TITLE
CLOUDSTACK-10129: Allow navigation from VRs to network, instances, owners etc.

### DIFF
--- a/ui/scripts/accounts.js
+++ b/ui/scripts/accounts.js
@@ -137,6 +137,19 @@
                             });
                         }
 
+                        if ("routers" in args.context) {
+                            if ("account" in args.context.routers[0]) {
+                                $.extend(data, {
+                                    name: args.context.routers[0].account
+                                });
+                            }
+                            if ("domainid" in args.context.routers[0]) {
+                                $.extend(data, {
+                                    domainid: args.context.routers[0].domainid
+                                });
+                            }
+                        }
+
                         $.ajax({
                             url: createURL('listAccounts'),
                             data: data,

--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -379,6 +379,31 @@
                     });
                 }
 
+                if ("routers" in args.context) {
+                    if ("vpcid" in args.context.routers[0]) {
+                        $.extend(data, {
+                            vpcid: args.context.routers[0].vpcid
+                        });
+                    } else {
+                        if ("guestnetworkid" in args.context.routers[0]) {
+                            $.extend(data, {
+                                networkid: args.context.routers[0].guestnetworkid
+                            });
+                        }
+                    }
+                    if ("projectid" in args.context.routers[0]) {
+                        $.extend(data, {
+                            projectid: args.context.routers[0].projectid
+                        });
+                    }
+                }
+
+                if ("networks" in args.context) {
+                    $.extend(data, {
+                        networkid: args.context.networks[0].id
+                    });
+                }
+
                 if ("templates" in args.context) {
                     $.extend(data, {
                         templateid: args.context.templates[0].id

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -914,6 +914,25 @@
                         var data = {};
                         listViewDataProvider(args, data);
 
+                        if ("routers" in args.context) {
+                            if ("vpcid" in args.context.routers[0]) {
+                                $.extend(data, {
+                                    vpcid: args.context.routers[0].vpcid
+                                });
+                            } else {
+                                if ("guestnetworkid" in args.context.routers[0]) {
+                                    $.extend(data, {
+                                        id: args.context.routers[0].guestnetworkid
+                                    });
+                                }
+                            }
+                            if ("projectid" in args.context.routers[0]) {
+                                $.extend(data, {
+                                    projectid: args.context.routers[0].projectid
+                                });
+                            }
+                        }
+
                         $.ajax({
                             url: createURL('listNetworks'),
                             data: data,
@@ -931,7 +950,7 @@
 
                     detailView: {
                         name: 'label.guest.network.details',
-                        viewAll: {
+                        viewAll: [{
                             path: 'network.ipAddresses',
                             label: 'label.menu.ipaddresses',
                             preFilter: function(args) {
@@ -940,7 +959,10 @@
 
                                 return true;
                             }
-                        },
+                        }, {
+                            label: 'label.instances',
+                            path: 'instances'
+                        }],
                         actions: {
                             edit: {
                                 label: 'label.edit',
@@ -6334,7 +6356,6 @@
                                 }
                             },
                             action: function(args) {
-                                console.log(args.context);
                                 $.ajax({
                                     url: createURL('removeVpnUser'),
                                     data: {

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -31,6 +31,7 @@
 
         if (router.projectid) routerType = _l('label.project');
         if (router.vpcid) routerType = _l('label.vpc');
+        if ("isredundantrouter" in router && router.isredundantrouter) routerType = routerType + " (" + router.redundantstate + ")";
 
         return $.extend(router, {
             routerType: routerType
@@ -9599,6 +9600,23 @@
                             },
                             detailView: {
                                 name: 'label.virtual.appliance.details',
+                                viewAll: [{
+                                    label: 'label.account',
+                                    path: 'accounts',
+                                    preFilter: function(args) {
+                                        if (args.context.routers[0].projectid)
+                                            return false;
+                                        if (args.context.routers[0].account == 'system')
+                                            return false;
+                                        return true;
+                                    }
+                                }, {
+                                    label: 'label.networks',
+                                    path: 'network',
+                                }, {
+                                    label: 'label.instances',
+                                    path: 'instances'
+                                }],
                                 actions: {
                                     start: {
                                         label: 'label.action.start.router',


### PR DESCRIPTION
The following navigation filtering is supported:
- Instances connected to a network, Networks -> view instances
- View account/owner and instances from a VR, Infra -> VR -> View account (if it's not project or system), view instances, view network(s) (Network -> list of VRs/tab already exists)
- Show redundant state for VPC VRs in parenthesis at Infra -> VRs -> list of VPC VRs

Pinging for review @DaanHoogland @wido @PaulAngus @nvazquez @borisstoyanov @DagSonstebo @glennwagner @rafaelweingartner @GabrielBrascher @fmaximus @ustcweizhou @resmo @NuxRo and others

## Screenshots:

### Network to Instances:
![screenshot from 2017-11-03 15-00-43](https://user-images.githubusercontent.com/95203/32367354-d6972f66-c0a7-11e7-90b5-0854c6e1e619.png)
![screenshot from 2017-11-03 15-00-49](https://user-images.githubusercontent.com/95203/32367356-d6e3ecde-c0a7-11e7-9c9c-afe4f09e20ae.png)

### VR listing
![screenshot from 2017-11-03 15-01-43](https://user-images.githubusercontent.com/95203/32367392-efa3ee68-c0a7-11e7-86a1-2e66a48f5554.png)

### VR to instances, owner account and networks
![screenshot from 2017-11-03 15-02-25](https://user-images.githubusercontent.com/95203/32367448-20bdc334-c0a8-11e7-98dc-383370f7fc7e.png)
![screenshot from 2017-11-03 15-02-31](https://user-images.githubusercontent.com/95203/32367449-2102b372-c0a8-11e7-9390-9b9eead3e35f.png)
![screenshot from 2017-11-03 15-02-42](https://user-images.githubusercontent.com/95203/32367450-2144336a-c0a8-11e7-84d0-16bd9053908f.png)


