### PR TITLE
CLOUDSTACK-10217: Clean up old MAC addresses from DHCP lease file

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs_dhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs_dhcp.py
@@ -25,12 +25,18 @@ def merge(dbag, data):
         if data['ipv4_address'] in dbag:
             del(dbag[data['ipv4_address']])
     else:
-        remove_key = None
+        remove_keys = set()
         for key, entry in dbag.iteritems():
             if key != 'id' and entry['host_name'] == data['host_name']:
-                remove_key = key
+                remove_keys.add(key)
                 break
-        if remove_key is not None:
+
+        for key, entry in dbag.iteritems():
+            if key != 'id' and entry['mac_address'] == data['mac_address']:
+                remove_keys.add(key)
+                break
+
+        for remove_key in remove_keys:
             del(dbag[remove_key])
 
         dbag[data['ipv4_address']] = data


### PR DESCRIPTION
When the IPv4 address of a Instance changes we need to make sure the
old entry is removed from the DHCP lease file on the Virtual Router
otherwise the Instance will still get the old lease.

Signed-off-by: Wido den Hollander <wido@widodh.nl>