### PR TITLE
CLOUDSTACK-10331: Remove reference to deleted script vm_snapshots.js

### DIFF
--- a/scripts/installer/windows/client.wxs
+++ b/scripts/installer/windows/client.wxs
@@ -437,9 +437,6 @@
                     <Component Id="cmpA9C076F1199B904BB57D1BC96A919814" Guid="{91870ECD-F1AA-4B69-BCEC-9536BA94A0DC}">
                         <File Id="fil4CE0C842A4EF2E3C8322F88626C527E4" KeyPath="yes" Source="!(wix.SourceClient)\scripts\templates.js" />
                     </Component>
-                    <Component Id="cmp429AD4BBE2ABA44D598EF5DC4482C2A4" Guid="{29B7D8A7-D7FB-46C3-8808-4EBE6D848116}">
-                        <File Id="filDFD0025C484842DE376C881CFB81DC80" KeyPath="yes" Source="!(wix.SourceClient)\scripts\vm_snapshots.js" />
-                    </Component>
                     <Component Id="cmpA7B70148FAF23BE9246895B84B8E76EE" Guid="{06FB0332-62B7-4753-A0DA-B4906498D3A6}">
                         <File Id="fil560BA36DCB23B6FD4BCC65D8B062DAE6" KeyPath="yes" Source="!(wix.SourceClient)\scripts\vpc.js" />
                     </Component>
@@ -1948,7 +1945,6 @@
             <ComponentRef Id="cmp71D078D75E83971F80181453EA717D8B" />
             <ComponentRef Id="cmpD605A23799365004C20E5DE80CA738F3" />
             <ComponentRef Id="cmpA9C076F1199B904BB57D1BC96A919814" />
-            <ComponentRef Id="cmp429AD4BBE2ABA44D598EF5DC4482C2A4" />
             <ComponentRef Id="cmpA7B70148FAF23BE9246895B84B8E76EE" />
             <ComponentRef Id="cmpA09401C5AC6539FD960D21860A2494EA" />
             <ComponentRef Id="cmp4EF2024F5F084664B8B4EA6D2CFC68B7" />

--- a/ui/index.html
+++ b/ui/index.html
@@ -1881,7 +1881,6 @@
         <script type="text/javascript" src="scripts/network.js"></script>
         <script type="text/javascript" src="scripts/domains.js"></script>
         <script type="text/javascript" src="scripts/docs.js"></script>
-        <script type="text/javascript" src="scripts/vm_snapshots.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/projectSelect.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/saml.js"></script>
         <script type="text/javascript" src="scripts/ui-custom/ca.js"></script>


### PR DESCRIPTION
## Description
CloudStack main page requests a script "client/scripts/vm_snapshots.js", which does exist since ACS 4.10, causing a HTTP 404 error.

This commit remove the references to this deleted file (deleted in commit a2428508e29)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

Run CloudStack and access to UI.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

