### PR TITLE
CLOUDSTACK-10319: Allow TLSv1, v1.1 for XenServer, Vmware

### DIFF
--- a/client/conf/java.security.ciphers.in
+++ b/client/conf/java.security.ciphers.in
@@ -15,4 +15,4 @@
  # specific language governing permissions and limitations
  # under the License.
 
-jdk.tls.disabledAlgorithms=DH keySize < 128, RSA keySize < 128, DES keySize < 128, SHA1 keySize < 128, MD5 keySize < 128, RC4
+jdk.tls.disabledAlgorithms=SSLv2Hello, SSLv3, TLSv1, TLSv1.1, DH keySize < 128, RSA keySize < 128, DES keySize < 128, SHA1 keySize < 128, MD5 keySize < 128, RC4

--- a/utils/src/main/java/org/apache/cloudstack/utils/security/SSLUtils.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/security/SSLUtils.java
@@ -34,7 +34,7 @@ public class SSLUtils {
     public static String[] getSupportedProtocols(String[] protocols) {
         Set<String> set = new HashSet<String>();
         for (String s : protocols) {
-            if (s.equals("TLSv1") || s.equals("TLSv1.1") || s.equals("SSLv3") || s.equals("SSLv2Hello")) {
+            if (s.equals("SSLv3") || s.equals("SSLv2Hello")) {
                 continue;
             }
             set.add(s);
@@ -46,7 +46,7 @@ public class SSLUtils {
      * It returns recommended protocols that are considered secure.
      */
     public static String[] getRecommendedProtocols() {
-        return new String[] { "TLSv1.2" };
+        return new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
     }
 
     /**

--- a/utils/src/test/java/com/cloud/utils/security/SSLUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/security/SSLUtilsTest.java
@@ -69,9 +69,9 @@ public class SSLUtilsTest {
     }
 
     private void verifyProtocols(ArrayList<String> protocolsList) {
+        Assert.assertTrue(protocolsList.contains("TLSv1"));
+        Assert.assertTrue(protocolsList.contains("TLSv1.1"));
         Assert.assertTrue(protocolsList.contains("TLSv1.2"));
-        Assert.assertFalse(protocolsList.contains("TLSv1"));
-        Assert.assertFalse(protocolsList.contains("TLSv1.1"));
         Assert.assertFalse(protocolsList.contains("SSLv3"));
         Assert.assertFalse(protocolsList.contains("SSLv2Hello"));
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This reverts changes from #2480, instead moves TLS settings to
java ciphers settings config file. It should be sufficient to enforce
TLS v1.2 on public facing CloudStack services:
- CloudStack webserver (Jetty based)
- Apache2 for secondary storage VM
- CPVM HTTPs server

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
