### PR TITLE
listostypes: Fixes #2529 return boolean than string in response

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/GuestOSResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/GuestOSResponse.java
@@ -41,7 +41,7 @@ public class GuestOSResponse extends BaseResponse {
 
     @SerializedName(ApiConstants.IS_USER_DEFINED)
     @Param(description = "is the guest OS user defined")
-    private String isUserDefined;
+    private Boolean isUserDefined;
 
     public String getId() {
         return id;
@@ -67,11 +67,11 @@ public class GuestOSResponse extends BaseResponse {
         this.description = description;
     }
 
-    public String getIsUserDefined() {
+    public Boolean getIsUserDefined() {
         return isUserDefined;
     }
 
-    public void setIsUserDefined(String isUserDefined) {
+    public void setIsUserDefined(Boolean isUserDefined) {
         this.isUserDefined = isUserDefined;
     }
 

--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -3203,7 +3203,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         GuestOSResponse response = new GuestOSResponse();
         response.setDescription(guestOS.getDisplayName());
         response.setId(guestOS.getUuid());
-        response.setIsUserDefined(Boolean.valueOf(guestOS.getIsUserDefined()).toString());
+        response.setIsUserDefined(guestOS.getIsUserDefined());
         GuestOSCategoryVO category = ApiDBUtils.findGuestOsCategoryById(guestOS.getCategoryId());
         if (category != null) {
             response.setOsCategoryId(category.getUuid());


### PR DESCRIPTION
This returns the boolean value of the `isuserdefined` key than
converting it to string. Fixes #2529.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

