### PR TITLE
Remove annotation and "depends-on" declaration not needed at cloud-engine-storage-image

### DIFF
--- a/engine/storage/snapshot/resources/META-INF/cloudstack/core/spring-engine-storage-snapshot-core-context.xml
+++ b/engine/storage/snapshot/resources/META-INF/cloudstack/core/spring-engine-storage-snapshot-core-context.xml
@@ -28,12 +28,10 @@
                       >
 
     <bean id="snapshotServiceImpl"
-        class="org.apache.cloudstack.storage.snapshot.SnapshotServiceImpl"
-        depends-on="snapshotStateMachineManagerImpl, snapshotDataFactoryImpl, dataStoreManagerImpl, dataMotionServiceImpl, objectInDataStoreManagerImpl" />
+        class="org.apache.cloudstack.storage.snapshot.SnapshotServiceImpl" />
 
     <bean id="snapshotDataFactoryImpl"
-        class="org.apache.cloudstack.storage.snapshot.SnapshotDataFactoryImpl"
-        depends-on="dataStoreManagerImpl, snapshotDataStoreDaoImpl, volumeDataFactoryImpl" />
+        class="org.apache.cloudstack.storage.snapshot.SnapshotDataFactoryImpl"/>
 
     <bean id="snapshotStateMachineManagerImpl"
         class="org.apache.cloudstack.storage.snapshot.SnapshotStateMachineManagerImpl" />

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotDataFactoryImpl.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotDataFactoryImpl.java
@@ -23,8 +23,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Component;
-
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -39,7 +37,6 @@ import com.cloud.storage.SnapshotVO;
 import com.cloud.storage.dao.SnapshotDao;
 import com.cloud.utils.exception.CloudRuntimeException;
 
-@Component
 public class SnapshotDataFactoryImpl implements SnapshotDataFactory {
     @Inject
     SnapshotDao snapshotDao;

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotServiceImpl.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotServiceImpl.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
 import org.apache.cloudstack.engine.subsystem.api.storage.CopyCommandResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.CreateCmdResult;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataMotionService;
@@ -48,6 +46,7 @@ import org.apache.cloudstack.storage.command.CommandResult;
 import org.apache.cloudstack.storage.command.CopyCmdAnswer;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
+import org.apache.log4j.Logger;
 
 import com.cloud.storage.CreateSnapshotPayload;
 import com.cloud.storage.DataStoreRole;
@@ -62,7 +61,6 @@ import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.NoTransitionException;
 
-@Component
 public class SnapshotServiceImpl implements SnapshotService {
     private static final Logger s_logger = Logger.getLogger(SnapshotServiceImpl.class);
     @Inject

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotStateMachineManagerImpl.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotStateMachineManagerImpl.java
@@ -19,8 +19,6 @@ package org.apache.cloudstack.storage.snapshot;
 
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Component;
-
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.Snapshot.Event;
 import com.cloud.storage.Snapshot.State;
@@ -30,7 +28,6 @@ import com.cloud.storage.listener.SnapshotStateListener;
 import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateMachine2;
 
-@Component
 public class SnapshotStateMachineManagerImpl implements SnapshotStateMachineManager {
     private StateMachine2<State, Event, SnapshotVO> stateMachine = new StateMachine2<State, Event, SnapshotVO>();
     @Inject

--- a/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeDataFactoryImpl.java
+++ b/engine/storage/volume/src/org/apache/cloudstack/storage/volume/VolumeDataFactoryImpl.java
@@ -23,8 +23,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Component;
-
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -37,7 +35,6 @@ import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
 
-@Component
 public class VolumeDataFactoryImpl implements VolumeDataFactory {
     @Inject
     VolumeDao volumeDao;


### PR DESCRIPTION
Following the discussion on [1], I am proposing the removal of some unnecessary annotation and Spring configurations at cloud-engine-storage-image.


[1] http://mail-archives.apache.org/mod_mbox/cloudstack-dev/201711.mbox/%3CCAGQtxvZ1kc1EmzsMPRqUjOtcDSjr9aEAQGigBNUdVVg4ee%2BHGw%40mail.gmail.com%3E