### PR TITLE
CLOUDSTACK-10292:Hostname in metadata when using external DNS is inco…

### DIFF
--- a/api/src/main/java/com/cloud/network/NetworkModel.java
+++ b/api/src/main/java/com/cloud/network/NetworkModel.java
@@ -310,7 +310,7 @@ public interface NetworkModel {
     boolean getNetworkEgressDefaultPolicy(Long networkId);
 
     List<String[]> generateVmData(String userData, String serviceOffering, String zoneName,
-                                  String vmName, long vmId, String publicKey, String password, Boolean isWindows);
+                                  String vmName, String vmHostName, long vmId, String publicKey, String password, Boolean isWindows);
 
     String getValidNetworkCidr(Network guestNetwork);
 

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2526,7 +2526,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                     final String zoneName = _dcDao.findById(vm.getDataCenterId()).getName();
                     boolean isWindows = _guestOSCategoryDao.findById(_guestOSDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
 
-                    vmData = _networkModel.generateVmData(userVm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
+                    vmData = _networkModel.generateVmData(userVm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getHostName(), vm.getId(),
                             (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
                     String vmName = vm.getInstanceName();
                     String configDriveIsoRootFolder = "/tmp";

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2345,7 +2345,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
 
     @Override
     public List<String[]> generateVmData(String userData, String serviceOffering, String zoneName,
-                                         String vmName, long vmId, String publicKey, String password, Boolean isWindows) {
+                                         String vmName, String hostName, long vmId, String publicKey, String password, Boolean isWindows) {
         final List<String[]> vmData = new ArrayList<String[]>();
 
         if (userData != null) {
@@ -2353,7 +2353,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
         }
         vmData.add(new String[]{METATDATA_DIR, SERVICE_OFFERING_FILE, StringUtils.unicodeEscape(serviceOffering)});
         vmData.add(new String[]{METATDATA_DIR, AVAILABILITY_ZONE_FILE, StringUtils.unicodeEscape(zoneName)});
-        vmData.add(new String[]{METATDATA_DIR, LOCAL_HOSTNAME_FILE, StringUtils.unicodeEscape(vmName)});
+        vmData.add(new String[]{METATDATA_DIR, LOCAL_HOSTNAME_FILE, StringUtils.unicodeEscape(hostName)});
         vmData.add(new String[]{METATDATA_DIR, INSTANCE_ID_FILE, vmName});
         vmData.add(new String[]{METATDATA_DIR, VM_ID_FILE, String.valueOf(vmId)});
         vmData.add(new String[]{METATDATA_DIR, PUBLIC_KEYS_FILE, publicKey});

--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -374,7 +374,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
             final String zoneName = _dcDao.findById(vm.getDataCenterId()).getName();
             boolean isWindows = _guestOSCategoryDao.findById(_guestOSDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
 
-            List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
+            List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getHostName(), vm.getId(),
                     publicKey, (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
             profile.setVmData(vmData);
             profile.setConfigDriveLabel(VirtualMachineManager.VmConfigDriveLabel.value());

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4126,7 +4126,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 final String zoneName = _dcDao.findById(vm.getDataCenterId()).getName();
                 boolean isWindows = _guestOSCategoryDao.findById(_guestOSDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
 
-                List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getId(),
+                List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, zoneName, vm.getInstanceName(), vm.getHostName(), vm.getId(),
                         (String) profile.getParameter(VirtualMachineProfile.Param.VmSshPubKey), (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
                 String vmName = vm.getInstanceName();
                 String configDriveIsoRootFolder = "/tmp";

--- a/server/src/test/java/com/cloud/network/MockNetworkModelImpl.java
+++ b/server/src/test/java/com/cloud/network/MockNetworkModelImpl.java
@@ -898,7 +898,7 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
     }
 
     @Override
-    public List<String[]> generateVmData(String userData, String serviceOffering, String zoneName, String vmName, long vmId, String publicKey, String password, Boolean isWindows) {
+    public List<String[]> generateVmData(String userData, String serviceOffering, String zoneName, String vmName, String vmHostName, long vmId, String publicKey, String password, Boolean isWindows) {
         return null;
     }
 

--- a/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/src/test/java/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -97,6 +97,7 @@ public class ConfigDriveNetworkElementTest {
     private final long DATACENTERID = NETWORK_ID;
     private final String ZONENAME = "zone1";
     private final String VMINSTANCENAME = "vm_name";
+    private final String VMHOSTNAME = "vm_host_name";
     private final String VMOFFERING = "custom_instance";
     private final long VMID = 30L;
     private final String VMUSERDATA = "userdata";
@@ -160,6 +161,7 @@ public class ConfigDriveNetworkElementTest {
         when(virtualMachine.getId()).thenReturn(VMID);
         when(virtualMachine.getServiceOfferingId()).thenReturn(SOID);
         when(virtualMachine.getDataCenterId()).thenReturn(DATACENTERID);
+        when(virtualMachine.getHostName()).thenReturn(VMHOSTNAME);
         when(virtualMachine.getInstanceName()).thenReturn(VMINSTANCENAME);
         when(virtualMachine.getUserData()).thenReturn(Base64.encode(VMUSERDATA.getBytes()));
         when(deployDestination.getHost()).thenReturn(hostVO);
@@ -260,7 +262,7 @@ public class ConfigDriveNetworkElementTest {
                 new String[]{"userdata", "user_data", VMUSERDATA},
                 new String[]{"metadata", "service-offering", VMOFFERING},
                 new String[]{"metadata", "availability-zone", ZONENAME},
-                new String[]{"metadata", "local-hostname", VMINSTANCENAME},
+                new String[]{"metadata", "local-hostname", VMHOSTNAME},
                 new String[]{"metadata", "vm-id", String.valueOf(VMID)},
                 new String[]{"metadata", "instance-id", String.valueOf(VMINSTANCENAME)},
                 new String[]{"metadata", "public-keys", PUBLIC_KEY},

--- a/server/src/test/java/com/cloud/vpc/MockNetworkModelImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockNetworkModelImpl.java
@@ -913,7 +913,7 @@ public class MockNetworkModelImpl extends ManagerBase implements NetworkModel {
     }
 
     @Override
-    public List<String[]> generateVmData(String userData, String serviceOffering, String zoneName, String vmName, long vmId, String publicKey, String password, Boolean isWindows) {
+    public List<String[]> generateVmData(String userData, String serviceOffering, String zoneName, String vmName, String vmHostName, long vmId, String publicKey, String password, Boolean isWindows) {
         return null;
     }
 


### PR DESCRIPTION
In the current implementation, both the local-hostname and instance-id in the metadata are pointing to same thing when VM is deployed in a network with Network Offering that has no services. 
The metadata for the VM is presented in configdrive.iso for a VM having network with network offering that has no services. However the metadata doesn't have any info around the name of the VM user has passed when deploying the VM, instead the local_hostname.txt in the metadata refers to VM internal name "i-12-254-VM" doesn't it needs to be the name of the VM user has passed when creating the VM?
 