### PR TITLE
CLOUDSTACK-9736 Incoherent validation and error message when you chan…

### DIFF
--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -689,7 +689,7 @@ import com.cloud.vm.dao.VMInstanceDao;
 public class ManagementServerImpl extends ManagerBase implements ManagementServer, Configurable {
     public static final Logger s_logger = Logger.getLogger(ManagementServerImpl.class.getName());
 
-    static final ConfigKey<Integer> vmPasswordLength = new ConfigKey<Integer>("Advanced", Integer.class, "vm.password.length", "10",
+    static final ConfigKey<Integer> vmPasswordLength = new ConfigKey<Integer>("Advanced", Integer.class, "vm.password.length", "6",
                                                                                       "Specifies the length of a randomly generated password", false);
     @Inject
     public AccountManager _accountMgr;


### PR DESCRIPTION
…ge the vm.password.length configuration parameter

Default value introduce in schema-430to440.sql are 6 for the length

CLOUDSTACK-10111 have already fix the error message