### PR TITLE
CLOUDSTACK-10215: Excessive log4j debug level in CPVM could lead to FS overflow

### DIFF
--- a/systemvm/agent/conf/log4j-cloud.xml
+++ b/systemvm/agent/conf/log4j-cloud.xml
@@ -87,11 +87,11 @@ under the License.
     <!-- ================ -->
 
     <category name="com.cloud">
-      <priority value="DEBUG"/>
+      <priority value="INFO"/>
     </category>
 
     <category name="org.apache.cloudstack">
-      <priority value="DEBUG"/>
+      <priority value="INFO"/>
     </category>
 
     <!-- Limit the org.apache category to INFO as its DEBUG is verbose -->


### PR DESCRIPTION
Jira reference: https://issues.apache.org/jira/browse/CLOUDSTACK-10215