### PR TITLE
CLOUDSTACK-10233: use namespace in Libvirt domain metadata.

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1544,7 +1544,7 @@ public class LibvirtVMDef {
         public String toString() {
             StringBuilder fsBuilder = new StringBuilder();
             for (Map.Entry<String, String> address : addresses.entrySet()) {
-                fsBuilder.append("<nuage-extension>\n")
+                fsBuilder.append("<nuage-extension xmlns='nuagenetworks.net/nuage/cna'>\n")
                         .append("  <interface mac='")
                         .append(address.getKey())
                         .append("' vsp-vr-ip='")


### PR DESCRIPTION
The documentation of Libvirt specifies the requirement of using an XML namespace,
when having metadata in the Domain XML. The Nuage extenstion metadata was not
adhering to this specification, and the lastest Libvirt version ignores it in that case.