### PR TITLE
Support multiple volume access groups per compute cluster

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -1654,18 +1654,18 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         details.put(ModifyTargetsCommand.STORAGE_HOST, storagePool.getHostAddress());
         details.put(ModifyTargetsCommand.STORAGE_PORT, String.valueOf(storagePool.getPort()));
 
-        ModifyTargetsCommand modifyTargetsCommand = new ModifyTargetsCommand();
+        ModifyTargetsCommand cmd = new ModifyTargetsCommand();
 
         List<Map<String, String>> targets = new ArrayList<>();
 
         targets.add(details);
 
-        modifyTargetsCommand.setTargets(targets);
-        modifyTargetsCommand.setApplyToAllHostsInCluster(true);
-        modifyTargetsCommand.setAdd(add);
-        modifyTargetsCommand.setTargetTypeToRemove(ModifyTargetsCommand.TargetTypeToRemove.DYNAMIC);
+        cmd.setTargets(targets);
+        cmd.setApplyToAllHostsInCluster(true);
+        cmd.setAdd(add);
+        cmd.setTargetTypeToRemove(ModifyTargetsCommand.TargetTypeToRemove.DYNAMIC);
 
-        return modifyTargetsCommand;
+        return cmd;
     }
 
     private List<String> sendModifyTargetsCommand(ModifyTargetsCommand cmd, long hostId) {

--- a/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/api/command/admin/solidfire/GetSolidFireVolumeAccessGroupIdsCmd.java
+++ b/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/api/command/admin/solidfire/GetSolidFireVolumeAccessGroupIdsCmd.java
@@ -26,16 +26,16 @@ import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
-import org.apache.cloudstack.api.response.solidfire.ApiSolidFireVolumeAccessGroupIdResponse;
+import org.apache.cloudstack.api.response.solidfire.ApiSolidFireVolumeAccessGroupIdsResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.solidfire.SolidFireIntegrationTestManager;
 import org.apache.cloudstack.util.solidfire.SolidFireIntegrationTestUtil;
 
-@APICommand(name = "getSolidFireVolumeAccessGroupId", responseObject = ApiSolidFireVolumeAccessGroupIdResponse.class, description = "Get the SF Volume Access Group ID",
+@APICommand(name = "getSolidFireVolumeAccessGroupIds", responseObject = ApiSolidFireVolumeAccessGroupIdsResponse.class, description = "Get the SF Volume Access Group IDs",
         requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
-public class GetSolidFireVolumeAccessGroupIdCmd extends BaseCmd {
-    private static final Logger LOGGER = Logger.getLogger(GetSolidFireVolumeAccessGroupIdCmd.class.getName());
-    private static final String NAME = "getsolidfirevolumeaccessgroupidresponse";
+public class GetSolidFireVolumeAccessGroupIdsCmd extends BaseCmd {
+    private static final Logger LOGGER = Logger.getLogger(GetSolidFireVolumeAccessGroupIdsCmd.class.getName());
+    private static final String NAME = "getsolidfirevolumeaccessgroupidsresponse";
 
     @Parameter(name = ApiConstants.CLUSTER_ID, type = CommandType.STRING, description = "Cluster UUID", required = true)
     private String clusterUuid;
@@ -67,14 +67,14 @@ public class GetSolidFireVolumeAccessGroupIdCmd extends BaseCmd {
 
     @Override
     public void execute() {
-        LOGGER.info("'GetSolidFireVolumeAccessGroupIdCmd.execute' method invoked");
+        LOGGER.info("'GetSolidFireVolumeAccessGroupIdsCmd.execute' method invoked");
 
-        long sfVagId = manager.getSolidFireVolumeAccessGroupId(clusterUuid, storagePoolUuid);
+        long[] sfVagIds = manager.getSolidFireVolumeAccessGroupIds(clusterUuid, storagePoolUuid);
 
-        ApiSolidFireVolumeAccessGroupIdResponse response = new ApiSolidFireVolumeAccessGroupIdResponse(sfVagId);
+        ApiSolidFireVolumeAccessGroupIdsResponse response = new ApiSolidFireVolumeAccessGroupIdsResponse(sfVagIds);
 
         response.setResponseName(getCommandName());
-        response.setObjectName("apisolidfirevolumeaccessgroupid");
+        response.setObjectName("apisolidfirevolumeaccessgroupids");
 
         this.setResponseObject(response);
     }

--- a/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/api/response/solidfire/ApiSolidFireVolumeAccessGroupIdsResponse.java
+++ b/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/api/response/solidfire/ApiSolidFireVolumeAccessGroupIdsResponse.java
@@ -22,12 +22,12 @@ import com.google.gson.annotations.SerializedName;
 
 import org.apache.cloudstack.api.BaseResponse;
 
-public class ApiSolidFireVolumeAccessGroupIdResponse extends BaseResponse {
-    @SerializedName("solidFireVolumeAccessGroupId")
-    @Param(description = "SolidFire Volume Access Group Id")
-    private long solidFireVolumeAccessGroupId;
+public class ApiSolidFireVolumeAccessGroupIdsResponse extends BaseResponse {
+    @SerializedName("solidFireVolumeAccessGroupIds")
+    @Param(description = "SolidFire Volume Access Group Ids")
+    private long[] solidFireVolumeAccessGroupIds;
 
-    public ApiSolidFireVolumeAccessGroupIdResponse(long sfVolumeAccessGroupId) {
-        solidFireVolumeAccessGroupId = sfVolumeAccessGroupId;
+    public ApiSolidFireVolumeAccessGroupIdsResponse(long[] sfVolumeAccessGroupIds) {
+        solidFireVolumeAccessGroupIds = sfVolumeAccessGroupIds;
     }
 }

--- a/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/api/solidfire/ApiSolidFireIntegrationTestServiceImpl.java
+++ b/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/api/solidfire/ApiSolidFireIntegrationTestServiceImpl.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import org.apache.cloudstack.api.command.admin.solidfire.GetPathForVolumeCmd;
 // import org.apache.log4j.Logger;
 import org.apache.cloudstack.api.command.admin.solidfire.GetSolidFireAccountIdCmd;
-import org.apache.cloudstack.api.command.admin.solidfire.GetSolidFireVolumeAccessGroupIdCmd;
+import org.apache.cloudstack.api.command.admin.solidfire.GetSolidFireVolumeAccessGroupIdsCmd;
 import org.apache.cloudstack.api.command.admin.solidfire.GetVolumeSnapshotDetailsCmd;
 import org.apache.cloudstack.api.command.admin.solidfire.GetVolumeiScsiNameCmd;
 import org.apache.cloudstack.api.command.admin.solidfire.GetSolidFireVolumeSizeCmd;
@@ -38,7 +38,7 @@ public class ApiSolidFireIntegrationTestServiceImpl extends AdapterBase implemen
 
         cmdList.add(GetPathForVolumeCmd.class);
         cmdList.add(GetSolidFireAccountIdCmd.class);
-        cmdList.add(GetSolidFireVolumeAccessGroupIdCmd.class);
+        cmdList.add(GetSolidFireVolumeAccessGroupIdsCmd.class);
         cmdList.add(GetVolumeiScsiNameCmd.class);
         cmdList.add(GetSolidFireVolumeSizeCmd.class);
         cmdList.add(GetVolumeSnapshotDetailsCmd.class);

--- a/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/solidfire/SolidFireIntegrationTestManager.java
+++ b/plugins/api/solidfire-intg-test/src/main/java/org/apache/cloudstack/solidfire/SolidFireIntegrationTestManager.java
@@ -18,6 +18,6 @@ package org.apache.cloudstack.solidfire;
 
 public interface SolidFireIntegrationTestManager {
     long getSolidFireAccountId(String csAccountUuid, String storagePoolUuid);
-    long getSolidFireVolumeAccessGroupId(String csClusterUuid, String storagePoolUuid);
+    long[] getSolidFireVolumeAccessGroupIds(String csClusterUuid, String storagePoolUuid);
     long getSolidFireVolumeSize(String volumeUuid);
 }

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -17,13 +17,16 @@
 package org.apache.cloudstack.storage.datastore.util;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.UUID;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -32,8 +35,6 @@ import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailVO;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 
-import com.cloud.dc.ClusterDetailsDao;
-import com.cloud.dc.ClusterDetailsVO;
 import com.cloud.dc.ClusterVO;
 import com.cloud.dc.dao.ClusterDao;
 import com.cloud.host.Host;
@@ -44,11 +45,14 @@ import com.cloud.user.AccountDetailsDao;
 import com.cloud.utils.db.GlobalLock;
 import com.cloud.utils.exception.CloudRuntimeException;
 
+import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
 
 import com.solidfire.client.ElementFactory;
 import com.solidfire.element.api.Account;
 import com.solidfire.element.api.AddAccountRequest;
+import com.solidfire.element.api.AddInitiatorsToVolumeAccessGroupRequest;
+import com.solidfire.element.api.AddVolumesToVolumeAccessGroupRequest;
 import com.solidfire.element.api.CloneVolumeRequest;
 import com.solidfire.element.api.CloneVolumeResult;
 import com.solidfire.element.api.CreateSnapshotRequest;
@@ -62,9 +66,10 @@ import com.solidfire.element.api.GetAsyncResultRequest;
 import com.solidfire.element.api.ListSnapshotsRequest;
 import com.solidfire.element.api.ListVolumeAccessGroupsRequest;
 import com.solidfire.element.api.ListVolumesRequest;
-import com.solidfire.element.api.ModifyVolumeAccessGroupRequest;
 import com.solidfire.element.api.ModifyVolumeRequest;
 import com.solidfire.element.api.QoS;
+import com.solidfire.element.api.RemoveInitiatorsFromVolumeAccessGroupRequest;
+import com.solidfire.element.api.RemoveVolumesFromVolumeAccessGroupRequest;
 import com.solidfire.element.api.RollbackToSnapshotRequest;
 import com.solidfire.element.api.Snapshot;
 import com.solidfire.element.api.SolidFireElement;
@@ -75,12 +80,13 @@ import com.solidfire.jsvcgen.javautil.Optional;
 import static org.apache.commons.lang.ArrayUtils.toPrimitive;
 
 public class SolidFireUtil {
-    private static final Logger s_logger = Logger.getLogger(SolidFireUtil.class);
+    private static final Logger LOGGER = Logger.getLogger(SolidFireUtil.class);
 
     public static final String PROVIDER_NAME = "SolidFire";
     public static final String SHARED_PROVIDER_NAME = "SolidFireShared";
 
-    public static final int s_lockTimeInSeconds = 300;
+    private static final Random RANDOM = new Random(System.nanoTime());
+    public static final int LOCK_TIME_IN_SECONDS = 300;
 
     public static final String LOG_PREFIX = "SolidFire: ";
 
@@ -127,6 +133,8 @@ public class SolidFireUtil {
     public static final String DATASTORE_NAME = "datastoreName";
     public static final String IQN = "iqn";
 
+    private static final String SF_CS_ACCOUNT_PREFIX = "CloudStack_";
+
     public static final long MIN_VOLUME_SIZE = 1000000000;
 
     public static final long MIN_IOPS_PER_VOLUME = 100;
@@ -135,6 +143,9 @@ public class SolidFireUtil {
 
     private static final int DEFAULT_MANAGEMENT_PORT = 443;
     private static final int DEFAULT_STORAGE_PORT = 3260;
+
+    private static final int MAX_NUM_VAGS_PER_VOLUME = 4;
+    private static final int MAX_NUM_INITIATORS_PER_VAG = 64;
 
     public static class SolidFireConnection {
         private final String _managementVip;
@@ -300,7 +311,7 @@ public class SolidFireUtil {
     }
 
     public static String getSolidFireAccountName(String csAccountUuid, long csAccountId) {
-        return "CloudStack_" + csAccountUuid + "_" + csAccountId;
+        return SF_CS_ACCOUNT_PREFIX + csAccountUuid + "_" + csAccountId;
     }
 
     public static void updateCsDbWithSolidFireIopsInfo(long storagePoolId, PrimaryDataStoreDao primaryDataStoreDao,
@@ -344,17 +355,72 @@ public class SolidFireUtil {
         }
     }
 
-    public static void hostAddedToOrRemovedFromCluster(long hostId, long clusterId, boolean added, String storageProvider,
-            ClusterDao clusterDao, ClusterDetailsDao clusterDetailsDao, PrimaryDataStoreDao storagePoolDao,
-            StoragePoolDetailsDao storagePoolDetailsDao, HostDao hostDao) {
+    private static boolean isCloudStackOnlyVag(SolidFireConnection sfConnection, SolidFireVag sfVag) {
+        long[] volumeIds = sfVag.getVolumeIds();
+
+        if (ArrayUtils.isEmpty(volumeIds)) {
+            // We count this situation as being "CloudStack only" because the reason we call this method is to determine
+            // if we can remove a host from a VAG (we only want to allow the host to be removed from the VAG if there are
+            // no non-CloudStack volumes in it).
+            return true;
+        }
+
+        List<Long> knownSfAccountsForCs = new ArrayList<>();
+
+        for (long volumeId : volumeIds) {
+            SolidFireVolume sfVolume = getVolume(sfConnection, volumeId);
+            long sfAccountId = sfVolume.getAccountId();
+
+            if (!knownSfAccountsForCs.contains(sfAccountId)) {
+                SolidFireAccount sfAccount = getAccountById(sfConnection, sfAccountId);
+
+                if (sfAccount.getName().startsWith(SF_CS_ACCOUNT_PREFIX)) {
+                    knownSfAccountsForCs.add(sfAccountId);
+                }
+                else {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean isStorageApplicableToZoneOrCluster(StoragePoolVO storagePoolVO, long clusterId, ClusterDao clusterDao) {
+        if (storagePoolVO.getClusterId() != null) {
+            if (storagePoolVO.getClusterId() == clusterId) {
+                return true;
+            }
+        }
+        else {
+            List<ClusterVO> clustersInZone = clusterDao.listByZoneId(storagePoolVO.getDataCenterId());
+
+            if (clustersInZone != null) {
+                for (ClusterVO clusterInZone : clustersInZone) {
+                    if (clusterInZone.getId() == clusterId) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public static void hostRemovedFromCluster(long hostId, long clusterId, String storageProvider, ClusterDao clusterDao, HostDao hostDao,
+                                              PrimaryDataStoreDao storagePoolDao, StoragePoolDetailsDao storagePoolDetailsDao) {
+        HostVO hostVO = hostDao.findByIdIncludingRemoved(hostId);
+
+        Preconditions.checkArgument(hostVO != null, "Could not locate host for ID: " + hostId);
+
         ClusterVO cluster = clusterDao.findById(clusterId);
 
         GlobalLock lock = GlobalLock.getInternLock(cluster.getUuid());
 
-        if (!lock.lock(s_lockTimeInSeconds)) {
+        if (!lock.lock(LOCK_TIME_IN_SECONDS)) {
             String errMsg = "Couldn't lock the DB on the following string: " + cluster.getUuid();
 
-            s_logger.debug(errMsg);
+            LOGGER.warn(errMsg);
 
             throw new CloudRuntimeException(errMsg);
         }
@@ -366,26 +432,20 @@ public class SolidFireUtil {
                 List<SolidFireUtil.SolidFireConnection> sfConnections = new ArrayList<>();
 
                 for (StoragePoolVO storagePool : storagePools) {
-                    ClusterDetailsVO clusterDetail = clusterDetailsDao.findDetail(clusterId, SolidFireUtil.getVagKey(storagePool.getId()));
+                    if (!isStorageApplicableToZoneOrCluster(storagePool, clusterId, clusterDao)) {
+                        continue;
+                    }
 
-                    String vagId = clusterDetail != null ? clusterDetail.getValue() : null;
+                    SolidFireUtil.SolidFireConnection sfConnection = SolidFireUtil.getSolidFireConnection(storagePool.getId(), storagePoolDetailsDao);
 
-                    if (vagId != null) {
-                        SolidFireUtil.SolidFireConnection sfConnection = SolidFireUtil.getSolidFireConnection(storagePool.getId(), storagePoolDetailsDao);
+                    if (!sfConnections.contains(sfConnection)) {
+                        sfConnections.add(sfConnection);
 
-                        if (!sfConnections.contains(sfConnection)) {
-                            sfConnections.add(sfConnection);
+                        List<SolidFireUtil.SolidFireVag> sfVags = SolidFireUtil.getAllVags(sfConnection);
+                        SolidFireVag sfVag = getVolumeAccessGroup(hostVO.getStorageUrl(), sfVags);
 
-                            SolidFireUtil.SolidFireVag sfVag = SolidFireUtil.getVag(sfConnection, Long.parseLong(vagId));
-
-                            List<HostVO> hostsToAddOrRemove = new ArrayList<>();
-                            HostVO hostToAddOrRemove = hostDao.findByIdIncludingRemoved(hostId);
-
-                            hostsToAddOrRemove.add(hostToAddOrRemove);
-
-                            String[] hostIqns = SolidFireUtil.getNewHostIqns(sfVag.getInitiators(), SolidFireUtil.getIqnsFromHosts(hostsToAddOrRemove), added);
-
-                            SolidFireUtil.modifyVag(sfConnection, sfVag.getId(), hostIqns, sfVag.getVolumeIds());
+                        if (sfVag != null && isCloudStackOnlyVag(sfConnection, sfVag)) {
+                            removeInitiatorsFromSolidFireVag(sfConnection, sfVag.getId(), new String[] { hostVO.getStorageUrl() });
                         }
                     }
                 }
@@ -397,63 +457,342 @@ public class SolidFireUtil {
         }
     }
 
-    public static long placeVolumeInVolumeAccessGroup(SolidFireConnection sfConnection, long sfVolumeId, long storagePoolId,
-                                                      String vagUuid, List<HostVO> hosts, ClusterDetailsDao clusterDetailsDao) {
-        if (hosts == null || hosts.isEmpty()) {
-            throw new CloudRuntimeException("There must be at least one host in the cluster.");
-        }
+    public static void hostAddedToCluster(long hostId, long clusterId, String storageProvider, ClusterDao clusterDao, HostDao hostDao,
+                                          PrimaryDataStoreDao storagePoolDao, StoragePoolDetailsDao storagePoolDetailsDao) {
+        HostVO hostVO = hostDao.findById(hostId);
 
-        long lVagId;
+        Preconditions.checkArgument(hostVO != null, "Could not locate host for ID: " + hostId);
+
+        ClusterVO cluster = clusterDao.findById(clusterId);
+
+        GlobalLock lock = GlobalLock.getInternLock(cluster.getUuid());
+
+        if (!lock.lock(LOCK_TIME_IN_SECONDS)) {
+            String errMsg = "Couldn't lock the DB on the following string: " + cluster.getUuid();
+
+            LOGGER.warn(errMsg);
+
+            throw new CloudRuntimeException(errMsg);
+        }
 
         try {
-            lVagId = SolidFireUtil.createVag(sfConnection, "CloudStack-" + vagUuid,
-                SolidFireUtil.getIqnsFromHosts(hosts), new long[] { sfVolumeId });
-        }
-        catch (Exception ex) {
-            String iqnInVagAlready1 = "Exceeded maximum number of Volume Access Groups per initiator";
-            String iqnInVagAlready2 = "Exceeded maximum number of VolumeAccessGroups per Initiator";
+            List<StoragePoolVO> storagePools = storagePoolDao.findPoolsByProvider(storageProvider);
 
-            if (!ex.getMessage().contains(iqnInVagAlready1) && !ex.getMessage().contains(iqnInVagAlready2)) {
-                throw new CloudRuntimeException(ex.getMessage());
+            if (storagePools != null && storagePools.size() > 0) {
+                List<SolidFireUtil.SolidFireConnection> sfConnections = new ArrayList<>();
+
+                for (StoragePoolVO storagePool : storagePools) {
+                    if (!isStorageApplicableToZoneOrCluster(storagePool, clusterId, clusterDao)) {
+                        continue;
+                    }
+
+                    SolidFireUtil.SolidFireConnection sfConnection = SolidFireUtil.getSolidFireConnection(storagePool.getId(), storagePoolDetailsDao);
+
+                    if (!sfConnections.contains(sfConnection)) {
+                        sfConnections.add(sfConnection);
+
+                        List<SolidFireUtil.SolidFireVag> sfVags = SolidFireUtil.getAllVags(sfConnection);
+                        SolidFireVag sfVag = getVolumeAccessGroup(hostVO.getStorageUrl(), sfVags);
+
+                        if (sfVag != null) {
+                            placeVolumeIdsInVag(sfConnection, sfVags, sfVag, hostVO, hostDao);
+                        } else {
+                            handleVagForHost(sfConnection, sfVags, hostVO, hostDao);
+                        }
+                    }
+                }
             }
-
-            // getCompatibleVag throws an exception if an existing VAG can't be located
-            SolidFireUtil.SolidFireVag sfVag = getCompatibleVag(sfConnection, hosts);
-
-            lVagId = sfVag.getId();
-
-            long[] volumeIds = getNewVolumeIds(sfVag.getVolumeIds(), sfVolumeId, true);
-
-            SolidFireUtil.modifyVag(sfConnection, lVagId, sfVag.getInitiators(), volumeIds);
         }
-
-        ClusterDetailsVO clusterDetail = new ClusterDetailsVO(hosts.get(0).getClusterId(), getVagKey(storagePoolId), String.valueOf(lVagId));
-
-        clusterDetailsDao.persist(clusterDetail);
-
-        return lVagId;
+        finally {
+            lock.unlock();
+            lock.releaseRef();
+        }
     }
 
-    public static boolean hostsSupport_iScsi(List<HostVO> hosts) {
+    // Put the host in an existing VAG or create a new one (only create a new one if all existing VAGs are full (i.e. 64 hosts max per VAG) and if
+    // creating a new VAG won't exceed 4 VAGs for the computer cluster).
+    // If none of the hosts in the cluster are in a VAG, then leave this host out of a VAG.
+    // Place applicable volume IDs in VAG, if need be (account of volume starts with SF_CS_ACCOUNT_PREFIX).
+    private static void handleVagForHost(SolidFireUtil.SolidFireConnection sfConnection, List<SolidFireUtil.SolidFireVag> sfVags, Host host, HostDao hostDao) {
+        List<HostVO> hostVOs = hostDao.findByClusterId(host.getClusterId());
+
+        if (hostVOs != null) {
+            int numVags = 0;
+
+            Collections.shuffle(hostVOs, RANDOM);
+
+            for (HostVO hostVO : hostVOs) {
+                if (hostVO.getId() != host.getId()) {
+                    SolidFireVag sfVag = getVolumeAccessGroup(hostVO.getStorageUrl(), sfVags);
+
+                    if (sfVag != null) {
+                        numVags++;
+
+                        // A volume should be visible to all hosts that are in the same compute cluster. That being the case, you
+                        // can use MAX_NUM_VAGS_PER_VOLUME here. This is to limit the number of VAGs being used in a compute cluster
+                        // to MAX_NUM_VAGS_PER_VOLUME.
+                        if (numVags > MAX_NUM_VAGS_PER_VOLUME) {
+                            throw new CloudRuntimeException("Can support at most four volume access groups per compute cluster (>)");
+                        }
+
+                        if (sfVag.getInitiators().length < MAX_NUM_INITIATORS_PER_VAG) {
+                            if (!hostSupports_iScsi(host)) {
+                                String errMsg = "Host with ID " + host.getId() + " does not support iSCSI.";
+
+                                LOGGER.warn(errMsg);
+
+                                throw new CloudRuntimeException(errMsg);
+                            }
+
+                            addInitiatorsToSolidFireVag(sfConnection, sfVag.getId(), new String[] { host.getStorageUrl() });
+
+                            return;
+                        }
+                    }
+                }
+            }
+
+            if (numVags == MAX_NUM_VAGS_PER_VOLUME) {
+                throw new CloudRuntimeException("Can support at most four volume access groups per compute cluster (==)");
+            }
+
+            if (numVags > 0) {
+                if (!hostSupports_iScsi(host)) {
+                    String errMsg = "Host with ID " + host.getId() + " does not support iSCSI.";
+
+                    LOGGER.warn(errMsg);
+
+                    throw new CloudRuntimeException(errMsg);
+                }
+
+                SolidFireUtil.createVag(sfConnection, "CloudStack-" + UUID.randomUUID().toString(),
+                        new String[]{host.getStorageUrl()}, getVolumeIds(sfConnection, sfVags, host, hostDao));
+            }
+        }
+    }
+
+    /**
+     * Make use of the volume access group (VAG) of a random host in the cluster. With this VAG, collect all of its volume IDs that are for
+     * volumes that are in SolidFire accounts that are for CloudStack.
+     */
+    private static long[] getVolumeIds(SolidFireUtil.SolidFireConnection sfConnection, List<SolidFireUtil.SolidFireVag> sfVags,
+                                       Host host, HostDao hostDao) {
+        List<Long> volumeIdsToReturn = new ArrayList<>();
+
+        SolidFireVag sfVagForRandomHostInCluster = getVagForRandomHostInCluster(sfVags, host, hostDao);
+
+        if (sfVagForRandomHostInCluster != null) {
+            long[] volumeIds = sfVagForRandomHostInCluster.getVolumeIds();
+
+            if (volumeIds != null) {
+                List<Long> knownSfAccountsForCs = new ArrayList<>();
+                List<Long> knownSfAccountsNotForCs = new ArrayList<>();
+
+                for (long volumeId : volumeIds) {
+                    SolidFireVolume sfVolume = getVolume(sfConnection, volumeId);
+                    long sfAccountId = sfVolume.getAccountId();
+
+                    if (knownSfAccountsForCs.contains(sfAccountId)) {
+                        volumeIdsToReturn.add(volumeId);
+                    }
+                    else if (!knownSfAccountsNotForCs.contains(sfAccountId)) {
+                        SolidFireAccount sfAccount = getAccountById(sfConnection, sfAccountId);
+
+                        if (sfAccount.getName().startsWith(SF_CS_ACCOUNT_PREFIX)) {
+                            knownSfAccountsForCs.add(sfAccountId);
+
+                            volumeIdsToReturn.add(volumeId);
+                        }
+                        else {
+                            knownSfAccountsNotForCs.add(sfAccountId);
+                        }
+                    }
+                }
+            }
+        }
+
+        return volumeIdsToReturn.stream().mapToLong(l -> l).toArray();
+    }
+
+    private static void placeVolumeIdsInVag(SolidFireUtil.SolidFireConnection sfConnection, List<SolidFireUtil.SolidFireVag> sfVags,
+                                            SolidFireVag sfVag, Host host, HostDao hostDao) {
+        SolidFireVag sfVagForRandomHostInCluster = getVagForRandomHostInCluster(sfVags, host, hostDao);
+
+        if (sfVagForRandomHostInCluster != null) {
+            long[] volumeIds = sfVagForRandomHostInCluster.getVolumeIds();
+
+            if (volumeIds != null) {
+                List<Long> knownSfAccountsForCs = new ArrayList<>();
+                List<Long> knownSfAccountsNotForCs = new ArrayList<>();
+
+                List<Long> newVolumeIds = new ArrayList<>();
+
+                for (long volumeId : volumeIds) {
+                    SolidFireVolume sfVolume = getVolume(sfConnection, volumeId);
+                    long sfAccountId = sfVolume.getAccountId();
+
+                    if (knownSfAccountsForCs.contains(sfAccountId)) {
+                        addVolumeIdToSolidFireVag(volumeId, sfVag, newVolumeIds);
+                    }
+                    else if (!knownSfAccountsNotForCs.contains(sfAccountId)) {
+                        SolidFireAccount sfAccount = getAccountById(sfConnection, sfAccountId);
+
+                        if (sfAccount.getName().startsWith(SF_CS_ACCOUNT_PREFIX)) {
+                            knownSfAccountsForCs.add(sfAccountId);
+
+                            addVolumeIdToSolidFireVag(volumeId, sfVag, newVolumeIds);
+                        }
+                        else {
+                            knownSfAccountsNotForCs.add(sfAccountId);
+                        }
+                    }
+                }
+
+                if (newVolumeIds.size() > 0) {
+                    addVolumeIdsToSolidFireVag(sfConnection, sfVag.getId(), newVolumeIds.toArray(new Long[0]));
+                }
+            }
+        }
+    }
+
+    private static void addVolumeIdToSolidFireVag(long volumeId, SolidFireVag sfVag, List<Long> newVolumeIds) {
+        List<Long> existingVolumeIds = Longs.asList(sfVag.getVolumeIds());
+
+        if (!existingVolumeIds.contains(volumeId) && !newVolumeIds.contains(volumeId)) {
+            newVolumeIds.add(volumeId);
+        }
+    }
+
+    private static SolidFireVag getVagForRandomHostInCluster(List<SolidFireUtil.SolidFireVag> sfVags, Host host, HostDao hostDao) {
+        List<HostVO> hostVOs = hostDao.findByClusterId(host.getClusterId());
+
+        if (hostVOs != null) {
+            Collections.shuffle(hostVOs, RANDOM);
+
+            for (HostVO hostVO : hostVOs) {
+                if (hostVO.getId() != host.getId() && hostSupports_iScsi(hostVO)) {
+                    SolidFireVag sfVag = getVolumeAccessGroup(hostVO.getStorageUrl(), sfVags);
+
+                    if (sfVag != null) {
+                        return sfVag;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static void placeVolumeInVolumeAccessGroups(SolidFireConnection sfConnection, long sfVolumeId, List<HostVO> hosts) {
+        if (!SolidFireUtil.hostsSupport_iScsi(hosts)) {
+            String errMsg = "Not all hosts in the compute cluster support iSCSI.";
+
+            LOGGER.warn(errMsg);
+
+            throw new CloudRuntimeException(errMsg);
+        }
+
+        List<SolidFireUtil.SolidFireVag> sfVags = SolidFireUtil.getAllVags(sfConnection);
+
+        Map<SolidFireUtil.SolidFireVag, List<String>> sfVagToIqnsMap = new HashMap<>();
+
+        for (HostVO hostVO : hosts) {
+            String iqn = hostVO.getStorageUrl();
+
+            SolidFireUtil.SolidFireVag sfVag = getVolumeAccessGroup(iqn, sfVags);
+
+            List<String> iqnsInVag = sfVagToIqnsMap.computeIfAbsent(sfVag, k -> new ArrayList<>());
+
+            iqnsInVag.add(iqn);
+        }
+
+        if (sfVagToIqnsMap.size() > MAX_NUM_VAGS_PER_VOLUME) {
+            throw new CloudRuntimeException("A SolidFire volume can be in at most four volume access groups simultaneously.");
+        }
+
+        for (SolidFireUtil.SolidFireVag sfVag : sfVagToIqnsMap.keySet()) {
+            if (sfVag != null) {
+                if (!SolidFireUtil.isVolumeIdInSfVag(sfVolumeId, sfVag)) {
+                    SolidFireUtil.addVolumeIdsToSolidFireVag(sfConnection, sfVag.getId(), new Long[] { sfVolumeId });
+                }
+            }
+            else {
+                List<String> iqnsNotInVag = sfVagToIqnsMap.get(null);
+
+                SolidFireUtil.createVag(sfConnection, "CloudStack-" + UUID.randomUUID().toString(),
+                        iqnsNotInVag.toArray(new String[0]), new long[] { sfVolumeId });
+            }
+        }
+    }
+
+    public static SolidFireUtil.SolidFireVag getVolumeAccessGroup(String hostIqn, List<SolidFireUtil.SolidFireVag> sfVags) {
+        if (hostIqn == null) {
+            return null;
+        }
+
+        hostIqn = hostIqn.toLowerCase();
+
+        if (sfVags != null) {
+            for (SolidFireUtil.SolidFireVag sfVag : sfVags) {
+                List<String> lstInitiators = getStringArrayAsLowerCaseStringList(sfVag.getInitiators());
+
+                // lstInitiators should not be returned from getStringArrayAsLowerCaseStringList as null
+                if (lstInitiators.contains(hostIqn)) {
+                    return sfVag;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static boolean sfVagContains(SolidFireUtil.SolidFireVag sfVag, long sfVolumeId, long clusterId, HostDao hostDao) {
+        if (isVolumeIdInSfVag(sfVolumeId, sfVag)) {
+            String[] iqns = sfVag.getInitiators();
+            List<HostVO> hosts = hostDao.findByClusterId(clusterId);
+
+            for (String iqn : iqns) {
+                for (HostVO host : hosts) {
+                    String hostIqn = host.getStorageUrl();
+
+                    if (iqn.equalsIgnoreCase(hostIqn)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isVolumeIdInSfVag(long sfVolumeIdToCheck, SolidFireUtil.SolidFireVag sfVag) {
+        long[] sfVolumeIds = sfVag.getVolumeIds();
+
+        for (long sfVolumeId : sfVolumeIds) {
+            if (sfVolumeId == sfVolumeIdToCheck) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean hostSupports_iScsi(Host host) {
+        return host != null && host.getStorageUrl() != null && host.getStorageUrl().trim().length() > 0 && host.getStorageUrl().startsWith("iqn");
+    }
+
+    private static boolean hostsSupport_iScsi(List<HostVO> hosts) {
         if (hosts == null || hosts.size() == 0) {
             return false;
         }
 
         for (Host host : hosts) {
-            if (host == null || host.getStorageUrl() == null || host.getStorageUrl().trim().length() == 0 || !host.getStorageUrl().startsWith("iqn")) {
+            if (!hostSupports_iScsi(host)) {
                 return false;
             }
         }
 
         return true;
-    }
-
-    public static long[] getNewVolumeIds(long[] volumeIds, long volumeIdToAddOrRemove, boolean add) {
-        if (add) {
-            return getNewVolumeIdsAdd(volumeIds, volumeIdToAddOrRemove);
-        }
-
-        return getNewVolumeIdsRemove(volumeIds, volumeIdToAddOrRemove);
     }
 
     public static String getVagKey(long storagePoolId) {
@@ -851,32 +1190,43 @@ public class SolidFireUtil {
         return getSolidFireElement(sfConnection).createVolumeAccessGroup(request).getVolumeAccessGroupID();
     }
 
-    public static void modifyVag(SolidFireConnection sfConnection, long vagId, String[] iqns, long[] volumeIds) {
-        ModifyVolumeAccessGroupRequest request = ModifyVolumeAccessGroupRequest.builder()
+    private static void addInitiatorsToSolidFireVag(SolidFireConnection sfConnection, long vagId, String[] initiators) {
+        AddInitiatorsToVolumeAccessGroupRequest request = AddInitiatorsToVolumeAccessGroupRequest.builder()
                 .volumeAccessGroupID(vagId)
-                .optionalInitiators(iqns)
-                .optionalVolumes(Longs.asList(volumeIds).toArray(new Long[volumeIds.length]))
+                .initiators(initiators)
                 .build();
 
-        getSolidFireElement(sfConnection).modifyVolumeAccessGroup(request);
+        getSolidFireElement(sfConnection).addInitiatorsToVolumeAccessGroup(request);
     }
 
-    public static SolidFireVag getVag(SolidFireConnection sfConnection, long vagId)
-    {
-        ListVolumeAccessGroupsRequest request = ListVolumeAccessGroupsRequest.builder()
-                .optionalStartVolumeAccessGroupID(vagId)
-                .optionalLimit(1L)
+    private static void removeInitiatorsFromSolidFireVag(SolidFireConnection sfConnection, long vagId, String[] initiators) {
+        RemoveInitiatorsFromVolumeAccessGroupRequest request = RemoveInitiatorsFromVolumeAccessGroupRequest.builder()
+                .volumeAccessGroupID(vagId)
+                .initiators(initiators)
                 .build();
 
-        VolumeAccessGroup vag = getSolidFireElement(sfConnection).listVolumeAccessGroups(request).getVolumeAccessGroups()[0];
-
-        String[] vagIqns = vag.getInitiators();
-        long[] vagVolumeIds = toPrimitive(vag.getVolumes());
-
-        return new SolidFireVag(vagId, vagIqns, vagVolumeIds);
+        getSolidFireElement(sfConnection).removeInitiatorsFromVolumeAccessGroup(request);
     }
 
-    private static List<SolidFireVag> getAllVags(SolidFireConnection sfConnection)
+    private static void addVolumeIdsToSolidFireVag(SolidFireConnection sfConnection, long vagId, Long[] volumeIds) {
+        AddVolumesToVolumeAccessGroupRequest request = AddVolumesToVolumeAccessGroupRequest.builder()
+                .volumeAccessGroupID(vagId)
+                .volumes(volumeIds)
+                .build();
+
+        getSolidFireElement(sfConnection).addVolumesToVolumeAccessGroup(request);
+    }
+
+    public static void removeVolumeIdsFromSolidFireVag(SolidFireConnection sfConnection, long vagId, Long[] volumeIds) {
+        RemoveVolumesFromVolumeAccessGroupRequest request = RemoveVolumesFromVolumeAccessGroupRequest.builder()
+                .volumeAccessGroupID(vagId)
+                .volumes(volumeIds)
+                .build();
+
+        getSolidFireElement(sfConnection).removeVolumesFromVolumeAccessGroup(request);
+    }
+
+    public static List<SolidFireVag> getAllVags(SolidFireConnection sfConnection)
     {
         ListVolumeAccessGroupsRequest request = ListVolumeAccessGroupsRequest.builder().build();
 
@@ -980,113 +1330,6 @@ public class SolidFireUtil {
         return portNumber;
     }
 
-    private static String[] getNewHostIqns(String[] iqns, String[] iqnsToAddOrRemove, boolean add) {
-        if (add) {
-            return getNewHostIqnsAdd(iqns, iqnsToAddOrRemove);
-        }
-
-        return getNewHostIqnsRemove(iqns, iqnsToAddOrRemove);
-    }
-
-    private static String[] getNewHostIqnsAdd(String[] iqns, String[] iqnsToAdd) {
-        List<String> lstIqns = iqns != null ? new ArrayList<>(Arrays.asList(iqns)) : new ArrayList<String>();
-
-        if (iqnsToAdd != null) {
-            for (String iqnToAdd : iqnsToAdd) {
-                if (!lstIqns.contains(iqnToAdd)) {
-                    lstIqns.add(iqnToAdd);
-                }
-            }
-        }
-
-        return lstIqns.toArray(new String[0]);
-    }
-
-    private static String[] getNewHostIqnsRemove(String[] iqns, String[] iqnsToRemove) {
-        List<String> lstIqns = iqns != null ? new ArrayList<>(Arrays.asList(iqns)) : new ArrayList<String>();
-
-        if (iqnsToRemove != null) {
-            for (String iqnToRemove : iqnsToRemove) {
-                lstIqns.remove(iqnToRemove);
-            }
-        }
-
-        return lstIqns.toArray(new String[0]);
-    }
-
-    private static long[] getNewVolumeIdsAdd(long[] volumeIds, long volumeIdToAdd) {
-        List<Long> lstVolumeIds = new ArrayList<>();
-
-        if (volumeIds != null) {
-            for (long volumeId : volumeIds) {
-                lstVolumeIds.add(volumeId);
-            }
-        }
-
-        if (lstVolumeIds.contains(volumeIdToAdd)) {
-            return volumeIds;
-        }
-
-        lstVolumeIds.add(volumeIdToAdd);
-
-        return toPrimitive(lstVolumeIds.toArray(new Long[lstVolumeIds.size()]));
-    }
-
-    private static long[] getNewVolumeIdsRemove(long[] volumeIds, long volumeIdToRemove) {
-        List<Long> lstVolumeIds = new ArrayList<>();
-
-        if (volumeIds != null) {
-            for (long volumeId : volumeIds) {
-                lstVolumeIds.add(volumeId);
-            }
-        }
-
-        lstVolumeIds.remove(volumeIdToRemove);
-
-        return toPrimitive(lstVolumeIds.toArray(new Long[lstVolumeIds.size()]));
-    }
-
-    private static String[] getIqnsFromHosts(List<? extends Host> hosts) {
-        if (hosts == null || hosts.size() == 0) {
-            throw new CloudRuntimeException("There do not appear to be any hosts in this cluster.");
-        }
-
-        List<String> lstIqns = new ArrayList<>();
-
-        for (Host host : hosts) {
-            lstIqns.add(host.getStorageUrl());
-        }
-
-        return lstIqns.toArray(new String[0]);
-    }
-
-    // this method takes in a collection of hosts and tries to find an existing VAG that has all of them in it
-    // if successful, the VAG is returned; else, a CloudRuntimeException is thrown and this issue should be corrected by an admin
-    private static SolidFireUtil.SolidFireVag getCompatibleVag(SolidFireConnection sfConnection, List<HostVO> hosts) {
-        List<SolidFireUtil.SolidFireVag> sfVags = SolidFireUtil.getAllVags(sfConnection);
-
-        if (sfVags != null) {
-            List<String> hostIqns = new ArrayList<>();
-
-            // where the method we're in is called, hosts should not be null
-            for (HostVO host : hosts) {
-                // where the method we're in is called, host.getStorageUrl() should not be null (it actually should start with "iqn")
-                hostIqns.add(host.getStorageUrl().toLowerCase());
-            }
-
-            for (SolidFireUtil.SolidFireVag sfVag : sfVags) {
-                List<String> lstInitiators = getStringArrayAsLowerCaseStringList(sfVag.getInitiators());
-
-                // lstInitiators should not be returned from getStringArrayAsLowerCaseStringList as null
-                if (lstInitiators.containsAll(hostIqns)) {
-                    return sfVag;
-                }
-            }
-        }
-
-        throw new CloudRuntimeException("Unable to locate the appropriate SolidFire Volume Access Group");
-    }
-
     private static List<String> getStringArrayAsLowerCaseStringList(String[] aString) {
         List<String> lstLowerCaseString = new ArrayList<>();
 
@@ -1106,10 +1349,6 @@ public class SolidFireUtil {
             return null;
         }
 
-        Map<String, Object> convertedMap = new HashMap<>();
-
-        convertedMap.putAll(map);
-
-        return convertedMap;
+        return new HashMap<>(map);
     }
 }

--- a/test/integration/plugins/solidfire/TestCapacityManagement.py
+++ b/test/integration/plugins/solidfire/TestCapacityManagement.py
@@ -33,7 +33,7 @@ from marvin.cloudstackTestCase import cloudstackTestCase
 from marvin.lib.base import Account, ServiceOffering, StoragePool, User, VirtualMachine
 
 # common - commonly used methods for all tests are listed here
-from marvin.lib.common import get_domain, get_template, get_zone, list_clusters, list_hosts
+from marvin.lib.common import get_domain, get_template, get_zone, list_hosts
 
 # utils - utility classes for common cleanup, external library wrappers, etc.
 from marvin.lib.utils import cleanup_resources
@@ -47,7 +47,7 @@ from marvin.lib.utils import cleanup_resources
 #  If using XenServer, verify the "xen_server_hostname" variable is correct.
 #
 # Note:
-#  If you do have more than one cluster, you might need to change this line: cls.cluster = list_clusters(cls.apiClient)[0]
+#  If you do have more than one cluster, you might need to change this variable: TestData.clusterId.
 
 
 class TestData():
@@ -193,7 +193,6 @@ class TestCapacityManagement(cloudstackTestCase):
 
         # Get Resources from Cloud Infrastructure
         cls.zone = get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId])
-        cls.cluster = list_clusters(cls.apiClient)[0]
         cls.template = get_template(cls.apiClient, cls.zone.id, hypervisor=TestData.hypervisor_type)
         cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
 

--- a/test/integration/plugins/solidfire/TestSnapshots.py
+++ b/test/integration/plugins/solidfire/TestSnapshots.py
@@ -35,7 +35,7 @@ from nose.plugins.attrib import attr
 from marvin.lib.base import Account, DiskOffering, ServiceOffering, Snapshot, StoragePool, Template, User, VirtualMachine, Volume
 
 # common - commonly used methods for all tests are listed here
-from marvin.lib.common import get_domain, get_template, get_zone, list_clusters, list_volumes, list_snapshots
+from marvin.lib.common import get_domain, get_template, get_zone, list_volumes, list_snapshots
 
 # utils - utility classes for common cleanup, external library wrappers, etc.
 from marvin.lib.utils import cleanup_resources, wait_until
@@ -87,16 +87,16 @@ class TestData():
     def __init__(self):
         self.testdata = {
             TestData.solidFire: {
-                TestData.mvip: "10.117.40.120",
+                TestData.mvip: "10.117.78.225",
                 TestData.username: "admin",
                 TestData.password: "admin",
                 TestData.port: 443,
-                TestData.url: "https://10.117.40.120:443"
+                TestData.url: "https://10.117.78.225:443"
             },
             TestData.primaryStorage: {
                 "name": "SolidFire-%d" % random.randint(0, 100),
                 TestData.scope: "ZONE",
-                "url": "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
+                "url": "MVIP=10.117.78.225;SVIP=10.117.94.225;" +
                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                        "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
                        "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",
@@ -155,7 +155,6 @@ class TestData():
                 TestData.diskName: "test-volume-2",
             },
             TestData.zoneId: 1,
-            TestData.clusterId: 1,
             TestData.domainId: 1,
             TestData.url: "10.117.40.114"
         }
@@ -198,7 +197,6 @@ class TestSnapshots(cloudstackTestCase):
 
         # Get Resources from Cloud Infrastructure
         cls.zone = get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId])
-        cls.cluster = list_clusters(cls.apiClient)[0]
         cls.template = get_template(cls.apiClient, cls.zone.id, hypervisor=TestData.hypervisor_type)
         cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
 

--- a/test/integration/plugins/solidfire/TestUploadDownload.py
+++ b/test/integration/plugins/solidfire/TestUploadDownload.py
@@ -185,7 +185,7 @@ class TestUploadDownload(cloudstackTestCase):
 
         # Get Resources from Cloud Infrastructure
         cls.zone = get_zone(cls.apiClient, zone_id=cls.testdata[TestData.zoneId])
-        cls.cluster = list_clusters(cls.apiClient)[1]
+        cls.cluster = list_clusters(cls.apiClient)[0]
         cls.template = get_template(cls.apiClient, cls.zone.id, hypervisor=TestData.hypervisor_type)
         cls.domain = get_domain(cls.apiClient, cls.testdata[TestData.domainId])
 

--- a/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
+++ b/test/integration/plugins/solidfire/TestVMMigrationWithStorage.py
@@ -40,6 +40,9 @@ from marvin.lib.utils import cleanup_resources
 #  Only one zone
 #  Only one pod
 #  Two clusters (have system VMs (including the VR) running on local or NFS storage)
+#
+# Running the tests:
+#  Verify the "xen_server_hostname_src" and "xen_server_hostname_dest" variables are correct.
 
 
 class TestData():
@@ -80,6 +83,9 @@ class TestData():
     volume_1 = "volume_1"
     xenServer = "xenserver"
     zoneId = "zoneid"
+
+    xen_server_hostname_src = "XenServer-6.5-1"
+    xen_server_hostname_dest = "XenServer-6.5-3"
 
     def __init__(self):
         self.testdata = {
@@ -233,7 +239,7 @@ class TestVMMigrationWithStorage(cloudstackTestCase):
 
         # Set up xenAPI connection
         host_ip = "https://" + \
-                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId1], name="XenServer-6.5-1")[0].ipaddress
+                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId1], name=TestData.xen_server_hostname_src)[0].ipaddress
 
         # Set up XenAPI connection
         cls.xen_session_1 = XenAPI.Session(host_ip)
@@ -242,7 +248,7 @@ class TestVMMigrationWithStorage(cloudstackTestCase):
 
         # Set up xenAPI connection
         host_ip = "https://" + \
-                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId2], name="XenServer-6.5-3")[0].ipaddress
+                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId2], name=TestData.xen_server_hostname_dest)[0].ipaddress
 
         # Set up XenAPI connection
         cls.xen_session_2 = XenAPI.Session(host_ip)
@@ -532,9 +538,9 @@ class TestVMMigrationWithStorage(cloudstackTestCase):
         hosts = list_hosts(self.apiClient)
 
         for host in hosts:
-            if host.name == "XenServer-6.5-1":
+            if host.name == TestData.xen_server_hostname_src:
                 src_host = host
-            elif host.name == "XenServer-6.5-3":
+            elif host.name == TestData.xen_server_hostname_dest:
                 dest_host = host
 
         self.assertIsNotNone(src_host, "Could not locate the source host")

--- a/test/integration/plugins/solidfire/TestVMSnapshots.py
+++ b/test/integration/plugins/solidfire/TestVMSnapshots.py
@@ -44,6 +44,10 @@ from marvin.lib.utils import cleanup_resources
 #  Only one pod
 #  Only one cluster
 
+# Running the tests:
+#  Change the "hypervisor_type" variable to control which hypervisor type to test.
+#  If using XenServer, verify the "xen_server_hostname" variable is correct.
+
 
 class TestData:
     account = "account"
@@ -74,6 +78,7 @@ class TestData:
 
     # modify to control which hypervisor type to test
     hypervisor_type = xenServer
+    xen_server_hostname = "XenServer-6.5-1"
 
     def __init__(self):
         self.testdata = {
@@ -129,7 +134,7 @@ class TestData:
                 "customizediops": False,
                 "miniops": "10000",
                 "maxiops": "15000",
-                "hypervisorsnapshotreserve": 200,
+                "hypervisorsnapshotreserve": 400,
                 TestData.tags: TestData.storageTag
             },
             TestData.diskOffering: {
@@ -139,7 +144,7 @@ class TestData:
                 "customizediops": False,
                 "miniops": 300,
                 "maxiops": 500,
-                "hypervisorsnapshotreserve": 200,
+                "hypervisorsnapshotreserve": 400,
                 TestData.tags: TestData.storageTag,
                 "storagetype": "shared"
             },
@@ -179,7 +184,7 @@ class TestVMSnapshots(cloudstackTestCase):
 
         # Set up XenAPI connection
         host_ip = "https://" + \
-                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId], name="XenServer-6.5-1")[0].ipaddress
+                  list_hosts(cls.apiClient, clusterid=cls.testdata[TestData.clusterId], name=TestData.xen_server_hostname)[0].ipaddress
 
         cls.xen_session = XenAPI.Session(host_ip)
 

--- a/test/integration/plugins/solidfire/TestVolumes.py
+++ b/test/integration/plugins/solidfire/TestVolumes.py
@@ -51,7 +51,8 @@ from marvin.lib.utils import cleanup_resources
 #  If using XenServer, change the "supports_cloning" variable to True or False as desired.
 #
 # Note:
-#  If you do have more than one cluster, you might need to change this line: cls.cluster = list_clusters(cls.apiClient)[0]
+#  If you do have more than one cluster, you might need to change this line: cls.cluster = list_clusters(cls.apiClient)[0] and
+#   this variable's value: TestData.clusterId.
 
 
 class TestData():
@@ -79,6 +80,7 @@ class TestData():
     tags = "tags"
     templateCacheNameKvm = "centos55-x86-64"
     templateCacheNameXenServer = "centos56-x86-64-xen"
+    # templateCacheNameXenServer = "centos65-x86-64-XenServer"
     testAccount = "testaccount"
     url = "url"
     user = "user"
@@ -91,17 +93,17 @@ class TestData():
     zoneId = "zoneId"
 
     # modify to control which hypervisor type to test
-    hypervisor_type = kvm
+    hypervisor_type = xenServer
     xen_server_hostname = "XenServer-6.5-1"
 
     def __init__(self):
         self.testdata = {
             TestData.solidFire: {
-                TestData.mvip: "10.117.40.120",
+                TestData.mvip: "10.117.78.225",
                 TestData.username: "admin",
                 TestData.password: "admin",
                 TestData.port: 443,
-                TestData.url: "https://10.117.40.120:443"
+                TestData.url: "https://10.117.78.225:443"
             },
             TestData.kvm: {
                 TestData.username: "root",
@@ -135,7 +137,7 @@ class TestData():
             TestData.primaryStorage: {
                 "name": "SolidFire-%d" % random.randint(0, 100),
                 TestData.scope: "ZONE",
-                "url": "MVIP=10.117.40.120;SVIP=10.117.41.120;" +
+                "url": "MVIP=10.117.78.225;SVIP=10.117.94.225;" +
                        "clusterAdminUsername=admin;clusterAdminPassword=admin;" +
                        "clusterDefaultMinIops=10000;clusterDefaultMaxIops=15000;" +
                        "clusterDefaultBurstIopsPercentOfMaxIops=1.5;",


### PR DESCRIPTION
## Description
Previously, the SolidFire storage plug-in for managed storage had a 1:1 mapping between a compute cluster and a volume access group (VAG). A VAG is a type of ACL in the SolidFire cluster.

This PR expands that support to be 1:M.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
I confirmed after the code changes that you can now have multiple volume access groups support a single compute cluster. Also, you can still have a single volume access group support a compute cluster.

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- The following will kick a packaging job, remove it as applicable -->
@blueorangutan package
