### PR TITLE
Create database upgrade from 4.11.0.0 to 4.11.1.0 & VMWare version to OS mappings

### DIFF
--- a/engine/schema/resources/META-INF/db/schema-41100to41110-cleanup.sql
+++ b/engine/schema/resources/META-INF/db/schema-41100to41110-cleanup.sql
@@ -1,0 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.11.0.0 to 4.11.1.0
+--;

--- a/engine/schema/resources/META-INF/db/schema-41100to41110.sql
+++ b/engine/schema/resources/META-INF/db/schema-41100to41110.sql
@@ -1,0 +1,81 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+--;
+-- Schema upgrade from 4.11.0.0 to 4.11.1.0
+--;
+
+-- VMWare hypervisor guest OS mappings
+
+DELETE from`cloud`.`guest_os_hypervisor` WHERE guest_os_id='269' AND hypervisor_version = '6.0' AND hypervisor_type='VMware';
+DELETE from`cloud`.`guest_os_hypervisor` WHERE guest_os_id='270' AND hypervisor_version = '6.0' AND hypervisor_type='VMware';
+
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.0', 'debian6_64Guest', 133, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.0', 'debian6Guest', 132, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'centosGuest', 171, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'centosGuest', 179, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'debian6_64Guest', 133, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'debian6Guest', 132, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.1', 'debian7_64Guest', 184, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'centos6Guest', 171, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'centos6Guest', 179, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'debian6_64Guest', 133, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'debian6Guest', 132, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '5.5', 'debian7_64Guest', 184, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centos64Guest', 172, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centos64Guest', 178, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centos64Guest', 180, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centos64Guest', 182, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centos64Guest', 228, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centosGuest', 177, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centosGuest', 181, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'centosGuest', 227, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'debian6_64Guest', 133, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'debian6Guest', 132, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'debian7_64Guest', 184, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.0', 'debian8Guest', 269, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6_64Guest', 172, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6_64Guest', 178, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6_64Guest', 180, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6_64Guest', 182, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6_64Guest', 228, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos64Guest', 174, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos64Guest', 176, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6Guest', 177, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6Guest', 181, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centos6Guest', 227, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centosGuest', 173, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'centosGuest', 175, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'debian6_64Guest', 133, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'debian6Guest', 132, now(), 0);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'VMware', '6.5', 'debian7_64Guest', 184, now(), 0);
+
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos6_64Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='144';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos6_64Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='262';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos6_64Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='264';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos64Guest' WHERE `hypervisor_version`='default' AND hypervisor_type='VmWare' AND guest_os_id='162';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos6Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='143';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos6Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='261';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos6Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='263';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos7_64Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='246';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos7_64Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='260';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='centos7_64Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='274';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='debian5_64Guest' WHERE `hypervisor_version`='5.0' AND hypervisor_type='VMware' AND guest_os_id='15';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='debian5_64Guest' WHERE `hypervisor_version`='5.1' AND hypervisor_type='VMware' AND guest_os_id='15';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='debian5_64Guest' WHERE `hypervisor_version`='5.5' AND hypervisor_type='VMware' AND guest_os_id='15';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='debian5_64Guest' WHERE `hypervisor_version`='6.0' AND hypervisor_type='VMware' AND guest_os_id='15';
+UPDATE `cloud`.`guest_os_hypervisor` SET `guest_os_name`='debian5_64Guest' WHERE `hypervisor_version`='6.5' AND hypervisor_type='VMware' AND guest_os_id='15';

--- a/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -68,6 +68,7 @@ import com.cloud.upgrade.dao.Upgrade4910to4920;
 import com.cloud.upgrade.dao.Upgrade4920to4930;
 import com.cloud.upgrade.dao.Upgrade4930to41000;
 import com.cloud.upgrade.dao.Upgrade41000to41100;
+import com.cloud.upgrade.dao.Upgrade41100to41110;
 import com.cloud.upgrade.dao.UpgradeSnapshot217to224;
 import com.cloud.upgrade.dao.UpgradeSnapshot223to224;
 import com.cloud.upgrade.dao.VersionDao;
@@ -120,7 +121,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(),
                 new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(),
                 new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(),
-                new Upgrade41000to41100()});
+                new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.1.8"),
             new DbUpgrade[] {new Upgrade218to22(), new Upgrade221to222(), new UpgradeSnapshot217to224(), new Upgrade222to224(), new Upgrade218to224DomainVlans(),
@@ -138,7 +139,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(),
                 new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(),
                 new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.1"),
             new DbUpgrade[] {new Upgrade221to222(), new UpgradeSnapshot223to224(), new Upgrade222to224(), new Upgrade224to225(), new Upgrade225to226(), new Upgrade227to228(),
@@ -146,7 +147,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(),
                 new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(),
                 new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.2"),
             new DbUpgrade[] {new Upgrade222to224(), new UpgradeSnapshot223to224(), new Upgrade224to225(), new Upgrade225to226(), new Upgrade227to228(), new Upgrade228to229(),
@@ -154,7 +155,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(),
                 new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(),
                 new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.3"),
             new DbUpgrade[] {new Upgrade222to224(), new UpgradeSnapshot223to224(), new Upgrade224to225(), new Upgrade225to226(), new Upgrade227to228(), new Upgrade228to229(),
@@ -162,7 +163,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(),
                 new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(),
                 new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.4"),
             new DbUpgrade[] {new Upgrade224to225(), new Upgrade225to226(), new Upgrade227to228(), new Upgrade228to229(), new Upgrade229to2210(), new Upgrade2210to2211(),
@@ -170,7 +171,7 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(),
                 new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(),
                 new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.5"),
             new DbUpgrade[] {new Upgrade225to226(), new Upgrade227to228(), new Upgrade228to229(), new Upgrade229to2210(), new Upgrade2210to2211(), new Upgrade2211to2212(),
@@ -178,273 +179,283 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
                 new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(),
                 new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(),
                 new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(),
-                new Upgrade41000to41100()});
+                new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.6"),
             new DbUpgrade[] {new Upgrade227to228(), new Upgrade228to229(), new Upgrade229to2210(), new Upgrade2210to2211(), new Upgrade2211to2212(), new Upgrade2212to2213(),
                 new Upgrade2213to2214(), new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(),
                 new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(),
                 new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(),
-                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.7"),
             new DbUpgrade[] {new Upgrade227to228(), new Upgrade228to229(), new Upgrade229to2210(), new Upgrade2210to2211(), new Upgrade2211to2212(), new Upgrade2212to2213(),
                 new Upgrade2213to2214(), new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(),
                 new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(),
                 new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(),
-                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.8"),
             new DbUpgrade[] {new Upgrade228to229(), new Upgrade229to2210(), new Upgrade2210to2211(), new Upgrade2211to2212(), new Upgrade2212to2213(), new Upgrade2213to2214(),
                 new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(),
                 new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(),
                 new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.9"),
             new DbUpgrade[] {new Upgrade229to2210(), new Upgrade2210to2211(), new Upgrade2211to2212(), new Upgrade2212to2213(), new Upgrade2213to2214(), new Upgrade2214to30(),
                 new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(),
                 new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(),
                 new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.10"),
             new DbUpgrade[] {new Upgrade2210to2211(), new Upgrade2211to2212(), new Upgrade2212to2213(), new Upgrade2213to2214(), new Upgrade2214to30(), new Upgrade30to301(),
                 new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(),
                 new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(),
                 new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.12"),
             new DbUpgrade[] {new Upgrade2212to2213(), new Upgrade2213to2214(), new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(),
                 new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(),
                 new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(),
                 new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.13"),
             new DbUpgrade[] {new Upgrade2213to2214(), new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(),
                 new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(),
                 new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(),
                 new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(),
-                new Upgrade41000to41100()});
+                new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.14"),
             new DbUpgrade[] {new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(),
                 new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(),
                 new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(),
-                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("3.0.0"),
             new DbUpgrade[] {new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(),
                 new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(),
                 new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("3.0.1"),
             new DbUpgrade[] {new Upgrade301to302(), new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(),
                 new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(),
                 new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("3.0.2"),
             new DbUpgrade[] {new Upgrade302to40(), new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(),
                 new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(),
                 new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.0.0"),
             new DbUpgrade[] {new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(),
                 new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(),
                 new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.0.1"),
             new DbUpgrade[] {new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(),
                 new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(),
                 new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.0.2"),
             new DbUpgrade[] {new Upgrade40to41(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(),
                 new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(),
                 new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.1.0"),
             new DbUpgrade[] {new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(),
                 new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(),
                 new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.1.1"),
             new DbUpgrade[] {new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(),
                 new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(),
                 new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.2.0"),
             new DbUpgrade[] {new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(),
                 new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(),
                 new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(),
-                new Upgrade41000to41100()});
+                new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.2.1"),
             new DbUpgrade[] {new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(),
                 new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(),
-                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.3.0"),
             new DbUpgrade[] {new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(),
                 new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.3.1"),
             new DbUpgrade[] {new Upgrade431to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(),
                 new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.3.2"),
             new DbUpgrade[] {new Upgrade432to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(),
                 new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.4.0"),
             new DbUpgrade[] {new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(),
                 new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.4.1"),
             new DbUpgrade[] {new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(),
                 new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.4.2"),
             new DbUpgrade[] {new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(),
                 new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.4.3"),
             new DbUpgrade[] {new Upgrade443to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(),
                 new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.4.4"),
             new DbUpgrade[] {new Upgrade444to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(),
                 new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.5.0"),
             new DbUpgrade[] {new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(),
                 new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.5.1"),
             new DbUpgrade[] {new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(),
                 new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(),
-                new Upgrade41000to41100()});
+                new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.5.2"),
             new DbUpgrade[] {new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(),
-                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                    new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.5.3"),
             new DbUpgrade[] {new Upgrade453to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(),
-                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.6.0"),
             new DbUpgrade[] {new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.6.1"),
             new DbUpgrade[] {new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.6.2"),
             new DbUpgrade[] {new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.7.0"),
             new DbUpgrade[] {new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.7.1"),
             new DbUpgrade[] {new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.7.2"),
             new DbUpgrade[] {new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(),
-                new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.8.0"),
             new DbUpgrade[] {new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(),
-                new Upgrade41000to41100()});
+                new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.8.1"),
-            new DbUpgrade[] {new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+            new DbUpgrade[] {new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.8.2.0"),
-            new DbUpgrade[] {new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+            new DbUpgrade[] {new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.9.0"),
-            new DbUpgrade[] {new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+            new DbUpgrade[] {new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.9.1.0"),
-            new DbUpgrade[] {new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+            new DbUpgrade[] {new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.9.2.0"),
-            new DbUpgrade[] {new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+            new DbUpgrade[] {new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.9.3.0"),
-            new DbUpgrade[] {new Upgrade4930to41000(), new Upgrade41000to41100()});
+            new DbUpgrade[] {new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("4.10.0.0"),
-            new DbUpgrade[] {new Upgrade41000to41100()});
+            new DbUpgrade[] {new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         //CP Upgrades
         _upgradeMap.put(CloudStackVersion.parse("3.0.3"),
             new DbUpgrade[] {new Upgrade303to304(), new Upgrade304to305(), new Upgrade305to306(), new Upgrade306to307(), new Upgrade307to410(), new Upgrade410to420(),
                 new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(),
                 new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(),
-                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(),
+                new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("3.0.4"),
             new DbUpgrade[] {new Upgrade304to305(), new Upgrade305to306(), new Upgrade306to307(), new Upgrade307to410(), new Upgrade410to420(), new Upgrade420to421(),
                 new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(),
                 new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(),
-                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade490to4910(), new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("3.0.5"),
             new DbUpgrade[] {new Upgrade305to306(), new Upgrade306to307(), new Upgrade307to410(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(),
                 new Upgrade430to440(), new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(),
                 new Upgrade460to461(), new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(),
-                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4910to4920(), new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("3.0.6"),
             new DbUpgrade[] {new Upgrade306to307(), new Upgrade307to410(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(),
                 new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(),
                 new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("3.0.7"),
             new DbUpgrade[] {new Upgrade307to410(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(), new Upgrade440to441(),
                 new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(), new Upgrade461to470(),
                 new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.15"),
             new DbUpgrade[] {new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to303(), new Upgrade303to304(), new Upgrade304to305(),
                 new Upgrade305to306(), new Upgrade306to307(), new Upgrade307to410(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(),
                 new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(),
                 new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         _upgradeMap.put(CloudStackVersion.parse("2.2.16"),
             new DbUpgrade[] {new Upgrade2214to30(), new Upgrade30to301(), new Upgrade301to302(), new Upgrade302to303(), new Upgrade303to304(), new Upgrade304to305(),
                 new Upgrade305to306(), new Upgrade306to307(), new Upgrade307to410(), new Upgrade410to420(), new Upgrade420to421(), new Upgrade421to430(), new Upgrade430to440(),
                 new Upgrade440to441(), new Upgrade441to442(), new Upgrade442to450(), new Upgrade450to451(), new Upgrade451to452(), new Upgrade452to460(), new Upgrade460to461(),
                 new Upgrade461to470(), new Upgrade470to471(), new Upgrade471to480(), new Upgrade480to481(), new Upgrade481to490(), new Upgrade490to4910(), new Upgrade4910to4920(),
-                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100()});
+                new Upgrade4920to4930(), new Upgrade4930to41000(), new Upgrade41000to41100(), new Upgrade41100to41110()});
 
         final List<CloudStackVersion> sortedVersions = newArrayList(_upgradeMap.keySet());
         sort(sortedVersions);

--- a/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
+++ b/engine/schema/src/com/cloud/upgrade/DatabaseUpgradeChecker.java
@@ -411,6 +411,9 @@ public class DatabaseUpgradeChecker implements SystemIntegrityChecker {
         _upgradeMap.put(CloudStackVersion.parse("4.10.0.0"),
             new DbUpgrade[] {new Upgrade41000to41100(), new Upgrade41100to41110()});
 
+        _upgradeMap.put(CloudStackVersion.parse("4.11.0.0"),
+            new DbUpgrade[] {new Upgrade41100to41110()});
+
         //CP Upgrades
         _upgradeMap.put(CloudStackVersion.parse("3.0.3"),
             new DbUpgrade[] {new Upgrade303to304(), new Upgrade304to305(), new Upgrade305to306(), new Upgrade306to307(), new Upgrade307to410(), new Upgrade410to420(),

--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade41100to41110.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade41100to41110.java
@@ -1,0 +1,69 @@
+/*
+ * // Licensed to the Apache Software Foundation (ASF) under one
+ * // or more contributor license agreements.  See the NOTICE file
+ * // distributed with this work for additional information
+ * // regarding copyright ownership.  The ASF licenses this file
+ * // to you under the Apache License, Version 2.0 (the
+ * // "License"); you may not use this file except in compliance
+ * // with the License.  You may obtain a copy of the License at
+ * //
+ * //   http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing,
+ * // software distributed under the License is distributed on an
+ * // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * // KIND, either express or implied.  See the License for the
+ * // specific language governing permissions and limitations
+ * // under the License.
+ */
+
+package com.cloud.upgrade.dao;
+
+import com.cloud.utils.exception.CloudRuntimeException;
+
+import java.io.InputStream;
+import java.sql.Connection;
+
+public class Upgrade41100to41110 implements DbUpgrade {
+    @Override
+    public String[] getUpgradableVersionRange() {
+        return new String[]{"4.11.0.0", "4.11.1.0"};
+    }
+
+    @Override
+    public String getUpgradedVersion() {
+        return "4.11.1.0";
+    }
+
+    @Override
+    public boolean supportsRollingUpgrade() {
+        return false;
+    }
+
+    @Override
+    public InputStream[] getPrepareScripts() {
+        final String scriptFile = "META-INF/db/schema-41100to41110.sql";
+        final InputStream script = Thread.currentThread().getContextClassLoader().getResourceAsStream(scriptFile);
+        if (script == null) {
+            throw new CloudRuntimeException("Unable to find " + scriptFile);
+        }
+
+        return new InputStream[] {script};
+    }
+
+    @Override
+    public void performDataMigration(Connection conn) {
+
+    }
+
+    @Override
+    public InputStream[] getCleanupScripts() {
+        final String scriptFile = "META-INF/db/schema-41100to41110-cleanup.sql";
+        final InputStream script = Thread.currentThread().getContextClassLoader().getResourceAsStream(scriptFile);
+        if (script == null) {
+            throw new CloudRuntimeException("Unable to find " + scriptFile);
+        }
+
+        return new InputStream[] {script};
+    }
+}

--- a/engine/schema/test/com/cloud/upgrade/DatabaseUpgradeCheckerTest.java
+++ b/engine/schema/test/com/cloud/upgrade/DatabaseUpgradeCheckerTest.java
@@ -24,6 +24,7 @@ import com.cloud.upgrade.dao.Upgrade470to471;
 import com.cloud.upgrade.dao.Upgrade471to480;
 import com.cloud.upgrade.dao.Upgrade480to481;
 import com.cloud.upgrade.dao.Upgrade490to4910;
+import com.cloud.upgrade.dao.Upgrade41100to41110;
 import org.apache.cloudstack.utils.CloudStackVersion;
 import org.junit.Test;
 
@@ -70,6 +71,28 @@ public class DatabaseUpgradeCheckerTest {
         assertTrue(upgrades[0] instanceof Upgrade490to4910);
 
         assertTrue(Arrays.equals(new String[] { "4.9.0", currentVersion.toString()}, upgrades[0].getUpgradableVersionRange()));
+        assertEquals(currentVersion.toString(), upgrades[0].getUpgradedVersion());
+
+    }
+
+    @Test
+    public void testCalculateUpgradePath4110to4111() {
+
+        final CloudStackVersion dbVersion = CloudStackVersion.parse("4.11.0.0");
+        assertNotNull(dbVersion);
+
+        final CloudStackVersion currentVersion = CloudStackVersion.parse("4.11.1.0");
+        assertNotNull(currentVersion);
+
+        final DatabaseUpgradeChecker checker = new DatabaseUpgradeChecker();
+        final DbUpgrade[] upgrades = checker.calculateUpgradePath(dbVersion, currentVersion);
+
+        assertNotNull(upgrades);
+        assertTrue(upgrades.length >= 1);
+        assertTrue(upgrades[0] instanceof Upgrade41100to41110);
+
+        assertTrue(Arrays.equals(new String[] { "4.11.0.0", currentVersion.toString()},
+                upgrades[0].getUpgradableVersionRange()));
         assertEquals(currentVersion.toString(), upgrades[0].getUpgradedVersion());
 
     }


### PR DESCRIPTION
Jira ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-10325

Also, add the missing 'VMWare version to OS mappings' SQL in the schema-41100to41110.sql file. This fixes an upgrade failure for certain guest OSs where the Virtual Router fails to start when these version mappings are missing.

Dev Tested the schema-41100to41110.sql file by executing it with the com/cloud/utils/db/ScriptRunner.java class. Before and after data samples confirm a test pass status.