### PR TITLE
CLOUDSTACK-8313: Support overprovisioning for local storage

### DIFF
--- a/api/src/com/cloud/storage/Storage.java
+++ b/api/src/com/cloud/storage/Storage.java
@@ -117,27 +117,29 @@ public class Storage {
     }
 
     public static enum StoragePoolType {
-        Filesystem(false), // local directory
-        NetworkFilesystem(true), // NFS
-        IscsiLUN(true), // shared LUN, with a clusterfs overlay
-        Iscsi(true), // for e.g., ZFS Comstar
-        ISO(false), // for iso image
-        LVM(false), // XenServer local LVM SR
-        CLVM(true),
-        RBD(true), // http://libvirt.org/storage.html#StorageBackendRBD
-        SharedMountPoint(true),
-        VMFS(true), // VMware VMFS storage
-        PreSetup(true), // for XenServer, Storage Pool is set up by customers.
-        EXT(false), // XenServer local EXT SR
-        OCFS2(true),
-        SMB(true),
-        Gluster(true),
-        ManagedNFS(true);
+        Filesystem(false, true), // local directory
+        NetworkFilesystem(true, true), // NFS
+        IscsiLUN(true, false), // shared LUN, with a clusterfs overlay
+        Iscsi(true, false), // for e.g., ZFS Comstar
+        ISO(false, false), // for iso image
+        LVM(false, false), // XenServer local LVM SR
+        CLVM(true, false),
+        RBD(true, true), // http://libvirt.org/storage.html#StorageBackendRBD
+        SharedMountPoint(true, false),
+        VMFS(true, true), // VMware VMFS storage
+        PreSetup(true, true), // for XenServer, Storage Pool is set up by customers.
+        EXT(false, true), // XenServer local EXT SR
+        OCFS2(true, false),
+        SMB(true, false),
+        Gluster(true, false),
+        ManagedNFS(true, false);
 
-        boolean shared;
+        private final boolean shared;
+        private final boolean overprovisioning;
 
-        StoragePoolType(boolean shared) {
+        StoragePoolType(boolean shared, boolean overprovisioning) {
             this.shared = shared;
+            this.overprovisioning = overprovisioning;
         }
 
         public boolean isShared() {
@@ -145,7 +147,7 @@ public class Storage {
         }
 
         public boolean supportsOverProvisioning() {
-            return this == StoragePoolType.NetworkFilesystem || this == StoragePoolType.VMFS || this == StoragePoolType.PreSetup || this == StoragePoolType.EXT;
+            return overprovisioning;
         }
     }
 

--- a/api/test/com/cloud/storage/StorageTest.java
+++ b/api/test/com/cloud/storage/StorageTest.java
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.storage;
+
+import com.cloud.storage.Storage.StoragePoolType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StorageTest {
+    @Before
+    public void setUp() {
+    }
+
+    @Test
+    public void isSharedStoragePool() {
+        Assert.assertFalse(StoragePoolType.Filesystem.isShared());
+        Assert.assertTrue(StoragePoolType.NetworkFilesystem.isShared());
+        Assert.assertTrue(StoragePoolType.IscsiLUN.isShared());
+        Assert.assertTrue(StoragePoolType.Iscsi.isShared());
+        Assert.assertFalse(StoragePoolType.ISO.isShared());
+        Assert.assertTrue(StoragePoolType.Iscsi.isShared());
+        Assert.assertFalse(StoragePoolType.LVM.isShared());
+        Assert.assertTrue(StoragePoolType.CLVM.isShared());
+        Assert.assertTrue(StoragePoolType.RBD.isShared());
+        Assert.assertTrue(StoragePoolType.SharedMountPoint.isShared());
+        Assert.assertTrue(StoragePoolType.VMFS.isShared());
+        Assert.assertTrue(StoragePoolType.PreSetup.isShared());
+        Assert.assertFalse(StoragePoolType.EXT.isShared());
+        Assert.assertTrue(StoragePoolType.OCFS2.isShared());
+        Assert.assertTrue(StoragePoolType.SMB.isShared());
+        Assert.assertTrue(StoragePoolType.Gluster.isShared());
+        Assert.assertTrue(StoragePoolType.ManagedNFS.isShared());
+    }
+
+    @Test
+    public void supportsOverprovisioningStoragePool() {
+        Assert.assertTrue(StoragePoolType.Filesystem.supportsOverProvisioning());
+        Assert.assertTrue(StoragePoolType.NetworkFilesystem.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.IscsiLUN.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.Iscsi.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.ISO.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.Iscsi.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.LVM.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.CLVM.supportsOverProvisioning());
+        Assert.assertTrue(StoragePoolType.RBD.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.SharedMountPoint.supportsOverProvisioning());
+        Assert.assertTrue(StoragePoolType.VMFS.supportsOverProvisioning());
+        Assert.assertTrue(StoragePoolType.PreSetup.supportsOverProvisioning());
+        Assert.assertTrue(StoragePoolType.EXT.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.OCFS2.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.SMB.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.Gluster.supportsOverProvisioning());
+        Assert.assertFalse(StoragePoolType.ManagedNFS.supportsOverProvisioning());
+    }
+}


### PR DESCRIPTION
This used to work in earlier version but was broken during a earlier
refactor.

This commit restores the functionality, but is also adds a boolean
per storage pool type if it supports overprovisioning.

This removes the nasty if which hard codes it.

UnitTests are also added to this commit to verify this functionality
remains stable in future releases.

Signed-off-by: Wido den Hollander <wido@widodh.nl>