### PR TITLE
CLOUDSTACK-10274: L2 network refused to be designed on VXLAN physical network

### DIFF
--- a/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
+++ b/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
@@ -73,6 +73,10 @@ public class VxlanGuestNetworkGuru extends GuestNetworkGuru {
             return null;
         }
 
+        if (offering.getGuestType() == GuestType.L2) {
+            String vxlan = BroadcastDomainType.getValue(network.getBroadcastUri());
+            network.setBroadcastUri(BroadcastDomainType.Vxlan.toUri(vxlan));
+        }
         network.setBroadcastDomainType(BroadcastDomainType.Vxlan);
 
         return network;

--- a/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
+++ b/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
@@ -73,7 +73,7 @@ public class VxlanGuestNetworkGuru extends GuestNetworkGuru {
             return null;
         }
 
-        if (offering.getGuestType() == GuestType.L2) {
+        if (offering.getGuestType() == GuestType.L2 && network.getBroadcastUri() != null) {
             String vxlan = BroadcastDomainType.getValue(network.getBroadcastUri());
             network.setBroadcastUri(BroadcastDomainType.Vxlan.toUri(vxlan));
         }

--- a/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
+++ b/plugins/network-elements/vxlan/src/com/cloud/network/guru/VxlanGuestNetworkGuru.java
@@ -55,11 +55,12 @@ public class VxlanGuestNetworkGuru extends GuestNetworkGuru {
     @Override
     protected boolean canHandle(NetworkOffering offering, final NetworkType networkType, final PhysicalNetwork physicalNetwork) {
         // This guru handles only Guest Isolated network that supports Source nat service
-        if (networkType == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) && offering.getGuestType() == Network.GuestType.Isolated &&
-            isMyIsolationMethod(physicalNetwork)) {
+        if (networkType == NetworkType.Advanced && isMyTrafficType(offering.getTrafficType()) &&
+                (offering.getGuestType() == Network.GuestType.Isolated || offering.getGuestType() == Network.GuestType.L2) &&
+                isMyIsolationMethod(physicalNetwork)) {
             return true;
         } else {
-            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " in zone of type " + NetworkType.Advanced);
+            s_logger.trace("We only take care of Guest networks of type   " + GuestType.Isolated + " or " + GuestType.L2 + " in zone of type " + NetworkType.Advanced);
             return false;
         }
     }


### PR DESCRIPTION
JIRA Ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-10274

Issue reported by @NuxRo while trying to add an L2 network on a VXLAN physical network:

````
2018-02-06 11:20:27,748 DEBUG [c.c.n.NetworkServiceImpl] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Found physical network id=201 based on requested tags mellanoxvxlan
2018-02-06 11:20:27,749 DEBUG [c.c.n.NetworkServiceImpl] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Found physical network id=201 based on requested tags mellanoxvxlan
2018-02-06 11:20:27,766 DEBUG [c.c.n.g.BigSwitchBcfGuestNetworkGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Refusing to design this network, the physical isolation type is not BCF_SEGMENT
2018-02-06 11:20:27,766 DEBUG [o.a.c.n.c.m.ContrailGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Refusing to design this network
2018-02-06 11:20:27,767 DEBUG [c.c.n.g.NiciraNvpGuestNetworkGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Refusing to design this network
2018-02-06 11:20:27,767 DEBUG [o.a.c.n.o.OpendaylightGuestNetworkGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Refusing to design this network
2018-02-06 11:20:27,767 DEBUG [c.c.n.g.OvsGuestNetworkGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Refusing to design this network
2018-02-06 11:20:27,769 DEBUG [o.a.c.n.g.SspGuestNetworkGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) SSP not configured to be active
2018-02-06 11:20:27,769 DEBUG [c.c.n.g.BrocadeVcsGuestNetworkGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Refusing to design this network
2018-02-06 11:20:27,769 DEBUG [c.c.n.g.NuageVspGuestNetworkGuru] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Refusing to design network using network offering 19 on physical network 201
2018-02-06 11:20:27,770 DEBUG [o.a.c.e.o.NetworkOrchestrator] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Releasing lock for Acct[6af2875b-04fc-11e8-923e-002590474525-admin]
2018-02-06 11:20:27,789 DEBUG [c.c.u.d.T.Transaction] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) Rolling back the transaction: Time = 38 Name =  qtp788117692-390; called by -TransactionLegacy.rollback:889-TransactionLegacy.removeUpTo:832-TransactionLegacy.close:656-Transaction.execute:43-Transaction.execute:47-NetworkOrchestrator.createGuestNetwork:2315-NetworkServiceImpl$4.doInTransaction:1383-NetworkServiceImpl$4.doInTransaction:1331-Transaction.execute:40-NetworkServiceImpl.commitNetwork:1331-NetworkServiceImpl.createGuestNetwork:1294-NativeMethodAccessorImpl.invoke0:-2
2018-02-06 11:20:27,798 ERROR [c.c.a.ApiServer] (qtp788117692-390:ctx-f1a980be ctx-61be30e8) (logid:0ca0c866) unhandled exception executing api command: [Ljava.lang.String;@43b9df02
com.cloud.utils.exception.CloudRuntimeException: Unable to convert network offering with specified id to network profile
        at org.apache.cloudstack.engine.orchestration.NetworkOrchestrator.setupNetwork(NetworkOrchestrator.java:726)
        at org.apache.cloudstack.engine.orchestration.NetworkOrchestrator$10.doInTransaction(NetworkOrchestrator.java:2364)
        at org.apache.cloudstack.engine.orchestration.NetworkOrchestrator$10.doInTransaction(NetworkOrchestrator.java:2315)
        at com.cloud.utils.db.Transaction$2.doInTransaction(Transaction.java:50)
        at com.cloud.utils.db.Transaction.execute(Transaction.java:40)
        at com.cloud.utils.db.Transaction.execute(Transaction.java:47)
````