### PR TITLE
fixes #2611

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/LibvirtStorageAdaptor.java
@@ -661,7 +661,7 @@ public class LibvirtStorageAdaptor implements StorageAdaptor {
 
         switch (pool.getType()) {
             case RBD:
-                return createPhysicalDiskByLibVirt(name, pool, format, provisioningType, size);
+                return createPhysicalDiskByLibVirt(name, pool, PhysicalDiskFormat.RAW, provisioningType, size);
             case NetworkFilesystem:
             case Filesystem:
                 switch (format) {


### PR DESCRIPTION
fix issue where kvm / ceph cannot create volumes #2611

## Description
This hard codes the disk format to RAW in the case of RBD

 Fixes: #2611

## How Has This Been Tested?

This was tested in a centos 7 based lab on kvm with ceph primary storage.  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

