### PR TITLE
CLOUDSTACK-9184: Fixes #2631 VMware dvs portgroup autogrowth

### DIFF
--- a/engine/schema/resources/META-INF/db/schema-41100to41110-cleanup.sql
+++ b/engine/schema/resources/META-INF/db/schema-41100to41110-cleanup.sql
@@ -18,3 +18,5 @@
 --;
 -- Schema upgrade from 4.11.0.0 to 4.11.1.0
 --;
+
+DELETE FROM `cloud`.`configuration` WHERE `name`='vmware.ports.per.dvportgroup';

--- a/server/src/com/cloud/configuration/Config.java
+++ b/server/src/com/cloud/configuration/Config.java
@@ -1139,14 +1139,6 @@ public enum Config {
             "false",
             "Enable/Disable Nexus/Vmware dvSwitch in VMware environment",
             null),
-    VmwarePortsPerDVPortGroup(
-            "Network",
-            ManagementServer.class,
-            Integer.class,
-            "vmware.ports.per.dvportgroup",
-            "256",
-            "Default number of ports per Vmware dvPortGroup in VMware environment",
-            null),
     VmwareCreateFullClone(
             "Advanced",
             ManagementServer.class,

--- a/vmware-base/src/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
+++ b/vmware-base/src/com/cloud/hypervisor/vmware/mo/HypervisorHostHelper.java
@@ -755,9 +755,8 @@ public class HypervisorHostHelper {
             dvsPortSetting = createVmwareDVPortSettingSpec(shapingPolicy, secPolicy, pvlanSpec);
         }
 
-        newDvPortGroupSpec = createDvPortGroupSpec(networkName, dvsPortSetting, numPorts, autoExpandSupported);
-        if (portGroupPolicy != null)
-        {
+        newDvPortGroupSpec = createDvPortGroupSpec(networkName, dvsPortSetting, autoExpandSupported);
+        if (portGroupPolicy != null) {
             newDvPortGroupSpec.setPolicy(portGroupPolicy);
         }
 
@@ -765,6 +764,7 @@ public class HypervisorHostHelper {
             s_logger.info("Distributed Virtual Port group " + networkName + " not found.");
             // TODO(sateesh): Handle Exceptions
             try {
+                newDvPortGroupSpec.setNumPorts(numPorts);
                 dvSwitchMo.createDVPortGroup(newDvPortGroupSpec);
             } catch (Exception e) {
                 String msg = "Failed to create distributed virtual port group " + networkName + " on dvSwitch " + physicalNetwork;
@@ -994,13 +994,12 @@ public class HypervisorHostHelper {
         return true;
     }
 
-    public static DVPortgroupConfigSpec createDvPortGroupSpec(String dvPortGroupName, DVPortSetting portSetting, int numPorts, boolean autoExpandSupported) {
+    public static DVPortgroupConfigSpec createDvPortGroupSpec(String dvPortGroupName, DVPortSetting portSetting, boolean autoExpandSupported) {
         DVPortgroupConfigSpec spec = new DVPortgroupConfigSpec();
         spec.setName(dvPortGroupName);
         spec.setDefaultPortConfig(portSetting);
         spec.setPortNameFormat("vnic<portIndex>");
         spec.setType("earlyBinding");
-        spec.setNumPorts(numPorts);
         spec.setAutoExpand(autoExpandSupported);
         return spec;
     }


### PR DESCRIPTION
This deprecates the vmware.ports.per.dvportgroup global setting.

The vSphere Auto Expand feature (introduced in vSphere 5.0) will take
care of dynamically increasing/decreasing the dvPorts when running out
of distributed ports . But in case of vSphere 4.1/4.0 (If used), as this
feature is not there, the new default value (=> 8) have an impact in the
existing deployments. Action item for vSphere 4.1/4.0: Admin should
modify the global configuration setting "vmware.ports.per.dvportgroup"
from 8 to any number based on their environment because the proposal
default value of 8 would be very less without auto expand feature in
general. The current default value of 256 may not need immediate
modification after deployment, but 8 would be very less which means
admin need to update immediately after upgrade.

This continues and take-over from PR https://github.com/apache/cloudstack/pull/1253

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

I deployed ACS 4.6 and performed an upgrade to latest 4.11 with dvs, I could not reproduce the issues shared on #2631 
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

