### PR TITLE
[CLOUDSTACK-10318] Bug on sorting ACL rules list in chrome

### DIFF
--- a/ui/scripts/vpc.js
+++ b/ui/scripts/vpc.js
@@ -1325,7 +1325,7 @@
 
                                                     if(items){
                                                         items.sort(function(a, b) {
-                                                            return a.number >= b.number;
+                                                            return a.number - b.number;
                                                         }).map(function(acl) {
                                                             if (parseInt(acl.protocol)) { // protocol number
                                                                 acl.protocolnumber = acl.protocol;


### PR DESCRIPTION
There is a bug on ACL rules list when a user creates more than 10 rules.

Steps to reproduce this issue:
- Create more than 10 ACL rules.
- Access the ACL rules list page.
- You will see that they are not sorted as they should by the ACL rule number

