### PR TITLE
CLOUDSTACK-10283: Sudo to setup agent keystore, fail on host add failure

### DIFF
--- a/agent/src/com/cloud/agent/Agent.java
+++ b/agent/src/com/cloud/agent/Agent.java
@@ -647,7 +647,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             _shell.setPersistentProperty(null, KeyStoreUtils.passphrasePropertyName, storedPassword);
         }
 
-        Script script = new Script(_keystoreSetupPath, 60000, s_logger);
+        Script script = new Script(true, _keystoreSetupPath, 60000, s_logger);
         script.add(agentFile.getAbsolutePath());
         script.add(keyStoreFile);
         script.add(storedPassword);
@@ -691,7 +691,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             throw new CloudRuntimeException("Unable to save received agent client and ca certificates", e);
         }
 
-        Script script = new Script(_keystoreCertImportPath, 60000, s_logger);
+        Script script = new Script(true, _keystoreCertImportPath, 60000, s_logger);
         script.add(agentFile.getAbsolutePath());
         script.add(keyStoreFile);
         script.add(KeyStoreUtils.agentMode);

--- a/server/src/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -62,6 +62,7 @@ import com.cloud.resource.ServerResource;
 import com.cloud.resource.UnableDeleteHostException;
 import com.cloud.utils.PasswordGenerator;
 import com.cloud.utils.StringUtils;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.ssh.SSHCmdHelper;
 import com.trilead.ssh2.Connection;
 
@@ -144,8 +145,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
         }
 
         if (sshConnection == null) {
-            s_logger.warn("Cannot secure agent communication because ssh connection is invalid for host ip=" + agentIp);
-            return;
+            throw new CloudRuntimeException("Cannot secure agent communication because ssh connection is invalid for host ip=" + agentIp);
         }
 
         Integer validityPeriod = CAManager.CertValidityPeriod.value();
@@ -154,7 +154,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
         }
 
         final SSHCmdHelper.SSHCmdResult keystoreSetupResult = SSHCmdHelper.sshExecuteCmdWithResult(sshConnection,
-                String.format("/usr/share/cloudstack-common/scripts/util/%s " +
+                String.format("sudo /usr/share/cloudstack-common/scripts/util/%s " +
                                 "/etc/cloudstack/agent/agent.properties " +
                                 "/etc/cloudstack/agent/%s " +
                                 "%s %d " +
@@ -166,19 +166,17 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
                         KeyStoreUtils.defaultCsrFile));
 
         if (!keystoreSetupResult.isSuccess()) {
-            s_logger.error("Failing, the keystore setup script failed execution on the KVM host: " + agentIp);
-            return;
+            throw new CloudRuntimeException("Failed to setup keystore on the KVM host: " + agentIp);
         }
 
         final Certificate certificate = caManager.issueCertificate(keystoreSetupResult.getStdOut(), Collections.singletonList(agentHostname), Collections.singletonList(agentIp), null, null);
         if (certificate == null || certificate.getClientCertificate() == null) {
-            s_logger.error("Failing, the configured CA plugin failed to issue certificates for KVM host agent: " + agentIp);
-            return;
+            throw new CloudRuntimeException("Failed to issue certificates for KVM host agent: " + agentIp);
         }
 
         final SetupCertificateCommand certificateCommand = new SetupCertificateCommand(certificate);
         final SSHCmdHelper.SSHCmdResult setupCertResult = SSHCmdHelper.sshExecuteCmdWithResult(sshConnection,
-                    String.format("/usr/share/cloudstack-common/scripts/util/%s " +
+                    String.format("sudo /usr/share/cloudstack-common/scripts/util/%s " +
                                     "/etc/cloudstack/agent/agent.properties " +
                                     "/etc/cloudstack/agent/%s %s " +
                                     "/etc/cloudstack/agent/%s \"%s\" " +
@@ -195,8 +193,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
                             certificateCommand.getEncodedPrivateKey()));
 
         if (setupCertResult != null && !setupCertResult.isSuccess()) {
-            s_logger.error("Failed to setup certificate in the KVM agent's keystore file, please configure manually!");
-            return;
+            throw new CloudRuntimeException("Failed to setup certificate in the KVM agent's keystore file, please see logs and configure manually!");
         }
 
         if (s_logger.isDebugEnabled()) {


### PR DESCRIPTION
This would make keystore utility scripts being executed as sudoer
in case the process uid/owner is not root but still a sudoer user.

Also fails addHost while securing a KVM host and if keystore fails to be
setup for any reason.

@blueorangutan package