### PR TITLE
hvm checkbox visibility

### DIFF
--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -251,12 +251,14 @@
                                                     $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
                                                     $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
                                                     $form.find('.form-item[rel=directdownload]').hide();
+                                                    $form.find('.form-item[rel=requireshvm]').hide();
                                                 } else if ($(this).val() == "XenServer") {
                                                     $form.find('.form-item[rel=rootDiskControllerType]').hide();
                                                     $form.find('.form-item[rel=nicAdapterType]').hide();
                                                     $form.find('.form-item[rel=keyboardType]').hide();
                                                     $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
                                                     $form.find('.form-item[rel=directdownload]').hide();
+                                                    $form.find('.form-item[rel=requireshvm]').css('display', 'inline-block');
 
                                                     if (isAdmin()) {
                                                         $form.find('.form-item[rel=xenserverToolsVersion61plus]').css('display', 'inline-block');
@@ -268,6 +270,7 @@
                                                     $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
                                                     $form.find('.form-item[rel=rootDiskControllerTypeKVM]').css('display', 'inline-block');
                                                     $('#label_root_disk_controller').prop('selectedIndex', 2);
+                                                    $form.find('.form-item[rel=requireshvm]').css('display', 'inline-block');
                                                     if (isAdmin()) {
                                                       $form.find('.form-item[rel=directdownload]').css('display', 'inline-block');
                                                     }
@@ -278,6 +281,7 @@
                                                     $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
                                                     $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
                                                     $form.find('.form-item[rel=directdownload]').hide();
+                                                    $form.find('.form-item[rel=requireshvm]').css('display', 'inline-block');
                                                 }
                                             });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
On the 'Register Template From URL' screen, when a user selects the VMware option from the Hypervisor dropdown:

It incorrectly displays the 'HVM' checkbox. 
This checkbox must be hidden in the VMware context.
This checkbox must still be visible in any other hypervisor context.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
To Reproduce:
Go to the 'Register Template From URL' screen by clicking the 'Templates' tab on the lefthand side.
On the 'Templates' screen click the 'Add' button to display the 'Register Template From URL' screen.
On the 'Register Template From URL' screen, select the VMware option from the Hypervisor dropdown:

Actual Behaviour:
It incorrectly displays the 'HVM' checkbox. 

Expected behaviour:
This checkbox must be hidden in the VMware context.
This checkbox must still be visible in any other hypervisor context.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30108093/43462589-c9e86dee-94d6-11e8-808d-31c19475a327.png)

## How Has This Been Tested?
Manually (See the screenshot above):
Go to the 'Register Template From URL' screen by clicking the 'Templates' tab on the lefthand side.
On the 'Templates' screen click the 'Add' button to display the 'Register Template From URL' screen.
On the 'Register Template From URL' screen, select the VMware option from the Hypervisor dropdown.
It now hides the HVM checkbox.

Environment:
CloudStack version 4.11, KVM hypervisor.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

