### PR TITLE
change dashboard events cursor to default to prevent user confusion

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -4987,7 +4987,7 @@ textarea {
 
 .dashboard.user .status-lists ul li.events .content li {
   width: 97%;
-  cursor: pointer;
+  cursor: default;
   margin: 6px 11px 0 0;
   font-size: 11px;
   padding: 13px 0 12px 16px;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When a regular user navigates to the Dashboard screen and hovers over the 'Latest events' entries, the mouse cursor changes to a hand pointer, but it cannot select any of these entries.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Expected Behaviour:
When a user navigates to the Dashboard screen and hovers over the 'Latest events' entries, the mouse cursor must not change to a hand pointer. This will allow the user to make the correct interpretation that the 'Latest events' entries are not selectable.

Actual Behaviour:
When a user navigates to the Dashboard screen and hovers over the 'Latest events' entries, the mouse cursor changes to a hand pointer. This causes a user to incorrectly interpret that the entries are selectable.

To Reproduce:
Log in to the Cloudstack UI as a regular User.
On the Dashboard screen, hover the mouse over the 'Latest events' entries, the cursor changes to a hand pointer. Confirm that the entries cannot be selected.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30108093/43593183-7641774c-9677-11e8-9c22-15ba9736d5af.png)

## How Has This Been Tested?
Manually (See screenshot above)

<!-- Please describe in detail how you tested your changes. -->
Log in to the Cloudstack UI as a regular User.
On the Dashboard screen, hover the mouse over the 'Latest events' entries, the cursor does not change to a hand pointer but remains a default arrow pointer. Confirm that the entries cannot be selected.
<!-- Include details of your testing environment, and the tests you ran to -->

Environment:
CloudStack version 4.11, KVM hypervisor.
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

