### PR TITLE
router: Fixes #2789 fix proper mark based packet routing across interfaces

### DIFF
--- a/server/src/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/com/cloud/api/ApiResponseHelper.java
@@ -501,7 +501,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 snapshotResponse.setZoneId(zone.getUuid());
             }
 
-            if (volume.getVolumeType() == Volume.Type.ROOT) {
+            if (volume.getVolumeType() == Volume.Type.ROOT && volume.getInstanceId() != null) {
                 //TODO combine lines and 489 into a join in the volume dao
                 VMInstanceVO instance = ApiDBUtils.findVMInstanceById(volume.getInstanceId());
                 if (instance != null) {

--- a/systemvm/debian/opt/cloud/bin/cloud-nic.sh
+++ b/systemvm/debian/opt/cloud/bin/cloud-nic.sh
@@ -69,7 +69,7 @@ unplug_nic() {
 
 action=$1
 dev=$2
-tableNo=${dev:3}
+tableNo=$((100+${dev:3}))
 tableName="Table_$dev"
 
 if [ $action == 'add' ]

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -189,7 +189,8 @@ class CsNetfilters(object):
     def add_chain(self, rule):
         """ Add the given chain if it is not already present """
         if not self.has_chain(rule.get_table(), rule.get_chain()):
-            CsHelper.execute("iptables -t %s -N %s" % (rule.get_table(), rule.get_chain()))
+            if rule.get_chain() != "":
+                CsHelper.execute("iptables -t %s -N %s" % (rule.get_table(), rule.get_chain()))
             self.chain.add(rule.get_table(), rule.get_chain())
 
     def del_standard(self):

--- a/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py
@@ -189,7 +189,7 @@ class CsNetfilters(object):
     def add_chain(self, rule):
         """ Add the given chain if it is not already present """
         if not self.has_chain(rule.get_table(), rule.get_chain()):
-            if rule.get_chain() != "":
+            if rule.get_chain():
                 CsHelper.execute("iptables -t %s -N %s" % (rule.get_table(), rule.get_chain()))
             self.chain.add(rule.get_table(), rule.get_chain())
 

--- a/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
@@ -30,7 +30,7 @@ class CsRoute:
         return self.table_prefix + name
 
     def add_table(self, devicename):
-        tablenumber = devicename[3:]
+        tablenumber = 100 + int(devicename[3:])
         tablename = self.get_tablename(devicename)
         str = "%s %s" % (tablenumber, tablename)
         filename = "/etc/iproute2/rt_tables"

--- a/systemvm/debian/opt/cloud/bin/cs/CsRule.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRule.py
@@ -27,7 +27,7 @@ class CsRule:
 
     def __init__(self, dev):
         self.dev = dev
-        self.tableNo = int(dev[3:])
+        self.tableNo = 100 + int(dev[3:])
         self.table = "Table_%s" % (dev)
 
     def addRule(self, rule):

--- a/systemvm/debian/opt/cloud/bin/ipassoc.sh
+++ b/systemvm/debian/opt/cloud/bin/ipassoc.sh
@@ -103,7 +103,7 @@ remove_routing() {
   logger -t cloud "$(basename $0):Remove routing $pubIp on interface $ethDev"
   local ipNoMask=$(echo $pubIp | awk -F'/' '{print $1}')
   local mask=$(echo $pubIp | awk -F'/' '{print $2}')
-  local tableNo=$(echo $ethDev | awk -F'eth' '{print $2}')
+  local tableNo=$((100+$(echo $ethDev | awk -F'eth' '{print $2}')))
 
   local tableName="Table_$ethDev"
   local remainip=`ip addr show $ethDev | grep "inet "`
@@ -149,7 +149,7 @@ add_routing() {
 
   local tableName="Table_$ethDev"
   local tablePresent=$(grep $tableName /etc/iproute2/rt_tables)
-  local tableNo=$(echo $ethDev | awk -F'eth' '{print $2}')
+  local tableNo=$((100+$(echo $ethDev | awk -F'eth' '{print $2}')))
   if [ "$tablePresent" == "" ]
   then
      if [ "$tableNo" == "" ]

--- a/systemvm/debian/opt/cloud/bin/update_config.py
+++ b/systemvm/debian/opt/cloud/bin/update_config.py
@@ -30,7 +30,7 @@ logging.basicConfig(filename='/var/log/cloud.log', level=logging.INFO, format='%
 
 # first commandline argument should be the file to process
 if (len(sys.argv) != 2):
-    logging.error("Invalid usage, args passed: %" % sys.argv )
+    logging.error("Invalid usage, args passed: %" % sys.argv)
     sys.exit(1)
 
 # FIXME we should get this location from a configuration class

--- a/systemvm/debian/opt/cloud/bin/update_config.py
+++ b/systemvm/debian/opt/cloud/bin/update_config.py
@@ -30,7 +30,7 @@ logging.basicConfig(filename='/var/log/cloud.log', level=logging.INFO, format='%
 
 # first commandline argument should be the file to process
 if (len(sys.argv) != 2):
-    logging.error("Invalid usage, args passed: %" % sys.argv)
+    logging.error("Invalid usage, args passed: %s" % sys.argv)
     sys.exit(1)
 
 # FIXME we should get this location from a configuration class

--- a/systemvm/debian/opt/cloud/bin/update_config.py
+++ b/systemvm/debian/opt/cloud/bin/update_config.py
@@ -30,7 +30,7 @@ logging.basicConfig(filename='/var/log/cloud.log', level=logging.INFO, format='%
 
 # first commandline argument should be the file to process
 if (len(sys.argv) != 2):
-    print "[ERROR]: Invalid usage"
+    logging.error("Invalid usage, args passed: %" % sys.argv )
     sys.exit(1)
 
 # FIXME we should get this location from a configuration class
@@ -47,7 +47,7 @@ def finish_config():
 
 
 def process_file():
-    print "[INFO] Processing JSON file %s" % sys.argv[1]
+    logging.info("Processing JSON file %s" % sys.argv[1])
     qf = QueueFile()
     qf.setFile(sys.argv[1])
     qf.load(None)
@@ -70,7 +70,7 @@ def is_guestnet_configured(guestnet_dict, keys):
         '''
         It seems all the interfaces have been removed. Let's allow a new configuration to come in.
         '''
-        print "[WARN] update_config.py :: Reconfiguring guest network..."
+        logging.warn("update_config.py :: Reconfiguring guest network...")
         return False
 
     file = open(jsonConfigFile)
@@ -80,7 +80,7 @@ def is_guestnet_configured(guestnet_dict, keys):
         '''
         Guest network has to be removed.
         '''
-        print "[INFO] update_config.py :: Removing guest network..."
+        logging.info("update_config.py :: Removing guest network...")
         return False
 
     '''
@@ -121,7 +121,10 @@ if jsonFilename != "cmd_line.json" and os.path.isfile(jsonPath % "cmd_line.json"
     qf.load(None)
 
 if not (os.path.isfile(jsonConfigFile) and os.access(jsonConfigFile, os.R_OK)):
-    print "[ERROR] update_config.py :: Unable to read and access %s to process it" % jsonConfigFile
+    # Ignore if file is already processed
+    if os.path.isfile(jsonPath % ("processed/" + jsonFilename + ".gz")):
+        sys.exit(0)
+    logging.error("update_config.py :: Unable to read and access %s to process it" % jsonConfigFile)
     sys.exit(1)
 
 # If the guest network is already configured and have the same IP, do not try to configure it again otherwise it will break
@@ -131,14 +134,14 @@ if jsonFilename.startswith("guest_network.json"):
         guestnet_dict = json.load(file)
 
         if not is_guestnet_configured(guestnet_dict, ['eth1', 'eth2', 'eth3', 'eth4', 'eth5', 'eth6', 'eth7', 'eth8', 'eth9']):
-            print "[INFO] update_config.py :: Processing Guest Network."
+            logging.info("update_config.py :: Processing Guest Network.")
             process_file()
         else:
-            print "[INFO] update_config.py :: No need to process Guest Network."
+            logging.info("update_config.py :: No need to process Guest Network.")
             finish_config()
     else:
-        print "[INFO] update_config.py :: No GuestNetwork configured yet. Configuring first one now."
+        logging.info("update_config.py :: No GuestNetwork configured yet. Configuring first one now.")
         process_file()
 else:
-    print "[INFO] update_config.py :: Processing incoming file => %s" % sys.argv[1]
+    logging.info("update_config.py :: Processing incoming file => %s" % sys.argv[1])
     process_file()

--- a/test/integration/smoke/test_vm_life_cycle.py
+++ b/test/integration/smoke/test_vm_life_cycle.py
@@ -918,7 +918,7 @@ class TestSecuredVmMigration(cloudstackTestCase):
             cmd = provisionCertificate.provisionCertificateCmd()
             cmd.hostid = host.id
             cmd.reconnect = True
-            self.apiclient.updateConfiguration(cmd)
+            self.apiclient.provisionCertificate(cmd)
 
         for host in self.hosts:
             self.check_connection(secured='true', host=host)


### PR DESCRIPTION
Previously, the ethernet device index was used as `rt_table` index and
packet marking id/integer. With eth0 that is sometimes used as link-local
interface, the rt_table index `0` would fail as `0` is already defined
as a catchall (unspecified). The fwmarking on packets on eth0 with 0x0
would also fail. This fixes the routing issues, by adding 100 to the
ethernet device index so the value is a non-zero, for example then the
relationship between rt_table index and ethernet would be like:

100 -> Table_eth0 -> eth0 -> fwmark 100 or 0x64
101 -> Table_eth1 -> eth1 -> fwmark 101 or 0x65
101 -> Table_eth2 -> eth2 -> fwmark 102 or 0x66

This would maintain the legacy design of routing based on packet mark
and appropriate routing table rules per table/ids. This also fixes a
minor NPE issue around listing of snapshots.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

