### PR TITLE
consoleproxy: use consoleproxy.domain for non-ssl enable env

### DIFF
--- a/core/src/com/cloud/info/ConsoleProxyInfo.java
+++ b/core/src/com/cloud/info/ConsoleProxyInfo.java
@@ -19,6 +19,8 @@
 
 package com.cloud.info;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class ConsoleProxyInfo {
 
     private boolean sslEnabled;
@@ -55,6 +57,9 @@ public class ConsoleProxyInfo {
                 proxyImageUrl += ":" + this.proxyUrlPort;
         } else {
             proxyAddress = proxyIpAddress;
+            if (StringUtils.isNotBlank(consoleProxyUrlDomain)) {
+                proxyAddress = consoleProxyUrlDomain;
+            }
             proxyPort = port;
             this.proxyUrlPort = proxyUrlPort;
 

--- a/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -231,7 +231,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
     private String _instance;
 
     private int _proxySessionTimeoutValue = DEFAULT_PROXY_SESSION_TIMEOUT;
-    private boolean _sslEnabled = true;
+    private boolean _sslEnabled = false;
     private String _consoleProxyUrlDomain;
 
     // global load picture at zone basis
@@ -1246,8 +1246,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
 
         Map<String, String> configs = _configDao.getConfiguration("management-server", params);
 
-        String value = configs.get(Config.ConsoleProxyCmdPort.key());
-        value = configs.get("consoleproxy.sslEnabled");
+        String value = configs.get("consoleproxy.sslEnabled");
         if (value != null && value.equalsIgnoreCase("true")) {
             _sslEnabled = true;
         }


### PR DESCRIPTION
This allows CloudStack to use a console proxy domain instead of public
IP address even when ssl is not enabled but console proxy url/domain
is defined in global settings.

This allows use of domain url for console proxy endpoint, without needing to have
SSL certificates setup.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

I was trying to setup a lab for testing CloudStack, this lab is in my home. To make it
publicly accessible, I've a DO machine to which one of my machines does autossh
and port forwards to it. The DO machine has apache2 running that reverse proxies
to only certain paths on the forwarded port. The DO endpoint is secured by letsencrypt
certs. With this change, a user/admin will be able to run console proxy via a URL/domain
but on http instead of https internally. Externally, such as my setup, one can secure
urls/paths using a single frontend machine. The apache2 reverse proxy setup I'm using is
where the ip of the CPVM is 192.168.1.51 (home network/internal)
```
        # Console proxy
        ProxyPass /ajax http://192.168.1.51/ajax
        ProxyPassReverse /ajax http://192.168.1.51/ajax
        ProxyPass /ajaximg http://192.168.1.51/ajaximg
        ProxyPassReverse /ajaximg http://192.168.1.51/ajaximg
        ProxyPass /resource http://192.168.1.51/resource
        ProxyPassReverse /resource http://192.168.1.51/resource
```

![screenshot from 2018-04-11 22-56-22](https://user-images.githubusercontent.com/95203/38632881-a7f2187c-3ddb-11e8-90e0-8b5b9f29f47e.png)

The following shows my home lab setup:
![untitled diagram](https://user-images.githubusercontent.com/95203/38634142-51fe43ce-3ddf-11e8-844e-382f3b0c3543.png)


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
