### PR TITLE
CLOUDSTACK-10242: Properly parse incoming rules to Sec Group

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -951,16 +951,15 @@ def parse_network_rules(rules):
   if rules is None or len(rules) == 0:
     return ret
 
-  lines = rules.split(';')[:-1]
+  lines = rules.split('NEXT;')[:-1]
   for line in lines:
-    tokens = line.split(':', 4)
-    if len(tokens) != 5:
+    tokens = line.split(';', 3)
+    if len(tokens) != 4:
       continue
 
-    ruletype = tokens[0]
-    protocol = tokens[1]
-    start = int(tokens[2])
-    end = int(tokens[3])
+    ruletype, protocol = tokens[0].split(':')
+    start = int(tokens[1])
+    end = int(tokens[2])
     cidrs = tokens.pop();
 
     ipv4 = []


### PR DESCRIPTION
With merge of PR #2028 the separator for lines to the Security Group
Python script changed from : to ; to support IPv6 addresses.

This broke certain situations where rules were parsed improperly.

This commit fixes that

Signed-off-by: Wido den Hollander <wido@widodh.nl>