### PR TITLE
CLOUDSTACK-10070: Rearrange tests to avoid timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,8 @@ env:
              component/test_acl_sharednetwork_deployVM-impersonation
              component/test_affinity_groups_projects
              component/test_cpu_domain_limits
-             component/test_cpu_limits"
+             component/test_cpu_limits
+             component/test_volumes"
 
     - TESTS="component/test_cpu_max_limits
              component/test_acl_isolatednetwork
@@ -135,8 +136,8 @@ env:
              component/test_non_contiguous_vlan
              component/test_persistent_networks"
 
-    - TESTS="component/test_project_configs
-             component/test_project_limits
+    - TESTS="component/test_project_limits
+             component/test_project_configs
              component/test_project_usage
              component/test_project_resources
              component/test_regions_accounts
@@ -146,11 +147,10 @@ env:
 
     - TESTS="component/test_resource_limits
              component/test_tags
-             component/test_templates"
+             component/test_templates
+             component/test_update_vm"
 
-    - TESTS="component/test_update_vm
-             component/test_volumes
-             component/test_vpc
+    - TESTS="component/test_vpc
              component/test_vpc_network
              component/test_vpc_offerings
              component/test_vpn_users"


### PR DESCRIPTION
This rearranges tests in travis.yml to avoid Travis test job timeout.

We can accept this once Travis passed on this PR.