### PR TITLE
Changing to the right api call for securing hosts

### DIFF
--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -918,7 +918,7 @@ class TestSecuredVmMigration(cloudstackTestCase):
             cmd = provisionCertificate.provisionCertificateCmd()
             cmd.hostid = host.id
             cmd.reconnect = True
-            self.apiclient.updateConfiguration(cmd)
+            self.apiclient.provisionCertificate(cmd)
 
         for host in self.hosts:
             self.check_connection(secured='true', host=host)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fixes the tests for secure live migration, looks like they were pointing to the wrong api call. However during testing of this I've hit a new issue #2753 which is blocking the tests. 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## GitHub Issue/PRs
The tests will pass when #2753 is fixed, since they are using a parameter in the provisionCertificate api call which makes a NPE

<!-- Fixes: # -->

## Screenshots (if appropriate):
NA
## How Has This Been Tested?
Locally with a debugger, api call seem right but it hits the mentioned issue

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [x] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

