### PR TITLE
cs-45to411-ugrade-fix: database errors during upgrade to 4.11

### DIFF
--- a/engine/schema/resources/META-INF/db/schema-41000to41100.sql
+++ b/engine/schema/resources/META-INF/db/schema-41000to41100.sql
@@ -392,7 +392,7 @@ CREATE VIEW `cloud`.`volume_view` AS
         `cloud`.`domain` resource_tag_domain ON resource_tag_domain.id = resource_tags.domain_id;
 
 -- Extra Dhcp Options
-CREATE TABLE  IF NOT EXISTS `cloud`.`nic_extra_dhcp_options` (
+CREATE TABLE IF NOT EXISTS `cloud`.`nic_extra_dhcp_options` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT COMMENT 'id',
   `uuid` varchar(255) UNIQUE,
   `nic_id` bigint unsigned NOT NULL COMMENT ' nic id where dhcp options are applied',
@@ -427,8 +427,7 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervi
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) SELECT UUID(),'Xenserver', '7.2.0', guest_os_name, guest_os_id, utc_timestamp(), 0  FROM `cloud`.`guest_os_hypervisor` WHERE hypervisor_type='Xenserver' AND hypervisor_version='7.1.0' AND guest_os_id not in (1,2,3,4,56,101,56,58,93,94,50,51,87,88,89,90,91,92,26,27,28,29,40,41,42,43,44,45,96,97,107,108,109,110,151,152,153);
 
 -- Add table to track primary storage in use for snapshots
-DROP TABLE IF EXISTS `cloud_usage`.`usage_snapshot_on_primary`;
-CREATE TABLE `cloud_usage`.`usage_snapshot_on_primary` (
+CREATE TABLE IF NOT EXISTS `cloud_usage`.`usage_snapshot_on_primary` (
   `id` bigint(20) unsigned NOT NULL,
   `zone_id` bigint(20) unsigned NOT NULL,
   `account_id` bigint(20) unsigned NOT NULL,

--- a/engine/schema/resources/META-INF/db/schema-452to460.sql
+++ b/engine/schema/resources/META-INF/db/schema-452to460.sql
@@ -385,8 +385,7 @@ INSERT IGNORE INTO `cloud`.`configuration` VALUES ('Advanced', 'DEFAULT', 'Netwo
 
 UPDATE IGNORE `cloud`.`configuration` SET `value`="PLAINTEXT" WHERE `name`="user.authenticators.exclude";
 
-DROP TABLE IF EXISTS `cloud`.`external_bigswitch_vns_devices`;
-CREATE TABLE `cloud`.`external_bigswitch_bcf_devices` (
+CREATE TABLE IF NOT EXISTS `cloud`.`external_bigswitch_bcf_devices` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT COMMENT 'id',
   `uuid` varchar(255) UNIQUE,
   `physical_network_id` bigint unsigned NOT NULL COMMENT 'id of the physical network in to which bigswitch bcf device is added',
@@ -405,7 +404,7 @@ CREATE TABLE `cloud`.`external_bigswitch_bcf_devices` (
 
 UPDATE `cloud`.`host` SET `resource`='com.cloud.hypervisor.xenserver.resource.XenServer600Resource' WHERE `resource`='com.cloud.hypervisor.xenserver.resource.XenServer602Resource';
 
-CREATE TABLE `cloud`.`ldap_trust_map` (
+CREATE TABLE IF NOT EXISTS `cloud`.`ldap_trust_map` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `domain_id` bigint unsigned NOT NULL,
   `type` varchar(10) NOT NULL,

--- a/engine/schema/resources/META-INF/db/schema-4930to41000.sql
+++ b/engine/schema/resources/META-INF/db/schema-4930to41000.sql
@@ -111,7 +111,7 @@ INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervi
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'KVM', 'default', 'CentOS 7.2', 274, now(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'KVM', 'default', 'Other PV Virtio-SCSI (64-bit)', 275, now(), 0);
 
-CREATE TABLE `cloud`.`vlan_details` (
+CREATE TABLE IF NOT EXISTS `cloud`.`vlan_details` (
   `id` bigint unsigned NOT NULL auto_increment,
   `vlan_id` bigint unsigned NOT NULL COMMENT 'vlan id',
   `name` varchar(255) NOT NULL,
@@ -137,7 +137,7 @@ INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`,
 INSERT INTO `cloud`.`role_permissions` (`uuid`, `role_id`, `rule`, `permission`, `sort_order`) values (UUID(), 4, 'createSnapshotFromVMSnapshot', 'ALLOW', 260) ON DUPLICATE KEY UPDATE rule=rule;
 
 -- Create table storage_pool_tags
-CREATE TABLE `cloud`.`storage_pool_tags` (
+CREATE TABLE IF NOT EXISTS `cloud`.`storage_pool_tags` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `pool_id` bigint(20) unsigned NOT NULL COMMENT "pool id",
   `tag` varchar(255) NOT NULL,
@@ -235,7 +235,7 @@ WHERE (o.cpu is null AND o.speed IS NULL AND o.ram_size IS NULL) AND
 -- CLOUDSTACK-9827: Storage tags stored in multiple places
 DROP VIEW IF EXISTS `cloud`.`storage_tag_view`;
 
-CREATE TABLE `cloud`.`guest_os_details` (
+CREATE TABLE IF NOT EXISTS `cloud`.`guest_os_details` (
   `id` bigint unsigned NOT NULL auto_increment,
   `guest_os_id` bigint unsigned NOT NULL COMMENT 'VPC gateway id',
   `name` varchar(255) NOT NULL,
@@ -246,7 +246,7 @@ CREATE TABLE `cloud`.`guest_os_details` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `user_ip_address` ADD COLUMN `rule_state` VARCHAR(32) COMMENT 'static  rule state while removing';
-CREATE TABLE `cloud`.`firewall_rules_dcidrs`(
+CREATE TABLE IF NOT EXISTS `cloud`.`firewall_rules_dcidrs`(
   `id` BIGINT(20) unsigned NOT NULL AUTO_INCREMENT,
   `firewall_rule_id` BIGINT(20) unsigned NOT NULL,
   `destination_cidr` VARCHAR(18) DEFAULT NULL,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fixes a database error that occurs when upgrading from 4.5 to 4.11. A 'table already exists' SQL error is encountered during the upgrade.
If a table already exists in the database, it should only attempt to create a table if it does not exist.
The fix adds SQL syntax create a table only if not exists and also removes the drop table statements since there may be users that already have such a table with data in their database.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Expected behaviour: when upgrading from an older version of cloudstack, it should upgrade the database without producing any SQL errors. Specifically, the SQL upgrade scripts should not attempt to create a table if it already exists. It should also not attempt to drop existing tables unless it is in the cleanup scripts. 
Actual behaviour: a database error that occurs when upgrading from 4.5 to 4.11. A 'table already exists' SQL error is encountered during the upgrade.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This was manually tested by installing a 4.5 version of cloudstack environment and then did the upgrade to version 4.11.1.0.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

<!-- The following will kick a packaging job, remove if as applicable -->
@blueorangutan package
