### PR TITLE
reuse ip for non redundant VPC

### DIFF
--- a/test/integration/smoke/test_privategw_acl.py
+++ b/test/integration/smoke/test_privategw_acl.py
@@ -720,7 +720,7 @@ class TestPrivateGwACL(cloudstackTestCase):
         succeeded_pings = 0
         minimum_vms_to_pass = 2
         for vm_ip in vms_ips:
-            ssh_command = "ping -c 5 %s" % vm_ip
+            ssh_command = "ping -c 10 %s" % vm_ip
 
             # Should be able to SSH VM
             packet_loss = 100

--- a/test/integration/smoke/test_vpc_redundant.py
+++ b/test/integration/smoke/test_vpc_redundant.py
@@ -692,7 +692,7 @@ class TestVPCRedundancy(cloudstackTestCase):
     def do_default_routes_test(self):
         for o in self.networks:
             for vmObj in o.get_vms():
-                ssh_command = "ping -c 3 8.8.8.8"
+                ssh_command = "ping -c 10 8.8.8.8"
 
                 # Should be able to SSH VM
                 packet_loss = 100

--- a/test/integration/smoke/test_vpc_router_nics.py
+++ b/test/integration/smoke/test_vpc_router_nics.py
@@ -451,7 +451,7 @@ class TestVPCNics(cloudstackTestCase):
     def do_default_routes_test(self):
         for o in self.networks:
             for vmObj in o.get_vms():
-                ssh_command = "ping -c 5 8.8.8.8"
+                ssh_command = "ping -c 10 8.8.8.8"
 
                 # Should be able to SSH VM
                 packet_loss = 100


### PR DESCRIPTION
 As rolling restart does not deallocate an IP before configuring it on a new VR,
 the code must allow it to be reused on a non-redundant VPCs gateway nic.

## Description
<!--- Describe your changes in detail -->

removed the condition to only look for reuse of IP on redundant VPCs

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

