### PR TITLE
CLOUDSTACK-10295 Marvin: add support for password-enabled templates

### DIFF
--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -593,6 +593,10 @@ class VirtualMachine:
 
         virtual_machine = apiclient.deployVirtualMachine(cmd, method=method)
 
+        if 'password' in virtual_machine.__dict__.keys():
+            if virtual_machine.password:
+                services['password'] = virtual_machine.password
+
         virtual_machine.ssh_ip = virtual_machine.nic[0].ipaddress
         if startvm is False:
             virtual_machine.public_ip = virtual_machine.nic[0].ipaddress


### PR DESCRIPTION
Currently when new VM created, password property always set to 'password' even if it was auto-generated. Because of this impossible establish SSH connection to host during testing.
https://issues.apache.org/jira/browse/CLOUDSTACK-10295