### PR TITLE
createNetworkACL: number has the wrong doc

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkACLCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/CreateNetworkACLCmd.java
@@ -91,7 +91,7 @@ public class CreateNetworkACLCmd extends BaseAsyncCreateCmd {
         + "can be ingress or egress, defaulted to ingress if not specified")
     private String trafficType;
 
-    @Parameter(name = ApiConstants.NUMBER, type = CommandType.INTEGER, description = "The network of the VM the ACL will be created for")
+    @Parameter(name = ApiConstants.NUMBER, type = CommandType.INTEGER, description = "The number of the ACL item, its ordering")
     private Integer number;
 
     @Parameter(name = ApiConstants.ACTION, type = CommandType.STRING, description = "scl entry action, allow or deny")


### PR DESCRIPTION
`number` contains the doc from another field.

![screenshot from 2018-03-12 14-30-16](https://user-images.githubusercontent.com/1388/37286338-ee6e8890-2601-11e8-94ec-341b940251c2.png)

http://cloudstack.apache.org/api/apidocs-4.11/apis/createNetworkACL.html