### PR TITLE
data table header cursor type and title

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -125,6 +125,7 @@ table thead th {
   text-shadow: 0px 1px 1px #FFFFFF;
   font-weight: bold;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 table thead th.sorted {
@@ -243,10 +244,7 @@ table thead th.quick-view {
   height: 14px !important;
   text-indent: 2px;
   white-space: nowrap;
-}
-
-table tbody td.quick-view {
-  cursor: pointer;
+  cursor: default;
 }
 
 table tbody td.quick-view .icon {

--- a/ui/scripts/ui/widgets/listView.js
+++ b/ui/scripts/ui/widgets/listView.js
@@ -780,7 +780,7 @@
 
         var addColumnToTr = function($tr, key, colspan, label, needsCollapsibleColumn) {
             var trText = _l(label);
-            var $th = $('<th>').addClass(key).attr('colspan', colspan).appendTo($tr);
+            var $th = $('<th>').addClass(key).attr('colspan', colspan).attr('title', trText).appendTo($tr);
             if ($th.index()) $th.addClass('reduced-hide');
             $th.css({'border-right': '1px solid #C6C3C3', 'border-left': '1px solid #C6C3C3'});
             if (needsCollapsibleColumn) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In the UI, when a user navigates to a screen that displays a table of data and hovers the mouse over a sortable column header, the cursor does not change to a hand pointer, indicating to the user that it can be clicked on, in order to sort the table's data rows according to that column. 
When the mouse hovers over the non-sortable 'Quickview' column header, it incorrectly displays a hand pointer cursor instead of a default cursor.
When the mouse hovers over a column header, it also does not display the column header's value as a tooltip. 
 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Expected Behaviour:
The cursor type for a sortable column header must display a hand pointer.
The cursor type for the non-sortable 'Quickview' column header must display a default pointer.
When the mouse hovers over a column header it must display the column header's value as a tooltip. 

Actual Behaviour:
The cursor type for a sortable column header incorrectly displays a default pointer.
The cursor type for the non-sortable 'Quickview' column header incorrectly displays a hand pointer.
When the mouse hovers over a column header it does not display the column header's value as a tooltip. 

To Reproduce:
In the UI, navigate to a screen that displays a table of data and hover the mouse over a sortable column header, the cursor does not change to a hand pointer.
Hover the mouse over the non-sortable 'Quickview' column header and notice that it incorrectly displays a hand pointer cursor instead of a default cursor.
Hover the mouse over a column header and notice that it does not display the column header's value as a tooltip.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30108093/43644838-63499dc2-9730-11e8-808a-04de03c4775c.png)

## How Has This Been Tested?
Manually (See screenshot above)
<!-- Please describe in detail how you tested your changes. -->
In the UI, navigate to a screen that displays a table of data and hover the mouse over a sortable column header, the cursor now changes to a hand pointer, indicating that it is a sortable column.
Hover the mouse over the non-sortable 'Quickview' column header. It now correctly displays a default cursor, indicating that it is a non-sortable column.
Hover the mouse over a column header and notice that it now displays the column header's value as a tooltip.
<!-- Include details of your testing environment, and the tests you ran to -->

Environment:
CloudStack version 4.11, KVM hypervisor.
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

