### PR TITLE
dateutil: constistency of tzdate input and output

### DIFF
--- a/utils/src/main/java/com/cloud/utils/DateUtil.java
+++ b/utils/src/main/java/com/cloud/utils/DateUtil.java
@@ -38,10 +38,14 @@ public class DateUtil {
         return new Date();
     }
 
-    // yyyy-MM-ddTHH:mm:ssZxxxx
+    // yyyy-MM-ddTHH:mm:ssZZZZ or yyyy-MM-ddTHH:mm:ssZxxxx
     public static Date parseTZDateString(String str) throws ParseException {
-        DateFormat dfParse = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'Z");
-        return dfParse.parse(str);
+        try {
+            return s_outputFormat.parse(str);
+        } catch (ParseException e) {
+            final DateFormat dfParse = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'Z");
+            return dfParse.parse(str);
+        }
     }
 
     public static Date parseDateString(TimeZone tz, String dateString) {

--- a/utils/src/test/java/com/cloud/utils/DateUtilTest.java
+++ b/utils/src/test/java/com/cloud/utils/DateUtilTest.java
@@ -27,6 +27,9 @@ import java.util.TimeZone;
 
 import com.cloud.utils.DateUtil.IntervalType;
 
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class DateUtilTest {
 
@@ -44,17 +47,25 @@ public class DateUtilTest {
         if (args.length == 2) {
             System.out.println("Next run time: " + DateUtil.getNextRunTime(IntervalType.getIntervalType(args[0]), args[1], "GMT", time).toString());
         }
-
-        time = new Date();
-        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'Z");
-        String str = dfDate.format(time);
-        System.out.println("Formated TZ time string : " + str);
-        try {
-            Date dtParsed = DateUtil.parseTZDateString(str);
-            System.out.println("Parsed TZ time string : " + dtParsed.toString());
-        } catch (ParseException e) {
-            System.err.println("Parsing failed\n string : " + str + "\nexception :" + e.getLocalizedMessage());
-        }
     }
 
+    @Test
+    public void zonedTimeFormatLegacy() throws ParseException {
+        Date time = new Date();
+        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'Z");
+        String str = dfDate.format(time);
+        Date dtParsed = DateUtil.parseTZDateString(str);
+
+        assertEquals(time.toString(), dtParsed.toString());
+    }
+
+    @Test
+    public void zonedTimeFormat() throws ParseException {
+        Date time = new Date();
+        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        String str = dfDate.format(time);
+        Date dtParsed = DateUtil.parseTZDateString(str);
+
+        assertEquals(time.toString(), dtParsed.toString());
+    }
 }


### PR DESCRIPTION
Hey, I've stumbled upon a case were I had to jump into the Java code to understand my mistake. When listing an async job, the timestamp is formated in a way that is incompatible with the parameter `startdate`. Notice the `Z` that is required to work.

```console
$ cs listAsyncJobs | jq ".asyncjobs[].created"
"2018-01-08T08:06:20+0100"
"2018-01-08T08:11:52+0100"
```

```
$ cs listAsyncJobs startdate="2018-01-08T08:10:00+0100" | \
    jq ".listasyncjobsresponse.errortext"

Cloudstack error: HTTP response 431
"Unable to parse date 2018-01-08T08:10:00+0100 for command
listasyncjobs, please pass dates in the format mentioned in
the api documentation"
```

```
$ cs listAsyncJobs startdate="2018-01-08T08:10:00Z+0100" | jq ".asyncjobs[].created"
"2018-01-08T08:11:52+0100"
```