### PR TITLE
CLOUDSTACK-10362: Change the "getXXX" method names to "isXXX".

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateServiceOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateServiceOfferingCmd.java
@@ -166,15 +166,15 @@ public class CreateServiceOfferingCmd extends BaseCmd {
         return serviceOfferingName;
     }
 
-    public Boolean getOfferHa() {
+    public Boolean isOfferHa() {
         return offerHa == null ? Boolean.FALSE : offerHa;
     }
 
-    public Boolean GetLimitCpuUse() {
+    public Boolean isLimitCpuUse() {
         return limitCpuUse == null ? Boolean.FALSE : limitCpuUse;
     }
 
-    public Boolean getVolatileVm() {
+    public Boolean isVolatileVm() {
         return isVolatile == null ? Boolean.FALSE : isVolatile;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vlan/ListVlanIpRangesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vlan/ListVlanIpRangesCmd.java
@@ -119,7 +119,7 @@ public class ListVlanIpRangesCmd extends BaseListCmd {
         return networkId;
     }
 
-    public Boolean getForVirtualNetwork() {
+    public Boolean isForVirtualNetwork() {
         return forVirtualNetwork;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vpc/UpdateVPCCmdByAdmin.java
@@ -34,7 +34,7 @@ public class UpdateVPCCmdByAdmin extends UpdateVPCCmd {
 
     @Override
     public void execute(){
-        Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc());
+        Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), isDisplayVpc());
         if (result != null) {
             VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Full, result);
             response.setResponseName(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/address/ListPublicIpAddressesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/address/ListPublicIpAddressesCmd.java
@@ -133,11 +133,11 @@ public class ListPublicIpAddressesCmd extends BaseListTaggedResourcesCmd {
         return associatedNetworkId;
     }
 
-    public Boolean getIsSourceNat() {
+    public Boolean isSourceNat() {
         return isSourceNat;
     }
 
-    public Boolean getIsStaticNat() {
+    public Boolean isStaticNat() {
         return isStaticNat;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/network/ListNetworksCmd.java
@@ -123,11 +123,11 @@ public class ListNetworksCmd extends BaseListTaggedResourcesCmd {
         return supportedServices;
     }
 
-    public Boolean getRestartRequired() {
+    public Boolean isRestartRequired() {
         return restartRequired;
     }
 
-    public Boolean getSpecifyIpRanges() {
+    public Boolean isSpecifyIpRanges() {
         return specifyIpRanges;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -256,7 +256,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return HypervisorType.getType(hypervisor);
     }
 
-    public Boolean getDisplayVm() {
+    public Boolean isDisplayVm() {
         return displayVm;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/UpdateVPCCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/UpdateVPCCmd.java
@@ -73,7 +73,7 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
         return id;
     }
 
-    public Boolean getDisplayVpc() {
+    public Boolean isDisplayVpc() {
         return display;
     }
 
@@ -97,7 +97,7 @@ public class UpdateVPCCmd extends BaseAsyncCustomIdCmd {
 
     @Override
     public void execute() {
-        Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), getDisplayVpc());
+        Vpc result = _vpcService.updateVpc(getId(), getVpcName(), getDisplayText(), getCustomId(), isDisplayVpc());
         if (result != null) {
             VpcResponse response = _responseGenerator.createVpcResponse(ResponseView.Restricted, result);
             response.setResponseName(getCommandName());

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -630,7 +630,7 @@ public class HostResponse extends BaseResponse {
         return clusterType;
     }
 
-    public Boolean getLocalStorageActive() {
+    public Boolean isLocalStorageActive() {
         return localStorageActive;
     }
 
@@ -646,11 +646,11 @@ public class HostResponse extends BaseResponse {
         return events;
     }
 
-    public Boolean getHasEnoughCapacity() {
+    public Boolean hasEnoughCapacity() {
         return hasEnoughCapacity;
     }
 
-    public Boolean getSuitableForMigration() {
+    public Boolean isSuitableForMigration() {
         return suitableForMigration;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/ServiceOfferingResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ServiceOfferingResponse.java
@@ -180,7 +180,7 @@ public class ServiceOfferingResponse extends BaseResponse {
         this.isSystem = isSystem;
     }
 
-    public Boolean getDefaultUse() {
+    public Boolean isDefaultUse() {
         return defaultUse;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/SnapshotPolicyResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SnapshotPolicyResponse.java
@@ -104,7 +104,7 @@ public class SnapshotPolicyResponse extends BaseResponse {
         this.timezone = timezone;
     }
 
-    public Boolean getForDisplay() {
+    public Boolean isForDisplay() {
         return forDisplay;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/VolumeResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VolumeResponse.java
@@ -276,7 +276,7 @@ public class VolumeResponse extends BaseResponseWithTagInformation implements Co
         return this.getId();
     }
 
-    public Boolean getDestroyed() {
+    public Boolean isDestroyed() {
         return destroyed;
     }
 

--- a/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
+++ b/plugins/database/quota/src/main/java/org/apache/cloudstack/api/command/QuotaSummaryCmd.java
@@ -63,7 +63,7 @@ public class QuotaSummaryCmd extends BaseListCmd {
             if (getAccountName() != null && getDomainId() != null)
                 responses = _responseBuilder.createQuotaSummaryResponse(caller.getAccountName(), caller.getDomainId());
             else
-                responses = _responseBuilder.createQuotaSummaryResponse(getListAll());
+                responses = _responseBuilder.createQuotaSummaryResponse(isListAll());
         } else {
             responses = _responseBuilder.createQuotaSummaryResponse(caller.getAccountName(), caller.getDomainId());
         }
@@ -94,7 +94,7 @@ public class QuotaSummaryCmd extends BaseListCmd {
         return s_name;
     }
 
-    public Boolean getListAll() {
+    public Boolean isListAll() {
         return listAll == null ? false: listAll;
     }
 

--- a/plugins/storage/volume/nexenta/src/main/java/org/apache/cloudstack/storage/datastore/lifecylce/NexentaPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/nexenta/src/main/java/org/apache/cloudstack/storage/datastore/lifecylce/NexentaPrimaryDataStoreLifeCycle.java
@@ -102,7 +102,7 @@ public class NexentaPrimaryDataStoreLifeCycle
         details.put(NexentaUtil.NMS_URL, params.getNmsUrl().toString());
 
         details.put(NexentaUtil.VOLUME, params.getVolume());
-        details.put(NexentaUtil.SPARSE_VOLUMES, params.getSparseVolumes().toString());
+        details.put(NexentaUtil.SPARSE_VOLUMES, params.isSparseVolumes().toString());
 
         details.put(NexentaUtil.STORAGE_TYPE, params.getStorageType().toString());
         details.put(NexentaUtil.STORAGE_HOST, params.getStorageHost());

--- a/plugins/storage/volume/nexenta/src/main/java/org/apache/cloudstack/storage/datastore/util/NexentaStorAppliance.java
+++ b/plugins/storage/volume/nexenta/src/main/java/org/apache/cloudstack/storage/datastore/util/NexentaStorAppliance.java
@@ -337,7 +337,7 @@ public class NexentaStorAppliance {
         final String zvolName = getVolumeName(volumeName);
         String volumeSizeString = String.format("%dB", volumeSize);
 
-        client.execute(NmsResponse.class, "zvol", "create", zvolName, volumeSizeString, parameters.getVolumeBlockSize(), parameters.getSparseVolumes());
+        client.execute(NmsResponse.class, "zvol", "create", zvolName, volumeSizeString, parameters.getVolumeBlockSize(), parameters.isSparseVolumes());
 
         final String targetName = getTargetName(volumeName);
         final String targetGroupName = getTargetGroupName(volumeName);

--- a/plugins/storage/volume/nexenta/src/main/java/org/apache/cloudstack/storage/datastore/util/NexentaUtil.java
+++ b/plugins/storage/volume/nexenta/src/main/java/org/apache/cloudstack/storage/datastore/util/NexentaUtil.java
@@ -194,7 +194,7 @@ public class NexentaUtil {
             this.sparseVolumes = Boolean.TRUE.toString().equalsIgnoreCase(sparseVolumes);
         }
 
-        public Boolean getSparseVolumes() {
+        public Boolean isSparseVolumes() {
             return sparseVolumes;
         }
 

--- a/plugins/storage/volume/nexenta/src/test/java/org/apache/cloudstack/storage/datastore/util/NexentaUtilTest.java
+++ b/plugins/storage/volume/nexenta/src/test/java/org/apache/cloudstack/storage/datastore/util/NexentaUtilTest.java
@@ -74,7 +74,7 @@ public class NexentaUtilTest {
         assertEquals(parameters.getStorageHost(), "192.168.1.1");
         assertEquals((int) parameters.getStoragePort(), NexentaUtil.DEFAULT_ISCSI_TARGET_PORTAL_PORT);
         assertNull(parameters.getStoragePath());
-        assertEquals((boolean) parameters.getSparseVolumes(), false);
+        assertEquals((boolean) parameters.isSparseVolumes(), false);
         assertEquals(parameters.getVolumeBlockSize(), "8K");
 
         url += "volume=cloudstack";
@@ -109,7 +109,7 @@ public class NexentaUtilTest {
 
         url += "sparseVolumes=true;";
         parameters = NexentaUtil.parseNexentaPluginUrl(url);
-        assertEquals(parameters.getSparseVolumes(), Boolean.TRUE);
+        assertEquals(parameters.isSparseVolumes(), Boolean.TRUE);
 
         url += "volumeBlockSize=128K;";
         parameters = NexentaUtil.parseNexentaPluginUrl(url);
@@ -124,7 +124,7 @@ public class NexentaUtilTest {
         assertEquals(parameters.getStorageHost(), "192.168.1.2");
         assertEquals((int) parameters.getStoragePort(), 3000);
         assertEquals(parameters.getStoragePath(), "/volumes/cloudstack");
-        assertEquals(parameters.getSparseVolumes(), Boolean.TRUE);
+        assertEquals(parameters.isSparseVolumes(), Boolean.TRUE);
         assertEquals(parameters.getVolumeBlockSize(), "128K");
 
         exception.expect(RuntimeException.class);

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -2255,7 +2255,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             throw new InvalidParameterValueException("Please specify a valid domain id");
         }
 
-        final Boolean offerHA = cmd.getOfferHa();
+        final Boolean offerHA = cmd.isOfferHa();
 
         boolean localStorageRequired = false;
         final String storageType = cmd.getStorageType();
@@ -2270,8 +2270,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
         }
 
-        final Boolean limitCpuUse = cmd.GetLimitCpuUse();
-        final Boolean volatileVm = cmd.getVolatileVm();
+        final Boolean limitCpuUse = cmd.isLimitCpuUse();
+        final Boolean volatileVm = cmd.isVolatileVm();
 
         final String vmTypeString = cmd.getSystemVmType();
         VirtualMachine.Type vmType = null;

--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -1427,10 +1427,10 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
         String path = null;
         Long physicalNetworkId = cmd.getPhysicalNetworkId();
         List<String> supportedServicesStr = cmd.getSupportedServices();
-        Boolean restartRequired = cmd.getRestartRequired();
+        Boolean restartRequired = cmd.isRestartRequired();
         boolean listAll = cmd.listAll();
         boolean isRecursive = cmd.isRecursive();
-        Boolean specifyIpRanges = cmd.getSpecifyIpRanges();
+        Boolean specifyIpRanges = cmd.isSpecifyIpRanges();
         Long vpcId = cmd.getVpcId();
         Boolean canUseForDeploy = cmd.canUseForDeploy();
         Map<String, String> tags = cmd.getTags();

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -1588,7 +1588,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final Long domainId = cmd.getDomainId();
         Long accountId = null;
         final Long networkId = cmd.getNetworkId();
-        final Boolean forVirtual = cmd.getForVirtualNetwork();
+        final Boolean forVirtual = cmd.isForVirtualNetwork();
         String vlanType = null;
         final Long projectId = cmd.getProjectId();
         final Long physicalNetworkId = cmd.getPhysicalNetworkId();
@@ -1823,8 +1823,8 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final Boolean forVirtualNetwork = cmd.isForVirtualNetwork();
         final Boolean forLoadBalancing = cmd.isForLoadBalancing();
         final Long ipId = cmd.getId();
-        final Boolean sourceNat = cmd.getIsSourceNat();
-        final Boolean staticNat = cmd.getIsStaticNat();
+        final Boolean sourceNat = cmd.isSourceNat();
+        final Boolean staticNat = cmd.isStaticNat();
         final Long vpcId = cmd.getVpcId();
         final Boolean forDisplay = cmd.getDisplay();
         final Map<String, String> tags = cmd.getTags();

--- a/server/src/main/java/com/cloud/storage/TemplateProfile.java
+++ b/server/src/main/java/com/cloud/storage/TemplateProfile.java
@@ -164,7 +164,7 @@ public class TemplateProfile {
         this.bits = bits;
     }
 
-    public Boolean getPasswordEnabled() {
+    public Boolean isPasswordEnabled() {
         return passwordEnabled;
     }
 
@@ -172,7 +172,7 @@ public class TemplateProfile {
         this.passwordEnabled = enabled;
     }
 
-    public Boolean getRequiresHVM() {
+    public Boolean isRequiresHVM() {
         return requiresHvm;
     }
 
@@ -188,7 +188,7 @@ public class TemplateProfile {
         this.url = url;
     }
 
-    public Boolean getIsPublic() {
+    public Boolean isPublic() {
         return isPublic;
     }
 
@@ -196,7 +196,7 @@ public class TemplateProfile {
         this.isPublic = is;
     }
 
-    public Boolean getFeatured() {
+    public Boolean isFeatured() {
         return featured;
     }
 
@@ -204,7 +204,7 @@ public class TemplateProfile {
         this.featured = featured;
     }
 
-    public Boolean getIsExtractable() {
+    public Boolean isExtractable() {
         return isExtractable;
     }
 
@@ -264,7 +264,7 @@ public class TemplateProfile {
         this.chksum = chksum;
     }
 
-    public Boolean getBootable() {
+    public Boolean isBootable() {
         return this.bootable;
     }
 
@@ -300,7 +300,7 @@ public class TemplateProfile {
         this.sshKeyEnbaled = enabled;
     }
 
-    public Boolean getSshKeyEnabled() {
+    public Boolean isSshKeyEnabled() {
         return this.sshKeyEnbaled;
     }
 

--- a/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
@@ -338,10 +338,10 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
     protected VMTemplateVO persistTemplate(TemplateProfile profile, VirtualMachineTemplate.State initialState) {
         List<Long> zoneIdList = profile.getZoneIdList();
         VMTemplateVO template =
-            new VMTemplateVO(profile.getTemplateId(), profile.getName(), profile.getFormat(), profile.getIsPublic(), profile.getFeatured(), profile.getIsExtractable(),
-                profile.getTemplateType(), profile.getUrl(), profile.getRequiresHVM(), profile.getBits(), profile.getAccountId(), profile.getCheckSum(),
-                profile.getDisplayText(), profile.getPasswordEnabled(), profile.getGuestOsId(), profile.getBootable(), profile.getHypervisorType(),
-                profile.getTemplateTag(), profile.getDetails(), profile.getSshKeyEnabled(), profile.IsDynamicallyScalable(), profile.isDirectDownload());
+            new VMTemplateVO(profile.getTemplateId(), profile.getName(), profile.getFormat(), profile.isPublic(), profile.isFeatured(), profile.isExtractable(),
+                profile.getTemplateType(), profile.getUrl(), profile.isRequiresHVM(), profile.getBits(), profile.getAccountId(), profile.getCheckSum(),
+                profile.getDisplayText(), profile.isPasswordEnabled(), profile.getGuestOsId(), profile.isBootable(), profile.getHypervisorType(),
+                profile.getTemplateTag(), profile.getDetails(), profile.isSshKeyEnabled(), profile.IsDynamicallyScalable(), profile.isDirectDownload());
         template.setState(initialState);
 
         if (profile.isDirectDownload()) {

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4791,7 +4791,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         String group = cmd.getGroup();
         String userData = cmd.getUserData();
         String sshKeyPairName = cmd.getSSHKeyPairName();
-        Boolean displayVm = cmd.getDisplayVm();
+        Boolean displayVm = cmd.isDisplayVm();
         String keyboard = cmd.getKeyboard();
         Map<Long, DiskOffering> dataDiskTemplateToDiskOfferingMap = cmd.getDataDiskTemplateToDiskOfferingMap();
         if (zone.getNetworkType() == NetworkType.Basic) {


### PR DESCRIPTION
These Boolean-return methods are named "getXXX",
but other Boolean-return methods are named "isXXX", such as the following two methods.
They will return boolean values, rename them as "isXXX" should be more clear than "getXXX".

api/src/main/java/org/apache/cloudstack/api/command/admin/vlan/ListVlanIpRangesCmd.java
   ```
  public Boolean getForVirtualNetwork() {
         return forVirtualNetwork;
     }
```
api/src/main/java/org/apache/cloudstack/api/command/user/address/ListPublicIpAddressesCmd.java
   ```
public Boolean isForVirtualNetwork() {
        return forVirtualNetwork;
    }
```