### PR TITLE
CLOUDSTACK-10012: Jetty 9.4

### DIFF
--- a/client/conf/server.properties.in
+++ b/client/conf/server.properties.in
@@ -24,6 +24,9 @@ context.path=/client
 # The HTTP port to be used by the management server
 http.port=8080
 
+# Max inactivity time in minutes for the session
+session.timeout=10
+
 # Options to configure and enable HTTPS on management server
 #
 # For management server to pickup these configuration settings, the configured

--- a/client/conf/server.properties.in
+++ b/client/conf/server.properties.in
@@ -25,7 +25,7 @@ context.path=/client
 http.port=8080
 
 # Max inactivity time in minutes for the session
-session.timeout=10
+session.timeout=30
 
 # Options to configure and enable HTTPS on management server
 #

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -491,7 +491,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.22.v20170606</version>
+        <version>${cs.jetty-maven-plugin.version}</version>
         <dependencies>
           <!-- specify the dependent jdbc driver here -->
           <dependency>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -491,7 +491,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>${cs.jetty.version}</version>
+        <version>9.2.22.v20170606</version>
         <dependencies>
           <!-- specify the dependent jdbc driver here -->
           <dependency>

--- a/client/src/org/apache/cloudstack/ServerDaemon.java
+++ b/client/src/org/apache/cloudstack/ServerDaemon.java
@@ -82,7 +82,7 @@ public class ServerDaemon implements Daemon {
 
     private int httpPort = 8080;
     private int httpsPort = 8443;
-    private int sessionTimeout = 10;
+    private int sessionTimeout = 30;
     private boolean httpsEnable = false;
     private String accessLogFile = "access.log";
     private String bindInterface = "";
@@ -126,7 +126,7 @@ public class ServerDaemon implements Daemon {
             setKeystorePassword(properties.getProperty(KEYSTORE_PASSWORD));
             setWebAppLocation(properties.getProperty(WEBAPP_DIR));
             setAccessLogFile(properties.getProperty(ACCESS_LOG, "access.log"));
-            setSessionTimeout(Integer.valueOf(properties.getProperty(SESSION_TIMEOUT, "10")));
+            setSessionTimeout(Integer.valueOf(properties.getProperty(SESSION_TIMEOUT, "30")));
         } catch (final IOException e) {
             LOG.warn("Failed to load configuration from server.properties file", e);
         }

--- a/plugins/integrations/cloudian/pom.xml
+++ b/plugins/integrations/cloudian/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${cs.wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <cs.cxf.version>3.2.0</cs.cxf.version>
     <cs.groovy.version>2.4.12</cs.groovy.version>
     <cs.nitro.version>10.1</cs.nitro.version>
-    <cs.wiremock.version>2.8.0</cs.wiremock.version>
+    <cs.wiremock.version>2.11.0</cs.wiremock.version>
     <cs.jetty.version>9.4.7.v20170914</cs.jetty.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <cs.groovy.version>2.4.12</cs.groovy.version>
     <cs.nitro.version>10.1</cs.nitro.version>
     <cs.wiremock.version>2.8.0</cs.wiremock.version>
-    <cs.jetty.version>9.2.22.v20170606</cs.jetty.version>
+    <cs.jetty.version>9.4.7.v20170914</cs.jetty.version>
   </properties>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <cs.nitro.version>10.1</cs.nitro.version>
     <cs.wiremock.version>2.11.0</cs.wiremock.version>
     <cs.jetty.version>9.4.7.v20170914</cs.jetty.version>
+    <cs.jetty-maven-plugin.version>9.2.22.v20170606</cs.jetty-maven-plugin.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Upgrading to jetty 9.4 along with:
- new gzip handler
- redirect `/` to the context path
- add session timeout configuration
- change for cloudian tests