### PR TITLE
CLOUDSTACK-10360: Change the method name.

### DIFF
--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -152,7 +152,7 @@ public class ConfigKey<T> {
             return value();
         }
 
-        String value = s_depot != null ? s_depot.findStorage(this).getConfigValue(id, this) : null;
+        String value = s_depot != null ? s_depot.findScopedConfigStorage(this).getConfigValue(id, this) : null;
         if (value == null) {
             return value();
         } else {

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/ConfigKey.java
@@ -152,7 +152,7 @@ public class ConfigKey<T> {
             return value();
         }
 
-        String value = s_depot != null ? s_depot.scoped(this).getConfigValue(id, this) : null;
+        String value = s_depot != null ? s_depot.findStorage(this).getConfigValue(id, this) : null;
         if (value == null) {
             return value();
         } else {

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
@@ -166,7 +166,7 @@ public class ConfigDepotImpl implements ConfigDepot, ConfigDepotAdmin {
         return _configDao;
     }
 
-    public ScopedConfigStorage findStorage(ConfigKey<?> config) {
+    public ScopedConfigStorage findScopedConfigStorage(ConfigKey<?> config) {
         for (ScopedConfigStorage storage : _scopedStorages) {
             if (storage.getScope() == config.scope()) {
                 return storage;

--- a/framework/config/src/main/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
+++ b/framework/config/src/main/java/org/apache/cloudstack/framework/config/impl/ConfigDepotImpl.java
@@ -166,7 +166,7 @@ public class ConfigDepotImpl implements ConfigDepot, ConfigDepotAdmin {
         return _configDao;
     }
 
-    public ScopedConfigStorage scoped(ConfigKey<?> config) {
+    public ScopedConfigStorage findStorage(ConfigKey<?> config) {
         for (ScopedConfigStorage storage : _scopedStorages) {
             if (storage.getScope() == config.scope()) {
                 return storage;


### PR DESCRIPTION
The method is named as "scoped" that seems to whether the variable config is scoped in _scopedStorages or not.
Actually, the method tries to find a storage of which scope equals to the scope of config.
So that, the method name "findStorage" should be more clear than "scoped".
