### PR TITLE
CLOUDSTACK-10147 Disabled Xenserver Cluster can still deploy VM's

### DIFF
--- a/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -1040,6 +1040,11 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
         for (Long clusterId : clusterList) {
             ClusterVO clusterVO = _clusterDao.findById(clusterId);
 
+            if (clusterVO.getAllocationState() == Grouping.AllocationState.Disabled) {
+                s_logger.debug("Cannot deploy in disabled cluster " + clusterId + ", skipping this cluster");
+                avoid.addCluster(clusterVO.getId());
+            }
+
             if (clusterVO.getHypervisorType() != vmProfile.getHypervisorType()) {
                 s_logger.debug("Cluster: " + clusterId + " has HyperVisorType that does not match the VM, skipping this cluster");
                 avoid.addCluster(clusterVO.getId());


### PR DESCRIPTION
ENVIRONMENT 
===================== 
XenServer Version : 6.2 , 7

ISSUE 
================== 
Disabled Xenserver Cluster can still deploy VM's , hosts in the cluster are still active

Repro. steps followed 
================== 
Disabled Cluster from UI. 
Deploy a new VM

Expected Behavior 
===============
After disabling the cluster , the hosts should be disabled. and no VM's can be deployed

Note:
it's the same results for XenServer or simulator, can't deploy on disabled hosts, but can deploy on disabled cluster

Solution:

Added a check to skip disabled clusters when selecting a host to deploy on.
Deploying on a disabled cluster will now result in a InsufficientServerCapacityException, if no enabled clusters are found.

i didn't want to propagate disabling a cluster down to the hosts, because then you would have to enable all the hosts again when you enable the cluster, and we won't know which hosts should be left in a disabled state