### PR TITLE
ui: fix create VPC dialog box failure when zone is SG enabled

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -5199,10 +5199,13 @@
                                                         }
                                                     };
 
-                                                    nuageDomainTemplateHandler(null, advZones[0].id);
-                                                    args.$select.bind('click', nuageDomainTemplateHandler); //bind on both events click, change, change event of dropdown.
-                                                    args.$select.bind('change', nuageDomainTemplateHandler);
-                                                    args.$form.find("[rel=nuageusedomaintemplate]").find("input").attr('checked', false);
+                                                    if (advZones && advZones.length > 0) {
+                                                        nuageDomainTemplateHandler(null, advZones[0].id);
+                                                        args.$select.bind('click', nuageDomainTemplateHandler); //bind on both events click, change, change event of dropdown.
+                                                        args.$select.bind('change', nuageDomainTemplateHandler);
+                                                        args.$form.find("[rel=nuageusedomaintemplate]").find("input").attr('checked', false);
+                                                    }
+
                                                     args.response.success({
                                                         data: $.map(advZones, function(zone) {
                                                             return {


### PR DESCRIPTION
This fixes a case where at least the create VPC dialog/form is shown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

Fixes https://github.com/apache/cloudstack/issues/2698

<!-- Fixes: # -->

## Screenshots (if appropriate):

Before the fix, the create VPC form does not show up. After the fix, the following is seen:
![screenshot from 2018-06-08 14-52-45](https://user-images.githubusercontent.com/95203/41150484-b739a7c8-6b2b-11e8-9825-c4c6ad823c53.png)

Note: SG + Adv zone does not allow VPC (at least from what I saw/found today).

## How Has This Been Tested?

Deployed a KVM+SG zone and tried the fix with clicking on create VPC button. This shows up the form.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

