### PR TITLE
Issue 2774: Changed the implementation of isVolumeOnManagedStorage(VolumeInfo) to…

### DIFF
--- a/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategy.java
@@ -196,10 +196,16 @@ public class StorageSystemDataMotionStrategy implements DataMotionStrategy {
     }
 
     private boolean isVolumeOnManagedStorage(VolumeInfo volumeInfo) {
-        long storagePooldId = volumeInfo.getDataStore().getId();
-        StoragePoolVO storagePoolVO = _storagePoolDao.findById(storagePooldId);
+        DataStore dataStore = volumeInfo.getDataStore();
 
-        return storagePoolVO.isManaged();
+        if (dataStore.getRole() == DataStoreRole.Primary) {
+            long storagePooldId = dataStore.getId();
+            StoragePoolVO storagePoolVO = _storagePoolDao.findById(storagePooldId);
+
+            return storagePoolVO.isManaged();
+        }
+
+        return false;
     }
 
     // canHandle returns true if the storage driver for the DataObject that's passed in can support certain features (what features we

--- a/engine/storage/datamotion/test/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategyTest.java
+++ b/engine/storage/datamotion/test/org/apache/cloudstack/storage/motion/StorageSystemDataMotionStrategyTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cloudstack.storage.motion;
+
+import com.cloud.storage.DataStoreRole;
+import com.cloud.storage.ImageStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataMotionStrategy;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.StrategyPriority;
+import org.apache.cloudstack.storage.datastore.PrimaryDataStoreImpl;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.cloudstack.storage.image.store.ImageStoreImpl;
+import org.apache.cloudstack.storage.volume.VolumeObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StorageSystemDataMotionStrategyTest {
+
+    @Mock
+    VolumeObject source;
+    @Mock
+    DataObject destination;
+    @Mock
+    PrimaryDataStore sourceStore;
+    @Mock
+    ImageStore destinationStore;
+
+    @InjectMocks
+    DataMotionStrategy strategy = new StorageSystemDataMotionStrategy();
+    @Mock
+    PrimaryDataStoreDao _storagePoolDao;
+
+    @Before public void setUp() throws Exception {
+        sourceStore = mock(PrimaryDataStoreImpl.class);
+        destinationStore = mock(ImageStoreImpl.class);
+        source = mock(VolumeObject.class);
+        destination = mock(VolumeObject.class);
+
+                initMocks(strategy);
+    }
+
+    @Test
+    public void cantHandleSecondary() {
+        doReturn(sourceStore).when(source).getDataStore();
+        doReturn(DataStoreRole.Primary).when(sourceStore).getRole();
+        doReturn(destinationStore).when(destination).getDataStore();
+        doReturn(DataStoreRole.Image).when((DataStore)destinationStore).getRole();
+        doReturn(sourceStore).when(source).getDataStore();
+        doReturn(destinationStore).when(destination).getDataStore();
+        StoragePoolVO storeVO = new StoragePoolVO();
+        doReturn(storeVO).when(_storagePoolDao).findById(0l);
+
+        assertTrue(strategy.canHandle(source,destination) == StrategyPriority.CANT_HANDLE);
+    }
+}


### PR DESCRIPTION
… check if the data store in question is for primary storage

## Description
In the StorageSystemDataMotionStrategy.isVolumeOnManagedStorage(VolumeInfo) method, we should have been checking if the DataStore associated with the VolumeInfo was on primary storage before checking if it is managed storage.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
Fixes: #2774

## How Has This Been Tested?
Regression testing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

