### PR TITLE
WIP perform config drive creation on primary storage (CLOUDSTACK-10290)

### DIFF
--- a/api/src/com/cloud/network/NetworkModel.java
+++ b/api/src/com/cloud/network/NetworkModel.java
@@ -73,7 +73,7 @@ public interface NetworkModel {
             AVAILABILITY_ZONE_FILE, "availability_zone",
             LOCAL_HOSTNAME_FILE, "hostname",
             VM_ID_FILE, "uuid",
-            INSTANCE_ID_FILE, "name"
+            PUBLIC_HOSTNAME_FILE, "name"
     );
 
     static final ConfigKey<Integer> MACIdentifier = new ConfigKey<Integer>("Advanced",Integer.class, "mac.identifier", "0",

--- a/config-drive/pom.xml
+++ b/config-drive/pom.xml
@@ -10,7 +10,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>cloudstack-config-drive</artifactId>
+  <artifactId>cloud-config-drive</artifactId>
   <name>Apache CloudStack Config-Drive Component</name>
   <parent>
     <groupId>org.apache.cloudstack</groupId>

--- a/config-drive/pom.xml
+++ b/config-drive/pom.xml
@@ -1,0 +1,71 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to you under
+  the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cloudstack-config-drive</artifactId>
+  <name>Apache CloudStack Config-Drive Component</name>
+  <parent>
+    <groupId>org.apache.cloudstack</groupId>
+    <artifactId>cloudstack</artifactId>
+    <version>4.11.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/java</sourceDirectory>
+    <testSourceDirectory>src/test/java</testSourceDirectory>
+    <outputDirectory>target/classes</outputDirectory>
+    <testOutputDirectory>target/test-classes</testOutputDirectory>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/config-drive/src/main/java/org/apache/cloudstack/storage/ConfigDriveFactory.java
+++ b/config-drive/src/main/java/org/apache/cloudstack/storage/ConfigDriveFactory.java
@@ -1,0 +1,407 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.storage;
+
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.HandleConfigDriveIsoCommand;
+import com.cloud.agent.api.to.DataStoreTO;
+import com.cloud.agent.api.to.NfsTO;
+import com.cloud.network.NetworkModel;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import javax.naming.ConfigurationException;
+
+import static com.cloud.network.NetworkModel.CONFIGDATA_CONTENT;
+import static com.cloud.network.NetworkModel.CONFIGDATA_DIR;
+import static com.cloud.network.NetworkModel.CONFIGDATA_FILE;
+
+import static com.cloud.network.NetworkModel.METATDATA_DIR;
+import static com.cloud.network.NetworkModel.PASSWORD_DIR;
+import static com.cloud.network.NetworkModel.PASSWORD_FILE;
+import static com.cloud.network.NetworkModel.PUBLIC_KEYS_FILE;
+import static com.cloud.network.NetworkModel.USERDATA_DIR;
+import static com.cloud.network.NetworkModel.USERDATA_FILE;
+
+public class ConfigDriveFactory {
+    public static final Logger s_logger = Logger.getLogger(ConfigDriveFactory.class);
+
+    private static final String CLOUD_STACK_CONFIG_DRIVE_NAME = "/cloudstack/";
+    private static final String OPEN_STACK_CONFIG_DRIVE_NAME = "/openstack/latest/";
+    public static final String FAILED_TO_CREATE_FOLDER = "Failed to create folder ";
+    public static final String FAILED_TO_CREATE_FILE = "Failed to create file ";
+    public static final String EMPTY_SET = "{}";
+    private final Integer nfsVersion;
+    protected boolean inSystemVM = false;
+
+    private StorageAttacher attacher;
+
+    private static final Map<String, String> updatableConfigData = Maps.newHashMap();
+    static {
+
+        updatableConfigData.put(PUBLIC_KEYS_FILE, METATDATA_DIR);
+        updatableConfigData.put(USERDATA_FILE, USERDATA_DIR);
+        updatableConfigData.put(PASSWORD_FILE, PASSWORD_DIR);
+    }
+
+
+    private int timeout;
+
+    public ConfigDriveFactory(Integer pNfsVersion, StorageAttacher pAttacher) {
+        nfsVersion = pNfsVersion;
+        attacher = pAttacher;
+    }
+
+    public int getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+    private String linkUserData(String tempDirName) {
+        //Hard link the user_data.txt file with the user_data file in the OpenStack directory.
+        String userDataFilePath = tempDirName + CLOUD_STACK_CONFIG_DRIVE_NAME + "userdata/user_data.txt";
+        if ((new File(userDataFilePath).exists())) {
+            Script hardLink = new Script(!inSystemVM, "ln", timeout, s_logger);
+            hardLink.add(userDataFilePath);
+            hardLink.add(tempDirName + OPEN_STACK_CONFIG_DRIVE_NAME + "user_data");
+            s_logger.debug("execute command: " + hardLink.toString());
+            return hardLink.execute();
+        }
+        return null;
+    }
+
+    public Answer executeRequest(HandleConfigDriveIsoCommand cmd) {
+
+        if (cmd.isCreate()) {
+            s_logger.debug(String.format("VMdata %s, attach = %s", cmd.getVmData(), cmd.isCreate()));
+            if(cmd.getVmData() == null) return new Answer(cmd, false, "No Vmdata available");
+            String nfsMountPoint = attacher.getRootDir(cmd.getDestStore().getUrl(), nfsVersion);
+            File isoFile = new File(nfsMountPoint, cmd.getIsoFile());
+            if(isoFile.exists()) {
+                if (!cmd.isUpdate()) {
+                    return new Answer(cmd, true, "ISO already available");
+                } else {
+                    // Find out if we have to recover the password/ssh-key from the already available ISO.
+                    try {
+                        List<String[]> recoveredVmData = recoverVmData(isoFile);
+                        for (String[] vmDataEntry : cmd.getVmData()) {
+                            if (updatableConfigData.containsKey(vmDataEntry[CONFIGDATA_FILE])
+                                    && updatableConfigData.get(vmDataEntry[CONFIGDATA_FILE]).equals(vmDataEntry[CONFIGDATA_DIR])) {
+                                updateVmData(recoveredVmData, vmDataEntry);
+                            }
+                        }
+                        cmd.setVmData(recoveredVmData);
+                    } catch (IOException e) {
+                        return new Answer(cmd, e);
+                    }
+                }
+            }
+            return createConfigDriveIsoForVM(cmd);
+        } else {
+            DataStoreTO dstore = cmd.getDestStore();
+            if (dstore instanceof NfsTO) {
+                NfsTO nfs = (NfsTO) dstore;
+                String relativeTemplatePath = new File(cmd.getIsoFile()).getParent();
+                String nfsMountPoint = attacher.getRootDir(nfs.getUrl(), nfsVersion);
+                File tmpltPath = new File(nfsMountPoint, relativeTemplatePath);
+                try {
+                    FileUtils.deleteDirectory(tmpltPath);
+                } catch (IOException e) {
+                    return new Answer(cmd, e);
+                }
+                return new Answer(cmd);
+            } else {
+                return new Answer(cmd, false, "Not implemented yet");
+            }
+        }
+    }
+
+    public Answer createConfigDriveIsoForVM(HandleConfigDriveIsoCommand cmd) {
+        //create folder for the VM
+        if (cmd.getVmData() != null) {
+
+            Path tempDir = null;
+            String tempDirName = null;
+            try {
+                tempDir = java.nio.file.Files.createTempDirectory("ConfigDrive");
+                tempDirName = tempDir.toString();
+
+                //create OpenStack files
+                //create folder with empty files
+                File openStackFolder = new File(tempDirName + OPEN_STACK_CONFIG_DRIVE_NAME);
+                if (openStackFolder.exists() || openStackFolder.mkdirs()) {
+                    File vendorDataFile = new File(openStackFolder,"vendor_data.json");
+                    WriteFileProcedure writeFileProcedure = new WriteFileProcedure(cmd, vendorDataFile, EMPTY_SET);
+                    if (writeFileProcedure.invoke())
+                        return new Answer(cmd, writeFileProcedure.getEx());
+                    File networkDataFile = new File(openStackFolder, "network_data.json");
+                    writeFileProcedure = new WriteFileProcedure(cmd, networkDataFile, EMPTY_SET);
+                    if (writeFileProcedure.invoke())
+                        return new Answer(cmd, writeFileProcedure.getEx());
+                } else {
+                    s_logger.error(FAILED_TO_CREATE_FOLDER + openStackFolder);
+                    return new Answer(cmd, false, FAILED_TO_CREATE_FOLDER + openStackFolder);
+                }
+
+                JsonObject metaData = new JsonObject();
+                for (String[] item : cmd.getVmData()) {
+                    String dataType = item[CONFIGDATA_DIR];
+                    String fileName = item[CONFIGDATA_FILE];
+                    String content = item[CONFIGDATA_CONTENT];
+                    s_logger.debug(String.format("[createConfigDriveIsoForVM] dataType=%s, filename=%s, content=%s",
+                            dataType, fileName, (fileName.equals(PASSWORD_FILE)?"********":content)));
+
+                    // create file with content in folder
+                    if (dataType != null && !dataType.isEmpty()) {
+                        //create folder
+                        File typeFolder = new File(tempDirName + CLOUD_STACK_CONFIG_DRIVE_NAME + dataType);
+                        if (typeFolder.exists() || typeFolder.mkdirs()) {
+                            if (StringUtils.isNotEmpty(content)) {
+                                File file = new File(typeFolder, fileName + ".txt");
+                                WriteFileProcedure writeFileProcedure = new WriteFileProcedure(cmd, file, content);
+                                if (writeFileProcedure.invoke())
+                                    return new Answer(cmd, writeFileProcedure.getEx());
+                            }
+                        } else {
+                            s_logger.error(FAILED_TO_CREATE_FOLDER + typeFolder);
+                            return new Answer(cmd, false, FAILED_TO_CREATE_FOLDER + typeFolder);
+                        }
+
+                        //now write the file to the OpenStack directory
+                        metaData = constructOpenStackMetaData(metaData, dataType, fileName, content);
+                    }
+                }
+
+                File metaDataFile = new File(openStackFolder, "meta_data.json");
+                WriteFileProcedure writeFileProcedure = new WriteFileProcedure(cmd, metaDataFile, metaData.toString());
+                if(writeFileProcedure.invoke())
+                    return new Answer(cmd,writeFileProcedure.getEx());
+
+                String linkResult = linkUserData(tempDirName);
+                if (linkResult != null) {
+                    String errMsg = "Unable to create user_data link due to " + linkResult;
+                    s_logger.warn(errMsg);
+                    return new Answer(cmd, false, errMsg);
+                }
+
+                File tmpIsoStore = new File(tempDirName, new File(cmd.getIsoFile()).getName());
+                Script command = new Script(!inSystemVM, "/usr/bin/genisoimage", timeout, s_logger);
+                command.add("-o", tmpIsoStore.getAbsolutePath());
+                command.add("-ldots");
+                command.add("-allow-lowercase");
+                command.add("-allow-multidot");
+                command.add("-cache-inodes"); // Enable caching inode and device numbers to find hard links to files.
+                command.add("-l");
+                command.add("-quiet");
+                command.add("-J");
+                command.add("-r");
+                command.add("-V", cmd.getConfigDriveLabel());
+                command.add(tempDirName);
+                s_logger.debug("execute command: " + command.toString());
+                String result = command.execute();
+                if (result != null) {
+                    String errMsg = "Unable to create iso file: " + cmd.getIsoFile() + " due to " + result;
+                    s_logger.warn(errMsg);
+                    return new Answer(cmd, false, errMsg);
+                }
+                copyLocalToNfs(tmpIsoStore, new File(cmd.getIsoFile()), cmd.getDestStore());
+
+            } catch (IOException e) {
+                return new Answer(cmd, e);
+            } catch (ConfigurationException e) {
+                s_logger.warn("SecondStorageException ", e);
+                return new Answer(cmd, e);
+            } finally {
+                try {
+                    FileUtils.deleteDirectory(tempDir.toFile());
+                } catch (IOException ioe) {
+                    s_logger.warn("Failed to delete ConfigDrive temporary directory: " + tempDirName, ioe);
+                }
+            }
+        }
+        return new Answer(cmd);
+    }
+
+    private List<String[]> recoverVmData(File isoFile) throws IOException {
+        String tempDirName = null;
+        List<String[]> recoveredVmData = Lists.newArrayList();
+        boolean mounted = false;
+        try {
+            Path tempDir = java.nio.file.Files.createTempDirectory("ConfigDrive");
+            tempDirName = tempDir.toString();
+
+            // Unpack the current config drive file
+            Script command = new Script(!inSystemVM, "mount", timeout, s_logger);
+            command.add("-o", "loop");
+            command.add(isoFile.getAbsolutePath());
+            command.add(tempDirName);
+            String result = command.execute();
+
+            if (result != null) {
+                String errMsg = "Unable to mount " + isoFile.getAbsolutePath() + " at " + tempDirName + " due to " + result;
+                s_logger.error(errMsg);
+                throw new IOException(errMsg);
+            }
+            mounted = true;
+
+
+            // Scan directory structure
+            for (File configDirectory: (new File(tempDirName, "cloudstack")).listFiles()){
+                for (File configFile: configDirectory.listFiles()) {
+                    recoveredVmData.add(new String[]{configDirectory.getName(),
+                            Files.getNameWithoutExtension(configFile.getName()),
+                            Files.readFirstLine(configFile, Charset.defaultCharset())});
+                }
+            }
+
+        } finally {
+            if (mounted) {
+                Script command = new Script(!inSystemVM, "umount", timeout, s_logger);
+                command.add(tempDirName);
+                String result = command.execute();
+                if (result != null) {
+                    s_logger.warn("Unable to umount " + tempDirName + " due to " + result);
+                }
+            }
+            try {
+                FileUtils.deleteDirectory(new File(tempDirName));
+            } catch (IOException ioe) {
+                s_logger.warn("Failed to delete ConfigDrive temporary directory: " + tempDirName, ioe);
+            }
+        }
+        return  recoveredVmData;
+    }
+    JsonObject constructOpenStackMetaData(JsonObject metaData, String dataType, String fileName, String content) {
+        if (dataType.equals(NetworkModel.METATDATA_DIR) &&  StringUtils.isNotEmpty(content)) {
+            //keys are a special case in OpenStack format
+            if (NetworkModel.PUBLIC_KEYS_FILE.equals(fileName)) {
+                String[] keyArray = content.replace("\\n", "").split(" ");
+                String keyName = "key";
+                if (keyArray.length > 3 && StringUtils.isNotEmpty(keyArray[2])){
+                    keyName = keyArray[2];
+                }
+
+                JsonObject keyLegacy = new JsonObject();
+                keyLegacy.addProperty("type", "ssh");
+                keyLegacy.addProperty("data", content.replace("\\n", ""));
+                keyLegacy.addProperty("name", keyName);
+                metaData.add("keys", arrayOf(keyLegacy));
+
+                JsonObject key = new JsonObject();
+                key.addProperty(keyName, content);
+                metaData.add("public_keys", key);
+            } else if (NetworkModel.openStackFileMapping.get(fileName) != null) {
+                metaData.addProperty(NetworkModel.openStackFileMapping.get(fileName), content);
+            }
+        }
+        return metaData;
+    }
+    private static JsonArray arrayOf(JsonElement... elements) {
+        JsonArray array = new JsonArray();
+        for (JsonElement element : elements) {
+            array.add(element);
+        }
+        return array;
+    }
+
+    private void updateVmData(List<String[]> recoveredVmData, String[] vmDataEntry) {
+        for (String[] recoveredEntry : recoveredVmData) {
+            if (recoveredEntry[CONFIGDATA_DIR].equals(vmDataEntry[CONFIGDATA_DIR])
+                    && recoveredEntry[CONFIGDATA_FILE].equals(vmDataEntry[CONFIGDATA_FILE])) {
+                recoveredEntry[CONFIGDATA_CONTENT] = vmDataEntry[CONFIGDATA_CONTENT];
+                return;
+            }
+        }
+        recoveredVmData.add(vmDataEntry);
+    }
+
+    protected void copyLocalToNfs(File localFile, File isoFile, DataStoreTO destData) throws ConfigurationException, IOException {
+        String scriptsDir = "scripts/storage/secondary";
+        String createVolScr = Script.findScript(scriptsDir, "createvolume.sh");
+        if (createVolScr == null) {
+            throw new ConfigurationException("Unable to find createvolume.sh");
+        }
+        s_logger.info("createvolume.sh found in " + createVolScr);
+
+        int installTimeoutPerGig = 180 * 60 * 1000;
+        int imgSizeGigs = (int) Math.ceil(localFile.length() * 1.0d / (1024 * 1024 * 1024));
+        imgSizeGigs++; // add one just in case
+        long timeout = imgSizeGigs * installTimeoutPerGig;
+
+        Script scr = new Script(createVolScr, timeout, s_logger);
+        scr.add("-s", Integer.toString(imgSizeGigs));
+        scr.add("-n", isoFile.getName());
+        scr.add("-t", attacher.getRootDir(destData.getUrl(), nfsVersion) + "/" + isoFile.getParent());
+        scr.add("-f", localFile.getAbsolutePath());
+        scr.add("-d", "configDrive");
+        String result;
+        result = scr.execute();
+
+        if (result != null) {
+            // script execution failure
+            throw new CloudRuntimeException("Failed to run script " + createVolScr);
+        }
+    }
+
+    private class WriteFileProcedure {
+        private HandleConfigDriveIsoCommand cmd;
+        private File vendorDataFile;
+        private String content;
+        private IOException ex;
+
+        public WriteFileProcedure(HandleConfigDriveIsoCommand cmd, File vendorDataFile, String content) {
+            this.cmd = cmd;
+            this.vendorDataFile = vendorDataFile;
+            this.content = content;
+        }
+
+        public IOException getEx() {
+            return ex;
+        }
+
+        public boolean invoke() {
+            try (FileWriter fw = new FileWriter(vendorDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
+                bw.write(content);
+            } catch (IOException ex) {ConfigDriveFactory.WriteFileProcedure.this.ex = ex;
+                s_logger.error(FAILED_TO_CREATE_FILE, ex);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/config-drive/src/main/java/org/apache/cloudstack/storage/ConfigDriveFactory.java
+++ b/config-drive/src/main/java/org/apache/cloudstack/storage/ConfigDriveFactory.java
@@ -93,13 +93,17 @@ public class ConfigDriveFactory {
     }
 
     private String linkUserData(String tempDirName) {
-        //Hard link the user_data.txt file with the user_data file in the OpenStack directory.
+        if(s_logger.isDebugEnabled()) {
+            s_logger.debug("Hard link the user_data.txt file with the user_data file in the OpenStack directory in " + tempDirName);
+        }
         String userDataFilePath = tempDirName + CLOUD_STACK_CONFIG_DRIVE_NAME + "userdata/user_data.txt";
         if ((new File(userDataFilePath).exists())) {
             Script hardLink = new Script(!inSystemVM, "ln", timeout, s_logger);
             hardLink.add(userDataFilePath);
             hardLink.add(tempDirName + OPEN_STACK_CONFIG_DRIVE_NAME + "user_data");
-            s_logger.debug("execute command: " + hardLink.toString());
+            if(s_logger.isDebugEnabled()) {
+                s_logger.debug("execute command: " + hardLink.toString());
+            }
             return hardLink.execute();
         }
         return null;
@@ -154,6 +158,9 @@ public class ConfigDriveFactory {
     }
 
     public Answer createConfigDriveIsoForVM(HandleConfigDriveIsoCommand cmd) {
+        if (s_logger.isDebugEnabled()) {
+            s_logger.debug("handling configdrive: " + cmd.getConfigDriveLabel());
+        }
         //create folder for the VM
         if (cmd.getVmData() != null) {
 
@@ -309,6 +316,9 @@ public class ConfigDriveFactory {
         return  recoveredVmData;
     }
     JsonObject constructOpenStackMetaData(JsonObject metaData, String dataType, String fileName, String content) {
+        if(s_logger.isDebugEnabled()) {
+            s_logger.debug("adding " + content + " to " + fileName);
+        }
         if (dataType.equals(NetworkModel.METATDATA_DIR) &&  StringUtils.isNotEmpty(content)) {
             //keys are a special case in OpenStack format
             if (NetworkModel.PUBLIC_KEYS_FILE.equals(fileName)) {
@@ -353,6 +363,9 @@ public class ConfigDriveFactory {
     }
 
     protected void copyLocalToNfs(File localFile, File isoFile, DataStoreTO destData) throws ConfigurationException, IOException {
+        if(s_logger.isDebugEnabled()) {
+            s_logger.debug("copyfest: from " + localFile + " to " + isoFile + " on " + destData.getUrl());
+        }
         String scriptsDir = "scripts/storage/secondary";
         String createVolScr = Script.findScript(scriptsDir, "createvolume.sh");
         if (createVolScr == null) {
@@ -371,6 +384,9 @@ public class ConfigDriveFactory {
         scr.add("-t", attacher.getRootDir(destData.getUrl(), nfsVersion) + "/" + isoFile.getParent());
         scr.add("-f", localFile.getAbsolutePath());
         scr.add("-d", "configDrive");
+        if(s_logger.isDebugEnabled()) {
+            s_logger.debug("executing " + scr.toString());
+        }
         String result;
         result = scr.execute();
 

--- a/config-drive/src/main/java/org/apache/cloudstack/storage/ConfigDriveFactory.java
+++ b/config-drive/src/main/java/org/apache/cloudstack/storage/ConfigDriveFactory.java
@@ -107,8 +107,10 @@ public class ConfigDriveFactory {
 
     public Answer executeRequest(HandleConfigDriveIsoCommand cmd) {
 
-        if (cmd.isCreate()) {
+        if(s_logger.isDebugEnabled()) {
             s_logger.debug(String.format("VMdata %s, attach = %s", cmd.getVmData(), cmd.isCreate()));
+        }
+        if (cmd.isCreate()) {
             if(cmd.getVmData() == null) return new Answer(cmd, false, "No Vmdata available");
             String nfsMountPoint = attacher.getRootDir(cmd.getDestStore().getUrl(), nfsVersion);
             File isoFile = new File(nfsMountPoint, cmd.getIsoFile());

--- a/config-drive/src/main/java/org/apache/cloudstack/storage/StorageAttacher.java
+++ b/config-drive/src/main/java/org/apache/cloudstack/storage/StorageAttacher.java
@@ -19,7 +19,7 @@ package org.apache.cloudstack.storage;
 import java.net.URI;
 
 public interface StorageAttacher {
-    String getRootDir(String secUrl, Integer nfsVersion);
+    String getRootDir(String url, Integer nfsVersion);
 
     void umount(String localRootPath, URI uri);
 

--- a/config-drive/src/main/java/org/apache/cloudstack/storage/StorageAttacher.java
+++ b/config-drive/src/main/java/org/apache/cloudstack/storage/StorageAttacher.java
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.storage;
+
+import java.net.URI;
+
+public interface StorageAttacher {
+    String getRootDir(String secUrl, Integer nfsVersion);
+
+    void umount(String localRootPath, URI uri);
+
+    void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion);
+}

--- a/config-drive/src/test/java/org/apache/cloudstack/storage/ConfigDriveFactoryTest.java
+++ b/config-drive/src/test/java/org/apache/cloudstack/storage/ConfigDriveFactoryTest.java
@@ -1,0 +1,50 @@
+package org.apache.cloudstack.storage;
+
+import com.cloud.agent.api.HandleConfigDriveIsoCommand;
+import com.cloud.agent.api.to.DataStoreTO;
+import com.cloud.storage.DataStoreRole;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigDriveFactoryTest {
+    private final static String CONFIGDRIVEFILENAME = "configdrive.iso";
+    private final static String CONFIGDRIVEDIR = "ConfigDrive";
+
+    @Mock
+    StorageAttacher storageAttacher;
+
+    @Test
+    public void executeRequest() {
+        List<String[]> vmData = null;
+        String label = null;
+        DataStoreTO destStore = new DataStoreTO() {
+            @Override public DataStoreRole getRole() {
+                return DataStoreRole.Primary;
+            }
+
+            @Override public String getUuid() {
+                return "0123456789abcdef";
+            }
+
+            @Override public String getUrl() {
+                return "";
+            }
+
+            @Override public String getPathSeparator() {
+                return "/";
+            }
+        };
+        String isoFile = "/" + CONFIGDRIVEDIR + "/" + "bla" + "/" + CONFIGDRIVEFILENAME;
+        boolean create = false;
+        boolean update = false;
+        HandleConfigDriveIsoCommand cmd = new HandleConfigDriveIsoCommand(null,
+                null, destStore, isoFile, false, false);
+        ConfigDriveFactory configDriveFactory = new ConfigDriveFactory(1,storageAttacher);
+        configDriveFactory.executeRequest(cmd);
+    }
+}

--- a/config-drive/src/test/java/org/apache/cloudstack/storage/ConfigDriveFactoryTest.java
+++ b/config-drive/src/test/java/org/apache/cloudstack/storage/ConfigDriveFactoryTest.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package org.apache.cloudstack.storage;
 
 import com.cloud.agent.api.HandleConfigDriveIsoCommand;

--- a/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
+++ b/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
@@ -64,6 +64,10 @@ public class HandleConfigDriveIsoCommand extends Command {
         return configDriveLabel;
     }
 
+    /**
+     *
+     * @return a PrimaryDataStore when executed in a HostAgent else a SecStore
+     */
     public DataStoreTO getDestStore() {
         return destStore;
     }

--- a/engine/storage/pom.xml
+++ b/engine/storage/pom.xml
@@ -30,13 +30,6 @@
       <artifactId>cloud-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- 
-    <dependency>
-      <groupId>org.apache.cloudstack</groupId>
-      <artifactId>cloud-server</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-engine-components-api</artifactId>

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -130,6 +130,7 @@ Requires: perl
 Requires: libvirt-python
 Requires: qemu-img
 Requires: qemu-kvm
+Requires: genisoimage
 Provides: cloud-agent
 Obsoletes: cloud-agent < 4.1.0
 Obsoletes: cloud-agent-libs < 4.1.0

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -111,6 +111,7 @@ Requires: perl
 Requires: libvirt-python
 Requires: qemu-img
 Requires: qemu-kvm
+Requires: genisoimage
 Provides: cloud-agent
 Group: System Environment/Libraries
 %description agent

--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -40,6 +40,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-config-drive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.ceph</groupId>
       <artifactId>rados</artifactId>
       <version>${cs.rados-java.version}</version>

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -581,7 +581,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
     }
 
-    @Override public void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
+    @Override
+    public void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
         s_logger.debug("mount " + uri.toString() + " on " + localRootPath + ((nfsVersion != null) ? " nfsVersion=" + nfsVersion : ""));
         ensureLocalRootPathExists(localRootPath, uri);
 
@@ -598,6 +599,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         Script command = new Script("mount", _timeout, s_logger);
 
         String scheme = uri.getScheme().toLowerCase();
+        if("networkfilesystem".equals(scheme)) {
+            scheme = "nfs";
+        }
         command.add("-t", scheme);
 
         command.add(remoteDevice);

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
@@ -1,0 +1,15 @@
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.HandleConfigDriveIsoCommand;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+
+@ResourceWrapper(handles = HandleConfigDriveIsoCommand.class)
+public class LibvirtHandleConfigDriveCommandWrapper  extends CommandWrapper<HandleConfigDriveIsoCommand, Answer, LibvirtComputingResource>
+{
+    @Override public Answer execute(HandleConfigDriveIsoCommand command, LibvirtComputingResource serverResource) {
+        return serverResource.getConfigDriveFactory().executeRequest(command);
+    }
+}

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
@@ -1,3 +1,22 @@
+//
+//Licensed to the Apache Software Foundation (ASF) under one
+//or more contributor license agreements.  See the NOTICE file
+//distributed with this work for additional information
+//regarding copyright ownership.  The ASF licenses this file
+//to you under the Apache License, Version 2.0 (the
+//"License"); you may not use this file except in compliance
+//with the License.  You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing,
+//software distributed under the License is distributed on an
+//"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//KIND, either express or implied.  See the License for the
+//specific language governing permissions and limitations
+//under the License.
+//
+
 package com.cloud.hypervisor.kvm.resource.wrapper;
 
 import com.cloud.agent.api.Answer;

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
     <module>tools/checkstyle</module>
     <module>api</module>
     <module>agent</module>
+    <module>config-drive</module>
     <module>core</module>
     <module>server</module>
     <module>usage</module>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
-      <artifactId>cloudstack-config-drive</artifactId>
+      <artifactId>cloud-config-drive</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -34,6 +34,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloudstack-config-drive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-framework-cluster</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -166,6 +166,7 @@ public class ConfigDriveNetworkElementTest {
         when(virtualMachine.getDataCenterId()).thenReturn(DATACENTERID);
         when(virtualMachine.getInstanceName()).thenReturn(VMINSTANCENAME);
         when(virtualMachine.getUserData()).thenReturn(VMUSERDATA);
+        when(virtualMachine.getHostName()).thenReturn("vm-hostname");
         when(deployDestination.getHost()).thenReturn(hostVO);
         when(hostVO.getId()).thenReturn(HOSTID);
         when(nic.isDefaultNic()).thenReturn(true);

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -47,7 +47,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.cloudstack</groupId>
-        <artifactId>cloudstack-config-drive</artifactId>
+        <artifactId>cloud-config-drive</artifactId>
         <version>${project.version}</version>
       </dependency>
     <dependency>

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -40,11 +40,16 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <!-- required deps for the systemvm -->
-    <dependency>
-      <groupId>org.apache.cloudstack</groupId>
-      <artifactId>cloud-agent</artifactId>
-      <version>${project.version}</version>
-    </dependency>
+      <dependency>
+        <groupId>org.apache.cloudstack</groupId>
+        <artifactId>cloud-agent</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cloudstack</groupId>
+        <artifactId>cloudstack-config-drive</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-server</artifactId>

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/LocalNfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/LocalNfsSecondaryStorageResource.java
@@ -66,7 +66,7 @@ public class LocalNfsSecondaryStorageResource extends NfsSecondaryStorageResourc
     }
 
     @Override
-    protected void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
+    public void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
         ensureLocalRootPathExists(localRootPath, uri);
 
         if (mountExists(localRootPath, uri)) {

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/LocalNfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/LocalNfsSecondaryStorageResource.java
@@ -53,13 +53,13 @@ public class LocalNfsSecondaryStorageResource extends NfsSecondaryStorageResourc
     }
 
     @Override
-    synchronized public String getRootDir(String secUrl, Integer nfsVersion) {
+    synchronized public String getRootDir(String url, Integer nfsVersion) {
         try {
-            URI uri = new URI(secUrl);
+            URI uri = new URI(url);
             String dir = mountUri(uri, nfsVersion);
             return _parent + "/" + dir;
         } catch (Exception e) {
-            String msg = "GetRootDir for " + secUrl + " failed due to " + e.toString();
+            String msg = "GetRootDir for " + url + " failed due to " + e.toString();
             s_logger.error(msg, e);
             throw new CloudRuntimeException(msg);
         }

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -16,15 +16,6 @@
 // under the License.
 package org.apache.cloudstack.storage.resource;
 
-import static com.cloud.network.NetworkModel.CONFIGDATA_CONTENT;
-import static com.cloud.network.NetworkModel.CONFIGDATA_DIR;
-import static com.cloud.network.NetworkModel.CONFIGDATA_FILE;
-import static com.cloud.network.NetworkModel.METATDATA_DIR;
-import static com.cloud.network.NetworkModel.PASSWORD_DIR;
-import static com.cloud.network.NetworkModel.PASSWORD_FILE;
-import static com.cloud.network.NetworkModel.PUBLIC_KEYS_FILE;
-import static com.cloud.network.NetworkModel.USERDATA_DIR;
-import static com.cloud.network.NetworkModel.USERDATA_FILE;
 import static com.cloud.utils.StringUtils.join;
 import static com.cloud.utils.storage.S3.S3Utils.putFile;
 import static java.lang.String.format;
@@ -45,8 +36,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -71,6 +60,7 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.cloudstack.storage.ConfigDriveFactory;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -87,16 +77,11 @@ import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 
 import org.apache.cloudstack.framework.security.keystore.KeystoreManager;
+import org.apache.cloudstack.storage.StorageAttacher;
 import org.apache.cloudstack.storage.command.CopyCmdAnswer;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.DeleteCommand;
@@ -164,7 +149,6 @@ import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.host.Host;
 import com.cloud.host.Host.Type;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
-import com.cloud.network.NetworkModel;
 import com.cloud.resource.ServerResourceBase;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage;
@@ -193,23 +177,15 @@ import com.cloud.utils.script.Script;
 import com.cloud.utils.storage.S3.S3Utils;
 import com.cloud.vm.SecondaryStorageVm;
 
-public class NfsSecondaryStorageResource extends ServerResourceBase implements SecondaryStorageResource {
+import java.io.OutputStreamWriter;
+
+public class NfsSecondaryStorageResource extends ServerResourceBase implements SecondaryStorageResource, StorageAttacher {
 
     public static final Logger s_logger = Logger.getLogger(NfsSecondaryStorageResource.class);
 
     private static final String TEMPLATE_ROOT_DIR = "template/tmpl";
     private static final String VOLUME_ROOT_DIR = "volumes";
     private static final String POST_UPLOAD_KEY_LOCATION = "/etc/cloudstack/agent/ms-psk";
-    private static final String cloudStackConfigDriveName = "/cloudstack/";
-    private static final String openStackConfigDriveName = "/openstack/latest/";
-
-    private static final Map<String, String> updatableConfigData = Maps.newHashMap();
-    static {
-
-        updatableConfigData.put(PUBLIC_KEYS_FILE, METATDATA_DIR);
-        updatableConfigData.put(USERDATA_FILE, USERDATA_DIR);
-        updatableConfigData.put(PASSWORD_FILE, PASSWORD_DIR);
-    }
 
     int _timeout;
 
@@ -253,6 +229,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     private String _ssvmPSK = null;
     private long processTimeout;
 
+    ConfigDriveFactory configDriveFactory;
     public void setParentPath(String path) {
         _parent = path;
     }
@@ -338,309 +315,13 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     }
 
     private Answer execute(HandleConfigDriveIsoCommand cmd) {
-
-        if (cmd.isCreate()) {
-            s_logger.debug(String.format("VMdata %s, attach = %s", cmd.getVmData(), cmd.isCreate()));
-            if(cmd.getVmData() == null) return new Answer(cmd, false, "No Vmdata available");
-            String nfsMountPoint = getRootDir(cmd.getDestStore().getUrl(), _nfsVersion);
-            File isoFile = new File(nfsMountPoint, cmd.getIsoFile());
-            if(isoFile.exists()) {
-                if (!cmd.isUpdate()) {
-                    return new Answer(cmd, true, "ISO already available");
-                } else {
-                    // Find out if we have to recover the password/ssh-key from the already available ISO.
-                    try {
-                        List<String[]> recoveredVmData = recoverVmData(isoFile);
-                        for (String[] vmDataEntry : cmd.getVmData()) {
-                            if (updatableConfigData.containsKey(vmDataEntry[CONFIGDATA_FILE])
-                                    && updatableConfigData.get(vmDataEntry[CONFIGDATA_FILE]).equals(vmDataEntry[CONFIGDATA_DIR])) {
-                                   updateVmData(recoveredVmData, vmDataEntry);
-                            }
-                        }
-                        cmd.setVmData(recoveredVmData);
-                    } catch (IOException e) {
-                        return new Answer(cmd, e);
-                    }
-                }
-            }
-            return createConfigDriveIsoForVM(cmd);
-        } else {
-            DataStoreTO dstore = cmd.getDestStore();
-            if (dstore instanceof NfsTO) {
-                NfsTO nfs = (NfsTO) dstore;
-                String relativeTemplatePath = new File(cmd.getIsoFile()).getParent();
-                String nfsMountPoint = getRootDir(nfs.getUrl(), _nfsVersion);
-                File tmpltPath = new File(nfsMountPoint, relativeTemplatePath);
-                try {
-                    FileUtils.deleteDirectory(tmpltPath);
-                } catch (IOException e) {
-                    return new Answer(cmd, e);
-                }
-                return new Answer(cmd);
-            } else {
-                return new Answer(cmd, false, "Not implemented yet");
-            }
-        }
+        return configDriveFactory.executeRequest(cmd);
     }
 
-    private void updateVmData(List<String[]> recoveredVmData, String[] vmDataEntry) {
-        for (String[] recoveredEntry : recoveredVmData) {
-            if (recoveredEntry[CONFIGDATA_DIR].equals(vmDataEntry[CONFIGDATA_DIR])
-                    && recoveredEntry[CONFIGDATA_FILE].equals(vmDataEntry[CONFIGDATA_FILE])) {
-                recoveredEntry[CONFIGDATA_CONTENT] = vmDataEntry[CONFIGDATA_CONTENT];
-                return;
-            }
-        }
-        recoveredVmData.add(vmDataEntry);
-    }
-
-    private List<String[]> recoverVmData(File isoFile) throws IOException {
-        String tempDirName = null;
-        List<String[]> recoveredVmData = Lists.newArrayList();
-        boolean mounted = false;
-        try {
-            Path tempDir = java.nio.file.Files.createTempDirectory("ConfigDrive");
-            tempDirName = tempDir.toString();
-
-            // Unpack the current config drive file
-            Script command = new Script(!_inSystemVM, "mount", _timeout, s_logger);
-            command.add("-o", "loop");
-            command.add(isoFile.getAbsolutePath());
-            command.add(tempDirName);
-            String result = command.execute();
-
-            if (result != null) {
-                String errMsg = "Unable to mount " + isoFile.getAbsolutePath() + " at " + tempDirName + " due to " + result;
-                s_logger.error(errMsg);
-                throw new IOException(errMsg);
-            }
-            mounted = true;
 
 
-            // Scan directory structure
-            for (File configDirectory: (new File(tempDirName, "cloudstack")).listFiles()){
-                for (File configFile: configDirectory.listFiles()) {
-                    recoveredVmData.add(new String[]{configDirectory.getName(),
-                            Files.getNameWithoutExtension(configFile.getName()),
-                            Files.readFirstLine(configFile, Charset.defaultCharset())});
-                }
-            }
 
-        } finally {
-            if (mounted) {
-                Script command = new Script(!_inSystemVM, "umount", _timeout, s_logger);
-                command.add(tempDirName);
-                String result = command.execute();
-                if (result != null) {
-                    s_logger.warn("Unable to umount " + tempDirName + " due to " + result);
-                }
-            }
-            try {
-                FileUtils.deleteDirectory(new File(tempDirName));
-            } catch (IOException ioe) {
-                s_logger.warn("Failed to delete ConfigDrive temporary directory: " + tempDirName, ioe);
-            }
-        }
-        return  recoveredVmData;
-    }
 
-    public Answer createConfigDriveIsoForVM(HandleConfigDriveIsoCommand cmd) {
-        //create folder for the VM
-        if (cmd.getVmData() != null) {
-
-            Path tempDir = null;
-            String tempDirName = null;
-            try {
-                tempDir = java.nio.file.Files.createTempDirectory("ConfigDrive");
-                tempDirName = tempDir.toString();
-
-                //create OpenStack files
-                //create folder with empty files
-                File openStackFolder = new File(tempDirName + openStackConfigDriveName);
-                if (openStackFolder.exists() || openStackFolder.mkdirs()) {
-                    File vendorDataFile = new File(openStackFolder,"vendor_data.json");
-                    try (FileWriter fw = new FileWriter(vendorDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
-                        bw.write("{}");
-                    } catch (IOException ex) {
-                        s_logger.error("Failed to create file ", ex);
-                        return new Answer(cmd, ex);
-                    }
-                    File networkDataFile = new File(openStackFolder, "network_data.json");
-                    try (FileWriter fw = new FileWriter(networkDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
-                        bw.write("{}");
-                    } catch (IOException ex) {
-                        s_logger.error("Failed to create file ", ex);
-                        return new Answer(cmd, ex);
-                    }
-                } else {
-                    s_logger.error("Failed to create folder " + openStackFolder);
-                    return new Answer(cmd, false, "Failed to create folder " + openStackFolder);
-                }
-
-                JsonObject metaData = new JsonObject();
-                for (String[] item : cmd.getVmData()) {
-                    String dataType = item[CONFIGDATA_DIR];
-                    String fileName = item[CONFIGDATA_FILE];
-                    String content = item[CONFIGDATA_CONTENT];
-                    s_logger.debug(String.format("[createConfigDriveIsoForVM] dataType=%s, filename=%s, content=%s",
-                            dataType, fileName, (fileName.equals(PASSWORD_FILE)?"********":content)));
-
-                    // create file with content in folder
-                    if (dataType != null && !dataType.isEmpty()) {
-                        //create folder
-                        File typeFolder = new File(tempDirName + cloudStackConfigDriveName + dataType);
-                        if (typeFolder.exists() || typeFolder.mkdirs()) {
-                            if (StringUtils.isNotEmpty(content)) {
-                                File file = new File(typeFolder, fileName + ".txt");
-                                try  {
-                                    if (fileName.equals(USERDATA_FILE)) {
-                                        // User Data is passed as a base64 encoded string
-                                        FileUtils.writeByteArrayToFile(file, Base64.decodeBase64(content));
-                                    } else {
-                                        FileUtils.write(file, content, com.cloud.utils.StringUtils.getPreferredCharset());
-                                    }
-                                } catch (IOException ex) {
-                                    s_logger.error("Failed to create file ", ex);
-                                    return new Answer(cmd, ex);
-                                }
-                            }
-                        } else {
-                            s_logger.error("Failed to create folder " + typeFolder);
-                            return new Answer(cmd, false, "Failed to create folder " + typeFolder);
-                        }
-
-                        //now write the file to the OpenStack directory
-                        metaData = constructOpenStackMetaData(metaData, dataType, fileName, content);
-                    }
-                }
-
-                File metaDataFile = new File(openStackFolder, "meta_data.json");
-                try (FileWriter fw = new FileWriter(metaDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
-                    bw.write(metaData.toString());
-                } catch (IOException ex) {
-                    s_logger.error("Failed to create file ", ex);
-                    return new Answer(cmd, ex);
-                }
-
-                String linkResult = linkUserData(tempDirName);
-                if (linkResult != null) {
-                    String errMsg = "Unable to create user_data link due to " + linkResult;
-                    s_logger.warn(errMsg);
-                    return new Answer(cmd, false, errMsg);
-                }
-
-                File tmpIsoStore = new File(tempDirName, new File(cmd.getIsoFile()).getName());
-                Script command = new Script(!_inSystemVM, "/usr/bin/genisoimage", _timeout, s_logger);
-                command.add("-o", tmpIsoStore.getAbsolutePath());
-                command.add("-ldots");
-                command.add("-allow-lowercase");
-                command.add("-allow-multidot");
-                command.add("-cache-inodes"); // Enable caching inode and device numbers to find hard links to files.
-                command.add("-l");
-                command.add("-quiet");
-                command.add("-J");
-                command.add("-r");
-                command.add("-V", cmd.getConfigDriveLabel());
-                command.add(tempDirName);
-                s_logger.debug("execute command: " + command.toString());
-                String result = command.execute();
-                if (result != null) {
-                    String errMsg = "Unable to create iso file: " + cmd.getIsoFile() + " due to " + result;
-                    s_logger.warn(errMsg);
-                    return new Answer(cmd, false, errMsg);
-                }
-                copyLocalToNfs(tmpIsoStore, new File(cmd.getIsoFile()), cmd.getDestStore());
-
-            } catch (IOException e) {
-                return new Answer(cmd, e);
-            } catch (ConfigurationException e) {
-                s_logger.warn("SecondStorageException ", e);
-                return new Answer(cmd, e);
-            } finally {
-                try {
-                    FileUtils.deleteDirectory(tempDir.toFile());
-                } catch (IOException ioe) {
-                    s_logger.warn("Failed to delete ConfigDrive temporary directory: " + tempDirName, ioe);
-                }
-            }
-        }
-        return new Answer(cmd);
-    }
-
-    JsonObject constructOpenStackMetaData(JsonObject metaData, String dataType, String fileName, String content) {
-        if (dataType.equals(NetworkModel.METATDATA_DIR) &&  StringUtils.isNotEmpty(content)) {
-            //keys are a special case in OpenStack format
-            if (NetworkModel.PUBLIC_KEYS_FILE.equals(fileName)) {
-                String[] keyArray = content.replace("\\n", "").split(" ");
-                String keyName = "key";
-                if (keyArray.length > 3 && StringUtils.isNotEmpty(keyArray[2])){
-                    keyName = keyArray[2];
-                }
-
-                JsonObject keyLegacy = new JsonObject();
-                keyLegacy.addProperty("type", "ssh");
-                keyLegacy.addProperty("data", content.replace("\\n", ""));
-                keyLegacy.addProperty("name", keyName);
-                metaData.add("keys", arrayOf(keyLegacy));
-
-                JsonObject key = new JsonObject();
-                key.addProperty(keyName, content);
-                metaData.add("public_keys", key);
-            } else if (NetworkModel.openStackFileMapping.get(fileName) != null) {
-                    metaData.addProperty(NetworkModel.openStackFileMapping.get(fileName), content);
-            }
-        }
-        return metaData;
-    }
-
-    private static JsonArray arrayOf(JsonElement... elements) {
-        JsonArray array = new JsonArray();
-        for (JsonElement element : elements) {
-            array.add(element);
-        }
-        return array;
-    }
-
-    private String linkUserData(String tempDirName) {
-        //Hard link the user_data.txt file with the user_data file in the OpenStack directory.
-        String userDataFilePath = tempDirName + cloudStackConfigDriveName + "userdata/user_data.txt";
-        if ((new File(userDataFilePath).exists())) {
-            Script hardLink = new Script(!_inSystemVM, "ln", _timeout, s_logger);
-            hardLink.add(userDataFilePath);
-            hardLink.add(tempDirName + openStackConfigDriveName + "user_data");
-            s_logger.debug("execute command: " + hardLink.toString());
-            return hardLink.execute();
-        }
-        return null;
-    }
-
-    protected void copyLocalToNfs(File localFile, File isoFile, DataStoreTO destData) throws ConfigurationException, IOException {
-        String scriptsDir = "scripts/storage/secondary";
-        String createVolScr = Script.findScript(scriptsDir, "createvolume.sh");
-        if (createVolScr == null) {
-            throw new ConfigurationException("Unable to find createvolume.sh");
-        }
-        s_logger.info("createvolume.sh found in " + createVolScr);
-
-        int installTimeoutPerGig = 180 * 60 * 1000;
-        int imgSizeGigs = (int) Math.ceil(localFile.length() * 1.0d / (1024 * 1024 * 1024));
-        imgSizeGigs++; // add one just in case
-        long timeout = imgSizeGigs * installTimeoutPerGig;
-
-        Script scr = new Script(createVolScr, timeout, s_logger);
-        scr.add("-s", Integer.toString(imgSizeGigs));
-        scr.add("-n", isoFile.getName());
-        scr.add("-t", getRootDir(destData.getUrl(), _nfsVersion) + "/" + isoFile.getParent());
-        scr.add("-f", localFile.getAbsolutePath());
-        scr.add("-d", "configDrive");
-        String result;
-        result = scr.execute();
-
-        if (result != null) {
-            // script execution failure
-            throw new CloudRuntimeException("Failed to run script " + createVolScr);
-        }
-    }
 
     public Answer execute(GetDatadisksCommand cmd) {
         DataTO srcData = cmd.getData();
@@ -658,7 +339,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
 
         try {
             String secondaryMountPoint = getRootDir(secondaryStorageUrl, _nfsVersion);
-            s_logger.info("MDOVE Secondary storage mount point: " + secondaryMountPoint);
+            s_logger.info("MOVE Secondary storage mount point: " + secondaryMountPoint);
 
             String srcOVAFileName = getTemplateOnSecStorageFilePath(secondaryMountPoint, templateRelativeFolderPath, templateInfo.second(), ImageFormat.OVA.getFileExtension());
 
@@ -2759,7 +2440,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         String inSystemVM = (String)params.get("secondary.storage.vm");
         if (inSystemVM == null || "true".equalsIgnoreCase(inSystemVM)) {
             s_logger.debug("conf secondary.storage.vm is true, act as if executing in SSVM");
-            _inSystemVM = true;
+            setInSystemVM(true);
         }
 
         _storageIp = (String)params.get("storageip");
@@ -2850,8 +2531,9 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             _nfsVersion = retrieveNfsVersionFromParams(params);
         }
 
+        configDriveFactory = new ConfigDriveFactory(_nfsVersion, this);
+        _params.put(StorageLayer.InstanceConfigKey, _storage);
         try {
-            _params.put(StorageLayer.InstanceConfigKey, _storage);
             _dlMgr = new DownloadManagerImpl();
             _dlMgr.configure("DownloadManager", _params);
             _upldMgr = new UploadManagerImpl();
@@ -3047,7 +2729,8 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         return dir;
     }
 
-    protected void umount(String localRootPath, URI uri) {
+    @Override
+    public void umount(String localRootPath, URI uri) {
         ensureLocalRootPathExists(localRootPath, uri);
 
         if (!mountExists(localRootPath, uri)) {
@@ -3070,7 +2753,8 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
         s_logger.debug("Successfully umounted " + localRootPath);
     }
 
-    protected void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
+    @Override
+    public void mount(String localRootPath, String remoteDevice, URI uri, Integer nfsVersion) {
         s_logger.debug("mount " + uri.toString() + " on " + localRootPath + ((nfsVersion != null) ? " nfsVersion=" + nfsVersion : ""));
         ensureLocalRootPathExists(localRootPath, uri);
 

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -59,7 +59,6 @@ import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.cloudstack.storage.ConfigDriveFactory;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
@@ -176,8 +175,6 @@ import com.cloud.utils.script.OutputInterpreter;
 import com.cloud.utils.script.Script;
 import com.cloud.utils.storage.S3.S3Utils;
 import com.cloud.vm.SecondaryStorageVm;
-
-import java.io.OutputStreamWriter;
 
 public class NfsSecondaryStorageResource extends ServerResourceBase implements SecondaryStorageResource, StorageAttacher {
 

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -2362,16 +2362,16 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     }
 
     @Override
-    synchronized public String getRootDir(String secUrl, Integer nfsVersion) {
+    synchronized public String getRootDir(String url, Integer nfsVersion) {
         if (!_inSystemVM) {
             return _parent;
         }
         try {
-            URI uri = new URI(secUrl);
+            URI uri = new URI(url);
             String dir = mountUri(uri, nfsVersion);
             return _parent + "/" + dir;
         } catch (Exception e) {
-            String msg = "GetRootDir for " + secUrl + " failed due to " + e.toString();
+            String msg = "GetRootDir for " + url + " failed due to " + e.toString();
             s_logger.error(msg, e);
             throw new CloudRuntimeException(msg);
         }

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -255,7 +255,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             try {
                 nfsVersion = Integer.valueOf(nfsVersionParam);
             } catch (NumberFormatException e){
-                s_logger.error("Couldn't cast " + nfsVersionParam + " to integer");
+                s_logger.error("No NFS version known; Couldn't cast " + nfsVersionParam + " to integer");
                 return null;
             }
         }


### PR DESCRIPTION
## Description
The present configdrive generation happens on secondary storage, which is also used in public facing functionality. For those that wnat it can be processed on primary storage. This will be optional for now as using localstorage will complicate things when migrating.

First phase is factoring out the config drive creation code into a separate project (done)
next it will be made available to the host agent (KVM only)
finally the decision to look for a primary storage to do the processing on will be implemented on the basis of a global setting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
this is tested manually in a kvm env with a custom network offering that has everything in the VR except userdata. An isolated network created has been created using this offering. Finally a VM was succesfully deployed in this network.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

