### PR TITLE
make Broadcast- and IsolationURI visible to admin

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -2835,6 +2835,16 @@
                                 }
                             }
                         },
+                        preFilter: function(args) {
+                            var hiddenFields;
+                            if (isAdmin()) {
+                                hiddenFields = [];
+                            } else {
+                                hiddenFields = ["broadcasturi", "isolationuri"];
+                            }
+
+                            return hiddenFields;
+                        },
                         fields: [{
                             id: {
                                 label: 'label.id'
@@ -2871,7 +2881,12 @@
                             ip6cidr: {
                                 label: 'label.ipv6.CIDR'
                             },
-
+                            broadcasturi : {
+                                label: 'label.broadcast.uri'
+                            },
+                            isolationuri : {
+                                label: 'label.isolation.uri'
+                            },
                             isdefault: {
                                 label: 'label.is.default',
                                 converter: function(data) {


### PR DESCRIPTION
## Description
As an admin /me wants to have easy access the broadcast uri ad the isolation uri used for a nic. these fields were missing in the UI while available in the API.

This can be argued to not be a bug, but it is a trivial fix of an old ommision, so feel free to argue it should't go in 4.11.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
<img width="386" alt="normaluserview" src="https://user-images.githubusercontent.com/2486961/38199392-f81b398e-3690-11e8-94cb-6c2d3f6072cf.png">
<img width="402" alt="adminuserview" src="https://user-images.githubusercontent.com/2486961/38199408-0193c5a8-3691-11e8-8505-6116c01115f6.png">

## How Has This Been Tested?
tested this by creating a user in the simulator and let it create a VM. Next view the NICs tab of the VM as normal user and as admin. The proof is in the screenshots.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
