### PR TITLE
CLOUDSTACK-10317: Fix SNAT rules for additional public nics

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -388,7 +388,7 @@ class CsIP:
             self.fw.append(["mangle", "",
                             "-A VPN_%s -j RETURN" % self.address['public_ip']])
             self.fw.append(["nat", "",
-                            "-A POSTROUTING -o eth2 -j SNAT --to-source %s" % self.address['public_ip']])
+                            "-A POSTROUTING -o %s -j SNAT --to-source %s" % (self.dev, self.address['public_ip'])])
             self.fw.append(["mangle", "",
                             "-A PREROUTING -i %s -m state --state NEW " % self.dev +
                             "-j CONNMARK --set-xmark %s/0xffffffff" % self.dnum])

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -388,7 +388,7 @@ class CsIP:
             self.fw.append(["mangle", "",
                             "-A VPN_%s -j RETURN" % self.address['public_ip']])
             self.fw.append(["nat", "",
-                            "-A POSTROUTING -o %s -j SNAT --to-source %s" % (self.dev, self.address['public_ip'])])
+                            "-A POSTROUTING -o %s -j SNAT --to-source %s" % (self.dev, self.cl.get_eth2_ip())])
             self.fw.append(["mangle", "",
                             "-A PREROUTING -i %s -m state --state NEW " % self.dev +
                             "-j CONNMARK --set-xmark %s/0xffffffff" % self.dnum])


### PR DESCRIPTION
This allows networks with additional public nics to have correct SNAT iptables rules applied on configuration.

Pinging for review - @ustcweizhou @PaulAngus @DagSonstebo and others.