### PR TITLE
CLOUDSTACK-10327: Do not invalidate the session when API command not found

### DIFF
--- a/api/src/main/java/com/cloud/exception/UnavailableCommandException.java
+++ b/api/src/main/java/com/cloud/exception/UnavailableCommandException.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.exception;
+
+import com.cloud.utils.SerialVersionUID;
+
+public class UnavailableCommandException extends PermissionDeniedException {
+
+    private static final long serialVersionUID = SerialVersionUID.UnavailableCommandException;
+
+    protected UnavailableCommandException() {
+        super();
+    }
+
+    public UnavailableCommandException(String msg) {
+        super(msg);
+    }
+
+    public UnavailableCommandException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/plugins/acl/dynamic-role-based/src/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
+++ b/plugins/acl/dynamic-role-based/src/org/apache/cloudstack/acl/DynamicRoleBasedAPIAccessChecker.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.exception.UnavailableCommandException;
 import org.apache.cloudstack.api.APICommand;
 
 import com.cloud.exception.PermissionDeniedException;
@@ -53,8 +54,7 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
     }
 
     private void denyApiAccess(final String commandName) throws PermissionDeniedException {
-        throw new PermissionDeniedException("The API does not exist or is blacklisted for the account's role. " +
-                "The account with is not allowed to request the api: " + commandName);
+        throw new PermissionDeniedException("The API " + commandName + " is blacklisted for the account's role.");
     }
 
     public boolean isDisabled() {
@@ -99,8 +99,7 @@ public class DynamicRoleBasedAPIAccessChecker extends AdapterBase implements API
         }
 
         // Default deny all
-        denyApiAccess(commandName);
-        return false;
+        throw new UnavailableCommandException("The API " + commandName + " does not exist or is not available for this account.");
     }
 
     public void addApiToRoleBasedAnnotationsMap(final RoleType roleType, final String commandName) {

--- a/server/src/com/cloud/api/ApiServer.java
+++ b/server/src/com/cloud/api/ApiServer.java
@@ -34,6 +34,7 @@ import com.cloud.exception.PermissionDeniedException;
 import com.cloud.exception.RequestLimitException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.exception.UnavailableCommandException;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
 import com.cloud.user.DomainManager;
@@ -958,6 +959,9 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
         } catch (final RequestLimitException ex) {
             s_logger.debug(ex.getMessage());
             throw new ServerApiException(ApiErrorCode.API_LIMIT_EXCEED, ex.getMessage());
+        }  catch (final UnavailableCommandException ex) {
+            s_logger.debug(ex.getMessage());
+            throw new ServerApiException(ApiErrorCode.UNSUPPORTED_ACTION_ERROR, ex.getMessage());
         } catch (final PermissionDeniedException ex) {
             final String errorMessage = "The given command '" + commandName + "' either does not exist, is not available" +
                     " for user, or not available from ip address '" + remoteAddress + "'.";

--- a/utils/src/main/java/com/cloud/utils/SerialVersionUID.java
+++ b/utils/src/main/java/com/cloud/utils/SerialVersionUID.java
@@ -68,4 +68,5 @@ public interface SerialVersionUID {
     public static final long NioConnectionException = Base | 0x2c;
     public static final long TaskExecutionException = Base | 0x2d;
     public static final long SnapshotBackupException = Base | 0x2e;
+    public static final long UnavailableCommandException = Base | 0x2f;
 }


### PR DESCRIPTION
## Description

CloudStack SSO (using `security.singlesignon.key`) does not work anymore with CloudStack 4.11, since commit 9988c26, which introduced a regression due to a refactoring: every API request that is not "validated" generates the same error (401 - Unauthorized) and invalidates the session.

However, CloudStack UI executes a call to `listConfigurations` [in method `bypassLoginCheck`](https://github.com/apache/cloudstack/blob/1c99fd73881938/ui/scripts/cloudStack.js#L172). A non-admin user does not have the permissions to execute this request, which causes an error 401:

```
{"listconfigurationsresponse":{"uuidList":[],"errorcode":401,"errortext":"unable to verify user credentials and/or request signature"}}
```

The session (already created by SSO) is then invalidated and the user cannot access to CloudStack UI (error "Session Expired").

Before 9988c26 (up to CloudStack 4.10), an error 432 was returned (and ignored):

```
{"errorresponse":{"uuidList":[],"errorcode":432,"cserrorcode":9999,"errortext":"The user is not allowed to request the API command or the API command does not exist"}}
```

Even if the call to `listConfigurations` was removed, another call to [`listIdps`](https://github.com/apache/cloudstack/blob/1c99fd73881938/ui/scripts/cloudStack.js#L192) also lead to an error 401 for user accounts if the SAML plugin is not enabled.

This pull request aims to fix the SSO issue, by restoring errors 432 (instead of 401 + invalidate session) for commands not available. However, if an API command is explicitly denied using ACLs or if the session key is incorrect, it still generates an error 401 and invalidates the session.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

Compiled and ran CloudStack.

- API commands not explicitly allowed for a role (e.g. `listConfigurations` for a user) generate 432.
- API commands not enabled (e.g. `listIdps` with SAML disabled) generate 432.
- non-existing API commands (e.g. `fooBar`) generate 432

However, API calls with session key removed generate 401 and invalidate session.
SSO is ok.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.