### PR TITLE
CLOUDSTACK-10160: Fix typo in Libvirt XML definition for Virtio-SCSI

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1411,10 +1411,10 @@ public class LibvirtVMDef {
         public String toString() {
             StringBuilder scsiBuilder = new StringBuilder();
 
-            scsiBuilder.append(String.format("<controller type='scsi' index='%d' mode='virtio-scsi'>\n", this.index ));
+            scsiBuilder.append(String.format("<controller type='scsi' index='%d' model='virtio-scsi'>\n", this.index ));
             scsiBuilder.append(String.format("<address type='pci' domain='0x%04X' bus='0x%02X' slot='0x%02X' function='0x%01X'/>\n",
                     this.domain, this.bus, this.slot, this.function ) );
-            scsiBuilder.append("</controller>");
+            scsiBuilder.append("</controller>\n");
             return scsiBuilder.toString();
         }
     }

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
@@ -22,6 +22,7 @@ package com.cloud.hypervisor.kvm.resource;
 import junit.framework.TestCase;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.ChannelDef;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.SCSIDef;
 import com.cloud.utils.Pair;
 
 import java.io.File;
@@ -156,6 +157,15 @@ public class LibvirtVMDefTest extends TestCase {
         LibvirtVMDef.WatchDogDef def = new LibvirtVMDef.WatchDogDef(action, model);
         assertEquals(def.getModel(), model);
         assertEquals(def.getAction(), action);
+    }
+
+    public void testSCSIDef() {
+        SCSIDef def = new SCSIDef();
+        String str = def.toString();
+        String expected = "<controller type='scsi' index='0' model='virtio-scsi'>\n" +
+                "<address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>\n" +
+                "</controller>\n";
+        assertEquals(str, expected);
     }
 
 }


### PR DESCRIPTION
The attribute for the XML element 'controller' should be 'model' and
not 'mode'.

Source: https://libvirt.org/formatdomain.html#elementsControllers

  A scsi controller has an optional attribute model, which is one of
  'auto', 'buslogic', 'ibmvscsi', 'lsilogic', 'lsisas1068', 'lsisas1078',
  'virtio-scsi' or 'vmpvscsi'.

In the current state a regular SCSI device is attached and not a Virtio-SCSI
device.

Afterwards this is what *lspci* reports:

<pre>
root@ub-scsi:~# lspci |grep -i scsi
00:09.0 SCSI storage controller: Red Hat, Inc Virtio SCSI
root@ub-scsi:~# 
</pre>