### PR TITLE
CLOUDSTACK-10227: Add delay before reverting VM snapshot

### DIFF
--- a/test/integration/smoke/test_vm_snapshots.py
+++ b/test/integration/smoke/test_vm_snapshots.py
@@ -513,7 +513,8 @@ class TestChangeServiceOfferingForVmWithSnapshots(cloudstackTestCase):
             virtual_machine.stop(self.apiclient)
         except Exception as e:
             self.fail("Failed to stop VM: %s" % e)
-        
+
+        time.sleep(30)
         # 8) Revert to VM Snapshot
         self.debug("Revert to vm snapshot: %s" % vm_snapshot.id)
         try:


### PR DESCRIPTION
As discovered and discussed in #2376, adding some delay after stopping
the VM and reverting VM snapshot passes the
`test_change_service_offering_for_vm_with_snapshots` test case. The
suspect here is userVMDao or background vmsync that may not update
the VM state to PowerOff.

Pinging for review @mike-tutkowski @rafaelweingartner @DaanHoogland and others.
Manually verified with QA:
```
=== TestName: test_change_service_offering_for_vm_with_snapshots | Status : SUCCESS ===
ok

Ran 1 test in 501.359s
OK
```

I think since this only changes the test file, it may be accepted only with at least code reviews. It's not a blocker, but fixing this smoketest will avoid getting incorrect failures.