### PR TITLE
kvm: Agent should not check if remaining memory on host is sufficient

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -277,7 +277,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     protected int _rngRateBytes = 2048;
     private File _qemuSocketsPath;
     private final String _qemuGuestAgentSocketName = "org.qemu.guest_agent.0";
-    private long _totalMemory;
     protected WatchDogAction _watchDogAction = WatchDogAction.NONE;
     protected WatchDogModel _watchDogModel = WatchDogModel.I6300ESB;
 
@@ -2603,7 +2602,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     public StartupCommand[] initialize() {
 
         final List<Object> info = getHostInfo();
-        _totalMemory = (Long)info.get(2);
 
         final StartupRoutingCommand cmd =
                 new StartupRoutingCommand((Integer)info.get(0), (Long)info.get(1), (Long)info.get(2), (Long)info.get(4), (String)info.get(3), _hypervisorType,
@@ -3790,10 +3788,6 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 continue;
             }
         }
-    }
-
-    public long getTotalMemory() {
-        return _totalMemory;
     }
 
     public String getHostDistro() {

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -5038,7 +5038,6 @@ public class LibvirtComputingResourceTest {
             when(conn.domainLookupByID(vmId)).thenReturn(dm);
             when(dm.getMaxMemory()).thenReturn(1024L);
             when(dm.getName()).thenReturn(vmName);
-            when(libvirtComputingResource.getTotalMemory()).thenReturn(2048*1024L);
             doNothing().when(libvirtComputingResource).createVbd(conn, vmSpec, vmName, vmDef);
         } catch (final LibvirtException e) {
             fail(e.getMessage());


### PR DESCRIPTION
When a Instance is (attempted to be) started in KVM Host the Agent
should not worry about the allocated memory on this host.

To make a proper judgement we need to take more into account:

- Memory Overcommit ratio
- Host reserved memory
- Host overcommit memory

The Management Server has all the information and the DeploymentPlanner
has to make the decision if a Instance should and can be started on a
Host, not the host itself.

Signed-off-by: Wido den Hollander <wido@widodh.nl>

