### PR TITLE
CLOUDSTACK-10178: Hotfixes to make 4.10 work

### DIFF
--- a/core/src/com/cloud/storage/template/TemplateLocation.java
+++ b/core/src/com/cloud/storage/template/TemplateLocation.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Properties;
+import java.util.Arrays;
 
 import org.apache.log4j.Logger;
 
@@ -81,12 +82,12 @@ public class TemplateLocation {
         boolean purged = true;
         String[] files = _storage.listFiles(_templatePath);
         for (String file : files) {
-            boolean r = _storage.delete(file);
-            if (!r) {
+            boolean isRemoved = _storage.delete(file);
+            if (!isRemoved) {
                 purged = false;
             }
             if (s_logger.isDebugEnabled()) {
-                s_logger.debug((r ? "R" : "Unable to r") + "emove " + file);
+                s_logger.debug((isRemoved ? "Removed " : "Unable to remove") + file);
             }
         }
 
@@ -97,43 +98,60 @@ public class TemplateLocation {
         try (FileInputStream strm = new FileInputStream(_file);) {
             _props.load(strm);
         } catch (IOException e) {
-            s_logger.warn("Unable to load the template properties", e);
+            s_logger.warn("Unable to load the template properties for '" + _file + "': ", e);
         }
 
         for (ImageFormat format : ImageFormat.values()) {
-            String ext = _props.getProperty(format.getFileExtension());
+            String currentExtension = format.getFileExtension();
+            String ext = _props.getProperty(currentExtension);
             if (ext != null) {
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("File extension '" + currentExtension + "' was found in '" + _file + "'.");
+                }
                 FormatInfo info = new FormatInfo();
                 info.format = format;
-                info.filename = _props.getProperty(format.getFileExtension() + ".filename");
+                info.filename = _props.getProperty(currentExtension + ".filename");
                 if (info.filename == null) {
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug("Property '" + currentExtension + ".filename' was not found in '" + _file + "'. Current format is ignored.");
+                    }
                     continue;
                 }
-                info.size = NumbersUtil.parseLong(_props.getProperty(format.getFileExtension() + ".size"), -1);
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Property '" + currentExtension + ".filename' was found in '" + _file + "'. Current format will be parsed.");
+                }
+                info.size = NumbersUtil.parseLong(_props.getProperty(currentExtension + ".size"), -1);
                 _props.setProperty("physicalSize", Long.toString(info.size));
-                info.virtualSize = NumbersUtil.parseLong(_props.getProperty(format.getFileExtension() + ".virtualsize"), -1);
+                info.virtualSize = NumbersUtil.parseLong(_props.getProperty(currentExtension + ".virtualsize"), -1);
                 _formats.add(info);
 
                 if (!checkFormatValidity(info)) {
                     _isCorrupted = true;
                     s_logger.warn("Cleaning up inconsistent information for " + format);
                 }
+            } else {
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Format extension '" + currentExtension + "' wasn't found in '" + _file + "'.");
+                }
             }
         }
 
         if (_props.getProperty("uniquename") == null || _props.getProperty("virtualsize") == null) {
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug("Property 'uniquename' or 'virtualsize' weren't found in '" + _file + "'. Loading failed.");
+            }
             return false;
         }
-
         return (_formats.size() > 0);
     }
 
     public boolean save() {
         for (FormatInfo info : _formats) {
-            _props.setProperty(info.format.getFileExtension(), "true");
-            _props.setProperty(info.format.getFileExtension() + ".filename", info.filename);
-            _props.setProperty(info.format.getFileExtension() + ".size", Long.toString(info.size));
-            _props.setProperty(info.format.getFileExtension() + ".virtualsize", Long.toString(info.virtualSize));
+            String formatExtension = info.format.getFileExtension();
+            _props.setProperty(formatExtension, "true");
+            _props.setProperty(formatExtension + ".filename", info.filename);
+            _props.setProperty(formatExtension + ".size", Long.toString(info.size));
+            _props.setProperty(formatExtension + ".virtualsize", Long.toString(info.virtualSize));
         }
         try (FileOutputStream strm =  new FileOutputStream(_file);) {
             _props.store(strm, "");
@@ -205,10 +223,11 @@ public class TemplateLocation {
             FormatInfo info = it.next();
             if (info.format == format) {
                 it.remove();
-                _props.remove(format.getFileExtension());
-                _props.remove(format.getFileExtension() + ".filename");
-                _props.remove(format.getFileExtension() + ".size");
-                _props.remove(format.getFileExtension() + ".virtualsize");
+                String formatExtension = format.getFileExtension();
+                _props.remove(formatExtension);
+                for(String propertySuffix : Arrays.asList("filename","size","virtualsize")) {
+                        _props.remove(formatExtension + "." + propertySuffix);
+                }
                 return info;
             }
         }

--- a/debian/cloudstack-agent.postinst
+++ b/debian/cloudstack-agent.postinst
@@ -35,6 +35,15 @@ case "$1" in
             done
         fi
 
+        BR_NETFILTER_MODULE=br_netfilter
+        MODULES_FILE=/etc/modules
+        if /sbin/modinfo $BR_NETFILTER_MODULE >/dev/null 2>&1; then
+            /sbin/modprobe $BR_NETFILTER_MODULE
+            if ! grep $BR_NETFILTER_MODULE $MODULES_FILE >/dev/null 2>&1; then
+                echo "$BR_NETFILTER_MODULE" >> $MODULES_FILE
+            fi
+        fi
+
         # Running cloudstack-agent-upgrade to update bridge name for upgrade from CloudStack 4.0.x (and before) to CloudStack 4.1 (and later)
         /usr/bin/cloudstack-agent-upgrade
         if [ ! -d "/etc/libvirt/hooks" ] ; then

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2572,9 +2572,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             s_logger.trace("VM Operation Thread Running");
             try {
                 _workDao.cleanup(VmOpCleanupWait.value());
-
-                // TODO. hard-coded to one hour after job has been completed
-                final Date cutDate = new Date(new Date().getTime() - 3600000);
+                final Date cutDate = new Date(DateUtil.currentGMTTime().getTime() - VmOpCleanupInterval.value() * 1000);
                 _workJobDao.expungeCompletedWorkJobs(cutDate);
             } catch (final Exception e) {
                 s_logger.error("VM Operations failed due to ", e);
@@ -2944,7 +2942,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             try {
                 scanStalledVMInTransitionStateOnDisconnectedHosts();
 
-                final List<VMInstanceVO> instances = _vmDao.findVMInTransition(new Date(new Date().getTime() - AgentManager.Wait.value() * 1000), State.Starting, State.Stopping);
+                final List<VMInstanceVO> instances = _vmDao.findVMInTransition(new Date(DateUtil.currentGMTTime().getTime() - AgentManager.Wait.value() * 1000), State.Starting, State.Stopping);
                 for (final VMInstanceVO instance : instances) {
                     final State state = instance.getState();
                     if (state == State.Stopping) {

--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -18,8 +18,8 @@
 [Unit]
 Description=CloudStack Agent
 Documentation=http://www.cloudstack.org/
-Requires=libvirtd.service
-After=libvirtd.service
+Requires=libvirt-bin.service
+After=libvirt-bin.service
 
 [Service]
 Type=simple

--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -18,8 +18,8 @@
 [Unit]
 Description=CloudStack Agent
 Documentation=http://www.cloudstack.org/
-Requires=libvirt-bin.service
-After=libvirt-bin.service
+Requires=libvirtd.service
+After=libvirtd.service
 
 [Service]
 Type=simple

--- a/plugins/database/quota/test/org/apache/cloudstack/api/response/QuotaResponseBuilderImplTest.java
+++ b/plugins/database/quota/test/org/apache/cloudstack/api/response/QuotaResponseBuilderImplTest.java
@@ -16,14 +16,17 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.cloud.exception.InvalidParameterValueException;
-import com.cloud.user.Account;
-import com.cloud.user.AccountManager;
-import com.cloud.user.AccountVO;
-import com.cloud.user.dao.AccountDao;
-import com.cloud.user.dao.UserDao;
-import com.cloud.utils.db.TransactionLegacy;
-import junit.framework.TestCase;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import javax.inject.Inject;
+
 import org.apache.cloudstack.api.command.QuotaEmailTemplateListCmd;
 import org.apache.cloudstack.api.command.QuotaEmailTemplateUpdateCmd;
 import org.apache.cloudstack.quota.QuotaService;
@@ -36,7 +39,7 @@ import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
 import org.apache.cloudstack.quota.vo.QuotaCreditsVO;
 import org.apache.cloudstack.quota.vo.QuotaEmailTemplatesVO;
 import org.apache.cloudstack.quota.vo.QuotaTariffVO;
-import org.joda.time.DateTime;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,13 +47,15 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.user.Account;
+import com.cloud.user.AccountManager;
+import com.cloud.user.AccountVO;
+import com.cloud.user.dao.AccountDao;
+import com.cloud.user.dao.UserDao;
+import com.cloud.utils.db.TransactionLegacy;
 
-import javax.inject.Inject;
+import junit.framework.TestCase;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QuotaResponseBuilderImplTest extends TestCase {
@@ -218,13 +223,24 @@ public class QuotaResponseBuilderImplTest extends TestCase {
     }
 
     @Test
-    public void testStartOfNextDay() {
-        DateTime now = new DateTime();
-        DateTime nextDay = new DateTime(quotaResponseBuilder.startOfNextDay(now.toDate()));
-        DateTime nextDay2 = new DateTime(quotaResponseBuilder.startOfNextDay());
-        assertTrue(now.toLocalDate().equals(nextDay.minusDays(1).toLocalDate()));
-        assertTrue(now.toLocalDate().equals(nextDay2.minusDays(1).toLocalDate()));
+    public void testStartOfNextDayWithoutParameters() {
+        Date nextDate = quotaResponseBuilder.startOfNextDay();
+
+        LocalDateTime tomorrowAtStartOfTheDay = LocalDate.now().atStartOfDay().plusDays(1);
+        Date expectedNextDate = Date.from(tomorrowAtStartOfTheDay.atZone(ZoneId.systemDefault()).toInstant());
+
+        Assert.assertEquals(expectedNextDate, nextDate);
     }
 
+    @Test
+    public void testStartOfNextDayWithParameter() {
+        Date anyDate = new Date(1242421545757532l);
 
+        Date nextDayDate = quotaResponseBuilder.startOfNextDay(anyDate);
+
+        LocalDateTime nextDayLocalDateTimeAtStartOfTheDay = anyDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate().plusDays(1).atStartOfDay();
+        Date expectedNextDate = Date.from(nextDayLocalDateTimeAtStartOfTheDay.atZone(ZoneId.systemDefault()).toInstant());
+
+        Assert.assertEquals(expectedNextDate, nextDayDate);
+    }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3419,7 +3419,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         cmd.add("--vmname", vmName);
         cmd.add("--vmid", vmId);
         cmd.add("--vmip", guestIP);
-        cmd.add("--vmip6", guestIP6);
+        if (guestIP6 != null) {
+            cmd.add("--vmip6", guestIP6);
+        }
         cmd.add("--sig", sig);
         cmd.add("--seq", seq);
         cmd.add("--vmmac", mac);

--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -1051,21 +1051,27 @@ def add_network_rules(vm_name, vm_id, vm_ip, vm_ip6, signature, seqno, vmMac, ru
                 range = 'any'
 
         for ip in rule['ipv4']:
-            if protocol == 'all':
-                execute('iptables -I ' + vmchain + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
-            elif protocol != 'icmp':
-                execute('iptables -I ' + vmchain + ' -p ' + protocol + ' -m ' + protocol + ' --dport ' + range + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
-            else:
-                execute('iptables -I ' + vmchain + ' -p icmp --icmp-type ' + range + ' ' + direction + ' ' + ip + ' -j ' + action)
-
+            try:
+                if protocol == 'all':
+                    execute('iptables -I ' + vmchain + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
+                elif protocol != 'icmp':
+                    execute('iptables -I ' + vmchain + ' -p ' + protocol + ' -m ' + protocol + ' --dport ' + range + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
+                else:
+                    execute('iptables -I ' + vmchain + ' -p icmp --icmp-type ' + range + ' ' + direction + ' ' + ip + ' -j ' + action)
+            except:
+                pass
+                    
         for ip in rule['ipv6']:
-            if protocol == 'all':
-                execute('ip6tables -I ' + vmchain + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
-            elif 'icmp' != protocol:
-                execute('ip6tables -I ' + vmchain + ' -p ' + protocol + ' -m ' + protocol + ' --dport ' + range + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
-            else:
-                execute('ip6tables -I ' + vmchain + ' -p icmpv6 --icmpv6-type ' + range + ' ' + direction + ' ' + ip + ' -j ' + action)
-
+            try:
+                if protocol == 'all':
+                    execute('ip6tables -I ' + vmchain + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
+                elif 'icmp' != protocol:
+                    execute('ip6tables -I ' + vmchain + ' -p ' + protocol + ' -m ' + protocol + ' --dport ' + range + ' -m state --state NEW ' + direction + ' ' + ip + ' -j ' + action)
+                else:
+                    execute('ip6tables -I ' + vmchain + ' -p icmpv6 --icmpv6-type ' + range + ' ' + direction + ' ' + ip + ' -j ' + action)
+            except:
+                pass
+                    
     egress_vmchain = egress_chain_name(vm_name)
     if egressrule_v4 == 0 :
         execute('iptables -A ' + egress_vmchain + ' -j RETURN')

--- a/server/src/com/cloud/test/DatabaseConfig.java
+++ b/server/src/com/cloud/test/DatabaseConfig.java
@@ -55,7 +55,6 @@ import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.dao.DiskOfferingDaoImpl;
 import com.cloud.storage.Storage.ProvisioningType;
 import com.cloud.utils.DateUtil;
-
 import com.cloud.utils.PropertiesUtil;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.DB;

--- a/server/src/com/cloud/test/DatabaseConfig.java
+++ b/server/src/com/cloud/test/DatabaseConfig.java
@@ -54,6 +54,8 @@ import com.cloud.service.dao.ServiceOfferingDaoImpl;
 import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.dao.DiskOfferingDaoImpl;
 import com.cloud.storage.Storage.ProvisioningType;
+import com.cloud.utils.DateUtil;
+
 import com.cloud.utils.PropertiesUtil;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.db.DB;
@@ -641,7 +643,7 @@ public class DatabaseConfig {
             stmt.setLong(8, 0);
             stmt.setString(9, hostAddress);
             stmt.setString(10, hostPath);
-            stmt.setDate(11, new Date(new java.util.Date().getTime()));
+            stmt.setDate(11, new Date(DateUtil.currentGMTTime().getTime()));
             stmt.setLong(12, podId);
             stmt.setString(13, Status.Up.toString());
             stmt.setLong(14, clusterId);

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -460,7 +460,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             FormatInfo info = processor.process(destPath, null, templateUuid);
 
             TemplateLocation loc = new TemplateLocation(_storage, destPath);
-            loc.create(1, true, templateUuid);
+            loc.create(destData.getId(), true, templateUuid);
             loc.addFormat(info);
             loc.save();
             TemplateProp prop = loc.getTemplateInfo();
@@ -548,7 +548,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
 
                     FormatInfo info = processor.process(destPath, null, templateName);
                     TemplateLocation loc = new TemplateLocation(_storage, destPath);
-                    loc.create(1, true, destData.getName());
+                    loc.create(destData.getId(), true, destData.getName());
                     loc.addFormat(info);
                     loc.save();
 

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -522,10 +522,8 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                     bufferWriter.write("uniquename=" + destData.getName());
                     bufferWriter.write("\n");
                     bufferWriter.write("filename=" + fileName);
-                    bufferWriter.write("\n");
-                    long size = _storage.getSize(destFileFullPath);
-                    bufferWriter.write("size=" + size);
-
+                }
+                try {
                     /**
                      * Snapshots might be in either QCOW2 or RAW image format
                      *


### PR DESCRIPTION
This PR implements several fixes which are vital for CS 4.10 to work:
1. Fixes absent IPv6 network definition bugs for basic zone which lead to exceptions on KVM agent if it uses SGs (management and agent affected)
2. Fixes the case when template is created from a snapshot (CLOUDSTACK-10140, merged https://github.com/apache/cloudstack/pull/2322)
3. Fixes ubuntu/debian br_netfilter dependency (CLOUDSTACK-10138, merged CLOUDSTACK-10138: Load br_netfilter in security_group management script)
4. Fixes quota plugin bug (https://github.com/apache/cloudstack/pull/2326)
