### PR TITLE
Source NAT option on Private Gateway

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -937,12 +937,9 @@ class CsForwardingRules(CsDataBag):
         self.fw.append(["filter", "",
                         "-A FORWARD -i %s -o eth0  -d %s  -m state  --state NEW -j ACCEPT " % (device, rule["internal_ip"])])
 
-        # Configure the hairpin nat
-        self.fw.append(["nat", "front",
-                        "-A PREROUTING -d %s -i eth0 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])
-
-        self.fw.append(["nat", "front", "-A POSTROUTING -s %s -d %s -j SNAT -o eth0 --to-source %s" %
-                        (self.getNetworkByIp(rule['internal_ip']), rule["internal_ip"], self.getGuestIp())])
+        # Configure the hairpin snat
+        self.fw.append(["nat", "front", "-A POSTROUTING -s %s -d %s -j SNAT -o %s --to-source %s" %
+                        (self.getNetworkByIp(rule['internal_ip']), rule["internal_ip"], self.getDeviceByIp(rule["internal_ip"]), self.getGuestIp())])
 
 
 class IpTablesExecutor:

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -476,9 +476,10 @@ class CsIP:
             self.fw.append(["", "front", "-A NETWORK_STATS_%s -o %s -s %s" %
                             ("eth1", "eth1", guestNetworkCidr)])
 
-            self.fw.append(["nat", "front",
-                            "-A POSTROUTING -s %s -o %s -j SNAT --to-source %s" %
-                            (guestNetworkCidr, self.dev, self.address['public_ip'])])
+            if self.address["source_nat"]:
+                self.fw.append(["nat", "front",
+                                "-A POSTROUTING -o %s -j SNAT --to-source %s" %
+                                (self.dev, self.address['public_ip'])])
 
         if self.get_type() in ["public"]:
             self.fw.append(


### PR DESCRIPTION
Using Source NAT option on Private Gateway does not work
This fixes #2680 

## Description
<!--- Describe your changes in detail -->
When you use the Source NAT feature of Private Gateways on a VPC.  This should Source NAT all traffic from CloudStack VMs going towards IPs reachable through Private Gateways.

This change in this PR, stops adding the Source CIDR to SNAT rules.  This should be discussed/reviewed, but i can see no reason why the Source CIDR is needed.  There can only be one SNAT IP per interface, except for Static (one-to-one) NATs, which still work with this change in place.  The outbound interface is what matters in the rule.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
##### SUMMARY
<!-- Explain the problem/feature briefly -->
There is a bug in the Private Gateway functionality, when Source NAT is enabled for the Private Gateway.  When the SNAT is added to iptables, it has the source CIDR of the private gateway subnet.  Since no VMs live in that private gateway subnet, the SNAT doesn’t work.  

##### STEPS TO REPRODUCE
<!--
For bugs, show exactly how to reproduce the problem, using a minimal test-case. Use Screenshots if accurate.

For new features, show how the feature would be used.
-->

<!-- Paste example playbooks or commands between quotes below -->
Below is an example:

- VMs have IP addresses in the 10.0.0.0/24 subnet.
- The Private Gateway address is 10.101.141.2/30
 
In the outputs below, the SOURCE field for the new SNAT (eth3) only matches if the source is 10.101.141.0/30.  Since the VM has an IP address in 10.0.0.0/24, the VMs don’t get SNAT’d as they should when talking across the private gateway.  The SOURCE should be set to ANYWHERE.
##### BEFORE ADDING PRIVATE GATEWAY
~~~
Chain POSTROUTING (policy ACCEPT 1 packets, 52 bytes)
pkts bytes target     prot opt in     out     source               destination
    2   736 SNAT       all  --  any    eth2    10.0.0.0/24          anywhere             to:10.0.0.1
   16  1039 SNAT       all  --  any    eth1    anywhere             anywhere             to:46.99.52.18
~~~

<!-- You can also paste gist.github.com links for larger files -->

##### EXPECTED RESULTS
<!-- What did you expect to happen when running the steps above? -->

~~~
Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
pkts bytes target     prot opt in     out     source               destination
    0     0 SNAT       all  --  any    eth3    anywhere             anywhere             to:10.101.141.2
    2   736 SNAT       all  --  any    eth2    anywhere             anywhere             to:10.0.0.1
   23  1515 SNAT       all  --  any    eth1    anywhere             anywhere             to:46.99.52.18
~~~

##### ACTUAL RESULTS
<!-- What actually happened? -->

<!-- Paste verbatim command output between quotes below -->
~~~
Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
pkts bytes target     prot opt in     out     source               destination
    0     0 SNAT       all  --  any    eth3    10.101.141.0/30      anywhere             to:10.101.141.2
    2   736 SNAT       all  --  any    eth2    10.0.0.0/24          anywhere             to:10.0.0.1
   23  1515 SNAT       all  --  any    eth1    anywhere             anywhere             to:46.99.52.18
~~~
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

Fixes: #2680 

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

