### PR TITLE
Fix Python code checkstyle execute by "systemvm\test\runtests.sh"

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -196,7 +196,7 @@ class CsAcl(CsDataBag):
                 egressIpsetStr = ''
                 if sflag and dflag:
                     egressIpsetStr = " -m set --match-set %s src " % sourceIpsetName + \
-                                " -m set --match-set %s dst " % destIpsetName
+                                     " -m set --match-set %s dst " % destIpsetName
                 elif sflag:
                     egressIpsetStr = " -m set --match-set %s src " % sourceIpsetName
                 elif dflag:
@@ -204,10 +204,10 @@ class CsAcl(CsDataBag):
 
                 if rule['protocol'] == "icmp":
                     fwr += egressIpsetStr + " -p %s " % rule['protocol'] + " -m %s " % rule['protocol'] + \
-                                    " --icmp-type %s" % icmp_type
+                                     " --icmp-type %s" % icmp_type
                 elif rule['protocol'] != "all":
                     fwr += egressIpsetStr + " -p %s " % rule['protocol'] + " -m %s " % rule['protocol'] + \
-                           " %s" % rnge
+                                     " %s" % rnge
                 elif rule['protocol'] == "all":
                     fwr += egressIpsetStr
 

--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -1052,5 +1052,6 @@ def main(argv):
     red.set()
     return 0
 
+
 if __name__ == "__main__":
     main(sys.argv)

--- a/systemvm/debian/opt/cloud/bin/cs/CsProcess.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsProcess.py
@@ -42,10 +42,10 @@ class CsProcess(object):
         self.pid = []
         for i in CsHelper.execute("ps aux"):
             items = len(self.search)
-            proc = re.split("\s+", i)[items*-1:]
+            proc = re.split(r"\s+", i)[items*-1:]
             matches = len([m for m in proc if m in self.search])
             if matches == items:
-                self.pid.append(re.split("\s+", i)[1])
+                self.pid.append(re.split(r"\s+", i)[1])
 
         logging.debug("CsProcess:: Searching for process ==> %s and found PIDs ==> %s", self.search, self.pid)
         return self.pid
@@ -61,5 +61,5 @@ class CsProcess(object):
     def grep(self, str):
         for i in CsHelper.execute("ps aux"):
             if i.find(str) != -1:
-                return re.split("\s+", i)[1]
+                return re.split(r"\s+", i)[1]
         return -1

--- a/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRedundant.py
@@ -127,7 +127,7 @@ class CsRedundant(object):
             "%s/%s" % (self.CS_TEMPLATES_DIR, "checkrouter.sh.templ"), "/opt/cloud/bin/checkrouter.sh")
 
         CsHelper.execute(
-            'sed -i "s/--exec\ \$DAEMON;/--exec\ \$DAEMON\ --\ --vrrp;/g" /etc/init.d/keepalived')
+            'sed -i "s/--exec $DAEMON;/--exec $DAEMON -- --vrrp;/g" /etc/init.d/keepalived')
         # checkrouter.sh configuration
         check_router = CsFile("/opt/cloud/bin/checkrouter.sh")
         check_router.greplace("[RROUTER_LOG]", self.RROUTER_LOG)
@@ -319,7 +319,7 @@ class CsRedundant(object):
                     logging.info("Adding gateway ==> %s to device ==> %s" % (gateway, dev))
                     if dev == CsHelper.PUBLIC_INTERFACES[self.cl.get_type()]:
                         route.add_defaultroute(gateway)
-                except:
+                except Exception:
                     logging.error("ERROR getting gateway from device %s" % dev)
             else:
                 logging.error("Device %s was not ready could not bring it up" % dev)

--- a/systemvm/debian/opt/cloud/bin/line_edit.py
+++ b/systemvm/debian/opt/cloud/bin/line_edit.py
@@ -193,6 +193,7 @@ class LineEditingFile(object):
                 os.unlink(changed_filename)
         return changes
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     import doctest

--- a/systemvm/debian/opt/cloud/bin/update_config.py
+++ b/systemvm/debian/opt/cloud/bin/update_config.py
@@ -112,6 +112,7 @@ def is_guestnet_configured(guestnet_dict, keys):
 
     return exists
 
+
 # If the command line json file is unprocessed process it
 # This is important or, the control interfaces will get deleted!
 if jsonFilename != "cmd_line.json" and os.path.isfile(jsonPath % "cmd_line.json"):

--- a/systemvm/debian/opt/cloud/bin/vmdata.py
+++ b/systemvm/debian/opt/cloud/bin/vmdata.py
@@ -164,5 +164,6 @@ def unflock(file):
         sys.exit(1)
     return True
 
+
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/systemvm/test/TestCsAddress.py
+++ b/systemvm/test/TestCsAddress.py
@@ -38,5 +38,6 @@ class TestCsAddress(unittest.TestCase):
     def test_get_guest_netmask(self):
         self.assertTrue(self.csaddress.get_guest_netmask() == "255.255.255.0")
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsApp.py
+++ b/systemvm/test/TestCsApp.py
@@ -34,5 +34,6 @@ class TestCsApp(unittest.TestCase):
         csapp = CsApp(csip)
         self.assertTrue(csapp is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsCmdLine.py
+++ b/systemvm/test/TestCsCmdLine.py
@@ -42,5 +42,6 @@ class TestCsCmdLine(unittest.TestCase):
         self.cscmdline.set_guest_gw(tval)
         self.assertTrue(self.cscmdline.get_guest_gw() == tval)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsConfig.py
+++ b/systemvm/test/TestCsConfig.py
@@ -29,5 +29,6 @@ class TestCsConfig(unittest.TestCase):
         csconfig = CsConfig()
         self.assertTrue(csconfig is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsDatabag.py
+++ b/systemvm/test/TestCsDatabag.py
@@ -29,5 +29,6 @@ class TestCsDatabag(unittest.TestCase):
         csdatabag = CsDataBag("koffie")
         self.assertTrue(csdatabag is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsDhcp.py
+++ b/systemvm/test/TestCsDhcp.py
@@ -33,5 +33,6 @@ class TestCsDhcp(unittest.TestCase):
         csdhcp = CsDhcp("dhcpentry", {})
         self.assertTrue(csdhcp is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsFile.py
+++ b/systemvm/test/TestCsFile.py
@@ -29,5 +29,6 @@ class TestCsFile(unittest.TestCase):
         csfile = CsFile("testfile")
         self.assertTrue(csfile is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsGuestNetwork.py
+++ b/systemvm/test/TestCsGuestNetwork.py
@@ -41,5 +41,6 @@ class TestCsGuestNetwork(unittest.TestCase):
         dns = csguestnetwork.get_dns()
         self.assertTrue(len(dns) == 2)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsHelper.py
+++ b/systemvm/test/TestCsHelper.py
@@ -31,5 +31,6 @@ class TestCsHelper(unittest.TestCase):
         result = CsHelper.execute("/bin/false")
         self.assertTrue(result is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsInterface.py
+++ b/systemvm/test/TestCsInterface.py
@@ -34,5 +34,6 @@ class TestCsInterface(unittest.TestCase):
     def test_is_public(self):
         self.assertTrue(self.csinterface.is_public() is False)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsNetfilter.py
+++ b/systemvm/test/TestCsNetfilter.py
@@ -29,5 +29,6 @@ class TestCsNetfilter(unittest.TestCase):
         csnetfilter = CsNetfilter()
         self.assertTrue(csnetfilter is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsProcess.py
+++ b/systemvm/test/TestCsProcess.py
@@ -29,5 +29,6 @@ class TestCsProcess(unittest.TestCase):
         csprocess = CsProcess({})
         self.assertTrue(csprocess is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsRedundant.py
+++ b/systemvm/test/TestCsRedundant.py
@@ -36,5 +36,6 @@ class TestCsRedundant(unittest.TestCase):
         csredundant = CsRedundant(csconfig)
         self.assertTrue(csredundant is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsRoute.py
+++ b/systemvm/test/TestCsRoute.py
@@ -43,5 +43,6 @@ class TestCsRoute(unittest.TestCase):
         name = "eth1"
         self.assertEqual("Table_eth1", csroute.get_tablename(name))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/TestCsRule.py
+++ b/systemvm/test/TestCsRule.py
@@ -29,5 +29,6 @@ class TestCsRule(unittest.TestCase):
         csrule = CsRule("eth1")
         self.assertTrue(csrule is not None)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/systemvm/test/runtests.sh
+++ b/systemvm/test/runtests.sh
@@ -21,9 +21,9 @@
 export PYTHONPATH="../debian/opt/cloud/bin/"
 export PYTHONDONTWRITEBYTECODE=False
 
-echo "Running pep8 to check systemvm/python code for errors"
-pep8 --max-line-length=179 *py
-pep8 --max-line-length=179 --exclude=monitorServices.py,baremetal-vr.py,passwd_server_ip.py `find ../debian -name \*.py`
+echo "Running pycodestyle to check systemvm/python code for errors"
+pycodestyle --max-line-length=179 *py
+pycodestyle --max-line-length=179 --exclude=monitorServices.py,baremetal-vr.py,passwd_server_ip.py `find ../debian -name \*.py`
 if [ $? -gt 0 ]
 then
     echo "Pylint failed, please check your code"

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -22,6 +22,8 @@
 #
 
 echo -e "#### System Information ####"
+echo -e "\nO.S. information:"
+echo $(uname -a)
 
 echo -e "\nWho am I:"
 whoami
@@ -100,7 +102,7 @@ pip install --user --upgrade pip
 
 for ((i=0;i<$RETRY_COUNT;i++))
 do
-  pip install --user --upgrade lxml paramiko nose texttable ipmisim pyopenssl mock flask netaddr pylint pep8 > /tmp/piplog
+  pip install --user --upgrade lxml paramiko nose texttable ipmisim pyopenssl mock flask netaddr pylint pycodestyle six astroid > /tmp/piplog
   if [[ $? -eq 0 ]]; then
     echo -e "\npython packages installed successfully"
     break;
@@ -109,3 +111,5 @@ do
   cat /tmp/piplog
 done
 
+echo -e "\nVersion of pip troublesome packages:\n"
+echo $(pip freeze | grep -e six -e mock -e astroid -e enum34)

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -111,5 +111,5 @@ do
   cat /tmp/piplog
 done
 
-echo -e "\nVersion of pip troublesome packages:\n"
-echo $(pip freeze | grep -e six -e mock -e astroid -e enum34)
+echo -e "\nVersion of pip packages:\n"
+echo $(pip freeze)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I noticed a failure in travis for PR #2574 relating to Python code check style. While investigating that error, I found out that when running `cloudstack/systemvm/test/runtests.sh` I was receiving the following errors:
```
[root@AcsBuildVm test]# ./runtests.sh
Running pep8 to check systemvm/python code for errors
../debian/opt/cloud/bin/configure.py:199:33: E126 continuation line over-indented for hanging indent
../debian/opt/cloud/bin/configure.py:207:37: E126 continuation line over-indented for hanging indent
../debian/opt/cloud/bin/configure.py:210:28: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:817:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:818:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:819:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:820:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:821:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:822:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:823:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:827:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:828:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:829:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:830:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:831:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:832:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:833:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:837:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:838:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:839:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:840:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:841:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:842:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:846:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:847:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:848:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:849:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:850:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:851:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:852:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:856:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:857:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:858:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:859:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:860:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:861:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:865:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:866:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:867:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:868:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:869:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:873:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:874:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:875:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:876:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/configure.py:877:17: E121 continuation line indentation is not a multiple of four
../debian/opt/cloud/bin/cs/CsRedundant.py:159:23: E121 continuation line indentation is not a multiple of four
```
That command is executed by Travis. After fixing these issues. The "systemvm\test\runtests.sh" stopped failing.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Locally
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [X] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package