### PR TITLE
CLOUDSTACK-10197: Rename xentools iso for XenServer 7.0+

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/discoverer/XcpServerDiscoverer.java
@@ -536,7 +536,7 @@ public class XcpServerDiscoverer extends DiscovererBase implements Discoverer, L
             id = _tmpltDao.getNextInSequence(Long.class, "id");
             VMTemplateVO template =
                     VMTemplateVO.createPreHostIso(id, isoName, isoName, ImageFormat.ISO, true, true, TemplateType.PERHOST, null, null, true, 64, Account.ACCOUNT_ID_SYSTEM,
-                            null, "xen-pv-drv-iso", false, 1, false, HypervisorType.XenServer);
+                            null, "XenServer Tools Installer ISO (xen-pv-drv-iso)", false, 1, false, HypervisorType.XenServer);
             _tmpltDao.persist(template);
         } else {
             id = tmplt.getId();

--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -2592,9 +2592,10 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         String mountpoint = null;
         if (isoURL.startsWith("xs-tools")) {
             try {
-                final Set<VDI> vdis = VDI.getByNameLabel(conn, isoURL);
+                final String actualIsoURL = actualIsoTemplate(conn);
+                final Set<VDI> vdis = VDI.getByNameLabel(conn, actualIsoURL);
                 if (vdis.isEmpty()) {
-                    throw new CloudRuntimeException("Could not find ISO with URL: " + isoURL);
+                    throw new CloudRuntimeException("Could not find ISO with URL: " + actualIsoURL);
                 }
                 return vdis.iterator().next();
 
@@ -2628,6 +2629,22 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         } else {
             throw new CloudRuntimeException("Could not find ISO with URL: " + isoURL);
         }
+    }
+
+    private String actualIsoTemplate(final Connection conn) throws BadServerResponse, XenAPIException, XmlRpcException {
+        final Host host = Host.getByUuid(conn, _host.getUuid());
+        final Host.Record record = host.getRecord(conn);
+        final String xenBrand = record.softwareVersion.get("product_brand");
+        final String xenVersion = record.softwareVersion.get("product_version");
+        final String[] items = xenVersion.split("\\.");
+
+        // guest-tools.iso for XenServer version 7.0+
+        if (xenBrand.equals("XenServer") && Integer.parseInt(items[0]) >= 7) {
+            return "guest-tools.iso";
+        }
+
+        // xs-tools.iso for older XenServer versions
+        return "xs-tools.iso";
     }
 
     public String getLabel() {
@@ -3882,9 +3899,10 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             final String templateName = iso.getName();
             if (templateName.startsWith("xs-tools")) {
                 try {
-                    final Set<VDI> vdis = VDI.getByNameLabel(conn, templateName);
+                    final String actualTemplateName = actualIsoTemplate(conn);
+                    final Set<VDI> vdis = VDI.getByNameLabel(conn, actualTemplateName);
                     if (vdis.isEmpty()) {
-                        throw new CloudRuntimeException("Could not find ISO with URL: " + templateName);
+                        throw new CloudRuntimeException("Could not find ISO with URL: " + actualTemplateName);
                     }
                     return vdis.iterator().next();
                 } catch (final XenAPIException e) {


### PR DESCRIPTION
The xentools iso has been renamed from xs-tools to guest-tools
starting from XenServer 7.0.

This PR is the follow up of #2346

@Reviewers: The main change is in `getIsoVDIByURL` method [line ~2589] the rest is autoformatting.