### PR TITLE
CLOUDSTACK-10220: Configure IPv4 alias on VR regardless of IPv6

### DIFF
--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -1308,7 +1308,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                 final DhcpServiceProvider sp = (DhcpServiceProvider)element;
                 final Map<Capability, String> dhcpCapabilities = element.getCapabilities().get(Service.Dhcp);
                 final String supportsMultipleSubnets = dhcpCapabilities.get(Capability.DhcpAccrossMultipleSubnets);
-                if (supportsMultipleSubnets != null && Boolean.valueOf(supportsMultipleSubnets) && profile.getIPv6Address() == null) {
+                if (supportsMultipleSubnets != null && Boolean.valueOf(supportsMultipleSubnets)) {
                     if (!sp.configDhcpSupportForSubnet(network, profile, vmProfile, dest, context)) {
                         return false;
                     }

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -1306,9 +1306,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dhcp)
                     && _networkModel.isProviderSupportServiceInNetwork(network.getId(), Service.Dhcp, element.getProvider()) && element instanceof DhcpServiceProvider) {
                 final DhcpServiceProvider sp = (DhcpServiceProvider)element;
-                final Map<Capability, String> dhcpCapabilities = element.getCapabilities().get(Service.Dhcp);
-                final String supportsMultipleSubnets = dhcpCapabilities.get(Capability.DhcpAccrossMultipleSubnets);
-                if (supportsMultipleSubnets != null && Boolean.valueOf(supportsMultipleSubnets)) {
+                if (isDhcpAccrossMultipleSubnetsSupported(sp)) {
                     if (!sp.configDhcpSupportForSubnet(network, profile, vmProfile, dest, context)) {
                         return false;
                     }


### PR DESCRIPTION
For some reason when a IPv6 address is present for a NIC IPv4 subnet aliases are not configured on the VR.

This seems to be very old code (>5 yr) and written at a time when IPv6 wasn't implemented in CloudStack

Removing this additional evaluation in the if-statement works for us in Basic Networking