### PR TITLE
CLOUDSTACK-10213: Allow specify SSH key lengh

### DIFF
--- a/server/src/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/com/cloud/server/ManagementServerImpl.java
@@ -696,6 +696,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     static final ConfigKey<Integer> vmPasswordLength = new ConfigKey<Integer>("Advanced", Integer.class, "vm.password.length", "6",
                                                                                       "Specifies the length of a randomly generated password", false);
+    static final ConfigKey<Integer> sshKeyLength = new ConfigKey<Integer>("Advanced", Integer.class, "ssh.key.length",
+            "2048", "Specifies custom SSH key length (bit)", true, ConfigKey.Scope.Global);
     @Inject
     public AccountManager _accountMgr;
     @Inject
@@ -3045,7 +3047,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {vmPasswordLength};
+        return new ConfigKey<?>[] {vmPasswordLength, sshKeyLength};
     }
 
     protected class EventPurgeTask extends ManagedContextRunnable {
@@ -3577,7 +3579,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             throw new InvalidParameterValueException("A key pair with name '" + cmd.getName() + "' already exists.");
         }
 
-        final SSHKeysHelper keys = new SSHKeysHelper();
+        final SSHKeysHelper keys = new SSHKeysHelper(sshKeyLength.value());
 
         final String name = cmd.getName();
         final String publicKey = keys.getPublicKey();

--- a/utils/src/main/java/com/cloud/utils/ssh/SSHKeysHelper.java
+++ b/utils/src/main/java/com/cloud/utils/ssh/SSHKeysHelper.java
@@ -43,9 +43,9 @@ public class SSHKeysHelper {
         return sb.toString();
     }
 
-    public SSHKeysHelper() {
+    public SSHKeysHelper(Integer keyLength) {
         try {
-            keyPair = KeyPair.genKeyPair(new JSch(), KeyPair.RSA);
+            keyPair = KeyPair.genKeyPair(new JSch(), KeyPair.RSA, keyLength);
         } catch (JSchException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
SSH keys generated by the ACS are only 1024 bit (RSA). The common standard is now at least 2048 bit.
https://issues.apache.org/jira/browse/CLOUDSTACK-10213