### PR TITLE
Remove packaging job from pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -37,5 +37,3 @@
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
 
-<!-- The following will kick a packaging job, remove if as applicable -->
-@blueorangutan package


### PR DESCRIPTION
## Description
Remove the packaging job invocation from the PR description as when closing/merging a PR, an extra packaging job is executed.

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs

## Screenshots (if appropriate):

## How Has This Been Tested?

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.