### PR TITLE
CLOUDSTACK-4045 IP address acquired with associateIpAddress is marked as source NAT

### DIFF
--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -1384,6 +1384,11 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         if (!sharedSourceNat) {
             if (getExistingSourceNatInNetwork(owner.getId(), networkId) == null) {
                 if (network.getGuestType() == GuestType.Isolated && network.getVpcId() == null && !ipToAssoc.isPortable()) {
+                    if (network.getState() == Network.State.Allocated) {
+                        //prevent associating an ip address to an allocated (unimplemented network).
+                        //it will cause the ip to become source nat, and it can't be disassociated later on.
+                        throw new InvalidParameterValueException("Network is in allocated state, implement network first before acquiring an IP address");
+                    }
                     isSourceNat = true;
                 }
             }

--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -1378,7 +1378,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
             }
         }
 
-        boolean isSourceNat = isSourceNatAvailableForNetwork(networkId, owner, ipToAssoc, network);
+        boolean isSourceNat = isSourceNatAvailableForNetwork(owner, ipToAssoc, network);
 
         s_logger.debug("Associating ip " + ipToAssoc + " to network " + network);
 
@@ -1416,12 +1416,12 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         }
     }
 
-    protected boolean isSourceNatAvailableForNetwork(long networkId, Account owner, IPAddressVO ipToAssoc, Network network) {
+    protected boolean isSourceNatAvailableForNetwork(Account owner, IPAddressVO ipToAssoc, Network network) {
         NetworkOffering offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
         boolean sharedSourceNat = offering.getSharedSourceNat();
         boolean isSourceNat = false;
         if (!sharedSourceNat) {
-            if (getExistingSourceNatInNetwork(owner.getId(), networkId) == null) {
+            if (getExistingSourceNatInNetwork(owner.getId(), network.getId()) == null) {
                 if (network.getGuestType() == GuestType.Isolated && network.getVpcId() == null && !ipToAssoc.isPortable()) {
                     if (network.getState() == Network.State.Allocated) {
                         //prevent associating an ip address to an allocated (unimplemented network).

--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -1418,7 +1418,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
 
     protected boolean isSourceNatAvailableForNetwork(Account owner, IPAddressVO ipToAssoc, Network network) {
         NetworkOffering offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        boolean sharedSourceNat = offering.getSharedSourceNat();
+        boolean sharedSourceNat = offering.isSharedSourceNat();
         boolean isSourceNat = false;
         if (!sharedSourceNat) {
             if (getExistingSourceNatInNetwork(owner.getId(), network.getId()) == null) {

--- a/test/integration/component/test_tags.py
+++ b/test/integration/component/test_tags.py
@@ -2516,6 +2516,21 @@ class TestResourceTags(cloudstackTestCase):
             domainid=self.child_do_admin.domainid,
             zoneid=self.zone.id
         )
+        tag = "tag1"
+        self.so_with_tag = ServiceOffering.create(
+            self.apiclient,
+            self.services["service_offering"],
+            hosttags=tag
+        )
+        self.vm = VirtualMachine.create(
+            self.api_client,
+            self.services["virtual_machine"],
+            accountid=self.child_do_admin.name,
+            domainid=self.child_do_admin.domainid,
+            networkids=self.network.id,
+            serviceofferingid=self.so_with_tag.id
+        )
+
         self.debug("Fetching the network details for account: %s" %
                    self.child_do_admin.name
         )

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -110,7 +110,6 @@ class TestPublicIP(cloudstackTestCase):
             cls.user.domainid
         )
 
-        tag = "tag1"
         cls.service_offering = ServiceOffering.create(
             cls.apiclient,
             cls.services["service_offerings"]["tiny"],

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -115,14 +115,14 @@ class TestPublicIP(cloudstackTestCase):
             cls.services["service_offerings"]["tiny"],
         )
 
-        cls.template = get_template(
+        cls.hypervisor = testClient.getHypervisorInfo()
+        cls.template = get_test_template(
             cls.apiclient,
             cls.zone.id,
-            cls.services["ostype"]
+            cls.hypervisor
         )
         if cls.template == FAILED:
-            assert False, "get_template() failed to return template\
-                    with description %s" % cls.services["ostype"]
+            assert False, "get_test_template() failed to return template"
 
         cls.services["virtual_machine"]["zoneid"] = cls.zone.id
 

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -110,6 +110,43 @@ class TestPublicIP(cloudstackTestCase):
             cls.user.domainid
         )
 
+        tag = "tag1"
+        cls.service_offering = ServiceOffering.create(
+            cls.apiclient,
+            cls.services["service_offerings"]["tiny"],
+        )
+
+        cls.template = get_template(
+            cls.apiclient,
+            cls.zone.id,
+            cls.services["ostype"]
+        )
+        if cls.template == FAILED:
+            assert False, "get_template() failed to return template\
+                    with description %s" % cls.services["ostype"]
+
+        cls.services["virtual_machine"]["zoneid"] = cls.zone.id
+
+        cls.account_vm = VirtualMachine.create(
+            cls.apiclient,
+            cls.services["virtual_machine"],
+            templateid=cls.template.id,
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            networkids=cls.account_network.id,
+            serviceofferingid=cls.service_offering.id
+        )
+
+        cls.user_vm = VirtualMachine.create(
+            cls.apiclient,
+            cls.services["virtual_machine"],
+            templateid=cls.template.id,
+            accountid=cls.user.name,
+            domainid=cls.user.domainid,
+            networkids=cls.user_network.id,
+            serviceofferingid=cls.service_offering.id
+        )
+
         # Create Source NAT IP addresses
         PublicIPAddress.create(
             cls.apiclient,
@@ -124,6 +161,8 @@ class TestPublicIP(cloudstackTestCase):
             cls.user.domainid
         )
         cls._cleanup = [
+            cls.account_vm,
+            cls.user_vm,
             cls.account_network,
             cls.user_network,
             cls.account,

--- a/test/integration/smoke/test_portforwardingrules.py
+++ b/test/integration/smoke/test_portforwardingrules.py
@@ -234,26 +234,18 @@ class TestPortForwardingRules(cloudstackTestCase):
             self.services["service_offerings"]["tiny"],
         )
 
-        self.template = get_template(
-            self.userapiclient,
-            self.zone.id,
-            self.services["ostype"]
-        )
-        if self.template == FAILED:
-            assert False, "get_template() failed to return template\
-                        with description %s" % self.services["ostype"]
-
         self.services["virtual_machine"]["zoneid"] = self.zone.id
 
         vm = VirtualMachine.create(
             self.userapiclient,
             self.services["virtual_machine"],
-            templateid=self.template.id,
             accountid=self.account.name,
             domainid=self.account.domainid,
             networkids=network.id,
             serviceofferingid=self.service_offering.id
         )
+
+        VirtualMachine.delete(vm, self.userapiclient, expunge=False)
 
         self.cleanup.append(vm)
 

--- a/test/integration/smoke/test_portforwardingrules.py
+++ b/test/integration/smoke/test_portforwardingrules.py
@@ -16,6 +16,7 @@
 # under the License.
 
 # Import Local Modules
+from marvin.codes import (FAILED)
 from marvin.cloudstackTestCase import cloudstackTestCase, unittest
 from marvin.lib.base import (PublicIPAddress,
                              NetworkOffering,
@@ -42,6 +43,7 @@ from marvin.lib.common import (get_domain,
 from marvin.lib.utils import validateList, cleanup_resources
 from marvin.codes import PASS
 from nose.plugins.attrib import attr
+
 
 class TestPortForwardingRules(cloudstackTestCase):
 
@@ -121,6 +123,7 @@ class TestPortForwardingRules(cloudstackTestCase):
             cleanup_resources(cls.api_client, cls._cleanup)
         except Exception as e:
             raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
 
     def __verify_values(self, expected_vals, actual_vals):
         """
@@ -152,8 +155,6 @@ class TestPortForwardingRules(cloudstackTestCase):
                     %
                     (exp_val, act_val))
         return return_flag
-
-
 
     @attr(tags=["advanced"], required_hardware="true")
     def test_01_create_delete_portforwarding_fornonvpc(self):
@@ -227,6 +228,35 @@ class TestPortForwardingRules(cloudstackTestCase):
             list_ipaddresses_before,
             "IP Addresses listed for newly created User"
         )
+
+        self.service_offering = ServiceOffering.create(
+            self.apiClient,
+            self.services["service_offerings"]["tiny"],
+        )
+
+        self.template = get_template(
+            self.userapiclient,
+            self.zone.id,
+            self.services["ostype"]
+        )
+        if self.template == FAILED:
+            assert False, "get_template() failed to return template\
+                        with description %s" % self.services["ostype"]
+
+        self.services["virtual_machine"]["zoneid"] = self.zone.id
+
+        vm = VirtualMachine.create(
+            self.userapiclient,
+            self.services["virtual_machine"],
+            templateid=self.template.id,
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            networkids=network.id,
+            serviceofferingid=self.service_offering.id
+        )
+
+        self.cleanup.append(vm)
+
         # Associating an IP Addresses to Network created
         associated_ipaddress = PublicIPAddress.create(
             self.userapiclient,
@@ -250,7 +280,7 @@ class TestPortForwardingRules(cloudstackTestCase):
         )
         # Verifying the length of the list is 1
         self.assertEqual(
-            1,
+            2,
             len(list_ipaddresses_after),
             "Number of IP Addresses associated are not matching expected"
         )
@@ -283,7 +313,7 @@ class TestPortForwardingRules(cloudstackTestCase):
         )
         # Verifying the length of the list is 1
         self.assertEqual(
-            1,
+            2,
             len(list_ipaddresses_after),
             "VM Created is not in Running state"
         )
@@ -370,7 +400,6 @@ class TestPortForwardingRules(cloudstackTestCase):
         # Deleting Port Forwarding Rule
         portfwd_rule.delete(self.userapiclient)
 
-
         # Creating a Port Forwarding rule with port range
         portfwd_rule = NATRule.create(
             self.userapiclient,
@@ -382,7 +411,7 @@ class TestPortForwardingRules(cloudstackTestCase):
             portfwd_rule,
             "Failed to create Port Forwarding Rule"
         )
-        #update the private port for port forwarding rule
+        # update the private port for port forwarding rule
         updatefwd_rule = portfwd_rule.update(self.userapiclient,
                             portfwd_rule.id,
                             virtual_machine=vm_created,
@@ -425,4 +454,3 @@ class TestPortForwardingRules(cloudstackTestCase):
         vm_created.delete(self.apiClient)
         self.cleanup.append(self.account)
         return
-


### PR DESCRIPTION
added a check for network state when determining whether a new IP should be source NAT. this prevents associated IP's to be marked as source NAT when the network is in allocated state, causing disassociateIpAddress to fail later

Code will now throw a InvalidParameterValueException in the above scenario.