### PR TITLE
List template with id no longer works as domain admin

### DIFF
--- a/server/src/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/com/cloud/api/query/QueryManagerImpl.java
@@ -3147,15 +3147,16 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 ex.addProxyObject(template.getUuid(), "templateId");
                 throw ex;
             }
-            if (caller.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN) {
-                Account template_acc = _accountMgr.getAccount(template.getAccountId());
-                DomainVO domain = _domainDao.findById(template_acc.getDomainId());
-                _accountMgr.checkAccess(caller, domain);
 
-
-            }// if template is not public, perform permission check here
-            else if (!template.isPublicTemplate() && caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
-                _accountMgr.checkAccess(caller, null, false, template);
+            // if template is not public, perform permission check here
+            if (!template.isPublicTemplate()) {
+                if (caller.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN) {
+                    Account template_acc = _accountMgr.getAccount(template.getAccountId());
+                    DomainVO domain = _domainDao.findById(template_acc.getDomainId());
+                    _accountMgr.checkAccess(caller, domain);
+                } else if (caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
+                    _accountMgr.checkAccess(caller, null, false, template);
+                }
             }
 
             // if templateId is specified, then we will just use the id to


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Original ticket: https://issues.apache.org/jira/browse/CLOUDSTACK-9862
As domain admin, listTemplates templatefilter=featured no longer work if id= is specified.

Using cloudmonkey with domain-admin credential:

```
(beta2r1-ninja) > list templates templatefilter=featured filter=name,id
count = 9
template:
+--------------------------------------+---------------------------------+
|                  id                  |               name              |
+--------------------------------------+---------------------------------+
| 513b3a6d-c011-46f0-a4a3-2a954cadb673 |      CoreOS Alpha 1367.5.0      |
| 0c04d876-1f85-45a7-b6f4-504de435bf12 |    Debian 8.5 PV base (64bit)   |
| 285f2203-449a-428f-997a-1ffbebbf1382 |           CoreOS Alpha          |
| 332b6ca8-b3d6-42c7-83e5-60fe87be6576 |          CoreOS Stable          |
| 3b705008-c186-464d-ad59-312d902420af |   Windows Server 2016 std SPLA  |
| 4256aebe-a1c1-4b49-9993-de2bc712d521 |       Ubuntu 16.04.01 HVM       |
| 59e6b00a-b88e-4539-aa3c-75c9c7e9fa6c | Ubuntu 14.04.5 HVM base (64bit) |
| 3ab936eb-d8c2-44d8-a64b-17ad5adf8a51 |          CentOS 6.8 PV          |
| 7de5d423-c91e-49cc-86e8-9d6ed6abd997 |          CentOS 7.2 HVM         |
+--------------------------------------+---------------------------------+
(beta2r1-ninja) > list templates templatefilter=featured id=7de5d423-c91e-49cc-86e8-9d6ed6abd997 filter=name,id
Error 531: Acct[b285d62e-0ec2-4a7c-b773-961595ec6356-Ninja-5664] does not have permission to operate within domain id=c9b4f83d-16eb-11e7-a8b9-367e6fe958a9
cserrorcode = 4365
errorcode = 531
errortext = Acct[b285d62e-0ec2-4a7c-b773-961595ec6356-Ninja-5664] does not have permission to operate within domain id=c9b4f83d-16eb-11e7-a8b9-367e6fe958a9
uuidList:
(beta2r1-ninja) > list templates templatefilter=featured ids=7de5d423-c91e-49cc-86e8-9d6ed6abd997 filter=name,id
count = 1
template:
+--------------------------------------+----------------+
|                  id                  |      name      |
+--------------------------------------+----------------+
| 7de5d423-c91e-49cc-86e8-9d6ed6abd997 | CentOS 7.2 HVM |
+--------------------------------------+----------------+
```

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
