### PR TITLE
WIP: Connection pool replacement - HikariCP attempt

### DIFF
--- a/client/conf/db.properties.in
+++ b/client/conf/db.properties.in
@@ -101,3 +101,6 @@ db.usage.autoReconnectForPools=true
 db.usage.secondsBeforeRetryMaster=3600
 db.usage.queriesBeforeRetryMaster=5000
 db.usage.initialTimeout=3600
+
+# Connection Pool - Valid options: dbcp, hikari
+db.cloud.connPool=hikari

--- a/framework/db/pom.xml
+++ b/framework/db/pom.xml
@@ -20,6 +20,11 @@
   </parent>
   <dependencies>
     <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+      <version>2.7.8</version>
+    </dependency>
+    <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
     </dependency>

--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -31,6 +31,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -388,6 +389,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
         addFilter(str, filter);
 
         final TransactionLegacy txn = TransactionLegacy.currentTxn();
+
         if (lock != null) {
             assert (txn.dbTxnStarted() == true) : "As nice as I can here now....how do you lock when there's no DB transaction?  Review your db 101 course from college.";
             str.append(lock ? FOR_UPDATE_CLAUSE : SHARE_MODE_CLAUSE);
@@ -398,6 +400,8 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
         PreparedStatement pstmt = null;
         final List<T> result = new ArrayList<T>();
         try {
+            Connection currentConnection = txn.getCurrentConnection();
+            s_logger.info("Connection: " + (currentConnection.isClosed() ? "closed" : "open"));
             pstmt = txn.prepareAutoCloseStatement(sql);
             int i = 1;
             if (clause != null) {


### PR DESCRIPTION
## Description
Provide ability to select a connection pool, as a replacement for DBCP. Testing with HikariCP.

CloudStack is failing to start due to null connection

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs

## Screenshots (if appropriate):

## How Has This Been Tested?

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

