### PR TITLE
debian: Use only `-l` for libvirtd default file on debian

### DIFF
--- a/python/lib/cloud_utils.py
+++ b/python/lib/cloud_utils.py
@@ -759,7 +759,7 @@ class SetupLiveMigration(ConfigTask):
 			if os.path.exists("/etc/init/libvirt-bin.conf"):
 				replace_line("/etc/init/libvirt-bin.conf", "exec /usr/sbin/libvirtd","exec /usr/sbin/libvirtd -d -l")
 			else:
-				replace_or_add_line("/etc/default/libvirt-bin","libvirtd_opts=","libvirtd_opts='-l -d'")
+				replace_or_add_line("/etc/default/libvirt-bin","libvirtd_opts=","libvirtd_opts='-l'")
 			
 		else:
 			raise AssertionError("Unsupported distribution")

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -526,9 +526,12 @@ class libvirtConfigUbuntu(serviceCfgBase):
         if os.path.exists("/etc/init/libvirt-bin.conf"):
             cfo = configFileOps("/etc/init/libvirt-bin.conf", self)
             cfo.replace_line("exec /usr/sbin/libvirtd","exec /usr/sbin/libvirtd -d -l")
-        else:
+        elif os.path.exists("/etc/default/libvirt-bin"):
             cfo = configFileOps("/etc/default/libvirt-bin", self)
-            cfo.replace_or_add_line("libvirtd_opts=","libvirtd_opts='-l -d'")
+            cfo.replace_or_add_line("libvirtd_opts=","libvirtd_opts='-l'")
+        elif os.path.exists("/etc/default/libvirtd"):
+            cfo = configFileOps("/etc/default/libvirtd", self)
+            cfo.replace_or_add_line("libvirtd_opts=","libvirtd_opts='-l'")
 
     def config(self):
         try:


### PR DESCRIPTION
## Description

This fixes #2546

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
