### PR TITLE
[CLOUDSTACK-10259] Missing float part of secondary storage data in listAccounts method

### DIFF
--- a/api/src/main/java/com/cloud/configuration/Resource.java
+++ b/api/src/main/java/com/cloud/configuration/Resource.java
@@ -38,8 +38,8 @@ public interface Resource {
         private ResourceOwnerType[] supportedOwners;
         private int ordinal;
         public static final long bytesToKiB = 1024;
-        public static final long bytesToMiB = 1024 * 1024;
-        public static final long bytesToGiB = 1024 * 1024 * 1024;
+        public static final long bytesToMiB = bytesToKiB * 1024;
+        public static final long bytesToGiB = bytesToMiB * 1024;
 
         ResourceType(String name, int ordinal, ResourceOwnerType... supportedOwners) {
             this.name = name;

--- a/api/src/main/java/org/apache/cloudstack/api/response/AccountResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/AccountResponse.java
@@ -29,7 +29,6 @@ import org.apache.cloudstack.api.EntityReference;
 import com.cloud.serializer.Param;
 import com.cloud.user.Account;
 
-@SuppressWarnings("unused")
 @EntityReference(value = Account.class)
 public class AccountResponse extends BaseResponse implements ResourceLimitAndCountResponse {
     @SerializedName(ApiConstants.ID)
@@ -222,7 +221,7 @@ public class AccountResponse extends BaseResponse implements ResourceLimitAndCou
 
     @SerializedName("secondarystoragetotal")
     @Param(description = "the total secondary storage space (in GiB) owned by account", since = "4.2.0")
-    private Long secondaryStorageTotal;
+    private float secondaryStorageTotal;
 
     @SerializedName("secondarystorageavailable")
     @Param(description = "the total secondary storage space (in GiB) available to be used for this account", since = "4.2.0")
@@ -501,7 +500,7 @@ public class AccountResponse extends BaseResponse implements ResourceLimitAndCou
     }
 
     @Override
-    public void setSecondaryStorageTotal(Long secondaryStorageTotal) {
+    public void setSecondaryStorageTotal(float secondaryStorageTotal) {
         this.secondaryStorageTotal = secondaryStorageTotal;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/DomainResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/DomainResponse.java
@@ -165,7 +165,7 @@ public class DomainResponse extends BaseResponse implements ResourceLimitAndCoun
     private String secondaryStorageLimit;
 
     @SerializedName("secondarystoragetotal") @Param(description="the total secondary storage space (in GiB) owned by domain", since="4.2.0")
-    private Long secondaryStorageTotal;
+    private float secondaryStorageTotal;
 
     @SerializedName("secondarystorageavailable") @Param(description="the total secondary storage space (in GiB) available to be used for this domain", since="4.2.0")
     private String secondaryStorageAvailable;
@@ -399,7 +399,7 @@ public class DomainResponse extends BaseResponse implements ResourceLimitAndCoun
     }
 
     @Override
-    public void setSecondaryStorageTotal(Long secondaryStorageTotal) {
+    public void setSecondaryStorageTotal(float secondaryStorageTotal) {
         this.secondaryStorageTotal = secondaryStorageTotal;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
@@ -29,7 +29,6 @@ import com.cloud.projects.Project;
 import com.cloud.serializer.Param;
 
 @EntityReference(value = Project.class)
-@SuppressWarnings("unused")
 public class ProjectResponse extends BaseResponse implements ResourceLimitAndCountResponse {
 
     @SerializedName(ApiConstants.ID)
@@ -134,7 +133,7 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
 
     @SerializedName("secondarystoragetotal")
     @Param(description = "the total secondary storage space (in GiB) owned by project", since = "4.2.0")
-    private Long secondaryStorageTotal;
+    private float secondaryStorageTotal;
 
     @SerializedName("secondarystorageavailable")
     @Param(description = "the total secondary storage space (in GiB) available to be used for this project", since = "4.2.0")
@@ -414,7 +413,7 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
     }
 
     @Override
-    public void setSecondaryStorageTotal(Long secondaryStorageTotal) {
+    public void setSecondaryStorageTotal(float secondaryStorageTotal) {
         this.secondaryStorageTotal = secondaryStorageTotal;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/ResourceLimitAndCountResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ResourceLimitAndCountResponse.java
@@ -54,7 +54,7 @@ public interface ResourceLimitAndCountResponse {
 
     public void setSecondaryStorageLimit(String secondaryStorageLimit);
 
-    public void setSecondaryStorageTotal(Long secondaryStorageTotal);
+    public void setSecondaryStorageTotal(float secondaryStorageTotal);
 
     public void setSecondaryStorageAvailable(String secondaryStorageAvailable);
 

--- a/server/src/main/java/com/cloud/api/query/dao/AccountJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/AccountJoinDaoImpl.java
@@ -214,7 +214,7 @@ public class AccountJoinDaoImpl extends GenericDaoBase<AccountJoinVO, Long> impl
         //get resource limits for secondary storage space and convert it from Bytes to GiB
         long secondaryStorageLimit = ApiDBUtils.findCorrectResourceLimit(account.getSecondaryStorageLimit(), account.getId(), ResourceType.secondary_storage);
         String secondaryStorageLimitDisplay = (fullView || secondaryStorageLimit == -1) ? "Unlimited" : String.valueOf(secondaryStorageLimit / ResourceType.bytesToGiB);
-        long secondaryStorageTotal = (account.getSecondaryStorageTotal() == null) ? 0 : (account.getSecondaryStorageTotal() / ResourceType.bytesToGiB);
+        float secondaryStorageTotal = (account.getSecondaryStorageTotal() == null) ? 0 : (account.getSecondaryStorageTotal() / (ResourceType.bytesToGiB * 1f));
         String secondaryStorageAvail = (fullView || secondaryStorageLimit == -1) ? "Unlimited" : String.valueOf((secondaryStorageLimit / ResourceType.bytesToGiB)
                 - secondaryStorageTotal);
 

--- a/server/src/main/java/com/cloud/api/query/dao/DomainJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/DomainJoinDaoImpl.java
@@ -183,7 +183,7 @@ public class DomainJoinDaoImpl extends GenericDaoBase<DomainJoinVO, Long> implem
         //get resource limits for secondary storage space and convert it from Bytes to GiB
         long secondaryStorageLimit = ApiDBUtils.findCorrectResourceLimitForDomain(domain.getSecondaryStorageLimit(), ResourceType.secondary_storage, domain.getId());
         String secondaryStorageLimitDisplay = (fullView || secondaryStorageLimit == -1) ? "Unlimited" : String.valueOf(secondaryStorageLimit / ResourceType.bytesToGiB);
-        long secondaryStorageTotal = (domain.getSecondaryStorageTotal() == null) ? 0 : (domain.getSecondaryStorageTotal() / ResourceType.bytesToGiB);
+        float secondaryStorageTotal = (domain.getSecondaryStorageTotal() == null) ? 0 : (domain.getSecondaryStorageTotal() / (ResourceType.bytesToGiB * 1f));
         String secondaryStorageAvail = (fullView || secondaryStorageLimit == -1) ? "Unlimited" : String.valueOf((secondaryStorageLimit / ResourceType.bytesToGiB) - secondaryStorageTotal);
         response.setSecondaryStorageLimit(secondaryStorageLimitDisplay);
         response.setSecondaryStorageTotal(secondaryStorageTotal);


### PR DESCRIPTION
There is a non-floating points division that is missing the floating part of the secondary storage usage. This will affect methods that use the following SET method org.apache.cloudstack.api.response.AccountResponse.setSecondaryStorageLimit(String).

It affects the listAccounts API method, making it differ from the updateResource count method, which is presented in bytes.
