### PR TITLE
agent: Add logging to libvirt qemu hook and cleanup

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -6,25 +6,36 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import sys
+
+import logging
 import re
+import sys
 from xml.dom.minidom import parse
 from cloudutils.configFileOps import configFileOps
 from cloudutils.networkConfig import networkConfig
+
+logging.basicConfig(filename='/var/log/libvirt/qemu-hook.log',
+                    filemode='a',
+                    format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+                    datefmt='%H:%M:%S',
+                    level=logging.INFO)
+logger = logging.getLogger('qemu-hook')
+
 def isOldStyleBridge(brName):
     if brName.find("cloudVirBr") == 0:
        return True
     else:
        return False
+
 def isNewStyleBridge(brName):
     if brName.startswith('brvx-'):
         return False
@@ -32,12 +43,14 @@ def isNewStyleBridge(brName):
        return False
     else:
        return True
+
 def getGuestNetworkDevice():
-    netlib = networkConfig() 
+    netlib = networkConfig()
     cfo = configFileOps("/etc/cloudstack/agent/agent.properties")
     guestDev = cfo.getEntry("guest.network.device")
     enslavedDev = netlib.getEnslavedDev(guestDev, 1)
     return enslavedDev.split(".")[0]
+
 def handleMigrateBegin():
     try:
         domain = parse(sys.stdin)
@@ -45,20 +58,26 @@ def handleMigrateBegin():
             source = interface.getElementsByTagName("source")[0]
             bridge = source.getAttribute("bridge")
             if isOldStyleBridge(bridge):
-                vlanId = bridge.replace("cloudVirBr","")
+                vlanId = bridge.replace("cloudVirBr", "")
             elif isNewStyleBridge(bridge):
-                vlanId = re.sub(r"br(\w+)-","",bridge)
+                vlanId = re.sub(r"br(\w+)-", "", bridge)
             else:
                 continue
             phyDev = getGuestNetworkDevice()
-            newBrName="br" + phyDev + "-" + vlanId
+            newBrName = "br" + phyDev + "-" + vlanId
             source.setAttribute("bridge", newBrName)
         print(domain.toxml())
     except:
         pass
+
+
 if __name__ == '__main__':
     if len(sys.argv) != 5:
         sys.exit(0)
 
-    if sys.argv[2] == "migrate" and sys.argv[3] == "begin":
-        handleMigrateBegin() 
+    # For docs refer https://libvirt.org/hooks.html#qemu
+    logger.debug("Executing qemu hook with args: %s" % sys.argv)
+    action, status = sys.argv[2:4]
+
+    if action == "migrate" and status == "begin":
+        handleMigrateBegin()


### PR DESCRIPTION
This allows logging to the default libvirt qemu hook and cleans up the script.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

Installed the hook script on centos6 and xenial/16.04 based kvm hosts, changes the logging scope to `DEBUG`, performed VM migration, which caused the following logs:

```
16:57:25,61 qemu-hook DEBUG Executing qemu-hook with args: ['/etc/libvirt/hooks/qemu', 'i-2-39-VM', 'stopped', 'end', '-']
16:57:25,275 qemu-hook DEBUG Executing qemu-hook with args: ['/etc/libvirt/hooks/qemu', 'i-2-39-VM', 'release', 'end', '-']
16:57:34,685 qemu-hook DEBUG Executing qemu-hook with args: ['/etc/libvirt/hooks/qemu', 'i-2-39-VM', 'migrate', 'begin', '-']
16:57:34,904 qemu-hook DEBUG Executing qemu-hook with args: ['/etc/libvirt/hooks/qemu', 'i-2-39-VM', 'prepare', 'begin', '-']
16:57:36,880 qemu-hook DEBUG Executing qemu-hook with args: ['/etc/libvirt/hooks/qemu', 'i-2-39-VM', 'start', 'begin', '-']
16:57:37,388 qemu-hook DEBUG Executing qemu-hook with args: ['/etc/libvirt/hooks/qemu', 'i-2-39-VM', 'started', 'begin', '-']
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
