### PR TITLE
Add managed storage pool constraints to MigrateWithVolume API method

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2298,8 +2298,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     private List<Volume> findVolumesThatWereNotMappedByTheUser(VirtualMachineProfile profile, Map<Volume, StoragePool> volumeToStoragePoolObjectMap) {
         List<VolumeVO> allVolumes = _volsDao.findUsableVolumesForInstance(profile.getId());
         List<Volume> volumesNotMapped = new ArrayList<>();
-        for (Volume volume : volumeToStoragePoolObjectMap.keySet()) {
-            if (!allVolumes.contains(volume)) {
+        for (Volume volume : allVolumes) {
+            if (!volumeToStoragePoolObjectMap.containsKey(volume)) {
                 volumesNotMapped.add(volume);
             }
         }

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2320,7 +2320,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             StoragePoolVO targetPool = _storagePoolDao.findById(poolId);
             StoragePoolVO currentPool = _storagePoolDao.findById(volume.getPoolId());
 
-            executeManagedStorageChecksWhenTargetStoragePoolProvided(currentPool, volume, targetPool);
+            executeManagedStorageChecks(targetHost, currentPool, volume);
             if (_poolHostDao.findByPoolHost(targetPool.getId(), targetHost.getId()) == null) {
                 throw new CloudRuntimeException(
                         String.format("Cannot migrate the volume [%s] to the storage pool [%s] while migrating VM [%s] to target host [%s]. The host does not have access to the storage pool entered.",
@@ -2341,7 +2341,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         for (Volume volume : allVolumes) {
             StoragePoolVO currentPool = _storagePoolDao.findById(volume.getPoolId());
 
-            executeManagedStorageChecksWhenTargetStoragePoolNotProvided(targetHost, currentPool, volume);
+            executeManagedStorageChecks(targetHost, currentPool, volume);
             if (ScopeType.HOST.equals(currentPool.getScope()) || isStorageCrossClusterMigration(targetHost, currentPool)) {
                 createVolumeToStoragePoolMappingIfPossible(profile, targetHost, volumeToPoolObjectMap, volume, currentPool);
             } else {
@@ -2357,27 +2357,18 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
      *      <li> Cross cluster migration with cluster-wide storage pool. Volumes in managed storage cannot be migrated out of their current pool. Therefore, an exception is thrown.
      *  </ul>
      */
-    protected void executeManagedStorageChecksWhenTargetStoragePoolProvided(StoragePoolVO currentPool, Volume volume, StoragePoolVO targetPool) {
-        if (!currentPool.isManaged()) {
-            return;
-        }
-        if (currentPool.getId() == targetPool.getId()) {
-            return;
-        }
-        throw new CloudRuntimeException(String.format("Currently, a volume on managed storage can only be 'migrated' to itself " + "[volumeId=%s, currentStoragePoolId=%s, targetStoragePoolId=%s].",
-                volume.getUuid(), currentPool.getUuid(), targetPool.getUuid()));
-    }
-
-    protected void executeManagedStorageChecksWhenTargetStoragePoolNotProvided(Host targetHost, StoragePoolVO currentPool, Volume volume) {
+    protected void executeManagedStorageChecks(Host targetHost, StoragePoolVO currentPool, Volume volume) {
         if (!currentPool.isManaged()) {
             return;
         }
         if (ScopeType.ZONE.equals(currentPool.getScope())) {
             return;
         }
-        throw new CloudRuntimeException(
-                String.format("Currently, you can only 'migrate' a volume on managed storage if its storage pool is zone wide " + "[volumeId=%s, storageId=%s, targetHostId=%s].", volume.getUuid(),
-                        currentPool.getUuid(), targetHost.getUuid()));
+        if (currentPool.getClusterId() == targetHost.getClusterId()) {
+            return;
+        }
+        throw new CloudRuntimeException(String.format("Currently, a volume on managed storage can only be 'migrated' to itself " + "[volumeId=%s, currentStoragePoolId=%s, targetHostID=%s].",
+                volume.getUuid(), currentPool.getUuid(), targetHost.getUuid()));
     }
 
     /**

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2283,8 +2283,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
      * If the user did not enter a complete mapping, the volumes that were left behind will be auto mapped using {@link #createStoragePoolMappingsForVolumes(VirtualMachineProfile, Host, Map, List)}
      */
     protected Map<Volume, StoragePool> createMappingVolumeAndStoragePool(VirtualMachineProfile profile, Host targetHost, Map<Long, Long> userDefinedMapOfVolumesAndStoragePools) {
-        Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
-        buildMapUsingUserInformation(profile, targetHost, userDefinedMapOfVolumesAndStoragePools, volumeToPoolObjectMap);
+        Map<Volume, StoragePool> volumeToPoolObjectMap = buildMapUsingUserInformation(profile, targetHost, userDefinedMapOfVolumesAndStoragePools);
 
         List<Volume> volumesNotMapped = findVolumesThatWereNotMappedByTheUser(profile, volumeToPoolObjectMap);
         createStoragePoolMappingsForVolumes(profile, targetHost, volumeToPoolObjectMap, volumesNotMapped);
@@ -2309,9 +2308,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     /**
      *  Builds the map of storage pools and volumes with the information entered by the user. Before creating the an entry we validate if the migration is feasible checking if the migration is allowed and if the target host can access the defined target storage pool.
      */
-    private void buildMapUsingUserInformation(VirtualMachineProfile profile, Host targetHost, Map<Long, Long> userDefinedVolumeToStoragePoolMap, Map<Volume, StoragePool> volumeToPoolObjectMap) {
+    private Map<Volume, StoragePool> buildMapUsingUserInformation(VirtualMachineProfile profile, Host targetHost, Map<Long, Long> userDefinedVolumeToStoragePoolMap) {
+        Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
         if (MapUtils.isEmpty(userDefinedVolumeToStoragePoolMap)) {
-            return;
+            return volumeToPoolObjectMap;
         }
         for(Long volumeId: userDefinedVolumeToStoragePoolMap.keySet()) {
             VolumeVO volume = _volsDao.findById(volumeId);
@@ -2331,6 +2331,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             }
             volumeToPoolObjectMap.put(volume, targetPool);
         }
+        return volumeToPoolObjectMap;
     }
 
     /**

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2283,7 +2283,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
      * If the user did not enter a complete mapping, the volumes that were left behind will be auto mapped using {@link #createStoragePoolMappingsForVolumes(VirtualMachineProfile, Host, Map, List)}
      */
     protected Map<Volume, StoragePool> createMappingVolumeAndStoragePool(VirtualMachineProfile profile, Host targetHost, Map<Long, Long> userDefinedMapOfVolumesAndStoragePools) {
-        Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<Volume, StoragePool>();
+        Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
         buildMapUsingUserInformation(profile, targetHost, userDefinedMapOfVolumesAndStoragePools, volumeToPoolObjectMap);
 
         List<Volume> volumesNotMapped = findVolumesThatWereNotMappedByTheUser(profile, volumeToPoolObjectMap);
@@ -2334,20 +2334,6 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     }
 
     /**
-     * We create the default mapping of volumes and storage pools for the migration of the VM to the target host. We execute the following checks an operations according to some scenarios:
-     * <ul>
-     *  <li>If the current storage pool of one of the volumes is using local storage in the host, it then needs to be migrated to a local storage in the target host. Otherwise, we do not need to migrate, and the volume can be kept in its current storage pool.
-     *  <li>If the current storage pool cluster is different from the target host cluster, we need to migrate the volume to one storage pool at the target cluster where the target host resides on.
-     * </ul>
-     */
-    protected Map<Volume, StoragePool> getDefaultMappingOfVolumesAndStoragePoolForMigration(VirtualMachineProfile profile, Host targetHost) {
-        Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<Volume, StoragePool>();
-        List<VolumeVO> allVolumes = _volsDao.findUsableVolumesForInstance(profile.getId());
-        createStoragePoolMappingsForVolumes(profile, targetHost, volumeToPoolObjectMap, new ArrayList<>(allVolumes));
-        return volumeToPoolObjectMap;
-    }
-
-    /**
      * For each one of the volumes we will map it to a storage pool that is available via the target host.
      * An exception is thrown if we cannot find a storage pool that is accessible in the target host to migrate the volume to.
      */
@@ -2381,8 +2367,8 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         if (currentPool.getClusterId() == targetHost.getClusterId()) {
             return;
         }
-        throw new CloudRuntimeException(String.format("Currently, a volume on managed storage can only be 'migrated' to itself [volumeId=%s, storageId=%s, targetHostId=%s].", volume.getUuid(),
-                currentPool.getUuid(), targetHost.getUuid()));
+        throw new CloudRuntimeException(String.format("Currently, you can only 'migrate' a volume on managed storage if its storage pool is zone wide " +
+                "[volumeId=%s, storageId=%s, targetHostId=%s].", volume.getUuid(), currentPool.getUuid(), targetHost.getUuid()));
     }
 
     /**

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -191,54 +191,6 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test
-    public void executeManagedStorageChecksTestNonManagedStorage() {
-        Mockito.doReturn(false).when(storagePoolVoMock).isManaged();
-
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
-
-        Mockito.verify(storagePoolVoMock).isManaged();
-        Mockito.verify(storagePoolVoMock, Mockito.times(0)).getClusterId();
-        Mockito.verify(storagePoolVoMock, Mockito.times(0)).getScope();
-    }
-
-    @Test
-    public void executeManagedStorageChecksTestManagedStorageAndSameClusterAsTargetHost() {
-        Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
-        Mockito.doReturn(1L).when(hostMock).getClusterId();
-        Mockito.doReturn(1L).when(storagePoolVoMock).getClusterId();
-
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
-
-        Mockito.verify(storagePoolVoMock).isManaged();
-        Mockito.verify(storagePoolVoMock, Mockito.times(1)).getClusterId();
-        Mockito.verify(storagePoolVoMock, Mockito.times(1)).getScope();
-    }
-
-    @Test
-    public void executeManagedStorageChecksTestManagedStorageAndDifferentClusterAsTargetHostWithZoneWideStorage() {
-        Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
-        Mockito.doReturn(1L).when(hostMock).getClusterId();
-        Mockito.doReturn(2L).when(storagePoolVoMock).getClusterId();
-        Mockito.doReturn(ScopeType.ZONE).when(storagePoolVoMock).getScope();
-
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
-
-        Mockito.verify(storagePoolVoMock).isManaged();
-        Mockito.verify(storagePoolVoMock, Mockito.times(0)).getClusterId();
-        Mockito.verify(storagePoolVoMock, Mockito.times(1)).getScope();
-    }
-
-    @Test(expected = CloudRuntimeException.class)
-    public void executeManagedStorageChecksTestManagedStorageAndDifferentClusterAsTargetHostWithClusterWideStorage() {
-        Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
-        Mockito.doReturn(1L).when(hostMock).getClusterId();
-        Mockito.doReturn(2L).when(storagePoolVoMock).getClusterId();
-        Mockito.doReturn(ScopeType.CLUSTER).when(storagePoolVoMock).getScope();
-
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
-    }
-
-    @Test
     public void isStorageCrossClusterMigrationTestStorageTypeEqualsCluster() {
         Mockito.doReturn(1L).when(hostMock).getClusterId();
         Mockito.doReturn(2L).when(storagePoolVoMock).getClusterId();

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -191,10 +191,10 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test
-    public void executeManagedStorageChecksTestNonManagedStorage() {
+    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestNonManagedStorage() {
         Mockito.doReturn(false).when(storagePoolVoMock).isManaged();
 
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
 
         Mockito.verify(storagePoolVoMock).isManaged();
         Mockito.verify(storagePoolVoMock, Mockito.times(0)).getClusterId();
@@ -202,12 +202,12 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test
-    public void executeManagedStorageChecksTestManagedStorageAndSameClusterAsTargetHost() {
+    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestManagedStorageAndSameClusterAsTargetHost() {
         Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
         Mockito.doReturn(1L).when(hostMock).getClusterId();
         Mockito.doReturn(1L).when(storagePoolVoMock).getClusterId();
 
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
 
         Mockito.verify(storagePoolVoMock).isManaged();
         Mockito.verify(storagePoolVoMock, Mockito.times(1)).getClusterId();
@@ -215,13 +215,13 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test
-    public void executeManagedStorageChecksTestManagedStorageAndDifferentClusterAsTargetHostWithZoneWideStorage() {
+    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestManagedStorageAndDifferentClusterAsTargetHostWithZoneWideStorage() {
         Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
         Mockito.doReturn(1L).when(hostMock).getClusterId();
         Mockito.doReturn(2L).when(storagePoolVoMock).getClusterId();
         Mockito.doReturn(ScopeType.ZONE).when(storagePoolVoMock).getScope();
 
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
 
         Mockito.verify(storagePoolVoMock).isManaged();
         Mockito.verify(storagePoolVoMock, Mockito.times(0)).getClusterId();
@@ -229,13 +229,13 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test(expected = CloudRuntimeException.class)
-    public void executeManagedStorageChecksTestManagedStorageAndDifferentClusterAsTargetHostWithClusterWideStorage() {
+    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestManagedStorageAndDifferentClusterAsTargetHostWithClusterWideStorage() {
         Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
         Mockito.doReturn(1L).when(hostMock).getClusterId();
         Mockito.doReturn(2L).when(storagePoolVoMock).getClusterId();
         Mockito.doReturn(ScopeType.CLUSTER).when(storagePoolVoMock).getScope();
 
-        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
     }
 
     @Test

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -24,8 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
@@ -44,15 +42,12 @@ import com.cloud.agent.api.Command;
 import com.cloud.agent.api.StopAnswer;
 import com.cloud.agent.api.StopCommand;
 import com.cloud.deploy.DeploymentPlanner;
-import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.storage.ScopeType;
-import com.cloud.storage.StoragePool;
-import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.utils.exception.CloudRuntimeException;
@@ -275,32 +270,4 @@ public class VirtualMachineManagerImplTest {
 
         Assert.assertFalse(returnedValue);
     }
-
-    @Test
-    public void getDefaultMappingOfVolumesAndStoragePoolForMigrationTestSharedStorageMigratingToHostOfSameCluster() {
-        Mockito.doNothing().when(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfPossible(Mockito.any(VirtualMachineProfile.class), Mockito.any(Host.class),
-                Mockito.anyMapOf(Volume.class, StoragePool.class), Mockito.any(VolumeVO.class), Mockito.any(StoragePoolVO.class));
-
-        Mockito.doNothing().when(virtualMachineManagerImpl).executeManagedStorageChecks(Mockito.any(Host.class), Mockito.any(StoragePoolVO.class), Mockito.any(VolumeVO.class));
-        Mockito.doReturn(false).when(virtualMachineManagerImpl).isStorageCrossClusterMigration(Mockito.any(Host.class), Mockito.any(StoragePoolVO.class));
-
-        Mockito.doReturn(ScopeType.CLUSTER).when(storagePoolVoMock).getScope();
-
-        List<VolumeVO> listOfVolumesForVm = new ArrayList<>();
-        listOfVolumesForVm.add(volumeVoMock);
-
-        Mockito.doReturn(listOfVolumesForVm).when(volumeDaoMock).findUsableVolumesForInstance(vmInstanceVoMockId);
-        Mockito.doReturn(storagePoolVoMock).when(storagePoolDaoMock).findById(storagePoolVoMockId);
-
-        Map<Volume, StoragePool> defaultMappingOfVolumesAndStoragePoolForMigration = virtualMachineManagerImpl.getDefaultMappingOfVolumesAndStoragePoolForMigration(virtualMachineProfileMock,
-                hostMock);
-
-        Assert.assertEquals(1, defaultMappingOfVolumesAndStoragePoolForMigration.size());
-        Assert.assertEquals(defaultMappingOfVolumesAndStoragePoolForMigration.get(volumeVoMock), storagePoolVoMock);
-
-        Mockito.verify(virtualMachineManagerImpl).executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
-        Mockito.verify(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
-
-    }
 }
-

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -194,35 +193,6 @@ public class VirtualMachineManagerImplTest {
         when(serviceOfferingMock.getTags()).thenReturn("z,x,y");
 
         virtualMachineManagerImpl.checkIfCanUpgrade(vmInstanceMock, serviceOfferingMock);
-    }
-
-    @Test
-    public void getPoolListForVolumesForMigrationTestEmptyVolumeMap() {
-        Mockito.doReturn(new HashMap<>()).when(virtualMachineManagerImpl).getDefaultMappingOfVolumesAndStoragePoolForMigration(virtualMachineProfileMock, hostMock);
-        Mockito.doReturn(new HashMap<>()).when(virtualMachineManagerImpl).createMappingVolumeAndStoragePoolEnteredByUser(Mockito.eq(virtualMachineProfileMock), Mockito.eq(hostMock),
-                Mockito.anyMapOf(Long.class, Long.class));
-
-        virtualMachineManagerImpl.getPoolListForVolumesForMigration(virtualMachineProfileMock, hostMock, new HashMap<>());
-
-        Mockito.verify(virtualMachineManagerImpl, Mockito.times(1)).getDefaultMappingOfVolumesAndStoragePoolForMigration(virtualMachineProfileMock, hostMock);
-        Mockito.verify(virtualMachineManagerImpl, Mockito.times(0)).createMappingVolumeAndStoragePoolEnteredByUser(Mockito.eq(virtualMachineProfileMock), Mockito.eq(hostMock),
-                Mockito.anyMapOf(Long.class, Long.class));
-    }
-
-    @Test
-    public void getPoolListForVolumesForMigrationTestUserDefinedStoragePoolMigrationMap() {
-        Mockito.doReturn(new HashMap<>()).when(virtualMachineManagerImpl).getDefaultMappingOfVolumesAndStoragePoolForMigration(virtualMachineProfileMock, hostMock);
-        Mockito.doReturn(new HashMap<>()).when(virtualMachineManagerImpl).createMappingVolumeAndStoragePoolEnteredByUser(Mockito.eq(virtualMachineProfileMock), Mockito.eq(hostMock),
-                Mockito.anyMapOf(Long.class, Long.class));
-
-        HashMap<Long, Long> volumeToPool = new HashMap<>();
-        volumeToPool.put(1L, 1L);
-
-        virtualMachineManagerImpl.getPoolListForVolumesForMigration(virtualMachineProfileMock, hostMock, volumeToPool);
-
-        Mockito.verify(virtualMachineManagerImpl, Mockito.times(0)).getDefaultMappingOfVolumesAndStoragePoolForMigration(virtualMachineProfileMock, hostMock);
-        Mockito.verify(virtualMachineManagerImpl, Mockito.times(1)).createMappingVolumeAndStoragePoolEnteredByUser(Mockito.eq(virtualMachineProfileMock), Mockito.eq(hostMock),
-                Mockito.anyMapOf(Long.class, Long.class));
     }
 
     @Test

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -246,7 +246,7 @@ public class VirtualMachineManagerImplTest {
 
         Mockito.verify(storagePoolVoMock).isManaged();
         Mockito.verify(storagePoolVoMock, Mockito.times(1)).getClusterId();
-        Mockito.verify(storagePoolVoMock, Mockito.times(0)).getScope();
+        Mockito.verify(storagePoolVoMock, Mockito.times(1)).getScope();
     }
 
     @Test
@@ -259,7 +259,7 @@ public class VirtualMachineManagerImplTest {
         virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
 
         Mockito.verify(storagePoolVoMock).isManaged();
-        Mockito.verify(storagePoolVoMock, Mockito.times(1)).getClusterId();
+        Mockito.verify(storagePoolVoMock, Mockito.times(0)).getClusterId();
         Mockito.verify(storagePoolVoMock, Mockito.times(1)).getScope();
     }
 
@@ -308,7 +308,7 @@ public class VirtualMachineManagerImplTest {
 
     @Test
     public void getDefaultMappingOfVolumesAndStoragePoolForMigrationTestSharedStorageMigratingToHostOfSameCluster() {
-        Mockito.doNothing().when(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfNeeded(Mockito.any(VirtualMachineProfile.class), Mockito.any(Host.class),
+        Mockito.doNothing().when(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfPossible(Mockito.any(VirtualMachineProfile.class), Mockito.any(Host.class),
                 Mockito.anyMapOf(Volume.class, StoragePool.class), Mockito.any(VolumeVO.class), Mockito.any(StoragePoolVO.class));
 
         Mockito.doNothing().when(virtualMachineManagerImpl).executeManagedStorageChecks(Mockito.any(Host.class), Mockito.any(StoragePoolVO.class), Mockito.any(VolumeVO.class));

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -21,16 +21,22 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.apache.cloudstack.engine.subsystem.api.storage.StoragePoolAllocator;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -41,14 +47,22 @@ import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.StopAnswer;
 import com.cloud.agent.api.StopCommand;
+import com.cloud.deploy.DeploymentPlan;
 import com.cloud.deploy.DeploymentPlanner;
+import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.host.HostVO;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.hypervisor.HypervisorGuru;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
+import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.ScopeType;
+import com.cloud.storage.StoragePool;
+import com.cloud.storage.StoragePoolHostVO;
+import com.cloud.storage.Volume;
 import com.cloud.storage.VolumeVO;
+import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.StoragePoolHostDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.vm.VirtualMachine.State;
@@ -76,8 +90,11 @@ public class VirtualMachineManagerImplTest {
 
     @Mock
     private ServiceOfferingVO serviceOfferingMock;
+
+    private long hostMockId = 1L;
     @Mock
     private HostVO hostMock;
+
     @Mock
     private VirtualMachineProfile virtualMachineProfileMock;
     @Mock
@@ -89,6 +106,15 @@ public class VirtualMachineManagerImplTest {
     private VolumeVO volumeVoMock;
     private long volumeMockId = 1111L;
 
+    @Mock
+    private StoragePoolHostDao storagePoolHostDaoMock;
+
+    @Mock
+    private StoragePoolAllocator storagePoolAllocatorMock;
+
+    @Mock
+    private DiskOfferingDao diskOfferingDaoMock;
+
     @Before
     public void setup() {
         virtualMachineManagerImpl.setHostAllocators(new ArrayList<>());
@@ -98,7 +124,7 @@ public class VirtualMachineManagerImplTest {
         when(vmInstanceMock.getInstanceName()).thenReturn("myVm");
         when(vmInstanceMock.getHostId()).thenReturn(2L);
         when(vmInstanceMock.getType()).thenReturn(VirtualMachine.Type.User);
-        when(hostMock.getId()).thenReturn(1L);
+        when(hostMock.getId()).thenReturn(hostMockId);
 
         Mockito.doReturn(vmInstanceVoMockId).when(virtualMachineProfileMock).getId();
 
@@ -107,6 +133,13 @@ public class VirtualMachineManagerImplTest {
 
         Mockito.doReturn(volumeMockId).when(volumeVoMock).getId();
         Mockito.doReturn(storagePoolVoMockId).when(volumeVoMock).getPoolId();
+
+        Mockito.doReturn(volumeVoMock).when(volumeDaoMock).findById(volumeMockId);
+        Mockito.doReturn(storagePoolVoMock).when(storagePoolDaoMock).findById(storagePoolVoMockId);
+
+        ArrayList<StoragePoolAllocator> storagePoolAllocators = new ArrayList<>();
+        storagePoolAllocators.add(storagePoolAllocatorMock);
+        virtualMachineManagerImpl.setStoragePoolAllocators(storagePoolAllocators);
     }
 
     @Test(expected = CloudRuntimeException.class)
@@ -221,5 +254,337 @@ public class VirtualMachineManagerImplTest {
         boolean returnedValue = virtualMachineManagerImpl.isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
 
         Assert.assertFalse(returnedValue);
+    }
+
+    @Test
+    public void executeManagedStorageChecksWhenTargetStoragePoolProvidedTestCurrentStoragePoolNotManaged() {
+        Mockito.doReturn(false).when(storagePoolVoMock).isManaged();
+
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolProvided(storagePoolVoMock, volumeVoMock, Mockito.mock(StoragePoolVO.class));
+
+        Mockito.verify(storagePoolVoMock).isManaged();
+        Mockito.verify(storagePoolVoMock, Mockito.times(0)).getId();
+    }
+
+    @Test
+    public void executeManagedStorageChecksWhenTargetStoragePoolProvidedTestCurrentStoragePoolEqualsTargetPool() {
+        Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
+
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolProvided(storagePoolVoMock, volumeVoMock, storagePoolVoMock);
+
+        Mockito.verify(storagePoolVoMock).isManaged();
+        Mockito.verify(storagePoolVoMock, Mockito.times(2)).getId();
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void executeManagedStorageChecksWhenTargetStoragePoolProvidedTestCurrentStoragePoolNotEqualsTargetPool() {
+        Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
+
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolProvided(storagePoolVoMock, volumeVoMock, Mockito.mock(StoragePoolVO.class));
+    }
+
+    @Test
+    public void buildMapUsingUserInformationTestUserDefinedMigrationMapEmpty() {
+        HashMap<Long, Long> userDefinedVolumeToStoragePoolMap = Mockito.spy(new HashMap<>());
+
+        Map<Volume, StoragePool> volumeToPoolObjectMap = virtualMachineManagerImpl.buildMapUsingUserInformation(virtualMachineProfileMock, hostMock, userDefinedVolumeToStoragePoolMap);
+
+        Assert.assertTrue(volumeToPoolObjectMap.isEmpty());
+
+        Mockito.verify(userDefinedVolumeToStoragePoolMap, times(0)).keySet();
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void buildMapUsingUserInformationTestTargetHostDoesNotHaveAccessToPool() {
+        HashMap<Long, Long> userDefinedVolumeToStoragePoolMap = new HashMap<>();
+        userDefinedVolumeToStoragePoolMap.put(volumeMockId, storagePoolVoMockId);
+
+        Mockito.doNothing().when(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolProvided(Mockito.any(StoragePoolVO.class), Mockito.any(VolumeVO.class), Mockito.any(StoragePoolVO.class));
+        Mockito.doReturn(null).when(storagePoolHostDaoMock).findByPoolHost(storagePoolVoMockId, hostMockId);
+
+        virtualMachineManagerImpl.buildMapUsingUserInformation(virtualMachineProfileMock, hostMock, userDefinedVolumeToStoragePoolMap);
+
+    }
+
+    @Test
+    public void buildMapUsingUserInformationTestTargetHostHasAccessToPool() {
+        HashMap<Long, Long> userDefinedVolumeToStoragePoolMap = Mockito.spy(new HashMap<>());
+        userDefinedVolumeToStoragePoolMap.put(volumeMockId, storagePoolVoMockId);
+
+        Mockito.doNothing().when(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolProvided(Mockito.any(StoragePoolVO.class), Mockito.any(VolumeVO.class),
+                Mockito.any(StoragePoolVO.class));
+        Mockito.doReturn(Mockito.mock(StoragePoolHostVO.class)).when(storagePoolHostDaoMock).findByPoolHost(storagePoolVoMockId, hostMockId);
+
+        Map<Volume, StoragePool> volumeToPoolObjectMap = virtualMachineManagerImpl.buildMapUsingUserInformation(virtualMachineProfileMock, hostMock, userDefinedVolumeToStoragePoolMap);
+
+        Assert.assertFalse(volumeToPoolObjectMap.isEmpty());
+        Assert.assertEquals(storagePoolVoMock, volumeToPoolObjectMap.get(volumeVoMock));
+
+        Mockito.verify(userDefinedVolumeToStoragePoolMap, times(1)).keySet();
+    }
+
+    @Test
+    public void findVolumesThatWereNotMappedByTheUserTest() {
+        Map<Volume, StoragePool> volumeToStoragePoolObjectMap = Mockito.spy(new HashMap<>());
+        volumeToStoragePoolObjectMap.put(volumeVoMock, storagePoolVoMock);
+
+        Volume volumeVoMock2 = Mockito.mock(Volume.class);
+
+        List<Volume> volumesOfVm = new ArrayList<>();
+        volumesOfVm.add(volumeVoMock);
+        volumesOfVm.add(volumeVoMock2);
+
+        Mockito.doReturn(volumesOfVm).when(volumeDaoMock).findUsableVolumesForInstance(vmInstanceVoMockId);
+        List<Volume> volumesNotMapped = virtualMachineManagerImpl.findVolumesThatWereNotMappedByTheUser(virtualMachineProfileMock, volumeToStoragePoolObjectMap);
+
+        Assert.assertEquals(1, volumesNotMapped.size());
+        Assert.assertEquals(volumeVoMock2, volumesNotMapped.get(0));
+    }
+
+    @Test
+    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestCurrentStoragePoolNotManaged() {
+        Mockito.doReturn(false).when(storagePoolVoMock).isManaged();
+
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+
+        Mockito.verify(storagePoolVoMock).isManaged();
+        Mockito.verify(storagePoolHostDaoMock, Mockito.times(0)).findByPoolHost(Mockito.anyLong(), Mockito.anyLong());
+    }
+
+    @Test
+    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestCurrentStoragePoolManagedIsConnectedToHost() {
+        Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
+        Mockito.doReturn(Mockito.mock(StoragePoolHostVO.class)).when(storagePoolHostDaoMock).findByPoolHost(storagePoolVoMockId, hostMockId);
+
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+
+        Mockito.verify(storagePoolVoMock).isManaged();
+        Mockito.verify(storagePoolHostDaoMock, Mockito.times(1)).findByPoolHost(storagePoolVoMockId, hostMockId);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestCurrentStoragePoolManagedIsNotConnectedToHost() {
+        Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
+        Mockito.doReturn(null).when(storagePoolHostDaoMock).findByPoolHost(storagePoolVoMockId, hostMockId);
+
+        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+    }
+
+    @Test
+    public void getCandidateStoragePoolsToMigrateLocalVolumeTestLocalVolume() {
+        Mockito.doReturn(Mockito.mock(DiskOfferingVO.class)).when(diskOfferingDaoMock).findById(Mockito.anyLong());
+
+        Mockito.doReturn(true).when(storagePoolVoMock).isLocal();
+
+        List<StoragePool> poolListMock = new ArrayList<>();
+        poolListMock.add(storagePoolVoMock);
+
+        Mockito.doReturn(poolListMock).when(storagePoolAllocatorMock).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+
+        List<StoragePool> poolList = virtualMachineManagerImpl.getCandidateStoragePoolsToMigrateLocalVolume(virtualMachineProfileMock, hostMock, volumeVoMock);
+
+        Assert.assertEquals(1, poolList.size());
+        Assert.assertEquals(storagePoolVoMock, poolList.get(0));
+    }
+
+    @Test
+    public void getCandidateStoragePoolsToMigrateLocalVolumeTestCrossClusterMigration() {
+        Mockito.doReturn(Mockito.mock(DiskOfferingVO.class)).when(diskOfferingDaoMock).findById(Mockito.anyLong());
+
+        Mockito.doReturn(false).when(storagePoolVoMock).isLocal();
+
+        List<StoragePool> poolListMock = new ArrayList<>();
+        poolListMock.add(storagePoolVoMock);
+
+        Mockito.doReturn(poolListMock).when(storagePoolAllocatorMock).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+
+        Mockito.doReturn(true).when(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
+        List<StoragePool> poolList = virtualMachineManagerImpl.getCandidateStoragePoolsToMigrateLocalVolume(virtualMachineProfileMock, hostMock, volumeVoMock);
+
+        Assert.assertEquals(1, poolList.size());
+        Assert.assertEquals(storagePoolVoMock, poolList.get(0));
+    }
+
+    @Test
+    public void getCandidateStoragePoolsToMigrateLocalVolumeTestWithinClusterMigration() {
+        Mockito.doReturn(Mockito.mock(DiskOfferingVO.class)).when(diskOfferingDaoMock).findById(Mockito.anyLong());
+
+        Mockito.doReturn(false).when(storagePoolVoMock).isLocal();
+
+        List<StoragePool> poolListMock = new ArrayList<>();
+        poolListMock.add(storagePoolVoMock);
+
+        Mockito.doReturn(poolListMock).when(storagePoolAllocatorMock).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+
+        Mockito.doReturn(false).when(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
+        List<StoragePool> poolList = virtualMachineManagerImpl.getCandidateStoragePoolsToMigrateLocalVolume(virtualMachineProfileMock, hostMock, volumeVoMock);
+
+        Assert.assertTrue(poolList.isEmpty());
+    }
+
+    @Test
+    public void getCandidateStoragePoolsToMigrateLocalVolumeTestMoreThanOneAllocator() {
+        StoragePoolAllocator storagePoolAllocatorMock2 = Mockito.mock(StoragePoolAllocator.class);
+        StoragePoolAllocator storagePoolAllocatorMock3 = Mockito.mock(StoragePoolAllocator.class);
+
+        List<StoragePoolAllocator> storagePoolAllocatorsMock = new ArrayList<>();
+        storagePoolAllocatorsMock.add(storagePoolAllocatorMock);
+        storagePoolAllocatorsMock.add(storagePoolAllocatorMock2);
+        storagePoolAllocatorsMock.add(storagePoolAllocatorMock3);
+
+        virtualMachineManagerImpl.setStoragePoolAllocators(storagePoolAllocatorsMock);
+
+        Mockito.doReturn(Mockito.mock(DiskOfferingVO.class)).when(diskOfferingDaoMock).findById(Mockito.anyLong());
+
+        Mockito.doReturn(false).when(storagePoolVoMock).isLocal();
+
+        List<StoragePool> poolListMock = new ArrayList<>();
+        poolListMock.add(storagePoolVoMock);
+
+        Mockito.doReturn(poolListMock).when(storagePoolAllocatorMock).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+
+        Mockito.doReturn(null).when(storagePoolAllocatorMock2).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+
+        Mockito.doReturn(new ArrayList<>()).when(storagePoolAllocatorMock3).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+
+        Mockito.doReturn(false).when(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
+        List<StoragePool> poolList = virtualMachineManagerImpl.getCandidateStoragePoolsToMigrateLocalVolume(virtualMachineProfileMock, hostMock, volumeVoMock);
+
+        Assert.assertTrue(poolList.isEmpty());
+
+        Mockito.verify(storagePoolAllocatorMock).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+        Mockito.verify(storagePoolAllocatorMock2).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+        Mockito.verify(storagePoolAllocatorMock3).allocateToPool(Mockito.any(DiskProfile.class), Mockito.any(VirtualMachineProfile.class), Mockito.any(DeploymentPlan.class),
+                Mockito.any(ExcludeList.class), Mockito.eq(StoragePoolAllocator.RETURN_UPTO_ALL));
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void createVolumeToStoragePoolMappingIfPossibleTestNotStoragePoolsAvailable() {
+        Mockito.doReturn(null).when(virtualMachineManagerImpl).getCandidateStoragePoolsToMigrateLocalVolume(virtualMachineProfileMock, hostMock, volumeVoMock);
+
+        virtualMachineManagerImpl.createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, new HashMap<>(), volumeVoMock, storagePoolVoMock);
+    }
+
+    @Test
+    public void createVolumeToStoragePoolMappingIfPossibleTestTargetHostAccessCurrentStoragePool() {
+        List<StoragePool> storagePoolList = new ArrayList<>();
+        storagePoolList.add(storagePoolVoMock);
+
+        Mockito.doReturn(storagePoolList).when(virtualMachineManagerImpl).getCandidateStoragePoolsToMigrateLocalVolume(virtualMachineProfileMock, hostMock, volumeVoMock);
+
+        HashMap<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
+        virtualMachineManagerImpl.createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock, storagePoolVoMock);
+
+        Assert.assertTrue(volumeToPoolObjectMap.isEmpty());
+    }
+
+    @Test
+    public void createVolumeToStoragePoolMappingIfPossibleTestTargetHostDoesNotAccessCurrentStoragePool() {
+        StoragePoolVO storagePoolMockOther = Mockito.mock(StoragePoolVO.class);
+        String storagePoolMockOtherUuid = "storagePoolMockOtherUuid";
+        Mockito.doReturn(storagePoolMockOtherUuid).when(storagePoolMockOther).getUuid();
+        Mockito.doReturn(storagePoolMockOther).when(storagePoolDaoMock).findByUuid(storagePoolMockOtherUuid);
+
+        List<StoragePool> storagePoolList = new ArrayList<>();
+        storagePoolList.add(storagePoolMockOther);
+
+        Mockito.doReturn(storagePoolList).when(virtualMachineManagerImpl).getCandidateStoragePoolsToMigrateLocalVolume(virtualMachineProfileMock, hostMock, volumeVoMock);
+
+        HashMap<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
+        virtualMachineManagerImpl.createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock, storagePoolVoMock);
+
+        Assert.assertFalse(volumeToPoolObjectMap.isEmpty());
+        Assert.assertEquals(storagePoolMockOther, volumeToPoolObjectMap.get(volumeVoMock));
+    }
+
+    @Test
+    public void createStoragePoolMappingsForVolumesTestLocalStoragevolume() {
+        ArrayList<Volume> allVolumes = new ArrayList<>();
+        allVolumes.add(volumeVoMock);
+
+        HashMap<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
+
+        Mockito.doReturn(ScopeType.HOST).when(storagePoolVoMock).getScope();
+        Mockito.doNothing().when(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        Mockito.doNothing().when(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock,
+                storagePoolVoMock);
+
+        virtualMachineManagerImpl.createStoragePoolMappingsForVolumes(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, allVolumes);
+
+        Assert.assertTrue(volumeToPoolObjectMap.isEmpty());
+        Mockito.verify(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        Mockito.verify(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock, storagePoolVoMock);
+    }
+
+    @Test
+    public void createStoragePoolMappingsForVolumesTestCrossCluterMigration() {
+        ArrayList<Volume> allVolumes = new ArrayList<>();
+        allVolumes.add(volumeVoMock);
+
+        HashMap<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
+
+        Mockito.doReturn(ScopeType.CLUSTER).when(storagePoolVoMock).getScope();
+        Mockito.doNothing().when(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        Mockito.doNothing().when(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock, storagePoolVoMock);
+        Mockito.doReturn(true).when(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
+
+        virtualMachineManagerImpl.createStoragePoolMappingsForVolumes(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, allVolumes);
+
+        Assert.assertTrue(volumeToPoolObjectMap.isEmpty());
+        Mockito.verify(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        Mockito.verify(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock, storagePoolVoMock);
+        Mockito.verify(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
+    }
+
+    @Test
+    public void createStoragePoolMappingsForVolumesTestNotCrossCluterMigrationWithClusterStorage() {
+        ArrayList<Volume> allVolumes = new ArrayList<>();
+        allVolumes.add(volumeVoMock);
+
+        HashMap<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
+
+        Mockito.doReturn(ScopeType.CLUSTER).when(storagePoolVoMock).getScope();
+        Mockito.doNothing().when(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        Mockito.doNothing().when(virtualMachineManagerImpl).createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock, storagePoolVoMock);
+        Mockito.doReturn(false).when(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
+
+        virtualMachineManagerImpl.createStoragePoolMappingsForVolumes(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, allVolumes);
+
+        Assert.assertFalse(volumeToPoolObjectMap.isEmpty());
+        Assert.assertEquals(storagePoolVoMock, volumeToPoolObjectMap.get(volumeVoMock));
+
+        Mockito.verify(virtualMachineManagerImpl).executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        Mockito.verify(virtualMachineManagerImpl).isStorageCrossClusterMigration(hostMock, storagePoolVoMock);
+        Mockito.verify(virtualMachineManagerImpl, Mockito.times(0)).createVolumeToStoragePoolMappingIfPossible(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumeVoMock,
+                storagePoolVoMock);
+    }
+
+    @Test
+    public void createMappingVolumeAndStoragePoolTest() {
+        Map<Volume, StoragePool> volumeToPoolObjectMap = new HashMap<>();
+        List<Volume> volumesNotMapped = new ArrayList<>();
+
+        Mockito.doReturn(volumeToPoolObjectMap).when(virtualMachineManagerImpl).buildMapUsingUserInformation(Mockito.eq(virtualMachineProfileMock), Mockito.eq(hostMock),
+                Mockito.anyMapOf(Long.class, Long.class));
+
+        Mockito.doReturn(volumesNotMapped).when(virtualMachineManagerImpl).findVolumesThatWereNotMappedByTheUser(virtualMachineProfileMock, volumeToPoolObjectMap);
+        Mockito.doNothing().when(virtualMachineManagerImpl).createStoragePoolMappingsForVolumes(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumesNotMapped);
+
+        Map<Volume, StoragePool> mappingVolumeAndStoragePool = virtualMachineManagerImpl.createMappingVolumeAndStoragePool(virtualMachineProfileMock, hostMock, new HashMap<>());
+
+        Assert.assertEquals(mappingVolumeAndStoragePool, volumeToPoolObjectMap);
+
+        InOrder inOrder = Mockito.inOrder(virtualMachineManagerImpl);
+        inOrder.verify(virtualMachineManagerImpl).buildMapUsingUserInformation(Mockito.eq(virtualMachineProfileMock), Mockito.eq(hostMock), Mockito.anyMapOf(Long.class, Long.class));
+        inOrder.verify(virtualMachineManagerImpl).findVolumesThatWereNotMappedByTheUser(virtualMachineProfileMock, volumeToPoolObjectMap);
+        inOrder.verify(virtualMachineManagerImpl).createStoragePoolMappingsForVolumes(virtualMachineProfileMock, hostMock, volumeToPoolObjectMap, volumesNotMapped);
     }
 }

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -191,10 +191,10 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test
-    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestNonManagedStorage() {
+    public void executeManagedStorageChecksTestNonManagedStorage() {
         Mockito.doReturn(false).when(storagePoolVoMock).isManaged();
 
-        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
 
         Mockito.verify(storagePoolVoMock).isManaged();
         Mockito.verify(storagePoolVoMock, Mockito.times(0)).getClusterId();
@@ -202,12 +202,12 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test
-    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestManagedStorageAndSameClusterAsTargetHost() {
+    public void executeManagedStorageChecksTestManagedStorageAndSameClusterAsTargetHost() {
         Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
         Mockito.doReturn(1L).when(hostMock).getClusterId();
         Mockito.doReturn(1L).when(storagePoolVoMock).getClusterId();
 
-        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
 
         Mockito.verify(storagePoolVoMock).isManaged();
         Mockito.verify(storagePoolVoMock, Mockito.times(1)).getClusterId();
@@ -215,13 +215,13 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test
-    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestManagedStorageAndDifferentClusterAsTargetHostWithZoneWideStorage() {
+    public void executeManagedStorageChecksTestManagedStorageAndDifferentClusterAsTargetHostWithZoneWideStorage() {
         Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
         Mockito.doReturn(1L).when(hostMock).getClusterId();
         Mockito.doReturn(2L).when(storagePoolVoMock).getClusterId();
         Mockito.doReturn(ScopeType.ZONE).when(storagePoolVoMock).getScope();
 
-        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
 
         Mockito.verify(storagePoolVoMock).isManaged();
         Mockito.verify(storagePoolVoMock, Mockito.times(0)).getClusterId();
@@ -229,13 +229,13 @@ public class VirtualMachineManagerImplTest {
     }
 
     @Test(expected = CloudRuntimeException.class)
-    public void executeManagedStorageChecksWhenTargetStoragePoolNotProvidedTestManagedStorageAndDifferentClusterAsTargetHostWithClusterWideStorage() {
+    public void executeManagedStorageChecksTestManagedStorageAndDifferentClusterAsTargetHostWithClusterWideStorage() {
         Mockito.doReturn(true).when(storagePoolVoMock).isManaged();
         Mockito.doReturn(1L).when(hostMock).getClusterId();
         Mockito.doReturn(2L).when(storagePoolVoMock).getClusterId();
         Mockito.doReturn(ScopeType.CLUSTER).when(storagePoolVoMock).getScope();
 
-        virtualMachineManagerImpl.executeManagedStorageChecksWhenTargetStoragePoolNotProvided(hostMock, storagePoolVoMock, volumeVoMock);
+        virtualMachineManagerImpl.executeManagedStorageChecks(hostMock, storagePoolVoMock, volumeVoMock);
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Mike discovered that when PR https://github.com/apache/cloudstack/pull/2425/ was merged, we created a bug with managed storage. The following constraints needed to be added to ACS:
* If I want to migrate a VM across clusters, but if at least one of its volumes is placed in a cluster-wide managed storage, the migration is not allowed. On the other hand, if the VM is placed in a managed zone-wide storage, the migration can be executed;
* A volume placed in managed storage can never (at least not using this migrateWithVolume method) be migrated out of the storage pool it resides; 
* When migrating a VM that does not have volumes in managed storage, it should be possible to migrate it cross clusters. Therefore, we should try to use the volume allocators to find a suitable storage pool for its volumes in the target cluster.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [X] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.
