### PR TITLE
Only use the host if its Resource State is Enabled.

### DIFF
--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -43,6 +43,7 @@ import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
 import com.cloud.host.dao.HostDetailsDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
+import com.cloud.resource.ResourceState;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.Snapshot;
@@ -1933,7 +1934,11 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         if (hosts != null && hosts.size() > 0) {
             Collections.shuffle(hosts, RANDOM);
 
-            return hosts.get(0);
+            for (HostVO host : hosts) {
+                if (ResourceState.Enabled.equals(host.getResourceState())) {
+                    return host;
+                }
+            }
         }
 
         throw new CloudRuntimeException("Unable to locate a host");
@@ -1954,6 +1959,10 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
         Collections.shuffle(hosts, RANDOM);
 
         for (HostVO host : hosts) {
+            if (!ResourceState.Enabled.equals(host.getResourceState())) {
+                continue;
+            }
+
             if (computeClusterMustSupportResign) {
                 long clusterId = host.getClusterId();
 


### PR DESCRIPTION
## Description
Update the StorageSystemSnapshotStrategy and StorageSystemDataMotionStrategy classes to only leverage a host when its Resource State is Enabled.

https://issues.apache.org/jira/browse/CLOUDSTACK-10345

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

Checked to see if a host in maintenance mode is avoided

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- The following will kick a packaging job, remove it as applicable -->
@blueorangutan package
