### PR TITLE
CLOUDSTACK-10284:Creating a snapshot from VM Snapshot generates error if hypervisor is not KVM.

### DIFF
--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -2859,7 +2859,10 @@
         if (jsonObj.state == "Ready") {
             allowedActions.push("remove");
             allowedActions.push("revertToVMSnapshot");
-            allowedActions.push("takeSnapshot");
+
+            if (args && args.context && args.context.instances && args.context.instances[0].hypervisor && args.context.instances[0].hypervisor === "KVM") {
+                allowedActions.push("takeSnapshot");
+            }
         }
 
         return allowedActions;


### PR DESCRIPTION
ISSUE
========================
Creating a snapshot from VM Snapshot generates error if hypervisor is not KVM.

STEPS TO REPRODUCE
========================
Create a cloudstack setup with hypervisor other than KVM.
Create an instance.
Take Snapshot of that VM.
Try to take volume snapshot from newly created VM snapshot.
It will throw an error as hypervisor is not KVM.

FIX
========================
As a fix, "Create Snapshot From VM Snapshot" will be hidden from UI, if hypervisor associated with VM snapshot is not KVM.

SCREENSHOT BEFORE FIX
========================
![screenshot before fix](https://user-images.githubusercontent.com/25146827/36085233-453088b4-0fea-11e8-8028-90e9e64b66d6.PNG)

![screenshot before fix - 1](https://user-images.githubusercontent.com/25146827/36085235-4e058322-0fea-11e8-9d0b-ae285879d989.PNG)

SCREENSHOT AFTER FIX
========================
![screenshot after fix](https://user-images.githubusercontent.com/25146827/36085244-60063eea-0fea-11e8-9645-5b3ce7f53c9e.PNG)

