### PR TITLE
add height sizing to detail view so that it renders all detail items

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -2077,6 +2077,7 @@ div.copypasteicon:hover {
 
 .detail-view .details.group-multiple {
   float: left;
+  height: 600px;
   width: 100%;
   margin-bottom: 30px;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In the UI, when a VM instance has more than one NIC, the NICs screen does not display all the details of the first NIC. The last few rows of text overlap with the second NIC's text. This is due to the incorrect placement of the second NIC's bar. The default height sizing does not allow enough head space to display all the details of the first NIC before displaying the second NIC's details.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Expected Behaviour:
When a VM instance has more than one NIC, the NICs screen must allow enough height size to display all the details of the first NIC before displaying the second NIC's details. The last few rows of text must not overlap with the second NIC's text.

Current Behaviour:
When a VM instance has more than one NIC, the NICs screen does not allow enough height size to display all the details of the first NIC before displaying the second NIC's details. The last few rows of text overlap with the second NIC's text.

To Reproduce:
In the UI, on the lefthand side, select the Instances link. On the Instances screen, select a VM instance that has more than one NIC and then select the NICs screen. Scroll down to where the second NIC bar is displayed. Notice that it does not display all the details of the first NIC correctly. The last few rows of text overlap with the second NIC's text.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30108093/43705904-283bba86-9964-11e8-9562-acd3e1c0db42.png)

## How Has This Been Tested?
Manually (See screenshot above):
<!-- Please describe in detail how you tested your changes. -->
In the UI, on the lefthand side, select the Instances link. On the Instances screen, select a VM instance that has more than one NIC and then select the NICs screen. Scroll down to where the second NIC bar is displayed. Notice that it now displays all the details of the first NIC before displaying the details of the second NIC. The last few rows of text do not overlap with the second NIC's text.
<!-- Include details of your testing environment, and the tests you ran to -->
Environment:
CloudStack version 4.11, KVM hypervisor.
<!-- see how your change affects other areas of the code, etc. -->
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

