### PR TITLE
CLOUDSTACK-10129: Show account, network info in VR list view

### DIFF
--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -29,9 +29,19 @@
     var mapRouterType = function (index, router) {
         var routerType = _l('label.menu.system');
 
-        if (router.projectid) routerType = _l('label.project');
-        if (router.vpcid) routerType = _l('label.vpc');
-        if ("isredundantrouter" in router && router.isredundantrouter) routerType = routerType + " (" + router.redundantstate + ")";
+        if (router.projectid) {
+            routerType = _l('label.project');
+            router.account = router.project;
+        }
+
+        if (router.vpcid) {
+            routerType = _l('label.vpc');
+            router.guestnetworkname = router.vpcname;
+        }
+
+        if ("isredundantrouter" in router && router.isredundantrouter) {
+            router.guestnetworkname = router.guestnetworkname + " (" + router.redundantstate + ")";
+        }
 
         return $.extend(router, {
             routerType: routerType
@@ -9478,6 +9488,12 @@
                                 },
                                 publicip: {
                                     label: 'label.public.ip'
+                                },
+                                account: {
+                                    label: 'label.account'
+                                },
+                                guestnetworkname: {
+                                    label: 'label.network'
                                 },
                                 routerType: {
                                     label: 'label.type'


### PR DESCRIPTION
This shows the owner account and network of a VR in the VR list view,
and for VPCs shows the VPC name and redundant state of the VPC rVR.

![screenshot from 2017-11-16 10-30-45](https://user-images.githubusercontent.com/95203/32875597-d21915e6-cabe-11e7-8b83-38bf90ee5e0f.png)

Pinging for review @PaulAngus @borisstoyanov @resmo @nvazquez @DaanHoogland @wido @ustcweizhou @rafaelweingartner  and others