### PR TITLE
Add End Time To Async Job API

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -548,6 +548,7 @@ public class ApiConstants {
     public static final String IPSEC_PSK = "ipsecpsk";
     public static final String GUEST_IP = "guestip";
     public static final String REMOVED = "removed";
+    public static final String END_TIME = "endtime";
     public static final String IKE_POLICY = "ikepolicy";
     public static final String ESP_POLICY = "esppolicy";
     public static final String IKE_LIFETIME = "ikelifetime";

--- a/api/src/main/java/org/apache/cloudstack/api/response/AsyncJobResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/AsyncJobResponse.java
@@ -75,6 +75,10 @@ public class AsyncJobResponse extends BaseResponse {
     @Param(description = "  the created date of the job")
     private Date created;
 
+    @SerializedName(ApiConstants.END_TIME)
+    @Param(description = "  the removed date of the job")
+    private Date removed;
+
     public void setAccountId(String accountId) {
         this.accountId = accountId;
     }
@@ -118,5 +122,9 @@ public class AsyncJobResponse extends BaseResponse {
 
     public void setCreated(Date created) {
         this.created = created;
+    }
+
+    public void setRemoved(final Date removed) {
+        this.removed = removed;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/jobs/JobInfo.java
+++ b/api/src/main/java/org/apache/cloudstack/jobs/JobInfo.java
@@ -68,6 +68,8 @@ public interface JobInfo extends Identity, InternalIdentity {
 
     Date getCreated();
 
+    Date getRemoved();
+
     Date getLastUpdated();
 
     Date getLastPolled();

--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/dao/AsyncJobDaoImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/dao/AsyncJobDaoImpl.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.cloudstack.api.ApiConstants;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.framework.jobs.impl.AsyncJobVO;
@@ -71,7 +72,7 @@ public class AsyncJobDaoImpl extends GenericDaoBase<AsyncJobVO, Long> implements
         expiringUnfinishedAsyncJobSearch.done();
 
         expiringCompletedAsyncJobSearch = createSearchBuilder();
-        expiringCompletedAsyncJobSearch.and("created", expiringCompletedAsyncJobSearch.entity().getCreated(), SearchCriteria.Op.LTEQ);
+        expiringCompletedAsyncJobSearch.and(ApiConstants.REMOVED, expiringCompletedAsyncJobSearch.entity().getRemoved(), SearchCriteria.Op.LTEQ);
         expiringCompletedAsyncJobSearch.and("completeMsId", expiringCompletedAsyncJobSearch.entity().getCompleteMsid(), SearchCriteria.Op.NNULL);
         expiringCompletedAsyncJobSearch.and("jobStatus", expiringCompletedAsyncJobSearch.entity().getStatus(), SearchCriteria.Op.NEQ);
         expiringCompletedAsyncJobSearch.done();
@@ -168,11 +169,11 @@ public class AsyncJobDaoImpl extends GenericDaoBase<AsyncJobVO, Long> implements
     }
 
     @Override
-    public List<AsyncJobVO> getExpiredCompletedJobs(Date cutTime, int limit) {
-        SearchCriteria<AsyncJobVO> sc = expiringCompletedAsyncJobSearch.create();
-        sc.setParameters("created", cutTime);
+    public List<AsyncJobVO> getExpiredCompletedJobs(final Date cutTime, final int limit) {
+        final SearchCriteria<AsyncJobVO> sc = expiringCompletedAsyncJobSearch.create();
+        sc.setParameters(ApiConstants.REMOVED, cutTime);
         sc.setParameters("jobStatus", JobInfo.Status.IN_PROGRESS);
-        Filter filter = new Filter(AsyncJobVO.class, "created", true, 0L, (long)limit);
+        final Filter filter = new Filter(AsyncJobVO.class, ApiConstants.REMOVED, true, 0L, (long)limit);
         return listIncludingRemovedBy(sc, filter);
     }
 

--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -286,9 +286,9 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Wake up jobs related to job-" + jobId);
         }
-        List<Long> wakeupList = Transaction.execute(new TransactionCallback<List<Long>>() {
+        final List<Long> wakeupList = Transaction.execute(new TransactionCallback<List<Long>>() {
             @Override
-            public List<Long> doInTransaction(TransactionStatus status) {
+            public List<Long> doInTransaction(final TransactionStatus status) {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Update db status for job-" + jobId);
                 }
@@ -302,14 +302,16 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                     job.setResult(null);
                 }
 
-                job.setLastUpdated(DateUtil.currentGMTTime());
+                final Date currentGMTTime = DateUtil.currentGMTTime();
+                job.setLastUpdated(currentGMTTime);
+                job.setRemoved(currentGMTTime);
                 job.setExecutingMsid(null);
                 _jobDao.update(jobId, job);
 
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Wake up jobs joined with job-" + jobId + " and disjoin all subjobs created from job- " + jobId);
                 }
-                List<Long> wakeupList = wakeupByJoinedJobCompletion(jobId);
+                final List<Long> wakeupList = wakeupByJoinedJobCompletion(jobId);
                 _joinMapDao.disjoinAllJobs(jobId);
 
                 // purge the job sync item from queue
@@ -445,8 +447,8 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
     }
 
     @Override
-    public AsyncJob queryJob(long jobId, boolean updatePollTime) {
-        AsyncJobVO job = _jobDao.findById(jobId);
+    public AsyncJob queryJob(final long jobId, final boolean updatePollTime) {
+        final AsyncJobVO job = _jobDao.findByIdIncludingRemoved(jobId);
 
         if (updatePollTime) {
             job.setLastPolled(DateUtil.currentGMTTime());
@@ -1025,8 +1027,8 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                     // purge sync queue item running on this ms node
                     _queueMgr.cleanupActiveQueueItems(msid, true);
                     // reset job status for all jobs running on this ms node
-                    List<AsyncJobVO> jobs = _jobDao.getResetJobs(msid);
-                    for (AsyncJobVO job : jobs) {
+                    final List<AsyncJobVO> jobs = _jobDao.getResetJobs(msid);
+                    for (final AsyncJobVO job : jobs) {
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("Cancel left-over job-" + job.getId());
                         }
@@ -1034,6 +1036,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                         job.setResultCode(ApiErrorCode.INTERNAL_ERROR.getHttpCode());
                         job.setResult("job cancelled because of management server restart or shutdown");
                         job.setCompleteMsid(msid);
+                        job.setRemoved(DateUtil.currentGMTTime());
                         _jobDao.update(job.getId(), job);
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("Purge queue item for cancelled job-" + job.getId());
@@ -1049,8 +1052,8 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                             }
                         }
                     }
-                    List<SnapshotDetailsVO> snapshotList = _snapshotDetailsDao.findDetails(AsyncJob.Constants.MS_ID, Long.toString(msid), false);
-                    for (SnapshotDetailsVO snapshotDetailsVO : snapshotList) {
+                    final List<SnapshotDetailsVO> snapshotList = _snapshotDetailsDao.findDetails(AsyncJob.Constants.MS_ID, Long.toString(msid), false);
+                    for (final SnapshotDetailsVO snapshotDetailsVO : snapshotList) {
                         SnapshotInfo snapshot = snapshotFactory.getSnapshot(snapshotDetailsVO.getResourceId(), DataStoreRole.Primary);
                         snapshotSrv.processEventOnSnapshotObject(snapshot, Snapshot.Event.OperationFailed);
                         _snapshotDetailsDao.removeDetail(snapshotDetailsVO.getResourceId(), AsyncJob.Constants.MS_ID);

--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobVO.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobVO.java
@@ -373,6 +373,15 @@ public class AsyncJobVO implements AsyncJob, JobInfo {
     }
 
     @Override
+    public Date getRemoved() {
+        return removed;
+    }
+
+    public void setRemoved(final Date removed) {
+        this.removed = removed;
+    }
+
+    @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
         sb.append("AsyncJobVO {id:").append(getId());
@@ -392,6 +401,7 @@ public class AsyncJobVO implements AsyncJob, JobInfo {
         sb.append(", lastUpdated: ").append(getLastUpdated());
         sb.append(", lastPolled: ").append(getLastPolled());
         sb.append(", created: ").append(getCreated());
+        sb.append(", removed: ").append(getRemoved());
         sb.append("}");
         return sb.toString();
     }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1808,16 +1808,16 @@ public class ApiResponseHelper implements ResponseGenerator {
     }
 
     @Override
-    public AsyncJobResponse queryJobResult(QueryAsyncJobResultCmd cmd) {
-        Account caller = CallContext.current().getCallingAccount();
+    public AsyncJobResponse queryJobResult(final QueryAsyncJobResultCmd cmd) {
+        final Account caller = CallContext.current().getCallingAccount();
 
-        AsyncJob job = _entityMgr.findById(AsyncJob.class, cmd.getId());
+        final AsyncJob job = _entityMgr.findByIdIncludingRemoved(AsyncJob.class, cmd.getId());
         if (job == null) {
             throw new InvalidParameterValueException("Unable to find a job by id " + cmd.getId());
         }
 
-        User userJobOwner = _accountMgr.getUserIncludingRemoved(job.getUserId());
-        Account jobOwner = _accountMgr.getAccount(userJobOwner.getAccountId());
+        final User userJobOwner = _accountMgr.getUserIncludingRemoved(job.getUserId());
+        final Account jobOwner = _accountMgr.getAccount(userJobOwner.getAccountId());
 
         //check permissions
         if (_accountMgr.isNormalUser(caller.getId())) {

--- a/server/src/main/java/com/cloud/api/query/dao/AsyncJobJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/AsyncJobJoinDaoImpl.java
@@ -50,12 +50,13 @@ public class AsyncJobJoinDaoImpl extends GenericDaoBase<AsyncJobJoinVO, Long> im
     }
 
     @Override
-    public AsyncJobResponse newAsyncJobResponse(AsyncJobJoinVO job) {
-        AsyncJobResponse jobResponse = new AsyncJobResponse();
+    public AsyncJobResponse newAsyncJobResponse(final AsyncJobJoinVO job) {
+        final AsyncJobResponse jobResponse = new AsyncJobResponse();
         jobResponse.setAccountId(job.getAccountUuid());
         jobResponse.setUserId(job.getUserUuid());
         jobResponse.setCmd(job.getCmd());
         jobResponse.setCreated(job.getCreated());
+        jobResponse.setRemoved(job.getRemoved());
         jobResponse.setJobId(job.getUuid());
         jobResponse.setJobStatus(job.getStatus());
         jobResponse.setJobProcStatus(job.getProcessStatus());
@@ -68,15 +69,15 @@ public class AsyncJobJoinDaoImpl extends GenericDaoBase<AsyncJobJoinVO, Long> im
         }
         jobResponse.setJobResultCode(job.getResultCode());
 
-        boolean savedValue = SerializationContext.current().getUuidTranslation();
+        final boolean savedValue = SerializationContext.current().getUuidTranslation();
         SerializationContext.current().setUuidTranslation(false);
 
-        Object resultObject = ApiSerializerHelper.fromSerializedString(job.getResult());
+        final Object resultObject = ApiSerializerHelper.fromSerializedString(job.getResult());
         jobResponse.setJobResult((ResponseObject)resultObject);
         SerializationContext.current().setUuidTranslation(savedValue);
 
         if (resultObject != null) {
-            Class<?> clz = resultObject.getClass();
+            final Class<?> clz = resultObject.getClass();
             if (clz.isPrimitive() || clz.getSuperclass() == Number.class || clz == String.class || clz == Date.class) {
                 jobResponse.setJobResultType("text");
             } else {

--- a/server/src/test/java/com/cloud/storage/dao/AsyncJobJoinDaoTest.java
+++ b/server/src/test/java/com/cloud/storage/dao/AsyncJobJoinDaoTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.cloud.storage.dao;
 
 import com.cloud.api.query.dao.AsyncJobJoinDaoImpl;
@@ -23,7 +41,6 @@ public class AsyncJobJoinDaoTest {
 
     @Test
     public void testNewAsyncJobResponseValidValues() {
-
         final AsyncJobJoinVO job = new AsyncJobJoinVO();
         ReflectionTestUtils.setField(job,"uuid","a2b22932-1b61-4406-8e89-4ae19968e8d3");
         ReflectionTestUtils.setField(job,"accountUuid","4dea2836-72cc-11e8-b2de-107b4429825a");

--- a/server/src/test/java/com/cloud/storage/dao/AsyncJobJoinDaoTest.java
+++ b/server/src/test/java/com/cloud/storage/dao/AsyncJobJoinDaoTest.java
@@ -1,0 +1,74 @@
+package com.cloud.storage.dao;
+
+import com.cloud.api.query.dao.AsyncJobJoinDaoImpl;
+import com.cloud.api.query.vo.AsyncJobJoinVO;
+import org.apache.cloudstack.api.ApiCommandJobType;
+import org.apache.cloudstack.api.response.AsyncJobResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.inject.Inject;
+import java.util.Date;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "classpath:/AsyncJobJoinDaoTestContext.xml")
+public class AsyncJobJoinDaoTest {
+
+    @Inject
+    AsyncJobJoinDaoImpl dao;
+
+    @Test
+    public void testNewAsyncJobResponseValidValues() {
+
+        final AsyncJobJoinVO job = new AsyncJobJoinVO();
+        ReflectionTestUtils.setField(job,"uuid","a2b22932-1b61-4406-8e89-4ae19968e8d3");
+        ReflectionTestUtils.setField(job,"accountUuid","4dea2836-72cc-11e8-b2de-107b4429825a");
+        ReflectionTestUtils.setField(job,"domainUuid","4dea136b-72cc-11e8-b2de-107b4429825a");
+        ReflectionTestUtils.setField(job,"userUuid","4decc724-72cc-11e8-b2de-107b4429825a");
+        ReflectionTestUtils.setField(job,"cmd","org.apache.cloudstack.api.command.admin.vm.StartVMCmdByAdmin");
+        ReflectionTestUtils.setField(job,"status",0);
+        ReflectionTestUtils.setField(job,"resultCode",0);
+        ReflectionTestUtils.setField(job,"result",null);
+        ReflectionTestUtils.setField(job,"created",new Date());
+        ReflectionTestUtils.setField(job,"removed",new Date());
+        ReflectionTestUtils.setField(job,"instanceType",ApiCommandJobType.VirtualMachine);
+        ReflectionTestUtils.setField(job,"instanceId",3L);
+        final AsyncJobResponse response = dao.newAsyncJobResponse(job);
+        Assert.assertEquals(job.getUuid(),response.getJobId());
+        Assert.assertEquals(job.getAccountUuid(), ReflectionTestUtils.getField(response, "accountId"));
+        Assert.assertEquals(job.getUserUuid(), ReflectionTestUtils.getField(response, "userId"));
+        Assert.assertEquals(job.getCmd(), ReflectionTestUtils.getField(response, "cmd"));
+        Assert.assertEquals(job.getStatus(), ReflectionTestUtils.getField(response, "jobStatus"));
+        Assert.assertEquals(job.getStatus(), ReflectionTestUtils.getField(response, "jobProcStatus"));
+        Assert.assertEquals(job.getResultCode(), ReflectionTestUtils.getField(response, "jobResultCode"));
+        Assert.assertEquals(null, ReflectionTestUtils.getField(response, "jobResultType"));
+        Assert.assertEquals(job.getResult(), ReflectionTestUtils.getField(response, "jobResult"));
+        Assert.assertEquals(job.getInstanceType().toString(), ReflectionTestUtils.getField(response, "jobInstanceType"));
+        Assert.assertEquals(job.getInstanceUuid(), ReflectionTestUtils.getField(response, "jobInstanceId"));
+        Assert.assertEquals(job.getCreated(), ReflectionTestUtils.getField(response, "created"));
+        Assert.assertEquals(job.getRemoved(), ReflectionTestUtils.getField(response, "removed"));
+    }
+
+    @Test
+    public void testNewAsyncJobResponseNullValues() {
+        final AsyncJobJoinVO job = new AsyncJobJoinVO();
+        final AsyncJobResponse response = dao.newAsyncJobResponse(job);
+        Assert.assertEquals(job.getUuid(),response.getJobId());
+        Assert.assertEquals(job.getAccountUuid(), ReflectionTestUtils.getField(response, "accountId"));
+        Assert.assertEquals(job.getUserUuid(), ReflectionTestUtils.getField(response, "userId"));
+        Assert.assertEquals(job.getCmd(), ReflectionTestUtils.getField(response, "cmd"));
+        Assert.assertEquals(job.getStatus(), ReflectionTestUtils.getField(response, "jobStatus"));
+        Assert.assertEquals(job.getStatus(), ReflectionTestUtils.getField(response, "jobProcStatus"));
+        Assert.assertEquals(job.getResultCode(), ReflectionTestUtils.getField(response, "jobResultCode"));
+        Assert.assertEquals(null, ReflectionTestUtils.getField(response, "jobResultType"));
+        Assert.assertEquals(job.getResult(), ReflectionTestUtils.getField(response, "jobResult"));
+        Assert.assertEquals(job.getInstanceType(), ReflectionTestUtils.getField(response, "jobInstanceType"));
+        Assert.assertEquals(job.getInstanceUuid(), ReflectionTestUtils.getField(response, "jobInstanceId"));
+        Assert.assertEquals(job.getCreated(), ReflectionTestUtils.getField(response, "created"));
+        Assert.assertEquals(job.getRemoved(), ReflectionTestUtils.getField(response, "removed"));
+    }
+}

--- a/server/src/test/resources/AsyncJobJoinDaoTestContext.xml
+++ b/server/src/test/resources/AsyncJobJoinDaoTestContext.xml
@@ -1,0 +1,19 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  you under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/context
+                      http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:annotation-config />
+    <bean id="asyncJobJoinDaoImpl" class="com.cloud.api.query.dao.AsyncJobJoinDaoImpl" />
+</beans>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Overview:
CloudStack has the concept of executing certain API calls asynchronously when they take a long period of time to complete. They will immediately return a job id of the job that will be responsible for executing the command. This job id can be used to query the status of the job by using the queryAsyncJobResult application programming interface (API) call.
Among other fields, the result of this API query returns the 'created' field, which is the timestamp of when an asynchronous job started. There is currently no functional mechanism that captures or persists the end time of when the job has finished. As a result, the above "queryAsyncJobResult" API does not return an 'end_time' field.
QueryAsyncJobResult API changes:
The requirement outlined here is for Cloudstack to capture the job end timestamp of when the asynchronous job has finished and to populate this into the existing database field called 'removed' in the async_job table. Please note the 'removed' field is not currently being used anywhere else in the CloudStack code, and the 'removed' database column is also not currently being populated by any other processes. A new response tag should be added to the queryAsyncJobResult API called 'end_time'. When making a queryAsyncJobResult API request, the value of the database column 'removed' should be mapped to this 'end_time' response tag. The queryAsyncJobResult API field should be called 'end_time' instead of 'removed' because it will be more descriptive to an API user.
Management server process changes:
When an asynchronous job completes it is marked as complete by updating its finished status in the database. New functionality should be added to also update the 'removed' field with the timestamp of when an asynchronous job has completed.
In addition, when the Cloudstack management server is stopped and started again (gracefully or ungracefully), neither this management server nor other running management servers have any knowledge of the true status of the asynchronous jobs that completed during this time it was down. Their statuses are not tracked or updated in the database by any management server during this time, regardless of whether they are still running, finished successfully or finished with an error status. Currently, there is no mechanism to notify other running management servers that a specific management server is stopping or to notify a specific running management server that it should start to monitor/track the currently running asynchronous jobs belonging to the management server being stopped. When a Cloudstack management server starts up, it does not do a blanket delete of the asynchronous jobs it is the owner of. Instead, it finds in the database all the asynchronous jobs it is the owner of, whose statuses are in an 'in_progress' state and updates them to a 'failed' status. At the same time, it should now also mark them as 'removed' by updating the 'removed' field with the current timestamp.
Garbage collection:
CloudStack also has a garbage collector that does database clean-up of asynchronous jobs, whereby it periodically deletes unfinished and completed job records from the async_job database table. It uses the configurable global setting 'job.cancel.threshold.minutes' to cancel jobs that are still in the queue. It also uses a configurable global setting 'job.expire.minutes' that allows a user to specify how long in minutes to keep asynchronous jobs that have not been processed yet, as well as completed asynchronous job records in the database before deleting them. Unfinished jobs that haven't been processed yet and that are older than this expiry time will be expired and deleted by the garbage collector.
Asynchronous jobs that have completed before the timeout threshold will also be deleted. When these jobs complete they are marked as complete by updating their finished status in the database. Currently, the garbage collector uses the 'created' database column to find completed asynchronous job records that are older than the 'job.expire.minutes' global setting's timestamp. It should no longer use the 'created' column to do this. It should use the 'removed' column instead.
Due to the nature of the garbage collector, any reporting that needs to be done on asynchronous jobs, should be done before the garbage collector starts its cleaning up task.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
*  Start a virtual machine to initiate an asynchronous job. Query the cloud.async_job table to find the record that was created in response to the 'start virtual machine' job. When the job finishes, verify that the 'removed' column has been correctly updated with the end timestamp of the relevant record.
* Using cloudmonkey, make an API call to queryAsyncJobResult using the uuid as the jobid and verify that the 'endtime' field returns the correct timestamp value of the relevant database record's 'removed' column.
* Verify that the garbage collector deletes the correct expired asynchronous job records from the cloud.async_job table.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

