### PR TITLE
CLOUDSTACK-10244: KVM online storage migration fails and corrupts disk

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <dependencies>
     <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <dependencies>
     <dependency>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
 
   <repositories>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <dependencies>
     <dependency>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloudstack (4.11.0.0) unstable; urgency=low
+
+  * Update the version to 4.11.0.0
+
+ -- the Apache CloudStack project <dev@cloudstack.apache.org>  Mon, 15 Jan 2018 16:03:05 +0530
+
 cloudstack (4.11.0.0-SNAPSHOT) unstable; urgency=low
 
   * Update the version to 4.11.0.0-SNAPSHOT

--- a/developer/pom.xml
+++ b/developer/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <dependencies>
     <dependency>

--- a/engine/api/pom.xml
+++ b/engine/api/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/components-api/pom.xml
+++ b/engine/components-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/network/pom.xml
+++ b/engine/network/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/orchestration/pom.xml
+++ b/engine/orchestration/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/service/pom.xml
+++ b/engine/service/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <artifactId>cloud-engine-service</artifactId>
   <packaging>war</packaging>

--- a/engine/storage/cache/pom.xml
+++ b/engine/storage/cache/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/datamotion/pom.xml
+++ b/engine/storage/datamotion/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/image/pom.xml
+++ b/engine/storage/image/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/integration-test/pom.xml
+++ b/engine/storage/integration-test/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/pom.xml
+++ b/engine/storage/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/snapshot/pom.xml
+++ b/engine/storage/snapshot/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/engine/storage/volume/pom.xml
+++ b/engine/storage/volume/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-engine</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/ca/pom.xml
+++ b/framework/ca/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 </project>

--- a/framework/cluster/pom.xml
+++ b/framework/cluster/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/config/pom.xml
+++ b/framework/config/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/db/pom.xml
+++ b/framework/db/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/direct-download/pom.xml
+++ b/framework/direct-download/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>cloudstack-framework</artifactId>
         <groupId>org.apache.cloudstack</groupId>
-        <version>4.11.0.0-SNAPSHOT</version>
+        <version>4.11.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/framework/events/pom.xml
+++ b/framework/events/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/ipc/pom.xml
+++ b/framework/ipc/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/jobs/pom.xml
+++ b/framework/jobs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>  
   <dependencies>

--- a/framework/managed-context/pom.xml
+++ b/framework/managed-context/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-maven-standard</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../maven-standard/pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/framework/quota/pom.xml
+++ b/framework/quota/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/rest/pom.xml
+++ b/framework/rest/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-framework-rest</artifactId>

--- a/framework/security/pom.xml
+++ b/framework/security/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/framework/spring/lifecycle/pom.xml
+++ b/framework/spring/lifecycle/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-maven-standard</artifactId>
-        <version>4.11.0.0-SNAPSHOT</version>
+        <version>4.11.0.0</version>
         <relativePath>../../../maven-standard/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/spring/module/pom.xml
+++ b/framework/spring/module/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-maven-standard</artifactId>
-        <version>4.11.0.0-SNAPSHOT</version>
+        <version>4.11.0.0</version>
         <relativePath>../../../maven-standard/pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/maven-standard/pom.xml
+++ b/maven-standard/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/acl/dynamic-role-based/pom.xml
+++ b/plugins/acl/dynamic-role-based/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/acl/static-role-based/pom.xml
+++ b/plugins/acl/static-role-based/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/affinity-group-processors/explicit-dedication/pom.xml
+++ b/plugins/affinity-group-processors/explicit-dedication/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/affinity-group-processors/host-anti-affinity/pom.xml
+++ b/plugins/affinity-group-processors/host-anti-affinity/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/alert-handlers/snmp-alerts/pom.xml
+++ b/plugins/alert-handlers/snmp-alerts/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cloudstack-plugins</artifactId>
     <groupId>org.apache.cloudstack</groupId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/plugins/alert-handlers/syslog-alerts/pom.xml
+++ b/plugins/alert-handlers/syslog-alerts/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cloudstack-plugins</artifactId>
     <groupId>org.apache.cloudstack</groupId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/plugins/api/discovery/pom.xml
+++ b/plugins/api/discovery/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/api/rate-limit/pom.xml
+++ b/plugins/api/rate-limit/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/api/solidfire-intg-test/pom.xml
+++ b/plugins/api/solidfire-intg-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/api/vmware-sioc/pom.xml
+++ b/plugins/api/vmware-sioc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/ca/root-ca/pom.xml
+++ b/plugins/ca/root-ca/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/database/mysql-ha/pom.xml
+++ b/plugins/database/mysql-ha/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/database/quota/pom.xml
+++ b/plugins/database/quota/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/dedicated-resources/pom.xml
+++ b/plugins/dedicated-resources/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/deployment-planners/implicit-dedication/pom.xml
+++ b/plugins/deployment-planners/implicit-dedication/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/deployment-planners/user-concentrated-pod/pom.xml
+++ b/plugins/deployment-planners/user-concentrated-pod/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/deployment-planners/user-dispersing/pom.xml
+++ b/plugins/deployment-planners/user-dispersing/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/event-bus/inmemory/pom.xml
+++ b/plugins/event-bus/inmemory/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/event-bus/rabbitmq/pom.xml
+++ b/plugins/event-bus/rabbitmq/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/file-systems/netapp/pom.xml
+++ b/plugins/file-systems/netapp/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/ha-planners/skip-heurestics/pom.xml
+++ b/plugins/ha-planners/skip-heurestics/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/host-allocators/random/pom.xml
+++ b/plugins/host-allocators/random/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/hypervisors/baremetal/pom.xml
+++ b/plugins/hypervisors/baremetal/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-plugin-hypervisor-baremetal</artifactId>

--- a/plugins/hypervisors/hyperv/pom.xml
+++ b/plugins/hypervisors/hyperv/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <properties>

--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -132,8 +132,9 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             vmsnapshots = libvirtComputingResource.cleanVMSnapshotMetadata(dm);
 
             Map<String, MigrateCommand.MigrateDiskInfo> mapMigrateStorage = command.getMigrateStorage();
+            boolean migrateStorage = MapUtils.isNotEmpty(mapMigrateStorage);
 
-            if (MapUtils.isNotEmpty(mapMigrateStorage)) {
+            if (migrateStorage) {
                 xmlDesc = replaceStorage(xmlDesc, mapMigrateStorage);
             }
 
@@ -142,7 +143,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
             //run migration in thread so we can monitor it
             s_logger.info("Live migration of instance " + vmName + " initiated");
             final ExecutorService executor = Executors.newFixedThreadPool(1);
-            final Callable<Domain> worker = new MigrateKVMAsync(libvirtComputingResource, dm, dconn, xmlDesc, MapUtils.isNotEmpty(mapMigrateStorage),
+            final Callable<Domain> worker = new MigrateKVMAsync(libvirtComputingResource, dm, dconn, xmlDesc, migrateStorage,
                     command.isAutoConvergence(), vmName, command.getDestinationIp());
             final Future<Domain> migrateThread = executor.submit(worker);
             executor.shutdown();

--- a/plugins/hypervisors/ovm/pom.xml
+++ b/plugins/hypervisors/ovm/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/hypervisors/ovm3/pom.xml
+++ b/plugins/hypervisors/ovm3/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/hypervisors/simulator/pom.xml
+++ b/plugins/hypervisors/simulator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.11.0.0-SNAPSHOT</version>
+        <version>4.11.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>cloud-plugin-hypervisor-simulator</artifactId>

--- a/plugins/hypervisors/ucs/pom.xml
+++ b/plugins/hypervisors/ucs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-plugin-hypervisor-ucs</artifactId>

--- a/plugins/hypervisors/vmware/pom.xml
+++ b/plugins/hypervisors/vmware/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/hypervisors/xenserver/pom.xml
+++ b/plugins/hypervisors/xenserver/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/integrations/cloudian/pom.xml
+++ b/plugins/integrations/cloudian/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/integrations/prometheus/pom.xml
+++ b/plugins/integrations/prometheus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/metrics/pom.xml
+++ b/plugins/metrics/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/network-elements/bigswitch/pom.xml
+++ b/plugins/network-elements/bigswitch/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/network-elements/brocade-vcs/pom.xml
+++ b/plugins/network-elements/brocade-vcs/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.apache.cloudstack</groupId>
 		<artifactId>cloudstack-plugins</artifactId>
-		<version>4.11.0.0-SNAPSHOT</version>
+		<version>4.11.0.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/network-elements/cisco-vnmc/pom.xml
+++ b/plugins/network-elements/cisco-vnmc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/network-elements/dns-notifier/pom.xml
+++ b/plugins/network-elements/dns-notifier/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>cloud-plugin-example-dns-notifier</artifactId>

--- a/plugins/network-elements/elastic-loadbalancer/pom.xml
+++ b/plugins/network-elements/elastic-loadbalancer/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/network-elements/f5/pom.xml
+++ b/plugins/network-elements/f5/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/network-elements/globodns/pom.xml
+++ b/plugins/network-elements/globodns/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/network-elements/internal-loadbalancer/pom.xml
+++ b/plugins/network-elements/internal-loadbalancer/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <build>

--- a/plugins/network-elements/juniper-contrail/pom.xml
+++ b/plugins/network-elements/juniper-contrail/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <repositories>

--- a/plugins/network-elements/juniper-srx/pom.xml
+++ b/plugins/network-elements/juniper-srx/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/network-elements/netscaler/pom.xml
+++ b/plugins/network-elements/netscaler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/network-elements/nicira-nvp/pom.xml
+++ b/plugins/network-elements/nicira-nvp/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-utils</artifactId>
-      <version>4.11.0.0-SNAPSHOT</version>
+      <version>4.11.0.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/plugins/network-elements/nuage-vsp/pom.xml
+++ b/plugins/network-elements/nuage-vsp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <repositories>

--- a/plugins/network-elements/opendaylight/pom.xml
+++ b/plugins/network-elements/opendaylight/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/network-elements/ovs/pom.xml
+++ b/plugins/network-elements/ovs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/network-elements/palo-alto/pom.xml
+++ b/plugins/network-elements/palo-alto/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/network-elements/stratosphere-ssp/pom.xml
+++ b/plugins/network-elements/stratosphere-ssp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/network-elements/vxlan/pom.xml
+++ b/plugins/network-elements/vxlan/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/outofbandmanagement-drivers/ipmitool/pom.xml
+++ b/plugins/outofbandmanagement-drivers/ipmitool/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/outofbandmanagement-drivers/nested-cloudstack/pom.xml
+++ b/plugins/outofbandmanagement-drivers/nested-cloudstack/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
 
   <build>

--- a/plugins/storage-allocators/random/pom.xml
+++ b/plugins/storage-allocators/random/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/image/default/pom.xml
+++ b/plugins/storage/image/default/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/image/s3/pom.xml
+++ b/plugins/storage/image/s3/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/image/sample/pom.xml
+++ b/plugins/storage/image/sample/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/image/swift/pom.xml
+++ b/plugins/storage/image/swift/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/volume/cloudbyte/pom.xml
+++ b/plugins/storage/volume/cloudbyte/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/volume/default/pom.xml
+++ b/plugins/storage/volume/default/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/volume/nexenta/pom.xml
+++ b/plugins/storage/volume/nexenta/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/volume/sample/pom.xml
+++ b/plugins/storage/volume/sample/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/volume/solidfire/pom.xml
+++ b/plugins/storage/volume/solidfire/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/user-authenticators/md5/pom.xml
+++ b/plugins/user-authenticators/md5/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/user-authenticators/pbkdf2/pom.xml
+++ b/plugins/user-authenticators/pbkdf2/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/user-authenticators/plain-text/pom.xml
+++ b/plugins/user-authenticators/plain-text/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/plugins/user-authenticators/saml2/pom.xml
+++ b/plugins/user-authenticators/saml2/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/user-authenticators/sha256salted/pom.xml
+++ b/plugins/user-authenticators/sha256salted/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.apache.cloudstack</groupId>
   <artifactId>cloudstack</artifactId>
-  <version>4.11.0.0-SNAPSHOT</version>
+  <version>4.11.0.0</version>
   <packaging>pom</packaging>
   <name>Apache CloudStack</name>
   <description>Apache CloudStack is an IaaS ("Infrastructure as a Service") cloud orchestration platform.</description>

--- a/quickcloud/pom.xml
+++ b/quickcloud/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-maven-standard</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../maven-standard/pom.xml</relativePath>
   </parent>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <dependencies>
     <dependency>

--- a/services/console-proxy-rdp/rdpconsole/pom.xml
+++ b/services/console-proxy-rdp/rdpconsole/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-services</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/services/console-proxy/plugin/pom.xml
+++ b/services/console-proxy/plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-console-proxy</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 </project>

--- a/services/console-proxy/pom.xml
+++ b/services/console-proxy/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-services</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/services/console-proxy/server/pom.xml
+++ b/services/console-proxy/server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-console-proxy</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/services/iam/plugin/pom.xml
+++ b/services/iam/plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-iam</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/services/iam/server/pom.xml
+++ b/services/iam/server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-iam</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>

--- a/services/secondary-storage/controller/pom.xml
+++ b/services/secondary-storage/controller/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-secondary-storage</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/services/secondary-storage/pom.xml
+++ b/services/secondary-storage/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-services</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modules>

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-service-secondary-storage</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
     <dependencies>

--- a/systemvm/pom.xml
+++ b/systemvm/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.11.0.0-SNAPSHOT</version>
+        <version>4.11.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/tools/apidoc/pom.xml
+++ b/tools/apidoc/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-tools</artifactId>
-        <version>4.11.0.0-SNAPSHOT</version>
+        <version>4.11.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/tools/checkstyle/pom.xml
+++ b/tools/checkstyle/pom.xml
@@ -24,7 +24,7 @@
     <name>Apache CloudStack Developer Tools - Checkstyle Configuration</name>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>checkstyle</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
 
     <build>
       <plugins>

--- a/tools/devcloud-kvm/pom.xml
+++ b/tools/devcloud-kvm/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/tools/devcloud4/pom.xml
+++ b/tools/devcloud4/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -20,7 +20,7 @@
 FROM ubuntu:16.04
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.11.0.0-SNAPSHOT"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.11.0.0"
 
 RUN apt-get -y update && apt-get install -y \
     genisoimage \

--- a/tools/docker/Dockerfile.centos6
+++ b/tools/docker/Dockerfile.centos6
@@ -18,7 +18,7 @@
 FROM centos:6
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.11.0.0-SNAPSHOT"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.11.0.0"
 
 ENV PKG_URL=https://builds.cloudstack.org/job/package-master-rhel63/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64
 
@@ -26,8 +26,8 @@ ENV PKG_URL=https://builds.cloudstack.org/job/package-master-rhel63/lastSuccessf
 RUN rpm -i http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.3-1.el6.x86_64.rpm
 
 RUN yum install -y nc wget \
-    ${PKG_URL}/cloudstack-common-4.11.0.0-SNAPSHOT.el6.x86_64.rpm \
-    ${PKG_URL}/cloudstack-management-4.11.0.0-SNAPSHOT.el6.x86_64.rpm
+    ${PKG_URL}/cloudstack-common-4.11.0.0.el6.x86_64.rpm \
+    ${PKG_URL}/cloudstack-management-4.11.0.0.el6.x86_64.rpm
 
 RUN cd /etc/cloudstack/management; \
     ln -s tomcat6-nonssl.conf tomcat6.conf; \

--- a/tools/docker/Dockerfile.marvin
+++ b/tools/docker/Dockerfile.marvin
@@ -20,11 +20,11 @@
 FROM python:2
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.11.0.0-SNAPSHOT"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.11.0.0"
 
 ENV WORK_DIR=/marvin
 
-ENV PKG_URL=https://builds.cloudstack.org/job/build-master-marvin/lastSuccessfulBuild/artifact/tools/marvin/dist/Marvin-4.11.0.0-SNAPSHOT.tar.gz
+ENV PKG_URL=https://builds.cloudstack.org/job/build-master-marvin/lastSuccessfulBuild/artifact/tools/marvin/dist/Marvin-4.11.0.0.tar.gz
 
 RUN apt-get update && apt-get install -y vim
 RUN pip install --upgrade paramiko nose requests

--- a/tools/marvin/pom.xml
+++ b/tools/marvin/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -27,7 +27,7 @@ except ImportError:
         raise RuntimeError("python setuptools is required to build Marvin")
 
 
-VERSION = "4.11.0.0-SNAPSHOT"
+VERSION = "4.11.0.0"
 
 setup(name="Marvin",
       version=VERSION,

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.11.0.0-SNAPSHOT</version>
+        <version>4.11.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/tools/wix-cloudstack-maven-plugin/pom.xml
+++ b/tools/wix-cloudstack-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <dependencies>
     <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/vmware-base/pom.xml
+++ b/vmware-base/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.11.0.0-SNAPSHOT</version>
+    <version>4.11.0.0</version>
   </parent>
   <dependencies>
     <dependency>


### PR DESCRIPTION
This is an issue that was introduced in the code-review process of https://github.com/apache/cloudstack/pull/2298.

What is probably the simplest solution (and what this PR does) is to store the result of MapUtils.isNotEmpty(mapMigrateStorage) before passing mapMigrateStorage to the replaceStorage method.

The replaceStorage method can mutate the data in the passed-in map, thus leading to a different result for MapUtils.isNotEmpty(mapMigrateStorage) later on (and causing an issue for online storage migration).

If we just store the value up front and refer to it later, we, of course, get the same (boolean) result and online storage migration works properly.

A more long-term solution (and one that I plan on implementing for 4.12) would be to make a shallow copy of the map inside of replaceStorage so that replaceStorage does not actually mutate the data in the original map. While that isn't a difficult solution to implement, I feel the one I have implemented in this PR is safer as we are in the release-candidate process already.

Here is a link to the JIRA ticket:

https://issues.apache.org/jira/browse/CLOUDSTACK-10244

I have tested the code and validated that it works.

This use case only applies to online storage migration from NFS or Ceph to managed storage, which is a new feature for 4.11.