### PR TITLE
security_group: Use execute() function instead of non-existing bash()

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -61,7 +61,7 @@ def execute(cmd):
     try:
         return check_output(cmd, shell=True)
     except CalledProcessError as e:
-        logging.exception('Failed to execute: %s', e.cmd)
+        pass
 
 
 def can_bridge_firewall(privnic):
@@ -1151,8 +1151,8 @@ def getvmId(vmName):
 
 def getBrfw(brname):
     cmd = "iptables-save |grep physdev-is-bridged |grep FORWARD |grep BF |grep '\-o' | grep -w " + brname  + "|awk '{print $9}' | head -1"
-    brfwname = bash("-c", cmd).stdout.strip()
-    if brfwname == "":
+    brfwname = execute(cmd).strip()
+    if not brfwname:
         brfwname = "BF-" + brname
     return brfwname
 


### PR DESCRIPTION
In 6233a77d15adde86302a11b2bcda604313833e91 as a part of PR #2432 the
bash() function was replaced by the execute() function.

Somehow this last calling of the bash() function was not caught by testing
and is still in there.

This causes Exceptions to be thrown by the Security Group script.

Signed-off-by: Wido den Hollander <wido@widodh.nl>