### PR TITLE
CLOUDSTACK-10269: On deletion of role set name to null

### DIFF
--- a/server/src/org/apache/cloudstack/acl/RoleManagerImpl.java
+++ b/server/src/org/apache/cloudstack/acl/RoleManagerImpl.java
@@ -18,7 +18,6 @@ package org.apache.cloudstack.acl;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -172,7 +171,7 @@ public class RoleManagerImpl extends ManagerBase implements RoleService, Configu
                     }
                     if (roleDao.remove(role.getId())) {
                         RoleVO roleVO = roleDao.findByIdIncludingRemoved(role.getId());
-                        roleVO.setName(role.getName() + "-deleted-" + new Date());
+                        roleVO.setName(null);
                         return roleDao.update(role.getId(), roleVO);
                     }
                     return false;


### PR DESCRIPTION
During deletion of role, set name to null. This fixes concurrent
exception issue where previously it would rename the deleted role
with a timestamp.

Pinging for review - @DaanHoogland @nvazquez @borisstoyanov and others.

@blueorangutan package