### PR TITLE
CLOUDSTACK-10243: Do not use wait() on Python subprocess

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsHelper.py
@@ -183,13 +183,19 @@ def get_hostname():
 
 def execute(command):
     """ Execute command """
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    p.wait()
-    rc = p.returncode
+    returncode = -1
+    try:
+        logging.info("Executing: %s" % command)
+        result = subprocess.check_output(command, shell=True)
+        returncode = 0
+        return result.splitlines()
+    except subprocess.CalledProcessError as e:
+        logging.error(e)
+        returncode = e.returncode
+    finally:
+        logging.debug("Executed: %s - exitstatus=%s " % (command, returncode))
 
-    logging.debug("Executed: %s - exitstatus=%s " % (command, rc))
-    result = p.communicate()[0]
-    return result.splitlines()
+    return list()
 
 
 def save_iptables(command, iptables_file):


### PR DESCRIPTION
This might (and does block) in certain situations on the VR as
also explained in the Python documentation:

https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

  Warning This will deadlock when using stdout=PIPE and/or stderr=PIPE
  and the child process generates enough output to a pipe such that
  it blocks waiting for the OS pipe buffer to accept more data.
  Use communicate() to avoid that.

Using the check_output function handles most of this for us and
also provides better error handling.

Signed-off-by: Wido den Hollander <wido@widodh.nl>