### PR TITLE
CLOUDSTACK-8908 After copying the template charging for that template is stopped

### DIFF
--- a/engine/schema/src/com/cloud/usage/dao/UsageStorageDaoImpl.java
+++ b/engine/schema/src/com/cloud/usage/dao/UsageStorageDaoImpl.java
@@ -66,6 +66,7 @@ public class UsageStorageDaoImpl extends GenericDaoBase<UsageStorageVO, Long> im
         IdZoneSearch.and("id", IdZoneSearch.entity().getId(), SearchCriteria.Op.EQ);
         IdZoneSearch.and("type", IdZoneSearch.entity().getStorageType(), SearchCriteria.Op.EQ);
         IdZoneSearch.and("dcId", IdZoneSearch.entity().getZoneId(), SearchCriteria.Op.EQ);
+        IdZoneSearch.and("deleted", IdZoneSearch.entity().getDeleted(), SearchCriteria.Op.NULL);
         IdZoneSearch.done();
     }
 
@@ -85,6 +86,7 @@ public class UsageStorageDaoImpl extends GenericDaoBase<UsageStorageVO, Long> im
         sc.setParameters("id", id);
         sc.setParameters("type", type);
         sc.setParameters("dcId", dcId);
+        sc.setParameters("deleted", null);
         return listBy(sc, null);
     }
 


### PR DESCRIPTION
When a template is copied back to zone after it is deleted. deleted field gets reset to null. delete field is added to Search on template zone mapping table to take care of the existing mapping