### PR TITLE
CLOUDSTACK-10168 - VR duplicate entries in /etc/hosts when reusing VM name

### DIFF
--- a/api/src/com/cloud/offering/ServiceOffering.java
+++ b/api/src/com/cloud/offering/ServiceOffering.java
@@ -31,7 +31,7 @@ public interface ServiceOffering extends DiskOffering, InfrastructureEntity, Int
     public static final String routerDefaultOffUniqueName = "Cloud.Com-SoftwareRouter";
     public static final String elbVmDefaultOffUniqueName = "Cloud.Com-ElasticLBVm";
     public static final String internalLbVmDefaultOffUniqueName = "Cloud.Com-InternalLBVm";
-    // leaving cloud.com references as these are identifyers and no real world adresses (check against DB)
+    // leaving cloud.com references as these are identifyers and no real world addresses (check against DB)
 
     public enum StorageType {
         local, shared

--- a/core/src/com/cloud/agent/resource/virtualnetwork/model/VmDhcpConfig.java
+++ b/core/src/com/cloud/agent/resource/virtualnetwork/model/VmDhcpConfig.java
@@ -22,10 +22,10 @@ package com.cloud.agent.resource.virtualnetwork.model;
 public class VmDhcpConfig extends ConfigBase {
     private String hostName;
     private String macAddress;
-    private String ipv4Adress;
+    private String ipv4Address;
     private String ipv6Address;
     private String ipv6Duid;
-    private String dnsAdresses;
+    private String dnsAddresses;
     private String defaultGateway;
     private String staticRoutes;
     private boolean defaultEntry;
@@ -34,15 +34,15 @@ public class VmDhcpConfig extends ConfigBase {
         super(VM_DHCP);
     }
 
-    public VmDhcpConfig(String hostName, String macAddress, String ipv4Adress, String ipv6Address, String ipv6Duid, String dnsAdresses, String defaultGateway,
+    public VmDhcpConfig(String hostName, String macAddress, String ipv4Address, String ipv6Address, String ipv6Duid, String dnsAddresses, String defaultGateway,
             String staticRoutes, boolean defaultEntry) {
         super(VM_DHCP);
         this.hostName = hostName;
         this.macAddress = macAddress;
-        this.ipv4Adress = ipv4Adress;
+        this.ipv4Address = ipv4Address;
         this.ipv6Address = ipv6Address;
         this.ipv6Duid = ipv6Duid;
-        this.dnsAdresses = dnsAdresses;
+        this.dnsAddresses = dnsAddresses;
         this.defaultGateway = defaultGateway;
         this.staticRoutes = staticRoutes;
         this.defaultEntry = defaultEntry;
@@ -64,12 +64,12 @@ public class VmDhcpConfig extends ConfigBase {
         this.macAddress = macAddress;
     }
 
-    public String getIpv4Adress() {
-        return ipv4Adress;
+    public String getIpv4Address() {
+        return ipv4Address;
     }
 
-    public void setIpv4Adress(String ipv4Adress) {
-        this.ipv4Adress = ipv4Adress;
+    public void setIpv4Address(String ipv4Address) {
+        this.ipv4Address = ipv4Address;
     }
 
     public String getIpv6Address() {
@@ -88,12 +88,12 @@ public class VmDhcpConfig extends ConfigBase {
         this.ipv6Duid = ipv6Duid;
     }
 
-    public String getDnsAdresses() {
-        return dnsAdresses;
+    public String getDnsAddresses() {
+        return dnsAddresses;
     }
 
-    public void setDnsAdresses(String dnsAdresses) {
-        this.dnsAdresses = dnsAdresses;
+    public void setDnsAddresses(String dnsAddresses) {
+        this.dnsAddresses = dnsAddresses;
     }
 
     public String getDefaultGateway() {

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade218to22.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade218to22.java
@@ -641,13 +641,13 @@ public class Upgrade218to22 implements DbUpgrade {
                 s_logger.debug("Marking " + allocatedIps.size() + " ip addresses to belong to network " + networkId);
                 s_logger.debug("Updating mac addresses for data center id=" + dcId + ". Found " + allocatedIps.size() + " ip addresses to update");
                 for (Object[] allocatedIp : allocatedIps) {
-                    try (PreparedStatement selectMacAdresses = conn.prepareStatement("SELECT mac_address FROM data_center WHERE id = ?");) {
-                        selectMacAdresses.setLong(1, dcId);
-                        try (ResultSet selectedMacAdresses = selectMacAdresses.executeQuery();) {
-                            if (!selectedMacAdresses.next()) {
+                    try (PreparedStatement selectMacAddresses = conn.prepareStatement("SELECT mac_address FROM data_center WHERE id = ?");) {
+                        selectMacAddresses.setLong(1, dcId);
+                        try (ResultSet selectedMacAddresses = selectMacAddresses.executeQuery();) {
+                            if (!selectedMacAddresses.next()) {
                                 throw new CloudRuntimeException("Unable to get mac address for data center " + dcId);
                             }
-                            long mac = selectedMacAdresses.getLong(1);
+                            long mac = selectedMacAddresses.getLong(1);
                             try (PreparedStatement updateDataCenter = conn.prepareStatement("UPDATE data_center SET mac_address=mac_address+1 WHERE id = ?");) {
                                 updateDataCenter.setLong(1, dcId);
                                 updateDataCenter.executeUpdate();

--- a/server/src/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/com/cloud/network/IpAddressManagerImpl.java
@@ -694,7 +694,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         IPAddressVO addr = Transaction.execute(new TransactionCallbackWithException<IPAddressVO, InsufficientAddressCapacityException>() {
             @Override
             public IPAddressVO doInTransaction(TransactionStatus status) throws InsufficientAddressCapacityException {
-                StringBuilder errorMessage = new StringBuilder("Unable to get ip adress in ");
+                StringBuilder errorMessage = new StringBuilder("Unable to get ip address in ");
                 boolean fetchFromDedicatedRange = false;
                 List<Long> dedicatedVlanDbIds = new ArrayList<Long>();
                 List<Long> nonDedicatedVlanDbIds = new ArrayList<Long>();

--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1642,7 +1642,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                         final Long nextMac = mac + 1;
                         dc.setMacAddress(nextMac);
 
-                        s_logger.info("creating private ip adress for vpc (" + ipAddress + ", " + privateNtwk.getId() + ", " + nextMac + ", " + vpcId + ", " + isSourceNat + ")");
+                        s_logger.info("creating private ip address for vpc (" + ipAddress + ", " + privateNtwk.getId() + ", " + nextMac + ", " + vpcId + ", " + isSourceNat + ")");
                         privateIp = new PrivateIpVO(ipAddress, privateNtwk.getId(), nextMac, vpcId, isSourceNat);
                         _privateIpDao.persist(privateIp);
 

--- a/server/test/com/cloud/configuration/ConfigurationManagerTest.java
+++ b/server/test/com/cloud/configuration/ConfigurationManagerTest.java
@@ -247,7 +247,7 @@ public class ConfigurationManagerTest {
         /*
          * TEST 5: given range is already allocated to a different account DedicatePublicIpRange should fail
          */
-        runDedicatePublicIpRangeIPAdressAllocated();
+        runDedicatePublicIpRangeIPAddressAllocated();
     }
 
     @Test
@@ -373,8 +373,8 @@ public class ConfigurationManagerTest {
         }
     }
 
-    void runDedicatePublicIpRangeIPAdressAllocated() throws Exception {
-        TransactionLegacy txn = TransactionLegacy.open("runDedicatePublicIpRangeIPAdressAllocated");
+    void runDedicatePublicIpRangeIPAddressAllocated() throws Exception {
+        TransactionLegacy txn = TransactionLegacy.open("runDedicatePublicIpRangeIPAddressAllocated");
 
         when(configurationMgr._vlanDao.findById(anyLong())).thenReturn(vlan);
 
@@ -397,7 +397,7 @@ public class ConfigurationManagerTest {
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Public IP address in range is allocated to another account"));
         } finally {
-            txn.close("runDedicatePublicIpRangeIPAdressAllocated");
+            txn.close("runDedicatePublicIpRangeIPAddressAllocated");
         }
     }
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -972,7 +972,7 @@ def main(argv):
                         level=config.get_level(),
                         format=config.get_format())
     try:
-        # Load stored ip adresses from disk to CsConfig()
+        # Load stored ip addresses from disk to CsConfig()
         config.set_address()
 
         logging.debug("Configuring ip addresses")

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -130,28 +130,28 @@ class CsDhcp(CsDataBag):
             logging.debug("Hosts file unchanged")
 
     def add(self, entry):
-        self.add_host(entry['ipv4_adress'], entry['host_name'])
+        self.add_host(entry['ipv4_address'], entry['host_name'])
         # lease time boils down to once a month
         # with a splay of 60 hours to prevent storms
         lease = randint(700, 760)
 
         if entry['default_entry'] == True:
             self.cloud.add("%s,%s,%s,%sh" % (entry['mac_address'],
-                                             entry['ipv4_adress'],
+                                             entry['ipv4_address'],
                                              entry['host_name'],
                                              lease))
         else:
-            tag = entry['ipv4_adress'].replace(".","_")
+            tag = entry['ipv4_address'].replace(".","_")
             self.cloud.add("%s,set:%s,%s,%s,%sh" % (entry['mac_address'],
                                                     tag,
-                                                    entry['ipv4_adress'],
+                                                    entry['ipv4_address'],
                                                     entry['host_name'],
                                                     lease))
             self.dhcp_opts.add("%s,%s" % (tag, 3))
             self.dhcp_opts.add("%s,%s" % (tag, 6))
             self.dhcp_opts.add("%s,%s" % (tag, 15))
 
-        i = IPAddress(entry['ipv4_adress'])
+        i = IPAddress(entry['ipv4_address'])
         # Calculate the device
         for v in self.devinfo:
             if i > v['network'].network and i < v['network'].broadcast:
@@ -159,6 +159,6 @@ class CsDhcp(CsDataBag):
                 # Virtual Router
                 v['gateway'] = entry['default_gateway']
 
-
     def add_host(self, ip, hosts):
         self.hosts[ip] = hosts
+        

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_dhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_dhcp.py
@@ -18,17 +18,22 @@
 from pprint import pprint
 from netaddr import *
 
-
 def merge(dbag, data):
-
     # A duplicate ip address wil clobber the old value
     # This seems desirable ....
-    if "add" in data and data['add'] is False and \
-            "ipv4_adress" in data:
-        if data['ipv4_adress'] in dbag:
-            del(dbag[data['ipv4_adress']])
-        return dbag
+    if "add" in data and data['add'] is False and "ipv4_address" in data:
+        if data['ipv4_address'] in dbag:
+            del(dbag[data['ipv4_address']])
     else:
-        dbag[data['ipv4_adress']] = data
-    return dbag
+        remove_key = None
+        for key, entry in dbag.iteritems():
+            if key != 'id' and entry['host_name'] == data['host_name']:
+                remove_key = key
+                break
+        if remove_key is not None:
+            del(dbag[remove_key])
+            
+        dbag[data['ipv4_address']] = data
 
+    return dbag
+                                                                                                                            

--- a/systemvm/patches/debian/config/opt/cloud/testdata/dhcp0001.json
+++ b/systemvm/patches/debian/config/opt/cloud/testdata/dhcp0001.json
@@ -1,7 +1,7 @@
 {
 	"host_name":"VM-58976c22-0832-451e-9ab2-039e9f27e415",
 	"mac_address":"02:00:26:c3:00:02",
-	"ipv4_adress":"172.16.1.102",
+	"ipv4_address":"172.16.1.102",
 	"ipv6_duid":"00:03:00:01:02:00:26:c3:00:02",
 	"default_gateway":"172.16.1.1",
 	"default_entry":true,

--- a/test/integration/component/test_escalations_networks.py
+++ b/test/integration/component/test_escalations_networks.py
@@ -1765,11 +1765,11 @@ class TestNetworks_2(cloudstackTestCase):
         return
 
     @attr(tags=["advanced"], required_hardware="true")
-    def test_14_list_public_ipadress_by_associated_networkid(self):
+    def test_14_list_public_ipaddress_by_associated_networkid(self):
         """
         @summary: Test List Public IPAddress with associatednetworkid
         @Steps
-        Step1: Listing all the public ipadresses for a user before creating
+        Step1: Listing all the public ipaddresses for a user before creating
                a public ipaddress
         Step2: Verifying no Public ipaddress are listed
         Step3: Creating a network
@@ -1781,11 +1781,11 @@ class TestNetworks_2(cloudstackTestCase):
         Step8: Verifying the list public ipaddress size is 1
         Step9: Verifying the details of the public ipaddress
         """
-        # Listing all the public ipadresses for a user
-        list_public_ipadress_before = PublicIPAddress.list(self.userapiclient)
+        # Listing all the public ipaddresses for a user
+        list_public_ipaddress_before = PublicIPAddress.list(self.userapiclient)
         # Verifying No VPCs are listed
         self.assertIsNone(
-            list_public_ipadress_before,
+            list_public_ipaddress_before,
             "Public ipaddresses listed for newly created user"
         )
         # Listing Network Offerings

--- a/test/systemvm/test_update_config.py
+++ b/test/systemvm/test_update_config.py
@@ -82,7 +82,7 @@ class UpdateConfigTestCase(SystemVMTestCase):
     basic_dhcp_entry = {
         "host_name":"VM-58976c22-0832-451e-9ab2-039e9f27e415",
         "mac_address":"02:00:26:c3:00:02",
-        "ipv4_adress":"172.16.1.102",
+        "ipv4_address":"172.16.1.102",
         "ipv6_duid":"00:03:00:01:02:00:26:c3:00:02",
         "default_gateway":"172.16.1.1",
         "default_entry":True,
@@ -372,7 +372,7 @@ class UpdateConfigTestCase(SystemVMTestCase):
             ipb = ".".join(octets[0:3])
             ipa = "%s.%s" % (ipb, n)
             gw = "%s.1" % ipb
-            self.basic_dhcp_entry['ipv4_adress'] =  ipa
+            self.basic_dhcp_entry['ipv4_address'] =  ipa
             self.basic_dhcp_entry['default_gateway'] =  gw
             self.basic_dhcp_entry['host_name'] =  "host_%s" % (ipa)
             self.update_config(self.basic_dhcp_entry)
@@ -382,7 +382,7 @@ class UpdateConfigTestCase(SystemVMTestCase):
         assert port.is_listening(53)
         assert port.is_listening(67)
         for o in configs:
-            line = "%s,%s,%s,infinite" % (o['mac_address'], o['ipv4_adress'], o['host_name'])
+            line = "%s,%s,%s,infinite" % (o['mac_address'], o['ipv4_address'], o['host_name'])
             assert file.has_line("/etc/dhcphosts.txt", line)
         config['add'] = False
         self.update_config(config)
@@ -400,7 +400,7 @@ class UpdateConfigTestCase(SystemVMTestCase):
             o['add'] = False
             self.update_config(o)
         for o in configs:
-            line = "%s,%s,%s,infinite" % (o['mac_address'], o['ipv4_adress'], o['host_name'])
+            line = "%s,%s,%s,infinite" % (o['mac_address'], o['ipv4_address'], o['host_name'])
             assert file.has_line("/etc/dhcphosts.txt", line) is False
         # If the network gets deleted so should the vpn
         assert not file.exists("/etc/ipsec.d/ipsec.vpn-%s.conf" % vpn_config['peer_gateway_ip'])


### PR DESCRIPTION
Bug is fixed. Fixed typo 'adress' to 'address' everywhere which leads to correct generation for agent communication json dhcp command.

@rhtyd
@dagsonstebo

Take a look please. Fixes the bug reported by Dag Sonstebo for Basic zone but unable to test carefully for Advanced zone VR. 

Tested in our pre-prod 4.10. 

Create / abc (x.y.z.11), cde (x.y.z.13)
Remove / abc, cde
Create / cde -> /etc/hosts (x.y.z.11 -> cde, x.y.z.13 removed) 
