### PR TITLE
CLOUDSTACK-10223 delete snapshots when deleting domain

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
@@ -34,6 +34,8 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
 
     List<VolumeVO> findByAccount(long accountId);
 
+    List<VolumeVO> findIncludingRemovedByAccount(long accountId);
+
     Pair<Long, Long> getCountAndTotalByPool(long poolId);
 
     Pair<Long, Long> getNonDestroyedCountAndTotalByPool(long poolId);

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -100,6 +100,13 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     }
 
     @Override
+    public List<VolumeVO> findIncludingRemovedByAccount(long accountId) {
+        SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
+        sc.setParameters("accountId", accountId);
+        return listIncludingRemovedBy(sc);
+    }
+
+    @Override
     public List<VolumeVO> findByInstance(long id) {
         SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
         sc.setParameters("instanceId", id);

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -715,7 +715,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
     @Override
     public boolean deleteSnapshotDirsForAccount(long accountId) {
 
-        List<VolumeVO> volumes = _volsDao.findByAccount(accountId);
+        List<VolumeVO> volumes = _volsDao.findIncludingRemovedByAccount(accountId);
         // The above call will list only non-destroyed volumes.
         // So call this method before marking the volumes as destroyed.
         // i.e Call them before the VMs for those volumes are destroyed.


### PR DESCRIPTION
After domain deletion, snapshot taken by the domain remains undeleted.

Steps to reproduce:
-----------------------------------------------
1. Create a test domain
2. Create test account with admin privileges.
3. Login as "test" acoount.
4. Create 3 instances - few having root disk and rest with root and data disks both.
5. For 2 instances take snapshots of root and data disks
6. Expunge above instances from ACP UI.
7. Make sure that those vm's should not be shown in ACP UI.
8. Login as root user again
9. Delete the test account
10. Delete the test domain

Snapshots taken for root volume in step 5 are not deleted.
Added the code to remove the snapshots when the domain is deleted.