### PR TITLE
[migrateVolume API method] Filter disk offerings based on target storage pool selected

### DIFF
--- a/ui/scripts/autoscaler.js
+++ b/ui/scripts/autoscaler.js
@@ -414,27 +414,20 @@
                     isHidden: true,
                     dependsOn: 'isAdvanced',
                     select: function(args) {
-                        $.ajax({
-                            url: createURL("listDiskOfferings&listAll=true"),
-                            dataType: "json",
-                            async: true,
-                            success: function(json) {
-                                var diskofferings = json.listdiskofferingsresponse.diskoffering;
-                                var items = [];
-                                items.push({
-                                    id: "",
-                                    description: ""
-                                });
-                                $(diskofferings).each(function() {
-                                    items.push({
-                                        id: this.id,
-                                        description: this.name
-                                    });
-                                });
-                                args.response.success({
-                                    data: items
-                                });
-                            }
+                        var diskOfferings = cloudStack.listDiskOfferings({listAll: true});
+                        var items = [];
+                        items.push({
+                            id: "",
+                            description: ""
+                        });
+                        $(diskOfferings).each(function() {
+                            items.push({
+                                id: this.id,
+                                description: this.name
+                            });
+                        });
+                        args.response.success({
+                            data: items
                         });
                     }
                 },

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -1683,19 +1683,16 @@
                     dataProvider: function(args) {
                         var data = {};
                         listViewDataProvider(args, data);
-
-                        $.ajax({
-                            url: createURL('listDiskOfferings&isrecursive=true'),
+                        var listDiskOfferingsOptions = {
+                            isRecursive: true,
                             data: data,
-                            success: function(json) {
-                                var items = json.listdiskofferingsresponse.diskoffering;
-                                args.response.success({
-                                    data: items
-                                });
-                            },
                             error: function(data) {
                                 args.response.error(parseXMLHttpResponse(data));
                             }
+                        };
+                        var diskOfferings = cloudStack.listDiskOfferings(listDiskOfferingsOptions);
+                        args.response.success({
+                            data: diskOfferings
                         });
                     },
 
@@ -2297,16 +2294,14 @@
                                     var data = {
                                         id: args.context.diskOfferings[0].id
                                     };
-                                    $.ajax({
-                                        url: createURL('listDiskOfferings&isrecursive=true'),
-                                        data: data,
-                                        success: function(json) {
-                                            var item = json.listdiskofferingsresponse.diskoffering[0];
-                                            args.response.success({
-                                                actionFilter: diskOfferingActionfilter,
-                                                data: item
-                                            });
-                                        }
+                                    var listDiskOfferingsOptions = {
+                                        isRecursive: true,
+                                        data: data
+                                    };
+                                    var diskOfferings = cloudStack.listDiskOfferings(listDiskOfferingsOptions);
+                                    args.response.success({
+                                        actionFilter: diskOfferingActionfilter,
+                                        data: diskOfferings[0]
                                     });
                                 }
                             }

--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -2851,3 +2851,34 @@ cloudStack.createArrayOfParametersForCreatePodCommand = function (zoneId, data){
     cloudStack.addParameterToCommandUrlParameterArrayIfValueIsNotEmpty(array, "endIp", data.podEndIp);
     return array;
 }
+
+cloudStack.listDiskOfferings = function(options){
+    var defaultOptions = {
+            listAll: false,
+            isRecursive: false,
+            error: function(data) {
+                args.response.error(data);
+            }
+    };
+    var mergedOptions = $.extend({}, defaultOptions, options);
+    
+    var listDiskOfferingsUrl = "listDiskOfferings";
+    if(mergedOptions.listAll){
+        listDiskOfferingsUrl = listDiskOfferingsUrl + "&listall=true";
+    }
+    if(mergedOptions.isRecursive){
+        listDiskOfferingsUrl = listDiskOfferingsUrl + "&isrecursive=true";
+    }
+    var diskOfferings = undefined;
+    $.ajax({
+        url: createURL(listDiskOfferingsUrl),
+        data: mergedOptions.data,
+        dataType: "json",
+        async: false,
+        success: function(json) {
+            diskOfferings = json.listdiskofferingsresponse.diskoffering;
+        },
+        error: mergedOptions.error
+    });
+    return diskOfferings;
+};


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
After using the feature introduced by #2486 in production, we felt the need for an improvement in the UI.  It is interesting to filter the displayed disk offerings according to the type of storage selected (local/shared) to migrate the volume to.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

## How Has This Been Tested?

Locally

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [X] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

