### PR TITLE
Fix ACL_INBOUND/OUTBOUND rules for PrivateGateway

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsNetfilter.py
@@ -168,7 +168,7 @@ class CsNetfilters(object):
                 if isinstance(fw[1], int):
                     # if the rule is for ACLs, we want to insert them in order, right before the DROP all
                     if rule_chain.startswith("ACL_INBOUND") or rule_chain.startswith("ACL_OUTBOUND"):
-                        rule_count = self.chain.get_count(rule_chain)
+                        rule_count = self.chain.get_count(rule_chain) if self.chain.get_count(rule_chain) > 0 else 1
                         cpy = cpy.replace("-A %s" % new_rule.get_chain(), '-I %s %s' % (new_rule.get_chain(), rule_count))
                     else:
                         cpy = cpy.replace("-A %s" % new_rule.get_chain(), '-I %s %s' % (new_rule.get_chain(), fw[1]))


### PR DESCRIPTION
We found bug in ACL rules for PrivateGateway for VPC

At a glance - rules not applied - switching Allow All or Deny All (default ACL) - showed as completed - but rules missed.
Result - traffic via PrivateGateway blocked by next DROP rule in next chains

How to reproduce:
1. Enable PrivateGateway for Cloudstack
2. Create VPC
3. Provision new PrivateGateway inside VPC with some VLAN
4. Change ACL (optional step to show that problem not in initial configuration but in config itself)

Expected:
ACL rules applied (inserted) into correspondig ACL_INBOUND/OUTBOUND chanins for PrivateGateway interface (ethX) based on ACL which user choose

Current:
No rules inserted. ACL_INBOUND/OUTBOUND_ethX - empty. Traffic blocked by next DROP rule in FORWARD chain

Affect - all our corporate customers blocked with access to their own nets via PG and vice-versa.

Root cause:
Issue happened because of CsNetFilter.py logic for inserting rules for ACL_INBOUND/OUTBOUND chains.

We choose rule numebr to isnert right before last DROP rule - but forget about fact - that if chain empty - we also return 0 as insert position. Which not true for iptables - numeration started from 0.

So we need very small patch to handle this special case - if number of rules inside chain equal to zero - return 1, else - return count of rules inside chain.

It's found only one - just because be default for PrivateGateway - we didn't insert any "service rules" (if SourceNat for PrivateGteway not ticked) - and we have by default empty ACL_INBOUND/OUTBOUND chains. Because same insert happened for all VPC networks (but when we call this insert - we already have at least 1 rule inside chains - and we successfully can process)

https://issues.apache.org/jira/browse/CLOUDSTACK-10200