### PR TITLE
CLOUDSTACK-10320 - Invalid pair for response object breaking response parsing

### DIFF
--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -1315,6 +1315,10 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     public Pair<List<T>, Integer> searchAndCount(final SearchCriteria<T> sc, final Filter filter) {
         List<T> objects = search(sc, filter, null, false);
         Integer count = getCount(sc);
+        // Count cannot be less than the result set but can be higher due to pagination, see CLOUDSTACK-10320
+        if (count < objects.size()) {
+            count = objects.size();
+        }
         return new Pair<List<T>, Integer>(objects, count);
     }
 
@@ -1323,6 +1327,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     public Pair<List<T>, Integer> searchAndDistinctCount(final SearchCriteria<T> sc, final Filter filter) {
         List<T> objects = search(sc, filter, null, false);
         Integer count = getDistinctCount(sc);
+        // Count cannot be 0 if there is at least a result in the list, see CLOUDSTACK-10320
+        if (count == 0 && !objects.isEmpty()) {
+            // Cannot assume if it's more than one since the count is distinct vs search
+            count = 1;
+        }
         return new Pair<List<T>, Integer>(objects, count);
     }
 
@@ -1331,6 +1340,11 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
     public Pair<List<T>, Integer> searchAndDistinctCount(final SearchCriteria<T> sc, final Filter filter, final String[] distinctColumns) {
         List<T> objects = search(sc, filter, null, false);
         Integer count = getDistinctCount(sc, distinctColumns);
+        // Count cannot be 0 if there is at least a result in the list, see CLOUDSTACK-10320
+        if (count == 0 && !objects.isEmpty()) {
+            // Cannot assume if it's more than one since the count is distinct vs search
+            count = 1;
+        }
         return new Pair<List<T>, Integer>(objects, count);
     }
 


### PR DESCRIPTION
Under some circumstances, the API is returning an invalid response, for simplicity I will expose the JSON case. The API response on a `listVirtualMachines` can be this string:
```
{ "listvirtualmachinesresponse" :  ] } }
```

To understand how this is possible, assume you have more than one management server and one is processing the destroy of a virtual machine in the account X which is the only one it has. Another process is returning the result of `listVirtualMachines` for that same account X. During the listVM command, the result set is fetch with a `searchAndDistinctCount` due to the view (https://github.com/apache/cloudstack/blob/master/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java#L1024). This is done through 2 queries in the GenericDao https://github.com/apache/cloudstack/blob/master/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java#L1323 and if you encounter the right conditions, the VM will be marked as removed in between those 2 queries. This results in having a Pair result with at least one object but a count of 0. Then following how is done the serialization of the response at https://github.com/apache/cloudstack/blob/master/server/src/main/java/com/cloud/api/response/ApiResponseSerializer.java#L86 you will reach the case where your output is the one previously mentioned.

To overcome this issue, there isn't a true fix but only a better pair response to ensure a correct response formatting. If the result set contains at least something, the count cannot be 0 but we cannot guess the correct answer, but only state it has at least one element.
