### PR TITLE
Do not send conserve mode param on L2 network offering creation from the UI

### DIFF
--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
@@ -286,7 +286,7 @@ public class ConfigDriveBuilder {
         if (!NetworkModel.METATDATA_DIR.equals(dataType)) {
             return;
         }
-        if (StringUtils.isNotBlank(content)) {
+        if (StringUtils.isEmpty(content)) {
             return;
         }
         //keys are a special case in OpenStack format

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -2412,14 +2412,17 @@
                                             if ($useVpcCb.is(':checked')) { //if useVpc is checked,
                                                 $useVpcCb.removeAttr("checked"); //remove "checked" attribute in useVpc
                                             }
+                                            $conservemode.css('display', 'inline-block');
                                         } else if ($guestTypeField.val() == 'Isolated') { //Isolated network offering
                                             $useVpc.css('display', 'inline-block');
                                             $supportedServices.css('display', 'inline-block');
                                             $userDataL2.hide();
+                                            $conservemode.css('display', 'inline-block');
                                         } else if ($guestTypeField.val() == 'L2') {
                                             $useVpc.hide();
                                             $supportedServices.hide();
                                             $userDataL2.css('display', 'inline-block');
+                                            $conservemode.hide();
                                         }
                                         var $providers = $useVpcCb.closest('form').find('.dynamic-input select[name!="service.Connectivity.provider"]');
                                         var $optionsOfProviders = $providers.find('option');
@@ -3403,6 +3406,9 @@
                                     } else {
                                         delete inputData.serviceProviderList;
                                     }
+
+                                    //Conserve mode is irrelevant on L2 network offerings as there are no resources to conserve, do not pass it, true by default on server side
+                                    delete inputData.conservemode;
                                 }
 
                                 if (inputData['forvpc'] == 'on') {
@@ -3411,10 +3417,12 @@
                                     delete inputData.forvpc; //if forVpc checkbox is unchecked, do not pass forVpc parameter to API call since we need to keep API call's size as small as possible (p.s. forVpc is defaulted as false at server-side)
                                 }
 
-                                if (inputData['conservemode'] == 'on') {
-                                    delete inputData.conservemode; //if ConserveMode checkbox is checked, do not pass conservemode parameter to API call since we need to keep API call's size as small as possible (p.s. conservemode is defaulted as true at server-side)
-                                } else {
-                                    inputData['conservemode'] = false;
+                                if (inputData['guestIpType'] == "Shared" || inputData['guestIpType'] == "Isolated") {
+                                    if (inputData['conservemode'] == 'on') {
+                                        delete inputData.conservemode; //if ConserveMode checkbox is checked, do not pass conservemode parameter to API call since we need to keep API call's size as small as possible (p.s. conservemode is defaulted as true at server-side)
+                                    } else {
+                                        inputData['conservemode'] = false;
+                                    }
                                 }
 
                                 // Make service provider map


### PR DESCRIPTION
## Description
Prevent creation of L2 network offerings with conserve mode = false. As conserve mode is irrelevant for L2 networks as there are no resources to conserve, we do not send the Conserve mode parameter to network offering creation, as it will be True by default. Conserve mode = false caused that L2 network offerings in a zone were not listed, as described in the issue below.

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
This fixes the issue #2690 

## Screenshots (if appropriate):
No Conserve mode checkbox when L2 is selected:
![image](https://user-images.githubusercontent.com/5295080/41046413-bc2cd1ee-6980-11e8-991f-8cb3e665b7bb.png)
List zone L2 network offerings:
![image](https://user-images.githubusercontent.com/5295080/41046566-08ab2f16-6981-11e8-9ddc-b224a1294b2e.png)

## How Has This Been Tested?
Create an L2 network offering (check that Conserve mode checkbox is not visible). Check that conserve mode is true for the created offering

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

