### PR TITLE
[Vmware] Fix for OVF parsing error

### DIFF
--- a/api/src/com/cloud/agent/api/storage/OVFHelper.java
+++ b/api/src/com/cloud/agent/api/storage/OVFHelper.java
@@ -113,7 +113,7 @@ public class OVFHelper {
                 String allocationUnits = disk.getAttribute("ovf:capacityAllocationUnits");
                 od._diskId = disk.getAttribute("ovf:diskId");
                 od._fileRef = disk.getAttribute("ovf:fileRef");
-                od._populatedSize = Long.parseLong(disk.getAttribute("ovf:populatedSize") == null ? "0" : disk.getAttribute("ovf:populatedSize"));
+                od._populatedSize = NumberUtils.toLong(disk.getAttribute("ovf:populatedSize"));
 
                 if ((od._capacity != 0) && (allocationUnits != null)) {
 


### PR DESCRIPTION
## Description
OVF files contained on OVA template files, with missing 'ovf:populatedSize' attribute fail the post download installation.

After template is downloaded, installation fails with error:

````
2018-04-12 13:36:47,959 INFO  [storage.template.OVAProcessor] (pool-1-thread-6:null) The ovf file /mnt/SecStorage/3544cb8f-d19d-3ebb-b8f2-bdc7ee4b7a4c/template/tmpl/2/206/3283498e6608-10f2-34c0-9ad4-808f
f593bea9.ovf is invalid
java.lang.NumberFormatException: For input string: ""

at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)

at java.lang.Long.parseLong(Long.java:601)

at java.lang.Long.parseLong(Long.java:631)

at com.cloud.agent.api.storage.OVFHelper.getOVFVolumeInfo(OVFHelper.java:116)

at com.cloud.storage.template.OVAProcessor.process(OVAProcessor.java:105)

at org.apache.cloudstack.storage.template.DownloadManagerImpl.postLocalDownload(DownloadManagerImpl.java:462)

at org.apache.cloudstack.storage.template.DownloadManagerImpl.setDownloadStatus(DownloadManagerImpl.java:302)

at org.apache.cloudstack.storage.template.DownloadManagerImpl$Completion.downloadComplete(DownloadManagerImpl.java:105)

at com.cloud.storage.template.HttpTemplateDownloader.download(HttpTemplateDownloader.java:228)

at com.cloud.storage.template.HttpTemplateDownloader.runInContext(HttpTemplateDownloader.java:426)

at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:49)

at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:56)

at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:103)

at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:53)

at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:46)

at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)

at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)

at java.lang.Thread.run(Thread.java:748)
2018-04-12 13:36:47,962 ERROR [storage.template.DownloadManagerImpl] (pool-1-thread-6:null) Template process exception
com.cloud.exception.InternalErrorException: OVA package has bad ovf file For input string: ""
````


## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Tested on Vmware environment registering a Windows 2012 OVA template.
OVF file didn't include the 'ovf:populatedSize' attribute

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

@blueorangutan package
