### PR TITLE
CLOUDSTACK-10132: Extend support for management servers LB for agents

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -30,6 +30,17 @@ workers=5
 #host= The IP address of management server
 host=localhost
 
+# The time interval in seconds after which agent will check if connected host
+# is the preferred host (the first host in the comma-separated list is preferred
+# one) and will attempt to reconnect to the preferred host when it's connected
+# to one of the secondary/backup hosts. The timer task is scheduled after agent
+# connects to a management server. On connection, it receives admin configured
+# cluster-level 'indirect.agent.lb.check.interval' setting that will be used by
+# the agent as the preferred host check interval however the following setting
+# if defined overrides the received value. The value 0 and lb algorithm 'shuffle'
+# disables this background task.
+#host.lb.check.interval=0
+
 #port = The port management server listening on, default is 8250
 port=8250
 

--- a/agent/src/com/cloud/agent/IAgentShell.java
+++ b/agent/src/com/cloud/agent/IAgentShell.java
@@ -22,33 +22,48 @@ import java.util.Properties;
 import com.cloud.utils.backoff.BackoffAlgorithm;
 
 public interface IAgentShell {
-    public Map<String, Object> getCmdLineProperties();
+    String hostLbAlgorithmSeparator = "@";
+    String preferredHostIntervalKey = "host.lb.check.interval";
 
-    public Properties getProperties();
+    Map<String, Object> getCmdLineProperties();
 
-    public String getPersistentProperty(String prefix, String name);
+    Properties getProperties();
 
-    public void setPersistentProperty(String prefix, String name, String value);
+    String getPersistentProperty(String prefix, String name);
 
-    public String getHost();
+    void setPersistentProperty(String prefix, String name, String value);
 
-    public String getPrivateIp();
+    String getNextHost();
 
-    public int getPort();
+    String getPrivateIp();
 
-    public int getWorkers();
+    int getPort();
 
-    public int getProxyPort();
+    int getWorkers();
 
-    public String getGuid();
+    int getProxyPort();
 
-    public String getZone();
+    String getGuid();
 
-    public String getPod();
+    String getZone();
 
-    public BackoffAlgorithm getBackoffAlgorithm();
+    String getPod();
 
-    public int getPingRetries();
+    BackoffAlgorithm getBackoffAlgorithm();
 
-    public String getVersion();
+    int getPingRetries();
+
+    String getVersion();
+
+    void setHosts(String hosts);
+
+    void resetHostCounter();
+
+    String[] getHosts();
+
+    long getLbCheckerInterval(Long receivedLbInterval);
+
+    void updateConnectedHost();
+
+    String getConnectedHost();
 }

--- a/agent/test/com/cloud/agent/AgentShellTest.java
+++ b/agent/test/com/cloud/agent/AgentShellTest.java
@@ -35,7 +35,7 @@ public class AgentShellTest {
         shell.parseCommand(new String[] {"port=55555", "threads=4", "host=localhost", "pod=pod1", "guid=" + anyUuid, "zone=zone1"});
         Assert.assertEquals(55555, shell.getPort());
         Assert.assertEquals(4, shell.getWorkers());
-        Assert.assertEquals("localhost", shell.getHost());
+        Assert.assertEquals("localhost", shell.getNextHost());
         Assert.assertEquals(anyUuid.toString(), shell.getGuid());
         Assert.assertEquals("pod1", shell.getPod());
         Assert.assertEquals("zone1", shell.getZone());
@@ -53,10 +53,10 @@ public class AgentShellTest {
     public void testGetHost() {
         AgentShell shell = new AgentShell();
         List<String> hosts = Arrays.asList("10.1.1.1", "20.2.2.2", "30.3.3.3", "2001:db8::1");
-        shell.setHost(StringUtils.listToCsvTags(hosts));
+        shell.setHosts(StringUtils.listToCsvTags(hosts));
         for (String host : hosts) {
-            Assert.assertEquals(host, shell.getHost());
+            Assert.assertEquals(host, shell.getNextHost());
         }
-        Assert.assertEquals(shell.getHost(), hosts.get(0));
+        Assert.assertEquals(shell.getNextHost(), hosts.get(0));
     }
 }

--- a/api/src/org/apache/cloudstack/config/ApiServiceConfiguration.java
+++ b/api/src/org/apache/cloudstack/config/ApiServiceConfiguration.java
@@ -20,7 +20,7 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 
 public class ApiServiceConfiguration implements Configurable {
-    public static final ConfigKey<String> ManagementHostIPAdr = new ConfigKey<String>("Advanced", String.class, "host", "localhost", "The ip address of management server", true);
+    public static final ConfigKey<String> ManagementServerAddresses = new ConfigKey<String>("Advanced", String.class, "host", "localhost", "The ip address of management server. This can also accept comma separated addresses.", true);
     public static final ConfigKey<String> ApiServletPath = new ConfigKey<String>("Advanced", String.class, "endpointe.url", "http://localhost:8080/client/api",
             "API end point. Can be used by CS components/services deployed remotely, for sending CS API requests", true);
     public static final ConfigKey<Long> DefaultUIPageSize = new ConfigKey<Long>("Advanced", Long.class, "default.ui.page.size", "20",
@@ -36,7 +36,7 @@ public class ApiServiceConfiguration implements Configurable {
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {ManagementHostIPAdr, ApiServletPath, DefaultUIPageSize, ApiSourceCidrChecksEnabled, ApiAllowedSourceCidrList};
+        return new ConfigKey<?>[] {ManagementServerAddresses, ApiServletPath, DefaultUIPageSize, ApiSourceCidrChecksEnabled, ApiAllowedSourceCidrList};
     }
 
 }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -315,6 +315,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-framework-agent-lb</artifactId>
+     <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-framework-ca</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/core/src/com/cloud/agent/api/ReadyCommand.java
+++ b/core/src/com/cloud/agent/api/ReadyCommand.java
@@ -19,6 +19,8 @@
 
 package com.cloud.agent.api;
 
+import java.util.List;
+
 public class ReadyCommand extends Command {
     private String _details;
 
@@ -28,13 +30,16 @@ public class ReadyCommand extends Command {
 
     private Long dcId;
     private Long hostId;
+    private List<String> msHostList;
+    private String lbAlgorithm;
+    private Long lbCheckInterval;
 
     public ReadyCommand(Long dcId) {
         super();
         this.dcId = dcId;
     }
 
-    public ReadyCommand(Long dcId, Long hostId) {
+    public ReadyCommand(final Long dcId, final Long hostId) {
         this(dcId);
         this.hostId = hostId;
     }
@@ -58,5 +63,29 @@ public class ReadyCommand extends Command {
 
     public Long getHostId() {
         return hostId;
+    }
+
+    public List<String> getMsHostList() {
+        return msHostList;
+    }
+
+    public void setMsHostList(List<String> msHostList) {
+        this.msHostList = msHostList;
+    }
+
+    public String getLbAlgorithm() {
+        return lbAlgorithm;
+    }
+
+    public void setLbAlgorithm(String lbAlgorithm) {
+        this.lbAlgorithm = lbAlgorithm;
+    }
+
+    public Long getLbCheckInterval() {
+        return lbCheckInterval;
+    }
+
+    public void setLbCheckInterval(Long lbCheckInterval) {
+        this.lbCheckInterval = lbCheckInterval;
     }
 }

--- a/core/src/com/cloud/agent/api/StartupCommand.java
+++ b/core/src/com/cloud/agent/api/StartupCommand.java
@@ -46,6 +46,7 @@ public class StartupCommand extends Command {
     String agentTag;
     String resourceName;
     String gatewayIpAddress;
+    String msHostList;
 
     public StartupCommand(Host.Type type) {
         this.type = type;
@@ -279,6 +280,14 @@ public class StartupCommand extends Command {
 
     public void setGatewayIpAddress(String gatewayIpAddress) {
         this.gatewayIpAddress = gatewayIpAddress;
+    }
+
+    public String getMsHostList() {
+        return msHostList;
+    }
+
+    public void setMSHostList(String msHostList) {
+        this.msHostList = msHostList;
     }
 
     @Override

--- a/core/src/org/apache/cloudstack/agent/lb/SetupMSListAnswer.java
+++ b/core/src/org/apache/cloudstack/agent/lb/SetupMSListAnswer.java
@@ -1,0 +1,30 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package org.apache.cloudstack.agent.lb;
+
+import com.cloud.agent.api.Answer;
+
+public class SetupMSListAnswer extends Answer {
+
+    public SetupMSListAnswer(final boolean result) {
+        super(null);
+        this.result = result;
+    }
+}

--- a/core/src/org/apache/cloudstack/agent/lb/SetupMSListCommand.java
+++ b/core/src/org/apache/cloudstack/agent/lb/SetupMSListCommand.java
@@ -1,0 +1,56 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package org.apache.cloudstack.agent.lb;
+
+import java.util.List;
+
+import com.cloud.agent.api.Command;
+
+public class SetupMSListCommand extends Command {
+
+    private List<String> msList;
+    private String lbAlgorithm;
+    private Long lbCheckInterval;
+
+    public SetupMSListCommand(final List<String> msList, final String lbAlgorithm, final Long lbCheckInterval) {
+        super();
+        this.msList = msList;
+        this.lbAlgorithm = lbAlgorithm;
+        this.lbCheckInterval = lbCheckInterval;
+    }
+
+    public List<String> getMsList() {
+        return msList;
+    }
+
+    public String getLbAlgorithm() {
+        return lbAlgorithm;
+    }
+
+    public Long getLbCheckInterval() {
+        return lbCheckInterval;
+    }
+
+    @Override
+    public boolean executeInSequence() {
+        return false;
+    }
+
+}

--- a/engine/orchestration/pom.xml
+++ b/engine/orchestration/pom.xml
@@ -60,6 +60,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-framework-agent-lb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-server</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/agent/manager/AgentManagerImpl.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +38,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import org.apache.cloudstack.agent.lb.IndirectAgentLB;
 import org.apache.cloudstack.ca.CAManager;
 import com.cloud.configuration.ManagementServiceConfiguration;
 import org.apache.cloudstack.framework.config.ConfigKey;
@@ -116,6 +118,7 @@ import com.cloud.utils.nio.Link;
 import com.cloud.utils.nio.NioServer;
 import com.cloud.utils.nio.Task;
 import com.cloud.utils.time.InaccurateClock;
+import com.google.common.base.Strings;
 
 /**
  * Implementation of the Agent Manager. This class controls the connection to the agents.
@@ -162,6 +165,9 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
 
     @Inject
     protected HypervisorGuruManager _hvGuruMgr;
+
+    @Inject
+    protected IndirectAgentLB indirectAgentLB;
 
     protected int _retry = 2;
 
@@ -1081,14 +1087,31 @@ public class AgentManagerImpl extends ManagerBase implements AgentManager, Handl
         AgentAttache attache = null;
         ReadyCommand ready = null;
         try {
+            final List<String> agentMSHostList = new ArrayList<>();
+            if (startup != null && startup.length > 0) {
+                final String agentMSHosts = startup[0].getMsHostList();
+                if (!Strings.isNullOrEmpty(agentMSHosts)) {
+                    agentMSHostList.addAll(Arrays.asList(agentMSHosts.split(",")));
+                }
+            }
+
             final HostVO host = _resourceMgr.createHostVOForConnectedAgent(startup);
             if (host != null) {
                 ready = new ReadyCommand(host.getDataCenterId(), host.getId());
+
+                if (!indirectAgentLB.compareManagementServerList(host.getId(), host.getDataCenterId(), agentMSHostList)) {
+                    final List<String> newMSList = indirectAgentLB.getManagementServerList(host.getId(), host.getDataCenterId(), null);
+                    ready.setMsHostList(newMSList);
+                    ready.setLbAlgorithm(indirectAgentLB.getLBAlgorithmName());
+                    ready.setLbCheckInterval(indirectAgentLB.getLBPreferredHostCheckInterval(host.getClusterId()));
+                    s_logger.debug("Agent's management server host list is not up to date, sending list update:" + newMSList);
+                }
+
                 attache = createAttacheForConnect(host, link);
                 attache = notifyMonitorsOfConnection(attache, startup, false);
             }
         } catch (final Exception e) {
-            s_logger.debug("Failed to handle host connection: " + e.toString());
+            s_logger.debug("Failed to handle host connection: ", e);
             ready = new ReadyCommand(null);
             ready.setDetails(e.toString());
         } finally {

--- a/framework/agent-lb/pom.xml
+++ b/framework/agent-lb/pom.xml
@@ -1,0 +1,32 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache CloudStack Agent Management Servers Load Balancer</name>
+    <artifactId>cloud-framework-agent-lb</artifactId>
+    <parent>
+        <artifactId>cloudstack-framework</artifactId>
+        <groupId>org.apache.cloudstack</groupId>
+        <version>4.11.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+</project>

--- a/framework/agent-lb/src/org/apache/cloudstack/agent/lb/IndirectAgentLB.java
+++ b/framework/agent-lb/src/org/apache/cloudstack/agent/lb/IndirectAgentLB.java
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.agent.lb;
+
+import java.util.List;
+
+public interface IndirectAgentLB {
+
+    /**
+     * Return list of management server addresses after applying configured lb algorithm
+     * for a host in a zone.
+     * @param hostId host id (if present)
+     * @param dcId zone id
+     * @param orderedHostIdList (optional) list of ordered host id list
+     * @return management servers string list
+     */
+    List<String> getManagementServerList(Long hostId, Long dcId, List<Long> orderedHostIdList);
+
+    /**
+     * Compares received management server list against expected list for a host in a zone.
+     * @param hostId host id
+     * @param dcId zone id
+     * @param receivedMSHosts received management server list
+     * @return true if mgmtHosts is up to date, false if not
+     */
+    boolean compareManagementServerList(Long hostId, Long dcId, List<String> receivedMSHosts);
+
+    /**
+     * Returns the configure LB algorithm
+     * @return returns algorithm name
+     */
+    String getLBAlgorithmName();
+
+    /**
+     * Returns the configured LB preferred host check interval (if applicable at cluster scope)
+     * @return returns interval in seconds
+     */
+    Long getLBPreferredHostCheckInterval(Long clusterId);
+}

--- a/framework/agent-lb/src/org/apache/cloudstack/agent/lb/IndirectAgentLBAlgorithm.java
+++ b/framework/agent-lb/src/org/apache/cloudstack/agent/lb/IndirectAgentLBAlgorithm.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.agent.lb;
+
+import java.util.List;
+
+public interface IndirectAgentLBAlgorithm {
+    /**
+     * Returns a sorted management server list to send to host after applying the algorithm
+     * @param msList management server list
+     * @param orderedHostList ordered host list
+     * @param hostId host id
+     * @return returns the list of management server addresses which will be sent to host id
+     */
+    List<String> sort(final List<String> msList, final List<Long> orderedHostList, final Long hostId);
+
+    /**
+     * Gets the unique name of the algorithm
+     * @return returns the name of the Agent MSLB algorithm
+     */
+    String getName();
+
+    /**
+     * Compares and return if received mgmt server list is equal to the actual mgmt server lists
+     * @param msList current mgmt server list
+     * @param receivedMsList received mgmt server list
+     * @return true if the lists are equal, false if not
+     */
+    boolean compare(final List<String> msList, final List<String> receivedMsList);
+}

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -55,7 +55,8 @@
     <module>managed-context</module>
     <module>spring/lifecycle</module>
     <module>spring/module</module>
-	<module>security</module>
+    <module>security</module>
+    <module>agent-lb</module>
     <module>direct-download</module>
   </modules>
 </project>

--- a/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/ElasticLoadBalancerManagerImpl.java
+++ b/plugins/network-elements/elastic-loadbalancer/src/com/cloud/network/lb/ElasticLoadBalancerManagerImpl.java
@@ -447,7 +447,7 @@ public class ElasticLoadBalancerManagerImpl extends ManagerBase implements Elast
                     if (s_logger.isInfoEnabled()) {
                         s_logger.info("Check if we need to add management server explicit route to ELB vm. pod cidr: " + dest.getPod().getCidrAddress() + "/"
                                 + dest.getPod().getCidrSize() + ", pod gateway: " + dest.getPod().getGateway() + ", management host: "
-                                + ApiServiceConfiguration.ManagementHostIPAdr.value());
+                                + ApiServiceConfiguration.ManagementServerAddresses.value());
                     }
 
                     if (s_logger.isDebugEnabled()) {

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -137,6 +137,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-framework-agent-lb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opensaml</groupId>
       <artifactId>opensaml</artifactId>
       <version>${cs.opensaml.version}</version>

--- a/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
+++ b/server/resources/META-INF/cloudstack/core/spring-server-core-managers-context.xml
@@ -295,5 +295,7 @@
 
     <bean id="annotationService" class="org.apache.cloudstack.annotation.AnnotationManagerImpl" />
 
+    <bean id="indirectAgentLBService" class="org.apache.cloudstack.agent.lb.IndirectAgentLBServiceImpl" />
+
     <bean id="directDownloadManager" class="org.apache.cloudstack.direct.download.DirectDownloadManagerImpl" />
 </beans>

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -76,6 +76,8 @@ import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
+import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.framework.messagebus.PublishScope;
 import org.apache.cloudstack.region.PortableIp;
 import org.apache.cloudstack.region.PortableIpDao;
 import org.apache.cloudstack.region.PortableIpRange;
@@ -352,6 +354,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     ImageStoreDao _imageStoreDao;
     @Inject
     ImageStoreDetailsDao _imageStoreDetailsDao;
+    @Inject
+    MessageBus messageBus;
 
 
     // FIXME - why don't we have interface for DataCenterLinkLocalIpAddressDao?
@@ -660,6 +664,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         txn.commit();
+        messageBus.publish(_name, EventTypes.EVENT_CONFIGURATION_VALUE_EDIT, PublishScope.GLOBAL, name);
         return _configDao.getValue(name);
     }
 

--- a/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.cloudstack.config.ApiServiceConfiguration;
+import org.apache.cloudstack.agent.lb.IndirectAgentLB;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
@@ -211,6 +211,8 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
     private KeysManager _keysMgr;
     @Inject
     private VirtualMachineManager _itMgr;
+    @Inject
+    private IndirectAgentLB indirectAgentLB;
 
     private ConsoleProxyListener _listener;
 
@@ -1355,7 +1357,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
 
         StringBuilder buf = profile.getBootArgsBuilder();
         buf.append(" template=domP type=consoleproxy");
-        buf.append(" host=").append(StringUtils.shuffleCSVList(ApiServiceConfiguration.ManagementHostIPAdr.value()));
+        buf.append(" host=").append(StringUtils.toCSVList(indirectAgentLB.getManagementServerList(dest.getHost().getId(), dest.getDataCenter().getId(), null)));
         buf.append(" port=").append(_mgmtPort);
         buf.append(" name=").append(profile.getVirtualMachine().getHostName());
         if (_sslEnabled) {

--- a/server/src/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -27,9 +27,9 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import org.apache.cloudstack.agent.lb.IndirectAgentLB;
 import org.apache.cloudstack.ca.CAManager;
 import org.apache.cloudstack.ca.SetupCertificateCommand;
-import org.apache.cloudstack.config.ApiServiceConfiguration;
 import org.apache.cloudstack.framework.ca.Certificate;
 import org.apache.cloudstack.utils.security.KeyStoreUtils;
 import org.apache.log4j.Logger;
@@ -76,6 +76,8 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
     private AgentManager agentMgr;
     @Inject
     private CAManager caManager;
+    @Inject
+    private IndirectAgentLB indirectAgentLB;
 
     @Override
     public abstract Hypervisor.HypervisorType getHypervisorType();
@@ -288,7 +290,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
 
             setupAgentSecurity(sshConnection, agentIp, hostname);
 
-            String parameters = " -m " + StringUtils.shuffleCSVList(ApiServiceConfiguration.ManagementHostIPAdr.value()) + " -z " + dcId + " -p " + podId + " -c " + clusterId + " -g " + guid + " -a";
+            String parameters = " -m " + StringUtils.toCSVList(indirectAgentLB.getManagementServerList(null, dcId, null)) + " -z " + dcId + " -p " + podId     + " -c " + clusterId + " -g " + guid + " -a";
 
             parameters += " --pubNic=" + kvmPublicNic;
             parameters += " --prvNic=" + kvmPrivateNic;

--- a/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1373,7 +1373,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                 if (dest.getHost().getHypervisorType() == HypervisorType.VMware || dest.getHost().getHypervisorType() == HypervisorType.Hyperv) {
                     s_logger.info("Check if we need to add management server explicit route to DomR. pod cidr: " + dest.getPod().getCidrAddress() + "/"
                             + dest.getPod().getCidrSize() + ", pod gateway: " + dest.getPod().getGateway() + ", management host: "
-                            + ApiServiceConfiguration.ManagementHostIPAdr.value());
+                            + ApiServiceConfiguration.ManagementServerAddresses.value());
 
                     if (s_logger.isInfoEnabled()) {
                         s_logger.info("Add management server explicit route to DomR.");
@@ -1484,7 +1484,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             } else {
                 buf.append(String.format(" baremetalnotificationsecuritykey=%s", user.getSecretKey()));
                 buf.append(String.format(" baremetalnotificationapikey=%s", user.getApiKey()));
-                buf.append(" host=").append(ApiServiceConfiguration.ManagementHostIPAdr.value());
+                buf.append(" host=").append(ApiServiceConfiguration.ManagementServerAddresses.value());
                 buf.append(" port=").append(_configDao.getValue(Config.BaremetalProvisionDoneNotificationPort.key()));
             }
         }

--- a/server/src/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/com/cloud/server/ConfigurationServerImpl.java
@@ -246,14 +246,14 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
             if (hostIpAdr != null) {
                 Boolean devel = Boolean.valueOf(_configDao.getValue("developer"));
                 if (devel) {
-                    String value = _configDao.getValue(ApiServiceConfiguration.ManagementHostIPAdr.key());
+                    String value = _configDao.getValue(ApiServiceConfiguration.ManagementServerAddresses.key());
                     if (value != null && !value.equals("localhost")) {
                         needUpdateHostIp = false;
                     }
                 }
 
                 if (needUpdateHostIp) {
-                    _configDepot.createOrUpdateConfigObject(ApiServiceConfiguration.class.getSimpleName(), ApiServiceConfiguration.ManagementHostIPAdr, hostIpAdr);
+                    _configDepot.createOrUpdateConfigObject(ApiServiceConfiguration.class.getSimpleName(), ApiServiceConfiguration.ManagementServerAddresses, hostIpAdr);
                     s_logger.debug("ConfigurationServer saved \"" + hostIpAdr + "\" as host.");
                 }
             }

--- a/server/src/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImpl.java
+++ b/server/src/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImpl.java
@@ -1,0 +1,231 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.agent.lb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+
+import org.apache.cloudstack.agent.lb.algorithm.IndirectAgentLBRoundRobinAlgorithm;
+import org.apache.cloudstack.agent.lb.algorithm.IndirectAgentLBShuffleAlgorithm;
+import org.apache.cloudstack.agent.lb.algorithm.IndirectAgentLBStaticAlgorithm;
+import org.apache.cloudstack.config.ApiServiceConfiguration;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
+import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.framework.messagebus.MessageSubscriber;
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.Answer;
+import com.cloud.event.EventTypes;
+import com.cloud.host.Host;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.resource.ResourceState;
+import com.cloud.utils.component.ComponentLifecycleBase;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.google.common.base.Strings;
+
+public class IndirectAgentLBServiceImpl extends ComponentLifecycleBase implements IndirectAgentLB, Configurable {
+    public static final Logger LOG = Logger.getLogger(IndirectAgentLBServiceImpl.class);
+
+    public static final ConfigKey<String> IndirectAgentLBAlgorithm = new ConfigKey<>("Advanced", String.class,
+            "indirect.agent.lb.algorithm", "static",
+            "The algorithm to be applied on the provided 'host' management server list that is sent to indirect agents. Allowed values are: static, roundrobin and shuffle.",
+            true, ConfigKey.Scope.Global);
+
+    public static final ConfigKey<Long> IndirectAgentLBCheckInterval = new ConfigKey<>("Advanced", Long.class,
+            "indirect.agent.lb.check.interval", "0",
+            "The interval in seconds after which agent should check and try to connect to its preferred host. Set 0 to disable it.",
+            true, ConfigKey.Scope.Cluster);
+
+    private static Map<String, org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm> algorithmMap = new HashMap<>();
+
+    @Inject
+    private HostDao hostDao;
+    @Inject
+    private MessageBus messageBus;
+    @Inject
+    private AgentManager agentManager;
+
+    //////////////////////////////////////////////////////
+    /////////////// Agent MSLB Methods ///////////////////
+    //////////////////////////////////////////////////////
+
+    @Override
+    public List<String> getManagementServerList(final Long hostId, final Long dcId, final List<Long> orderedHostIdList) {
+        final String msServerAddresses = ApiServiceConfiguration.ManagementServerAddresses.value();
+        if (Strings.isNullOrEmpty(msServerAddresses)) {
+            throw new CloudRuntimeException(String.format("No management server addresses are defined in '%s' setting",
+                    ApiServiceConfiguration.ManagementServerAddresses.key()));
+        }
+
+        List<Long> hostIdList = orderedHostIdList;
+        if (hostIdList == null) {
+            hostIdList = getOrderedHostIdList(dcId);
+        }
+
+        final org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm algorithm = getAgentMSLBAlgorithm();
+        final List<String> msList = Arrays.asList(msServerAddresses.replace(" ", "").split(","));
+        return algorithm.sort(msList, hostIdList, hostId);
+    }
+
+    @Override
+    public boolean compareManagementServerList(final Long hostId, final Long dcId, final List<String> receivedMSHosts) {
+        if (receivedMSHosts == null || receivedMSHosts.size() < 1) {
+            return false;
+        }
+        final List<String> expectedMSList = getManagementServerList(hostId, dcId, null);
+        final org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm algorithm = getAgentMSLBAlgorithm();
+        return algorithm.compare(expectedMSList, receivedMSHosts);
+    }
+
+    @Override
+    public String getLBAlgorithmName() {
+        return IndirectAgentLBAlgorithm.value();
+    }
+
+    @Override
+    public Long getLBPreferredHostCheckInterval(final Long clusterId) {
+        return IndirectAgentLBCheckInterval.valueIn(clusterId);
+    }
+
+    List<Long> getOrderedHostIdList(final Long dcId) {
+        final List<Long> hostIdList = new ArrayList<>();
+        for (final Host host : getAllAgentBasedHosts()) {
+            if (host.getDataCenterId() == dcId) {
+                hostIdList.add(host.getId());
+            }
+        }
+        Collections.sort(hostIdList, new Comparator<Long>() {
+            @Override
+            public int compare(Long x, Long y) {
+                return Long.compare(x,y);
+            }
+        });
+        return hostIdList;
+    }
+
+    private List<Host> getAllAgentBasedHosts() {
+        final List<HostVO> allHosts = hostDao.listAll();
+        if (allHosts == null) {
+            return new ArrayList<>();
+        }
+        final List <Host> agentBasedHosts = new ArrayList<>();
+        for (final Host host : allHosts) {
+            if (host == null || host.getResourceState() != ResourceState.Enabled) {
+                continue;
+            }
+            if (host.getType() == Host.Type.Routing || host.getType() == Host.Type.ConsoleProxy || host.getType() == Host.Type.SecondaryStorage || host.getType() == Host.Type.SecondaryStorageVM) {
+                if (host.getHypervisorType() != null && host.getHypervisorType() != Hypervisor.HypervisorType.KVM && host.getHypervisorType() != Hypervisor.HypervisorType.LXC) {
+                    continue;
+                }
+                agentBasedHosts.add(host);
+            }
+        }
+        return agentBasedHosts;
+    }
+
+    private org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm getAgentMSLBAlgorithm() {
+        final String algorithm = getLBAlgorithmName();
+        if (algorithmMap.containsKey(algorithm)) {
+            return algorithmMap.get(algorithm);
+        }
+        throw new CloudRuntimeException(String.format("Algorithm configured for '%s' not found, valid values are: %s",
+                IndirectAgentLBAlgorithm.key(), algorithmMap.keySet()));
+    }
+
+    ////////////////////////////////////////////////////////////
+    /////////////// Agent MSLB Configuration ///////////////////
+    ////////////////////////////////////////////////////////////
+
+    private void propagateMSListToAgents() {
+        LOG.debug("Propagating management server list update to agents");
+        final String lbAlgorithm = getLBAlgorithmName();
+        final Map<Long, List<Long>> dcOrderedHostsMap = new HashMap<>();
+        for (final Host host : getAllAgentBasedHosts()) {
+            final Long dcId = host.getDataCenterId();
+            if (!dcOrderedHostsMap.containsKey(dcId)) {
+                dcOrderedHostsMap.put(dcId, getOrderedHostIdList(dcId));
+            }
+            final List<String> msList = getManagementServerList(host.getId(), host.getDataCenterId(), dcOrderedHostsMap.get(dcId));
+            final Long lbCheckInterval = getLBPreferredHostCheckInterval(host.getClusterId());
+            final SetupMSListCommand cmd = new SetupMSListCommand(msList, lbAlgorithm, lbCheckInterval);
+            final Answer answer = agentManager.easySend(host.getId(), cmd);
+            if (answer == null || !answer.getResult()) {
+                LOG.warn("Failed to setup management servers list to the agent of host id=" + host.getId());
+            }
+        }
+    }
+
+    private void configureMessageBusListener() {
+        messageBus.subscribe(EventTypes.EVENT_CONFIGURATION_VALUE_EDIT, new MessageSubscriber() {
+            @Override
+            public void onPublishMessage(final String senderAddress, String subject, Object args) {
+                final String globalSettingUpdated = (String) args;
+                if (Strings.isNullOrEmpty(globalSettingUpdated)) {
+                    return;
+                }
+                if (globalSettingUpdated.equals(ApiServiceConfiguration.ManagementServerAddresses.key()) ||
+                        globalSettingUpdated.equals(IndirectAgentLBAlgorithm.key())) {
+                    propagateMSListToAgents();
+                }
+            }
+        });
+    }
+
+    private void configureAlgorithmMap() {
+        final List<org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm> algorithms = new ArrayList<>();
+        algorithms.add(new IndirectAgentLBStaticAlgorithm());
+        algorithms.add(new IndirectAgentLBRoundRobinAlgorithm());
+        algorithms.add(new IndirectAgentLBShuffleAlgorithm());
+        algorithmMap.clear();
+        for (org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm algorithm : algorithms) {
+            algorithmMap.put(algorithm.getName(), algorithm);
+        }
+    }
+
+    @Override
+    public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
+        super.configure(name, params);
+        configureAlgorithmMap();
+        configureMessageBusListener();
+        return true;
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return IndirectAgentLBServiceImpl.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[] {
+                IndirectAgentLBAlgorithm,
+                IndirectAgentLBCheckInterval
+        };
+    }
+}

--- a/server/src/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBRoundRobinAlgorithm.java
+++ b/server/src/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBRoundRobinAlgorithm.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.agent.lb.algorithm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm;
+
+public class IndirectAgentLBRoundRobinAlgorithm implements IndirectAgentLBAlgorithm {
+
+    private int findRRPivotIndex(final List<String> msList, final List<Long> orderedHostList, final Long hostId) {
+        return orderedHostList.indexOf(hostId) % msList.size();
+    }
+
+    @Override
+    public List<String> sort(final List<String> msList, final List<Long> orderedHostList, final Long hostId) {
+        if (msList.size() < 2) {
+            return msList;
+        }
+
+        final List<Long> hostList = new ArrayList<>(orderedHostList);
+        Long searchId = hostId;
+        if (hostId == null) {
+            searchId = -1L;
+            hostList.add(searchId);
+        }
+
+        final int pivotIndex = findRRPivotIndex(msList, hostList, searchId);
+        final List<String> roundRobin = new ArrayList<>(msList.subList(pivotIndex, msList.size()));
+        roundRobin.addAll(msList.subList(0, pivotIndex));
+
+        return roundRobin;
+    }
+
+    @Override
+    public String getName() {
+        return "roundrobin";
+    }
+
+    @Override
+    public boolean compare(final List<String> msList, final List<String> receivedMsList) {
+        return msList != null && receivedMsList != null && msList.equals(receivedMsList);
+    }
+}

--- a/server/src/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBShuffleAlgorithm.java
+++ b/server/src/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBShuffleAlgorithm.java
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.agent.lb.algorithm;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm;
+import org.apache.commons.collections.SetUtils;
+
+public class IndirectAgentLBShuffleAlgorithm implements IndirectAgentLBAlgorithm {
+
+    @Override
+    public List<String> sort(final List<String> msList, final List<Long> orderedHostList, final Long hostId) {
+        final List<String> randomList = new ArrayList<>(msList);
+        Collections.shuffle(randomList, new Random(System.currentTimeMillis()));
+        return randomList;
+    }
+
+    @Override
+    public String getName() {
+        return "shuffle";
+    }
+
+    @Override
+    public boolean compare(List<String> msList, List<String> receivedMsList) {
+        return SetUtils.isEqualSet(msList, receivedMsList);
+    }
+}

--- a/server/src/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBStaticAlgorithm.java
+++ b/server/src/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBStaticAlgorithm.java
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.agent.lb.algorithm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm;
+
+public class IndirectAgentLBStaticAlgorithm implements IndirectAgentLBAlgorithm {
+
+    @Override
+    public List<String> sort(final List<String> msList, final List<Long> orderedHostList, final Long hostId) {
+        return new ArrayList<>(msList);
+    }
+
+    @Override
+    public String getName() {
+        return "static";
+    }
+
+    @Override
+    public boolean compare(final List<String> msList, final List<String> receivedMsList) {
+        return msList != null && receivedMsList != null && msList.equals(receivedMsList);
+    }
+}

--- a/server/test/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImplTest.java
+++ b/server/test/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImplTest.java
@@ -1,0 +1,208 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.agent.lb;
+
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.cloudstack.config.ApiServiceConfiguration;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import com.cloud.agent.AgentManager;
+import com.cloud.host.Host;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.resource.ResourceState;
+import com.cloud.utils.exception.CloudRuntimeException;
+
+public class IndirectAgentLBServiceImplTest {
+
+    @Mock
+    HostDao hostDao;
+    @Mock
+    MessageBus messageBus;
+    @Mock
+    AgentManager agentManager;
+
+    @Mock
+    HostVO host1;
+    @Mock
+    HostVO host2;
+    @Mock
+    HostVO host3;
+    @Mock
+    HostVO host4;
+
+    @Spy
+    @InjectMocks
+    private IndirectAgentLBServiceImpl agentMSLB = new IndirectAgentLBServiceImpl();
+
+    private final String msCSVList = "192.168.10.10, 192.168.10.11, 192.168.10.12";
+    private final List<String> msList = Arrays.asList(msCSVList.replace(" ","").split(","));
+
+    private static final long DC_1_ID = 1L;
+    private static final long DC_2_ID = 2L;
+
+    private void overrideDefaultConfigValue(final ConfigKey configKey, final String name, final Object o) throws IllegalAccessException, NoSuchFieldException {
+        final Field f = ConfigKey.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(configKey, o);
+    }
+
+    private void addField(final IndirectAgentLBServiceImpl provider, final String name, final Object o) throws IllegalAccessException, NoSuchFieldException {
+        Field f = IndirectAgentLBServiceImpl.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(provider, o);
+    }
+
+    private void configureMocks() throws NoSuchFieldException, IllegalAccessException {
+        long id = 1;
+        for (HostVO h : Arrays.asList(host1, host2, host3, host4)) {
+            when(h.getId()).thenReturn(id);
+            when(h.getDataCenterId()).thenReturn(DC_1_ID);
+            when(h.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+            when(h.getType()).thenReturn(Host.Type.Routing);
+            when(h.getRemoved()).thenReturn(null);
+            when(h.getResourceState()).thenReturn(ResourceState.Enabled);
+            id++;
+        }
+        addField(agentMSLB, "hostDao", hostDao);
+        addField(agentMSLB, "messageBus", messageBus);
+        addField(agentMSLB, "agentManager", agentManager);
+
+        when(hostDao.listAll()).thenReturn(Arrays.asList(host4, host2, host1, host3));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        configureMocks();
+        agentMSLB.configure("someName", null);
+        overrideDefaultConfigValue(ApiServiceConfiguration.ManagementServerAddresses, "_defaultValue", msCSVList);
+    }
+
+    @Test
+    public void testStaticLBSetting() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "static");
+        for (HostVO host : Arrays.asList(host1, host2, host3, host4)) {
+            List<String> listToSend = agentMSLB.getManagementServerList(host.getId(), host.getDataCenterId(), null);
+            Assert.assertEquals(msList, listToSend);
+        }
+    }
+
+    @Test
+    public void testStaticLBSettingNullHostId() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "static");
+        List<String> listToSend = agentMSLB.getManagementServerList(host2.getId(), host2.getDataCenterId(), null);
+        Assert.assertEquals(listToSend, agentMSLB.getManagementServerList(null, DC_1_ID, null));
+    }
+
+    private void testRoundRobinForExistingHosts(List<String> list) {
+        for (HostVO hostVO : Arrays.asList(host1, host2, host3, host4)) {
+            List<String> listToSend = agentMSLB.getManagementServerList(hostVO.getId(), hostVO.getDataCenterId(), null);
+            Assert.assertEquals(list, listToSend);
+            Assert.assertEquals(list.get(0), listToSend.get(0));
+            list.add(list.get(0));
+            list.remove(0);
+        }
+    }
+
+    @Test
+    public void testRoundRobinDeterministicOrder() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "roundrobin");
+        List<String> listHost2 = agentMSLB.getManagementServerList(host2.getId(), host2.getDataCenterId(), null);
+        Assert.assertEquals(listHost2, agentMSLB.getManagementServerList(host2.getId(), host2.getDataCenterId(), null));
+    }
+
+    @Test
+    public void testRoundRobinLBSettingConnectedAgents() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "roundrobin");
+        List<String> list = new ArrayList<>(msList);
+        testRoundRobinForExistingHosts(list);
+    }
+
+    @Test
+    public void testRoundRobinLBSettingNullHostId() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "roundrobin");
+        List<String> list = new ArrayList<>(msList);
+        testRoundRobinForExistingHosts(list);
+        List<String> listToSend = agentMSLB.getManagementServerList(null, DC_1_ID, null);
+        Assert.assertEquals(list, listToSend);
+        Assert.assertEquals(list.get(0), listToSend.get(0));
+        list.add(list.get(0));
+        list.remove(0);
+    }
+
+    @Test
+    public void testShuffleLBSetting() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "shuffle");
+        List<String> shuffleListHost2 = agentMSLB.getManagementServerList(host2.getId(), host2.getDataCenterId(), null);
+        Assert.assertEquals(new HashSet<>(msList), new HashSet<>(shuffleListHost2));
+    }
+
+    @Test
+    public void testShuffleLBSettingNullHostId() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "shuffle");
+        Assert.assertEquals(new HashSet<>(msList), new HashSet<>(agentMSLB.getManagementServerList(null, DC_1_ID, null)));
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testInvalidAlgorithmSetting() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(IndirectAgentLBServiceImpl.IndirectAgentLBAlgorithm, "_defaultValue", "invalid-algo");
+        agentMSLB.getManagementServerList(host1.getId(), host1.getDataCenterId(), null);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testExceptionOnEmptyHostSetting() throws NoSuchFieldException, IllegalAccessException {
+        overrideDefaultConfigValue(ApiServiceConfiguration.ManagementServerAddresses, "_defaultValue", "");
+        // This should throw exception
+        agentMSLB.getManagementServerList(host1.getId(), host1.getDataCenterId(), null);
+    }
+
+    @Test
+    public void testGetOrderedRunningHostIdsNullList() {
+        when(hostDao.listAll()).thenReturn(null);
+        Assert.assertTrue(agentMSLB.getOrderedHostIdList(DC_1_ID).size() == 0);
+    }
+
+    @Test
+    public void testGetOrderedRunningHostIdsOrderList() {
+        when(hostDao.listAll()).thenReturn(Arrays.asList(host4, host2, host1, host3));
+        Assert.assertEquals(Arrays.asList(host1.getId(), host2.getId(), host3.getId(), host4.getId()),
+                agentMSLB.getOrderedHostIdList(DC_1_ID));
+    }
+
+    @Test
+    public void testGetHostsPerZoneNullHosts() {
+        when(hostDao.listAll()).thenReturn(null);
+        Assert.assertTrue(agentMSLB.getOrderedHostIdList(DC_2_ID).size() == 0);
+    }
+}

--- a/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBRoundRobinAlgorithmTest.java
+++ b/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBRoundRobinAlgorithmTest.java
@@ -1,0 +1,60 @@
+package org.apache.cloudstack.agent.lb.algorithm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IndirectAgentLBRoundRobinAlgorithmTest {
+    private IndirectAgentLBAlgorithm algorithm = new IndirectAgentLBRoundRobinAlgorithm();
+
+    private List<String> msList = Arrays.asList("10.1.1.1", "10.1.1.2", "10.1.1.3");
+    private List<Long> hostList = new ArrayList<>(Arrays.asList(1L, 5L, 10L, 20L, 50L, 60L, 70L, 80L));
+
+    @Test
+    public void testGetMSListForNewHost() throws Exception {
+        List<String> startList = algorithm.sort(msList, hostList, null);
+        Assert.assertNotEquals(msList, startList);
+        Assert.assertFalse(algorithm.compare(msList, startList));
+
+        hostList.add(100L);
+        List<String> nextList = algorithm.sort(msList, hostList, null);
+        List<String> expectedList = startList.subList(1, startList.size());
+        expectedList.addAll(startList.subList(0, 1));
+        Assert.assertEquals(nextList, expectedList);
+    }
+
+    @Test
+    public void testGetMSListForExistingHost() throws Exception {
+        List<String> startList = new ArrayList<>(msList);
+        for (Long hostId : hostList.subList(1, hostList.size())) {
+            List<String> nextList = new ArrayList<>(startList.subList(1, msList.size()));
+            nextList.addAll(startList.subList(0, 1));
+            List<String> expectedList = algorithm.sort(msList, hostList, hostId);
+            Assert.assertEquals(expectedList, nextList);
+            startList = nextList;
+        }
+    }
+
+    @Test
+    public void testName() throws Exception {
+        Assert.assertEquals(algorithm.getName(), "roundrobin");
+    }
+
+    @Test
+    public void testListComparison() throws Exception {
+        Assert.assertTrue(algorithm.compare(Collections.singletonList("10.1.1.1"), Collections.singletonList("10.1.1.1")));
+        Assert.assertTrue(algorithm.compare(Arrays.asList("10.1.1.2", "10.1.1.1"), Arrays.asList("10.1.1.2", "10.1.1.1")));
+        Assert.assertTrue(algorithm.compare(msList, Arrays.asList("10.1.1.1", "10.1.1.2", "10.1.1.3")));
+
+        Assert.assertFalse(algorithm.compare(msList, Arrays.asList("10.1.1.3", "10.1.1.2", "10.1.1.1")));
+        Assert.assertFalse(algorithm.compare(msList, Arrays.asList("10.1.1.0", "10.2.2.2")));
+        Assert.assertFalse(algorithm.compare(msList, new ArrayList<String>()));
+        Assert.assertFalse(algorithm.compare(msList, null));
+    }
+
+}

--- a/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBRoundRobinAlgorithmTest.java
+++ b/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBRoundRobinAlgorithmTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.agent.lb.algorithm;
 
 import java.util.ArrayList;

--- a/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBShuffleAlgorithmTest.java
+++ b/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBShuffleAlgorithmTest.java
@@ -1,0 +1,44 @@
+package org.apache.cloudstack.agent.lb.algorithm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IndirectAgentLBShuffleAlgorithmTest {
+    private IndirectAgentLBAlgorithm algorithm = new IndirectAgentLBShuffleAlgorithm();
+
+    private List<String> msList = Arrays.asList("10.1.1.1", "10.1.1.2", "10.1.1.3");
+
+    @Test
+    public void testGetMSList() throws Exception {
+        for (int i = 0; i < 100; i++) {
+            final List<String> newList = algorithm.sort(msList, null, null);
+            if (!msList.equals(newList)) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        Assert.fail("Shuffle failed to produce a randomly sorted management server list");
+    }
+
+    @Test
+    public void testName() throws Exception {
+        Assert.assertEquals(algorithm.getName(), "shuffle");
+    }
+
+    @Test
+    public void testListComparison() throws Exception {
+        Assert.assertTrue(algorithm.compare(Collections.singletonList("10.1.1.1"), Collections.singletonList("10.1.1.1")));
+        Assert.assertTrue(algorithm.compare(msList, Arrays.asList("10.1.1.1", "10.1.1.2", "10.1.1.3")));
+        Assert.assertTrue(algorithm.compare(msList, Arrays.asList("10.1.1.3", "10.1.1.2", "10.1.1.1")));
+
+        Assert.assertFalse(algorithm.compare(msList, Arrays.asList("10.1.1.0", "10.2.2.2")));
+        Assert.assertFalse(algorithm.compare(msList, new ArrayList<String>()));
+        Assert.assertFalse(algorithm.compare(msList, null));
+    }
+}

--- a/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBShuffleAlgorithmTest.java
+++ b/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBShuffleAlgorithmTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.agent.lb.algorithm;
 
 import java.util.ArrayList;

--- a/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBStaticAlgorithmTest.java
+++ b/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBStaticAlgorithmTest.java
@@ -1,0 +1,33 @@
+package org.apache.cloudstack.agent.lb.algorithm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.cloudstack.agent.lb.IndirectAgentLBAlgorithm;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IndirectAgentLBStaticAlgorithmTest {
+    private IndirectAgentLBAlgorithm algorithm = new IndirectAgentLBStaticAlgorithm();
+
+    private List<String> msList = Arrays.asList("10.1.1.1", "10.1.1.2", "10.1.1.3");
+
+    @Test
+    public void testGetMSList() throws Exception {
+        Assert.assertEquals(msList, algorithm.sort(msList, null, null));
+    }
+
+    @Test
+    public void testName() throws Exception {
+        Assert.assertEquals(algorithm.getName(), "static");
+    }
+
+    @Test
+    public void testListComparison() throws Exception {
+        Assert.assertTrue(algorithm.compare(msList, Arrays.asList("10.1.1.1", "10.1.1.2", "10.1.1.3")));
+        Assert.assertFalse(algorithm.compare(msList, Arrays.asList("10.1.1.0", "10.2.2.2")));
+        Assert.assertFalse(algorithm.compare(msList, new ArrayList<String>()));
+        Assert.assertFalse(algorithm.compare(msList, null));
+    }
+}

--- a/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBStaticAlgorithmTest.java
+++ b/server/test/org/apache/cloudstack/agent/lb/algorithm/IndirectAgentLBStaticAlgorithmTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.agent.lb.algorithm;
 
 import java.util.ArrayList;

--- a/server/test/resources/createNetworkOffering.xml
+++ b/server/test/resources/createNetworkOffering.xml
@@ -54,4 +54,5 @@
     <bean id="userIpAddressDetailsDao" class="org.apache.cloudstack.resourcedetail.dao.UserIpAddressDetailsDaoImpl" />
     <bean id="loadBalancerVMMapDaoImpl" class="com.cloud.network.dao.LoadBalancerVMMapDaoImpl" />
     <bean id="imageStoreDaoImpl" class="org.apache.cloudstack.storage.datastore.db.ImageStoreDaoImpl" />
+    <bean id="messageBus" class="org.apache.cloudstack.framework.messagebus.MessageBusBase" />
 </beans>

--- a/server/test/resources/testContext.xml
+++ b/server/test/resources/testContext.xml
@@ -81,6 +81,7 @@
   </bean>
 
   <bean id="eventBus" class = "org.apache.cloudstack.framework.eventbus.EventBusBase" />
+  <bean id="messageBus" class="org.apache.cloudstack.framework.messagebus.MessageBusBase" />
 
   <bean id="apiServlet" class = "com.cloud.api.ApiServlet" />
 

--- a/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.cloudstack.config.ApiServiceConfiguration;
+import org.apache.cloudstack.agent.lb.IndirectAgentLB;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -89,12 +89,12 @@ import com.cloud.info.RunningHostInfoAgregator.ZoneHostInfo;
 import com.cloud.network.Network;
 import com.cloud.network.NetworkModel;
 import com.cloud.network.Networks.TrafficType;
+import com.cloud.network.StorageNetworkManager;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.rules.RulesManager;
-import com.cloud.network.StorageNetworkManager;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.offerings.dao.NetworkOfferingDao;
@@ -246,6 +246,9 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
     VolumeDataStoreDao _volumeStoreDao;
     @Inject
     private ImageStoreDetailsUtil imageStoreDetailsUtil;
+    @Inject
+    private IndirectAgentLB indirectAgentLB;
+
     private long _capacityScanInterval = DEFAULT_CAPACITY_SCAN_INTERVAL;
     private int _secStorageVmMtuSize;
 
@@ -1119,7 +1122,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
 
         StringBuilder buf = profile.getBootArgsBuilder();
         buf.append(" template=domP type=secstorage");
-        buf.append(" host=").append(StringUtils.shuffleCSVList(ApiServiceConfiguration.ManagementHostIPAdr.value()));
+        buf.append(" host=").append(StringUtils.toCSVList(indirectAgentLB.getManagementServerList(dest.getHost().getId(), dest.getDataCenter().getId(), null)));
         buf.append(" port=").append(_mgmtPort);
         buf.append(" name=").append(profile.getVirtualMachine().getHostName());
 

--- a/utils/src/main/java/com/cloud/utils/StringUtils.java
+++ b/utils/src/main/java/com/cloud/utils/StringUtils.java
@@ -21,12 +21,10 @@ package com.cloud.utils;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -323,9 +321,7 @@ public class StringUtils {
         return listOfChunks;
     }
 
-    public static String shuffleCSVList(final String csvList) {
-        List<String> list = csvTagsToList(csvList);
-        Collections.shuffle(list, new Random(System.nanoTime()));
-        return join(list, ",");
+    public static String toCSVList(final List<String> csvList) {
+        return join(csvList, ",");
     }
 }

--- a/utils/src/test/java/com/cloud/utils/StringUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/StringUtilsTest.java
@@ -20,9 +20,8 @@
 package com.cloud.utils;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -254,13 +253,9 @@ public class StringUtilsTest {
     }
 
     @Test
-    public void testShuffleCSVList() {
+    public void testToCSVList() {
         String input = "one,two,three,four,five,six,seven,eight,nine,ten";
-        String output = StringUtils.shuffleCSVList(input);
-        assertFalse(input.equals(output));
-
-        input = "only-one";
-        output = StringUtils.shuffleCSVList("only-one");
+        String output = StringUtils.toCSVList(Arrays.asList(input.split(",")));
         assertTrue(input.equals(output));
     }
 }


### PR DESCRIPTION
The new CA framework introduced basic support for comma-separated
list of management servers for agent, which makes an external LB
unnecessary.

This extends that feature to implement LB sorting algorithms that
sorts the management server list before they are sent to the agents.
This adds a central intelligence in the management server and adds
additional enhancements to Agent class to be algorithm aware and
have a background mechanism to check/fallback to preferred management
server (assumed as the first in the list). This is support for any
indirect agent such as the KVM, CPVM and SSVM agent, and would
provide support for management server host migration during upgrade
(when instead of in-place, new hosts are used to setup new mgmt server).

This FR introduces two new global settings:

- `indirect.agent.lb.algorithm`: The algorithm for the indirect agent LB.
- `indirect.agent.lb.check.interval`: The preferred host check interval
  for the agent's background task that checks and switches to agent's
  preferred host.

The indirect.agent.lb.algorithm supports following algorithm options:

- static: use the list as provided.
- roundrobin: evenly spreads hosts across management servers based on
  host's id.
- shuffle: (pseudo) randomly sorts the list (not recommended for production).

Any changes to the global settings - `indirect.agent.lb.algorithm` and
`host` does not require restarting of the mangement server(s) and the
agents. A message bus based system dynamically reacts to change in these
global settings and propagates them to all connected agents.

Comma-separated management server list is propagated to agents on
following cases:
- Addition of a host (including ssvm, cpvm systevms).
- Connection or reconnection by the agents to a management server.
- After admin changes the 'host' and/or the
  'indirect.agent.lb.algorithm' global settings.

On the agent side, the 'host' setting is saved in its properties file as:
`host=<comma separated addresses>@<algorithm name>`.

First the agent connects to the management server and sends its current
management server list, which is compared by the management server and
in case of failure a new/update list is sent for the agent to persist.

From the agent's perspective, the first address in the propagated list
will be considered the preferred host. A new background task can be
activated by configuring the `indirect.agent.lb.check.interval` which is
a cluster level global setting from CloudStack and admins can also
override this by configuring the 'host.lb.check.interval' in the
`agent.properties` file.

Every time agent gets a ms-host list and the algorithm, the host specific
background check interval is also sent and it dynamically reconfigures
the background task without need to restart agents.

Note: The 'static' and 'roundrobin' algorithms, strictly checks for the
order as expected by them, however, the 'shuffle' algorithm just checks
for content and not the order of the comma separate ms host addresses.

@blueorangutan package