### PR TITLE
CLOUDSTACK-10043: fix restore default drop for egress rules in ACL

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -456,6 +456,9 @@ class CsIP:
             self.fw.append(
                 ["mangle", "front", "-A ACL_OUTBOUND_%s -d 224.0.0.18/32 -j ACCEPT" % self.dev])
             self.fw.append(
+                ["mangle", "", "-A ACL_OUTBOUND_%s -j DROP" % self.dev])
+
+            self.fw.append(
                 ["filter", "", "-A INPUT -i %s -p udp -m udp --dport 67 -j ACCEPT" % self.dev])
             self.fw.append(
                 ["mangle", "front", "-A POSTROUTING " + "-p udp -m udp --dport 68 -j CHECKSUM --checksum-fill"])
@@ -717,4 +720,3 @@ class CsRpsrfs:
         if count < 2:
             logging.debug("Single CPU machine")
         return count
-


### PR DESCRIPTION
While verifying the fix for CLOUDSTACK-10135 in #2313 we found a regression.

~At least to version 4.5.x (verified in 4.5.3) every ACL hat a default drop for egress (ACL_OUTBOUND). This commit restores this behavior (regression fix)~

Ok, after some more investigation and  help of @fmaximus it seems the 4.5 implementation is wrong as well. It does not add a deny egress all but a deny egress all if there is any egress rule (even a deny), but anyway. 

This is a not a bug fix anymore but a default deny.

/cc @rhtyd @yvsubhash