### PR TITLE
CLOUDSTACK-10310 Fix KVM reboot on storage issue

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/KVMHABase.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/KVMHABase.java
@@ -34,7 +34,8 @@ public class KVMHABase {
     protected static String s_heartBeatPath;
     protected long _heartBeatUpdateTimeout = 60000;
     protected long _heartBeatUpdateFreq = 60000;
-    protected long _heartBeatUpdateMaxRetry = 3;
+    protected long _heartBeatUpdateMaxTries = 5;
+    protected long _heartBeatUpdateRetrySleep = 15000;
 
     public static enum PoolType {
         PrimaryStorage, SecondaryStorage

--- a/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
+++ b/scripts/vm/hypervisor/kvm/kvmheartbeat.sh
@@ -155,10 +155,10 @@ then
   exit 0
 elif [ "$cflag" == "1" ]
 then
-  /usr/bin/logger -t heartbeat "kvmheartbeat.sh rebooted system because it was unable to write the heartbeat to the storage."
+  /usr/bin/logger -t heartbeat "kvmheartbeat.sh stopped cloudstack-agent because it was unable to write the heartbeat to the storage."
   sync &
   sleep 5
-  echo b > /proc/sysrq-trigger
+  service cloudstack-agent stop
   exit $?
 else
   write_hbLog 


### PR DESCRIPTION
Rebase of #2472 onto 4.11

If the KVM heartbeat file can't be written to, the host is rebooted, and thus taking down all VMs running on it. The code does try 5x times before the reboot, but the there is not a delay between the retires, so they are 5 simultaneous retries, which doesn't help. Standard SAN storage HA operations or quick network blip could cause this reboot to occur.

Some discussions on the dev mailing list revealed that some people are just commenting out the reboot line in their version of the CloudStack source.

A better option would be have it sleep between tries so it isn't 5x almost simultaneous tries. Plus, instead of rebooting, the cloudstack-agent could just be stopped on the host instead. This will cause alerts to be issued and if the host is disconnected long-enough, depending on the HA code in use, VM HA could handle the host failure.

The built-in reboot of the host seemed drastic