### PR TITLE
CLOUDSTACK-10012: Upgrade Jetty to 9.3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <cs.groovy.version>2.4.12</cs.groovy.version>
     <cs.nitro.version>10.1</cs.nitro.version>
     <cs.wiremock.version>2.8.0</cs.wiremock.version>
-    <cs.jetty.version>9.2.22.v20170606</cs.jetty.version>
+    <cs.jetty.version>9.3.22.v20171030</cs.jetty.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Upgrades Jetty to Java8 compatible version

Pinging for review @marcaurele @nvazquez @borisstoyanov @DaanHoogland @wido and others

@blueorangutan package