### PR TITLE
CLOUDSTACK-10246 Fix Host HA and VM HA issues

### DIFF
--- a/api/src/com/cloud/host/Status.java
+++ b/api/src/com/cloud/host/Status.java
@@ -61,10 +61,11 @@ public enum Status {
         PingTimeout(false, "Agent is behind on ping"),
         ShutdownRequested(false, "Shutdown requested by the agent"),
         AgentDisconnected(false, "Agent disconnected"),
+        AgentUnreachable(false, "Host is found to be disconnected by the investigator"),
         HostDown(false, "Host is found to be down by the investigator"),
         Ping(false, "Ping is received from the host"),
         ManagementServerDown(false, "Management Server that the agent is connected is going down"),
-        WaitedTooLong(false, "Waited too long from the agent to reconnect on its own.  Time to do HA"),
+        WaitedTooLong(false, "Waited too long from the agent to reconnect on its own."),
         Remove(true, "Host is removed"),
         Ready(false, "Host is ready for commands"),
         RequestAgentRebalance(false, "Request rebalance for the certain host"),
@@ -130,6 +131,7 @@ public enum Status {
         s_fsm.addTransition(Status.Connecting, Event.AgentDisconnected, Status.Alert);
         s_fsm.addTransition(Status.Up, Event.PingTimeout, Status.Alert);
         s_fsm.addTransition(Status.Up, Event.AgentDisconnected, Status.Alert);
+        s_fsm.addTransition(Status.Up, Event.AgentUnreachable, Status.Disconnected);
         s_fsm.addTransition(Status.Up, Event.ShutdownRequested, Status.Disconnected);
         s_fsm.addTransition(Status.Up, Event.HostDown, Status.Down);
         s_fsm.addTransition(Status.Up, Event.Ping, Status.Up);
@@ -152,10 +154,12 @@ public enum Status {
         s_fsm.addTransition(Status.Down, Event.PingTimeout, Status.Down);
         s_fsm.addTransition(Status.Alert, Event.AgentConnected, Status.Connecting);
         s_fsm.addTransition(Status.Alert, Event.Ping, Status.Up);
+        s_fsm.addTransition(Status.Alert, Event.PingTimeout, Status.Alert);
         s_fsm.addTransition(Status.Alert, Event.Remove, Status.Removed);
         s_fsm.addTransition(Status.Alert, Event.ManagementServerDown, Status.Alert);
         s_fsm.addTransition(Status.Alert, Event.AgentDisconnected, Status.Alert);
         s_fsm.addTransition(Status.Alert, Event.ShutdownRequested, Status.Disconnected);
+        s_fsm.addTransition(Status.Alert, Event.HostDown, Status.Down);
         s_fsm.addTransition(Status.Rebalancing, Event.RebalanceFailed, Status.Disconnected);
         s_fsm.addTransition(Status.Rebalancing, Event.RebalanceCompleted, Status.Connecting);
         s_fsm.addTransition(Status.Rebalancing, Event.ManagementServerDown, Status.Disconnected);


### PR DESCRIPTION
The HA logic just does not work.  VM's with HA enabled would never restart after a host failure.  Had to re-do most of that logic.  There are comments inline with the code, but down below is the general updated logic.  Sorry for the long notes... 

PS. We enabled virtlockd (https://libvirt.org/locking-lockd.html) and highly recommend it, otherwise you can have VM HA start a VM on multiple hosts.

We are running KVM FYI.

- If host-agent is unreachable, handleDisconnectWithInvestigation() is called as always.
- The investigators are called to see what happened, which is one of the following two scenarios.  (If it isn't one of the two below, then the host just came back UP, or another status was returned and that is also logged.  But the two scenarios below are what needed updated the most)

**If the investigators find the host is UP, but just the agent is unreachable**
The host is put into DISCONNECTED status.  It will stay in this status and the PingTimeouts will continue to call handleDisconnectWithoutInvestigation() periodically.  It will stay in DISCONNECTED status until the AlertWait config option expires.  If the AlertWait time eventually is hit, and the investigators are still just reporting that the host is DISCONNECTED and not DOWN.  Then we'll put the host into ALERT state and we'll stay there until the investigators say the host is UP or the investigators say the host is DOWN.  If the host goes DOWN, then VM HA will be initiated.

**If the investigators find the host is DOWN**
Then VM HA is initiated...

**VirtualNetworkApplianceManagerImpl.java**
The file VirtualNetworkApplianceManagerImpl.java is edited for a related VM HA problem.  When a Host is determined to be DOWN, CloudStack attempts to VM HA any affected routers.  The problem is, when the host is determined to be down, by code referenced above, the host may not actually be DOWN.  On KVM for example, the host is considered DOWN if the agent is stopped on the KVM host for too long.  In that case, the VMs could still be running just fine...  However when we think the host is DOWN, VM HA runs on the router and as part of that it unallocates/cleans-up the router and it's 169.x.x.x control IP is unallocated.  Then after it cleans it up, it tries to power on the router on another host, and as part of that it allocates a NEW 169.x.x.x control IP and writes that to the DB.  However, since the router isn't actually down (we just think the host is down) the VM HA fails as the vRouter is currently still running on the problem host.  

Next, in this example, when the host agent is back online again, it sends a power report to the mgmt servers, and the management servers think the router was powered-on OOB.  However, the GUI will not show a control IP for the vRouter, and the DB will have the NEW control IP it tried to allocated during the failed VM HA event.  Thus, leaving us unable to communicate with the vRouter.

This PR does a simple check that we can still communicate with the vRouter after any OOB power-on occurs.  If we can, then we have the correct control IP in the DB and we're good - so we do nothing.  If we can't communicate with the vRouter after the OOB power-on, we do a reboot of the vRouter to fix it.