### PR TITLE
manual mapped ldap fix

### DIFF
--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/ADLdapUserManagerImpl.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/ADLdapUserManagerImpl.java
@@ -59,7 +59,7 @@ public class ADLdapUserManagerImpl extends OpenLdapUserManagerImpl implements Ld
         return users;
     }
 
-    private String generateADGroupSearchFilter(String groupName, Long domainId) {
+    String generateADGroupSearchFilter(String groupName, Long domainId) {
         final StringBuilder userObjectFilter = new StringBuilder();
         userObjectFilter.append("(objectClass=");
         userObjectFilter.append(_ldapConfiguration.getUserObject(domainId));

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
@@ -215,7 +215,7 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
      * @param user cloudstack user object
      * @return false if either user object does not exist or authenitication fails
      */
-    private Pair<Boolean, ActionOnFailedAuthentication> authenticate(String username, String password, Long domainId, UserAccount user) {
+    Pair<Boolean, ActionOnFailedAuthentication> authenticate(String username, String password, Long domainId, UserAccount user) {
         boolean result = false;
 
         if(user != null ) {

--- a/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
+++ b/plugins/user-authenticators/ldap/src/org/apache/cloudstack/ldap/LdapAuthenticator.java
@@ -231,8 +231,8 @@ public class LdapAuthenticator extends AdapterBase implements UserAuthenticator 
             }
         }
         return (!result && user != null) ?
-                new Pair<Boolean, ActionOnFailedAuthentication>(false, ActionOnFailedAuthentication.INCREMENT_INCORRECT_LOGIN_ATTEMPT_COUNT):
-                new Pair<Boolean, ActionOnFailedAuthentication>(false, null);
+                new Pair<Boolean, ActionOnFailedAuthentication>(result, ActionOnFailedAuthentication.INCREMENT_INCORRECT_LOGIN_ATTEMPT_COUNT):
+                new Pair<Boolean, ActionOnFailedAuthentication>(result, null);
     }
 
     private void enableUserInCloudStack(UserAccount user) {

--- a/plugins/user-authenticators/ldap/test/org/apache/cloudstack/api/command/LdapConfigurationChanger.java
+++ b/plugins/user-authenticators/ldap/test/org/apache/cloudstack/api/command/LdapConfigurationChanger.java
@@ -38,7 +38,7 @@ interface LdapConfigurationChanger {
      * the first field found by this name in the class "klas" or any of it's superclasses except for {@code Object}. Implementers of this interface can decide to also return any field in implemented interfaces or in {@code Object}.
      *
      * @param name of the field to find
-     * @param klas class to gat a field by name "name" from
+     * @param klas class to get a field by name "name" from
      * @return a {@code Field} by the name "name"
      * @throws NoSuchFieldException
      */

--- a/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/ADLdapUserManagerImplTest.java
+++ b/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/ADLdapUserManagerImplTest.java
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.ldap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.naming.directory.SearchControls;
+import javax.naming.ldap.LdapContext;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ADLdapUserManagerImplTest {
+
+    ADLdapUserManagerImpl adLdapUserManager;
+
+    @Mock
+    LdapConfiguration ldapConfiguration;
+
+    @Before
+    public void init() throws Exception {
+        adLdapUserManager = new ADLdapUserManagerImpl();
+        adLdapUserManager._ldapConfiguration = ldapConfiguration;
+    }
+
+    @Test
+    public void testGenerateADSearchFilterWithNestedGroupsEnabled() {
+        when(ldapConfiguration.getUserObject(any())).thenReturn("user");
+        when(ldapConfiguration.getCommonNameAttribute()).thenReturn("CN");
+        when(ldapConfiguration.getBaseDn(any())).thenReturn("DC=cloud,DC=citrix,DC=com");
+        when(ldapConfiguration.isNestedGroupsEnabled(any())).thenReturn(true);
+
+        String [] groups = {"dev", "dev-hyd"};
+        for (String group: groups) {
+            String result = adLdapUserManager.generateADGroupSearchFilter(group, 1L);
+            assertTrue(("(&(objectClass=user)(memberOf:1.2.840.113556.1.4.1941:=CN=" + group + ",DC=cloud,DC=citrix,DC=com))").equals(result));
+        }
+
+    }
+
+    @Test
+    public void testGenerateADSearchFilterWithNestedGroupsDisabled() {
+        when(ldapConfiguration.getUserObject(any())).thenReturn("user");
+        when(ldapConfiguration.getCommonNameAttribute()).thenReturn("CN");
+        when(ldapConfiguration.getBaseDn(any())).thenReturn("DC=cloud,DC=citrix,DC=com");
+        when(ldapConfiguration.isNestedGroupsEnabled(any())).thenReturn(false);
+
+        String [] groups = {"dev", "dev-hyd"};
+        for (String group: groups) {
+            String result = adLdapUserManager.generateADGroupSearchFilter(group, 1L);
+            assertTrue(("(&(objectClass=user)(memberOf=CN=" + group + ",DC=cloud,DC=citrix,DC=com))").equals(result));
+        }
+    }
+
+    @Mock
+    LdapContext ldapContext;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetUsersInGroupUsingNullGroup() throws Exception {
+        String[] returnAttributes = {"username", "firstname", "lastname", "email"};
+        when(ldapConfiguration.getScope()).thenReturn(SearchControls.SUBTREE_SCOPE);
+        when(ldapConfiguration.getReturnAttributes(null)).thenReturn(returnAttributes);
+        when(ldapConfiguration.getBaseDn(any())).thenReturn(null).thenReturn(null).thenReturn("DC=cloud,DC=citrix,DC=com");
+
+        LdapContext context = ldapContext;
+        String [] groups = {null, "group", null};
+        for (String group: groups) {
+            adLdapUserManager.getUsersInGroup(group, context,null);
+        }
+    }
+}

--- a/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/LdapAuthenticatorTest.java
+++ b/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/LdapAuthenticatorTest.java
@@ -1,0 +1,54 @@
+package org.apache.cloudstack.ldap;
+
+import com.cloud.server.auth.*;
+import com.cloud.user.*;
+import com.cloud.user.dao.*;
+import com.cloud.utils.*;
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.runners.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LdapAuthenticatorTest {
+
+    @Mock
+    LdapManager ldapManager;
+    @Mock
+    UserAccountDao userAccountDao;
+    @Mock
+    UserAccount user = new UserAccountVO();
+
+    LdapAuthenticator ldapAuthenticator;
+    private String username  = "bbanner";
+    private String principal = "cd=bbanner";
+    private String hardcoded = "password";
+    private Long domainId = 1L;
+
+    @Before
+    public void setUp() throws Exception {
+        ldapAuthenticator = new LdapAuthenticator(ldapManager, userAccountDao);
+    }
+
+    @Test
+    public void authenticateWithoutAccount() throws Exception {
+        LdapUser ldapUser = new LdapUser(username,"a@b","b","banner",principal,"",false,null);
+        Pair<Boolean, UserAuthenticator.ActionOnFailedAuthentication> rc;
+        when(ldapManager.getUser(username, domainId)).thenReturn(ldapUser);
+        rc = ldapAuthenticator.authenticate(username, "password", domainId, user);
+        assertFalse("authentication succeded when it should have failed", rc.first());
+        assertEquals("", UserAuthenticator.ActionOnFailedAuthentication.INCREMENT_INCORRECT_LOGIN_ATTEMPT_COUNT,rc.second());
+    }
+    @Test
+    public void authenticate() throws Exception {
+        LdapUser ldapUser = new LdapUser(username, "a@b", "b", "banner", principal, "", false, null);
+        when(ldapManager.getUser(username, domainId)).thenReturn(ldapUser);
+        when(ldapManager.canAuthenticate(principal, hardcoded, domainId)).thenReturn(true);
+        Pair<Boolean, UserAuthenticator.ActionOnFailedAuthentication> rc = ldapAuthenticator.authenticate(username, hardcoded, domainId, user);
+        assertTrue("authentication failed when it should have succeeded", rc.first());
+        assertNull(rc.second());
+    }
+}

--- a/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/LdapAuthenticatorTest.java
+++ b/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/LdapAuthenticatorTest.java
@@ -1,16 +1,23 @@
 package org.apache.cloudstack.ldap;
 
-import com.cloud.server.auth.*;
-import com.cloud.user.*;
-import com.cloud.user.dao.*;
-import com.cloud.utils.*;
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.*;
-import org.mockito.runners.*;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import com.cloud.server.auth.UserAuthenticator;
+import com.cloud.user.UserAccount;
+import com.cloud.user.UserAccountVO;
+import com.cloud.user.dao.UserAccountDao;
+import com.cloud.utils.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 
 @RunWith(MockitoJUnitRunner.class)
 public class LdapAuthenticatorTest {

--- a/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/LdapAuthenticatorTest.java
+++ b/plugins/user-authenticators/ldap/test/org/apache/cloudstack/ldap/LdapAuthenticatorTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.ldap;
 
 


### PR DESCRIPTION
## Description
ldap accounts that where not automatically imported but mapped manually were not able to login. fixed.

see https://lists.apache.org/thread.html/43ef6cc4bcf12340f8ac1c05fbcb7bf3afc3d6ed3b05ff509b9c6152@%3Cusers.cloudstack.apache.org%3E

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

this has only unit tests as an integration test requires an external system

it was tested manually using an openldap and a microsoft ad implementation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
