### PR TITLE
CLOUDSTACK-10290: Introduce option to have config drives on primary storage

### DIFF
--- a/api/src/com/cloud/network/element/UserDataServiceProvider.java
+++ b/api/src/com/cloud/network/element/UserDataServiceProvider.java
@@ -26,7 +26,7 @@ import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VirtualMachineProfile;
 
 public interface UserDataServiceProvider extends NetworkElement {
-    public boolean addPasswordAndUserdata(Network network, NicProfile nic, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
+    boolean addPasswordAndUserdata(Network network, NicProfile nic, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context)
         throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException;
 
     boolean savePassword(Network network, NicProfile nic, VirtualMachineProfile vm) throws ResourceUnavailableException;

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -380,6 +380,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-engine-storage-configdrive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
       <artifactId>cloud-controller-secondary-storage</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
+++ b/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
@@ -26,17 +26,23 @@ import com.cloud.agent.api.to.DataStoreTO;
 public class HandleConfigDriveIsoCommand extends Command {
 
     String isoFile;
+    String isoData;
     List<String[]> vmData;
     String configDriveLabel;
     boolean create = false;
-    private boolean update = false;
     private DataStoreTO destStore;
 
-    public HandleConfigDriveIsoCommand(List<String[]> vmData, String label, DataStoreTO destStore, String isoFile, boolean create, boolean update) {
+    public HandleConfigDriveIsoCommand(String isoFile, String isoData, DataStoreTO destStore, boolean create) {
+        this.isoFile = isoFile;
+        this.isoData = isoData;
+        this.destStore = destStore;
+        this.create = create;
+    }
+
+    public HandleConfigDriveIsoCommand(List<String[]> vmData, String label, DataStoreTO destStore, String isoFile, boolean create) {
         this.vmData = vmData;
         this.configDriveLabel = label;
         this.create = create;
-        this.update = update;
         this.destStore = destStore;
 
         this.isoFile = isoFile;
@@ -45,6 +51,10 @@ public class HandleConfigDriveIsoCommand extends Command {
     @Override
     public boolean executeInSequence() {
         return false;
+    }
+
+    public String getIsoData() {
+        return isoData;
     }
 
     public List<String[]> getVmData() {
@@ -71,7 +81,4 @@ public class HandleConfigDriveIsoCommand extends Command {
         return isoFile;
     }
 
-    public boolean isUpdate() {
-        return update;
-    }
 }

--- a/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
+++ b/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
@@ -19,16 +19,13 @@
 
 package com.cloud.agent.api;
 
-import java.util.List;
-
 import com.cloud.agent.api.to.DataStoreTO;
 
 public class HandleConfigDriveIsoCommand extends Command {
 
-    String isoFile;
+    @LogLevel(LogLevel.Log4jLevel.Off)
     String isoData;
-    List<String[]> vmData;
-    String configDriveLabel;
+    String isoFile;
     boolean create = false;
     private DataStoreTO destStore;
 
@@ -37,15 +34,6 @@ public class HandleConfigDriveIsoCommand extends Command {
         this.isoData = isoData;
         this.destStore = destStore;
         this.create = create;
-    }
-
-    public HandleConfigDriveIsoCommand(List<String[]> vmData, String label, DataStoreTO destStore, String isoFile, boolean create) {
-        this.vmData = vmData;
-        this.configDriveLabel = label;
-        this.create = create;
-        this.destStore = destStore;
-
-        this.isoFile = isoFile;
     }
 
     @Override
@@ -57,20 +45,8 @@ public class HandleConfigDriveIsoCommand extends Command {
         return isoData;
     }
 
-    public List<String[]> getVmData() {
-        return vmData;
-    }
-
-    public void setVmData(List<String[]> vmData) {
-        this.vmData = vmData;
-    }
-
     public boolean isCreate() {
         return create;
-    }
-
-    public String getConfigDriveLabel() {
-        return configDriveLabel;
     }
 
     public DataStoreTO getDestStore() {
@@ -80,5 +56,4 @@ public class HandleConfigDriveIsoCommand extends Command {
     public String getIsoFile() {
         return isoFile;
     }
-
 }

--- a/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
+++ b/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
@@ -24,9 +24,10 @@ import com.cloud.agent.api.to.DataStoreTO;
 public class HandleConfigDriveIsoCommand extends Command {
 
     @LogLevel(LogLevel.Log4jLevel.Off)
-    String isoData;
-    String isoFile;
-    boolean create = false;
+    private String isoData;
+
+    private String isoFile;
+    private boolean create = false;
     private DataStoreTO destStore;
 
     public HandleConfigDriveIsoCommand(String isoFile, String isoData, DataStoreTO destStore, boolean create) {

--- a/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
+++ b/core/src/com/cloud/agent/api/HandleConfigDriveIsoCommand.java
@@ -39,7 +39,6 @@ public class HandleConfigDriveIsoCommand extends Command {
         this.update = update;
         this.destStore = destStore;
 
-
         this.isoFile = isoFile;
     }
 

--- a/engine/api/src/com/cloud/vm/VirtualMachineManager.java
+++ b/engine/api/src/com/cloud/vm/VirtualMachineManager.java
@@ -49,14 +49,17 @@ import com.cloud.utils.fsm.NoTransitionException;
  */
 public interface VirtualMachineManager extends Manager {
 
-    static final ConfigKey<Boolean> ExecuteInSequence = new ConfigKey<Boolean>("Advanced", Boolean.class, "execute.in.sequence.hypervisor.commands", "false",
+    ConfigKey<Boolean> ExecuteInSequence = new ConfigKey<>("Advanced", Boolean.class, "execute.in.sequence.hypervisor.commands", "false",
             "If set to true, start, stop, reboot, copy and migrate commands will be serialized on the agent side. If set to false the commands are executed in parallel. Default value is false.", false);
 
-    static final ConfigKey<String> VmConfigDriveLabel = new ConfigKey<String>("Hidden", String.class, "vm.configdrive.label", "config-2",
+    ConfigKey<String> VmConfigDriveLabel = new ConfigKey<>("Hidden", String.class, "vm.configdrive.label", "config-2",
             "The default label name for the config drive", false);
 
-    public interface Topics {
-        public static final String VM_POWER_STATE = "vm.powerstate";
+    ConfigKey<Boolean> VmConfigDriveOnPrimaryPool = new ConfigKey<>("Advanced", Boolean.class, "vm.configdrive.primarypool.enabled", "false",
+            "If config drive need to be created and hosted on primary storage pool. Currently only supported for KVM.", true);
+
+    interface Topics {
+        String VM_POWER_STATE = "vm.powerstate";
     }
 
     /**

--- a/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1105,10 +1105,11 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 }
 
                 try {
-                    _networkMgr.prepare(vmProfile, new DeployDestination(dest.getDataCenter(), dest.getPod(), null, null), ctx);
+                    _networkMgr.prepare(vmProfile, new DeployDestination(dest.getDataCenter(), dest.getPod(), null, null, dest.getStorageForDisks()), ctx);
                     if (vm.getHypervisorType() != HypervisorType.BareMetal) {
                         volumeMgr.prepare(vmProfile, dest);
                     }
+
                     //since StorageMgr succeeded in volume creation, reuse Volume for further tries until current cluster has capacity
                     if (!reuseVolume) {
                         reuseVolume = true;
@@ -4015,7 +4016,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {ClusterDeltaSyncInterval, StartRetry, VmDestroyForcestop, VmOpCancelInterval, VmOpCleanupInterval, VmOpCleanupWait,
                 VmOpLockStateRetry,
-                VmOpWaitInterval, ExecuteInSequence, VmJobCheckInterval, VmJobTimeout, VmJobStateReportInterval, VmConfigDriveLabel};
+                VmOpWaitInterval, ExecuteInSequence, VmJobCheckInterval, VmJobTimeout, VmJobStateReportInterval, VmConfigDriveLabel, VmConfigDriveOnPrimaryPool};
     }
 
     public List<StoragePoolAllocator> getStoragePoolAllocators() {

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -53,6 +53,7 @@
     <module>storage/datamotion</module>
     <module>storage/cache</module>
     <module>storage/snapshot</module>
+    <module>storage/configdrive</module>
     <module>components-api</module>
     <module>network</module>
     <module>service</module>

--- a/engine/storage/configdrive/pom.xml
+++ b/engine/storage/configdrive/pom.xml
@@ -1,0 +1,43 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>cloud-engine-storage-configdrive</artifactId>
+  <name>Apache CloudStack Framework - Storage Config Drive Component</name>
+  <parent>
+    <groupId>org.apache.cloudstack</groupId>
+    <artifactId>cloudstack-framework</artifactId>
+    <version>4.11.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/engine/storage/configdrive/pom.xml
+++ b/engine/storage/configdrive/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-framework</artifactId>
     <version>4.11.1.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/engine/storage/configdrive/pom.xml
+++ b/engine/storage/configdrive/pom.xml
@@ -22,7 +22,7 @@
   <name>Apache CloudStack Framework - Storage Config Drive Component</name>
   <parent>
     <groupId>org.apache.cloudstack</groupId>
-    <artifactId>cloudstack-framework</artifactId>
+    <artifactId>cloud-engine</artifactId>
     <version>4.11.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>

--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.storage.configdrive;
+
+public class ConfigDrive {
+
+    public final static String CONFIGDRIVEFILENAME = "configdrive.iso";
+    public final static String CONFIGDRIVEDIR = "configdrive";
+}

--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
@@ -24,4 +24,5 @@ public class ConfigDrive {
 
     public static final String cloudStackConfigDriveName = "/cloudstack/";
     public static final String openStackConfigDriveName = "/openstack/latest/";
+
 }

--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
@@ -25,4 +25,12 @@ public class ConfigDrive {
     public static final String cloudStackConfigDriveName = "/cloudstack/";
     public static final String openStackConfigDriveName = "/openstack/latest/";
 
+    /**
+     * This is the path to iso file relative to mount point
+     * @return config drive iso file path
+     */
+    public static String createConfigDrivePath(final String instanceName) {
+        return ConfigDrive.CONFIGDRIVEDIR + "/" + instanceName + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
+    }
+
 }

--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
@@ -21,4 +21,7 @@ public class ConfigDrive {
 
     public final static String CONFIGDRIVEFILENAME = "configdrive.iso";
     public final static String CONFIGDRIVEDIR = "configdrive";
+
+    public static final String cloudStackConfigDriveName = "/cloudstack/";
+    public static final String openStackConfigDriveName = "/openstack/latest/";
 }

--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
@@ -1,0 +1,217 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.storage.configdrive;
+
+import static com.cloud.network.NetworkModel.CONFIGDATA_CONTENT;
+import static com.cloud.network.NetworkModel.CONFIGDATA_DIR;
+import static com.cloud.network.NetworkModel.CONFIGDATA_FILE;
+import static com.cloud.network.NetworkModel.PASSWORD_FILE;
+import static com.cloud.network.NetworkModel.USERDATA_FILE;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.joda.time.Duration;
+
+import com.cloud.network.NetworkModel;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+import com.google.common.base.Strings;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class ConfigDriveBuilder {
+
+    public static final Logger LOG = Logger.getLogger(ConfigDriveBuilder.class);
+
+    private static void writeFile(final File folder, final String file, final String content) {
+        if (folder == null || Strings.isNullOrEmpty(file)) {
+            return;
+        }
+        final File vendorDataFile = new File(folder, file);
+        try (final FileWriter fw = new FileWriter(vendorDataFile); final BufferedWriter bw = new BufferedWriter(fw)) {
+            bw.write(content);
+        } catch (IOException ex) {
+            throw new CloudRuntimeException("Failed to create config drive file " + file, ex);
+        }
+    }
+
+    public static String fileToBase64String(final File isoFile) throws IOException {
+        byte[] encoded = Base64.encodeBase64(FileUtils.readFileToByteArray(isoFile));
+        return new String(encoded, StandardCharsets.US_ASCII);
+    }
+
+    public static File base64StringToFile(final String encodedIsoData, final String folder, final String fileName) throws IOException {
+        byte[] decoded = Base64.decodeBase64(encodedIsoData.getBytes(StandardCharsets.US_ASCII));
+        Path destPath = Paths.get(folder, fileName);
+        return Files.write(destPath, decoded).toFile();
+    }
+
+    public static String buildConfigDrive(final List<String[]> vmData, final String isoFileName, final String driveLabel) {
+        if (vmData == null) {
+            throw new CloudRuntimeException("No VM metadata provided");
+        }
+
+        Path tempDir = null;
+        String tempDirName = null;
+        try {
+            tempDir = Files.createTempDirectory(ConfigDrive.CONFIGDRIVEDIR);
+            tempDirName = tempDir.toString();
+
+            File openStackFolder = new File(tempDirName + ConfigDrive.openStackConfigDriveName);
+            if (openStackFolder.exists() || openStackFolder.mkdirs()) {
+                writeFile(openStackFolder, "vendor_data.json", "{}");
+                writeFile(openStackFolder, "network_data.json", "{}");
+            } else {
+                throw new CloudRuntimeException("Failed to create folder " + openStackFolder);
+            }
+
+            JsonObject metaData = new JsonObject();
+            for (String[] item : vmData) {
+                String dataType = item[CONFIGDATA_DIR];
+                String fileName = item[CONFIGDATA_FILE];
+                String content = item[CONFIGDATA_CONTENT];
+                LOG.debug(String.format("[createConfigDriveIsoForVM] dataType=%s, filename=%s, content=%s",
+                        dataType, fileName, (fileName.equals(PASSWORD_FILE)?"********":content)));
+
+                // create file with content in folder
+                if (dataType != null && !dataType.isEmpty()) {
+                    //create folder
+                    File typeFolder = new File(tempDirName + ConfigDrive.cloudStackConfigDriveName + dataType);
+                    if (typeFolder.exists() || typeFolder.mkdirs()) {
+                        if (StringUtils.isNotEmpty(content)) {
+                            File file = new File(typeFolder, fileName + ".txt");
+                            try  {
+                                if (fileName.equals(USERDATA_FILE)) {
+                                    // User Data is passed as a base64 encoded string
+                                    FileUtils.writeByteArrayToFile(file, Base64.decodeBase64(content));
+                                } else {
+                                    FileUtils.write(file, content, com.cloud.utils.StringUtils.getPreferredCharset());
+                                }
+                            } catch (IOException ex) {
+                                throw new CloudRuntimeException("Failed to create file ", ex);
+                            }
+                        }
+                    } else {
+                        throw new CloudRuntimeException("Failed to create folder: " + typeFolder);
+                    }
+
+                    //now write the file to the OpenStack directory
+                    metaData = buildOpenStackMetaData(metaData, dataType, fileName, content);
+                }
+            }
+            writeFile(openStackFolder, "meta_data.json", metaData.toString());
+
+            String linkResult = linkUserData(tempDirName);
+            if (linkResult != null) {
+                String errMsg = "Unable to create user_data link due to " + linkResult;
+                throw new CloudRuntimeException(errMsg);
+            }
+
+            File tmpIsoStore = new File(tempDirName, new File(isoFileName).getName());
+            Script command = new Script("/usr/bin/genisoimage", Duration.standardSeconds(300), LOG);
+            command.add("-o", tmpIsoStore.getAbsolutePath());
+            command.add("-ldots");
+            command.add("-allow-lowercase");
+            command.add("-allow-multidot");
+            command.add("-cache-inodes"); // Enable caching inode and device numbers to find hard links to files.
+            command.add("-l");
+            command.add("-quiet");
+            command.add("-J");
+            command.add("-r");
+            command.add("-V", driveLabel);
+            command.add(tempDirName);
+            LOG.debug("Executing config drive creation command: " + command.toString());
+            String result = command.execute();
+            if (result != null) {
+                String errMsg = "Unable to create iso file: " + isoFileName + " due to " + result;
+                LOG.warn(errMsg);
+                throw new CloudRuntimeException(errMsg);
+            }
+            return fileToBase64String(new File(tmpIsoStore.getAbsolutePath()));
+        } catch (IOException e) {
+            throw new CloudRuntimeException("Failed due to", e);
+        } finally {
+            try {
+                FileUtils.deleteDirectory(tempDir.toFile());
+            } catch (IOException ioe) {
+                LOG.warn("Failed to delete ConfigDrive temporary directory: " + tempDirName, ioe);
+            }
+        }
+    }
+
+    private static String linkUserData(String tempDirName) {
+        //Hard link the user_data.txt file with the user_data file in the OpenStack directory.
+        String userDataFilePath = tempDirName + ConfigDrive.cloudStackConfigDriveName + "userdata/user_data.txt";
+        if ((new File(userDataFilePath).exists())) {
+            Script hardLink = new Script("ln", Duration.standardSeconds(300), LOG);
+            hardLink.add(userDataFilePath);
+            hardLink.add(tempDirName + ConfigDrive.openStackConfigDriveName + "user_data");
+            LOG.debug("execute command: " + hardLink.toString());
+            return hardLink.execute();
+        }
+        return null;
+    }
+
+    private static JsonArray arrayOf(JsonElement... elements) {
+        JsonArray array = new JsonArray();
+        for (JsonElement element : elements) {
+            array.add(element);
+        }
+        return array;
+    }
+
+    private static JsonObject buildOpenStackMetaData(JsonObject metaData, String dataType, String fileName, String content) {
+        if (dataType.equals(NetworkModel.METATDATA_DIR) &&  StringUtils.isNotEmpty(content)) {
+            //keys are a special case in OpenStack format
+            if (NetworkModel.PUBLIC_KEYS_FILE.equals(fileName)) {
+                String[] keyArray = content.replace("\\n", "").split(" ");
+                String keyName = "key";
+                if (keyArray.length > 3 && StringUtils.isNotEmpty(keyArray[2])){
+                    keyName = keyArray[2];
+                }
+
+                JsonObject keyLegacy = new JsonObject();
+                keyLegacy.addProperty("type", "ssh");
+                keyLegacy.addProperty("data", content.replace("\\n", ""));
+                keyLegacy.addProperty("name", keyName);
+                metaData.add("keys", arrayOf(keyLegacy));
+
+                JsonObject key = new JsonObject();
+                key.addProperty(keyName, content);
+                metaData.add("public_keys", key);
+            } else if (NetworkModel.openStackFileMapping.get(fileName) != null) {
+                metaData.addProperty(NetworkModel.openStackFileMapping.get(fileName), content);
+            }
+        }
+        return metaData;
+    }
+
+}

--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
@@ -155,7 +155,12 @@ public class ConfigDriveBuilder {
                 LOG.warn(errMsg);
                 throw new CloudRuntimeException(errMsg);
             }
-            return fileToBase64String(new File(tmpIsoStore.getAbsolutePath()));
+            File tmpIsoFile = new File(tmpIsoStore.getAbsolutePath());
+            // Max allowed file size of config drive is 64MB: https://docs.openstack.org/project-install-guide/baremetal/draft/configdrive.html
+            if (tmpIsoFile.length() > (64L * 1024L * 1024L)) {
+                throw new CloudRuntimeException("Config drive file exceeds maximum allowed size of 64MB");
+            }
+            return fileToBase64String(tmpIsoFile);
         } catch (IOException e) {
             throw new CloudRuntimeException("Failed due to", e);
         } finally {

--- a/engine/storage/configdrive/test/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
+++ b/engine/storage/configdrive/test/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
@@ -1,24 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.cloudstack.storage.configdrive;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ConfigDriveBuilderTest {
-    @Before
-    public void setUp() throws Exception {
-    }
 
-    @After
-    public void tearDown() throws Exception {
+    @Test
+    public void testConfigDriveIsoPath() throws IOException {
+        Assert.assertEquals(ConfigDrive.createConfigDrivePath("i-x-y"), "configdrive/i-x-y/configdrive.iso");
     }
 
     @Test
-    public void testConfigDriveBuild() {
-
+    public void testConfigDriveBuild() throws IOException {
         List<String[]> actualVmData = Arrays.asList(
                 new String[]{"userdata", "user_data", "c29tZSB1c2VyIGRhdGE="},
                 new String[]{"metadata", "service-offering", "offering"},
@@ -33,6 +51,15 @@ public class ConfigDriveBuilderTest {
                 new String[]{"metadata", "cloud-identifier", String.format("CloudStack-{%s}", "uuid")},
                 new String[]{"password", "vm_password", "password123"}
         );
-        String encodedString = ConfigDriveBuilder.buildConfigDrive(actualVmData, "i-x-y.iso", "config-2");
+
+        final Path tempDir = Files.createTempDirectory(ConfigDrive.CONFIGDRIVEDIR);
+        final String isoData = ConfigDriveBuilder.buildConfigDrive(actualVmData, "i-x-y.iso", "config-2");
+        final File isoFile = ConfigDriveBuilder.base64StringToFile(isoData, tempDir.toAbsolutePath().toString(), ConfigDrive.CONFIGDRIVEFILENAME);
+
+        Assert.assertTrue(isoFile.exists());
+        Assert.assertTrue(isoFile.isFile());
+        Assert.assertTrue(isoFile.length() > 0L);
+
+        FileUtils.deleteDirectory(tempDir.toFile());
     }
 }

--- a/engine/storage/configdrive/test/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
+++ b/engine/storage/configdrive/test/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
@@ -1,0 +1,38 @@
+package org.apache.cloudstack.storage.configdrive;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConfigDriveBuilderTest {
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testConfigDriveBuild() {
+
+        List<String[]> actualVmData = Arrays.asList(
+                new String[]{"userdata", "user_data", "c29tZSB1c2VyIGRhdGE="},
+                new String[]{"metadata", "service-offering", "offering"},
+                new String[]{"metadata", "availability-zone", "zone1"},
+                new String[]{"metadata", "local-hostname", "hostname"},
+                new String[]{"metadata", "local-ipv4", "192.168.111.111"},
+                new String[]{"metadata", "public-hostname", "7.7.7.7"},
+                new String[]{"metadata", "public-ipv4", "7.7.7.7"},
+                new String[]{"metadata", "vm-id", "uuid"},
+                new String[]{"metadata", "instance-id", "i-x-y"},
+                new String[]{"metadata", "public-keys", "ssh-rsa some-key"},
+                new String[]{"metadata", "cloud-identifier", String.format("CloudStack-{%s}", "uuid")},
+                new String[]{"password", "vm_password", "password123"}
+        );
+        String encodedString = ConfigDriveBuilder.buildConfigDrive(actualVmData, "i-x-y.iso", "config-2");
+    }
+}

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -130,7 +130,6 @@ Requires: perl
 Requires: libvirt-python
 Requires: qemu-img
 Requires: qemu-kvm
-Requires: genisoimage
 Provides: cloud-agent
 Obsoletes: cloud-agent < 4.1.0
 Obsoletes: cloud-agent-libs < 4.1.0

--- a/packaging/centos63/cloud.spec
+++ b/packaging/centos63/cloud.spec
@@ -130,6 +130,7 @@ Requires: perl
 Requires: libvirt-python
 Requires: qemu-img
 Requires: qemu-kvm
+Requires: genisoimage
 Provides: cloud-agent
 Obsoletes: cloud-agent < 4.1.0
 Obsoletes: cloud-agent-libs < 4.1.0

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -111,6 +111,7 @@ Requires: perl
 Requires: libvirt-python
 Requires: qemu-img
 Requires: qemu-kvm
+Requires: genisoimage
 Provides: cloud-agent
 Group: System Environment/Libraries
 %description agent

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -75,7 +75,7 @@ Requires: sudo
 Requires: /sbin/service
 Requires: /sbin/chkconfig
 Requires: /usr/bin/ssh-keygen
-Requires: mkisofs
+Requires: genisoimage
 Requires: mysql-connector-python
 Requires: ipmitool
 Requires: %{name}-common = %{_ver}
@@ -111,7 +111,6 @@ Requires: perl
 Requires: libvirt-python
 Requires: qemu-img
 Requires: qemu-kvm
-Requires: genisoimage
 Provides: cloud-agent
 Group: System Environment/Libraries
 %description agent

--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -40,6 +40,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-engine-storage-configdrive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.ceph</groupId>
       <artifactId>rados</artifactId>
       <version>${cs.rados-java.version}</version>

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2200,9 +2200,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         final DataTO data = volume.getData();
         final DataStoreTO store = data.getDataStore();
 
-        if (volume.getType() == Volume.Type.ISO && data.getPath() != null) {
-            final NfsTO nfsStore = (NfsTO)store;
-            final String isoPath = nfsStore.getUrl() + File.separator + data.getPath();
+        if (volume.getType() == Volume.Type.ISO && data.getPath() != null && (store instanceof NfsTO || store instanceof PrimaryDataStoreTO)) {
+            final String isoPath = store.getUrl().split("\\?")[0] + File.separator + data.getPath();
             final int index = isoPath.lastIndexOf("/");
             final String path = isoPath.substring(0, index);
             final String name = isoPath.substring(index + 1);

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
@@ -56,7 +56,7 @@ public final class LibvirtHandleConfigDriveCommandWrapper extends CommandWrapper
             if (command.getIsoData() == null) {
                 return new Answer(command, false, "Invalid config drive ISO data received");
             }
-            if(isoFile.exists()) {
+            if (isoFile.exists()) {
                 LOG.debug("An old config drive iso already exists");
             }
             try {
@@ -74,6 +74,6 @@ public final class LibvirtHandleConfigDriveCommandWrapper extends CommandWrapper
             }
         }
 
-        return new Answer(command, true, "Successfully saved config drive at primary storage");
+        return new Answer(command);
     }
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.cloudstack.storage.configdrive.ConfigDriveBuilder;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.HandleConfigDriveIsoCommand;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.hypervisor.kvm.storage.KVMStoragePool;
+import com.cloud.hypervisor.kvm.storage.KVMStoragePoolManager;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+import com.cloud.storage.Storage;
+
+@ResourceWrapper(handles =  HandleConfigDriveIsoCommand.class)
+public final class LibvirtHandleConfigDriveCommandWrapper extends CommandWrapper<HandleConfigDriveIsoCommand, Answer, LibvirtComputingResource> {
+    private static final Logger LOG = Logger.getLogger(LibvirtHandleConfigDriveCommandWrapper.class);
+
+    @Override
+    public Answer execute(final HandleConfigDriveIsoCommand command, final LibvirtComputingResource libvirtComputingResource) {
+        final KVMStoragePoolManager storagePoolMgr = libvirtComputingResource.getStoragePoolMgr();
+        final KVMStoragePool pool = storagePoolMgr.getStoragePool(Storage.StoragePoolType.NetworkFilesystem, command.getDestStore().getUuid());
+        if (pool == null) {
+            return new Answer(command, false, "Pool not found, config drive for KVM is only supported for NFS");
+        }
+
+        final String mountPoint = pool.getLocalPath();
+        final Path isoPath = Paths.get(mountPoint, command.getIsoFile());
+        final File isoFile = new File(mountPoint, command.getIsoFile());
+        if (command.isCreate()) {
+            LOG.debug("Creating config drive: " + command.getIsoFile());
+            if (command.getIsoData() == null) {
+                return new Answer(command, false, "Invalid config drive ISO data received");
+            }
+            if(isoFile.exists()) {
+                LOG.debug("An old config drive iso already exists");
+            }
+            try {
+                Files.createDirectories(isoPath.getParent());
+                ConfigDriveBuilder.base64StringToFile(command.getIsoData(), mountPoint, command.getIsoFile());
+            } catch (IOException e) {
+                return new Answer(command, false, "Failed due to exception: " + e.getMessage());
+            }
+        } else {
+            try {
+                FileUtils.deleteDirectory(isoPath.getParent().toFile());
+            } catch (IOException e) {
+                LOG.warn("Failed to delete config drive: " + isoPath.toAbsolutePath().toString());
+                return new Answer(command, false, "Failed due to exception: " + e.getMessage());
+            }
+        }
+
+        return new Answer(command, true, "Successfully saved config drive at primary storage");
+    }
+}

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/storage/KVMStoragePoolManager.java
@@ -265,7 +265,7 @@ public class KVMStoragePoolManager {
         String uuid = null;
         String sourceHost = "";
         StoragePoolType protocol = null;
-        if (storageUri.getScheme().equalsIgnoreCase("nfs")) {
+        if (storageUri.getScheme().equalsIgnoreCase("nfs") || storageUri.getScheme().equalsIgnoreCase("NetworkFilesystem")) {
             sourcePath = storageUri.getPath();
             sourcePath = sourcePath.replace("//", "/");
             sourceHost = storageUri.getHost();

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -142,6 +142,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-engine-storage-configdrive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opensaml</groupId>
       <artifactId>opensaml</artifactId>
       <version>${cs.opensaml.version}</version>

--- a/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -20,21 +20,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.inject.Inject;
 
-import org.apache.cloudstack.storage.configdrive.ConfigDrive;
-import org.apache.log4j.Logger;
-
-import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
+import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
-import com.cloud.agent.AgentManager;
+import org.apache.log4j.Logger;
+
 import com.cloud.agent.api.Answer;
-import com.cloud.agent.api.AttachIsoAnswer;
-import com.cloud.agent.api.AttachIsoCommand;
 import com.cloud.agent.api.HandleConfigDriveIsoCommand;
 import com.cloud.agent.api.to.DiskTO;
 import com.cloud.configuration.ConfigurationManager;
@@ -42,7 +39,6 @@ import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.deploy.DeployDestination;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.InsufficientCapacityException;
-import com.cloud.exception.OperationTimedoutException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.exception.UnsupportedServiceException;
 import com.cloud.host.Host;
@@ -55,7 +51,6 @@ import com.cloud.network.NetworkMigrationResponder;
 import com.cloud.network.NetworkModel;
 import com.cloud.network.Networks.TrafficType;
 import com.cloud.network.PhysicalNetworkServiceProvider;
-import com.cloud.network.dao.NetworkDao;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.storage.Storage;
@@ -63,45 +58,36 @@ import com.cloud.storage.Volume;
 import com.cloud.storage.dao.GuestOSCategoryDao;
 import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.utils.component.AdapterBase;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.StateListener;
 import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.vm.Nic;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.UserVmDetailVO;
-import com.cloud.vm.UserVmManager;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.VirtualMachineProfile;
-import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
 
 public class ConfigDriveNetworkElement extends AdapterBase implements NetworkElement, UserDataServiceProvider,
         StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualMachine>, NetworkMigrationResponder {
-    private static final Logger s_logger = Logger.getLogger(ConfigDriveNetworkElement.class);
+    private static final Logger LOG = Logger.getLogger(ConfigDriveNetworkElement.class);
 
     private static final Map<Service, Map<Capability, String>> capabilities = setCapabilities();
 
     @Inject
-    NetworkDao _networkConfigDao;
-    @Inject
     NetworkModel _networkMgr;
-    @Inject
-    UserVmManager _userVmMgr;
     @Inject
     UserVmDao _userVmDao;
     @Inject
     UserVmDetailsDao _userVmDetailsDao;
     @Inject
-    DomainRouterDao _routerDao;
-    @Inject
     ConfigurationManager _configMgr;
     @Inject
     DataCenterDao _dcDao;
-    @Inject
-    AgentManager _agentManager;
     @Inject
     ServiceOfferingDao _serviceOfferingDao;
     @Inject
@@ -116,8 +102,6 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     DataStoreManager _dataStoreMgr;
     @Inject
     EndPointSelector _ep;
-    @Inject
-    VolumeOrchestrationService _volumeMgr;
 
     private final static Integer CONFIGDRIVEDISKSEQ = 4;
 
@@ -148,7 +132,8 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         if (!nic.isDefaultNic()) {
             return true;
         }
-        // Remove form secondary storage
+
+        // Remove from secondary storage
         DataStore secondaryStore = _dataStoreMgr.getImageStore(network.getDataCenterId());
 
         String isoFile =  "/" + ConfigDrive.CONFIGDRIVEDIR + "/" + vm.getInstanceName()+ "/" + ConfigDrive.CONFIGDRIVEFILENAME;
@@ -157,7 +142,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         // Delete the ISO on the secondary store
         EndPoint endpoint = _ep.select(secondaryStore);
         if (endpoint == null) {
-            s_logger.error(String.format("Secondary store: %s not available", secondaryStore.getName()));
+            LOG.error(String.format("Secondary store: %s not available", secondaryStore.getName()));
             return false;
         }
         Answer answer = endpoint.sendMessage(deleteCommand);
@@ -206,37 +191,49 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     }
 
     private String getSshKey(VirtualMachineProfile profile) {
-        UserVmDetailVO vmDetailSshKey = _userVmDetailsDao.findDetail(profile.getId(), "SSH.PublicKey");
+        final UserVmDetailVO vmDetailSshKey = _userVmDetailsDao.findDetail(profile.getId(), "SSH.PublicKey");
         return (vmDetailSshKey!=null ? vmDetailSshKey.getValue() : null);
     }
 
     @Override
     public boolean addPasswordAndUserdata(Network network, NicProfile nic, VirtualMachineProfile profile, DeployDestination dest, ReservationContext context)
             throws ConcurrentOperationException, InsufficientCapacityException, ResourceUnavailableException {
-        String sshPublicKey = getSshKey(profile);
         return (canHandle(network.getTrafficType())
-                && updateConfigDrive(profile, sshPublicKey, nic))
-                && updateConfigDriveIso(network, profile, dest.getHost(), false);
+                && addConfigDriveData(profile, nic))
+                && createConfigDriveIso(network, profile, dest.getHost());
     }
 
     @Override
-    public boolean savePassword(Network network, NicProfile nic, VirtualMachineProfile profile) throws ResourceUnavailableException {
-        String sshPublicKey = getSshKey(profile);
-        if (!(canHandle(network.getTrafficType()) && updateConfigDrive(profile, sshPublicKey, nic))) return false;
-        return updateConfigDriveIso(network, profile, true);
+    public boolean savePassword(final Network network, final NicProfile nic, final VirtualMachineProfile vm) throws ResourceUnavailableException {
+        // savePassword is called by resetPasswordForVirtualMachine API which requires VM to be shutdown
+        // Upper layers should save password in db, we do not need to update/create config drive iso at this point
+        // Config drive will be created with updated password when VM starts in future
+        if (vm != null && vm.getVirtualMachine().getState().equals(VirtualMachine.State.Running)) {
+            throw new CloudRuntimeException("VM should to stopped to reset password");
+        }
+        return canHandle(network.getTrafficType());
     }
 
     @Override
-    public boolean saveSSHKey(Network network, NicProfile nic, VirtualMachineProfile vm, String sshPublicKey) throws ResourceUnavailableException {
-        if (!(canHandle(network.getTrafficType()) && updateConfigDrive(vm, sshPublicKey, nic))) return false;
-        return updateConfigDriveIso(network, vm, true);
+    public boolean saveSSHKey(final Network network, final NicProfile nic, final VirtualMachineProfile vm, final String sshPublicKey) throws ResourceUnavailableException {
+        // saveSSHKey is called by resetSSHKeyForVirtualMachine API which requires VM to be shutdown
+        // Upper layers should save ssh public key in db, we do not need to update/create config drive iso at this point
+        // Config drive will be created with updated password when VM starts in future
+        if (vm != null && vm.getVirtualMachine().getState().equals(VirtualMachine.State.Running)) {
+            throw new CloudRuntimeException("VM should to stopped to reset password");
+        }
+        return canHandle(network.getTrafficType());
     }
 
     @Override
-    public boolean saveUserData(Network network, NicProfile nic, VirtualMachineProfile profile) throws ResourceUnavailableException {
-        String sshPublicKey = getSshKey(profile);
-        if (!(canHandle(network.getTrafficType()) && updateConfigDrive(profile, sshPublicKey, nic))) return false;
-        return updateConfigDriveIso(network, profile, true);
+    public boolean saveUserData(final Network network, final NicProfile nic, final VirtualMachineProfile vm) throws ResourceUnavailableException {
+        // saveUserData is called by updateVirtualMachine API which requires VM to be shutdown
+        // Upper layers should save userdata in db, we do not need to update/create config drive iso at this point
+        // Config drive will be created with updated password when VM starts in future
+        if (vm != null && vm.getVirtualMachine().getState().equals(VirtualMachine.State.Running)) {
+            throw new CloudRuntimeException("VM should to stopped to reset password");
+        }
+        return canHandle(network.getTrafficType());
     }
 
     @Override
@@ -266,12 +263,12 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
                                 null, secondaryStore.getTO(), isoFile, false, false);
                         EndPoint endpoint = _ep.select(secondaryStore);
                         if (endpoint == null) {
-                            s_logger.error(String.format("Secondary store: %s not available", secondaryStore.getName()));
+                            LOG.error(String.format("Secondary store: %s not available", secondaryStore.getName()));
                             return false;
                         }
                         Answer answer = endpoint.sendMessage(deleteCommand);
                         if (!answer.getResult()) {
-                            s_logger.error(String.format("Update ISO failed, details: %s", answer.getDetails()));
+                            LOG.error(String.format("Update ISO failed, details: %s", answer.getDetails()));
                             return false;
                         }
                     }
@@ -284,9 +281,9 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     @Override
     public boolean prepareMigration(NicProfile nic, Network network, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context) {
         if (nic.isDefaultNic() && _networkModel.getUserDataUpdateProvider(network).getProvider().equals(Provider.ConfigDrive)) {
-            s_logger.trace(String.format("[prepareMigration] for vm: %s", vm.getInstanceName()));
+            LOG.trace(String.format("[prepareMigration] for vm: %s", vm.getInstanceName()));
             DataStore secondaryStore = _dataStoreMgr.getImageStore(network.getDataCenterId());
-            configureConfigDriveDisk(vm, secondaryStore);
+            addConfigDriveDisk(vm, secondaryStore);
             return false;
         }
         else return  true;
@@ -294,20 +291,13 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
     @Override
     public void rollbackMigration(NicProfile nic, Network network, VirtualMachineProfile vm, ReservationContext src, ReservationContext dst) {
-
     }
 
     @Override
     public void commitMigration(NicProfile nic, Network network, VirtualMachineProfile vm, ReservationContext src, ReservationContext dst) {
-
     }
 
-    private boolean updateConfigDriveIso(Network network, VirtualMachineProfile profile, boolean update) throws ResourceUnavailableException {
-        return updateConfigDriveIso(network, profile, null, update);
-    }
-
-    private boolean updateConfigDriveIso(Network network, VirtualMachineProfile profile, Host host, boolean update) throws ResourceUnavailableException {
-        Integer deviceKey = null;
+    private boolean createConfigDriveIso(Network network, VirtualMachineProfile profile, Host host) throws ResourceUnavailableException {
         Long hostId;
         if (host == null) {
             hostId = (profile.getVirtualMachine().getHostId() == null ? profile.getVirtualMachine().getLastHostId(): profile.getVirtualMachine().getHostId());
@@ -317,39 +307,32 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
         DataStore secondaryStore = _dataStoreMgr.getImageStore(network.getDataCenterId());
         // Detach the existing ISO file if the machine is running
-        if (update && profile.getVirtualMachine().getState().equals(VirtualMachine.State.Running)) {
-            s_logger.debug("Detach config drive ISO for  vm " + profile.getInstanceName() + " in host " + _hostDao.findById(hostId));
-            deviceKey = detachIso(secondaryStore, profile.getInstanceName(), hostId);
+        if (profile.getVirtualMachine().getState().equals(VirtualMachine.State.Running)) {
+            throw new CloudRuntimeException("VM should not be in running state while creating config drive");
         }
 
         // Create/Update the iso on the secondary store
-        s_logger.debug(String.format("%s config drive ISO for  vm %s in host %s",
-                (update?"update":"create"), profile.getInstanceName(), _hostDao.findById(hostId).getName()));
+        LOG.debug(String.format("Creating config drive ISO for  vm %s in host %s",
+                profile.getInstanceName(), _hostDao.findById(hostId).getName()));
         EndPoint endpoint = _ep.select(secondaryStore);
         if (endpoint == null) {
-            throw new ResourceUnavailableException(String.format("%s failed, secondary store not available", (update ? "Update" : "Create")), secondaryStore.getClass(),
-                                                   secondaryStore.getId());
+            throw new ResourceUnavailableException("Config drive creation failed, secondary store not available",
+                    secondaryStore.getClass(), secondaryStore.getId());
         }
         String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + profile.getInstanceName() + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
         HandleConfigDriveIsoCommand configDriveIsoCommand = new HandleConfigDriveIsoCommand(profile.getVmData(),
-                profile.getConfigDriveLabel(), secondaryStore.getTO(), isoPath, true, update);
+                profile.getConfigDriveLabel(), secondaryStore.getTO(), isoPath, true, false);
         Answer createIsoAnswer = endpoint.sendMessage(configDriveIsoCommand);
         if (!createIsoAnswer.getResult()) {
-            throw new ResourceUnavailableException(String.format("%s ISO failed, details: %s",
-                    (update?"Update":"Create"), createIsoAnswer.getDetails()), ConfigDriveNetworkElement.class, 0L);
+            throw new ResourceUnavailableException(String.format("Config drive iso creation failed, details: %s",
+                    createIsoAnswer.getDetails()), ConfigDriveNetworkElement.class, 0L);
         }
-        configureConfigDriveDisk(profile, secondaryStore);
+        addConfigDriveDisk(profile, secondaryStore);
 
-        // Re-attach the ISO if the machine is running
-        if (update && profile.getVirtualMachine().getState().equals(VirtualMachine.State.Running)) {
-            s_logger.debug("Re-attach config drive ISO for  vm " + profile.getInstanceName() + " in host " + _hostDao.findById(hostId));
-            attachIso(secondaryStore, profile.getInstanceName(), hostId, deviceKey);
-        }
         return true;
-
     }
 
-    private void configureConfigDriveDisk(VirtualMachineProfile profile, DataStore secondaryStore) {
+    private void addConfigDriveDisk(VirtualMachineProfile profile, DataStore secondaryStore) {
         boolean isoAvailable = false;
         String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + profile.getInstanceName() + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
         for (DiskTO dataTo : profile.getDisks()) {
@@ -366,65 +349,28 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
             dataTO.setFormat(Storage.ImageFormat.ISO);
 
             profile.addDisk(new DiskTO(dataTO, CONFIGDRIVEDISKSEQ.longValue(), isoPath, Volume.Type.ISO));
+        } else {
+            LOG.warn("An ISO is already in VM profile, unable to configure a config drive disk object in the VM profile.");
         }
     }
 
-    private boolean updateConfigDrive(VirtualMachineProfile profile, String publicKey, NicProfile nic) {
-        UserVmVO vm = _userVmDao.findById(profile.getId());
+    private boolean addConfigDriveData(final VirtualMachineProfile profile, final NicProfile nic) {
+        final UserVmVO vm = _userVmDao.findById(profile.getId());
         if (vm.getType() != VirtualMachine.Type.User) {
             return false;
         }
-        // add/update userdata and/or password info into vm profile
-        Nic defaultNic = _networkModel.getDefaultNic(vm.getId());
+        final Nic defaultNic = _networkModel.getDefaultNic(vm.getId());
         if (defaultNic != null) {
+            final String sshPublicKey = getSshKey(profile);
             final String serviceOffering = _serviceOfferingDao.findByIdIncludingRemoved(vm.getId(), vm.getServiceOfferingId()).getDisplayText();
             boolean isWindows = _guestOSCategoryDao.findById(_guestOSDao.findById(vm.getGuestOSId()).getCategoryId()).getName().equalsIgnoreCase("Windows");
 
-            List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, vm.getDataCenterId(), vm.getInstanceName(), vm.getHostName(), vm.getId(),
-                    vm.getUuid(), nic.getIPv4Address(), publicKey, (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
+            final List<String[]> vmData = _networkModel.generateVmData(vm.getUserData(), serviceOffering, vm.getDataCenterId(), vm.getInstanceName(), vm.getHostName(), vm.getId(),
+                    vm.getUuid(), nic.getIPv4Address(), sshPublicKey, (String) profile.getParameter(VirtualMachineProfile.Param.VmPassword), isWindows);
             profile.setVmData(vmData);
             profile.setConfigDriveLabel(VirtualMachineManager.VmConfigDriveLabel.value());
         }
         return true;
-    }
-
-    private Integer detachIso (DataStore secondaryStore, String instanceName, Long hostId) throws ResourceUnavailableException {
-        String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + instanceName + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
-        AttachIsoCommand isoCommand = new AttachIsoCommand(instanceName, secondaryStore.getUri() + "/" + isoPath, false, CONFIGDRIVEDISKSEQ, true);
-        isoCommand.setStoreUrl(secondaryStore.getUri());
-        Answer attachIsoAnswer = null;
-
-        try {
-            attachIsoAnswer = _agentManager.send(hostId, isoCommand);
-        } catch (OperationTimedoutException e) {
-            throw new ResourceUnavailableException("Detach ISO failed: " + e.getMessage(), ConfigDriveNetworkElement.class, 0L);
-        }
-
-        if (!attachIsoAnswer.getResult()) {
-            throw new ResourceUnavailableException("Detach ISO failed: " + attachIsoAnswer.getDetails(), ConfigDriveNetworkElement.class, 0L);
-        }
-
-        if (attachIsoAnswer instanceof  AttachIsoAnswer) {
-            return ((AttachIsoAnswer)attachIsoAnswer).getDeviceKey();
-        } else {
-            return CONFIGDRIVEDISKSEQ;
-        }
-    }
-
-    private void attachIso (DataStore secondaryStore, String instanceName, Long hostId, Integer deviceKey) throws ResourceUnavailableException {
-        String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + instanceName + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
-        AttachIsoCommand isoCommand = new AttachIsoCommand(instanceName, secondaryStore.getUri() + "/" + isoPath, true);
-        isoCommand.setStoreUrl(secondaryStore.getUri());
-        isoCommand.setDeviceKey(deviceKey);
-        Answer attachIsoAnswer = null;
-        try {
-            attachIsoAnswer = _agentManager.send(hostId, isoCommand);
-        } catch (OperationTimedoutException e) {
-            throw new ResourceUnavailableException("Attach ISO failed: " + e.getMessage() ,ConfigDriveNetworkElement.class,0L);
-        }
-        if (!attachIsoAnswer.getResult()) {
-            throw new ResourceUnavailableException("Attach ISO failed: " + attachIsoAnswer.getDetails(),ConfigDriveNetworkElement.class,0L);
-        }
     }
 
 }

--- a/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 
+import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
@@ -118,8 +119,6 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     @Inject
     VolumeOrchestrationService _volumeMgr;
 
-    private final static String CONFIGDRIVEFILENAME = "configdrive.iso";
-    private final static String CONFIGDRIVEDIR = "ConfigDrive";
     private final static Integer CONFIGDRIVEDISKSEQ = 4;
 
     private boolean canHandle(TrafficType trafficType) {
@@ -152,7 +151,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         // Remove form secondary storage
         DataStore secondaryStore = _dataStoreMgr.getImageStore(network.getDataCenterId());
 
-        String isoFile =  "/" + CONFIGDRIVEDIR + "/" + vm.getInstanceName()+ "/" + CONFIGDRIVEFILENAME;
+        String isoFile =  "/" + ConfigDrive.CONFIGDRIVEDIR + "/" + vm.getInstanceName()+ "/" + ConfigDrive.CONFIGDRIVEFILENAME;
         HandleConfigDriveIsoCommand deleteCommand = new HandleConfigDriveIsoCommand(vm.getVmData(),
                 vm.getConfigDriveLabel(), secondaryStore.getTO(), isoFile, false, false);
         // Delete the ISO on the secondary store
@@ -262,7 +261,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
                     if (provider.equals(Provider.ConfigDrive)) {
                         // Delete config drive ISO on destroy
                         DataStore secondaryStore = _dataStoreMgr.getImageStore(vo.getDataCenterId());
-                        String isoFile = "/" + CONFIGDRIVEDIR + "/" + vo.getInstanceName() + "/" + CONFIGDRIVEFILENAME;
+                        String isoFile = "/" + ConfigDrive.CONFIGDRIVEDIR + "/" + vo.getInstanceName() + "/" + ConfigDrive.CONFIGDRIVEFILENAME;
                         HandleConfigDriveIsoCommand deleteCommand = new HandleConfigDriveIsoCommand(null,
                                 null, secondaryStore.getTO(), isoFile, false, false);
                         EndPoint endpoint = _ep.select(secondaryStore);
@@ -331,7 +330,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
             throw new ResourceUnavailableException(String.format("%s failed, secondary store not available", (update ? "Update" : "Create")), secondaryStore.getClass(),
                                                    secondaryStore.getId());
         }
-        String isoPath = CONFIGDRIVEDIR + "/" + profile.getInstanceName() + "/"  + CONFIGDRIVEFILENAME;
+        String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + profile.getInstanceName() + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
         HandleConfigDriveIsoCommand configDriveIsoCommand = new HandleConfigDriveIsoCommand(profile.getVmData(),
                 profile.getConfigDriveLabel(), secondaryStore.getTO(), isoPath, true, update);
         Answer createIsoAnswer = endpoint.sendMessage(configDriveIsoCommand);
@@ -352,7 +351,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
     private void configureConfigDriveDisk(VirtualMachineProfile profile, DataStore secondaryStore) {
         boolean isoAvailable = false;
-        String isoPath = CONFIGDRIVEDIR + "/" + profile.getInstanceName() + "/"  + CONFIGDRIVEFILENAME;
+        String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + profile.getInstanceName() + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
         for (DiskTO dataTo : profile.getDisks()) {
             if (dataTo.getPath().equals(isoPath)) {
                 isoAvailable = true;
@@ -390,7 +389,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     }
 
     private Integer detachIso (DataStore secondaryStore, String instanceName, Long hostId) throws ResourceUnavailableException {
-        String isoPath = CONFIGDRIVEDIR + "/" + instanceName + "/"  + CONFIGDRIVEFILENAME;
+        String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + instanceName + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
         AttachIsoCommand isoCommand = new AttachIsoCommand(instanceName, secondaryStore.getUri() + "/" + isoPath, false, CONFIGDRIVEDISKSEQ, true);
         isoCommand.setStoreUrl(secondaryStore.getUri());
         Answer attachIsoAnswer = null;
@@ -413,7 +412,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     }
 
     private void attachIso (DataStore secondaryStore, String instanceName, Long hostId, Integer deviceKey) throws ResourceUnavailableException {
-        String isoPath = CONFIGDRIVEDIR + "/" + instanceName + "/"  + CONFIGDRIVEFILENAME;
+        String isoPath = ConfigDrive.CONFIGDRIVEDIR + "/" + instanceName + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
         AttachIsoCommand isoCommand = new AttachIsoCommand(instanceName, secondaryStore.getUri() + "/" + isoPath, true);
         isoCommand.setStoreUrl(secondaryStore.getUri());
         isoCommand.setDeviceKey(deviceKey);

--- a/server/src/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/com/cloud/vm/UserVmManagerImpl.java
@@ -677,6 +677,11 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             throw new InvalidParameterValueException("Vm with id " + vmId + " is not in the right state");
         }
 
+        if (userVm.getState() != State.Stopped) {
+            s_logger.error("vm is not in the right state: " + vmId);
+            throw new InvalidParameterValueException("Vm " + userVm + " should be stopped to do password reset");
+        }
+
         _accountMgr.checkAccess(caller, null, true, userVm);
 
         boolean result = resetVMPasswordInternal(vmId, password);
@@ -4104,8 +4109,6 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 profile.setConfigDriveIsoFile(isoFile);
             }
         }
-
-
 
         _templateMgr.prepareIsoForVmProfile(profile, dest);
         return true;

--- a/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -36,20 +36,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
+import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
+import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-
-import com.google.common.collect.Maps;
-
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
-import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
-import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.HandleConfigDriveIsoCommand;
@@ -89,6 +86,7 @@ import com.cloud.vm.VirtualMachineProfileImpl;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
+import com.google.common.collect.Maps;
 
 public class ConfigDriveNetworkElementTest {
 
@@ -220,8 +218,6 @@ public class ConfigDriveNetworkElementTest {
         HandleConfigDriveIsoCommand deleteCommand = commandCaptor.getValue();
 
         assertThat(deleteCommand.isCreate(), is(false));
-        assertThat(deleteCommand.isUpdate(), is(false));
-
 
     }
 

--- a/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -16,7 +16,6 @@
 // under the License.
 package com.cloud.network.element;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -24,7 +23,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -34,7 +32,6 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
@@ -48,6 +45,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
+import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.HandleConfigDriveIsoCommand;
 import com.cloud.dc.DataCenterVO;
@@ -75,10 +73,8 @@ import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateListener;
 import com.cloud.utils.fsm.StateMachine2;
-import com.cloud.utils.net.Ip;
 import com.cloud.vm.Nic;
 import com.cloud.vm.NicProfile;
-import com.cloud.vm.UserVmDetailVO;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
@@ -86,7 +82,6 @@ import com.cloud.vm.VirtualMachineProfileImpl;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
-import com.google.common.collect.Maps;
 
 public class ConfigDriveNetworkElementTest {
 
@@ -132,6 +127,7 @@ public class ConfigDriveNetworkElementTest {
     @Mock private ServiceOfferingVO serviceOfferingVO;
     @Mock private UserVmVO virtualMachine;
     @Mock private IPAddressVO publicIp;
+    @Mock private AgentManager agentManager;
 
     @InjectMocks private final ConfigDriveNetworkElement _configDrivesNetworkElement = new ConfigDriveNetworkElement();
     @InjectMocks @Spy private NetworkModelImpl _networkModel = new NetworkModelImpl();
@@ -208,13 +204,13 @@ public class ConfigDriveNetworkElementTest {
         when(_vmInstanceDao.updateState(VirtualMachine.State.Stopped, VirtualMachine.Event.ExpungeOperation, VirtualMachine.State.Expunging, virtualMachine, null)).thenReturn(true);
 
         final Answer answer = mock(Answer.class);
-        when(endpoint.sendMessage(any(HandleConfigDriveIsoCommand.class))).thenReturn(answer);
+        when(agentManager.easySend(anyLong(), any(HandleConfigDriveIsoCommand.class))).thenReturn(answer);
         when(answer.getResult()).thenReturn(true);
 
         stateMachine.transitTo(virtualMachine, VirtualMachine.Event.ExpungeOperation, null, _vmInstanceDao);
 
         ArgumentCaptor<HandleConfigDriveIsoCommand> commandCaptor = ArgumentCaptor.forClass(HandleConfigDriveIsoCommand.class);
-        verify(endpoint, times(1)).sendMessage(commandCaptor.capture());
+        verify(agentManager, times(1)).easySend(anyLong(), commandCaptor.capture());
         HandleConfigDriveIsoCommand deleteCommand = commandCaptor.getValue();
 
         assertThat(deleteCommand.isCreate(), is(false));
@@ -235,6 +231,7 @@ public class ConfigDriveNetworkElementTest {
         assertThat(_configDrivesNetworkElement.getCapabilities(), hasEntry(Network.Service.UserData, null));
     }
 
+    /*
     @Test
     public void testAddPasswordAndUserdata() throws InsufficientCapacityException, ResourceUnavailableException {
         List<String[]> actualVmData = getVmData();
@@ -300,7 +297,9 @@ public class ConfigDriveNetworkElementTest {
                 new String[]{PASSWORD, "vm_password", PASSWORD}
         ));
     }
+    */
 
+    /*
     private List<String[]> getVmData() throws InsufficientCapacityException, ResourceUnavailableException {
         final Answer answer = mock(Answer.class);
         final UserVmDetailVO userVmDetailVO = mock(UserVmDetailVO.class);
@@ -323,4 +322,5 @@ public class ConfigDriveNetworkElementTest {
         HandleConfigDriveIsoCommand result = commandCaptor.getValue();
         return result.getVmData();
     }
+    */
 }

--- a/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
+++ b/server/test/com/cloud/network/element/ConfigDriveNetworkElementTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,12 +33,14 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -48,6 +51,7 @@ import org.mockito.Spy;
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.HandleConfigDriveIsoCommand;
+import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.deploy.DeployDestination;
@@ -73,8 +77,10 @@ import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateListener;
 import com.cloud.utils.fsm.StateMachine2;
+import com.cloud.utils.net.Ip;
 import com.cloud.vm.Nic;
 import com.cloud.vm.NicProfile;
+import com.cloud.vm.UserVmDetailVO;
 import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
@@ -82,6 +88,7 @@ import com.cloud.vm.VirtualMachineProfileImpl;
 import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.dao.UserVmDetailsDao;
 import com.cloud.vm.dao.VMInstanceDao;
+import com.google.common.collect.Maps;
 
 public class ConfigDriveNetworkElementTest {
 
@@ -99,6 +106,7 @@ public class ConfigDriveNetworkElementTest {
     private final long SOID = 31L;
     private final long HOSTID = NETWORK_ID;
 
+    @Mock private DataCenter dataCenter;
     @Mock private ConfigurationDao _configDao;
     @Mock private DataCenterDao _dcDao;
     @Mock private DataStoreManager _dataStoreMgr;
@@ -139,6 +147,7 @@ public class ConfigDriveNetworkElementTest {
         _configDrivesNetworkElement._networkModel = _networkModel;
 
         when(_dataStoreMgr.getImageStore(DATACENTERID)).thenReturn(dataStore);
+
         when(_ep.select(dataStore)).thenReturn(endpoint);
         when(_vmDao.findById(VMID)).thenReturn(virtualMachine);
         when(_dcDao.findById(DATACENTERID)).thenReturn(dataCenterVO);
@@ -161,7 +170,9 @@ public class ConfigDriveNetworkElementTest {
         when(virtualMachine.getInstanceName()).thenReturn(VMINSTANCENAME);
         when(virtualMachine.getUserData()).thenReturn(VMUSERDATA);
         when(virtualMachine.getHostName()).thenReturn(VMHOSTNAME);
+        when(dataCenter.getId()).thenReturn(DATACENTERID);
         when(deployDestination.getHost()).thenReturn(hostVO);
+        when(deployDestination.getDataCenter()).thenReturn(dataCenter);
         when(hostVO.getId()).thenReturn(HOSTID);
         when(nic.isDefaultNic()).thenReturn(true);
         when(nic.getNetworkId()).thenReturn(NETWORK_ID);
@@ -220,7 +231,7 @@ public class ConfigDriveNetworkElementTest {
     @Test
     public void testRelease() {
         final Answer answer = mock(Answer.class);
-        when(endpoint.sendMessage(any(HandleConfigDriveIsoCommand.class))).thenReturn(answer);
+        when(agentManager.easySend(anyLong(), any(HandleConfigDriveIsoCommand.class))).thenReturn(answer);
         when(answer.getResult()).thenReturn(true);
         VirtualMachineProfile profile = new VirtualMachineProfileImpl(virtualMachine, null, serviceOfferingVO, null, null);
         assertTrue(_configDrivesNetworkElement.release(network, nicp, profile, null));
@@ -231,85 +242,21 @@ public class ConfigDriveNetworkElementTest {
         assertThat(_configDrivesNetworkElement.getCapabilities(), hasEntry(Network.Service.UserData, null));
     }
 
-    /*
     @Test
-    public void testAddPasswordAndUserdata() throws InsufficientCapacityException, ResourceUnavailableException {
-        List<String[]> actualVmData = getVmData();
-
-        assertThat(actualVmData, containsInAnyOrder(
-                new String[]{"userdata", "user_data", VMUSERDATA},
-                new String[]{"metadata", "service-offering", VMOFFERING},
-                new String[]{"metadata", "availability-zone", ZONENAME},
-                new String[]{"metadata", "local-hostname", VMHOSTNAME},
-                new String[]{"metadata", "local-ipv4", "192.168.111.111"},
-                new String[]{"metadata", "public-hostname", null},
-                new String[]{"metadata", "public-ipv4", "192.168.111.111"},
-                new String[]{"metadata", "vm-id", String.valueOf(VMID)},
-                new String[]{"metadata", "instance-id", VMINSTANCENAME},
-                new String[]{"metadata", "public-keys", PUBLIC_KEY},
-                new String[]{"metadata", "cloud-identifier", String.format("CloudStack-{%s}", CLOUD_ID)},
-                new String[]{PASSWORD, "vm_password", PASSWORD}
-        ));
-    }
-
-    @Test
-    public void testAddPasswordAndUserdataStaticNat() throws InsufficientCapacityException, ResourceUnavailableException {
-        when(_ipAddressDao.findByAssociatedVmId(VMID)).thenReturn(publicIp);
-        when(publicIp.getAddress()).thenReturn(new Ip("7.7.7.7"));
-
-        List<String[]> actualVmData = getVmData();
-
-        assertThat(actualVmData, containsInAnyOrder(
-                new String[]{"userdata", "user_data", VMUSERDATA},
-                new String[]{"metadata", "service-offering", VMOFFERING},
-                new String[]{"metadata", "availability-zone", ZONENAME},
-                new String[]{"metadata", "local-hostname", VMHOSTNAME},
-                new String[]{"metadata", "local-ipv4", "192.168.111.111"},
-                new String[]{"metadata", "public-hostname", "7.7.7.7"},
-                new String[]{"metadata", "public-ipv4", "7.7.7.7"},
-                new String[]{"metadata", "vm-id", String.valueOf(VMID)},
-                new String[]{"metadata", "instance-id", VMINSTANCENAME},
-                new String[]{"metadata", "public-keys", PUBLIC_KEY},
-                new String[]{"metadata", "cloud-identifier", String.format("CloudStack-{%s}", CLOUD_ID)},
-                new String[]{PASSWORD, "vm_password", PASSWORD}
-        ));
-    }
-
-
-    @Test
-    public void testAddPasswordAndUserdataUuid() throws InsufficientCapacityException, ResourceUnavailableException {
-        when(virtualMachine.getUuid()).thenReturn("vm-uuid");
-
-        List<String[]> actualVmData = getVmData();
-
-        assertThat(actualVmData, containsInAnyOrder(
-                new String[]{"userdata", "user_data", VMUSERDATA},
-                new String[]{"metadata", "service-offering", VMOFFERING},
-                new String[]{"metadata", "availability-zone", ZONENAME},
-                new String[]{"metadata", "local-hostname", VMHOSTNAME},
-                new String[]{"metadata", "local-ipv4", "192.168.111.111"},
-                new String[]{"metadata", "public-hostname", null},
-                new String[]{"metadata", "public-ipv4", "192.168.111.111"},
-                new String[]{"metadata", "vm-id", "vm-uuid"},
-                new String[]{"metadata", "instance-id", "vm-uuid"},
-                new String[]{"metadata", "public-keys", PUBLIC_KEY},
-                new String[]{"metadata", "cloud-identifier", String.format("CloudStack-{%s}", CLOUD_ID)},
-                new String[]{PASSWORD, "vm_password", PASSWORD}
-        ));
-    }
-    */
-
-    /*
-    private List<String[]> getVmData() throws InsufficientCapacityException, ResourceUnavailableException {
+    public void testAddPasswordAndUserData() throws Exception {
         final Answer answer = mock(Answer.class);
         final UserVmDetailVO userVmDetailVO = mock(UserVmDetailVO.class);
-        when(endpoint.sendMessage(any(HandleConfigDriveIsoCommand.class))).thenReturn(answer);
+        when(agentManager.easySend(anyLong(), any(HandleConfigDriveIsoCommand.class))).thenReturn(answer);
         when(answer.getResult()).thenReturn(true);
         when(network.getTrafficType()).thenReturn(Networks.TrafficType.Guest);
         when(virtualMachine.getState()).thenReturn(VirtualMachine.State.Stopped);
+        when(virtualMachine.getUuid()).thenReturn("vm-uuid");
         when(userVmDetailVO.getValue()).thenReturn(PUBLIC_KEY);
         when(nicp.getIPv4Address()).thenReturn("192.168.111.111");
         when(_userVmDetailsDao.findDetail(anyLong(), anyString())).thenReturn(userVmDetailVO);
+        when(_ipAddressDao.findByAssociatedVmId(VMID)).thenReturn(publicIp);
+        when(publicIp.getAddress()).thenReturn(new Ip("7.7.7.7"));
+
         Map<VirtualMachineProfile.Param, Object> parms = Maps.newHashMap();
         parms.put(VirtualMachineProfile.Param.VmPassword, PASSWORD);
         parms.put(VirtualMachineProfile.Param.VmSshPubKey, PUBLIC_KEY);
@@ -318,9 +265,11 @@ public class ConfigDriveNetworkElementTest {
                 network, nicp, profile, deployDestination, null));
 
         ArgumentCaptor<HandleConfigDriveIsoCommand> commandCaptor = ArgumentCaptor.forClass(HandleConfigDriveIsoCommand.class);
-        verify(endpoint, times(1)).sendMessage(commandCaptor.capture());
-        HandleConfigDriveIsoCommand result = commandCaptor.getValue();
-        return result.getVmData();
+        verify(agentManager, times(1)).easySend(anyLong(), commandCaptor.capture());
+        HandleConfigDriveIsoCommand createCommand = commandCaptor.getValue();
+
+        assertTrue(createCommand.isCreate());
+        assertTrue(createCommand.getIsoData().length() > 0);
+        assertTrue(createCommand.getIsoFile().equals(ConfigDrive.createConfigDrivePath(profile.getInstanceName())));
     }
-    */
 }

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>cloud-server</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.cloudstack</groupId>
+      <artifactId>cloud-engine-storage-configdrive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- dependencies for starting a post upload server on ssvm -->
       <dependency>
         <groupId>io.netty</groupId>

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -16,9 +16,6 @@
 // under the License.
 package org.apache.cloudstack.storage.resource;
 
-import static com.cloud.network.NetworkModel.CONFIGDATA_CONTENT;
-import static com.cloud.network.NetworkModel.CONFIGDATA_DIR;
-import static com.cloud.network.NetworkModel.CONFIGDATA_FILE;
 import static com.cloud.network.NetworkModel.METATDATA_DIR;
 import static com.cloud.network.NetworkModel.PASSWORD_DIR;
 import static com.cloud.network.NetworkModel.PASSWORD_FILE;
@@ -45,7 +42,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -56,21 +52,29 @@ import java.util.UUID;
 
 import javax.naming.ConfigurationException;
 
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.codec.http.HttpContentCompressor;
-import io.netty.handler.codec.http.HttpRequestDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
-
-import org.apache.commons.codec.binary.Base64;
+import org.apache.cloudstack.framework.security.keystore.KeystoreManager;
+import org.apache.cloudstack.storage.command.CopyCmdAnswer;
+import org.apache.cloudstack.storage.command.CopyCommand;
+import org.apache.cloudstack.storage.command.DeleteCommand;
+import org.apache.cloudstack.storage.command.DownloadCommand;
+import org.apache.cloudstack.storage.command.DownloadProgressCommand;
+import org.apache.cloudstack.storage.command.TemplateOrVolumePostUploadCommand;
+import org.apache.cloudstack.storage.command.UploadStatusAnswer;
+import org.apache.cloudstack.storage.command.UploadStatusAnswer.UploadStatus;
+import org.apache.cloudstack.storage.command.UploadStatusCommand;
+import org.apache.cloudstack.storage.configdrive.ConfigDrive;
+import org.apache.cloudstack.storage.configdrive.ConfigDriveBuilder;
+import org.apache.cloudstack.storage.template.DownloadManager;
+import org.apache.cloudstack.storage.template.DownloadManagerImpl;
+import org.apache.cloudstack.storage.template.DownloadManagerImpl.ZfsPathParser;
+import org.apache.cloudstack.storage.template.UploadEntity;
+import org.apache.cloudstack.storage.template.UploadManager;
+import org.apache.cloudstack.storage.template.UploadManagerImpl;
+import org.apache.cloudstack.storage.to.SnapshotObjectTO;
+import org.apache.cloudstack.storage.to.TemplateObjectTO;
+import org.apache.cloudstack.storage.to.VolumeObjectTO;
+import org.apache.cloudstack.utils.imagestore.ImageStoreUtil;
+import org.apache.cloudstack.utils.security.DigestHelper;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -87,38 +91,6 @@ import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.io.Files;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-
-import org.apache.cloudstack.framework.security.keystore.KeystoreManager;
-import org.apache.cloudstack.storage.command.CopyCmdAnswer;
-import org.apache.cloudstack.storage.command.CopyCommand;
-import org.apache.cloudstack.storage.command.DeleteCommand;
-import org.apache.cloudstack.storage.command.DownloadCommand;
-import org.apache.cloudstack.storage.command.DownloadProgressCommand;
-import org.apache.cloudstack.storage.command.TemplateOrVolumePostUploadCommand;
-import org.apache.cloudstack.storage.command.UploadStatusAnswer;
-import org.apache.cloudstack.storage.command.UploadStatusAnswer.UploadStatus;
-import org.apache.cloudstack.storage.command.UploadStatusCommand;
-import org.apache.cloudstack.storage.configdrive.ConfigDrive;
-import org.apache.cloudstack.storage.template.DownloadManager;
-import org.apache.cloudstack.storage.template.DownloadManagerImpl;
-import org.apache.cloudstack.storage.template.DownloadManagerImpl.ZfsPathParser;
-import org.apache.cloudstack.storage.template.UploadEntity;
-import org.apache.cloudstack.storage.template.UploadManager;
-import org.apache.cloudstack.storage.template.UploadManagerImpl;
-import org.apache.cloudstack.storage.to.SnapshotObjectTO;
-import org.apache.cloudstack.storage.to.TemplateObjectTO;
-import org.apache.cloudstack.storage.to.VolumeObjectTO;
-import org.apache.cloudstack.utils.imagestore.ImageStoreUtil;
-import org.apache.cloudstack.utils.security.DigestHelper;
-
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.CheckHealthAnswer;
 import com.cloud.agent.api.CheckHealthCommand;
@@ -165,7 +137,6 @@ import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.host.Host;
 import com.cloud.host.Host.Type;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
-import com.cloud.network.NetworkModel;
 import com.cloud.resource.ServerResourceBase;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage;
@@ -193,6 +164,23 @@ import com.cloud.utils.script.OutputInterpreter;
 import com.cloud.utils.script.Script;
 import com.cloud.utils.storage.S3.S3Utils;
 import com.cloud.vm.SecondaryStorageVm;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 
 public class NfsSecondaryStorageResource extends ServerResourceBase implements SecondaryStorageResource {
 
@@ -337,32 +325,32 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     }
 
     private Answer execute(HandleConfigDriveIsoCommand cmd) {
-
         if (cmd.isCreate()) {
-            s_logger.debug(String.format("VMdata %s, attach = %s", cmd.getVmData(), cmd.isCreate()));
-            if(cmd.getVmData() == null) return new Answer(cmd, false, "No Vmdata available");
+            if (cmd.getIsoData() == null) {
+                return new Answer(cmd, false, "Invalid config drive ISO data");
+            }
             String nfsMountPoint = getRootDir(cmd.getDestStore().getUrl(), _nfsVersion);
             File isoFile = new File(nfsMountPoint, cmd.getIsoFile());
             if(isoFile.exists()) {
-                if (!cmd.isUpdate()) {
-                    return new Answer(cmd, true, "ISO already available");
-                } else {
-                    // Find out if we have to recover the password/ssh-key from the already available ISO.
-                    try {
-                        List<String[]> recoveredVmData = recoverVmData(isoFile);
-                        for (String[] vmDataEntry : cmd.getVmData()) {
-                            if (updatableConfigData.containsKey(vmDataEntry[CONFIGDATA_FILE])
-                                    && updatableConfigData.get(vmDataEntry[CONFIGDATA_FILE]).equals(vmDataEntry[CONFIGDATA_DIR])) {
-                                   updateVmData(recoveredVmData, vmDataEntry);
-                            }
-                        }
-                        cmd.setVmData(recoveredVmData);
-                    } catch (IOException e) {
-                        return new Answer(cmd, e);
+                s_logger.debug("config drive iso already exists");
+            }
+            Path tempDir = null;
+            try {
+                tempDir = java.nio.file.Files.createTempDirectory(ConfigDrive.CONFIGDRIVEDIR);
+                File tmpIsoFile = ConfigDriveBuilder.base64StringToFile(cmd.getIsoData(), tempDir.toAbsolutePath().toString(), ConfigDrive.CONFIGDRIVEFILENAME);
+                copyLocalToNfs(tmpIsoFile, new File(cmd.getIsoFile()), cmd.getDestStore());
+            } catch (IOException | ConfigurationException e) {
+                return new Answer(cmd, false, "Failed due to exception: " + e.getMessage());
+            } finally {
+                try {
+                    if (tempDir != null) {
+                        FileUtils.deleteDirectory(tempDir.toFile());
                     }
+                } catch (IOException ioe) {
+                    s_logger.warn("Failed to delete ConfigDrive temporary directory: " + tempDir.toString(), ioe);
                 }
             }
-            return createConfigDriveIsoForVM(cmd);
+            return new Answer(cmd, true, "Successfully saved config drive at secondary storage");
         } else {
             DataStoreTO dstore = cmd.getDestStore();
             if (dstore instanceof NfsTO) {
@@ -380,237 +368,6 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                 return new Answer(cmd, false, "Not implemented yet");
             }
         }
-    }
-
-    private void updateVmData(List<String[]> recoveredVmData, String[] vmDataEntry) {
-        for (String[] recoveredEntry : recoveredVmData) {
-            if (recoveredEntry[CONFIGDATA_DIR].equals(vmDataEntry[CONFIGDATA_DIR])
-                    && recoveredEntry[CONFIGDATA_FILE].equals(vmDataEntry[CONFIGDATA_FILE])) {
-                recoveredEntry[CONFIGDATA_CONTENT] = vmDataEntry[CONFIGDATA_CONTENT];
-                return;
-            }
-        }
-        recoveredVmData.add(vmDataEntry);
-    }
-
-    private List<String[]> recoverVmData(File isoFile) throws IOException {
-        String tempDirName = null;
-        List<String[]> recoveredVmData = Lists.newArrayList();
-        boolean mounted = false;
-        try {
-            Path tempDir = java.nio.file.Files.createTempDirectory("ConfigDrive");
-            tempDirName = tempDir.toString();
-
-            // Unpack the current config drive file
-            Script command = new Script(!_inSystemVM, "mount", _timeout, s_logger);
-            command.add("-o", "loop");
-            command.add(isoFile.getAbsolutePath());
-            command.add(tempDirName);
-            String result = command.execute();
-
-            if (result != null) {
-                String errMsg = "Unable to mount " + isoFile.getAbsolutePath() + " at " + tempDirName + " due to " + result;
-                s_logger.error(errMsg);
-                throw new IOException(errMsg);
-            }
-            mounted = true;
-
-
-            // Scan directory structure
-            for (File configDirectory: (new File(tempDirName, "cloudstack")).listFiles()){
-                for (File configFile: configDirectory.listFiles()) {
-                    recoveredVmData.add(new String[]{configDirectory.getName(),
-                            Files.getNameWithoutExtension(configFile.getName()),
-                            Files.readFirstLine(configFile, Charset.defaultCharset())});
-                }
-            }
-
-        } finally {
-            if (mounted) {
-                Script command = new Script(!_inSystemVM, "umount", _timeout, s_logger);
-                command.add(tempDirName);
-                String result = command.execute();
-                if (result != null) {
-                    s_logger.warn("Unable to umount " + tempDirName + " due to " + result);
-                }
-            }
-            try {
-                FileUtils.deleteDirectory(new File(tempDirName));
-            } catch (IOException ioe) {
-                s_logger.warn("Failed to delete ConfigDrive temporary directory: " + tempDirName, ioe);
-            }
-        }
-        return  recoveredVmData;
-    }
-
-    public Answer createConfigDriveIsoForVM(HandleConfigDriveIsoCommand cmd) {
-        //create folder for the VM
-        if (cmd.getVmData() != null) {
-
-            Path tempDir = null;
-            String tempDirName = null;
-            try {
-                tempDir = java.nio.file.Files.createTempDirectory("ConfigDrive");
-                tempDirName = tempDir.toString();
-
-                //create OpenStack files
-                //create folder with empty files
-                File openStackFolder = new File(tempDirName + ConfigDrive.openStackConfigDriveName);
-                if (openStackFolder.exists() || openStackFolder.mkdirs()) {
-                    File vendorDataFile = new File(openStackFolder,"vendor_data.json");
-                    try (FileWriter fw = new FileWriter(vendorDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
-                        bw.write("{}");
-                    } catch (IOException ex) {
-                        s_logger.error("Failed to create file ", ex);
-                        return new Answer(cmd, ex);
-                    }
-                    File networkDataFile = new File(openStackFolder, "network_data.json");
-                    try (FileWriter fw = new FileWriter(networkDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
-                        bw.write("{}");
-                    } catch (IOException ex) {
-                        s_logger.error("Failed to create file ", ex);
-                        return new Answer(cmd, ex);
-                    }
-                } else {
-                    s_logger.error("Failed to create folder " + openStackFolder);
-                    return new Answer(cmd, false, "Failed to create folder " + openStackFolder);
-                }
-
-                JsonObject metaData = new JsonObject();
-                for (String[] item : cmd.getVmData()) {
-                    String dataType = item[CONFIGDATA_DIR];
-                    String fileName = item[CONFIGDATA_FILE];
-                    String content = item[CONFIGDATA_CONTENT];
-                    s_logger.debug(String.format("[createConfigDriveIsoForVM] dataType=%s, filename=%s, content=%s",
-                            dataType, fileName, (fileName.equals(PASSWORD_FILE)?"********":content)));
-
-                    // create file with content in folder
-                    if (dataType != null && !dataType.isEmpty()) {
-                        //create folder
-                        File typeFolder = new File(tempDirName + ConfigDrive.cloudStackConfigDriveName + dataType);
-                        if (typeFolder.exists() || typeFolder.mkdirs()) {
-                            if (StringUtils.isNotEmpty(content)) {
-                                File file = new File(typeFolder, fileName + ".txt");
-                                try  {
-                                    if (fileName.equals(USERDATA_FILE)) {
-                                        // User Data is passed as a base64 encoded string
-                                        FileUtils.writeByteArrayToFile(file, Base64.decodeBase64(content));
-                                    } else {
-                                        FileUtils.write(file, content, com.cloud.utils.StringUtils.getPreferredCharset());
-                                    }
-                                } catch (IOException ex) {
-                                    s_logger.error("Failed to create file ", ex);
-                                    return new Answer(cmd, ex);
-                                }
-                            }
-                        } else {
-                            s_logger.error("Failed to create folder " + typeFolder);
-                            return new Answer(cmd, false, "Failed to create folder " + typeFolder);
-                        }
-
-                        //now write the file to the OpenStack directory
-                        metaData = constructOpenStackMetaData(metaData, dataType, fileName, content);
-                    }
-                }
-
-                File metaDataFile = new File(openStackFolder, "meta_data.json");
-                try (FileWriter fw = new FileWriter(metaDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
-                    bw.write(metaData.toString());
-                } catch (IOException ex) {
-                    s_logger.error("Failed to create file ", ex);
-                    return new Answer(cmd, ex);
-                }
-
-                String linkResult = linkUserData(tempDirName);
-                if (linkResult != null) {
-                    String errMsg = "Unable to create user_data link due to " + linkResult;
-                    s_logger.warn(errMsg);
-                    return new Answer(cmd, false, errMsg);
-                }
-
-                File tmpIsoStore = new File(tempDirName, new File(cmd.getIsoFile()).getName());
-                Script command = new Script(!_inSystemVM, "/usr/bin/genisoimage", _timeout, s_logger);
-                command.add("-o", tmpIsoStore.getAbsolutePath());
-                command.add("-ldots");
-                command.add("-allow-lowercase");
-                command.add("-allow-multidot");
-                command.add("-cache-inodes"); // Enable caching inode and device numbers to find hard links to files.
-                command.add("-l");
-                command.add("-quiet");
-                command.add("-J");
-                command.add("-r");
-                command.add("-V", cmd.getConfigDriveLabel());
-                command.add(tempDirName);
-                s_logger.debug("execute command: " + command.toString());
-                String result = command.execute();
-                if (result != null) {
-                    String errMsg = "Unable to create iso file: " + cmd.getIsoFile() + " due to " + result;
-                    s_logger.warn(errMsg);
-                    return new Answer(cmd, false, errMsg);
-                }
-                copyLocalToNfs(tmpIsoStore, new File(cmd.getIsoFile()), cmd.getDestStore());
-
-            } catch (IOException e) {
-                return new Answer(cmd, e);
-            } catch (ConfigurationException e) {
-                s_logger.warn("SecondStorageException ", e);
-                return new Answer(cmd, e);
-            } finally {
-                try {
-                    FileUtils.deleteDirectory(tempDir.toFile());
-                } catch (IOException ioe) {
-                    s_logger.warn("Failed to delete ConfigDrive temporary directory: " + tempDirName, ioe);
-                }
-            }
-        }
-        return new Answer(cmd);
-    }
-
-    JsonObject constructOpenStackMetaData(JsonObject metaData, String dataType, String fileName, String content) {
-        if (dataType.equals(NetworkModel.METATDATA_DIR) &&  StringUtils.isNotEmpty(content)) {
-            //keys are a special case in OpenStack format
-            if (NetworkModel.PUBLIC_KEYS_FILE.equals(fileName)) {
-                String[] keyArray = content.replace("\\n", "").split(" ");
-                String keyName = "key";
-                if (keyArray.length > 3 && StringUtils.isNotEmpty(keyArray[2])){
-                    keyName = keyArray[2];
-                }
-
-                JsonObject keyLegacy = new JsonObject();
-                keyLegacy.addProperty("type", "ssh");
-                keyLegacy.addProperty("data", content.replace("\\n", ""));
-                keyLegacy.addProperty("name", keyName);
-                metaData.add("keys", arrayOf(keyLegacy));
-
-                JsonObject key = new JsonObject();
-                key.addProperty(keyName, content);
-                metaData.add("public_keys", key);
-            } else if (NetworkModel.openStackFileMapping.get(fileName) != null) {
-                    metaData.addProperty(NetworkModel.openStackFileMapping.get(fileName), content);
-            }
-        }
-        return metaData;
-    }
-
-    private static JsonArray arrayOf(JsonElement... elements) {
-        JsonArray array = new JsonArray();
-        for (JsonElement element : elements) {
-            array.add(element);
-        }
-        return array;
-    }
-
-    private String linkUserData(String tempDirName) {
-        //Hard link the user_data.txt file with the user_data file in the OpenStack directory.
-        String userDataFilePath = tempDirName + ConfigDrive.cloudStackConfigDriveName + "userdata/user_data.txt";
-        if ((new File(userDataFilePath).exists())) {
-            Script hardLink = new Script(!_inSystemVM, "ln", _timeout, s_logger);
-            hardLink.add(userDataFilePath);
-            hardLink.add(tempDirName + ConfigDrive.openStackConfigDriveName + "user_data");
-            s_logger.debug("execute command: " + hardLink.toString());
-            return hardLink.execute();
-        }
-        return null;
     }
 
     protected void copyLocalToNfs(File localFile, File isoFile, DataStoreTO destData) throws ConfigurationException, IOException {

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -106,6 +106,7 @@ import org.apache.cloudstack.storage.command.TemplateOrVolumePostUploadCommand;
 import org.apache.cloudstack.storage.command.UploadStatusAnswer;
 import org.apache.cloudstack.storage.command.UploadStatusAnswer.UploadStatus;
 import org.apache.cloudstack.storage.command.UploadStatusCommand;
+import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.apache.cloudstack.storage.template.DownloadManager;
 import org.apache.cloudstack.storage.template.DownloadManagerImpl;
 import org.apache.cloudstack.storage.template.DownloadManagerImpl.ZfsPathParser;
@@ -200,8 +201,6 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     private static final String TEMPLATE_ROOT_DIR = "template/tmpl";
     private static final String VOLUME_ROOT_DIR = "volumes";
     private static final String POST_UPLOAD_KEY_LOCATION = "/etc/cloudstack/agent/ms-psk";
-    private static final String cloudStackConfigDriveName = "/cloudstack/";
-    private static final String openStackConfigDriveName = "/openstack/latest/";
 
     private static final Map<String, String> updatableConfigData = Maps.newHashMap();
     static {
@@ -456,7 +455,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
 
                 //create OpenStack files
                 //create folder with empty files
-                File openStackFolder = new File(tempDirName + openStackConfigDriveName);
+                File openStackFolder = new File(tempDirName + ConfigDrive.openStackConfigDriveName);
                 if (openStackFolder.exists() || openStackFolder.mkdirs()) {
                     File vendorDataFile = new File(openStackFolder,"vendor_data.json");
                     try (FileWriter fw = new FileWriter(vendorDataFile); BufferedWriter bw = new BufferedWriter(fw)) {
@@ -488,7 +487,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
                     // create file with content in folder
                     if (dataType != null && !dataType.isEmpty()) {
                         //create folder
-                        File typeFolder = new File(tempDirName + cloudStackConfigDriveName + dataType);
+                        File typeFolder = new File(tempDirName + ConfigDrive.cloudStackConfigDriveName + dataType);
                         if (typeFolder.exists() || typeFolder.mkdirs()) {
                             if (StringUtils.isNotEmpty(content)) {
                                 File file = new File(typeFolder, fileName + ".txt");
@@ -603,11 +602,11 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
 
     private String linkUserData(String tempDirName) {
         //Hard link the user_data.txt file with the user_data file in the OpenStack directory.
-        String userDataFilePath = tempDirName + cloudStackConfigDriveName + "userdata/user_data.txt";
+        String userDataFilePath = tempDirName + ConfigDrive.cloudStackConfigDriveName + "userdata/user_data.txt";
         if ((new File(userDataFilePath).exists())) {
             Script hardLink = new Script(!_inSystemVM, "ln", _timeout, s_logger);
             hardLink.add(userDataFilePath);
-            hardLink.add(tempDirName + openStackConfigDriveName + "user_data");
+            hardLink.add(tempDirName + ConfigDrive.openStackConfigDriveName + "user_data");
             s_logger.debug("execute command: " + hardLink.toString());
             return hardLink.execute();
         }


### PR DESCRIPTION
This introduces a new global setting `vm.configdrive.primarypool.enabled` to toggle creation/hosting of config drive iso files on primary storage, the default will be `false` causing them to be hosted on secondary storage. The support is limited from hypervisor resource side and in current implementation limited to KVM. The next big change is that config drive is created at a temporary location by management server and shipped to either KVM or SSVM agent via cmd-answer pattern, the data of which is not logged in logs. This saves us from adding `genisoimage` dependency on cloudstack-agent pkg.

The APIs to reset ssh public key, password and user-data (via update VM API) requires that VM should be shutdown. Therefore, in the refactoring I removed the case of updation of existing ISO. If there are objections I'll re-put the strategy to detach+attach new config iso as a way of updation. In the refactored implementation, the folder name is changed to lower-cased `configdrive`. And during VM start, migration or shutdown/removal if primary storage is enable for use, the KVM agent will handle cleanup tasks otherwise SSVM agent will handle them. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [x] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

