### PR TITLE
Fix migrate vol xen vmware test

### DIFF
--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -878,7 +878,7 @@ class TestVolumes(cloudstackTestCase):
         return response
 
 
-    @attr(tags=["boris", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags=["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
     def test_11_migrate_volume_and_change_offering(self):
 
     # Validates the following

--- a/test/integration/smoke/test_volumes.py
+++ b/test/integration/smoke/test_volumes.py
@@ -878,7 +878,7 @@ class TestVolumes(cloudstackTestCase):
         return response
 
 
-    @attr(tags=["advanced", "advancedns", "smoke", "basic"], required_hardware="true")
+    @attr(tags=["boris", "advancedns", "smoke", "basic"], required_hardware="true")
     def test_11_migrate_volume_and_change_offering(self):
 
     # Validates the following
@@ -929,11 +929,16 @@ class TestVolumes(cloudstackTestCase):
             StoragePool.update(self.apiclient, id=pool.id, tags="")
 
         self.debug("Migrating Volume-ID: %s to Pool: %s" % (volume.id, pool.id))
+        livemigrate = False
+        if self.virtual_machine.hypervisor.lower() == "vmware" or self.virtual_machine.hypervisor.lower() == 'xenserver':
+            livemigrate = True
+
         Volume.migrate(
             self.apiclient,
             volumeid = volume.id,
             storageid = pool.id,
-            newdiskofferingid = large_offering.id
+            newdiskofferingid = large_offering.id,
+            livemigrate = livemigrate
         )
         if self.virtual_machine.hypervisor == "KVM":
             self.virtual_machine.start(self.apiclient


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a livemigrate = True to vmware and xenserver test execution, since it was reported in the latest failures
`The volume Vol[254|vm=233|DATADISK]is attached to a vm and for migrating it the parameter livemigrate should be specified'`
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
NA
## How Has This Been Tested?
Trillian smoketests
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [x] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

