### PR TITLE
api: move default response from XML to JSON

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiServlet.java
+++ b/server/src/main/java/com/cloud/api/ApiServlet.java
@@ -140,9 +140,9 @@ public class ApiServlet extends HttpServlet {
             s_logger.warn("UnknownHostException when trying to lookup remote IP-Address. This should never happen. Blocking request.", e);
             final String response = apiServer.getSerializedApiError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "UnknownHostException when trying to lookup remote IP-Address", null,
-                    HttpUtils.RESPONSE_TYPE_XML);
+                    HttpUtils.RESPONSE_TYPE_JSON);
             HttpUtils.writeHttpResponse(resp, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                    HttpUtils.RESPONSE_TYPE_XML, ApiServer.JSONcontentType.value());
+                    HttpUtils.RESPONSE_TYPE_JSON, ApiServer.JSONcontentType.value());
             return;
         }
 
@@ -150,7 +150,7 @@ public class ApiServlet extends HttpServlet {
         auditTrailSb.append(" ").append(remoteAddress.getHostAddress());
         auditTrailSb.append(" -- ").append(req.getMethod()).append(' ');
         // get the response format since we'll need it in a couple of places
-        String responseType = HttpUtils.RESPONSE_TYPE_XML;
+        String responseType = HttpUtils.RESPONSE_TYPE_JSON;
         final Map<String, Object[]> params = new HashMap<String, Object[]>();
         params.putAll(req.getParameterMap());
 
@@ -169,12 +169,6 @@ public class ApiServlet extends HttpServlet {
         }
 
         try {
-
-            if (HttpUtils.RESPONSE_TYPE_JSON.equalsIgnoreCase(responseType)) {
-                resp.setContentType(ApiServer.JSONcontentType.value());
-            } else if (HttpUtils.RESPONSE_TYPE_XML.equalsIgnoreCase(responseType)){
-                resp.setContentType(HttpUtils.XML_CONTENT_TYPE);
-            }
 
             HttpSession session = req.getSession(false);
             final Object[] responseTypeParam = params.get(ApiConstants.RESPONSE);


### PR DESCRIPTION
## Description
Moving the default response type (when not provided) from XML to JSON.

Java community used to love XML a lot, but let's face it, nowadays people are using JSON whenever they can.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (https://github.com/apache/cloudstack-docs/pull/25)
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

