### PR TITLE
CLOUDSTACK-10225: Deprecate StringUtils in favor of Apache Commons

### DIFF
--- a/utils/src/main/java/com/cloud/utils/StringUtils.java
+++ b/utils/src/main/java/com/cloud/utils/StringUtils.java
@@ -82,11 +82,7 @@ public class StringUtils {
      */
     @Deprecated
     public static boolean isNotBlank(final String str) {
-        if (str != null && str.trim().length() > 0) {
-            return true;
-        }
-
-        return false;
+        return org.apache.commons.lang.StringUtils.isNotBlank(str);
     }
 
     public static String cleanupTags(String tags) {

--- a/utils/src/main/java/com/cloud/utils/StringUtils.java
+++ b/utils/src/main/java/com/cloud/utils/StringUtils.java
@@ -76,6 +76,11 @@ public class StringUtils {
         return org.apache.commons.lang.StringUtils.join(components, delimiter);
     }
 
+    /**
+     * @deprecated
+     * Please use org.apache.commons.lang.StringUtils.isNotBlank() as a replacement
+     */
+    @Deprecated
     public static boolean isNotBlank(final String str) {
         if (str != null && str.trim().length() > 0) {
             return true;

--- a/utils/src/main/java/com/cloud/utils/StringUtils.java
+++ b/utils/src/main/java/com/cloud/utils/StringUtils.java
@@ -30,8 +30,6 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.owasp.esapi.StringUtilities;
-
 public class StringUtils {
     private static final char[] hexChar = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
@@ -254,24 +252,6 @@ public class StringUtils {
         }
 
         return lstTags1.containsAll(lstTags2) && lstTags2.containsAll(lstTags1);
-    }
-
-    public static String stripControlCharacters(final String s) {
-        return StringUtilities.stripControls(s);
-    }
-
-    public static int formatForOutput(final String text, final int start, final int columns, final char separator) {
-        if (start >= text.length()) {
-            return -1;
-        }
-
-        int end = start + columns;
-        if (end > text.length()) {
-            end = text.length();
-        }
-        final String searchable = text.substring(start, end);
-        final int found = searchable.lastIndexOf(separator);
-        return found > 0 ? found : end - start;
     }
 
     public static Map<String, String> stringToMap(final String s) {


### PR DESCRIPTION
We have various places were we use our own StringUtils and other where we use the Apache Commons one.

This PR removes unused functions from the StringUtills but it also makes our own isNotBlank() just a wrapper around the Apache Commons.

In the future we should remove all references we find to our own StringUtils.isNotBlank()