### PR TITLE
config drive - send user-defined vm name as host name, not uuid

### DIFF
--- a/api/src/com/cloud/network/NetworkModel.java
+++ b/api/src/com/cloud/network/NetworkModel.java
@@ -73,7 +73,7 @@ public interface NetworkModel {
             AVAILABILITY_ZONE_FILE, "availability_zone",
             LOCAL_HOSTNAME_FILE, "hostname",
             VM_ID_FILE, "uuid",
-            INSTANCE_ID_FILE, "name"
+            PUBLIC_HOSTNAME_FILE, "name"
     );
 
     static final ConfigKey<Integer> MACIdentifier = new ConfigKey<Integer>("Advanced",Integer.class, "mac.identifier", "0",

--- a/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -104,7 +104,7 @@ public class ConfigDriveNetworkElementTest {
     private final String VMUSERDATA = "H4sIABCvw1oAAystTi1KSSxJ5AIAUPllwQkAAAA=";
     private final long SOID = 31L;
     private final long HOSTID = NETWORK_ID;
-    private final String HOSTNAME = "host1";
+    private final String HOSTNAME = "vm-hostname";
 
     @Mock private ConfigurationDao _configDao;
     @Mock private DataCenterDao _dcDao;
@@ -166,7 +166,7 @@ public class ConfigDriveNetworkElementTest {
         when(virtualMachine.getDataCenterId()).thenReturn(DATACENTERID);
         when(virtualMachine.getInstanceName()).thenReturn(VMINSTANCENAME);
         when(virtualMachine.getUserData()).thenReturn(VMUSERDATA);
-        when(virtualMachine.getHostName()).thenReturn("vm-hostname");
+        when(virtualMachine.getHostName()).thenReturn(HOSTNAME);
         when(deployDestination.getHost()).thenReturn(hostVO);
         when(hostVO.getId()).thenReturn(HOSTID);
         when(nic.isDefaultNic()).thenReturn(true);

--- a/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -166,6 +166,7 @@ public class ConfigDriveNetworkElementTest {
         when(virtualMachine.getDataCenterId()).thenReturn(DATACENTERID);
         when(virtualMachine.getInstanceName()).thenReturn(VMINSTANCENAME);
         when(virtualMachine.getUserData()).thenReturn(VMUSERDATA);
+        when(virtualMachine.getHostName()).thenReturn("vm-hostname");
         when(deployDestination.getHost()).thenReturn(hostVO);
         when(hostVO.getId()).thenReturn(HOSTID);
         when(nic.isDefaultNic()).thenReturn(true);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
For config drive to be Openstack compliant, in the openstack/latest/meta_data.json, we need the ‘name’ to be the name that the user sets as the VM name and the ‘hostname’ to be “<name that the user sets> . <domain name of network>” ie. the fqdn.
Cherry picked a commit that fixes this: https://github.com/apache/cloudstack/pull/2614/commits/105b3fe0650f9e18cc6d39655c0d58b62ed7b44e
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Create an L2 network offering with user data checkbox selected to pass user data and metadata to VMs via config Drive. Create an L2 network and create a vm with userdata. Launch the VM. Ssh to the vm instance. Mount the config drive and verify that the openstack/latest/meta_data.json file contains the name that the user set as the VM name and the ‘hostname’ as “<name that the user sets> . <domain name of network>” ie. the fqdn.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
Fixes https://github.com/apache/cloudstack/pull/2615
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [x] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

