### PR TITLE
Host Affinity plugin

### DIFF
--- a/api/src/com/cloud/deploy/DataCenterDeployment.java
+++ b/api/src/com/cloud/deploy/DataCenterDeployment.java
@@ -19,6 +19,9 @@ package com.cloud.deploy;
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.vm.ReservationContext;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DataCenterDeployment implements DeploymentPlan {
     long _dcId;
     Long _podId;
@@ -29,6 +32,7 @@ public class DataCenterDeployment implements DeploymentPlan {
     ExcludeList _avoids = null;
     boolean _recreateDisks;
     ReservationContext _context;
+    List<Long> preferredHostIds = new ArrayList<>();
 
     public DataCenterDeployment(long dataCenterId) {
         this(dataCenterId, null, null, null, null, null);
@@ -91,6 +95,16 @@ public class DataCenterDeployment implements DeploymentPlan {
     @Override
     public ReservationContext getReservationContext() {
         return _context;
+    }
+
+    @Override
+    public void setPreferredHosts(List<Long> hostIds) {
+        this.preferredHostIds = new ArrayList<>(hostIds);
+    }
+
+    @Override
+    public List<Long> getPreferredHosts() {
+        return this.preferredHostIds;
     }
 
 }

--- a/api/src/com/cloud/deploy/DeploymentPlan.java
+++ b/api/src/com/cloud/deploy/DeploymentPlan.java
@@ -19,6 +19,8 @@ package com.cloud.deploy;
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.vm.ReservationContext;
 
+import java.util.List;
+
 /**
  */
 public interface DeploymentPlan {
@@ -65,4 +67,8 @@ public interface DeploymentPlan {
     Long getPhysicalNetworkId();
 
     ReservationContext getReservationContext();
+
+    void setPreferredHosts(List<Long> hostIds);
+
+    List<Long> getPreferredHosts();
 }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -439,6 +439,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-plugin-host-affinity</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-plugin-api-solidfire-intg-test</artifactId>
         <version>${project.version}</version>

--- a/core/resources/META-INF/cloudstack/core/spring-core-registry-core-context.xml
+++ b/core/resources/META-INF/cloudstack/core/spring-core-registry-core-context.xml
@@ -248,7 +248,7 @@
         class="org.apache.cloudstack.spring.lifecycle.registry.ExtensionRegistry">
         <property name="orderConfigKey" value="affinity.processors.order" />
         <property name="orderConfigDefault"
-            value="HostAntiAffinityProcessor,ExplicitDedicationProcessor" />
+            value="HostAntiAffinityProcessor,ExplicitDedicationProcessor,HostAffinityProcessor" />
         <property name="excludeKey" value="affinity.processors.exclude" />
     </bean>
 

--- a/plugins/affinity-group-processors/host-affinity/pom.xml
+++ b/plugins/affinity-group-processors/host-affinity/pom.xml
@@ -1,0 +1,33 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache CloudStack Plugin - Host Affinity Processor</name>
+    <artifactId>cloud-plugin-host-affinity</artifactId>
+    <parent>
+        <artifactId>cloudstack-plugins</artifactId>
+        <groupId>org.apache.cloudstack</groupId>
+        <version>4.11.1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <build>
+        <defaultGoal>install</defaultGoal>
+        <sourceDirectory>src</sourceDirectory>
+    </build>
+</project>

--- a/plugins/affinity-group-processors/host-affinity/resources/META-INF/cloudstack/host-affinity/module.properties
+++ b/plugins/affinity-group-processors/host-affinity/resources/META-INF/cloudstack/host-affinity/module.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name=host-affinity
+parent=planner

--- a/plugins/affinity-group-processors/host-affinity/resources/META-INF/cloudstack/host-affinity/spring-host-affinity-context.xml
+++ b/plugins/affinity-group-processors/host-affinity/resources/META-INF/cloudstack/host-affinity/spring-host-affinity-context.xml
@@ -1,0 +1,35 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+                      http://www.springframework.org/schema/context
+                      http://www.springframework.org/schema/context/spring-context.xsd"
+    >
+
+    <bean id="HostAffinityProcessor"
+          class="org.apache.cloudstack.affinity.HostAffinityProcessor">
+        <property name="name" value="HostAffinityProcessor" />
+        <property name="type" value="host affinity" />
+    </bean>
+</beans>

--- a/plugins/affinity-group-processors/host-affinity/src/org/apache/cloudstack/affinity/HostAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-affinity/src/org/apache/cloudstack/affinity/HostAffinityProcessor.java
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.affinity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.ArrayList;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+
+import com.cloud.vm.VMInstanceVO;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.log4j.Logger;
+
+import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
+import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+
+import com.cloud.deploy.DeployDestination;
+import com.cloud.deploy.DeploymentPlan;
+import com.cloud.deploy.DeploymentPlanner.ExcludeList;
+import com.cloud.exception.AffinityConflictException;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineProfile;
+import com.cloud.vm.dao.VMInstanceDao;
+
+public class HostAffinityProcessor extends AffinityProcessorBase implements AffinityGroupProcessor {
+
+    private static final Logger s_logger = Logger.getLogger(HostAffinityProcessor.class);
+
+    @Inject
+    protected VMInstanceDao _vmInstanceDao;
+    @Inject
+    protected AffinityGroupDao _affinityGroupDao;
+    @Inject
+    protected AffinityGroupVMMapDao _affinityGroupVMMapDao;
+
+    @Inject
+    protected ConfigurationDao _configDao;
+
+    @Override
+    public void process(VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid) throws AffinityConflictException {
+        VirtualMachine vm = vmProfile.getVirtualMachine();
+        List<AffinityGroupVMMapVO> vmGroupMappings = _affinityGroupVMMapDao.findByVmIdType(vm.getId(), getType());
+        for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
+            if (vmGroupMapping != null) {
+                AffinityGroupVO group = _affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
+
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Processing affinity group " + group.getName() + " for VM Id: " + vm.getId());
+                }
+
+                List<Long> groupVMIds = _affinityGroupVMMapDao.listVmIdsByAffinityGroup(group.getId());
+                groupVMIds.remove(vm.getId());
+
+                Set<Long> hostIds = new HashSet<>();
+                for (Long groupVMId : groupVMIds) {
+                    VMInstanceVO groupVM = _vmInstanceDao.findById(groupVMId);
+                    hostIds.add(groupVM.getHostId());
+                }
+                List<Long> preferredHostIds = new ArrayList<>();
+                preferredHostIds.addAll(hostIds);
+                plan.setPreferredHosts(preferredHostIds);
+            }
+        }
+    }
+
+    @Override
+    public boolean configure(final String name, final Map<String, Object> params) throws ConfigurationException {
+        super.configure(name, params);
+        return true;
+    }
+
+    @Override
+    public boolean check(VirtualMachineProfile vmProfile, DeployDestination plannedDestination) throws AffinityConflictException {
+        if (plannedDestination.getHost() == null) {
+            return true;
+        }
+        long plannedHostId = plannedDestination.getHost().getId();
+
+        VirtualMachine vm = vmProfile.getVirtualMachine();
+
+        List<AffinityGroupVMMapVO> vmGroupMappings = _affinityGroupVMMapDao.findByVmIdType(vm.getId(), getType());
+
+        for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
+            List<Long> groupVMIds = _affinityGroupVMMapDao.listVmIdsByAffinityGroup(vmGroupMapping.getAffinityGroupId());
+            groupVMIds.remove(vm.getId());
+
+            Set<Long> hostIds = new HashSet<>();
+            for (Long groupVMId : groupVMIds) {
+                VMInstanceVO groupVM = _vmInstanceDao.findById(groupVMId);
+                hostIds.add(groupVM.getHostId());
+            }
+
+            if (CollectionUtils.isNotEmpty(groupVMIds) && !hostIds.contains(plannedHostId)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/plugins/affinity-group-processors/host-affinity/src/org/apache/cloudstack/affinity/HostAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-affinity/src/org/apache/cloudstack/affinity/HostAffinityProcessor.java
@@ -53,8 +53,10 @@ public class HostAffinityProcessor extends AffinityProcessorBase implements Affi
     public void process(VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid) throws AffinityConflictException {
         VirtualMachine vm = vmProfile.getVirtualMachine();
         List<AffinityGroupVMMapVO> vmGroupMappings = _affinityGroupVMMapDao.findByVmIdType(vm.getId(), getType());
-        for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
-            processAffinityGroup(vmGroupMapping, plan, vm);
+        if (CollectionUtils.isNotEmpty(vmGroupMappings)) {
+            for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
+                processAffinityGroup(vmGroupMapping, plan, vm);
+            }
         }
     }
 
@@ -62,16 +64,14 @@ public class HostAffinityProcessor extends AffinityProcessorBase implements Affi
      * Process Affinity Group for VM deployment
      */
     protected void processAffinityGroup(AffinityGroupVMMapVO vmGroupMapping, DeploymentPlan plan, VirtualMachine vm) {
-        if (vmGroupMapping != null) {
-            AffinityGroupVO group = _affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
-            s_logger.debug("Processing affinity group " + group.getName() + " for VM Id: " + vm.getId());
+        AffinityGroupVO group = _affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
+        s_logger.debug("Processing affinity group " + group.getName() + " for VM Id: " + vm.getId());
 
-            List<Long> groupVMIds = _affinityGroupVMMapDao.listVmIdsByAffinityGroup(group.getId());
-            groupVMIds.remove(vm.getId());
+        List<Long> groupVMIds = _affinityGroupVMMapDao.listVmIdsByAffinityGroup(group.getId());
+        groupVMIds.remove(vm.getId());
 
-            List<Long> preferredHosts = getPreferredHostsFromGroupVMIds(groupVMIds);
-            plan.setPreferredHosts(preferredHosts);
-        }
+        List<Long> preferredHosts = getPreferredHostsFromGroupVMIds(groupVMIds);
+        plan.setPreferredHosts(preferredHosts);
     }
 
     /**
@@ -102,11 +102,14 @@ public class HostAffinityProcessor extends AffinityProcessorBase implements Affi
         VirtualMachine vm = vmProfile.getVirtualMachine();
         List<AffinityGroupVMMapVO> vmGroupMappings = _affinityGroupVMMapDao.findByVmIdType(vm.getId(), getType());
 
-        for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
-            if (!checkAffinityGroup(vmGroupMapping, vm, plannedHostId)) {
-                return false;
+        if (CollectionUtils.isNotEmpty(vmGroupMappings)) {
+            for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
+                if (!checkAffinityGroup(vmGroupMapping, vm, plannedHostId)) {
+                    return false;
+                }
             }
         }
+
         return true;
     }
 

--- a/plugins/affinity-group-processors/host-affinity/src/org/apache/cloudstack/affinity/HostAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-affinity/src/org/apache/cloudstack/affinity/HostAffinityProcessor.java
@@ -31,7 +31,6 @@ import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 
 import com.cloud.deploy.DeployDestination;
 import com.cloud.deploy.DeploymentPlan;
@@ -52,9 +51,6 @@ public class HostAffinityProcessor extends AffinityProcessorBase implements Affi
     @Inject
     protected AffinityGroupVMMapDao _affinityGroupVMMapDao;
 
-    @Inject
-    protected ConfigurationDao _configDao;
-
     @Override
     public void process(VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid) throws AffinityConflictException {
         VirtualMachine vm = vmProfile.getVirtualMachine();
@@ -62,10 +58,7 @@ public class HostAffinityProcessor extends AffinityProcessorBase implements Affi
         for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
             if (vmGroupMapping != null) {
                 AffinityGroupVO group = _affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
-
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Processing affinity group " + group.getName() + " for VM Id: " + vm.getId());
-                }
+                s_logger.debug("Processing affinity group " + group.getName() + " for VM Id: " + vm.getId());
 
                 List<Long> groupVMIds = _affinityGroupVMMapDao.listVmIdsByAffinityGroup(group.getId());
                 groupVMIds.remove(vm.getId());

--- a/plugins/affinity-group-processors/host-affinity/test/org/apache/cloudstack/affinity/HostAffinityProcessorTest.java
+++ b/plugins/affinity-group-processors/host-affinity/test/org/apache/cloudstack/affinity/HostAffinityProcessorTest.java
@@ -1,0 +1,176 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.affinity;
+
+import com.cloud.deploy.DeployDestination;
+import com.cloud.deploy.DeploymentPlan;
+import com.cloud.host.Host;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineProfile;
+import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
+import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnit4.class)
+public class HostAffinityProcessorTest {
+
+    private static final long AFFINITY_GROUP_ID = 2L;
+    private static final String AFFINITY_GROUP_NAME = "Host affinity group";
+    private static final Long VM_ID = 3L;
+    private static final Long GROUP_VM_1_ID = 1L;
+    private static final Long GROUP_VM_2_ID = 2L;
+    private static final Long HOST_ID = 1L;
+    private static final Long HOST_2_ID = 2L;
+
+    @Mock
+    AffinityGroupDao affinityGroupDao;
+
+    @Mock
+    AffinityGroupVMMapDao affinityGroupVMMapDao;
+
+    @Mock
+    VMInstanceDao vmInstanceDao;
+
+    @Spy
+    @InjectMocks
+    HostAffinityProcessor processor = new HostAffinityProcessor();
+
+    @Mock
+    DeploymentPlan plan;
+
+    @Mock
+    VirtualMachine vm;
+
+    @Mock
+    VMInstanceVO groupVM1;
+
+    @Mock
+    VMInstanceVO groupVM2;
+
+    @Mock
+    AffinityGroupVO affinityGroupVO;
+
+    @Mock
+    AffinityGroupVMMapVO mapVO;
+
+    @Mock
+    DeployDestination dest;
+
+    @Mock
+    Host host;
+
+    @Mock
+    VirtualMachineProfile profile;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        when(groupVM1.getHostId()).thenReturn(HOST_ID);
+        when(groupVM2.getHostId()).thenReturn(HOST_ID);
+        when(vmInstanceDao.findById(GROUP_VM_1_ID)).thenReturn(groupVM1);
+        when(vmInstanceDao.findById(GROUP_VM_2_ID)).thenReturn(groupVM2);
+
+        when(affinityGroupVMMapDao.listVmIdsByAffinityGroup(AFFINITY_GROUP_ID)).thenReturn(new ArrayList<>(Arrays.asList(GROUP_VM_1_ID, GROUP_VM_2_ID, VM_ID)));
+
+        when(vm.getId()).thenReturn(VM_ID);
+
+        when(affinityGroupVO.getId()).thenReturn(AFFINITY_GROUP_ID);
+        when(affinityGroupVO.getName()).thenReturn(AFFINITY_GROUP_NAME);
+        when(mapVO.getAffinityGroupId()).thenReturn(AFFINITY_GROUP_ID);
+
+        when(affinityGroupDao.findById(AFFINITY_GROUP_ID)).thenReturn(affinityGroupVO);
+
+        when(dest.getHost()).thenReturn(host);
+        when(host.getId()).thenReturn(HOST_ID);
+        when(profile.getVirtualMachine()).thenReturn(vm);
+        when(affinityGroupVMMapDao.findByVmIdType(eq(VM_ID), any())).thenReturn(new ArrayList<>(Arrays.asList(mapVO)));
+    }
+
+    @Test
+    public void testProcessAffinityGroupMultipleVMs() {
+        processor.processAffinityGroup(mapVO, plan, vm);
+        verify(plan).setPreferredHosts(Arrays.asList(HOST_ID));
+    }
+
+    @Test
+    public void testProcessAffinityGroupEmptyGroup() {
+        when(affinityGroupVMMapDao.listVmIdsByAffinityGroup(AFFINITY_GROUP_ID)).thenReturn(new ArrayList<>());
+        processor.processAffinityGroup(mapVO, plan, vm);
+        verify(plan).setPreferredHosts(new ArrayList<>());
+    }
+
+    @Test
+    public void testGetPreferredHostsFromGroupVMIdsMultipleVMs() {
+        List<Long> list = new ArrayList<>(Arrays.asList(GROUP_VM_1_ID, GROUP_VM_2_ID));
+        List<Long> preferredHosts = processor.getPreferredHostsFromGroupVMIds(list);
+        assertNotNull(preferredHosts);
+        assertEquals(1, preferredHosts.size());
+        assertEquals(HOST_ID, preferredHosts.get(0));
+    }
+
+    @Test
+    public void testGetPreferredHostsFromGroupVMIdsEmptyVMsList() {
+        List<Long> list = new ArrayList<>();
+        List<Long> preferredHosts = processor.getPreferredHostsFromGroupVMIds(list);
+        assertNotNull(preferredHosts);
+        assertTrue(preferredHosts.isEmpty());
+    }
+
+    @Test
+    public void testCheckAffinityGroup() {
+        assertTrue(processor.checkAffinityGroup(mapVO, vm, HOST_ID));
+    }
+
+    @Test
+    public void testCheckAffinityGroupWrongHostId() {
+        assertFalse(processor.checkAffinityGroup(mapVO, vm, HOST_2_ID));
+    }
+
+    @Test
+    public void testCheck() {
+        assertTrue(processor.check(profile, dest));
+    }
+
+    @Test
+    public void testCheckWrongHostId() {
+        when(host.getId()).thenReturn(HOST_2_ID);
+        assertFalse(processor.check(profile, dest));
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -109,6 +109,7 @@
     <module>database/quota</module>
     <module>integrations/cloudian</module>
     <module>integrations/prometheus</module>
+    <module>affinity-group-processors/host-affinity</module>
   </modules>
 
   <dependencies>

--- a/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -33,6 +33,7 @@ import javax.naming.ConfigurationException;
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.fsm.StateMachine2;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.affinity.AffinityGroupProcessor;
 import org.apache.cloudstack.affinity.AffinityGroupService;
@@ -321,7 +322,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     suitableHosts.add(host);
                     Pair<Host, Map<Volume, StoragePool>> potentialResources = findPotentialDeploymentResources(
                             suitableHosts, suitableVolumeStoragePools, avoids,
-                            getPlannerUsage(planner, vmProfile, plan, avoids), readyAndReusedVolumes);
+                            getPlannerUsage(planner, vmProfile, plan, avoids), readyAndReusedVolumes, plan.getPreferredHosts());
                     if (potentialResources != null) {
                         pod = _podDao.findById(host.getPodId());
                         cluster = _clusterDao.findById(host.getClusterId());
@@ -461,7 +462,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                                 suitableHosts.add(host);
                                 Pair<Host, Map<Volume, StoragePool>> potentialResources = findPotentialDeploymentResources(
                                         suitableHosts, suitableVolumeStoragePools, avoids,
-                                        getPlannerUsage(planner, vmProfile, plan, avoids), readyAndReusedVolumes);
+                                        getPlannerUsage(planner, vmProfile, plan, avoids), readyAndReusedVolumes, plan.getPreferredHosts());
                                 if (potentialResources != null) {
                                     Map<Volume, StoragePool> storageVolMap = potentialResources.second();
                                     // remove the reused vol<->pool from
@@ -1077,7 +1078,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     // choose the potential host and pool for the VM
                     if (!suitableVolumeStoragePools.isEmpty()) {
                         Pair<Host, Map<Volume, StoragePool>> potentialResources = findPotentialDeploymentResources(suitableHosts, suitableVolumeStoragePools, avoid,
-                                resourceUsageRequired, readyAndReusedVolumes);
+                                resourceUsageRequired, readyAndReusedVolumes, plan.getPreferredHosts());
 
                         if (potentialResources != null) {
                             Host host = _hostDao.findById(potentialResources.first().getId());
@@ -1217,11 +1218,12 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
     }
 
     protected Pair<Host, Map<Volume, StoragePool>> findPotentialDeploymentResources(List<Host> suitableHosts, Map<Volume, List<StoragePool>> suitableVolumeStoragePools,
-            ExcludeList avoid, DeploymentPlanner.PlannerResourceUsage resourceUsageRequired, List<Volume> readyAndReusedVolumes) {
+            ExcludeList avoid, DeploymentPlanner.PlannerResourceUsage resourceUsageRequired, List<Volume> readyAndReusedVolumes, List<Long> preferredHosts) {
         s_logger.debug("Trying to find a potenial host and associated storage pools from the suitable host/pool lists for this VM");
 
         boolean hostCanAccessPool = false;
         boolean haveEnoughSpace = false;
+        boolean hostAffinity = true;
 
         if (readyAndReusedVolumes == null) {
             readyAndReusedVolumes = new ArrayList<Volume>();
@@ -1245,6 +1247,10 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 s_logger.debug("Checking if host: " + potentialHost.getId() + " can access any suitable storage pool for volume: " + vol.getVolumeType());
                 List<StoragePool> volumePoolList = suitableVolumeStoragePools.get(vol);
                 hostCanAccessPool = false;
+                hostAffinity = true;
+                if (CollectionUtils.isNotEmpty(preferredHosts) && !preferredHosts.contains(potentialHost.getId())) {
+                    hostAffinity = false;
+                }
                 for (StoragePool potentialSPool : volumePoolList) {
                     if (hostCanAccessSPool(potentialHost, potentialSPool)) {
                         hostCanAccessPool = true;
@@ -1274,7 +1280,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     break;
                 }
             }
-            if (hostCanAccessPool && haveEnoughSpace && checkIfHostFitsPlannerUsage(potentialHost.getId(), resourceUsageRequired)) {
+            if (hostCanAccessPool && haveEnoughSpace && hostAffinity && checkIfHostFitsPlannerUsage(potentialHost.getId(), resourceUsageRequired)) {
                 s_logger.debug("Found a potential host " + "id: " + potentialHost.getId() + " name: " + potentialHost.getName() +
                         " and associated storage pools for this VM");
                 return new Pair<Host, Map<Volume, StoragePool>>(potentialHost, storage);

--- a/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
+++ b/server/test/com/cloud/vm/DeploymentPlanningManagerImplTest.java
@@ -16,15 +16,19 @@
 // under the License.
 package com.cloud.vm;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import com.cloud.host.Host;
 import org.apache.cloudstack.affinity.dao.AffinityGroupDomainMapDao;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -136,9 +140,12 @@ public class DeploymentPlanningManagerImplTest {
     @Inject
     UserVmDetailsDao vmDetailsDao;
 
-    private static long domainId = 5L;
+    @Mock
+    Host host;
 
+    private static long domainId = 5L;
     private static long dataCenterId = 1L;
+    private static long hostId = 1l;
 
     @BeforeClass
     public static void setUp() throws ConfigurationException {
@@ -172,6 +179,7 @@ public class DeploymentPlanningManagerImplTest {
         planners.add(_planner);
         _dpm.setPlanners(planners);
 
+        Mockito.when(host.getId()).thenReturn(hostId);
     }
 
     @Test
@@ -220,6 +228,26 @@ public class DeploymentPlanningManagerImplTest {
         Mockito.when(((DeploymentClusterPlanner)_planner).orderClusters(vmProfile, plan, avoids)).thenReturn(null);
         DeployDestination dest = _dpm.planDeployment(vmProfile, plan, avoids, null);
         assertNull("Planner cannot handle, destination should be null! ", dest);
+    }
+
+    @Test
+    public void testCheckAffinityEmptyPreferredHosts() {
+        assertTrue(_dpm.checkAffinity(host, new ArrayList<>()));
+    }
+
+    @Test
+    public void testCheckAffinityNullPreferredHosts() {
+        assertTrue(_dpm.checkAffinity(host, null));
+    }
+
+    @Test
+    public void testCheckAffinityNotEmptyPreferredHostsContainingHost() {
+        assertTrue(_dpm.checkAffinity(host, Arrays.asList(3l, 4l, hostId, 2l)));
+    }
+
+    @Test
+    public void testCheckAffinityNotEmptyPreferredHostsNotContainingHost() {
+        assertFalse(_dpm.checkAffinity(host, Arrays.asList(3l, 4l, 2l)));
     }
 
     @Configuration


### PR DESCRIPTION
## Description
Introduce a new affinity group type: Host affinity.
VMs belonging to a host affinity group are on the same host, and new deployments using the affinity group are expected on the same host.
There is room for improvement by adding scope level which should be: host, cluster or pod

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5295080/39739816-471b742e-5269-11e8-84e5-0d6991d2b20f.png)

## How Has This Been Tested?
- 2 KVM hosts
- Create new host affinity group
- Deploy VM selecting the created affinity group
- Deploy another VMs selecting the same affinity group.
- Created VMs are all on the same host

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [x] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

