### PR TITLE
configdrive: make fewer mountpoints on hosts

### DIFF
--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDrive.java
@@ -19,7 +19,6 @@ package org.apache.cloudstack.storage.configdrive;
 
 public class ConfigDrive {
 
-    public final static String CONFIGDRIVEFILENAME = "configdrive.iso";
     public final static String CONFIGDRIVEDIR = "configdrive";
 
     public static final String cloudStackConfigDriveName = "/cloudstack/";
@@ -27,11 +26,20 @@ public class ConfigDrive {
 
     /**
      * Creates the path to ISO file relative to mount point.
-     * The config driver path will have the following formated: {@link #CONFIGDRIVEDIR} + / + instanceName + / + {@link #CONFIGDRIVEFILENAME}
+     * The config driver path will have the following format: {@link #CONFIGDRIVEDIR} + / + instanceName + ".iso"
      *
      * @return config drive ISO file path
      */
     public static String createConfigDrivePath(String instanceName) {
-        return ConfigDrive.CONFIGDRIVEDIR + "/" + instanceName + "/"  + ConfigDrive.CONFIGDRIVEFILENAME;
+        return ConfigDrive.CONFIGDRIVEDIR + "/" + configIsoFileName(instanceName);
+    }
+
+    /**
+     * Config Drive iso file name for an instance name
+     * @param instanceName
+     * @return
+     */
+    public static String configIsoFileName(String instanceName) {
+        return instanceName + ".iso";
     }
 }

--- a/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
+++ b/engine/storage/configdrive/src/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
@@ -79,6 +79,11 @@ public class ConfigDriveBuilder {
     public static File base64StringToFile(String encodedIsoData, String folder, String fileName) throws IOException {
         byte[] decoded = Base64.decodeBase64(encodedIsoData.getBytes(StandardCharsets.US_ASCII));
         Path destPath = Paths.get(folder, fileName);
+        try {
+            Files.createDirectories(destPath.getParent());
+        } catch (final IOException e) {
+            LOG.warn("Exception hit while trying to recreate directory: " + destPath.getParent().toString());
+        }
         return Files.write(destPath, decoded).toFile();
     }
 

--- a/engine/storage/configdrive/test/org/apache/cloudstack/storage/configdrive/ConfigDriveTest.java
+++ b/engine/storage/configdrive/test/org/apache/cloudstack/storage/configdrive/ConfigDriveTest.java
@@ -26,7 +26,7 @@ public class ConfigDriveTest {
 
     @Test
     public void testConfigDriveIsoPath() throws IOException {
-        Assert.assertEquals(ConfigDrive.createConfigDrivePath("i-x-y"), "configdrive/i-x-y/configdrive.iso");
+        Assert.assertEquals(ConfigDrive.createConfigDrivePath("i-x-y"), "configdrive/i-x-y.iso");
     }
 
 }

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtHandleConfigDriveCommandWrapper.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.cloudstack.storage.configdrive.ConfigDriveBuilder;
-import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.Answer;
@@ -67,7 +66,7 @@ public final class LibvirtHandleConfigDriveCommandWrapper extends CommandWrapper
             }
         } else {
             try {
-                FileUtils.deleteDirectory(isoPath.getParent().toFile());
+                Files.deleteIfExists(isoPath);
             } catch (IOException e) {
                 LOG.warn("Failed to delete config drive: " + isoPath.toAbsolutePath().toString());
                 return new Answer(command, false, "Failed due to exception: " + e.getMessage());

--- a/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -375,8 +375,9 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
         LOG.debug("Creating config drive ISO for vm: " + profile.getInstanceName());
 
+        final String isoFileName = ConfigDrive.configIsoFileName(profile.getInstanceName());
         final String isoPath = ConfigDrive.createConfigDrivePath(profile.getInstanceName());
-        final String isoData = ConfigDriveBuilder.buildConfigDrive(profile.getVmData(), ConfigDrive.CONFIGDRIVEFILENAME, profile.getConfigDriveLabel());
+        final String isoData = ConfigDriveBuilder.buildConfigDrive(profile.getVmData(), isoFileName, profile.getConfigDriveLabel());
         final HandleConfigDriveIsoCommand configDriveIsoCommand = new HandleConfigDriveIsoCommand(isoPath, isoData, dataStore.getTO(), true);
 
         final Answer answer = agentManager.easySend(agentId, configDriveIsoCommand);

--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -42,6 +42,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -337,7 +338,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             Path tempDir = null;
             try {
                 tempDir = java.nio.file.Files.createTempDirectory(ConfigDrive.CONFIGDRIVEDIR);
-                File tmpIsoFile = ConfigDriveBuilder.base64StringToFile(cmd.getIsoData(), tempDir.toAbsolutePath().toString(), ConfigDrive.CONFIGDRIVEFILENAME);
+                File tmpIsoFile = ConfigDriveBuilder.base64StringToFile(cmd.getIsoData(), tempDir.toAbsolutePath().toString(), cmd.getIsoFile());
                 copyLocalToNfs(tmpIsoFile, new File(cmd.getIsoFile()), cmd.getDestStore());
             } catch (IOException | ConfigurationException e) {
                 return new Answer(cmd, false, "Failed due to exception: " + e.getMessage());
@@ -355,11 +356,11 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             DataStoreTO dstore = cmd.getDestStore();
             if (dstore instanceof NfsTO) {
                 NfsTO nfs = (NfsTO) dstore;
-                String relativeTemplatePath = new File(cmd.getIsoFile()).getParent();
+                String relativeTemplatePath = new File(cmd.getIsoFile()).getPath();
                 String nfsMountPoint = getRootDir(nfs.getUrl(), _nfsVersion);
                 File tmpltPath = new File(nfsMountPoint, relativeTemplatePath);
                 try {
-                    FileUtils.deleteDirectory(tmpltPath);
+                    Files.deleteIfExists(tmpltPath.toPath());
                 } catch (IOException e) {
                     return new Answer(cmd, e);
                 }


### PR DESCRIPTION
In the current implementation, for any config drive on a VM it creates a mount point specific to the parent directory `i-x-y-VM` on a host. This means, for each config drive enabled VM there will be a separate mount point per VM per host. The legacy code that points ISOs mounts based on the isopath's parent directory, to workaround this the config drive layout has been changed to: `<sr or mount point>/configdrive/i-x-y-VM.iso`.

This ensures that fewer mount points are made on hosts for either primary storagepools or secondary storagepools.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

Created a L2 config drive enabled network, then deployed a VM to see config drive created and attached and then stopped VM to see config drive iso removed. Also confirmed that only one mount point is made specific to the configdrive directory. Performed the same test again with the config drive feature enabled on primary storage.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

@blueorangutan package