### PR TITLE
[CLOUDSTACK-10196] Remove ejb-api 3.0 dependency

### DIFF
--- a/agent/src/com/cloud/agent/dao/impl/PropertiesStorage.java
+++ b/agent/src/com/cloud/agent/dao/impl/PropertiesStorage.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.ejb.Local;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
@@ -37,7 +35,6 @@ import com.cloud.utils.PropertiesUtil;
  * @config {@table || Param Name | Description | Values | Default || || path |
  *         path to the properties _file | String | db/db.properties || * }
  **/
-@Local(value = {StorageComponent.class})
 public class PropertiesStorage implements StorageComponent {
     private static final Logger s_logger = Logger.getLogger(PropertiesStorage.class);
     Properties _properties = new Properties();

--- a/agent/src/com/cloud/agent/dhcp/FakeDhcpSnooper.java
+++ b/agent/src/com/cloud/agent/dhcp/FakeDhcpSnooper.java
@@ -24,7 +24,6 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
 import org.apache.log4j.Logger;
@@ -32,7 +31,6 @@ import org.apache.log4j.Logger;
 import com.cloud.utils.Pair;
 import com.cloud.utils.net.NetUtils;
 
-@Local(value = {DhcpSnooper.class})
 public class FakeDhcpSnooper implements DhcpSnooper {
     private static final Logger s_logger = Logger.getLogger(FakeDhcpSnooper.class);
     private Queue<String> _ipAddresses = new ConcurrentLinkedQueue<String>();

--- a/agent/src/com/cloud/agent/resource/DummyResource.java
+++ b/agent/src/com/cloud/agent/resource/DummyResource.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.ejb.Local;
-
 import com.cloud.agent.IAgentControl;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.CheckNetworkAnswer;
@@ -43,7 +41,6 @@ import com.cloud.storage.Storage;
 import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.utils.StringUtils;
 
-@Local(value = {ServerResource.class})
 public class DummyResource implements ServerResource {
     String _name;
     Host.Type _type;

--- a/api/src/org/apache/cloudstack/config/ApiServiceConfiguration.java
+++ b/api/src/org/apache/cloudstack/config/ApiServiceConfiguration.java
@@ -16,12 +16,9 @@
 // under the License.
 package org.apache.cloudstack.config;
 
-import javax.ejb.Local;
-
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 
-@Local(value = {ApiServiceConfiguration.class})
 public class ApiServiceConfiguration implements Configurable {
     public static final ConfigKey<String> ManagementHostIPAdr = new ConfigKey<String>("Advanced", String.class, "host", "localhost", "The ip address of management server", true);
     public static final ConfigKey<String> ApiServletPath = new ConfigKey<String>("Advanced", String.class, "endpointe.url", "http://localhost:8080/client/api",

--- a/core/src/com/cloud/storage/JavaStorageLayer.java
+++ b/core/src/com/cloud/storage/JavaStorageLayer.java
@@ -26,10 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.ejb.Local;
 import javax.naming.ConfigurationException;
 
-@Local(value = StorageLayer.class)
 public class JavaStorageLayer implements StorageLayer {
 
     String _name;
@@ -150,8 +148,9 @@ public class JavaStorageLayer implements StorageLayer {
             return mountPaths;
         }
         for (File file : files) {
-            if (file.getName().startsWith(String.valueOf(msHostId) + "."))
+            if (file.getName().startsWith(String.valueOf(msHostId) + ".")) {
                 mountPaths.add(file.getAbsolutePath());
+            }
         }
         return mountPaths;
     }
@@ -208,8 +207,9 @@ public class JavaStorageLayer implements StorageLayer {
                 dir = new File(dirPath);
                 if (!dir.exists()) {
                     success = dir.mkdir();
-                    if (_makeWorldWriteable)
+                    if (_makeWorldWriteable) {
                         success = success && setWorldReadableAndWriteable(dir);
+                    }
                 }
             }
 
@@ -284,32 +284,24 @@ public class JavaStorageLayer implements StorageLayer {
 
     @Override
     public void setName(String name) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
     public void setConfigParams(Map<String, Object> params) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
     public Map<String, Object> getConfigParams() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public int getRunLevel() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
     @Override
     public void setRunLevel(int level) {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/engine/schema/src/com/cloud/dc/dao/DomainVlanMapDaoImpl.java
+++ b/engine/schema/src/com/cloud/dc/dao/DomainVlanMapDaoImpl.java
@@ -18,8 +18,6 @@ package com.cloud.dc.dao;
 
 import java.util.List;
 
-import javax.ejb.Local;
-
 import org.springframework.stereotype.Component;
 
 import com.cloud.dc.DomainVlanMapVO;
@@ -28,7 +26,6 @@ import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 
 @Component
-@Local(value={DomainVlanMapDao.class})
 public class DomainVlanMapDaoImpl extends GenericDaoBase<DomainVlanMapVO, Long> implements DomainVlanMapDao {
     protected SearchBuilder<DomainVlanMapVO> DomainSearch;
     protected SearchBuilder<DomainVlanMapVO> VlanSearch;

--- a/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/com/cloud/host/dao/HostDaoImpl.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import javax.annotation.PostConstruct;
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.persistence.TableGenerator;
 
@@ -71,7 +70,6 @@ import com.cloud.utils.db.UpdateBuilder;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
-@Local(value = {HostDao.class})
 @DB
 @TableGenerator(name = "host_req_sq", table = "op_host", pkColumnName = "id", valueColumnName = "sequence", allocationSize = 1)
 public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao { //FIXME: , ExternalIdDao {

--- a/engine/schema/src/com/cloud/network/dao/FirewallRulesDcidrsDaoImpl.java
+++ b/engine/schema/src/com/cloud/network/dao/FirewallRulesDcidrsDaoImpl.java
@@ -25,12 +25,10 @@ import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionStatus;
 import org.springframework.stereotype.Component;
 
-import javax.ejb.Local;
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
-@Local(value = FirewallRulesDcidrsDao.class)
 public class FirewallRulesDcidrsDaoImpl extends GenericDaoBase<FirewallRulesDestCidrsVO, Long> implements FirewallRulesDcidrsDao {
 
     protected final SearchBuilder<FirewallRulesDestCidrsVO> cidrsSearch;

--- a/engine/schema/src/org/apache/cloudstack/acl/dao/RoleDaoImpl.java
+++ b/engine/schema/src/org/apache/cloudstack/acl/dao/RoleDaoImpl.java
@@ -24,11 +24,9 @@ import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.acl.RoleVO;
 import org.springframework.stereotype.Component;
 
-import javax.ejb.Local;
 import java.util.List;
 
 @Component
-@Local(value = {RoleDao.class})
 public class RoleDaoImpl extends GenericDaoBase<RoleVO, Long> implements RoleDao {
     private final SearchBuilder<RoleVO> RoleByNameSearch;
     private final SearchBuilder<RoleVO> RoleByTypeSearch;

--- a/engine/schema/src/org/apache/cloudstack/acl/dao/RolePermissionsDaoImpl.java
+++ b/engine/schema/src/org/apache/cloudstack/acl/dao/RolePermissionsDaoImpl.java
@@ -34,7 +34,6 @@ import org.apache.cloudstack.acl.RolePermissionVO;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
-import javax.ejb.Local;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Set;
 
 @Component
-@Local(value = {RolePermissionsDao.class})
 public class RolePermissionsDaoImpl extends GenericDaoBase<RolePermissionVO, Long> implements RolePermissionsDao {
     protected static final Logger LOGGER = Logger.getLogger(RolePermissionsDaoImpl.class);
 

--- a/engine/schema/src/org/apache/cloudstack/resourcedetail/dao/GuestOsDetailsDaoImpl.java
+++ b/engine/schema/src/org/apache/cloudstack/resourcedetail/dao/GuestOsDetailsDaoImpl.java
@@ -16,14 +16,11 @@
 // under the License.
 package org.apache.cloudstack.resourcedetail.dao;
 
-import javax.ejb.Local;
-
 import org.apache.cloudstack.resourcedetail.GuestOsDetailVO;
 import org.apache.cloudstack.resourcedetail.ResourceDetailsDaoBase;
 import org.springframework.stereotype.Component;
 
 @Component
-@Local(value = {GuestOsDetailsDao.class})
 public class GuestOsDetailsDaoImpl extends ResourceDetailsDaoBase<GuestOsDetailVO> implements GuestOsDetailsDao {
 
     @Override

--- a/framework/db/pom.xml
+++ b/framework/db/pom.xml
@@ -20,10 +20,6 @@
   </parent>
   <dependencies>
     <dependency>
-      <groupId>javax.ejb</groupId>
-      <artifactId>ejb-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
     </dependency>

--- a/framework/quota/src/org/apache/cloudstack/quota/QuotaManagerImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/QuotaManagerImpl.java
@@ -16,12 +16,16 @@
 //under the License.
 package org.apache.cloudstack.quota;
 
-import com.cloud.usage.UsageVO;
-import com.cloud.usage.dao.UsageDao;
-import com.cloud.user.AccountVO;
-import com.cloud.user.dao.AccountDao;
-import com.cloud.utils.Pair;
-import com.cloud.utils.component.ManagerBase;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.quota.constant.QuotaTypes;
@@ -39,19 +43,14 @@ import org.apache.cloudstack.utils.usage.UsageUtils;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
-import javax.ejb.Local;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import com.cloud.usage.UsageVO;
+import com.cloud.usage.dao.UsageDao;
+import com.cloud.user.AccountVO;
+import com.cloud.user.dao.AccountDao;
+import com.cloud.utils.Pair;
+import com.cloud.utils.component.ManagerBase;
 
 @Component
-@Local(value = QuotaManager.class)
 public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
     private static final Logger s_logger = Logger.getLogger(QuotaManagerImpl.class.getName());
 
@@ -360,7 +359,9 @@ public class QuotaManagerImpl extends ManagerBase implements QuotaManager {
         BigDecimal rawusage;
         // get service offering details
         ServiceOfferingVO serviceoffering = _serviceOfferingDao.findServiceOffering(usageRecord.getVmInstanceId(), usageRecord.getOfferingId());
-        if (serviceoffering == null) return quotalist;
+        if (serviceoffering == null) {
+            return quotalist;
+        }
         rawusage = new BigDecimal(usageRecord.getRawUsage());
 
         QuotaTariffVO tariff = _quotaTariffDao.findTariffPlanByUsageType(QuotaTypes.CPU_NUMBER, usageRecord.getEndDate());

--- a/framework/quota/src/org/apache/cloudstack/quota/QuotaStatementImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/QuotaStatementImpl.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
@@ -42,7 +41,6 @@ import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.component.ManagerBase;
 
 @Component
-@Local(value = QuotaStatement.class)
 public class QuotaStatementImpl extends ManagerBase implements QuotaStatement {
     private static final Logger s_logger = Logger.getLogger(QuotaStatementImpl.class);
 

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaAccountDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaAccountDaoImpl.java
@@ -16,25 +16,23 @@
 //under the License.
 package org.apache.cloudstack.quota.dao;
 
+import java.util.List;
+
+import org.apache.cloudstack.quota.vo.QuotaAccountVO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
 
-import org.apache.cloudstack.quota.vo.QuotaAccountVO;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
-import javax.ejb.Local;
-
-import java.util.List;
-
 @Component
-@Local(value = { QuotaAccountDao.class })
 public class QuotaAccountDaoImpl extends GenericDaoBase<QuotaAccountVO, Long> implements QuotaAccountDao {
     public static final Logger s_logger = Logger.getLogger(QuotaAccountDaoImpl.class);
 
+    @Override
     public List<QuotaAccountVO> listAllQuotaAccount() {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<List<QuotaAccountVO>>() {
             @Override
@@ -44,6 +42,7 @@ public class QuotaAccountDaoImpl extends GenericDaoBase<QuotaAccountVO, Long> im
         });
     }
 
+    @Override
     public QuotaAccountVO findByIdQuotaAccount(final Long id) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaAccountVO>() {
             @Override
@@ -53,6 +52,7 @@ public class QuotaAccountDaoImpl extends GenericDaoBase<QuotaAccountVO, Long> im
         });
     }
 
+    @Override
     public QuotaAccountVO persistQuotaAccount(final QuotaAccountVO entity) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaAccountVO>() {
             @Override
@@ -62,6 +62,7 @@ public class QuotaAccountDaoImpl extends GenericDaoBase<QuotaAccountVO, Long> im
         });
     }
 
+    @Override
     public boolean updateQuotaAccount(final Long id, final QuotaAccountVO entity) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<Boolean>() {
             @Override

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaBalanceDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaBalanceDaoImpl.java
@@ -16,6 +16,16 @@
 //under the License.
 package org.apache.cloudstack.quota.dao;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.QueryBuilder;
@@ -25,23 +35,11 @@ import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
 
-import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
-import javax.ejb.Local;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-
 @Component
-@Local(value = {QuotaBalanceDao.class})
 public class QuotaBalanceDaoImpl extends GenericDaoBase<QuotaBalanceVO, Long> implements QuotaBalanceDao {
     private static final Logger s_logger = Logger.getLogger(QuotaBalanceDaoImpl.class.getName());
 
+    @Override
     public QuotaBalanceVO findLastBalanceEntry(final Long accountId, final Long domainId, final Date beforeThis) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaBalanceVO>() {
             @Override
@@ -59,6 +57,7 @@ public class QuotaBalanceDaoImpl extends GenericDaoBase<QuotaBalanceVO, Long> im
         });
     }
 
+    @Override
     public QuotaBalanceVO findLaterBalanceEntry(final Long accountId, final Long domainId, final Date afterThis) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaBalanceVO>() {
             @Override
@@ -76,6 +75,7 @@ public class QuotaBalanceDaoImpl extends GenericDaoBase<QuotaBalanceVO, Long> im
         });
     }
 
+    @Override
     public QuotaBalanceVO saveQuotaBalance(final QuotaBalanceVO qb) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaBalanceVO>() {
             @Override
@@ -85,6 +85,7 @@ public class QuotaBalanceDaoImpl extends GenericDaoBase<QuotaBalanceVO, Long> im
         });
     }
 
+    @Override
     public List<QuotaBalanceVO> findCreditBalance(final Long accountId, final Long domainId, final Date lastbalancedate, final Date beforeThis) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<List<QuotaBalanceVO>>() {
             @Override
@@ -104,6 +105,7 @@ public class QuotaBalanceDaoImpl extends GenericDaoBase<QuotaBalanceVO, Long> im
         });
     }
 
+    @Override
     public List<QuotaBalanceVO> findQuotaBalance(final Long accountId, final Long domainId, final Date startDate, final Date endDate) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<List<QuotaBalanceVO>>() {
             @Override
@@ -132,6 +134,7 @@ public class QuotaBalanceDaoImpl extends GenericDaoBase<QuotaBalanceVO, Long> im
 
     }
 
+    @Override
     public List<QuotaBalanceVO> lastQuotaBalanceVO(final Long accountId, final Long domainId, final Date pivotDate) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<List<QuotaBalanceVO>>() {
             @Override
@@ -170,6 +173,7 @@ public class QuotaBalanceDaoImpl extends GenericDaoBase<QuotaBalanceVO, Long> im
         });
     }
 
+    @Override
     public BigDecimal lastQuotaBalance(final Long accountId, final Long domainId, Date startDate) {
         List<QuotaBalanceVO> quotaBalance = lastQuotaBalanceVO(accountId, domainId, startDate);
         BigDecimal finalBalance = new BigDecimal(0);

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaCreditsDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaCreditsDaoImpl.java
@@ -20,12 +20,11 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Component;
 import org.apache.cloudstack.quota.vo.QuotaBalanceVO;
 import org.apache.cloudstack.quota.vo.QuotaCreditsVO;
+import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.GenericDaoBase;
@@ -37,7 +36,6 @@ import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
 
 @Component
-@Local(value = { QuotaCreditsDao.class })
 public class QuotaCreditsDaoImpl extends GenericDaoBase<QuotaCreditsVO, Long> implements QuotaCreditsDao {
 
     @Inject

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaEmailTemplatesDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaEmailTemplatesDaoImpl.java
@@ -16,6 +16,12 @@
 //under the License.
 package org.apache.cloudstack.quota.dao;
 
+import java.util.List;
+
+import org.apache.cloudstack.quota.vo.QuotaEmailTemplatesVO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
@@ -25,16 +31,7 @@ import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
 import com.google.common.base.Strings;
 
-import org.apache.cloudstack.quota.vo.QuotaEmailTemplatesVO;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
-import javax.ejb.Local;
-
-import java.util.List;
-
 @Component
-@Local(value = { QuotaEmailTemplatesDao.class })
 public class QuotaEmailTemplatesDaoImpl extends GenericDaoBase<QuotaEmailTemplatesVO, Long> implements QuotaEmailTemplatesDao {
     private static final Logger s_logger = Logger.getLogger(QuotaEmailTemplatesDaoImpl.class);
 

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaTariffDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaTariffDaoImpl.java
@@ -16,6 +16,15 @@
 //under the License.
 package org.apache.cloudstack.quota.dao;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.cloudstack.quota.constant.QuotaTypes;
+import org.apache.cloudstack.quota.vo.QuotaTariffVO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
@@ -24,19 +33,8 @@ import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
-import org.apache.cloudstack.quota.constant.QuotaTypes;
-import org.apache.cloudstack.quota.vo.QuotaTariffVO;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
-import javax.ejb.Local;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 @Component
-@Local(value = {QuotaTariffDao.class})
 public class QuotaTariffDaoImpl extends GenericDaoBase<QuotaTariffVO, Long> implements QuotaTariffDao {
     private static final Logger s_logger = Logger.getLogger(QuotaTariffDaoImpl.class.getName());
 
@@ -55,6 +53,7 @@ public class QuotaTariffDaoImpl extends GenericDaoBase<QuotaTariffVO, Long> impl
         listAllIncludedUsageType.done();
     }
 
+    @Override
     public QuotaTariffVO findTariffPlanByUsageType(final int quotaType, final Date effectiveDate) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaTariffVO>() {
             @Override
@@ -77,6 +76,7 @@ public class QuotaTariffDaoImpl extends GenericDaoBase<QuotaTariffVO, Long> impl
         });
     }
 
+    @Override
     public List<QuotaTariffVO> listAllTariffPlans() {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<List<QuotaTariffVO>>() {
             @Override
@@ -86,6 +86,7 @@ public class QuotaTariffDaoImpl extends GenericDaoBase<QuotaTariffVO, Long> impl
         });
     }
 
+    @Override
     public List<QuotaTariffVO> listAllTariffPlans(final Date effectiveDate) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<List<QuotaTariffVO>>() {
             @Override
@@ -110,6 +111,7 @@ public class QuotaTariffDaoImpl extends GenericDaoBase<QuotaTariffVO, Long> impl
         });
     }
 
+    @Override
     public Boolean updateQuotaTariff(final QuotaTariffVO plan) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<Boolean>() {
             @Override
@@ -119,6 +121,7 @@ public class QuotaTariffDaoImpl extends GenericDaoBase<QuotaTariffVO, Long> impl
         });
     }
 
+    @Override
     public QuotaTariffVO addQuotaTariff(final QuotaTariffVO plan) {
         if (plan.getIdObj() != null) {
             throw new IllegalStateException("The QuotaTariffVO being added should not have an Id set ");

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaUsageDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/QuotaUsageDaoImpl.java
@@ -16,6 +16,15 @@
 //under the License.
 package org.apache.cloudstack.quota.dao;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.cloudstack.quota.vo.QuotaUsageVO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.QueryBuilder;
@@ -25,22 +34,11 @@ import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionLegacy;
 import com.cloud.utils.db.TransactionStatus;
 
-import org.apache.cloudstack.quota.vo.QuotaUsageVO;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
-import javax.ejb.Local;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 @Component
-@Local(value = {QuotaUsageDao.class})
 public class QuotaUsageDaoImpl extends GenericDaoBase<QuotaUsageVO, Long> implements QuotaUsageDao {
     private static final Logger s_logger = Logger.getLogger(QuotaUsageDaoImpl.class);
 
+    @Override
     public BigDecimal findTotalQuotaUsage(final Long accountId, final Long domainId, final Integer usageType, final Date startDate, final Date endDate) {
         List<QuotaUsageVO> quotaUsage = findQuotaUsage(accountId, domainId, null, startDate, endDate);
         BigDecimal total = new BigDecimal(0);
@@ -50,6 +48,7 @@ public class QuotaUsageDaoImpl extends GenericDaoBase<QuotaUsageVO, Long> implem
         return total;
     }
 
+    @Override
     public List<QuotaUsageVO> findQuotaUsage(final Long accountId, final Long domainId, final Integer usageType, final Date startDate, final Date endDate) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<List<QuotaUsageVO>>() {
             @Override
@@ -88,6 +87,7 @@ public class QuotaUsageDaoImpl extends GenericDaoBase<QuotaUsageVO, Long> implem
         });
     }
 
+    @Override
     public QuotaUsageVO findLastQuotaUsageEntry(final Long accountId, final Long domainId, final Date beforeThis) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaUsageVO>() {
             @Override
@@ -104,6 +104,7 @@ public class QuotaUsageDaoImpl extends GenericDaoBase<QuotaUsageVO, Long> implem
         });
     }
 
+    @Override
     public QuotaUsageVO persistQuotaUsage(final QuotaUsageVO quotaUsage) {
         return Transaction.execute(TransactionLegacy.USAGE_DB, new TransactionCallback<QuotaUsageVO>() {
             @Override

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/ServiceOfferingDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/ServiceOfferingDaoImpl.java
@@ -18,12 +18,11 @@ package org.apache.cloudstack.quota.dao;
 
 import java.util.Map;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 
+import org.apache.cloudstack.quota.vo.ServiceOfferingVO;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
-import org.apache.cloudstack.quota.vo.ServiceOfferingVO;
 
 import com.cloud.event.UsageEventVO;
 import com.cloud.utils.db.DB;
@@ -35,7 +34,6 @@ import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 @Component
-@Local(value = {ServiceOfferingDao.class})
 @DB()
 public class ServiceOfferingDaoImpl extends GenericDaoBase<ServiceOfferingVO, Long> implements ServiceOfferingDao {
     protected static final Logger s_logger = Logger.getLogger(ServiceOfferingDaoImpl.class);
@@ -43,6 +41,7 @@ public class ServiceOfferingDaoImpl extends GenericDaoBase<ServiceOfferingVO, Lo
     @Inject
     UserVmDetailsDao userVmDetailsDao;
 
+    @Override
     public ServiceOfferingVO findServiceOffering(final Long vmId, final long serviceOfferingId) {
         return Transaction.execute(TransactionLegacy.CLOUD_DB, new TransactionCallback<ServiceOfferingVO>() {
             @Override

--- a/framework/quota/src/org/apache/cloudstack/quota/dao/UserVmDetailsDaoImpl.java
+++ b/framework/quota/src/org/apache/cloudstack/quota/dao/UserVmDetailsDaoImpl.java
@@ -20,17 +20,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ejb.Local;
-
-import org.springframework.stereotype.Component;
 import org.apache.cloudstack.quota.vo.UserVmDetailVO;
+import org.springframework.stereotype.Component;
 
 import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 
 @Component
-@Local(value = UserVmDetailsDao.class)
 public class UserVmDetailsDaoImpl extends GenericDaoBase<UserVmDetailVO, Long> implements UserVmDetailsDao {
     private SearchBuilder<UserVmDetailVO> AllFieldsSearch;
 

--- a/plugins/acl/dynamic-role-based/src/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/dynamic-role-based/src/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
@@ -16,6 +16,17 @@
 // under the License.
 package org.apache.cloudstack.acl;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+
+import org.apache.cloudstack.api.APICommand;
+
 import com.cloud.exception.PermissionDeniedException;
 import com.cloud.user.Account;
 import com.cloud.user.AccountService;
@@ -23,18 +34,7 @@ import com.cloud.user.User;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.component.PluggableService;
 import com.google.common.base.Strings;
-import org.apache.cloudstack.api.APICommand;
 
-import javax.ejb.Local;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-@Local(value = APIChecker.class)
 public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements APIChecker {
 
     @Inject

--- a/plugins/database/quota/src/org/apache/cloudstack/quota/QuotaServiceImpl.java
+++ b/plugins/database/quota/src/org/apache/cloudstack/quota/QuotaServiceImpl.java
@@ -16,21 +16,22 @@
 //under the License.
 package org.apache.cloudstack.quota;
 
-import com.cloud.configuration.Config;
-import com.cloud.domain.dao.DomainDao;
-import com.cloud.exception.InvalidParameterValueException;
-import com.cloud.exception.PermissionDeniedException;
-import com.cloud.user.Account;
-import com.cloud.user.AccountVO;
-import com.cloud.user.dao.AccountDao;
-import com.cloud.utils.component.ManagerBase;
-import com.cloud.utils.db.Filter;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
 
 import org.apache.cloudstack.api.command.QuotaBalanceCmd;
 import org.apache.cloudstack.api.command.QuotaCreditsCmd;
+import org.apache.cloudstack.api.command.QuotaEmailTemplateListCmd;
 import org.apache.cloudstack.api.command.QuotaEmailTemplateUpdateCmd;
 import org.apache.cloudstack.api.command.QuotaEnabledCmd;
-import org.apache.cloudstack.api.command.QuotaEmailTemplateListCmd;
 import org.apache.cloudstack.api.command.QuotaStatementCmd;
 import org.apache.cloudstack.api.command.QuotaSummaryCmd;
 import org.apache.cloudstack.api.command.QuotaTariffListCmd;
@@ -52,20 +53,17 @@ import org.apache.cloudstack.utils.usage.UsageUtils;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
-import javax.ejb.Local;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import com.cloud.configuration.Config;
+import com.cloud.domain.dao.DomainDao;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.user.Account;
+import com.cloud.user.AccountVO;
+import com.cloud.user.dao.AccountDao;
+import com.cloud.utils.component.ManagerBase;
+import com.cloud.utils.db.Filter;
 
 @Component
-@Local(value = QuotaService.class)
 public class QuotaServiceImpl extends ManagerBase implements QuotaService, Configurable, QuotaConfig {
     private static final Logger s_logger = Logger.getLogger(QuotaServiceImpl.class);
 

--- a/plugins/dedicated-resources/src/org/apache/cloudstack/dedicated/DedicatedResourceManagerImpl.java
+++ b/plugins/dedicated-resources/src/org/apache/cloudstack/dedicated/DedicatedResourceManagerImpl.java
@@ -20,12 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
-
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.affinity.AffinityGroup;
 import org.apache.cloudstack.affinity.AffinityGroupService;
@@ -48,6 +44,8 @@ import org.apache.cloudstack.api.response.DedicatePodResponse;
 import org.apache.cloudstack.api.response.DedicateZoneResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.configuration.Config;
 import com.cloud.dc.ClusterVO;
@@ -84,7 +82,6 @@ import com.cloud.vm.UserVmVO;
 import com.cloud.vm.dao.UserVmDao;
 
 @Component
-@Local({DedicatedService.class})
 public class DedicatedResourceManagerImpl implements DedicatedService {
     private static final Logger s_logger = Logger.getLogger(DedicatedResourceManagerImpl.class);
 

--- a/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/manager/HypervManagerImpl.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/manager/HypervManagerImpl.java
@@ -26,16 +26,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
-
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.utils.identity.ManagementServerNode;
+import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.storage.JavaStorageLayer;
@@ -48,7 +46,6 @@ import com.cloud.utils.script.Script;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
-@Local(value = {HypervManager.class})
 public class HypervManagerImpl implements HypervManager {
     public static final Logger s_logger = Logger.getLogger(HypervManagerImpl.class);
 
@@ -126,6 +123,7 @@ public class HypervManagerImpl implements HypervManager {
         runLevel = level;
     }
 
+    @Override
     public String prepareSecondaryStorageStore(long zoneId) {
         String secondaryStorageUri = getSecondaryStorageStoreUrl(zoneId);
         if (secondaryStorageUri == null) {

--- a/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
+++ b/plugins/hypervisors/hyperv/src/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
@@ -32,7 +32,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import org.joda.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
@@ -63,6 +61,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.BasicClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 import org.apache.log4j.Logger;
+import org.joda.time.Duration;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.CheckRouterAnswer;
@@ -161,7 +160,6 @@ import com.google.gson.reflect.TypeToken;
 /**
  * Implementation of dummy resource to be returned from discoverer.
  **/
-@Local(value = ServerResource.class)
 public class HypervDirectConnectResource extends ServerResourceBase implements ServerResource, VirtualRouterDeployer {
     public static final int DEFAULT_AGENT_PORT = 8250;
     public static final String HOST_VM_STATE_REPORT_COMMAND = "org.apache.cloudstack.HostVmStateReportCommand";

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3VirtualRoutingResource.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3VirtualRoutingResource.java
@@ -17,11 +17,8 @@
 
 package com.cloud.hypervisor.ovm3.resources;
 
-import org.joda.time.Duration;
-
-import javax.ejb.Local;
-
 import org.apache.log4j.Logger;
+import org.joda.time.Duration;
 
 import com.cloud.agent.api.SetupGuestNetworkCommand;
 import com.cloud.agent.api.routing.IpAssocCommand;
@@ -36,7 +33,6 @@ import com.cloud.hypervisor.ovm3.objects.Connection;
 import com.cloud.hypervisor.ovm3.objects.Xen;
 import com.cloud.utils.ExecutionResult;
 
-@Local(value = VirtualRouterDeployer.class)
 public class Ovm3VirtualRoutingResource implements VirtualRouterDeployer {
     private final Logger logger = Logger
             .getLogger(Ovm3VirtualRoutingResource.class);

--- a/plugins/hypervisors/ucs/src/com/cloud/ucs/manager/UcsManagerImpl.java
+++ b/plugins/hypervisors/ucs/src/com/cloud/ucs/manager/UcsManagerImpl.java
@@ -26,11 +26,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
-
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.AddUcsManagerCmd;
 import org.apache.cloudstack.api.AssociateUcsProfileToBladeCmd;
@@ -44,6 +41,7 @@ import org.apache.cloudstack.api.response.UcsManagerResponse;
 import org.apache.cloudstack.api.response.UcsProfileResponse;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.log4j.Logger;
 
 import com.cloud.configuration.Config;
 import com.cloud.dc.ClusterDetailsDao;
@@ -68,7 +66,6 @@ import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.xmlobject.XmlObject;
 import com.cloud.utils.xmlobject.XmlObjectParser;
 
-@Local(value = {UcsManager.class})
 public class UcsManagerImpl implements UcsManager {
     public static final Logger s_logger = Logger.getLogger(UcsManagerImpl.class);
     public static final Long COOKIE_TTL = TimeUnit.MILLISECONDS.convert(100L, TimeUnit.MINUTES);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XcpServerResource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XcpServerResource.java
@@ -16,18 +16,14 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
-import javax.ejb.Local;
-
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
-import com.cloud.resource.ServerResource;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.Host;
 import com.xensource.xenapi.Types.XenAPIException;
 import com.xensource.xenapi.VM;
 
-@Local(value = ServerResource.class)
 public class XcpServerResource extends CitrixResourceBase {
 
     private final static Logger s_logger = Logger.getLogger(XcpServerResource.class);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer56FP1Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer56FP1Resource.java
@@ -18,16 +18,12 @@ package com.cloud.hypervisor.xenserver.resource;
 
 import java.util.Map;
 
-import javax.ejb.Local;
-
 import org.apache.xmlrpc.XmlRpcException;
 
-import com.cloud.resource.ServerResource;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.Host;
 import com.xensource.xenapi.Types.XenAPIException;
 
-@Local(value = ServerResource.class)
 public class XenServer56FP1Resource extends XenServer56Resource {
 
     @Override

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer56Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer56Resource.java
@@ -16,12 +16,9 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
-import javax.ejb.Local;
-
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.StartupCommand;
-import com.cloud.resource.ServerResource;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.ssh.SSHCmdHelper;
 import com.xensource.xenapi.Connection;
@@ -31,7 +28,6 @@ import com.xensource.xenapi.PIF;
 import com.xensource.xenapi.Types.XenAPIException;
 import com.xensource.xenapi.VLAN;
 
-@Local(value = ServerResource.class)
 public class XenServer56Resource extends CitrixResourceBase {
     private final static Logger s_logger = Logger.getLogger(XenServer56Resource.class);
 

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer56SP2Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer56SP2Resource.java
@@ -16,11 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
-import javax.ejb.Local;
-
-import com.cloud.resource.ServerResource;
-
-@Local(value = ServerResource.class)
 public class XenServer56SP2Resource extends XenServer56FP1Resource {
 
     public XenServer56SP2Resource() {

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer600Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer600Resource.java
@@ -16,11 +16,6 @@
 // under the License.
 package com.cloud.hypervisor.xenserver.resource;
 
-import javax.ejb.Local;
-
-import com.cloud.resource.ServerResource;
-
-@Local(value = ServerResource.class)
 public class XenServer600Resource extends XenServer56SP2Resource {
 
     @Override

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer610Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer610Resource.java
@@ -22,14 +22,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ejb.Local;
-
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
 import com.cloud.agent.api.to.DiskTO;
-import com.cloud.resource.ServerResource;
 import com.cloud.storage.Volume;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.xensource.xenapi.Connection;
@@ -40,7 +37,6 @@ import com.xensource.xenapi.VDI;
 import com.xensource.xenapi.VIF;
 import com.xensource.xenapi.VM;
 
-@Local(value = ServerResource.class)
 public class XenServer610Resource extends XenServer600Resource {
 
     private static final Logger s_logger = Logger.getLogger(XenServer610Resource.class);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer620Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer620Resource.java
@@ -18,19 +18,15 @@ package com.cloud.hypervisor.xenserver.resource;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ejb.Local;
-
 import org.apache.cloudstack.hypervisor.xenserver.XenserverConfigs;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.StartupRoutingCommand;
-import com.cloud.resource.ServerResource;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.Host;
 import com.xensource.xenapi.HostPatch;
 import com.xensource.xenapi.PoolPatch;
 
-@Local(value = ServerResource.class)
 public class XenServer620Resource extends XenServer610Resource {
 
     private static final Logger s_logger = Logger.getLogger(XenServer620Resource.class);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer620SP1Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer620SP1Resource.java
@@ -23,8 +23,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ejb.Local;
-
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
@@ -32,7 +30,6 @@ import com.cloud.agent.api.StartCommand;
 import com.cloud.agent.api.StartupRoutingCommand;
 import com.cloud.agent.api.VgpuTypesInfo;
 import com.cloud.agent.api.to.GPUDeviceTO;
-import com.cloud.resource.ServerResource;
 import com.xensource.xenapi.Connection;
 import com.xensource.xenapi.GPUGroup;
 import com.xensource.xenapi.Host;
@@ -43,7 +40,6 @@ import com.xensource.xenapi.VGPUType;
 import com.xensource.xenapi.VGPUType.Record;
 import com.xensource.xenapi.VM;
 
-@Local(value=ServerResource.class)
 public class XenServer620SP1Resource extends XenServer620Resource {
 
     private static final Logger s_logger = Logger.getLogger(XenServer620SP1Resource.class);

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer650Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/XenServer650Resource.java
@@ -18,11 +18,6 @@
  */
 package com.cloud.hypervisor.xenserver.resource;
 
-import javax.ejb.Local;
-
-import com.cloud.resource.ServerResource;
-
-@Local(value=ServerResource.class)
 public class XenServer650Resource extends Xenserver625Resource {
 
     @Override

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625Resource.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/Xenserver625Resource.java
@@ -18,13 +18,10 @@
  */
 package com.cloud.hypervisor.xenserver.resource;
 
-import javax.ejb.Local;
-
 import org.apache.cloudstack.hypervisor.xenserver.XenServerResourceNewBase;
 import org.apache.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 
-import com.cloud.resource.ServerResource;
 import com.cloud.storage.resource.StorageSubsystemCommandHandler;
 import com.cloud.storage.resource.StorageSubsystemCommandHandlerBase;
 import com.cloud.utils.exception.CloudRuntimeException;
@@ -34,7 +31,6 @@ import com.xensource.xenapi.Host;
 import com.xensource.xenapi.Types;
 import com.xensource.xenapi.VM;
 
-@Local(value=ServerResource.class)
 public class Xenserver625Resource extends XenServerResourceNewBase {
 
     private static final Logger s_logger = Logger.getLogger(Xenserver625Resource.class);

--- a/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ServiceManagerImpl.java
+++ b/plugins/network-elements/juniper-contrail/src/org/apache/cloudstack/network/contrail/management/ServiceManagerImpl.java
@@ -24,11 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
-
-import net.juniper.contrail.api.ApiConnector;
-import net.juniper.contrail.api.types.ServiceInstance;
 
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.network.contrail.api.response.ServiceInstanceResponse;
@@ -63,7 +59,9 @@ import com.cloud.vm.VirtualMachineName;
 import com.cloud.vm.dao.UserVmDao;
 import com.google.gson.Gson;
 
-@Local(value = {ServiceManager.class})
+import net.juniper.contrail.api.ApiConnector;
+import net.juniper.contrail.api.types.ServiceInstance;
+
 public class ServiceManagerImpl implements ServiceManager {
     private static final Logger s_logger = Logger.getLogger(ServiceManager.class);
 

--- a/plugins/network-elements/netscaler/src/com/cloud/network/vm/NetScalerVMManagerImpl.java
+++ b/plugins/network-elements/netscaler/src/com/cloud/network/vm/NetScalerVMManagerImpl.java
@@ -23,16 +23,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
-
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.lb.dao.ApplicationLoadBalancerRuleDao;
+import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
@@ -96,7 +94,6 @@ import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
-@Local(value = {NetScalerVMManager.class})
 public class NetScalerVMManagerImpl extends ManagerBase implements NetScalerVMManager, VirtualMachineGuru {
     private static final Logger s_logger = Logger.getLogger(NetScalerVMManagerImpl.class);
     static final private String NetScalerLbVmNamePrefix = "NS";

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapManagerImpl.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapManagerImpl.java
@@ -20,17 +20,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.NamingException;
 import javax.naming.ldap.LdapContext;
-
-import org.apache.cloudstack.api.command.LinkDomainToLdapCmd;
-import org.apache.cloudstack.api.response.LinkDomainToLdapResponse;
-import org.apache.cloudstack.ldap.dao.LdapTrustMapDao;
-import org.apache.commons.lang.Validate;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.api.LdapValidator;
 import org.apache.cloudstack.api.command.LDAPConfigCmd;
@@ -42,15 +34,20 @@ import org.apache.cloudstack.api.command.LdapImportUsersCmd;
 import org.apache.cloudstack.api.command.LdapListConfigurationCmd;
 import org.apache.cloudstack.api.command.LdapListUsersCmd;
 import org.apache.cloudstack.api.command.LdapUserSearchCmd;
+import org.apache.cloudstack.api.command.LinkDomainToLdapCmd;
 import org.apache.cloudstack.api.response.LdapConfigurationResponse;
 import org.apache.cloudstack.api.response.LdapUserResponse;
+import org.apache.cloudstack.api.response.LinkDomainToLdapResponse;
 import org.apache.cloudstack.ldap.dao.LdapConfigurationDao;
+import org.apache.cloudstack.ldap.dao.LdapTrustMapDao;
+import org.apache.commons.lang.Validate;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.utils.Pair;
 
 @Component
-@Local(value = LdapManager.class)
 public class LdapManagerImpl implements LdapManager, LdapValidator {
     private static final Logger s_logger = Logger.getLogger(LdapManagerImpl.class.getName());
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <cs.configuration.version>1.10</cs.configuration.version>
     <cs.logging.version>1.1.1</cs.logging.version>
     <cs.discovery.version>0.5</cs.discovery.version>
-    <cs.ejb.version>3.0</cs.ejb.version>
+    
     <!-- do not forget to also upgrade hamcrest library with junit -->
     <cs.junit.version>4.12</cs.junit.version>
     <cs.hamcrest.version>1.3</cs.hamcrest.version>
@@ -341,11 +341,6 @@
             <groupId>log4j</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>javax.ejb</groupId>
-        <artifactId>ejb-api</artifactId>
-        <version>${cs.ejb.version}</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.java-ipv6</groupId>

--- a/scripts/installer/windows/client.wxs
+++ b/scripts/installer/windows/client.wxs
@@ -1581,9 +1581,6 @@
                         <Component Id="cmp9FAD7DAD071299E1AAF045F54DE9F495" Guid="{73188CEE-DB1A-48F0-AF78-A37662859327}">
                             <File Id="filF642ECE1D8F64EBCECFA04A5600BF8E3" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\lib\ehcache-core-2.6.6.jar" />
                         </Component>
-                        <Component Id="cmp89F65AB47003394DE45F2F27D9992C86" Guid="{A523C269-1E43-4512-BDC1-48D76556443C}">
-                            <File Id="fil15FE2F49ABA53F783D33C935E0703143" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\lib\ejb-api-3.0.jar" />
-                        </Component>
                         <Component Id="cmp0C3372A952450A4EED8FDCC1B8EAF4A3" Guid="{D0DA328A-0956-4341-9D5D-CEAF84470F46}">
                             <File Id="filD619AEE8A024E5F335662217E6852A4C" KeyPath="yes" Source="!(wix.SourceClient)\WEB-INF\lib\esapi-2.0.1.jar" />
                         </Component>

--- a/server/src/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/com/cloud/network/router/NetworkHelperImpl.java
@@ -25,18 +25,12 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
-import javax.ejb.Local;
 import javax.inject.Inject;
-import com.cloud.configuration.Config;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import com.cloud.exception.InvalidParameterValueException;
-import com.cloud.network.lb.LoadBalancingRule;
-import com.cloud.network.rules.LbStickinessMethod;
-import com.cloud.utils.Pair;
 
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.log4j.Logger;
 import org.cloud.network.router.deployment.RouterDeploymentDefinition;
 
@@ -45,6 +39,7 @@ import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.manager.Commands;
 import com.cloud.alert.AlertManager;
+import com.cloud.configuration.Config;
 import com.cloud.dc.ClusterVO;
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.Pod;
@@ -58,6 +53,7 @@ import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientAddressCapacityException;
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.InsufficientServerCapacityException;
+import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.OperationTimedoutException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.exception.StorageUnavailableException;
@@ -75,8 +71,10 @@ import com.cloud.network.addr.PublicIp;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.UserIpv6AddressDao;
+import com.cloud.network.lb.LoadBalancingRule;
 import com.cloud.network.router.VirtualRouter.RedundantState;
 import com.cloud.network.router.VirtualRouter.Role;
+import com.cloud.network.rules.LbStickinessMethod;
 import com.cloud.network.vpn.Site2SiteVpnManager;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.resource.ResourceManager;
@@ -92,6 +90,7 @@ import com.cloud.user.AccountManager;
 import com.cloud.user.User;
 import com.cloud.user.UserVO;
 import com.cloud.user.dao.UserDao;
+import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils;
 import com.cloud.vm.DomainRouterVO;
@@ -105,7 +104,6 @@ import com.cloud.vm.VirtualMachineProfile.Param;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
 
-@Local(value = { NetworkHelper.class })
 public class NetworkHelperImpl implements NetworkHelper {
 
     private static final Logger s_logger = Logger.getLogger(NetworkHelperImpl.class);
@@ -779,6 +777,7 @@ public class NetworkHelperImpl implements NetworkHelper {
     public static void setVMInstanceName(final String vmInstanceName) {
         s_vmInstanceName = vmInstanceName;
     }
+    @Override
     public boolean validateHAProxyLBRule(final LoadBalancingRule rule) {
         final String timeEndChar = "dhms";
         int haproxy_stats_port = Integer.parseInt(_configDao.getValue(Config.NetworkLBHaproxyStatsPort.key()));

--- a/server/src/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/server/src/com/cloud/network/router/NicProfileHelperImpl.java
@@ -19,7 +19,6 @@ package com.cloud.network.router;
 
 import java.net.URI;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.cloud.network.router.deployment.RouterDeploymentDefinition;
@@ -43,7 +42,6 @@ import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 
-@Local(value = {NicProfileHelper.class})
 public class NicProfileHelperImpl implements NicProfileHelper {
 
     @Inject

--- a/server/src/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -26,24 +26,22 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
-
-import org.apache.cloudstack.framework.config.ConfigKey;
-import org.apache.cloudstack.framework.config.Configurable;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.managed.context.ManagedContextRunnable;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreVO;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
 
 import com.cloud.alert.AlertManager;
 import com.cloud.configuration.Config;
@@ -109,7 +107,6 @@ import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 @Component
-@Local(value = {ResourceLimitService.class})
 public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLimitService, Configurable{
     public static final Logger s_logger = Logger.getLogger(ResourceLimitManagerImpl.class);
 
@@ -876,8 +873,9 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
 
         ResourceCountVO accountRC = _resourceCountDao.findByOwnerAndType(accountId, ResourceOwnerType.Account, type);
         long oldCount = 0;
-        if (accountRC != null)
+        if (accountRC != null) {
             oldCount = accountRC.getCount();
+        }
 
         if (type == Resource.ResourceType.user_vm) {
             newCount = _userVmDao.countAllocatedVMsForAccount(accountId);
@@ -1007,10 +1005,11 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
             dedicatedCount += new Long(ips.size());
         }
         allocatedCount = _ipAddressDao.countAllocatedIPsForAccount(accountId);
-        if (dedicatedCount > allocatedCount)
+        if (dedicatedCount > allocatedCount) {
             return dedicatedCount;
-        else
+        } else {
             return allocatedCount;
+        }
     }
 
     @Override
@@ -1053,8 +1052,9 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
     public void changeResourceCount(long accountId, ResourceType type, Boolean displayResource, Long... delta) {
 
         // meaning that the display flag is not changed so neither increment or decrement
-        if (displayResource == null)
+        if (displayResource == null) {
             return;
+        }
 
         // Increment because the display is turned on.
         if (displayResource) {

--- a/server/src/com/cloud/storage/listener/SnapshotStateListener.java
+++ b/server/src/com/cloud/storage/listener/SnapshotStateListener.java
@@ -23,17 +23,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
-import javax.ejb.Local;
 import javax.inject.Inject;
-
-import com.cloud.utils.fsm.StateMachine2;
-import org.apache.log4j.Logger;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.stereotype.Component;
 
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.events.EventBus;
 import org.apache.cloudstack.framework.events.EventBusException;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.stereotype.Component;
 
 import com.cloud.configuration.Config;
 import com.cloud.event.EventCategory;
@@ -44,9 +41,9 @@ import com.cloud.storage.Snapshot.State;
 import com.cloud.storage.SnapshotVO;
 import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.fsm.StateListener;
+import com.cloud.utils.fsm.StateMachine2;
 
 @Component
-@Local(value = {SnapshotStateListener.class})
 public class SnapshotStateListener implements StateListener<State, Event, SnapshotVO> {
 
     protected static EventBus s_eventBus = null;
@@ -74,17 +71,18 @@ public class SnapshotStateListener implements StateListener<State, Event, Snapsh
 
     @Override
     public boolean postStateTransitionEvent(StateMachine2.Transition<State, Event> transition, SnapshotVO vo, boolean status, Object opaque) {
-      pubishOnEventBus(transition.getEvent().name(), "postStateTransitionEvent", vo, transition.getCurrentState(), transition.getToState());
-      return true;
+        pubishOnEventBus(transition.getEvent().name(), "postStateTransitionEvent", vo, transition.getCurrentState(), transition.getToState());
+        return true;
     }
 
-  private void pubishOnEventBus(String event, String status, Snapshot vo, State oldState, State newState) {
+    private void pubishOnEventBus(String event, String status, Snapshot vo, State oldState, State newState) {
 
         String configKey = Config.PublishResourceStateEvent.key();
         String value = s_configDao.getValue(configKey);
         boolean configValue = Boolean.parseBoolean(value);
-        if(!configValue)
+        if(!configValue) {
             return;
+        }
         try {
             s_eventBus = ComponentContext.getComponent(EventBus.class);
         } catch (NoSuchBeanDefinitionException nbe) {
@@ -93,8 +91,8 @@ public class SnapshotStateListener implements StateListener<State, Event, Snapsh
 
         String resourceName = getEntityFromClassName(Snapshot.class.getName());
         org.apache.cloudstack.framework.events.Event eventMsg =
-            new org.apache.cloudstack.framework.events.Event(ManagementService.Name, EventCategory.RESOURCE_STATE_CHANGE_EVENT.getName(), event, resourceName,
-                vo.getUuid());
+                new org.apache.cloudstack.framework.events.Event(ManagementService.Name, EventCategory.RESOURCE_STATE_CHANGE_EVENT.getName(), event, resourceName,
+                        vo.getUuid());
         Map<String, String> eventDescription = new HashMap<String, String>();
         eventDescription.put("resource", resourceName);
         eventDescription.put("id", vo.getUuid());

--- a/server/src/com/cloud/uuididentity/UUIDManagerImpl.java
+++ b/server/src/com/cloud/uuididentity/UUIDManagerImpl.java
@@ -18,7 +18,6 @@ package com.cloud.uuididentity;
 
 import java.util.UUID;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.context.CallContext;
@@ -31,7 +30,6 @@ import com.cloud.utils.db.EntityManager;
 import com.cloud.utils.db.UUIDManager;
 import com.cloud.utils.exception.CloudRuntimeException;
 
-@Local(value = {UUIDManager.class})
 public class UUIDManagerImpl implements UUIDManager {
 
     @Inject
@@ -44,8 +42,9 @@ public class UUIDManagerImpl implements UUIDManager {
     @Override
     public <T> void checkUuid(String uuid, Class<T> entityType) {
 
-        if (uuid == null)
+        if (uuid == null) {
             return;
+        }
 
         Account caller = CallContext.current().getCallingAccount();
 
@@ -60,16 +59,19 @@ public class UUIDManagerImpl implements UUIDManager {
     @Override
     public <T> void checkUuidSimple(String uuid, Class<T> entityType) {
 
-        if (uuid == null)
+        if (uuid == null) {
             return;
+        }
 
         // check format
-        if (!IsUuidFormat(uuid))
+        if (!IsUuidFormat(uuid)) {
             throw new InvalidParameterValueException("UUID: " + uuid + " doesn't follow the UUID format");
+        }
 
         // check unique
-        if (!IsUuidUnique(entityType, uuid))
+        if (!IsUuidUnique(entityType, uuid)) {
             throw new InvalidParameterValueException("UUID: " + uuid + " already exists so can't create/update with custom id");
+        }
 
     }
 
@@ -83,10 +85,11 @@ public class UUIDManagerImpl implements UUIDManager {
     public <T> boolean IsUuidUnique(Class<T> entityType, String uuid) {
 
         T obj = _entityMgr.findByUuid(entityType, uuid);
-        if (obj != null)
+        if (obj != null) {
             return false;
-        else
+        } else {
             return true;
+        }
     }
 
     @Override
@@ -96,8 +99,9 @@ public class UUIDManagerImpl implements UUIDManager {
             int retry = UUID_RETRY;
             while (retry-- != 0) {  // there might be collision so retry
                 String uuid = UUID.randomUUID().toString();
-                if (IsUuidUnique(entityType, uuid))
+                if (IsUuidUnique(entityType, uuid)) {
                     return uuid;
+                }
             }
 
             throw new CloudRuntimeException("Unable to generate a unique uuid, please try again");

--- a/server/src/org/apache/cloudstack/acl/RoleManagerImpl.java
+++ b/server/src/org/apache/cloudstack/acl/RoleManagerImpl.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.acl.dao.RoleDao;
@@ -53,7 +52,6 @@ import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionStatus;
 import com.google.common.base.Strings;
 
-@Local(value = {RoleService.class})
 public class RoleManagerImpl extends ManagerBase implements RoleService, Configurable, PluggableService {
     @Inject
     private AccountDao accountDao;

--- a/server/src/org/apache/cloudstack/network/ssl/CertServiceImpl.java
+++ b/server/src/org/apache/cloudstack/network/ssl/CertServiceImpl.java
@@ -16,47 +16,6 @@
 // under the License.
 package org.apache.cloudstack.network.ssl;
 
-import com.cloud.domain.DomainVO;
-import com.cloud.domain.dao.DomainDao;
-import com.cloud.event.ActionEvent;
-import com.cloud.event.EventTypes;
-import com.cloud.exception.InvalidParameterValueException;
-import com.cloud.network.dao.LoadBalancerCertMapDao;
-import com.cloud.network.dao.LoadBalancerCertMapVO;
-import com.cloud.network.dao.LoadBalancerVO;
-import com.cloud.network.dao.SslCertDao;
-import com.cloud.network.dao.SslCertVO;
-import org.apache.cloudstack.network.tls.CertService;
-import com.cloud.network.rules.LoadBalancer;
-import com.cloud.projects.Project;
-import com.cloud.projects.ProjectService;
-import com.cloud.user.Account;
-import com.cloud.user.AccountManager;
-import com.cloud.user.dao.AccountDao;
-import com.cloud.utils.db.DB;
-import com.cloud.utils.db.EntityManager;
-import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.security.CertificateHelper;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import org.apache.cloudstack.acl.SecurityChecker;
-import org.apache.cloudstack.api.command.user.loadbalancer.DeleteSslCertCmd;
-import org.apache.cloudstack.api.command.user.loadbalancer.ListSslCertsCmd;
-import org.apache.cloudstack.api.command.user.loadbalancer.UploadSslCertCmd;
-import org.apache.cloudstack.api.response.SslCertResponse;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.util.io.pem.PemObject;
-import org.bouncycastle.util.io.pem.PemReader;
-
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import javax.ejb.Local;
-import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
@@ -89,7 +48,48 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@Local(value = {CertService.class})
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.inject.Inject;
+
+import org.apache.cloudstack.acl.SecurityChecker;
+import org.apache.cloudstack.api.command.user.loadbalancer.DeleteSslCertCmd;
+import org.apache.cloudstack.api.command.user.loadbalancer.ListSslCertsCmd;
+import org.apache.cloudstack.api.command.user.loadbalancer.UploadSslCertCmd;
+import org.apache.cloudstack.api.response.SslCertResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.network.tls.CertService;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
+
+import com.cloud.domain.DomainVO;
+import com.cloud.domain.dao.DomainDao;
+import com.cloud.event.ActionEvent;
+import com.cloud.event.EventTypes;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.network.dao.LoadBalancerCertMapDao;
+import com.cloud.network.dao.LoadBalancerCertMapVO;
+import com.cloud.network.dao.LoadBalancerVO;
+import com.cloud.network.dao.SslCertDao;
+import com.cloud.network.dao.SslCertVO;
+import com.cloud.network.rules.LoadBalancer;
+import com.cloud.projects.Project;
+import com.cloud.projects.ProjectService;
+import com.cloud.user.Account;
+import com.cloud.user.AccountManager;
+import com.cloud.user.dao.AccountDao;
+import com.cloud.utils.db.DB;
+import com.cloud.utils.db.EntityManager;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.security.CertificateHelper;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
 public class CertServiceImpl implements CertService {
 
     private static final Logger s_logger = Logger.getLogger(CertServiceImpl.class);
@@ -438,6 +438,7 @@ public class CertServiceImpl implements CertService {
         }
     }
 
+    @Override
     public Certificate parseCertificate(final String cert) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(cert));
         final PemReader certPem = new PemReader(new StringReader(cert));

--- a/server/src/org/apache/cloudstack/region/gslb/GlobalLoadBalancingRulesServiceImpl.java
+++ b/server/src/org/apache/cloudstack/region/gslb/GlobalLoadBalancingRulesServiceImpl.java
@@ -22,10 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ejb.Local;
 import javax.inject.Inject;
-
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.SecurityChecker;
 import org.apache.cloudstack.api.command.user.region.ha.gslb.AssignToGlobalLoadBalancerRuleCmd;
@@ -38,6 +35,7 @@ import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.region.Region;
 import org.apache.cloudstack.region.dao.RegionDao;
+import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.routing.GlobalLoadBalancerConfigCommand;
@@ -69,7 +67,6 @@ import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils;
 
-@Local(value = {GlobalLoadBalancingRulesService.class})
 public class GlobalLoadBalancingRulesServiceImpl implements GlobalLoadBalancingRulesService {
 
     private static final Logger s_logger = Logger.getLogger(GlobalLoadBalancingRulesServiceImpl.class);
@@ -477,12 +474,10 @@ public class GlobalLoadBalancingRulesServiceImpl implements GlobalLoadBalancingR
             }
         });
 
-        boolean success = false;
         try {
             if (gslbLbMapVos != null) {
                 applyGlobalLoadBalancerRuleConfig(gslbRuleId, true);
             }
-            success = true;
         } catch (ResourceUnavailableException e) {
             throw new CloudRuntimeException("Failed to update the gloabal load balancer");
         }

--- a/tools/whisker/descriptor-for-packaging.xml
+++ b/tools/whisker/descriptor-for-packaging.xml
@@ -1959,10 +1959,10 @@ below. If you did not receive this Content directly from the Eclipse Foundation,
 the following is provided for informational purposes only, and you should look
 to the Redistributor's license for terms and conditions of use.
 
-Foundation Dependencies ASM EclipseLink JPA ANTLR Java Persistence API (JPA) 1.0
-- EJB 3.0 Java Persistence API (JPA) 2.0 EARLY ACCESS EclipseLink MOXy Java
-Architecture for XML Binding (JAXB) Java Mail Java Activation Framework
-Streaming API for XML (StAX) EclipseLink SDO Service Data Objects (SDO)
+Foundation Dependencies ASM EclipseLink JPA ANTLR Java Persistence API (JPA) 2.0
+EARLY ACCESS EclipseLink MOXy Java Architecture for XML Binding (JAXB) 
+Java Mail Java Activation Framework Streaming API for XML (StAX) 
+EclipseLink SDO Service Data Objects (SDO) 
 Utilities Java Connector Xerces WSDL4J 1.6.2 ASM v1.5.3
 
 The EclipseLink Project includes ASM for the purpose of byte code weaving. The
@@ -2019,19 +2019,19 @@ EclipseLink Project to enable the MOXY component's implementation of JAXB.
 
 JAXB Libraries:
 
-/jlib/moxy/javax.xml.bind_2.1.12.v20090708-1500.jar /jlib/moxy/jaxb-impl.jar
-/jlib/moxy/jaxb.xjc.jar Java Persistence (JPA) 1.0 - EJB 3.0
+/jlib/moxy/javax.xml.bind_2.1.12.v20090708-1500.jar 
+/jlib/moxy/jaxb-impl.jar
+/jlib/moxy/jaxb.xjc.jar
 
-The Java Persistence API, included with EJB 3.0, is available for download from
-the ejb-api directory in the glassfish CVS repository.It is distributed under
-CDDLv1.0 . The jar is being shipped as an OSGi bundle and is required for
-compilation of some container based fuctionality.
+Java Persistence (JPA) 2.0:
 
-Java Persistence (JPA) 2.0.
-
-EclipseLink is the Java Persistence (JPA) 2.0 Reference Implementation (JSR
-317). The JPA 2.0 specification API is included in EclipseLink under the EPL and
-EDL licenses.
+The Java Persistence API used is available in the Maven central repository 
+under the "org.eclipse.persistence" groupId. This jar is being shipped as
+an OSGi bundle and is required for compilation of some container based 
+functionality. The JAR "javax.persistence" is distributed under Eclipse 
+Public License v1.0 and Eclipse Distribution License v. 1.0 licenses. 
+EclipseLink is the Java Persistence (JPA) 2.0 Reference Implementation
+(JSR 317).
 
 Java Mail v1.4
 
@@ -2723,10 +2723,6 @@ Copyright (c) 2003-2007 Luck Consulting Pty Ltd
             <copyright-notice>
 Copyright (c) 2006 Sun Microsystems, Inc. All rights reserved.
             </copyright-notice>
-            <by-organisation id='glassfish.org'>
-                <resource name='cloud-ejb-api-3.0.jar' source='http://repo1.maven.org/maven2/javax/ejb/ejb-api/3.0/ejb-api-3.0-sources.jar' notice='cddlnotice' />
-                <resource name='cloud-jstl-1.2.jar' source='http://jstl.java.net/' notice='cddlnotice' />
-            </by-organisation>
         </with-license>
         <with-license id='CDDL'>
             <copyright-notice>

--- a/tools/whisker/descriptor.xml
+++ b/tools/whisker/descriptor.xml
@@ -1959,8 +1959,8 @@ below. If you did not receive this Content directly from the Eclipse Foundation,
 the following is provided for informational purposes only, and you should look
 to the Redistributor's license for terms and conditions of use.
 
-Foundation Dependencies ASM EclipseLink JPA ANTLR Java Persistence API (JPA) 1.0
-- EJB 3.0 Java Persistence API (JPA) 2.0 EARLY ACCESS EclipseLink MOXy Java
+Foundation Dependencies
+ASM EclipseLink JPA ANTLR Java Persistence API (JPA) 2.0 EARLY ACCESS EclipseLink MOXy Java
 Architecture for XML Binding (JAXB) Java Mail Java Activation Framework
 Streaming API for XML (StAX) EclipseLink SDO Service Data Objects (SDO)
 Utilities Java Connector Xerces WSDL4J 1.6.2 ASM v1.5.3
@@ -2019,19 +2019,19 @@ EclipseLink Project to enable the MOXY component's implementation of JAXB.
 
 JAXB Libraries:
 
-/jlib/moxy/javax.xml.bind_2.1.12.v20090708-1500.jar /jlib/moxy/jaxb-impl.jar
-/jlib/moxy/jaxb.xjc.jar Java Persistence (JPA) 1.0 - EJB 3.0
+/jlib/moxy/javax.xml.bind_2.1.12.v20090708-1500.jar 
+/jlib/moxy/jaxb-impl.jar
+/jlib/moxy/jaxb.xjc.jar 
 
-The Java Persistence API, included with EJB 3.0, is available for download from
-the ejb-api directory in the glassfish CVS repository.It is distributed under
-CDDLv1.0 . The jar is being shipped as an OSGi bundle and is required for
-compilation of some container based fuctionality.
+Java Persistence (JPA) 2.0:
 
-Java Persistence (JPA) 2.0.
-
-EclipseLink is the Java Persistence (JPA) 2.0 Reference Implementation (JSR
-317). The JPA 2.0 specification API is included in EclipseLink under the EPL and
-EDL licenses.
+The Java Persistence API used is available in the Maven central repository 
+under the "org.eclipse.persistence" groupId. This jar is being shipped as
+an OSGi bundle and is required for compilation of some container based 
+functionality. The JAR "javax.persistence" is distributed under Eclipse 
+Public License v1.0 and Eclipse Distribution License v. 1.0 licenses. 
+EclipseLink is the Java Persistence (JPA) 2.0 Reference Implementation
+(JSR 317).
 
 Java Mail v1.4
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -106,10 +106,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ejb</groupId>
-      <artifactId>ejb-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.googlecode.java-ipv6</groupId>
       <artifactId>java-ipv6</artifactId>
     </dependency>


### PR DESCRIPTION
This PR is proposing the removal of "ejb-api" 3.0 JAR. We use spring to manage objects creation and injection. Thus, spring beans do not need the annotation @Local. The @Component or the bean declaration in the XML is enough to wire the object in Spring life-cycle.