### PR TITLE
CLOUDSTACK-10306: Upgrade to VMware 6.5 vim jar dependency

### DIFF
--- a/deps/install-non-oss.sh
+++ b/deps/install-non-oss.sh
@@ -38,3 +38,6 @@ mvn install:install-file -Dfile=vim25_55.jar        -DgroupId=com.cloud.com.vmwa
 
 # From https://my.vmware.com VMware-vSphere-SDK-6.0.0-3634981.zip
 mvn install:install-file -Dfile=vim25_60.jar        -DgroupId=com.cloud.com.vmware -DartifactId=vmware-vim25    -Dversion=6.0   -Dpackaging=jar
+
+# From https://my.vmware.com/group/vmware/get-download?downloadGroup=VS-MGMT-SDK65
+mvn install:install-file -Dfile=vim25_65.jar        -DgroupId=com.cloud.com.vmware -DartifactId=vmware-vim25    -Dversion=6.5   -Dpackaging=jar

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <cs.jstl.version>1.2</cs.jstl.version>
     <cs.jstl-api.version>1.2.1</cs.jstl-api.version>
     <cs.selenium.server.version>1.0-20081010.060147</cs.selenium.server.version>
-    <cs.vmware.api.version>6.0</cs.vmware.api.version>
+    <cs.vmware.api.version>6.5</cs.vmware.api.version>
     <org.springframework.version>5.0.2.RELEASE</org.springframework.version>
     <cs.mockito.version>1.10.19</cs.mockito.version>
     <cs.powermock.version>1.6.4</cs.powermock.version>


### PR DESCRIPTION
Upgrade to VMware 6.5 vim jar dependency.

@blueorangutan package

Non-oss repo updated with the jar as well - https://github.com/rhtyd/cloudstack-nonoss.