### PR TITLE
CLOUDSTACK-10232: SystemVMs and VR to run as HVM on XenServer

### DIFF
--- a/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -283,6 +283,11 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
 
     protected StorageSubsystemCommandHandler storageHandler;
 
+    private static final String XENSTORE_DATA_IP = "vm-data/ip";
+    private static final String XENSTORE_DATA_GATEWAY = "vm-data/gateway";
+    private static final String XENSTORE_DATA_NETMASK = "vm-data/netmask";
+    private static final String XENSTORE_DATA_CS_INIT = "vm-data/cloudstack/init";
+
     public CitrixResourceBase() {
     }
 
@@ -1286,10 +1291,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             if(guestOsDetails.containsKey("xenserver.dynamicMax")){
                 recommendedMemoryMax = Long.valueOf(guestOsDetails.get("xenserver.dynamicMax")).longValue();
             }
-
         }
-
-
 
         if (isDmcEnabled(conn, host) && vmSpec.isEnableDynamicallyScaleVm()) {
             // scaling is allowed
@@ -1312,7 +1314,6 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             vmr.memoryStaticMin = vmSpec.getMinRam();
             vmr.memoryStaticMax = vmSpec.getMaxRam();
             vmr.memoryDynamicMin = vmSpec.getMinRam();
-            ;
             vmr.memoryDynamicMax = vmSpec.getMaxRam();
 
             vmr.VCPUsMax = (long) vmSpec.getCpus();
@@ -1326,17 +1327,15 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             NicTO mgmtNic = vmSpec.getNics()[0];
             if(mgmtNic != null ) {
                 Map<String, String> xenstoreData = new HashMap<String, String>(3);
-                xenstoreData.put("vm-data/ip", mgmtNic.getIp().toString().trim());
-                xenstoreData.put("vm-data/gateway", mgmtNic.getGateway().toString().trim());
-                xenstoreData.put("vm-data/netmask", mgmtNic.getNetmask().toString().trim());
+                xenstoreData.put(XENSTORE_DATA_IP, mgmtNic.getIp().toString().trim());
+                xenstoreData.put(XENSTORE_DATA_GATEWAY, mgmtNic.getGateway().toString().trim());
+                xenstoreData.put(XENSTORE_DATA_NETMASK, mgmtNic.getNetmask().toString().trim());
                 vmr.xenstoreData = xenstoreData;
             }
         }
 
         final VM vm = VM.create(conn, vmr);
-        if (s_logger.isDebugEnabled()) {
-            s_logger.debug("Created VM " + vm.getUuid(conn) + " for " + vmSpec.getName());
-        }
+        s_logger.debug("Created VM " + vm.getUuid(conn) + " for " + vmSpec.getName());
 
         final Map<String, String> vcpuParams = new HashMap<String, String>();
 
@@ -1368,12 +1367,18 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
 
         final String bootArgs = vmSpec.getBootArgs();
         if (bootArgs != null && bootArgs.length() > 0) {
+            // send boot args for PV instances
             String pvargs = vm.getPVArgs(conn);
             pvargs = pvargs + vmSpec.getBootArgs().replaceAll(" ", "%");
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("PV args are " + pvargs);
-            }
             vm.setPVArgs(conn, pvargs);
+            s_logger.debug("PV args are " + pvargs);
+
+            // send boot args into xenstore-data for HVM instances
+            Map<String, String> xenstoreData = new HashMap<>();
+
+            xenstoreData.put(XENSTORE_DATA_CS_INIT, bootArgs);
+            vm.setXenstoreData(conn, xenstoreData);
+            s_logger.debug("HVM args are " + bootArgs);
         }
 
         if (!(guestOsTypeName.startsWith("Windows") || guestOsTypeName.startsWith("Citrix") || guestOsTypeName.startsWith("Other"))) {

--- a/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
+++ b/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
@@ -42,7 +42,14 @@ hypervisor() {
   grep -q QEMU /var/log/messages && echo "kvm" && return 0
 
   [ -d /proc/xen ] && mount -t xenfs none /proc/xen
-  [ -d /proc/xen ] && echo "xen-domU" && return 0
+  if [ -d /proc/xen ]; then
+    $(dmesg | grep -q "Xen HVM")
+    if [ $? -eq 0 ]; then  # 1=PV,0=HVM
+      echo "xen-hvm" && return 0
+    else
+      echo "xen-pv" && return 0
+    fi
+  fi
 
   vmware-checkvm &> /dev/null && echo "vmware" && return 0
 
@@ -64,9 +71,16 @@ config_guest() {
 
 get_boot_params() {
   case $HYPERVISOR in
-     xen-domU|xen-hvm)
+     xen-pv)
           cat /proc/cmdline > $CMDLINE
           sed -i "s/%/ /g" $CMDLINE
+          ;;
+     xen-hvm)
+          if [ ! -f /usr/sbin/xenstore-read ]; then
+            log_it "ERROR: xentools not installed, cannot found xenstore-read" && exit 5
+          fi
+          /usr/sbin/xenstore-read vm-data/cloudstack/init > /var/cache/cloud/cmdline
+          sed -i "s/%/ /g" /var/cache/cloud/cmdline
           ;;
      kvm)
           VPORT=$(find /dev/virtio-ports -type l -name '*.vport' 2>/dev/null|head -1)


### PR DESCRIPTION
Publishing boot args both to grub and xenstore-data and let
cloud-early-config decides if the VM is in PV or HVM mode
to read from correct source.