### PR TITLE
Create an easy way to enable the Java remote Debug for ACS

### DIFF
--- a/packaging/systemd/cloudstack-management.default
+++ b/packaging/systemd/cloudstack-management.default
@@ -33,3 +33,7 @@ LOGDIR="/var/log/cloudstack/management"
 CLASSPATH="/etc/cloudstack/management:/usr/share/cloudstack-common:/usr/share/cloudstack-management/setup:/usr/share/cloudstack-management:/usr/share/java/mysql-connector-java.jar:/usr/share/java/commons-daemon.jar"
 
 BOOTSTRAP_CLASS=org.apache.cloudstack.ServerDaemon
+
+#You can uncomment this if you want to enable Java remote debugging.
+#You can change the parameters at your will. The 'address' field defines the port to be used. 
+#JAVA_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"

--- a/packaging/systemd/cloudstack-management.service
+++ b/packaging/systemd/cloudstack-management.service
@@ -28,7 +28,7 @@ Environment="NAME=cloudstack-management"
 EnvironmentFile=/etc/default/cloudstack-management
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment JAVA_HOME=$( readlink -f $( which java ) | sed s:bin/.*$:: )"
 ExecStartPre=/bin/bash -c "/bin/systemctl set-environment JARS=$(ls /usr/share/cloudstack-management/lib/*.jar | tr '\n' ':' | sed s'/.$//')"
-ExecStart=/usr/bin/jsvc -home "${JAVA_HOME}" -user "${CLOUDSTACK_USER}" -cp "${JARS}:${CLASSPATH}" -errfile ${LOGDIR}/${NAME}.err -cwd ${LOGDIR} -pidfile "${CLOUDSTACK_PID}" ${JAVA_OPTS} "${BOOTSTRAP_CLASS}"
+ExecStart=/usr/bin/jsvc $JAVA_DEBUG -home "${JAVA_HOME}" -user "${CLOUDSTACK_USER}" -cp "${JARS}:${CLASSPATH}" -errfile ${LOGDIR}/${NAME}.err -cwd ${LOGDIR} -pidfile "${CLOUDSTACK_PID}" ${JAVA_OPTS} "${BOOTSTRAP_CLASS}"
 ExecStop=/usr/bin/jsvc -cp "$JARS:$CLASSPATH" -pidfile "$CLOUDSTACK_PID" -stop "$BOOTSTRAP_CLASS"
 SuccessExitStatus=143
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The idea is to create a property in /etc/defaults/cloudstack-management that can be enabled/disabled (uncommented/commented) to control the enabling of Java remote debug in CloudStack's JVM.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Locally in my test environment. I applied this PR into my local ACS, and then checked if the remote debug using port 8000 would be available by uncommenting the 'JAVA_DEBUG' declaration in /etc/defaults/cloudstack-management. After uncommenting the variable I needed to restart the management server.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [X] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package