### PR TITLE
register template kvm context ui fix

### DIFF
--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -267,7 +267,7 @@
                                                     $form.find('.form-item[rel=keyboardType]').hide();
                                                     $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
                                                     $form.find('.form-item[rel=rootDiskControllerTypeKVM]').css('display', 'inline-block');
-                                                    $form.find('.form-item[rel=xenserverToolsVersion61plus]').css('display', 'inline-block');
+                                                    $('#label_root_disk_controller').prop('selectedIndex', 2);
                                                     if (isAdmin()) {
                                                       $form.find('.form-item[rel=directdownload]').css('display', 'inline-block');
                                                     }


### PR DESCRIPTION
## Description
On the 'Register Template From URL' screen, when a user selects the KVM option from the Hypervisor dropdown:
1) It incorrectly displays the 'Original XS Version is 6.1' checkbox. This checkbox should be hidden in the KVM context.
2) The 'Root Disk Controller' dropdown should display the default option of 'osdefault' instead of a blank default option.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Go to the 'Register Template From URL' screen by clicking the 'Templates' tab on the lefthand side.
On the 'Templates' screen click the 'Add' button to display the  the 'Register Template From URL' screen.
On the 'Register Template From URL' screen, select the KVM option from the Hypervisor dropdown:
1) It incorrectly displays the 'Original XS Version is 6.1' checkbox. This checkbox should be hidden in the KVM context.
2) The 'Root Disk Controller' dropdown should display the default option of 'osdefault' instead of a blank default option.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30108093/42943718-dc3397d4-8b63-11e8-8179-c630dc03bd19.png)

## How Has This Been Tested?
Manually. See the screenshot above.
<!-- Please describe in detail how you tested your changes. -->
Go to the 'Register Template From URL' screen by clicking the 'Templates' tab on the lefthand side.
On the 'Templates' screen click the 'Add' button to display the 'Register Template From URL' screen.
On the 'Register Template From URL' screen, select the KVM option from the Hypervisor dropdown:
1) It now correctly hides the 'Original XS Version is 6.1' checkbox. This checkbox is hidden in the KVM context.
2) The 'Root Disk Controller' dropdown now displays the default option of 'osdefault' instead of a blank default option.
CloudStack version 4.11, KVM hypervisor.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

