### PR TITLE
Fix failing test cases and proper resource cleanup

### DIFF
--- a/test/integration/smoke/test_deploy_virtio_scsi_vm.py
+++ b/test/integration/smoke/test_deploy_virtio_scsi_vm.py
@@ -25,34 +25,29 @@ from marvin.cloudstackTestCase import cloudstackTestCase
 # base - contains all resources as entities and defines create, delete,
 # list operations on them
 from marvin.lib.base import (Account,
-                            VirtualMachine,
-                            ServiceOffering,
-                            NetworkOffering,
-                            Network,
-                            Template,
-                            DiskOffering,
-                            StoragePool,
-                            Volume,
-                            Host,
-                            GuestOs)
-
-
+                             VirtualMachine,
+                             ServiceOffering,
+                             Template,
+                             DiskOffering,
+                             Volume,
+                             Host,
+                             GuestOs)
 
 # utils - utility classes for common cleanup, external library wrappers etc
 from marvin.lib.utils import cleanup_resources, get_hypervisor_type, validateList
 
 # common - commonly used methods for all tests are listed here
-from marvin.lib.common import get_zone, get_domain, get_template, list_hosts, get_pod
+from marvin.lib.common import get_zone, get_domain, get_pod
 
 from marvin.sshClient import SshClient
 
-from marvin.codes import FAILED, PASS
+from marvin.codes import FAILED
 
 from nose.plugins.attrib import attr
 
 import xml.etree.ElementTree as ET
-import code
 import logging
+
 
 class Templates:
     """Test data for templates
@@ -75,11 +70,12 @@ class Templates:
             }
         }
 
-class TestDeployVirtioSCSIVM(cloudstackTestCase):
 
+class TestDeployVirtioSCSIVM(cloudstackTestCase):
     """
     Test deploy a kvm virtio scsi template
     """
+
     @classmethod
     def setUpClass(cls):
         cls.logger = logging.getLogger('TestDeployVirtioSCSIVM')
@@ -91,7 +87,8 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
         cls.apiclient = testClient.getApiClient()
         cls.services = cls.testClient.getParsedTestDataConfig()
 
-        cls.hostConfig = cls.config.__dict__["zones"][0].__dict__["pods"][0].__dict__["clusters"][0].__dict__["hosts"][0].__dict__
+        cls.hostConfig = cls.config.__dict__["zones"][0].__dict__["pods"][0].__dict__["clusters"][0].__dict__["hosts"][
+            0].__dict__
         cls.hypervisorNotSupported = False
         cls.hypervisor = testClient.getHypervisorInfo()
 
@@ -100,7 +97,6 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.pod = get_pod(cls.apiclient, cls.zone.id)
         cls.services['mode'] = cls.zone.networktype
-        cls._cleanup = []
         if cls.hypervisor.lower() not in ['kvm']:
             cls.hypervisorNotSupported = True
             return
@@ -153,24 +149,32 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
 
         cls.vmhost = hosts[0]
 
-
+        # Stop VM to reset password
+        cls.virtual_machine.stop(cls.apiclient)
 
         password = cls.virtual_machine.resetPassword(cls.apiclient)
         cls.virtual_machine.username = "ubuntu"
         cls.virtual_machine.password = password
-        cls._cleanup = [
+
+        # Start VM after password reset
+        cls.virtual_machine.start(cls.apiclient)
+
+        cls.cleanup = [
             cls.template,
             cls.service_offering,
             cls.sparse_disk_offering,
             cls.account
         ]
 
-
     @classmethod
     def tearDownClass(cls):
         try:
+            cls.apiclient = super(
+                TestDeployVirtioSCSIVM,
+                cls
+            ).getClsTestClient().getApiClient()
             # Cleanup resources used
-            cleanup_resources(cls.apiclient, cls._cleanup)
+            cleanup_resources(cls.apiclient, cls.cleanup)
         except Exception as e:
             raise Exception("Warning: Exception during cleanup : %s" % e)
         return
@@ -178,16 +182,6 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
     def setUp(self):
         self.apiclient = self.testClient.getApiClient()
         self.dbclient = self.testClient.getDbConnection()
-        self.cleanup = []
-        return
-
-    def tearDown(self):
-        try:
-            # Clean up, terminate the created instance, volumes and snapshots
-            cleanup_resources(self.apiclient, self.cleanup)
-        except Exception as e:
-            raise Exception("Warning: Exception during cleanup : %s" % e)
-        return
 
     def verifyVirshState(self, diskcount):
         host = self.vmhost.ipaddress
@@ -212,14 +206,14 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
             for child in disk:
                 if child.tag.lower() == "target":
                     dev = child.get("dev")
-                    self.assert_(dev != None and dev.startswith("sd"), "disk dev is invalid")
+                    self.assert_(dev is not None and dev.startswith("sd"), "disk dev is invalid")
                 elif child.tag.lower() == "address":
                     con = child.get("controller")
                     self.assertEqual(con, scsiindex, "disk controller not equal to SCSI " \
-                                     "controller index")
+                                                     "controller index")
                 elif child.tag.lower() == "driver":
                     discard = child.get("discard")
-                    if discard: # may not be defined by older qemu/libvirt
+                    if discard:  # may not be defined by older qemu/libvirt
                         self.assertEqual(discard, "unmap", "discard settings not unmap")
 
     def verifyGuestState(self, diskcount):
@@ -234,21 +228,21 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
                          "Could not find appropriate number of scsi disks in guest")
 
     def getVirshXML(self, host, instancename):
-        if host == None:
+        if host is None:
             self.logger.debug("getVirshXML: host is none")
             return ""
         else:
             self.logger.debug("host is: " + host)
-        if instancename == None:
+        if instancename is None:
             self.logger.debug("getVirshXML: instancename is none")
             return ""
         else:
             self.logger.debug("instancename is: " + instancename)
         sshc = SshClient(
-                host=host,
-                port=self.services['configurableData']['host']["publicport"],
-                user=self.hostConfig['username'],
-                passwd=self.hostConfig['password'])
+            host=host,
+            port=self.services['configurableData']['host']["publicport"],
+            user=self.hostConfig['username'],
+            passwd=self.hostConfig['password'])
 
         ssh = sshc.ssh
 
@@ -354,9 +348,8 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
         self.assertIsNotNone(ostypeid,
                              "Could not find ostypeid for Ubuntu 16.0.4 (64-bit) mapped to kvm")
 
-
         self.virtual_machine.update(self.apiclient, ostypeid=ostypeid,
-                                    details=[{"rootDiskController":"scsi"}])
+                                    details=[{"rootDiskController": "scsi"}])
 
         self.virtual_machine.start(self.apiclient)
 
@@ -370,6 +363,7 @@ class TestDeployVirtioSCSIVM(cloudstackTestCase):
             self.skipTest("Hypervisor not supported")
 
         self.verifyGuestState(3)
+
 
 class CommandNonzeroException(Exception):
     def __init__(self, code, stderr):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the Marvin test failures seen in master for KVM hosts. I found the issue to be caused by the resetVirtualMachinePassword API call in the setUpClass class method, the VM has to be stopped prior to executing this API call.
API Doc: http://cloudstack.apache.org/api/apidocs-4.11/apis/resetPasswordForVirtualMachine.html

I have added the Stop command before resetting the password and restart the VM afterward. I have found that resources were not being cleaned up after test execution and I have fixed that as well.

I also made some minor changes to make the file Pep 8 compliant.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?
Start the management server in my local development environment with KVM host and run the associated marvin test:

test/integration/smoke/test_deploy_virtio_scsi_vm.py

Dev environment components:
- Platform: ACS-4.12
- Management OS: Ubuntu 18.04 LTS
- Hypervisor: 1 Host running KVM with CentOS 7

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

