### PR TITLE
router: fix routing table for marked packets

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -926,8 +926,8 @@ class CsForwardingRules(CsDataBag):
                         "-I PREROUTING -s %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
                         rule["internal_ip"]])
         self.fw.append(["mangle", "",
-                        "-I PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark 0x%s/0xffffffff" %
-                        (rule["internal_ip"], device[len("eth"):])])
+                        "-I PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
+                        (rule["internal_ip"], hex(int(device[len("eth"):])))])
         self.fw.append(["nat", "front",
                         "-A PREROUTING -d %s/32 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])
         self.fw.append(["nat", "front",

--- a/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
@@ -62,13 +62,16 @@ class CsRoute:
         table = self.get_tablename(dev)
         logging.info("Adding route: dev " + dev + " table: " +
                      table + " network: " + address + " if not present")
-        cmd = "dev %s table %s throw %s proto static" % (dev, table, address)
+        cmd = "throw %s table %s proto static" % (address, table)
         self.set_route(cmd)
 
     def set_route(self, cmd, method="add"):
         """ Add a route if it is not already defined """
         found = False
-        for i in CsHelper.execute("ip route show " + cmd):
+        search = cmd
+        if "throw" in search:
+            search = "type " + search
+        for i in CsHelper.execute("ip route show " + search):
             found = True
         if not found and method == "add":
             logging.info("Add " + cmd)


### PR DESCRIPTION
This fixes python code that applies NAT/address rules. This fixes routing rules based on ip addresses received to ensure that marked packets will have a routing rule. Thereby, this fixes the issue of
public IP NAT access from other VMs in the VPC.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

- Create a VPC and deployed two VMs in a single tier in 10.1.1.1/24, allow_all policy (egress/ingress)
- Added a public IP for the VPC enabled SNAT of that public IP to the VM1, similarly for VM2
- Before the fix, I was unable to SSH from VM1 to VM2's public SNAT IP
- After the fix ssh/ping/access via public IP works
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
