### PR TITLE
CLOUDSTACK-10253: JSON response for SuccessResponse as boolean instead of string

### DIFF
--- a/server/src/main/java/com/cloud/api/response/ApiResponseSerializer.java
+++ b/server/src/main/java/com/cloud/api/response/ApiResponseSerializer.java
@@ -131,12 +131,8 @@ public class ApiResponseSerializer {
                     sb.append("}");
                     log.append("}");
                 }
-            } else if (result instanceof SuccessResponse) {
-                sb.append("{\"success\":\"").append(((SuccessResponse)result).getSuccess()).append("\"}");
-                log.append("{\"success\":\"").append(((SuccessResponse)result).getSuccess()).append("\"}");
-            } else if (result instanceof ExceptionResponse) {
-                String jsonErrorText = responseBuilder.toJson(result);
-                jsonErrorText = unescape(jsonErrorText);
+            } else if (result instanceof SuccessResponse || result instanceof ExceptionResponse) {
+                final String jsonErrorText = unescape(responseBuilder.toJson(result));
                 sb.append(jsonErrorText);
                 log.append(jsonErrorText);
             } else {

--- a/test/integration/smoke/test_hostha_simulator.py
+++ b/test/integration/smoke/test_hostha_simulator.py
@@ -161,7 +161,7 @@ class TestHostHA(cloudstackTestCase):
         cmd.recover = recover
         cmd.fence = fence
         response = self.apiclient.configureSimulatorHAProviderState(cmd)
-        self.assertEqual(response.success, 'true')
+        self.assertEqual(response.success, True)
 
 
     def getSimulatorHAStateTransitions(self, hostId):


### PR DESCRIPTION
It changes the JSON output from: 
```json
{"success": "true"}
```
to 
```json
{"success": true}
```