### PR TITLE
doc: replace virutal by virtual (typo)

### DIFF
--- a/api/src/com/cloud/network/vpc/VpcOffering.java
+++ b/api/src/com/cloud/network/vpc/VpcOffering.java
@@ -52,7 +52,7 @@ public interface VpcOffering extends InternalIdentity, Identity {
     boolean isDefault();
 
     /**
-     * @return service offering id used by VPC virutal router
+     * @return service offering id used by VPC virtual router
      */
     Long getServiceOfferingId();
 

--- a/api/src/org/apache/cloudstack/api/response/AcquireIPAddressResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/AcquireIPAddressResponse.java
@@ -96,19 +96,19 @@ public class AcquireIPAddressResponse  extends BaseResponse implements Controlle
  private Boolean isSystem;
 
  @SerializedName(ApiConstants.VIRTUAL_MACHINE_ID)
- @Param(description = "virutal machine id the ip address is assigned to (not null only for static nat Ip)")
+ @Param(description = "virtual machine id the ip address is assigned to (not null only for static nat Ip)")
  private String virtualMachineId;
 
  @SerializedName("vmipaddress")
- @Param(description = "virutal machine (dnat) ip address (not null only for static nat Ip)")
+ @Param(description = "virtual machine (dnat) ip address (not null only for static nat Ip)")
  private String virtualMachineIp;
 
  @SerializedName("virtualmachinename")
- @Param(description = "virutal machine name the ip address is assigned to (not null only for static nat Ip)")
+ @Param(description = "virtual machine name the ip address is assigned to (not null only for static nat Ip)")
  private String virtualMachineName;
 
  @SerializedName("virtualmachinedisplayname")
- @Param(description = "virutal machine display name the ip address is assigned to (not null only for static nat Ip)")
+ @Param(description = "virtual machine display name the ip address is assigned to (not null only for static nat Ip)")
  private String virtualMachineDisplayName;
 
  @SerializedName(ApiConstants.ASSOCIATED_NETWORK_ID)

--- a/api/src/org/apache/cloudstack/api/response/IPAddressResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/IPAddressResponse.java
@@ -96,19 +96,19 @@ public class IPAddressResponse extends BaseResponse implements ControlledEntityR
     private Boolean isSystem;
 
     @SerializedName(ApiConstants.VIRTUAL_MACHINE_ID)
-    @Param(description = "virutal machine id the ip address is assigned to (not null only for static nat Ip)")
+    @Param(description = "virtual machine id the ip address is assigned to (not null only for static nat Ip)")
     private String virtualMachineId;
 
     @SerializedName("vmipaddress")
-    @Param(description = "virutal machine (dnat) ip address (not null only for static nat Ip)")
+    @Param(description = "virtual machine (dnat) ip address (not null only for static nat Ip)")
     private String virtualMachineIp;
 
     @SerializedName("virtualmachinename")
-    @Param(description = "virutal machine name the ip address is assigned to (not null only for static nat Ip)")
+    @Param(description = "virtual machine name the ip address is assigned to (not null only for static nat Ip)")
     private String virtualMachineName;
 
     @SerializedName("virtualmachinedisplayname")
-    @Param(description = "virutal machine display name the ip address is assigned to (not null only for static nat Ip)")
+    @Param(description = "virtual machine display name the ip address is assigned to (not null only for static nat Ip)")
     private String virtualMachineDisplayName;
 
     @SerializedName(ApiConstants.ASSOCIATED_NETWORK_ID)

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -765,7 +765,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             // Need to reboot the virtual machine so that the password gets
             // redownloaded from the DomR, and reset on the VM
             if (!result) {
-                s_logger.debug("Failed to reset password for the virutal machine; no need to reboot the vm");
+                s_logger.debug("Failed to reset password for the virtual machine; no need to reboot the vm");
                 return false;
             } else {
                 if (vmInstance.getState() == State.Stopped) {
@@ -874,7 +874,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         // Need to reboot the virtual machine so that the password gets redownloaded from the DomR, and reset on the VM
         if (!result) {
-            s_logger.debug("Failed to reset SSH Key for the virutal machine; no need to reboot the vm");
+            s_logger.debug("Failed to reset SSH Key for the virtual machine; no need to reboot the vm");
             return false;
         } else {
             if (vmInstance.getState() == State.Stopped) {

--- a/test/metadata/func/flatnetwork.xml
+++ b/test/metadata/func/flatnetwork.xml
@@ -496,7 +496,7 @@ under the License.
 	<command>
 		<name>destroyVirtualMachine</name>
 		<usercommand>true</usercommand>
-		<testcase>Destroying virutal machine</testcase>
+		<testcase>Destroying virtual machine</testcase>
 		<parameters>
 			<item getparam="true">
 				<name>id</name>

--- a/test/metadata/func/roughflatstress.xml
+++ b/test/metadata/func/roughflatstress.xml
@@ -619,7 +619,7 @@ under the License.
 	<command>
 		<name>destroyVirtualMachine</name>
 		<usercommand>true</usercommand>
-		<testcase>Destroying virutal machine</testcase>
+		<testcase>Destroying virtual machine</testcase>
 		<parameters>
 			<item getparam="true">
 				<name>id</name>
@@ -643,7 +643,7 @@ under the License.
 	<command>
 		<name>destroyVirtualMachine</name>
 		<usercommand>true</usercommand>
-		<testcase>Destroying virutal machine</testcase>
+		<testcase>Destroying virtual machine</testcase>
 		<parameters>
 			<item getparam="true">
 				<name>id</name>

--- a/test/metadata/func/securitygroups.xml
+++ b/test/metadata/func/securitygroups.xml
@@ -733,7 +733,7 @@ under the License.
 	<command>
 		<name>destroyVirtualMachine</name>
 		<usercommand>true</usercommand>
-		<testcase>Destroying virutal machine</testcase>
+		<testcase>Destroying virtual machine</testcase>
 		<parameters>
 			<item getparam="true">
 				<name>id</name>


### PR DESCRIPTION
A typo that hit me in the eye on the doc.

http://cloudstack.apache.org/api/apidocs-4.10/apis/listPublicIpAddresses.html

Signed-off-by: Yoan Blanc <yoan.blanc@exoscale.ch>