### PR TITLE
CLOUDSTACK-10137: Only link log4j if not already present

### DIFF
--- a/debian/cloudstack-management.postinst
+++ b/debian/cloudstack-management.postinst
@@ -57,7 +57,9 @@ if [ "$1" = configure ]; then
     chgrp cloud ${CONFDIR}/${DBPROPS}
     chown -R cloud:cloud /var/log/cloudstack/management
 
-    ln -s ${CONFDIR}/log4j-cloud.xml ${CONFDIR}/log4j.xml
+    if [ ! -e "$CONFDIR/log4j.xml" ]; then
+        ln -s ${CONFDIR}/log4j-cloud.xml ${CONFDIR}/log4j.xml
+    fi
 
     # Add jdbc MySQL driver settings to db.properties if not present
     grep -s -q "db.cloud.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS} || sed -i -e "\$adb.cloud.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS}

--- a/debian/cloudstack-management.postinst
+++ b/debian/cloudstack-management.postinst
@@ -57,9 +57,7 @@ if [ "$1" = configure ]; then
     chgrp cloud ${CONFDIR}/${DBPROPS}
     chown -R cloud:cloud /var/log/cloudstack/management
 
-    if [ ! -e "$CONFDIR/log4j.xml" ]; then
-        ln -s ${CONFDIR}/log4j-cloud.xml ${CONFDIR}/log4j.xml
-    fi
+    ln -sf ${CONFDIR}/log4j-cloud.xml ${CONFDIR}/log4j.xml
 
     # Add jdbc MySQL driver settings to db.properties if not present
     grep -s -q "db.cloud.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS} || sed -i -e "\$adb.cloud.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS}

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -295,7 +295,7 @@ do
   cp client/target/conf/$name ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/$name
 done
 
-ln -s log4j-cloud.xml  ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/log4j.xml
+ln -sf log4j-cloud.xml  ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/log4j.xml
 
 install python/bindir/cloud-external-ipallocator.py ${RPM_BUILD_ROOT}%{_bindir}/%{name}-external-ipallocator.py
 install -D client/target/pythonlibs/jasypt-1.9.2.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -265,7 +265,7 @@ do
   cp client/target/conf/$name ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/$name
 done
 
-ln -s log4j-cloud.xml  ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/log4j.xml
+ln -sf log4j-cloud.xml  ${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}/management/log4j.xml
 
 install python/bindir/cloud-external-ipallocator.py ${RPM_BUILD_ROOT}%{_bindir}/%{name}-external-ipallocator.py
 install -D client/target/pythonlibs/jasypt-1.9.2.jar ${RPM_BUILD_ROOT}%{_datadir}/%{name}-common/lib/jasypt-1.9.2.jar


### PR DESCRIPTION
When reinstalling the package, cloudstack-management fails to install properly due to the `log4j.xml` already present.