### PR TITLE
CLOUDSTACK-10321: CPU Cap for KVM

### DIFF
--- a/api/src/com/cloud/agent/api/to/VirtualMachineTO.java
+++ b/api/src/com/cloud/agent/api/to/VirtualMachineTO.java
@@ -70,6 +70,8 @@ public class VirtualMachineTO {
     String configDriveIsoRootFolder = null;
     String configDriveIsoFile = null;
 
+    Double cpuQuotaPercentage = null;
+
     Map<String, String> guestOsDetails = new HashMap<String, String>();
 
     public VirtualMachineTO(long id, String instanceName, VirtualMachine.Type type, int cpus, Integer speed, long minRam, long maxRam, BootloaderType bootloader,
@@ -339,5 +341,13 @@ public class VirtualMachineTO {
 
     public void setGuestOsDetails(Map<String, String> guestOsDetails) {
         this.guestOsDetails = guestOsDetails;
+    }
+
+    public Double getCpuQuotaPercentage() {
+        return cpuQuotaPercentage;
+    }
+
+    public void setCpuQuotaPercentage(Double cpuQuotaPercentage) {
+        this.cpuQuotaPercentage = cpuQuotaPercentage;
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1993,12 +1993,19 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             int period = CpuTuneDef.DEFAULT_PERIOD;
             int quota = (int) (period * cpuQuotaPercentage);
             if (quota < CpuTuneDef.MIN_QUOTA) {
+                s_logger.info("Calculated quota (" + quota + ") below the minimum (" + CpuTuneDef.MIN_QUOTA + ") for VM domain " + vmTO.getUuid() + ", setting it to minimum " +
+                        "and calculating period instead of using the default");
                 quota = CpuTuneDef.MIN_QUOTA;
                 period = (int) ((double) quota / cpuQuotaPercentage);
+                if (period > CpuTuneDef.MAX_PERIOD) {
+                    s_logger.info("Calculated period (" + period + ") exceeds the maximum (" + CpuTuneDef.MAX_PERIOD +
+                            "), setting it to the maximum");
+                    period = CpuTuneDef.MAX_PERIOD;
+                }
             }
             ctd.setQuota(quota);
             ctd.setPeriod(period);
-            s_logger.info("Setting quota=" + quota + ", period=" + period + " to VM domain " + vmTO.getId());
+            s_logger.info("Setting quota=" + quota + ", period=" + period + " to VM domain " + vmTO.getUuid());
         }
     }
 

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1175,6 +1175,7 @@ public class LibvirtVMDef {
         private int period = 0;
         static final int DEFAULT_PERIOD = 10000;
         static final int MIN_QUOTA = 1000;
+        static final int MAX_PERIOD = 1000000;
 
         public void setShares(int shares) {
             _shares = shares;

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1171,6 +1171,10 @@ public class LibvirtVMDef {
 
     public static class CpuTuneDef {
         private int _shares = 0;
+        private int quota = 0;
+        private int period = 0;
+        static final int DEFAULT_PERIOD = 10000;
+        static final int MIN_QUOTA = 1000;
 
         public void setShares(int shares) {
             _shares = shares;
@@ -1180,12 +1184,34 @@ public class LibvirtVMDef {
             return _shares;
         }
 
+        public int getQuota() {
+            return quota;
+        }
+
+        public void setQuota(int quota) {
+            this.quota = quota;
+        }
+
+        public int getPeriod() {
+            return period;
+        }
+
+        public void setPeriod(int period) {
+            this.period = period;
+        }
+
         @Override
         public String toString() {
             StringBuilder cpuTuneBuilder = new StringBuilder();
             cpuTuneBuilder.append("<cputune>\n");
             if (_shares > 0) {
                 cpuTuneBuilder.append("<shares>" + _shares + "</shares>\n");
+            }
+            if (quota > 0) {
+                cpuTuneBuilder.append("<quota>" + quota + "</quota>\n");
+            }
+            if (period > 0) {
+                cpuTuneBuilder.append("<period>" + period + "</period>\n");
             }
             cpuTuneBuilder.append("</cputune>\n");
             return cpuTuneBuilder.toString();

--- a/server/src/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/com/cloud/hypervisor/KVMGuru.java
@@ -82,17 +82,21 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
             if (host == null) {
                 throw new CloudRuntimeException("Host with id: " + vm.getHostId() + " not found");
             }
-            s_logger.debug("Limiting CPU usage for VM " + vm.getId() + " on host " + host.getId());
+            s_logger.debug("Limiting CPU usage for VM: " + vm.getUuid() + " on host: " + host.getUuid());
             double hostMaxSpeed = getHostCPUSpeed(host);
             double maxSpeed = getVmSpeed(to);
             try {
                 BigDecimal percent = new BigDecimal(maxSpeed / hostMaxSpeed);
                 percent = percent.setScale(2, RoundingMode.HALF_DOWN);
+                if (percent.compareTo(new BigDecimal(1)) == 1) {
+                    s_logger.debug("VM " + vm.getUuid() + " CPU MHz exceeded host " + host.getUuid() + " CPU MHz, limiting VM CPU to the host maximum");
+                    percent = new BigDecimal(1);
+                }
                 to.setCpuQuotaPercentage(percent.doubleValue());
-                s_logger.debug("Host " + host.getId() + " max CPU speed = " + hostMaxSpeed + "MHz, VM " + vm.getId() +
+                s_logger.debug("Host: " + host.getUuid() + " max CPU speed = " + hostMaxSpeed + "MHz, VM: " + vm.getUuid() +
                         "max CPU speed = " + maxSpeed + "MHz. Setting CPU quota percentage as: " + percent.doubleValue());
             } catch (NumberFormatException e) {
-                s_logger.error("Error calculating vm quota percentage, it wll not be set: " + e.getMessage());
+                s_logger.error("Error calculating VM: " + vm.getUuid() + " quota percentage, it wll not be set. Error: " + e.getMessage(), e);
             }
         }
     }

--- a/server/src/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/com/cloud/hypervisor/KVMGuru.java
@@ -28,11 +28,16 @@ import com.cloud.storage.GuestOSVO;
 import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.storage.dao.GuestOSHypervisorDao;
 import com.cloud.utils.Pair;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
+import org.apache.log4j.Logger;
 
 import javax.inject.Inject;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Map;
 
 public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
@@ -43,6 +48,8 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
     @Inject
     HostDao _hostDao;
 
+    public static final Logger s_logger = Logger.getLogger(KVMGuru.class);
+
     @Override
     public HypervisorType getHypervisorType() {
         return HypervisorType.KVM;
@@ -52,10 +59,49 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
         super();
     }
 
+    /**
+     * Retrieve host max CPU speed
+     */
+    protected double getHostCPUSpeed(HostVO host) {
+        return host.getSpeed();
+    }
+
+    protected double getVmSpeed(VirtualMachineTO to) {
+        return to.getMaxSpeed() != null ? to.getMaxSpeed() : to.getSpeed();
+    }
+
+    /**
+    * Set VM CPU quota percentage with respect to host CPU on 'to' if CPU limit option is set
+    * @param to vm to
+    * @param vmProfile vm profile
+    */
+    protected void setVmQuotaPercentage(VirtualMachineTO to, VirtualMachineProfile vmProfile) {
+        if (to.getLimitCpuUse()) {
+            VirtualMachine vm = vmProfile.getVirtualMachine();
+            HostVO host = _hostDao.findById(vm.getHostId());
+            if (host == null) {
+                throw new CloudRuntimeException("Host with id: " + vm.getHostId() + " not found");
+            }
+            s_logger.debug("Limiting CPU usage for VM " + vm.getId() + " on host " + host.getId());
+            double hostMaxSpeed = getHostCPUSpeed(host);
+            double maxSpeed = getVmSpeed(to);
+            try {
+                BigDecimal percent = new BigDecimal(maxSpeed / hostMaxSpeed);
+                percent = percent.setScale(2, RoundingMode.HALF_DOWN);
+                to.setCpuQuotaPercentage(percent.doubleValue());
+                s_logger.debug("Host " + host.getId() + " max CPU speed = " + hostMaxSpeed + "MHz, VM " + vm.getId() +
+                        "max CPU speed = " + maxSpeed + "MHz. Setting CPU quota percentage as: " + percent.doubleValue());
+            } catch (NumberFormatException e) {
+                s_logger.error("Error calculating vm quota percentage, it wll not be set: " + e.getMessage());
+            }
+        }
+    }
+
     @Override
 
     public VirtualMachineTO implement(VirtualMachineProfile vm) {
         VirtualMachineTO to = toVirtualMachineTO(vm);
+        setVmQuotaPercentage(to, vm);
 
         // Determine the VM's OS description
         GuestOSVO guestOS = _guestOsDao.findByIdIncludingRemoved(vm.getVirtualMachine().getGuestOSId());

--- a/server/test/com/cloud/hypervisor/KVMGuruTest.java
+++ b/server/test/com/cloud/hypervisor/KVMGuruTest.java
@@ -89,4 +89,11 @@ public class KVMGuruTest {
         Mockito.verify(vmProfile, Mockito.never()).getVirtualMachine();
         Mockito.verify(vmTO, Mockito.never()).setCpuQuotaPercentage(Mockito.anyDouble());
     }
+
+    @Test
+    public void testSetVmQuotaPercentageOverProvision() {
+        Mockito.when(vmTO.getMaxSpeed()).thenReturn(3000);
+        guru.setVmQuotaPercentage(vmTO, vmProfile);
+        Mockito.verify(vmTO).setCpuQuotaPercentage(1d);
+    }
 }

--- a/server/test/com/cloud/hypervisor/KVMGuruTest.java
+++ b/server/test/com/cloud/hypervisor/KVMGuruTest.java
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.hypervisor;
+
+import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineProfile;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KVMGuruTest {
+
+    @Mock
+    HostDao hostDao;
+
+    @Spy
+    @InjectMocks
+    private KVMGuru guru = new KVMGuru();
+
+    @Mock
+    VirtualMachineTO vmTO;
+    @Mock
+    VirtualMachineProfile vmProfile;
+    @Mock
+    VirtualMachine vm;
+    @Mock
+    HostVO host;
+
+    private static final long hostId = 1l;
+
+    @Before
+    public void setup() {
+        Mockito.when(vmTO.getLimitCpuUse()).thenReturn(true);
+        Mockito.when(vmProfile.getVirtualMachine()).thenReturn(vm);
+        Mockito.when(vm.getHostId()).thenReturn(hostId);
+        Mockito.when(hostDao.findById(hostId)).thenReturn(host);
+        Mockito.when(host.getCpus()).thenReturn(3);
+        Mockito.when(host.getSpeed()).thenReturn(1995l);
+        Mockito.when(vmTO.getMaxSpeed()).thenReturn(500);
+    }
+
+    @Test
+    public void testSetVmQuotaPercentage() {
+        guru.setVmQuotaPercentage(vmTO, vmProfile);
+        Mockito.verify(vmTO).setCpuQuotaPercentage(Mockito.anyDouble());
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testSetVmQuotaPercentageNullHost() {
+        Mockito.when(hostDao.findById(hostId)).thenReturn(null);
+        guru.setVmQuotaPercentage(vmTO, vmProfile);
+    }
+
+    @Test
+    public void testSetVmQuotaPercentageZeroDivision() {
+        Mockito.when(host.getSpeed()).thenReturn(0l);
+        guru.setVmQuotaPercentage(vmTO, vmProfile);
+        Mockito.verify(vmTO, Mockito.never()).setCpuQuotaPercentage(Mockito.anyDouble());
+    }
+
+    @Test
+    public void testSetVmQuotaPercentageNotCPULimit() {
+        Mockito.when(vmTO.getLimitCpuUse()).thenReturn(false);
+        guru.setVmQuotaPercentage(vmTO, vmProfile);
+        Mockito.verify(vmProfile, Mockito.never()).getVirtualMachine();
+        Mockito.verify(vmTO, Mockito.never()).setCpuQuotaPercentage(Mockito.anyDouble());
+    }
+}

--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -31,9 +31,12 @@ from marvin.lib.common import (list_service_offering,
                                list_virtual_machines,
                                get_domain,
                                get_zone,
-                               get_test_template)
+                               get_template)
 from nose.plugins.attrib import attr
 
+import time
+from marvin.sshClient import SshClient
+from marvin.lib.decoratorGenerators import skipTestIf
 
 _multiprocess_shared_ = True
 
@@ -163,13 +166,13 @@ class TestServiceOfferings(cloudstackTestCase):
             cls.apiclient,
             cls.services["service_offerings"]["tiny"]
         )
-        template = get_test_template(
+        template = get_template(
             cls.apiclient,
             cls.zone.id,
             cls.hypervisor
         )
         if template == FAILED:
-            assert False, "get_test_template() failed to return template"
+            assert False, "get_template() failed to return template"
 
         # Set Zones and disk offerings
         cls.services["small"]["zoneid"] = cls.zone.id
@@ -399,4 +402,163 @@ class TestServiceOfferings(cloudstackTestCase):
                           ),
             "Check Memory(kb) for small offering"
         )
+        return
+
+class TestCpuCapServiceOfferings(cloudstackTestCase):
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.dbclient = self.testClient.getDbConnection()
+        self.cleanup = []
+
+    def tearDown(self):
+        try:
+            # Clean up, terminate the created templates
+            cleanup_resources(self.apiclient, self.cleanup)
+
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+
+        return
+
+    def get_ssh_client(self, id, public_ip, username, password, retries):
+        """ Setup ssh client connection and return connection
+        vm requires attributes public_ip, public_port, username, password """
+
+        try:
+            ssh_client = SshClient(
+                public_ip,
+                22,
+                username,
+                password,
+                retries)
+
+        except Exception as e:
+            self.fail("Unable to create ssh connection: " % e)
+
+        self.assertIsNotNone(
+            ssh_client, "Failed to setup ssh connection to host=%s on public_ip=%s" % (id, public_ip))
+
+        return ssh_client
+
+    @classmethod
+    def setUpClass(cls):
+        testClient = super(TestCpuCapServiceOfferings, cls).getClsTestClient()
+        cls.apiclient = testClient.getApiClient()
+        cls.services = testClient.getParsedTestDataConfig()
+        cls.hypervisor = testClient.getHypervisorInfo()
+
+        cls.hypervisorNotSupported = False
+        if cls.hypervisor.lower() not in ["kvm"]:
+            cls.hypervisorNotSupported = True
+            return
+
+        domain = get_domain(cls.apiclient)
+        cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+
+        template = get_template(cls.apiclient, cls.zone.id, cls.hypervisor)
+        if template == FAILED:
+            assert False, "get_template() failed to return template"
+
+        cls.services["small"]["zoneid"] = cls.zone.id
+        cls.services["small"]["template"] = template.id
+        cls.services["small"]["hypervisor"] = cls.hypervisor
+
+        cls.account = Account.create(
+            cls.apiclient,
+            cls.services["account"],
+            domainid=domain.id
+        )
+
+        offering_data = {
+            'displaytext': 'TestOffering',
+            'cpuspeed': 512,
+            'cpunumber': 2,
+            'name': 'TestOffering',
+            'memory': 1024
+        }
+
+        cls.offering = ServiceOffering.create(
+            cls.apiclient,
+            offering_data,
+            limitcpuuse=True
+        )
+        cls.vm = VirtualMachine.create(
+            cls.apiclient,
+            cls.services["small"],
+            accountid=cls.account.name,
+            domainid=cls.account.domainid,
+            serviceofferingid=cls.offering.id,
+            mode=cls.services["mode"]
+        )
+        cls._cleanup = [
+            cls.offering,
+            cls.account
+        ]
+        return
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.apiclient = super(
+                TestCpuCapServiceOfferings,
+                cls).getClsTestClient().getApiClient()
+            # Clean up, terminate the created templates
+            cleanup_resources(cls.apiclient, cls._cleanup)
+
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    @skipTestIf("hypervisorNotSupported")
+    @attr(tags=["advanced", "advancedns", "smoke"], required_hardware="true")
+    def test_01_service_offering_cpu_limit_use(self):
+        """
+        Test CPU Cap on KVM
+        """
+        if self.hypervisor.lower() not in ["kvm"]:
+            self.skipTest("CPU Cap test is supported on KVM")
+
+        qresultset = self.dbclient.execute(
+            "select public_ip_address, id from host where uuid = '%s';" % str(self.vm.hostid)
+        )
+        self.assertEquals(1, len(qresultset), "Check DB Query result set")
+        qresult = qresultset[0]
+        host_ip_address = qresult[0]
+        host_id = qresult[1]
+
+        qresultset = self.dbclient.execute(
+            "select name, value from host_details where host_id = '%s' and name in ('username', 'password');" % str(host_id)
+        )
+        self.assertEquals(2, len(qresultset), "Check DB Query result set")
+        host_username = None
+        host_password = None
+
+        for res in qresultset:
+            if res[0] == "username":
+                host_username = res[1]
+            else:
+                host_password = res[1]
+
+        #Execute loop command in background on the VM
+        ssh_vm = self.vm.get_ssh_client(reconnect=True)
+        ssh_vm.execute("echo 'while true; do x=$(($x+1)); done' > cputest.sh")
+        ssh_vm.execute("sh cputest.sh > /dev/null 2>&1 &")
+
+        ssh_host = self.get_ssh_client(host_id, host_ip_address, host_username, host_password, 10)
+
+        #Get host CPU usage from top command before and after VM consuming 100% CPU
+        cpu_usage_cmd = "top -b n 2 -d 1 | grep '^%Cpu' | tail -n 1 | awk '{print $2+$4+$6}'"
+        host_cpu_usage_before_str = ssh_host.execute(cpu_usage_cmd)[0]
+        host_cpu_usage_before = round(float(host_cpu_usage_before_str))
+        self.debug("Host CPU usage before the infinite loop on the VM: " + str(host_cpu_usage_before))
+        time.sleep(5)
+        host_cpu_usage_after_str = ssh_host.execute(cpu_usage_cmd)[0]
+        host_cpu_usage_after = round(float(host_cpu_usage_after_str))
+        self.debug("Host CPU usage after the infinite loop on the VM: " + str(host_cpu_usage_after))
+
+        limit = 95
+        self.assertTrue(host_cpu_usage_after < limit, "Host CPU usage after VM usage increased is high")
+
         return

--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -537,16 +537,19 @@ class TestCpuCapServiceOfferings(cloudstackTestCase):
 
         for res in qresultset:
             if res[0] == "username":
-                host_username = res[1]
+                host_username = str(res[1])
             else:
-                host_password = res[1]
+                host_password = str(res[1])
+
+        if host_username is None or host_password is None:
+            self.skipTest("Host details cannot be retrieved, skipping test")
+
+        ssh_host = self.get_ssh_client(host_id, host_ip_address, host_username, host_password, 10)
 
         #Execute loop command in background on the VM
         ssh_vm = self.vm.get_ssh_client(reconnect=True)
         ssh_vm.execute("echo 'while true; do x=$(($x+1)); done' > cputest.sh")
         ssh_vm.execute("sh cputest.sh > /dev/null 2>&1 &")
-
-        ssh_host = self.get_ssh_client(host_id, host_ip_address, host_username, host_password, 10)
 
         #Get host CPU usage from top command before and after VM consuming 100% CPU
         cpu_usage_cmd = "top -b n 2 -d 1 | grep '^%Cpu' | tail -n 1 | awk '{print $2+$4+$6}'"

--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -541,8 +541,11 @@ class TestCpuCapServiceOfferings(cloudstackTestCase):
         ssh_host = self.get_ssh_client(self.host.id, self.host.ipaddress, self.hostConfig["username"], self.hostConfig["password"], 10)
 
         #Get host CPU usage from top command before and after VM consuming 100% CPU
-        cpu_usage_cmd = "top -b n 2 -d 1 | grep '^%Cpu' | tail -n 1 | awk '{print $2+$4+$6}'"
+        find_pid_cmd = "ps -ax | grep '%s' | head -1 | awk '{print $1}'" % self.vm.id
+        pid = ssh_host.execute(find_pid_cmd)[0]
+        cpu_usage_cmd = "top -b n 1 p %s | tail -1 | awk '{print $9}'" % pid
         host_cpu_usage_before_str = ssh_host.execute(cpu_usage_cmd)[0]
+
         host_cpu_usage_before = round(float(host_cpu_usage_before_str))
         self.debug("Host CPU usage before the infinite loop on the VM: " + str(host_cpu_usage_before))
 


### PR DESCRIPTION
JIRA Ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-10321

## Context
Libvirt has the concept of a 'period' and a 'quota'. If the period is 10000 microseconds, a quote can be set, say 5000 and the VM CPU will be limited to only using 5000 microseconds of CPU every 10000 microseconds. 
This patch basically looks at the host CPU MHz (say 2000 MHz), looks at the VM's configured MHz (say 500 MHz), comes up with a percent (25%), then uses that against the period to come up with a quota number (2500). Additionally, it only applies appropriately when the service offering has the CPU cap option set/checkmarked.

## Solution
These changes are restricted to the KVM hypervisor plugin, where creation of a VM (spec) will consider CPU cap (max speed) defined in the service offering to define and set quota/limits in the VM’s spec. This will set quota based on a fixed/pre-defined period value, and add respective flag/nodes in the VM/domain XML as documented here: https://libvirt.org/formatdomain.html#elementsCPUTuning 

## Behavior
- Setting the CPU cap option on a service offering must cause the VM created with that CPU offering, to run at the MHz value set until the core it is running on becomes contended (under KVM)
- If the CPU cap option is set in a service offering and the core that a VM is running on becomes contended, then (under KVM) the VM should receive the appropriate MHz according to its and the other VMs MHz values translated as 'shares' values.  (this is the current behaviour for contended and uncontended cores).