### PR TITLE
CLOUDSTACK-10154: fixing some smoketests failures

### DIFF
--- a/test/integration/smoke/test_deploy_vm_root_resize.py
+++ b/test/integration/smoke/test_deploy_vm_root_resize.py
@@ -155,6 +155,13 @@ class TestDeployVmRootSize(cloudstackTestCase):
                 Configurations.update(cls.api_client,
                                               "vmware.root.disk.controller",
                                               value=cls.defaultdiskcontroller)
+                StoragePool.update(cls.api_client, id=cls.storageID,
+                                   tags="")
+                cls.restartServer()
+
+                #Giving 30 seconds to management to warm-up,
+                #Experienced failures when trying to deploy a VM exactly when management came up
+                time.sleep(30)
 
             cleanup_resources(cls.api_client, cls._cleanup)
         except Exception as e:

--- a/test/integration/smoke/test_host_annotations.py
+++ b/test/integration/smoke/test_host_annotations.py
@@ -175,4 +175,3 @@ class TestHostAnnotations(cloudstackTestCase):
         else:
             self.fail("AddAnnotation is allowed for on an unknown entityType")
 
-        return self.added_annotations[-1]

--- a/test/integration/smoke/test_ssvm.py
+++ b/test/integration/smoke/test_ssvm.py
@@ -75,7 +75,7 @@ class TestSSVMs(cloudstackTestCase):
         return
 
     def waitForSystemVMAgent(self, vmname):
-        timeout = self.services["timeout"]
+        timeout = 120
 
         while True:
             list_host_response = list_hosts(
@@ -89,7 +89,7 @@ class TestSSVMs(cloudstackTestCase):
             if timeout == 0:
                 raise Exception("Timed out waiting for SSVM agent to be Up")
 
-            time.sleep(self.services["sleep"])
+            time.sleep(1)
             timeout = timeout - 1
 
     @attr(
@@ -798,7 +798,7 @@ class TestSSVMs(cloudstackTestCase):
         cmd.id = cpvm.id
         self.apiclient.stopSystemVm(cmd)
 
-        timeout = self.services["timeout"]
+        timeout = 120
         while True:
             list_cpvm_response = list_ssvms(
                 self.apiclient,
@@ -810,7 +810,7 @@ class TestSSVMs(cloudstackTestCase):
             if timeout == 0:
                 raise Exception("List CPVM call failed!")
 
-            time.sleep(self.services["sleep"])
+            time.sleep(1)
             timeout = timeout - 1
 
         cpvm_response = list_cpvm_response[0]

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -866,7 +866,7 @@ class TestVolumes(cloudstackTestCase):
                 listall=True
             )
 
-            if list_volume_response[0].virtualsize is not None:
+            if isinstance(list_volume_response, list) and list_volume_response[0].virtualsize is not None:
                 return True, list_volume_response[0]
             return False, None
 

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -24,7 +24,8 @@ from marvin.cloudstackAPI import (deleteVolume,
                                   resizeVolume)
 #from marvin.sshClient import SshClient
 from marvin.lib.utils import (cleanup_resources,
-                              format_volume_to_ext3)
+                              format_volume_to_ext3,
+                              wait_until)
 from marvin.lib.base import (ServiceOffering,
                              VirtualMachine,
                              Account,
@@ -857,15 +858,20 @@ class TestVolumes(cloudstackTestCase):
         self.assertEqual(root_volume.podname, list_pods.name)
 
     def wait_for_attributes_and_return_root_vol(self):
-
-        for i in range(360):
+        def checkVolumeResponse():
             list_volume_response = Volume.list(
                 self.apiClient,
                 virtualmachineid=self.virtual_machine.id,
                 type='ROOT',
                 listall=True
             )
-            if list_volume_response[0].virtualsize is not None:
-                return list_volume_response[0]
 
-            time.sleep(1)
+            if list_volume_response[0].virtualsize is not None:
+                return True, list_volume_response[0]
+            return False, None
+
+        # sleep interval is 1s, retries is 360, this will sleep atmost 360 seconds, or 6 mins
+        res, response = wait_until(1, 360, checkVolumeResponse)
+        if not res:
+            self.fail("Failed to return root volume response")
+        return response

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -814,7 +814,7 @@ class TestVolumes(cloudstackTestCase):
         host = Host.list(
             self.apiclient,
             type='Routing',
-            virtualmachineid=list_vm.id
+            id=list_vm.hostid
         )[0]
         list_pods = get_pod(self.apiclient, self.zone.id, host.podid)
 
@@ -858,7 +858,7 @@ class TestVolumes(cloudstackTestCase):
 
     def wait_for_attributes_and_return_root_vol(self):
 
-        for i in range(60):
+        for i in range(360):
             list_volume_response = Volume.list(
                 self.apiClient,
                 virtualmachineid=self.virtual_machine.id,


### PR DESCRIPTION
ssvm tests: 
==== Marvin Init Successful ====
=== TestName: test_01_list_sec_storage_vm | Status : SUCCESS ===
=== TestName: test_02_list_cpvm_vm | Status : SUCCESS ===
=== TestName: test_03_ssvm_internals | Status : SUCCESS ===
=== TestName: test_04_cpvm_internals | Status : SUCCESS ===
=== TestName: test_05_stop_ssvm | Status : SUCCESS ===
=== TestName: test_06_stop_cpvm | Status : SUCCESS ===
=== TestName: test_07_reboot_ssvm | Status : SUCCESS ===
=== TestName: test_08_reboot_cpvm | Status : SUCCESS ===
=== TestName: test_09_destroy_ssvm | Status : SUCCESS ===
=== TestName: test_10_destroy_cpvm | Status : SUCCESS ===

deploy_vm_root_resize:
=== TestName: test_00_deploy_vm_root_resize | Status : SUCCESS ===
=== TestName: test_01_deploy_vm_root_resize | Status : SUCCESS ===
=== TestName: test_02_deploy_vm_root_resize | Status : SUCCESS ===

test volumes:
=== TestName: test_10_list_volumes | Status : SUCCESS ===

test host annotations
=== TestName: test_01_add_annotation | Status : SUCCESS ===
=== TestName: test_02_add_multiple_annotations | Status : SUCCESS ===
=== TestName: test_03_user_role_dont_see_annotations | Status : SUCCESS ===
=== TestName: test_04_remove_annotations | Status : SUCCESS ===
=== TestName: test_05_add_annotation_for_invalid_entityType | Status : SUCCESS ===

ping @rhtyd @PaulAngus @nvazquez @DaanHoogland for review