### PR TITLE
CLOUDSTACK-10236: Enable dynamic roles for missing props file

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade41000to41100.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade41000to41100.java
@@ -31,6 +31,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.log4j.Logger;
 
 import com.cloud.hypervisor.Hypervisor;
+import com.cloud.utils.PropertiesUtil;
 import com.cloud.utils.exception.CloudRuntimeException;
 
 public class Upgrade41000to41100 implements DbUpgrade {
@@ -65,8 +66,23 @@ public class Upgrade41000to41100 implements DbUpgrade {
 
     @Override
     public void performDataMigration(Connection conn) {
+        checkAndEnableDynamicRoles(conn);
         validateUserDataInBase64(conn);
         updateSystemVmTemplates(conn);
+    }
+
+    private void checkAndEnableDynamicRoles(final Connection conn) {
+        final Map<String, String> apiMap = PropertiesUtil.processConfigFile(new String[] { "commands.properties" });
+        if (apiMap == null || apiMap.isEmpty()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No commands.properties file was found, enabling dynamic roles by setting dynamic.apichecker.enabled to true if not already enabled.");
+            }
+            try (final PreparedStatement updateStatement = conn.prepareStatement("INSERT INTO cloud.configuration (category, instance, name, default_value, value) VALUES ('Advanced', 'DEFAULT', 'dynamic.apichecker.enabled', 'false', 'true') ON DUPLICATE KEY UPDATE value='true'")) {
+                updateStatement.executeUpdate();
+            } catch (SQLException e) {
+                LOG.error("Failed to set dynamic.apichecker.enabled to true, please run migrate-dynamicroles.py script to manually migrate to dynamic roles.", e);
+            }
+        }
     }
 
     private void validateUserDataInBase64(Connection conn) {

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade41000to41100.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade41000to41100.java
@@ -82,6 +82,8 @@ public class Upgrade41000to41100 implements DbUpgrade {
             } catch (SQLException e) {
                 LOG.error("Failed to set dynamic.apichecker.enabled to true, please run migrate-dynamicroles.py script to manually migrate to dynamic roles.", e);
             }
+        } else {
+            LOG.warn("Old commands.properties static checker is deprecated, please use migrate-dynamicroles.py to migrate to dynamic roles. Refer http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/accounts.html#using-dynamic-roles");
         }
     }
 

--- a/plugins/acl/static-role-based/src/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/static-role-based/src/org/apache/cloudstack/acl/StaticRoleBasedAPIAccessChecker.java
@@ -39,6 +39,7 @@ import com.cloud.utils.component.PluggableService;
 
 // This is the default API access checker that grab's the user's account
 // based on the account type, access is granted
+@Deprecated
 public class StaticRoleBasedAPIAccessChecker extends AdapterBase implements APIChecker {
 
     protected static final Logger LOGGER = Logger.getLogger(StaticRoleBasedAPIAccessChecker.class);


### PR DESCRIPTION
- In case commands.properties file is missing, enables dynamic roles.
- Adds a new -D or --default flag to migrate-dynamicroles.py script
  to simply update the global setting and use the default role-rule
  permissions, without needing rules from old command.properties file.

@blueorangutan package

Pinging for review - @borisstoyanov @DaanHoogland @nvazquez @wido @rafaelweingartner @PaulAngus and others.

Example, dynamic roles migration script run:
````
> python scripts/util/migrate-dynamicroles.py -d --default
Apache CloudStack Role Permission Migration Tool
(c) Apache CloudStack Authors and the ASF, under the Apache License, Version 2.0

Applying the default role permissions, ignoring any provided properties files(s).
Running SQL query: UPDATE `cloud`.`configuration` SET value='true' where name='dynamic.apichecker.enabled'
Dynamic role based API checker has been enabled!

````