### PR TITLE
Allow changing disk offering of VMs' root volume during volume migration

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2125,9 +2125,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (newDiskOffering == null) {
             return;
         }
-        if (Volume.Type.ROOT.equals(volume.getVolumeType())) {
-            throw new InvalidParameterValueException(String.format("Cannot change the disk offering of a ROOT volume [id=%s].", volume.getUuid()));
-        }
         if ((destPool.isShared() && newDiskOffering.getUseLocalStorage()) || destPool.isLocal() && newDiskOffering.isShared()) {
             throw new InvalidParameterValueException("You cannot move the volume to a shared storage and assing a disk offering for local storage and vice versa.");
         }
@@ -2142,7 +2139,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     "You are migrating a volume [id=%s] and changing the disk offering[from id=%s to id=%s] to reflect this migration. However, the sizes of the volume and the new disk offering are different.",
                     volume.getUuid(), oldDiskOffering.getUuid(), newDiskOffering.getUuid()));
         }
-
+        s_logger.info(String.format("Changing disk offering to [uuid=%s] while migrating volume [uuid=%s, name=%s].", newDiskOffering.getUuid(), volume.getUuid(), volume.getName()));
     }
 
     /**

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -516,7 +516,7 @@ public class VolumeApiServiceImplTest {
         Mockito.verify(volumeVOMock, times(0)).getVolumeType();
     }
 
-    @Test(expected = InvalidParameterValueException.class)
+    @Test
     public void validateConditionsToReplaceDiskOfferingOfVolumeTestRootVolume() {
         Mockito.when(volumeVOMock.getVolumeType()).thenReturn(Type.ROOT);
 
@@ -575,7 +575,6 @@ public class VolumeApiServiceImplTest {
         volumeApiServiceImpl.validateConditionsToReplaceDiskOfferingOfVolume(volumeVOMock, newDiskOfferingMock, storagePoolMock);
 
         InOrder inOrder = Mockito.inOrder(volumeVOMock, newDiskOfferingMock, storagePoolMock, volumeApiServiceImpl);
-        inOrder.verify(volumeVOMock).getVolumeType();
         inOrder.verify(storagePoolMock).isShared();
         inOrder.verify(newDiskOfferingMock).getUseLocalStorage();
         inOrder.verify(storagePoolMock).isLocal();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Currently, users are not able to change the disk offering of VMs' root volumes. It might be interesting to allow such changes, so users would be able to move a VM initially deployed in shared storage to local storage and vice versa. It is also interesting to enable changing the quality of service offered to root disks.

We are allowing only administrators to execute the change of root volumes disk offerings during volume migration between storage. Therefore, we perform all at once, the migration of storage and the disk offering to reflect the new place.

This is a continuation of work #2486. After using that feature for a while we felt the need to change the disk offering of VM's root volume.

### Extra details
Compute offerings (system VM service offerings as well) are “linked”/bound to a disk offering. Therefore, each compute offering (are entries in the `service_offering` table) also has an entry in the disk_offering table. The idea is that when deploying a VM, you need some sort of disk_offering for the root volume. Then, you have some sort of default disk_offering that is bound to the compute offering used to deploy the VM. However, when changing the service offering of the VM, the disk_offering_id field is not being updated.

This might be a bug that is not addressed here (I can address this in other PR, it is not being a problem for us right now), but this information is useful to us here to highlight that we do not need the match of compute_offering and disk_offering.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## How Has This Been Tested?
Locally and via unit test cases that we have in place for these bit of code.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [X] I have added tests to cover my changes.
- [X] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.