### PR TITLE
CLOUDSTACK-10363: Change method names.

### DIFF
--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -482,7 +482,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
         throw new CloudRuntimeException("Unable to find dispatcher name: " + dispatcherName);
     }
 
-    private AsyncJobDispatcher getWakeupDispatcher(AsyncJob job) {
+    private AsyncJobDispatcher findWakeupDispatcher(AsyncJob job) {
         if (_jobDispatchers != null) {
             List<AsyncJobJoinMapVO> joinRecords = _joinMapDao.listJoinRecords(job.getId());
             if (joinRecords.size() > 0) {
@@ -567,7 +567,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                     }
 
                     if ((getAndResetPendingSignals(job) & AsyncJob.Constants.SIGNAL_MASK_WAKEUP) != 0) {
-                        AsyncJobDispatcher jobDispatcher = getWakeupDispatcher(job);
+                        AsyncJobDispatcher jobDispatcher = findWakeupDispatcher(job);
                         if (jobDispatcher != null) {
                             jobDispatcher.runJob(job);
                         } else {

--- a/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/OvsTunnelManagerImpl.java
+++ b/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/OvsTunnelManagerImpl.java
@@ -212,7 +212,7 @@ public class OvsTunnelManagerImpl extends ManagerBase implements OvsTunnelManage
         Long from = r.getFrom();
         Long to = r.getTo();
         long networkId = r.getNetworkId();
-        OvsTunnelNetworkVO tunnel = _tunnelNetworkDao.getByFromToNetwork(from, to, networkId);
+        OvsTunnelNetworkVO tunnel = _tunnelNetworkDao.findByFromToNetwork(from, to, networkId);
         if (tunnel == null) {
             throw new CloudRuntimeException(
                     String.format("Unable find tunnelNetwork record" +
@@ -321,7 +321,7 @@ public class OvsTunnelManagerImpl extends ManagerBase implements OvsTunnelManage
             if (rh == hostId) {
                 continue;
             }
-            OvsTunnelNetworkVO ta = _tunnelNetworkDao.getByFromToNetwork(hostId, rh.longValue(), nw.getId());
+            OvsTunnelNetworkVO ta = _tunnelNetworkDao.findByFromToNetwork(hostId, rh.longValue(), nw.getId());
             // Try and create the tunnel even if a previous attempt failed
             if (ta == null || ta.getState().equals(OvsTunnel.State.Failed.name())) {
                 s_logger.debug("Attempting to create tunnel from:" + hostId + " to:" + rh.longValue());
@@ -333,7 +333,7 @@ public class OvsTunnelManagerImpl extends ManagerBase implements OvsTunnelManage
                 }
             }
 
-            ta = _tunnelNetworkDao.getByFromToNetwork(rh.longValue(),
+            ta = _tunnelNetworkDao.findByFromToNetwork(rh.longValue(),
                     hostId, nw.getId());
             // Try and create the tunnel even if a previous attempt failed
             if (ta == null || ta.getState().equals(OvsTunnel.State.Failed.name())) {
@@ -605,7 +605,7 @@ public class OvsTunnelManagerImpl extends ManagerBase implements OvsTunnelManage
                 if (rh == hostId) {
                     continue;
                 }
-                tunnelRecord = _tunnelNetworkDao.getByFromToNetwork(hostId, rh.longValue(), vpcNetwork.getId());
+                tunnelRecord = _tunnelNetworkDao.findByFromToNetwork(hostId, rh.longValue(), vpcNetwork.getId());
                 // Try and create the tunnel if does not exit or previous attempt failed
                 if (tunnelRecord == null || tunnelRecord.getState().equals(OvsTunnel.State.Failed.name())) {
                     s_logger.debug("Attempting to create tunnel from:" + hostId + " to:" + rh.longValue());
@@ -616,7 +616,7 @@ public class OvsTunnelManagerImpl extends ManagerBase implements OvsTunnelManage
                         toHostIds.add(rh);
                     }
                 }
-                tunnelRecord = _tunnelNetworkDao.getByFromToNetwork(rh.longValue(), hostId, vpcNetwork.getId());
+                tunnelRecord = _tunnelNetworkDao.findByFromToNetwork(rh.longValue(), hostId, vpcNetwork.getId());
                 // Try and create the tunnel if does not exit or previous attempt failed
                 if (tunnelRecord == null || tunnelRecord.getState().equals(OvsTunnel.State.Failed.name())) {
                     s_logger.debug("Attempting to create tunnel from:" + rh.longValue() + " to:" + hostId);

--- a/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/dao/OvsTunnelNetworkDao.java
+++ b/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/dao/OvsTunnelNetworkDao.java
@@ -22,7 +22,7 @@ import java.util.List;
 import com.cloud.utils.db.GenericDao;
 
 public interface OvsTunnelNetworkDao extends GenericDao<OvsTunnelNetworkVO, Long> {
-    OvsTunnelNetworkVO getByFromToNetwork(long from, long to, long networkId);
+    OvsTunnelNetworkVO findByFromToNetwork(long from, long to, long networkId);
 
     void removeByFromNetwork(long from, long networkId);
 

--- a/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/dao/OvsTunnelNetworkDaoImpl.java
+++ b/plugins/network-elements/ovs/src/main/java/com/cloud/network/ovs/dao/OvsTunnelNetworkDaoImpl.java
@@ -53,7 +53,7 @@ public class OvsTunnelNetworkDaoImpl extends GenericDaoBase<OvsTunnelNetworkVO, 
     }
 
     @Override
-    public OvsTunnelNetworkVO getByFromToNetwork(long from, long to, long networkId) {
+    public OvsTunnelNetworkVO findByFromToNetwork(long from, long to, long networkId) {
         SearchCriteria<OvsTunnelNetworkVO> sc = fromToNetworkSearch.create();
         sc.setParameters("from", from);
         sc.setParameters("to", to);

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/PremiumSecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/PremiumSecondaryStorageManagerImpl.java
@@ -136,7 +136,7 @@ public class PremiumSecondaryStorageManagerImpl extends SecondaryStorageManagerI
 
             alreadyRunning = _secStorageVmDao.getSecStorageVmListInStates(null, dataCenterId, State.Running, State.Migrating, State.Starting);
 
-            List<CommandExecLogVO> activeCmds = listActiveCommands(dataCenterId, cutTime);
+            List<CommandExecLogVO> activeCmds = findActiveCommands(dataCenterId, cutTime);
             if (alreadyRunning.size() * _capacityPerSSVM - activeCmds.size() < _standbyCapacity) {
                 s_logger.info("secondary storage command execution standby capactiy low (running VMs: " + alreadyRunning.size() + ", active cmds: " + activeCmds.size() +
                         "), starting a new one");
@@ -163,7 +163,7 @@ public class PremiumSecondaryStorageManagerImpl extends SecondaryStorageManagerI
         return null;
     }
 
-    private List<CommandExecLogVO> listActiveCommands(long dcId, Date cutTime) {
+    private List<CommandExecLogVO> findActiveCommands(long dcId, Date cutTime) {
         SearchCriteria<CommandExecLogVO> sc = activeCommandSearch.create();
 
         sc.setParameters("created", cutTime);


### PR DESCRIPTION
…findXXX".

These three methods are not direct getter or list.
They try to find the target objects with the related arguments.
So that, renaming them as "findXXX" should be more intuitive.
