### PR TITLE
check volumes for state when retrieving pool for configDrive creation

### DIFF
--- a/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.cloud.storage.StoragePool;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
@@ -30,6 +31,8 @@ import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
 import org.apache.cloudstack.storage.configdrive.ConfigDrive;
 import org.apache.cloudstack.storage.configdrive.ConfigDriveBuilder;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
@@ -56,7 +59,6 @@ import com.cloud.offering.NetworkOffering;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage;
-import com.cloud.storage.StoragePool;
 import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.GuestOSCategoryDao;
@@ -322,25 +324,76 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
     private DataStore findDataStore(VirtualMachineProfile profile, DeployDestination dest) {
         DataStore dataStore = null;
         if (VirtualMachineManager.VmConfigDriveOnPrimaryPool.value()) {
-            if (dest.getStorageForDisks() != null) {
-                for (final Volume volume : dest.getStorageForDisks().keySet()) {
-                    if (volume.getVolumeType() == Volume.Type.ROOT) {
-                        final StoragePool primaryPool = dest.getStorageForDisks().get(volume);
-                        dataStore = _dataStoreMgr.getDataStore(primaryPool.getId(), DataStoreRole.Primary);
-                        break;
-                    }
-                }
+            if(MapUtils.isNotEmpty(dest.getStorageForDisks())) {
+                dataStore = getPlannedDataStore(dest, dataStore);
             }
             if (dataStore == null) {
-                final List<VolumeVO> volumes = _volumeDao.findByInstanceAndType(profile.getVirtualMachine().getId(), Volume.Type.ROOT);
-                if (volumes != null && volumes.size() > 0) {
-                    dataStore = _dataStoreMgr.getDataStore(volumes.get(0).getPoolId(), DataStoreRole.Primary);
-                }
+                dataStore = savelyPickExistingRootVolumeDataStore(profile, dataStore);
             }
         } else {
             dataStore = _dataStoreMgr.getImageStore(dest.getDataCenter().getId());
         }
         return dataStore;
+    }
+
+    private DataStore getPlannedDataStore(DeployDestination dest, DataStore dataStore) {
+        for (final Volume volume : dest.getStorageForDisks().keySet()) {
+            if (volume.getVolumeType() == Volume.Type.ROOT) {
+                final StoragePool primaryPool = dest.getStorageForDisks().get(volume);
+                dataStore = _dataStoreMgr.getDataStore(primaryPool.getId(), DataStoreRole.Primary);
+                break;
+            }
+        }
+        return dataStore;
+    }
+
+    private DataStore savelyPickExistingRootVolumeDataStore(VirtualMachineProfile profile, DataStore dataStore) {
+        final List<VolumeVO> volumes = _volumeDao.findByInstanceAndType(profile.getVirtualMachine().getId(), Volume.Type.ROOT);
+        if (CollectionUtils.isNotEmpty(volumes)) {
+            dataStore = pickDataStoreFromVolumes(volumes);
+        }
+        return dataStore;
+    }
+
+    private DataStore pickDataStoreFromVolumes(List<VolumeVO> volumes) {
+        DataStore dataStore = null;
+        for (Volume vol : volumes) {
+            if (doesVolumeStateCheckout(vol)) {
+                dataStore = _dataStoreMgr.getDataStore(vol.getPoolId(), DataStoreRole.Primary);
+                if (dataStore != null) {
+                    return dataStore;
+                }
+            }
+        }
+        return dataStore;
+    }
+
+    private boolean doesVolumeStateCheckout(Volume vol) {
+        switch (vol.getState()) {
+        case Allocated:
+        case Creating:
+        case Ready:
+        case Snapshotting:
+        case RevertSnapshotting:
+        case Resizing:
+        case Copying:
+        case Attaching:
+            return true;
+        case Migrating:
+        case Expunging:
+        case Expunged:
+        case Destroy:
+        case Destroying:
+        case UploadOp:
+        case Uploaded:
+        case NotUploaded:
+        case UploadInProgress:
+        case UploadError:
+        case UploadAbandoned:
+            return false;
+        default:
+            throw new IllegalArgumentException("volume has a state that does not compute: " +vol.getState());
+        }
     }
 
     private Long findAgentIdForImageStore(final DataStore dataStore) throws ResourceUnavailableException {

--- a/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -328,7 +328,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
                 dataStore = getPlannedDataStore(dest, dataStore);
             }
             if (dataStore == null) {
-                dataStore = savelyPickExistingRootVolumeDataStore(profile, dataStore);
+                dataStore = pickExistingRootVolumeFromDataStore(profile, dataStore);
             }
         } else {
             dataStore = _dataStoreMgr.getImageStore(dest.getDataCenter().getId());
@@ -347,7 +347,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         return dataStore;
     }
 
-    private DataStore savelyPickExistingRootVolumeDataStore(VirtualMachineProfile profile, DataStore dataStore) {
+    private DataStore pickExistingRootVolumeFromDataStore(VirtualMachineProfile profile, DataStore dataStore) {
         final List<VolumeVO> volumes = _volumeDao.findByInstanceAndType(profile.getVirtualMachine().getId(), Volume.Type.ROOT);
         if (CollectionUtils.isNotEmpty(volumes)) {
             dataStore = pickDataStoreFromVolumes(volumes);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When querying for a storage pool to create a config drive on, only pools for those volumes that have the right state should be considered.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

