### PR TITLE
CLOUDSTACK-10153: Introduce string API arg trust validation

### DIFF
--- a/api/src/org/apache/cloudstack/api/ApiArgValidator.java
+++ b/api/src/org/apache/cloudstack/api/ApiArgValidator.java
@@ -20,4 +20,5 @@ package org.apache.cloudstack.api;
 public enum ApiArgValidator {
     NotNullOrEmpty, // does Strings.isNullOrEmpty check
     PositiveNumber, // does != null and > 0 check
+    SkipSanitization, // does no HTML sanitization checks on string fields
 }

--- a/api/src/org/apache/cloudstack/api/command/admin/ca/IssueCertificateCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/ca/IssueCertificateCmd.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCmd;
@@ -60,7 +61,7 @@ public class IssueCertificateCmd extends BaseAsyncCmd {
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
 
-    @Parameter(name = ApiConstants.CSR, type = BaseCmd.CommandType.STRING, description = "The certificate signing request (in pem format), if CSR is not provided then configured/provided options are considered", length = 65535)
+    @Parameter(name = ApiConstants.CSR, type = BaseCmd.CommandType.STRING, description = "The certificate signing request (in pem format), if CSR is not provided then configured/provided options are considered", validations = {ApiArgValidator.SkipSanitization}, length = 65535)
     private String csr;
 
     @Parameter(name = ApiConstants.DOMAIN, type = BaseCmd.CommandType.STRING, description = "Comma separated list of domains, the certificate should be issued for. When csr is not provided, the first domain is used as a subject/CN")

--- a/api/src/org/apache/cloudstack/api/command/admin/resource/UploadCustomCertificateCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/admin/resource/UploadCustomCertificateCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.resource;
 
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -38,7 +39,7 @@ public class UploadCustomCertificateCmd extends BaseAsyncCmd {
 
     private static final String s_name = "uploadcustomcertificateresponse";
 
-    @Parameter(name = ApiConstants.CERTIFICATE, type = CommandType.STRING, required = true, description = "The certificate to be uploaded.", length = 65535)
+    @Parameter(name = ApiConstants.CERTIFICATE, type = CommandType.STRING, required = true, description = "The certificate to be uploaded.", validations = {ApiArgValidator.SkipSanitization}, length = 65535)
     private String certificate;
 
     @Parameter(name = ApiConstants.ID,

--- a/api/src/org/apache/cloudstack/api/command/user/loadbalancer/UploadSslCertCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/loadbalancer/UploadSslCertCmd.java
@@ -18,9 +18,8 @@ package org.apache.cloudstack.api.command.user.loadbalancer;
 
 import javax.inject.Inject;
 
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseCmd;
@@ -30,13 +29,14 @@ import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.ProjectResponse;
 import org.apache.cloudstack.api.response.SslCertResponse;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.network.tls.CertService;
+import org.apache.log4j.Logger;
 
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
-import org.apache.cloudstack.network.tls.CertService;
 
 @APICommand(name = "uploadSslCert", description = "Upload a certificate to CloudStack", responseObject = SslCertResponse.class,
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
@@ -52,13 +52,13 @@ public class UploadSslCertCmd extends BaseCmd {
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
 
-    @Parameter(name = ApiConstants.CERTIFICATE, type = CommandType.STRING, required = true, description = "SSL certificate", length = 16384)
+    @Parameter(name = ApiConstants.CERTIFICATE, type = CommandType.STRING, required = true, description = "SSL certificate", validations = {ApiArgValidator.SkipSanitization}, length = 16384)
     private String cert;
 
-    @Parameter(name = ApiConstants.PRIVATE_KEY, type = CommandType.STRING, required = true, description = "Private key", length = 16384)
+    @Parameter(name = ApiConstants.PRIVATE_KEY, type = CommandType.STRING, required = true, description = "Private key", validations = {ApiArgValidator.SkipSanitization}, length = 16384)
     private String key;
 
-    @Parameter(name = ApiConstants.CERTIFICATE_CHAIN, type = CommandType.STRING, description = "Certificate chain of trust", length = 2097152)
+    @Parameter(name = ApiConstants.CERTIFICATE_CHAIN, type = CommandType.STRING, description = "Certificate chain of trust", validations = {ApiArgValidator.SkipSanitization}, length = 2097152)
     private String chain;
 
     @Parameter(name = ApiConstants.PASSWORD, type = CommandType.STRING, description = "Password for the private key")

--- a/api/src/org/apache/cloudstack/api/command/user/ssh/RegisterSSHKeyPairCmd.java
+++ b/api/src/org/apache/cloudstack/api/command/user/ssh/RegisterSSHKeyPairCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.ssh;
 
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -42,7 +43,7 @@ public class RegisterSSHKeyPairCmd extends BaseCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, required = true, description = "Name of the keypair")
     private String name;
 
-    @Parameter(name = "publickey", type = CommandType.STRING, required = true, description = "Public key material of the keypair", length = 5120)
+    @Parameter(name = "publickey", type = CommandType.STRING, required = true, description = "Public key material of the keypair", validations = {ApiArgValidator.SkipSanitization}, length = 5120)
     private String publicKey;
 
     //Owner information

--- a/plugins/database/quota/src/org/apache/cloudstack/api/command/QuotaEmailTemplateUpdateCmd.java
+++ b/plugins/database/quota/src/org/apache/cloudstack/api/command/QuotaEmailTemplateUpdateCmd.java
@@ -18,6 +18,7 @@ package org.apache.cloudstack.api.command;
 
 import com.cloud.user.Account;
 import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiArgValidator;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
@@ -41,10 +42,10 @@ public class QuotaEmailTemplateUpdateCmd extends BaseCmd {
     @Parameter(name = "templatetype", type = CommandType.STRING, required=true, description = "Type of the quota email template, allowed types: QUOTA_LOW, QUOTA_EMPTY")
     private String templateName;
 
-    @Parameter(name = "templatesubject", type = CommandType.STRING, required=true, description = "The quota email template subject, max: 77 characters", length = 77)
+    @Parameter(name = "templatesubject", type = CommandType.STRING, required=true, description = "The quota email template subject, max: 77 characters", validations = {ApiArgValidator.SkipSanitization}, length = 77)
     private String templateSubject;
 
-    @Parameter(name = "templatebody", type = CommandType.STRING, required=true, description = "The quota email template body, max: 500k characters", length = 512000)
+    @Parameter(name = "templatebody", type = CommandType.STRING, required=true, description = "The quota email template body, max: 500k characters", validations = {ApiArgValidator.SkipSanitization}, length = 512000)
     private String templateBody;
 
     @Parameter(name = "locale", type = CommandType.STRING, description = "The locale of the email text")

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <cs.findbugs.version>3.0.3</cs.findbugs.version>
     <cs.javadoc.version>2.10.3</cs.javadoc.version>
     <cs.opensaml.version>2.6.4</cs.opensaml.version>
+    <cs.owasp.java.sanitizer.version>20171016.1</cs.owasp.java.sanitizer.version>
     <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
     <cs.batik.version>1.9.1</cs.batik.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <cs.findbugs.version>3.0.3</cs.findbugs.version>
     <cs.javadoc.version>2.10.3</cs.javadoc.version>
     <cs.opensaml.version>2.6.4</cs.opensaml.version>
-    <cs.owasp.java.sanitizer.version>20171016.1</cs.owasp.java.sanitizer.version>
+    <cs.jsoup.version>1.11.2</cs.jsoup.version>
     <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
     <cs.joda-time.version>2.8.1</cs.joda-time.version>
     <cs.batik.version>1.9.1</cs.batik.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -142,9 +142,9 @@
       <version>${cs.opensaml.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
-      <artifactId>owasp-java-html-sanitizer</artifactId>
-      <version>${cs.owasp.java.sanitizer.version}</version>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>${cs.jsoup.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -141,6 +141,11 @@
       <artifactId>opensaml</artifactId>
       <version>${cs.opensaml.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>${cs.owasp.java.sanitizer.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/server/test/com/cloud/api/dispatch/ParamProcessWorkerTest.java
+++ b/server/test/com/cloud/api/dispatch/ParamProcessWorkerTest.java
@@ -109,4 +109,32 @@ public class ParamProcessWorkerTest {
         Assert.assertTrue(Double.compare(cmd.doubleparam1, 11.89) == 0);
     }
 
+    @Test
+    public void validateUntrustedHtmlValid() {
+        paramProcessWorker.validateUntrustedString("cd360613-e1cf-3a32-b8ef-d07bad8dd92b", "uuid");
+        paramProcessWorker.validateUntrustedString("1000", "number");
+        paramProcessWorker.validateUntrustedString("123.456", "double");
+        paramProcessWorker.validateUntrustedString("somestringwithnospaces", "string");
+        paramProcessWorker.validateUntrustedString("some argument with spaces", "arg");
+        paramProcessWorker.validateUntrustedString("some argument with space at end ", "arg");
+        paramProcessWorker.validateUntrustedString(" some argument with spaces at beginning", "arg");
+        paramProcessWorker.validateUntrustedString("  some argument with spaces on both ends  ", "arg");
+        paramProcessWorker.validateUntrustedString("email@server.com", "email");
+        paramProcessWorker.validateUntrustedString("रोहित यादव", "unicode");
+        paramProcessWorker.validateUntrustedString("map[0].value=123", "map");
+        paramProcessWorker.validateUntrustedString("one,two,three,four", "list");
+        paramProcessWorker.validateUntrustedString(null, "null");
+        paramProcessWorker.validateUntrustedString("", "empty");
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void validateUntrustedHtmlFailTemplate() {
+        paramProcessWorker.validateUntrustedString("<div><h1>Title</h1><p>Some paragraph <a href='https://cloudstack.apache.org'>click here!</a></p></div>", "template");
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void validateUntrustedHtmlFailXSS() {
+        paramProcessWorker.validateUntrustedString("<script>alert(123);</script>", "xss-alert");
+    }
+
 }


### PR DESCRIPTION
Adds new API string argument/field validator that validates the string
as untrusted HTML using owasp's java-html-sanitizer. This also adds
a API argument validator type to skip validations, useful for fields
such as certificates and keys.

Signed-off-by: Rohit Yadav <rohit.yadav@shapeblue.com>