### PR TITLE
CLOUDSTACK-10377: Fix Network restart for Nuage

### DIFF
--- a/api/src/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/com/cloud/vm/VirtualMachineProfile.java
@@ -174,4 +174,6 @@ public interface VirtualMachineProfile {
 
     Float getMemoryOvercommitRatio();
 
+    boolean isRollingRestart();
+
 }

--- a/api/src/com/cloud/vm/VirtualMachineProfile.java
+++ b/api/src/com/cloud/vm/VirtualMachineProfile.java
@@ -56,6 +56,7 @@ public interface VirtualMachineProfile {
         public static final Param VmSshPubKey = new Param("VmSshPubKey");
         public static final Param ControlNic = new Param("ControlNic");
         public static final Param ReProgramGuestNetworks = new Param("RestartNetwork");
+        public static final Param RollingRestart = new Param("RollingRestart");
         public static final Param PxeSeverType = new Param("PxeSeverType");
         public static final Param HaTag = new Param("HaTag");
         public static final Param HaOperation = new Param("HaOperation");

--- a/engine/components-api/src/com/cloud/vm/VirtualMachineProfileImpl.java
+++ b/engine/components-api/src/com/cloud/vm/VirtualMachineProfileImpl.java
@@ -264,6 +264,11 @@ public class VirtualMachineProfileImpl implements VirtualMachineProfile {
     }
 
     @Override
+    public boolean isRollingRestart() {
+        return Boolean.TRUE.equals(getParameter(VirtualMachineProfile.Param.RollingRestart));
+    }
+
+    @Override
     public List<String[]> getVmData() {
         return vmData;
     }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/element/NuageVspElement.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/element/NuageVspElement.java
@@ -54,6 +54,7 @@ import org.apache.cloudstack.resourcedetail.dao.VpcDetailsDao;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.Command;
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.agent.api.StartupVspCommand;
 import com.cloud.agent.api.element.ApplyAclRuleVspCommand;
@@ -289,14 +290,41 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
         VspDhcpDomainOption vspDhcpOptions = _nuageVspEntityBuilder.buildNetworkDhcpOption(network, offering);
         HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(network.getPhysicalNetworkId());
         ImplementVspCommand cmd = new ImplementVspCommand(vspNetwork, ingressFirewallRules, egressFirewallRules, floatingIpUuids, vspDhcpOptions);
+        send(cmd, network);
+
+        return true;
+    }
+
+    private void send(Command cmd, Network network)
+            throws ResourceUnavailableException {
+        send(cmd, network.getPhysicalNetworkId(), Network.class, network);
+    }
+
+    private void send(Command cmd, Vpc vpc)
+            throws ResourceUnavailableException {
+        send(cmd, getPhysicalNetworkId(vpc.getZoneId()), Vpc.class, vpc);
+    }
+
+
+    private <R extends InternalIdentity> void send(Command cmd, long physicalNetworkId, Class<R> resourceClass,
+            R resource)
+            throws ResourceUnavailableException {
+        HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(physicalNetworkId);
         Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
-        if (answer == null || !answer.getResult()) {
-            s_logger.error("ImplementVspCommand for network " + network.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
-            if ((null != answer) && (null != answer.getDetails())) {
-                throw new ResourceUnavailableException(answer.getDetails(), Network.class, network.getId());
+        if (isFailure(answer)) {
+            s_logger.error(cmd.getClass().getName() + " for " + resourceClass.getName() + " " + resource.getId() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
+            if (hasFailureDetails(answer)) {
+                throw new ResourceUnavailableException(answer.getDetails(), resourceClass, resource.getId());
             }
         }
-        return true;
+    }
+
+    private boolean hasFailureDetails(Answer answer) {
+        return (null != answer) && (null != answer.getDetails());
+    }
+
+    private boolean isFailure(Answer answer) {
+        return answer == null || !answer.getResult();
     }
 
     private boolean applyACLRulesForVpc(Network network, NetworkOffering offering) throws ResourceUnavailableException {
@@ -358,15 +386,9 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
             NetworkOfferingVO networkOfferingVO = _ntwkOfferingDao.findById(network.getNetworkOfferingId());
             VspDhcpDomainOption vspDhcpOptions = _nuageVspEntityBuilder.buildNetworkDhcpOption(network, networkOfferingVO);
             VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(network);
-            HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(network.getPhysicalNetworkId());
+
             ShutDownVspCommand cmd = new ShutDownVspCommand(vspNetwork, vspDhcpOptions);
-            Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
-            if (answer == null || !answer.getResult()) {
-                s_logger.error("ShutDownVspCommand for network " + network.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
-                if ((null != answer) && (null != answer.getDetails())) {
-                    throw new ResourceUnavailableException(answer.getDetails(), Network.class, network.getId());
-                }
-            }
+            send(cmd, network);
         }
         return true;
     }
@@ -511,8 +533,7 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
 
         ExtraDhcpOptionsVspCommand extraDhcpOptionsVspCommand = new ExtraDhcpOptionsVspCommand(vspNetwork, nic.getUuid(), dhcpOptions);
         Answer answer = _agentMgr.easySend(nuageVspHost.getId(), extraDhcpOptionsVspCommand);
-
-        if (answer == null || !answer.getResult()) {
+        if (isFailure(answer)) {
             s_logger.error("[setExtraDhcpOptions] setting extra DHCP options for nic " + nic.getUuid() + " failed.");
             return false;
         }
@@ -543,15 +564,9 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
         }
 
         VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(config);
-        HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(config.getPhysicalNetworkId());
         ApplyStaticNatVspCommand cmd = new ApplyStaticNatVspCommand(vspNetwork, vspStaticNatDetails);
-        Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
-        if (answer == null || !answer.getResult()) {
-            s_logger.error("ApplyStaticNatNuageVspCommand for network " + config.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
-            if ((null != answer) && (null != answer.getDetails())) {
-                throw new ResourceUnavailableException(answer.getDetails(), Network.class, config.getId());
-            }
-        }
+        send(cmd,
+             config);
 
         return true;
     }
@@ -615,16 +630,10 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
             }
         });
 
-        HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(network.getPhysicalNetworkId());
         VspAclRule.ACLType vspAclType = isNetworkAcl ? VspAclRule.ACLType.NetworkACL : VspAclRule.ACLType.Firewall;
         ApplyAclRuleVspCommand cmd = new ApplyAclRuleVspCommand(vspAclType, vspNetwork, vspAclRules, networkReset);
-        Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
-        if (answer == null || !answer.getResult()) {
-            s_logger.error("ApplyAclRuleNuageVspCommand for network " + network.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
-            if ((null != answer) && (null != answer.getDetails())) {
-                throw new ResourceUnavailableException(answer.getDetails(), Network.class, network.getId());
-            }
-        }
+        send(cmd,
+             network);
         return true;
     }
 
@@ -690,7 +699,6 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
             });
 
             Domain vpcDomain = _domainDao.findById(vpc.getDomainId());
-            HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(getPhysicalNetworkId(vpc.getZoneId()));
 
             String preConfiguredDomainTemplateName;
             VpcDetailVO domainTemplateNameDetail = _vpcDetailsDao.findDetail(vpc.getId(), NuageVspManager.nuageDomainTemplateDetailName);
@@ -714,14 +722,7 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
             }
 
             ShutDownVpcVspCommand cmd = new ShutDownVpcVspCommand(vpcDomain.getUuid(), vpc.getUuid(), preConfiguredDomainTemplateName, domainRouterUuids, vpcDetails);
-            Answer answer =  _agentMgr.easySend(nuageVspHost.getId(), cmd);
-            if (answer == null || !answer.getResult()) {
-                s_logger.error("ShutDownVpcVspCommand for VPC " + vpc.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
-                if ((null != answer) && (null != answer.getDetails())) {
-                    throw new ResourceUnavailableException(answer.getDetails(), Vpc.class, vpc.getId());
-                }
-                return false;
-            }
+            send(cmd, vpc);
         }
         return true;
     }

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/element/NuageVspElement.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/element/NuageVspElement.java
@@ -501,6 +501,10 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
 
     @Override
     public boolean setExtraDhcpOptions(Network network, long nicId, Map<Integer, String> dhcpOptions) {
+        if (network.isRollingRestart()) {
+            return true;
+        }
+
         VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(network);
         HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(network.getPhysicalNetworkId());
         NicVO nic = _nicDao.findById(nicId);

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
@@ -82,6 +82,7 @@ import com.cloud.network.dao.NetworkDetailsDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.network.manager.NuageVspManager;
+import com.cloud.network.router.VirtualRouter;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
@@ -94,6 +95,7 @@ import com.cloud.utils.StringUtils;
 import com.cloud.utils.db.DB;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.Ip;
+import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.Nic;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.NicVO;
@@ -101,6 +103,7 @@ import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
+import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.VMInstanceDao;
 
 public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements NetworkGuruAdditionalFunctions {
@@ -134,6 +137,8 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
     DataCenterDetailsDao _dcDetailsDao;
     @Inject
     VlanDetailsDao _vlanDetailsDao;
+    @Inject
+    private DomainRouterDao _routerDao;
 
     public NuageVspGuestNetworkGuru() {
         super();
@@ -528,29 +533,35 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
             nic.setBroadcastUri(network.getBroadcastUri());
             nic.setIsolationUri(network.getBroadcastUri());
 
-            //NicProfile does not contain the NIC UUID. We need this information to set it in the VMInterface and VPort
-            //that we create in VSP
-            NicVO nicFromDb = _nicDao.findById(nic.getId());
-            IPAddressVO staticNatIp = _ipAddressDao.findByVmIdAndNetworkId(network.getId(), vm.getId());
             VspVm vspVm = _nuageVspEntityBuilder.buildVspVm(vm.getVirtualMachine(), network);
-            VspNic vspNic = _nuageVspEntityBuilder.buildVspNic(nicFromDb.getUuid(), nic);
-            VspStaticNat vspStaticNat = null;
-            if (staticNatIp != null) {
-                VlanVO staticNatVlan = _vlanDao.findById(staticNatIp.getVlanId());
-                vspStaticNat = _nuageVspEntityBuilder.buildVspStaticNat(null, staticNatIp, staticNatVlan, vspNic);
-            }
 
-            boolean defaultHasDns = getDefaultHasDns(networkHasDnsCache, nicFromDb);
-            VspDhcpVMOption dhcpOption = _nuageVspEntityBuilder.buildVmDhcpOption(nicFromDb, defaultHasDns, networkHasDns);
-            ReserveVmInterfaceVspCommand cmd = new ReserveVmInterfaceVspCommand(vspNetwork, vspVm, vspNic, vspStaticNat, dhcpOption);
-            Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
+            if (!Boolean.TRUE.equals(vm.getParameter(VirtualMachineProfile.Param.RollingRestart))) {
 
-            if (answer == null || !answer.getResult()) {
-                s_logger.error("ReserveVmInterfaceNuageVspCommand failed for NIC " + nic.getId() + " attached to VM " + vm.getId() + " in network " + network.getId());
-                if ((null != answer) && (null != answer.getDetails())) {
-                    s_logger.error(answer.getDetails());
+                //NicProfile does not contain the NIC UUID. We need this information to set it in the VMInterface and VPort
+                //that we create in VSP
+                NicVO nicFromDb = _nicDao.findById(nic.getId());
+                IPAddressVO staticNatIp = _ipAddressDao.findByVmIdAndNetworkId(network.getId(), vm.getId());
+                VspNic vspNic = _nuageVspEntityBuilder.buildVspNic(nicFromDb.getUuid(), nic);
+                VspStaticNat vspStaticNat = null;
+                if (staticNatIp != null) {
+                    VlanVO staticNatVlan = _vlanDao.findById(staticNatIp.getVlanId());
+                    vspStaticNat = _nuageVspEntityBuilder.buildVspStaticNat(null, staticNatIp, staticNatVlan, vspNic);
                 }
-                throw new InsufficientVirtualNetworkCapacityException("Failed to reserve VM in Nuage VSP.", Network.class, network.getId());
+
+                boolean defaultHasDns = getDefaultHasDns(networkHasDnsCache, nicFromDb);
+                VspDhcpVMOption dhcpOption = _nuageVspEntityBuilder.buildVmDhcpOption(nicFromDb, defaultHasDns, networkHasDns);
+                ReserveVmInterfaceVspCommand cmd = new ReserveVmInterfaceVspCommand(vspNetwork, vspVm, vspNic, vspStaticNat, dhcpOption);
+                Answer answer = _agentMgr.easySend(nuageVspHost.getId(), cmd);
+
+                if (answer == null || !answer.getResult()) {
+                    s_logger.error("ReserveVmInterfaceNuageVspCommand failed for NIC " + nic.getId() + " attached to VM " + vm.getId() + " in network " + network.getId());
+                    if ((null != answer) && (null != answer.getDetails())) {
+                        s_logger.error(answer.getDetails());
+                    }
+                    throw new InsufficientVirtualNetworkCapacityException("Failed to reserve VM in Nuage VSP.", Network.class, network.getId());
+                }
+            } else {
+                ((NetworkVO)network).setRollingRestart(true);
             }
 
             if (vspVm.getDomainRouter() == Boolean.TRUE) {
@@ -695,15 +706,20 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
         }
 
         try {
+            final VirtualMachine virtualMachine = vm.getVirtualMachine();
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Handling deallocate() call back, which is called when a VM is destroyed or interface is removed, " + "to delete VM Interface with IP "
-                        + nic.getIPv4Address() + " from a VM " + vm.getInstanceName() + " with state " + vm.getVirtualMachine().getState());
+                        + nic.getIPv4Address() + " from a VM " + vm.getInstanceName() + " with state " + virtualMachine
+                                                                                                           .getState());
             }
+
+
 
             NicVO nicFromDb = _nicDao.findById(nic.getId());
 
-            VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(vm.getVirtualMachine().getDomainId(), network);
-            VspVm vspVm = _nuageVspEntityBuilder.buildVspVm(vm.getVirtualMachine(), network);
+            VspNetwork vspNetwork = _nuageVspEntityBuilder.buildVspNetwork(virtualMachine
+                                                                             .getDomainId(), network);
+            VspVm vspVm = _nuageVspEntityBuilder.buildVspVm(virtualMachine, network);
             VspNic vspNic = _nuageVspEntityBuilder.buildVspNic(nicFromDb.getUuid(), nic);
             HostVO nuageVspHost = _nuageVspManager.getNuageVspHost(network.getPhysicalNetworkId());
 
@@ -722,6 +738,32 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
                 nic.deallocate();
             } else {
                 super.deallocate(network, nic, vm);
+            }
+
+            if (virtualMachine.getType() == VirtualMachine.Type.DomainRouter) {
+                final List<DomainRouterVO> routers = _routerDao.listByNetworkAndRole(network.getId(), VirtualRouter.Role.VIRTUAL_ROUTER);
+                final DomainRouterVO otherRouter = routers.stream()
+                                                          .filter(r -> r.getId() != vm.getId())
+                                                          .findFirst()
+                                                          .orElse(null);
+
+                if (otherRouter != null) {
+                    nicFromDb = _nicDao.findByNtwkIdAndInstanceId(network.getId(), otherRouter.getId());
+                    vspVm = _nuageVspEntityBuilder.buildVspVm(otherRouter, network);
+                    vspNic = _nuageVspEntityBuilder.buildVspNic(nicFromDb);
+
+                    VspDhcpVMOption dhcpOption = _nuageVspEntityBuilder.buildVmDhcpOption(nicFromDb, false, false);
+                    ReserveVmInterfaceVspCommand reserveCmd = new ReserveVmInterfaceVspCommand(vspNetwork, vspVm, vspNic, null, dhcpOption);
+
+                    answer = _agentMgr.easySend(nuageVspHost.getId(), reserveCmd);
+                    if (answer == null || !answer.getResult()) {
+                        s_logger.error("DeallocateVmNuageVspCommand for VM " + vm.getUuid() + " failed on Nuage VSD " + nuageVspHost.getDetail("hostname"));
+                        if ((null != answer) && (null != answer.getDetails())) {
+                            s_logger.error(answer.getDetails());
+                        }
+                    }
+                }
+
             }
         } finally {
             if (network != null && lockedNetwork) {

--- a/plugins/network-elements/nuage-vsp/src/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
+++ b/plugins/network-elements/nuage-vsp/src/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
@@ -535,8 +535,9 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
 
             VspVm vspVm = _nuageVspEntityBuilder.buildVspVm(vm.getVirtualMachine(), network);
 
-            if (!Boolean.TRUE.equals(vm.getParameter(VirtualMachineProfile.Param.RollingRestart))) {
-
+            if (vm.isRollingRestart()) {
+                ((NetworkVO)network).setRollingRestart(true);
+            } else {
                 //NicProfile does not contain the NIC UUID. We need this information to set it in the VMInterface and VPort
                 //that we create in VSP
                 NicVO nicFromDb = _nicDao.findById(nic.getId());
@@ -560,8 +561,6 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
                     }
                     throw new InsufficientVirtualNetworkCapacityException("Failed to reserve VM in Nuage VSP.", Network.class, network.getId());
                 }
-            } else {
-                ((NetworkVO)network).setRollingRestart(true);
             }
 
             if (vspVm.getDomainRouter() == Boolean.TRUE) {
@@ -712,8 +711,6 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
                         + nic.getIPv4Address() + " from a VM " + vm.getInstanceName() + " with state " + virtualMachine
                                                                                                            .getState());
             }
-
-
 
             NicVO nicFromDb = _nicDao.findById(nic.getId());
 

--- a/plugins/network-elements/nuage-vsp/test/com/cloud/network/guru/NuageVspGuestNetworkGuruTest.java
+++ b/plugins/network-elements/nuage-vsp/test/com/cloud/network/guru/NuageVspGuestNetworkGuruTest.java
@@ -19,15 +19,34 @@
 
 package com.cloud.network.guru;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
 
 import net.nuage.vsp.acs.client.api.model.NetworkRelatedVsdIds;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
@@ -39,10 +58,11 @@ import com.cloud.NuageTest;
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
+import com.cloud.agent.api.guru.DeallocateVmVspCommand;
 import com.cloud.agent.api.guru.ImplementNetworkVspCommand;
+import com.cloud.agent.api.guru.ReserveVmInterfaceVspCommand;
 import com.cloud.agent.api.manager.ImplementNetworkVspAnswer;
 import com.cloud.configuration.ConfigurationManager;
-import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenter.NetworkType;
 import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.dao.DataCenterDao;
@@ -71,6 +91,7 @@ import com.cloud.network.dao.NuageVspDao;
 import com.cloud.network.dao.PhysicalNetworkDao;
 import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.network.manager.NuageVspManager;
+import com.cloud.network.router.VirtualRouter;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
@@ -78,26 +99,34 @@ import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
 import com.cloud.user.Account;
 import com.cloud.user.AccountVO;
 import com.cloud.user.dao.AccountDao;
+import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.NicVO;
 import com.cloud.vm.ReservationContext;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
+import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class NuageVspGuestNetworkGuruTest extends NuageTest {
+    private static final long DATACENTER_ID = 100L;
+    private static final long HOST_ID = 101L;
+    private static final long DOMAIN_ID = 1L;
+    private static final long ACCOUNT_ID = 2L;
+    private static final long OFFERING_ID = 40L;
     private static final long NETWORK_ID = 42L;
+    private static final long VM_ID = 242L;
+    private static final long NIC_ID = 342L;
+
+    private static final String DATACENTER_UUID = "uuid-datacenter-100";
+    private static final String HOST_UUID = "uuid-host-101";
+    private static final String DOMAIN_UUID = "uuid-domain-001";
+    private static final String ACCOUNT_UUID = "uuid-account-002";
+    private static final String OFFERING_UUID = "uuid-offering-040";
+    private static final String NETWORK_UUID = "uuid-network-000-42";
+    private static final String VM_UUID = "uuid-vm-002-42";
+    private static final String NIC_UUID = "uuid-nic-003-42";
+
     @Mock private PhysicalNetworkDao _physicalNetworkDao;
     @Mock private DataCenterDao _dataCenterDao;
     @Mock private NetworkOfferingServiceMapDao _networkOfferingServiceMapDao;
@@ -115,39 +144,42 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
     @Mock private DataCenterDetailsDao _dcDetailsDao;
     @Mock private NetworkDetailsDao _networkDetailsDao;
     @Mock private PhysicalNetworkVO physnet;
+    @Mock private DomainRouterDao _routerDao;
+
+    private Account _account;
+    private Domain _domain;
+    private DataCenterVO _dc;
+    private ReservationContext _reservationContext;
 
     @InjectMocks
-    private NuageVspGuestNetworkGuru _nuageVspGuestNetworkGuru;
+    private NuageVspGuestNetworkGuru _nuageVspGuestNetworkGuru = new NuageVspGuestNetworkGuru();
 
     @Before
     public void setUp() throws Exception {
-        _nuageVspGuestNetworkGuru = new NuageVspGuestNetworkGuru();
-
         super.setUp();
 
-        _nuageVspGuestNetworkGuru._nuageVspEntityBuilder = _nuageVspEntityBuilder;
-
-        final DataCenterVO dc = mock(DataCenterVO.class);
-        when(dc.getNetworkType()).thenReturn(NetworkType.Advanced);
-        when(dc.getGuestNetworkCidr()).thenReturn("10.1.1.1/24");
-
-        when(_dataCenterDao.findById((Long)any())).thenReturn(dc);
+        _account = getMockAccount();
+        _domain = getMockDomain();
+        _dc = mockDataCenter();
+        _reservationContext = getMockReservationContext(_account, _domain);
 
         when(_physicalNetworkDao.findById(any(Long.class))).thenReturn(physnet);
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("VSP"));
+        when(physnet.getIsolationMethods()).thenReturn(Collections.singletonList("VSP"));
         when(physnet.getId()).thenReturn(NETWORK_ID);
 
         final HostVO host = mock(HostVO.class);
-        when(_hostDao.findById(NETWORK_ID)).thenReturn(host);
-        when(host.getId()).thenReturn(NETWORK_ID);
-        when(_agentManager.easySend(eq(NETWORK_ID), any(Command.class))).thenReturn(new Answer(null));
-        when(_agentManager.easySend(eq(NETWORK_ID), any(ImplementNetworkVspCommand.class))).thenAnswer(this::mockImplement);
+        when(host.getId()).thenReturn(HOST_ID);
+        when(host.getUuid()).thenReturn(HOST_UUID);
+        when(_hostDao.findById(HOST_ID)).thenReturn(host);
+
+        when(_agentManager.easySend(eq(HOST_ID), any(Command.class))).thenReturn(new Answer(null));
+        when(_agentManager.easySend(eq(HOST_ID), any(ImplementNetworkVspCommand.class))).thenAnswer(this::mockImplement);
         when(_nuageVspManager.getNuageVspHost(NETWORK_ID)).thenReturn(host);
 
         final NuageVspDeviceVO device = mock(NuageVspDeviceVO.class);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(device));
+        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Collections.singletonList(device));
         when(device.getId()).thenReturn(1L);
-        when(device.getHostId()).thenReturn(NETWORK_ID);
+        when(device.getHostId()).thenReturn(HOST_ID);
     }
 
     Answer mockImplement(InvocationOnMock invocation) {
@@ -161,18 +193,7 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
 
     @Test
     public void testCanHandle() {
-        final NetworkOffering offering = mock(NetworkOffering.class);
-        when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getIsPersistent()).thenReturn(false);
-        when(_configurationManager.isOfferingForVpc(any(NetworkOffering.class))).thenReturn(false);
-
-        when(_networkOfferingServiceMapDao.canProviderSupportServiceInNetworkOffering(NETWORK_ID, Service.Connectivity, Network.Provider.NuageVsp)).thenReturn(true);
-        when(_networkOfferingServiceMapDao.canProviderSupportServiceInNetworkOffering(NETWORK_ID, Service.SourceNat, Network.Provider.NuageVsp)).thenReturn(true);
-
-        when(_networkModel.getNetworkOfferingServiceProvidersMap(NETWORK_ID)).thenReturn(ImmutableMap.of(
-                Service.Connectivity, Sets.newSet(Network.Provider.NuageVsp),
-                Service.SourceNat, Sets.newSet(Network.Provider.NuageVsp)
-        ));
+        final NetworkOffering offering = mockNetworkOffering(false);
 
         when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
         when(offering.getGuestType()).thenReturn(GuestType.Isolated);
@@ -191,8 +212,8 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         when(offering.getGuestType()).thenReturn(GuestType.Isolated);
         assertThat(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Basic, physnet), is(false));
 
-        // Not supported: IsolationMethod != STT
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("VLAN"));
+        // Not supported: IsolationMethod != VSP
+        when(physnet.getIsolationMethods()).thenReturn(Collections.singletonList("VLAN"));
         assertThat(_nuageVspGuestNetworkGuru.canHandle(offering, NetworkType.Basic, physnet), is(false));
 
         // Not supported: Non-persistent VPC tier
@@ -202,272 +223,289 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
 
     @Test
     public void testDesign() {
-        final NuageVspDeviceVO device = mock(NuageVspDeviceVO.class);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(device));
-        when(device.getId()).thenReturn(1L);
-
-        final NetworkOffering offering = mock(NetworkOffering.class);
-        when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(offering.getGuestType()).thenReturn(GuestType.Isolated);
+        final NetworkOffering offering = mockNetworkOffering(false);
         when(offering.getIsPersistent()).thenReturn(false);
-        when(_configurationManager.isOfferingForVpc(any(NetworkOffering.class))).thenReturn(false);
 
-        when(_networkOfferingServiceMapDao.canProviderSupportServiceInNetworkOffering(NETWORK_ID, Service.Connectivity, Network.Provider.NuageVsp)).thenReturn(true);
-        when(_networkOfferingServiceMapDao.canProviderSupportServiceInNetworkOffering(NETWORK_ID, Service.SourceNat, Network.Provider.NuageVsp)).thenReturn(true);
-
-        when(_networkModel.getNetworkOfferingServiceProvidersMap(NETWORK_ID)).thenReturn(ImmutableMap.of(
-                Service.Connectivity, Sets.newSet(Network.Provider.NuageVsp),
-                Service.SourceNat, Sets.newSet(Network.Provider.NuageVsp)
-        ));
-
-        final DeploymentPlan plan = mock(DeploymentPlan.class);
+        final DeploymentPlan plan = mockDeploymentPlan();
         final Network network = mock(Network.class);
-        final Account account = mock(Account.class);
 
-        final Network designednetwork = _nuageVspGuestNetworkGuru.design(offering, plan, network, account);
+        final Network designednetwork = _nuageVspGuestNetworkGuru.design(offering, plan, network, _account);
         assertThat(designednetwork, notNullValue(Network.class));
         assertThat(designednetwork.getBroadcastDomainType(), is(BroadcastDomainType.Vsp));
 
         // Can't design non-persistent VPC tier
         when(_configurationManager.isOfferingForVpc(any(NetworkOffering.class))).thenReturn(true);
-        assertThat(_nuageVspGuestNetworkGuru.design(offering, plan, network, account), nullValue(Network.class));
-    }
-
-    @Test
-    public void testDesignNoElementOnPhysicalNetwork() {
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("STT"));
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Collections.<NuageVspDeviceVO>emptyList());
-
-        final NetworkOffering offering = mock(NetworkOffering.class);
-        when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(offering.getGuestType()).thenReturn(GuestType.Isolated);
-
-        final DeploymentPlan plan = mock(DeploymentPlan.class);
-        final Network network = mock(Network.class);
-        final Account account = mock(Account.class);
-
-        final Network designednetwork = _nuageVspGuestNetworkGuru.design(offering, plan, network, account);
-        assertTrue(designednetwork == null);
+        assertThat(_nuageVspGuestNetworkGuru.design(offering, plan, network, _account), nullValue(Network.class));
     }
 
     @Test
     public void testDesignNoIsolationMethodVSP() {
-        when(physnet.getIsolationMethods()).thenReturn(Arrays.asList("VLAN"));
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Collections.<NuageVspDeviceVO>emptyList());
+        when(physnet.getIsolationMethods()).thenReturn(Collections.singletonList("VLAN"));
 
-        final NetworkOffering offering = mock(NetworkOffering.class);
-        when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(offering.getGuestType()).thenReturn(GuestType.Isolated);
+        final NetworkOffering offering = mockNetworkOffering(false);
 
-        final DeploymentPlan plan = mock(DeploymentPlan.class);
+        final DeploymentPlan plan = mockDeploymentPlan();
         final Network network = mock(Network.class);
-        final Account account = mock(Account.class);
 
-        final Network designednetwork = _nuageVspGuestNetworkGuru.design(offering, plan, network, account);
-        assertTrue(designednetwork == null);
+        assertThat(_nuageVspGuestNetworkGuru.design(offering, plan, network, _account), nullValue(Network.class));
     }
 
     @Test
     public void testReserve() throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException, URISyntaxException {
-        final NetworkVO network = mock(NetworkVO.class);
-        when(network.getId()).thenReturn(NETWORK_ID);
-        when(network.getUuid()).thenReturn("aaaaaa");
-        when(network.getDataCenterId()).thenReturn(NETWORK_ID);
-        when(network.getNetworkOfferingId()).thenReturn(NETWORK_ID);
-        when(network.getPhysicalNetworkId()).thenReturn(NETWORK_ID);
-        when(network.getDomainId()).thenReturn(NETWORK_ID);
-        when(network.getAccountId()).thenReturn(NETWORK_ID);
-        when(network.getVpcId()).thenReturn(null);
-        when(network.getBroadcastUri()).thenReturn(new URI("vsp://aaaaaa-aavvv/10.1.1.1"));
-
-        final DataCenterVO dataCenter = mock(DataCenterVO.class);
-        when(_dataCenterDao.findById(NETWORK_ID)).thenReturn(dataCenter);
-        final AccountVO networksAccount = mock(AccountVO.class);
-        when(networksAccount.getId()).thenReturn(NETWORK_ID);
-        when(networksAccount.getUuid()).thenReturn("aaaa-abbbb");
-        when(networksAccount.getType()).thenReturn(Account.ACCOUNT_TYPE_NORMAL);
-        when(_accountDao.findById(NETWORK_ID)).thenReturn(networksAccount);
-        final DomainVO networksDomain = mock(DomainVO.class);
-        when(networksDomain.getId()).thenReturn(NETWORK_ID);
-        when(networksDomain.getUuid()).thenReturn("aaaaa-bbbbb");
-        when(_domainDao.findById(NETWORK_ID)).thenReturn(networksDomain);
-
-        final NicVO nicvo = mock(NicVO.class);
-        when(nicvo.getId()).thenReturn(NETWORK_ID);
-        when(nicvo.getMacAddress()).thenReturn("aa-aa-aa-aa-aa-aa");
-        when(nicvo.getUuid()).thenReturn("aaaa-fffff");
-        when(nicvo.getNetworkId()).thenReturn(NETWORK_ID);
-        when(nicvo.getInstanceId()).thenReturn(NETWORK_ID);
-        when(_nicDao.findById(NETWORK_ID)).thenReturn(nicvo);
-        when(_nicDao.findDefaultNicForVM(NETWORK_ID)).thenReturn(nicvo);
-
-        final VirtualMachine vm = mock(VirtualMachine.class);
-        when(vm.getId()).thenReturn(NETWORK_ID);
-        when(vm.getType()).thenReturn(VirtualMachine.Type.User);
-
-        final VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
-        when(vmProfile.getType()).thenReturn(VirtualMachine.Type.User);
-        when(vmProfile.getInstanceName()).thenReturn("");
-        when(vmProfile.getUuid()).thenReturn("aaaa-bbbbb");
-        when(vmProfile.getVirtualMachine()).thenReturn(vm);
-
-        NicProfile nicProfile = mock(NicProfile.class);
-        when(nicProfile.getUuid()).thenReturn("aaa-bbbb");
-        when(nicProfile.getId()).thenReturn(NETWORK_ID);
-        when(nicProfile.getMacAddress()).thenReturn("aa-aa-aa-aa-aa-aa");
-
-        final NetworkOfferingVO ntwkoffering = mock(NetworkOfferingVO.class);
-        when(ntwkoffering.getId()).thenReturn(NETWORK_ID);
-        when(_networkOfferingDao.findById(NETWORK_ID)).thenReturn(ntwkoffering);
-
-        when(_networkDao.acquireInLockTable(NETWORK_ID, 1200)).thenReturn(network);
-        when(_ipAddressDao.findByVmIdAndNetworkId(NETWORK_ID, NETWORK_ID)).thenReturn(null);
-        when(_domainDao.findById(NETWORK_ID)).thenReturn(mock(DomainVO.class));
-
-        final Answer answer = mock(Answer.class);
-        when(answer.getResult()).thenReturn(true);
-        when(_agentManager.easySend(eq(NETWORK_ID), (Command)any())).thenReturn(answer);
-
-        final ReservationContext reservationContext = mock(ReservationContext.class);
-        when(reservationContext.getAccount()).thenReturn(networksAccount);
-        when(reservationContext.getDomain()).thenReturn(networksDomain);
+        final NetworkVO network = mockNetwork();
+        final NicProfile nicProfile = mockNicProfile();
+        final VirtualMachineProfile vmProfile = mockVirtualMachineProfile(VirtualMachine.State.Starting);
 
         when(_networkDao.findById(NETWORK_ID)).thenReturn(network);
 
-        _nuageVspGuestNetworkGuru.reserve(nicProfile, network, vmProfile, mock(DeployDestination.class), reservationContext);
+        _nuageVspGuestNetworkGuru.reserve(nicProfile, network, vmProfile, mock(DeployDestination.class), _reservationContext);
+
+        verify(_agentManager).easySend(anyLong(), any(Command.class));
+    }
+
+    @Test
+    public void testReserveVRRollingRestart() throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException, URISyntaxException {
+        final NetworkVO network = mockNetwork();
+        final NicProfile nicProfile = mockNicProfile();
+        final VirtualMachineProfile vmProfile = mockVRProfile(VirtualMachine.State.Starting);
+
+        when(_networkDao.findById(NETWORK_ID)).thenReturn(network);
+
+        _nuageVspGuestNetworkGuru.reserve(nicProfile, network, vmProfile, mock(DeployDestination.class), _reservationContext);
+
+        verifyZeroInteractions(_agentManager);
+        verify(network).setRollingRestart(true);
     }
 
     @Test
     public void testImplementNetwork() throws URISyntaxException, InsufficientVirtualNetworkCapacityException {
-        final NetworkVO network = mock(NetworkVO.class);
-        when(network.getId()).thenReturn(NETWORK_ID);
-        when(network.getUuid()).thenReturn("aaaaaa");
-        when(network.getDataCenterId()).thenReturn(NETWORK_ID);
-        when(network.getNetworkOfferingId()).thenReturn(NETWORK_ID);
-        when(network.getPhysicalNetworkId()).thenReturn(NETWORK_ID);
-        when(network.getDomainId()).thenReturn(NETWORK_ID);
-        when(network.getAccountId()).thenReturn(NETWORK_ID);
-        when(network.getVpcId()).thenReturn(null);
+        final NetworkVO network = mockNetwork();
+
         when(network.getState()).thenReturn(com.cloud.network.Network.State.Implementing);
-        when(network.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(network.getMode()).thenReturn(Mode.Static);
-        when(network.getBroadcastDomainType()).thenReturn(BroadcastDomainType.Vsp);
-        when(network.getBroadcastUri()).thenReturn(new URI("vsp://aaaaaa-aavvv/10.1.1.1"));
-        when(network.getGateway()).thenReturn("10.1.1.1");
-        when(network.getCidr()).thenReturn("10.1.1.0/24");
-        when(network.getName()).thenReturn("iso");
 
-        final NetworkOffering offering = mock(NetworkOffering.class);
-        when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(offering.getTags()).thenReturn("aaaa");
-        when(offering.getEgressDefaultPolicy()).thenReturn(true);
+        final NetworkOffering offering = mockNetworkOffering(false);
 
-        when(_networkModel.findPhysicalNetworkId(NETWORK_ID, "aaa", TrafficType.Guest)).thenReturn(NETWORK_ID);
-
-        final ReservationContext reserveContext = mock(ReservationContext.class);
-        final Domain domain = mock(Domain.class);
-        when(domain.getId()).thenReturn(NETWORK_ID);
-        when(reserveContext.getDomain()).thenReturn(domain);
-        when(domain.getName()).thenReturn("aaaaa");
-        final Account account = mock(Account.class);
-        when(account.getId()).thenReturn(NETWORK_ID);
-        when(account.getAccountId()).thenReturn(NETWORK_ID);
-        when(reserveContext.getAccount()).thenReturn(account);
-        final DomainVO domainVo = mock(DomainVO.class);
-        when(_domainDao.findById(NETWORK_ID)).thenReturn(domainVo);
-        final AccountVO accountVo = mock(AccountVO.class);
-        when(_accountDao.findById(NETWORK_ID)).thenReturn(accountVo);
-
-        when(_networkDao.acquireInLockTable(NETWORK_ID, 1200)).thenReturn(network);
-        when(_nuageVspManager.getDnsDetails(network.getDataCenterId())).thenReturn(new ArrayList<String>());
-        when(_nuageVspManager.getGatewaySystemIds()).thenReturn(new ArrayList<String>());
-
-        final DataCenter dc = mock(DataCenter.class);
-        when(dc.getId()).thenReturn(NETWORK_ID);
         final DeployDestination deployDest = mock(DeployDestination.class);
-        when(deployDest.getDataCenter()).thenReturn(dc);
-        _nuageVspGuestNetworkGuru.implement(network, offering, deployDest, reserveContext);
+        when(deployDest.getDataCenter()).thenReturn(_dc);
+        _nuageVspGuestNetworkGuru.implement(network, offering, deployDest, _reservationContext);
     }
 
     @Test
     public void testDeallocate() throws Exception {
-        final NetworkVO network = mock(NetworkVO.class);
-        when(network.getId()).thenReturn(NETWORK_ID);
-        when(network.getUuid()).thenReturn("aaaaaa");
-        when(network.getNetworkOfferingId()).thenReturn(NETWORK_ID);
-        when(network.getPhysicalNetworkId()).thenReturn(NETWORK_ID);
-        when(network.getVpcId()).thenReturn(null);
-        when(network.getDomainId()).thenReturn(NETWORK_ID);
-        when(_networkDao.acquireInLockTable(NETWORK_ID, 1200)).thenReturn(network);
-
-        final NetworkOfferingVO offering = mock(NetworkOfferingVO.class);
-        when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(_networkOfferingDao.findById(NETWORK_ID)).thenReturn(offering);
-
-        final DomainVO domain = mock(DomainVO.class);
-        when(domain.getUuid()).thenReturn("aaaaaa");
-        when(_domainDao.findById(NETWORK_ID)).thenReturn(domain);
-
-        final NicVO nic = mock(NicVO.class);
-        when(nic.getId()).thenReturn(NETWORK_ID);
-        when(nic.getIPv4Address()).thenReturn("10.10.10.10");
-        when(nic.getMacAddress()).thenReturn("c8:60:00:56:e5:58");
-        when(_nicDao.findById(NETWORK_ID)).thenReturn(nic);
-
-        final NicProfile nicProfile = mock(NicProfile.class);
-        when(nicProfile.getId()).thenReturn(NETWORK_ID);
-        when(nicProfile.getIPv4Address()).thenReturn("10.10.10.10");
-        when(nicProfile.getMacAddress()).thenReturn("c8:60:00:56:e5:58");
-
-        final VirtualMachine vm = mock(VirtualMachine.class);
-        when(vm.getType()).thenReturn(VirtualMachine.Type.User);
-        when(vm.getState()).thenReturn(VirtualMachine.State.Expunging);
-
-        final VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
-        when(vmProfile.getUuid()).thenReturn("aaaaaa");
-        when(vmProfile.getInstanceName()).thenReturn("Test-VM");
-        when(vmProfile.getVirtualMachine()).thenReturn(vm);
+        final NetworkVO network = mockNetwork();
+        final NicProfile nicProfile = mockNicProfile();
+        final VirtualMachineProfile vmProfile = mockVirtualMachineProfile(VirtualMachine.State.Expunging);
 
         _nuageVspGuestNetworkGuru.deallocate(network, nicProfile, vmProfile);
+    }
+
+    @Test
+    public void testDeallocateVR() throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException, URISyntaxException {
+        final NetworkVO network = mockNetwork();
+        final NicProfile nicProfile = mockNicProfile();
+        final VirtualMachineProfile vmProfile = mockVRProfile(VirtualMachine.State.Expunging);
+
+        when(_networkDao.findById(NETWORK_ID)).thenReturn(network);
+
+        _nuageVspGuestNetworkGuru.deallocate(network, nicProfile, vmProfile);
+    }
+
+    @Test
+    public void testDeallocateVRRollingRestart() throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException, URISyntaxException {
+        final NetworkVO network = mockNetwork();
+        final NicProfile nicProfile = mockNicProfile();
+        final VirtualMachineProfile vmProfile = mockVRProfile(VirtualMachine.State.Expunging);
+
+        DomainRouterVO newVR = mock(DomainRouterVO.class);
+
+        when(_routerDao.listByNetworkAndRole(NETWORK_ID, VirtualRouter.Role.VIRTUAL_ROUTER)).thenReturn(Collections.singletonList(newVR));
+        when(_networkDao.findById(NETWORK_ID)).thenReturn(network);
+
+        _nuageVspGuestNetworkGuru.deallocate(network, nicProfile, vmProfile);
+
+        ArgumentCaptor<Command> argumentCaptor = ArgumentCaptor.forClass(Command.class);
+        verify(_agentManager, times(2)).easySend(eq(HOST_ID), argumentCaptor.capture());
+        final List<Command> commands = argumentCaptor.getAllValues();
+        assertThat(commands.get(0) instanceof DeallocateVmVspCommand, is(true));
+        assertThat(commands.get(1) instanceof ReserveVmInterfaceVspCommand, is(true));
     }
 
     @Test
     public void testTrash() throws Exception {
         final NetworkVO network = mock(NetworkVO.class);
         when(network.getId()).thenReturn(NETWORK_ID);
-        when(network.getUuid()).thenReturn("aaaaaa");
+        when(network.getUuid()).thenReturn(NETWORK_UUID);
         when(network.getName()).thenReturn("trash");
-        when(network.getDomainId()).thenReturn(NETWORK_ID);
-        when(network.getNetworkOfferingId()).thenReturn(NETWORK_ID);
+        when(network.getDomainId()).thenReturn(DOMAIN_ID);
+        when(network.getNetworkOfferingId()).thenReturn(OFFERING_ID);
         when(network.getPhysicalNetworkId()).thenReturn(NETWORK_ID);
-        when(network.getDataCenterId()).thenReturn(NETWORK_ID);
+        when(network.getDataCenterId()).thenReturn(DATACENTER_ID);
         when(network.getVpcId()).thenReturn(null);
         when(_networkDao.acquireInLockTable(NETWORK_ID, 1200)).thenReturn(network);
 
-        final NetworkOfferingVO offering = mock(NetworkOfferingVO.class);
-        when(offering.getId()).thenReturn(NETWORK_ID);
-        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
-        when(_networkOfferingDao.findById(NETWORK_ID)).thenReturn(offering);
+        final NetworkOffering offering = mockNetworkOffering(false);
 
-        final DomainVO domain = mock(DomainVO.class);
-        when(domain.getUuid()).thenReturn("aaaaaa");
-        when(_domainDao.findById(NETWORK_ID)).thenReturn(domain);
-
-        final HostVO host = mock(HostVO.class);
-        when(host.getId()).thenReturn(NETWORK_ID);
-        final NuageVspDeviceVO nuageVspDevice = mock(NuageVspDeviceVO.class);
-        when(nuageVspDevice.getHostId()).thenReturn(NETWORK_ID);
-        when(_nuageVspDao.listByPhysicalNetwork(NETWORK_ID)).thenReturn(Arrays.asList(new NuageVspDeviceVO[]{nuageVspDevice}));
-        when(_hostDao.findById(NETWORK_ID)).thenReturn(host);
-        when(_nuageVspManager.getDnsDetails(network.getDataCenterId())).thenReturn(new ArrayList<String>());
-        when(_nuageVspManager.getGatewaySystemIds()).thenReturn(new ArrayList<String>());
+        when(_nuageVspManager.getDnsDetails(network.getDataCenterId())).thenReturn(new ArrayList<>());
+        when(_nuageVspManager.getGatewaySystemIds()).thenReturn(new ArrayList<>());
 
         assertTrue(_nuageVspGuestNetworkGuru.trash(network, offering));
+    }
+
+    @Nonnull
+    private NetworkVO mockNetwork() throws URISyntaxException {
+        final NetworkVO network = mock(NetworkVO.class);
+        when(network.getId()).thenReturn(NETWORK_ID);
+        when(network.getUuid()).thenReturn(NETWORK_UUID);
+        when(network.getDataCenterId()).thenReturn(DATACENTER_ID);
+        when(network.getNetworkOfferingId()).thenReturn(OFFERING_ID);
+        when(network.getPhysicalNetworkId()).thenReturn(NETWORK_ID);
+        when(network.getDomainId()).thenReturn(DOMAIN_ID);
+        when(network.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(network.getVpcId()).thenReturn(null);
+        when(network.getTrafficType()).thenReturn(TrafficType.Guest);
+        when(network.getMode()).thenReturn(Mode.Dhcp);
+        when(network.getBroadcastDomainType()).thenReturn(BroadcastDomainType.Vsp);
+        when(network.getBroadcastUri()).thenReturn(new URI("vsp://" + NETWORK_UUID + "/10.1.1.1"));
+        when(network.getGateway()).thenReturn("10.1.1.1");
+        when(network.getCidr()).thenReturn("10.1.1.0/24");
+        when(network.getName()).thenReturn("iso");
+
+        when(_networkDao.acquireInLockTable(NETWORK_ID, 1200)).thenReturn(network);
+        when(_networkDao.findById(NETWORK_ID)).thenReturn(network);
+
+        return network;
+    }
+
+    @Nonnull
+    private NetworkOffering mockNetworkOffering(boolean forVpc) {
+        final NetworkOfferingVO offering = mock(NetworkOfferingVO.class);
+        when(offering.getId()).thenReturn(OFFERING_ID);
+        when(offering.getUuid()).thenReturn(OFFERING_UUID);
+        when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
+        when(offering.getGuestType()).thenReturn(GuestType.Isolated);
+        when(offering.getForVpc()).thenReturn(forVpc);
+        when(offering.getIsPersistent()).thenReturn(false);
+        when(offering.getTags()).thenReturn("aaaa");
+        when(offering.getEgressDefaultPolicy()).thenReturn(true);
+
+        when(_networkOfferingDao.findById(OFFERING_ID)).thenReturn(offering);
+
+        when(_configurationManager.isOfferingForVpc(offering)).thenReturn(forVpc);
+
+        when(_networkOfferingServiceMapDao.canProviderSupportServiceInNetworkOffering(OFFERING_ID, Service.Connectivity, Network.Provider.NuageVsp)).thenReturn(true);
+        when(_networkOfferingServiceMapDao.canProviderSupportServiceInNetworkOffering(OFFERING_ID, Service.SourceNat, Network.Provider.NuageVsp)).thenReturn(true);
+
+        when(_networkModel.getNetworkOfferingServiceProvidersMap(OFFERING_ID)).thenReturn(ImmutableMap.of(
+                Service.Connectivity, Sets.newSet(Network.Provider.NuageVsp),
+                Service.SourceNat, Sets.newSet(Network.Provider.NuageVsp)
+        ));
+
+        return offering;
+    }
+
+    private DeploymentPlan mockDeploymentPlan() {
+        final DeploymentPlan deploymentPlan = mock(DeploymentPlan.class);
+        when(deploymentPlan.getDataCenterId()).thenReturn(DATACENTER_ID);
+        return deploymentPlan;
+    }
+
+    private DataCenterVO mockDataCenter() {
+        DataCenterVO dc = mock(DataCenterVO.class);
+        when(dc.getId()).thenReturn(DATACENTER_ID);
+        when(dc.getUuid()).thenReturn(DATACENTER_UUID);
+        when(dc.getNetworkType()).thenReturn(NetworkType.Advanced);
+        when(dc.getGuestNetworkCidr()).thenReturn("10.1.1.1/24");
+        when(_dataCenterDao.findById(DATACENTER_ID)).thenReturn(dc);
+
+        return dc;
+    }
+
+    @Nonnull
+    private Account getMockAccount() {
+        final AccountVO account = mock(AccountVO.class);
+        when(account.getId()).thenReturn(ACCOUNT_ID);
+        when(account.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(account.getUuid()).thenReturn(ACCOUNT_UUID);
+        when(account.getDomainId()).thenReturn(DOMAIN_ID);
+        when(account.getType()).thenReturn(Account.ACCOUNT_TYPE_NORMAL);
+
+        when(_accountDao.findById(ACCOUNT_ID)).thenReturn(account);
+
+        return account;
+    }
+
+    @Nonnull
+    private Domain getMockDomain() {
+        final DomainVO domain = mock(DomainVO.class);
+        when(domain.getId()).thenReturn(DOMAIN_ID);
+        when(domain.getUuid()).thenReturn(DOMAIN_UUID);
+        when(domain.getName()).thenReturn("aaaaa");
+
+        when(_domainDao.findById(DOMAIN_ID)).thenReturn(domain);
+
+        return domain;
+    }
+
+    @Nonnull
+    private VirtualMachineProfile mockVirtualMachineProfile(VirtualMachine.State state) {
+        final VirtualMachine vm = mock(VirtualMachine.class);
+        when(vm.getId()).thenReturn(VM_ID);
+        when(vm.getType()).thenReturn(VirtualMachine.Type.User);
+        when(vm.getState()).thenReturn(state);
+
+        final VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
+        when(vmProfile.getType()).thenReturn(VirtualMachine.Type.User);
+        when(vmProfile.getInstanceName()).thenReturn("Test-VM");
+        when(vmProfile.getUuid()).thenReturn(VM_UUID);
+        when(vmProfile.getVirtualMachine()).thenReturn(vm);
+        return vmProfile;
+    }
+
+    @Nonnull
+    private VirtualMachineProfile mockVRProfile(VirtualMachine.State state) {
+        final VirtualMachine vm = mock(VirtualMachine.class);
+        when(vm.getId()).thenReturn(VM_ID);
+        when(vm.getUuid()).thenReturn(VM_UUID);
+        when(vm.getType()).thenReturn(VirtualMachine.Type.DomainRouter);
+        when(vm.getState()).thenReturn(state);
+
+
+        final VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
+        when(vmProfile.getType()).thenReturn(VirtualMachine.Type.DomainRouter);
+        when(vmProfile.getInstanceName()).thenReturn("Test-VR");
+        when(vmProfile.getId()).thenReturn(VM_ID);
+        when(vmProfile.getUuid()).thenReturn(VM_UUID);
+        when(vmProfile.getVirtualMachine()).thenReturn(vm);
+        when(vmProfile.isRollingRestart()).thenReturn(true);
+        return vmProfile;
+    }
+
+    @Nonnull
+    private NicProfile mockNicProfile() {
+        final NicVO nicvo = mock(NicVO.class);
+        when(nicvo.getId()).thenReturn(NIC_ID);
+        when(nicvo.getMacAddress()).thenReturn("c8:60:00:56:e5:58");
+        when(nicvo.getIPv4Address()).thenReturn("10.10.10.10");
+        when(nicvo.getUuid()).thenReturn("aaaa-fffff");
+        when(nicvo.getNetworkId()).thenReturn(NETWORK_ID);
+        when(nicvo.getInstanceId()).thenReturn(VM_ID);
+        when(_nicDao.findById(NIC_ID)).thenReturn(nicvo);
+        when(_nicDao.findDefaultNicForVM(VM_ID)).thenReturn(nicvo);
+
+        NicProfile nicProfile = mock(NicProfile.class);
+        when(nicProfile.getUuid()).thenReturn("aaa-bbbb");
+        when(nicProfile.getId()).thenReturn(NIC_ID);
+        when(nicProfile.getMacAddress()).thenReturn("c8:60:00:56:e5:58");
+        when(nicProfile.getIPv4Address()).thenReturn("10.10.10.10");
+        return nicProfile;
+    }
+
+    @Nonnull
+    private static ReservationContext getMockReservationContext(Account networksAccount, Domain networksDomain) {
+        final ReservationContext reservationContext = mock(ReservationContext.class);
+        when(reservationContext.getAccount()).thenReturn(networksAccount);
+        when(reservationContext.getDomain()).thenReturn(networksDomain);
+        return reservationContext;
     }
 
 }

--- a/server/src/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VirtualRouterElement.java
@@ -216,6 +216,10 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
         final Map<VirtualMachineProfile.Param, Object> params = new HashMap<VirtualMachineProfile.Param, Object>(1);
         params.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, true);
 
+        if (network.isRollingRestart()) {
+            params.put(VirtualMachineProfile.Param.RollingRestart, true);
+        }
+
         final RouterDeploymentDefinition routerDeploymentDefinition =
                 routerDeploymentDefinitionBuilder.create()
                 .setGuestNetwork(network)

--- a/server/src/com/cloud/network/element/VpcVirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VpcVirtualRouterElement.java
@@ -153,6 +153,10 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
         final Map<VirtualMachineProfile.Param, Object> params = new HashMap<VirtualMachineProfile.Param, Object>(1);
         params.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, true);
 
+        if (vpc.isRollingRestart()) {
+            params.put(VirtualMachineProfile.Param.RollingRestart, true);
+        }
+
         final RouterDeploymentDefinition routerDeploymentDefinition = routerDeploymentDefinitionBuilder.create().setVpc(vpc).setDeployDestination(dest)
                 .setAccountOwner(_accountMgr.getAccount(vpc.getAccountId())).setParams(params).build();
 
@@ -193,6 +197,10 @@ public class VpcVirtualRouterElement extends VirtualRouterElement implements Vpc
 
         final Map<VirtualMachineProfile.Param, Object> params = new HashMap<VirtualMachineProfile.Param, Object>(1);
         params.put(VirtualMachineProfile.Param.ReProgramGuestNetworks, true);
+
+        if (network.isRollingRestart()) {
+            params.put(VirtualMachineProfile.Param.RollingRestart, true);
+        }
 
         final RouterDeploymentDefinition routerDeploymentDefinition = routerDeploymentDefinitionBuilder.create()
                 .setGuestNetwork(network)

--- a/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vpc_network.py
@@ -20,7 +20,7 @@ Nuage VSP SDN plugin
 """
 # Import Local Modules
 from nuageTestCase import nuageTestCase
-from marvin.lib.base import Account
+from marvin.lib.base import Account, VPC
 # Import System Modules
 from nose.plugins.attrib import attr
 
@@ -117,6 +117,12 @@ class TestNuageVpcNetwork(nuageTestCase):
 
         # VSD verification for ACL item
         self.verify_vsd_firewall_rule(acl_item)
+
+        self.restart_Vpc(vpc, cleanup=True)
+
+        self.validate_Network(vpc_network, state="Implemented")
+        vr = self.get_Router(vpc_network)
+        self.verify_vsd_router(vr)
 
     @attr(
         tags=["advanced", "nuagevsp", "multizone"], required_hardware="false")

--- a/test/integration/plugins/nuagevsp/test_nuage_vsp.py
+++ b/test/integration/plugins/nuagevsp/test_nuage_vsp.py
@@ -19,7 +19,7 @@
 """
 # Import Local Modules
 from nuageTestCase import nuageTestCase
-from marvin.lib.base import Account, Nuage
+from marvin.lib.base import Account, Nuage, Network
 from marvin.cloudstackAPI import deleteNuageVspDevice
 # Import System Modules
 from nose.plugins.attrib import attr
@@ -158,7 +158,7 @@ class TestNuageVsp(nuageTestCase):
                        "Physical Network...")
             self.validate_NuageVspDevice()
 
-    @attr(tags=["advanced", "nuagevsp"], required_hardware="false")
+    @attr(tags=["advanced", "nuagevsp", "isolated"], required_hardware="false")
     def test_nuage_vsp(self):
         """ Test Nuage VSP SDN plugin with basic Isolated Network functionality
         """
@@ -222,6 +222,12 @@ class TestNuageVsp(nuageTestCase):
 
             # VSD verification
             self.verify_vsd_vm(vm_2)
+
+            Network.restart(network, self.api_client, cleanup=True)
+
+            self.validate_Network(network, state="Implemented")
+            vr = self.get_Router(network)
+            self.verify_vsd_router(vr)
 
             # Deleting the network
             self.debug("Deleting the Isolated Network with Nuage VSP Isolated "


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changes in PR #2508 have caused network restart to fail in a Nuage setup,
as the new VR takes the same IP as the old one, and the old VR is still running.
Nuage doesn't support multiple VM's having the same IP.
We delay provisioning the interfaces in VSD until the old VR interface is released.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [x] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

