### PR TITLE
CLOUDSTACK-10177: Only pass IPv6 address to Security Group Python scr…

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3478,7 +3478,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         cmd.add("--vmname", vmName);
         cmd.add("--vmid", vmId);
         cmd.add("--vmip", guestIP);
-        cmd.add("--vmip6", guestIP6);
+        if (StringUtils.isNotBlank(guestIP6)) {
+            cmd.add("--vmip6", guestIP6);
+        }
         cmd.add("--sig", sig);
         cmd.add("--seq", seq);
         cmd.add("--vmmac", mac);


### PR DESCRIPTION
…ipt if present

Otherwise we send down a 'null' to a ProcessBuilder in Java instead of a String and this
causes a NPE.

We should check first if the Instance has a IPv6 address before sending it there.

Signed-off-by: Wido den Hollander <wido@widodh.nl>