### PR TITLE
CLOUDSTACK-10013: Enable debian security repos during systemvm building

### DIFF
--- a/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
+++ b/tools/appliance/systemvmtemplate/scripts/apt_upgrade.sh
@@ -35,6 +35,7 @@ function add_backports() {
   sed -i '/deb-src/d' /etc/apt/sources.list
   sed -i '/backports/d' /etc/apt/sources.list
   echo 'deb http://http.debian.net/debian stretch-backports main' >> /etc/apt/sources.list
+  echo 'deb http://security.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
 }
 
 function apt_upgrade() {


### PR DESCRIPTION
This enables the Debian security repos for stretch

This is needed to build new 4.11 systemvmtemplates with the meltdown kernel fix. Please lgtm/review - @DaanHoogland @borisstoyanov @wido @rafaelweingartner @marcaurele and others.