### PR TITLE
"isdynamicallyscalable" Field to UpdateTemplate Response

### DIFF
--- a/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -186,7 +186,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
 
         // set details map
         if (template.getDetailName() != null) {
-            Map<String, String> details = new HashMap<String, String>();
+            Map<String, String> details = new HashMap<>();
             details.put(template.getDetailName(), template.getDetailValue());
             templateResponse.setDetails(details);
         }
@@ -216,6 +216,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         response.setOsTypeName(result.getGuestOSName());
         response.setBootable(result.isBootable());
         response.setHypervisor(result.getHypervisorType().toString());
+        response.setDynamicallyScalable(result.isDynamicallyScalable());
 
         // populate owner.
         ApiResponseHelper.populateOwner(response, result);
@@ -226,7 +227,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
 
         // set details map
         if (result.getDetailName() != null) {
-            Map<String, String> details = new HashMap<String, String>();
+            Map<String, String> details = new HashMap<>();
             details.put(result.getDetailName(), result.getDetailValue());
             response.setDetails(details);
         }
@@ -251,7 +252,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         if (template.getDetailName() != null) {
             Map<String, String> details = templateResponse.getDetails();
             if (details == null) {
-                details = new HashMap<String, String>();
+                details = new HashMap<>();
             }
             details.put(template.getDetailName(), template.getDetailValue());
             templateResponse.setDetails(details);

--- a/server/test/com/cloud/api/query/dao/TemplateJoinDaoImplTest.java
+++ b/server/test/com/cloud/api/query/dao/TemplateJoinDaoImplTest.java
@@ -16,7 +16,11 @@
 // under the License.
 package com.cloud.api.query.dao;
 
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.storage.Storage;
+import com.cloud.user.Account;
 import org.apache.cloudstack.api.response.TemplateResponse;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +30,10 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.vo.TemplateJoinVO;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ApiDBUtils.class)
@@ -37,14 +45,75 @@ public class TemplateJoinDaoImplTest extends GenericDaoBaseWithTagInformationBas
     private TemplateJoinVO template = new TemplateJoinVO();
     private TemplateResponse templateResponse = new TemplateResponse();
 
+    //TemplateJoinVO fields
+    private String uuid = "1234567890abc";
+    private String name = "xs-tools.iso";
+    private String displayText = "xen-pv-drv-iso";
+    private boolean publicTemplate = true;
+    private Date created = new Date();
+    private Storage.ImageFormat format = Storage.ImageFormat.ISO;
+    private String guestOSUuid = "987654321cba";
+    private String guestOSName = "CentOS 4.5 (32-bit)";
+    private boolean bootable = true;
+    private Hypervisor.HypervisorType hypervisorType = Hypervisor.HypervisorType.XenServer;
+    private boolean dynamicallyScalable = true;
+    private short accountType = Account.ACCOUNT_TYPE_NORMAL;
+    private String accountName = "system";
+    private String domainUuid = "abcde1234567890";
+    private String domainName = "ROOT";
+    private String detailName = "detail_name1";
+    private String detailValue = "detail_val";
+
     @Before
     public void setup() {
         prepareSetup();
+        populateTemplateJoinVO();
     }
 
     @Test
     public void testUpdateTemplateTagInfo(){
         testUpdateTagInformation(_templateJoinDaoImpl, template, templateResponse);
+    }
+
+    @Test
+    public void testNewUpdateResponse() {
+        final TemplateResponse response = _templateJoinDaoImpl.newUpdateResponse(template);
+        Assert.assertEquals(uuid, response.getId());
+        Assert.assertEquals(name, ReflectionTestUtils.getField(response, "name"));
+        Assert.assertEquals(displayText, ReflectionTestUtils.getField(response, "displayText"));
+        Assert.assertTrue((Boolean) ReflectionTestUtils.getField(response, "isPublic"));
+        Assert.assertEquals(created, ReflectionTestUtils.getField(response, "created"));
+        Assert.assertEquals(format, ReflectionTestUtils.getField(response, "format"));
+        Assert.assertEquals(guestOSUuid, ReflectionTestUtils.getField(response, "osTypeId"));
+        Assert.assertEquals(guestOSName, ReflectionTestUtils.getField(response, "osTypeName"));
+        Assert.assertTrue((Boolean) ReflectionTestUtils.getField(response, "bootable"));
+        Assert.assertEquals(hypervisorType, Hypervisor.HypervisorType.getType(ReflectionTestUtils.getField(response, "hypervisor").toString()));
+        Assert.assertTrue((Boolean) ReflectionTestUtils.getField(response, "isDynamicallyScalable"));
+        Assert.assertEquals(accountName, ReflectionTestUtils.getField(response, "account"));
+        Assert.assertEquals(domainUuid, ReflectionTestUtils.getField(response, "domainId"));
+        Assert.assertEquals(domainName, ReflectionTestUtils.getField(response, "domainName"));
+        Assert.assertTrue(((Map)ReflectionTestUtils.getField(response, "details")).containsKey(detailName));
+        Assert.assertEquals(detailValue, ((Map)ReflectionTestUtils.getField(response, "details")).get(detailName));
+    }
+
+    private void populateTemplateJoinVO() {
+        ReflectionTestUtils.setField(template, "uuid", uuid);
+        ReflectionTestUtils.setField(template, "name", name);
+        ReflectionTestUtils.setField(template, "displayText", displayText);
+        ReflectionTestUtils.setField(template, "publicTemplate", publicTemplate);
+        ReflectionTestUtils.setField(template, "created", created);
+        ReflectionTestUtils.setField(template, "format", format);
+        ReflectionTestUtils.setField(template, "guestOSUuid", guestOSUuid);
+        ReflectionTestUtils.setField(template, "guestOSName", guestOSName);
+        ReflectionTestUtils.setField(template, "bootable", bootable);
+        ReflectionTestUtils.setField(template, "hypervisorType", hypervisorType);
+        ReflectionTestUtils.setField(template, "dynamicallyScalable", dynamicallyScalable);
+        ReflectionTestUtils.setField(template, "accountType", accountType);
+        ReflectionTestUtils.setField(template, "accountName", accountName);
+        ReflectionTestUtils.setField(template, "domainUuid", domainUuid);
+        ReflectionTestUtils.setField(template, "domainName", domainName);
+        ReflectionTestUtils.setField(template, "detailName", detailName);
+        ReflectionTestUtils.setField(template, "detailValue", detailValue);
     }
 
 }

--- a/test/integration/smoke/test_templates.py
+++ b/test/integration/smoke/test_templates.py
@@ -540,6 +540,7 @@ class TestTemplates(cloudstackTestCase):
         cls.services["template"]["ostypeid"] = template.ostypeid
         cls.services["template_2"]["ostypeid"] = template.ostypeid
         cls.services["ostypeid"] = template.ostypeid
+        cls.services["isdynamicallyscalable"] = template.isdynamicallyscalable
         cls.account = Account.create(
                             cls.apiclient,
                             cls.services["account"],
@@ -712,6 +713,11 @@ class TestTemplates(cloudstackTestCase):
                             template_response.ostypeid,
                             self.services["ostypeid"],
                             "Check OSTypeID of updated template"
+                        )
+        self.assertEqual(
+                            template_response.isdynamicallyscalable,
+                            self.services["isdynamicallyscalable"],
+                            "Check isdynamicallyscalable of updated template"
                         )
         return
 


### PR DESCRIPTION
CLOUDSTACK-9599: 
problem:
Using cloudmonkey, when invoking the update template api call, it does not display the isdynamicallyscalable field as part of its template response.
fix done:
org.apache.cloudstack.api.response.TemplateResponse isdynamicallyscalable field is now populated in the server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java.newUpdateResponse method. 
Unit test:
the Unit test server/test/com/cloud/api/query/dao/TemplateJoinDaoImplTest.java testNewUpdateResponse() verifies that the TemplateResponse is populated correctly.
Marvin test:
the Marvin nosetest integration/smoke/test_templates.py test_02_edit_template(self) confirms that the template_response.isdynamicallyscalable field gets populated with the   correct user data.
Test scenario:
Using cloudmonkey, when invoking the 'update template' API call, it should now display the isdynamicallyscalable field as part of its template response. 