### PR TITLE
vmware: reboot VR after mac updates

### DIFF
--- a/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -401,9 +401,9 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
             return null;
         }
 
-        if (vm != null && vm.getState() != State.Running) {
+        if (vm != null && vm.getState() != State.Starting && vm.getState() != State.Running) {
             if (s_logger.isInfoEnabled()) {
-                s_logger.info("Detected that vm : " + vmId + " is not currently at running state, we will fail the proxy assignment for it");
+                s_logger.info("Detected that vm : " + vmId + " is not currently in starting or running state, we will fail the proxy assignment for it");
             }
             return null;
         }

--- a/systemvm/debian/opt/cloud/bin/setup/router.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/router.sh
@@ -61,6 +61,10 @@ setup_router() {
     then
       log_it "Reloading udev for new udev NIC assignment"
       udevadm control --reload-rules && udevadm trigger
+      if [ "$HYPERVISOR" == "vmware" ]; then
+          sync
+          reboot
+      fi
     fi
   fi
 

--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -3292,6 +3292,9 @@
             allowedActions.push("resetSSHKeyForVirtualMachine");
         } else if (jsonObj.state == 'Starting') {
             //  allowedActions.push("stop");
+            if (isAdmin()) {
+                allowedActions.push("viewConsole");
+            }
         } else if (jsonObj.state == 'Error') {
             allowedActions.push("destroy");
         } else if (jsonObj.state == 'Expunging') {

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -22126,10 +22126,6 @@
             allowedActions.push('upgradeRouterToUseNewerTemplate');
         }
 
-        if (isAdmin() || jsonObj.state == 'Running') {
-            allowedActions.push("viewConsole");
-        }
-
         if (jsonObj.state == 'Running') {
             allowedActions.push("stop");
 
@@ -22140,9 +22136,14 @@
 
             allowedActions.push("restart");
             allowedActions.push("remove");
+            allowedActions.push("viewConsole");
 
             if (isAdmin())
             allowedActions.push("migrate");
+        } else if (jsonObj.state == 'Starting') {
+            if (isAdmin()) {
+                allowedActions.push("viewConsole");
+            }
         } else if (jsonObj.state == 'Stopped') {
             allowedActions.push("start");
 
@@ -22158,14 +22159,15 @@
         var jsonObj = args.context.item;
         var allowedActions =[];
 
-        if (isAdmin() || jsonObj.state == 'Running') {
-            allowedActions.push("viewConsole");
-        }
-
         if (jsonObj.state == 'Running') {
             allowedActions.push("stop");
+            allowedActions.push("viewConsole");
             if (isAdmin())
             allowedActions.push("migrate");
+        } else if (jsonObj.state == 'Starting') {
+            if (isAdmin()) {
+                allowedActions.push("viewConsole");
+            }
         } else if (jsonObj.state == 'Stopped') {
             allowedActions.push("start");
         }
@@ -22175,10 +22177,6 @@
     var systemvmActionfilter = function (args) {
         var jsonObj = args.context.item;
         var allowedActions =[];
-
-        if (isAdmin() || jsonObj.state == 'Running') {
-            allowedActions.push("viewConsole");
-        }
 
         if (jsonObj.state == 'Running') {
             allowedActions.push("stop");
@@ -22190,8 +22188,13 @@
                 allowedActions.push("scaleUp");
             }
 
+            allowedActions.push("viewConsole");
             if (isAdmin())
             allowedActions.push("migrate");
+        } else if (jsonObj.state == 'Starting') {
+            if (isAdmin()) {
+                allowedActions.push("viewConsole");
+            }
         } else if (jsonObj.state == 'Stopped') {
             allowedActions.push("start");
 

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -22126,6 +22126,10 @@
             allowedActions.push('upgradeRouterToUseNewerTemplate');
         }
 
+        if (isAdmin() || jsonObj.state == 'Running') {
+            allowedActions.push("viewConsole");
+        }
+
         if (jsonObj.state == 'Running') {
             allowedActions.push("stop");
 
@@ -22136,7 +22140,6 @@
 
             allowedActions.push("restart");
             allowedActions.push("remove");
-            allowedActions.push("viewConsole");
 
             if (isAdmin())
             allowedActions.push("migrate");
@@ -22155,10 +22158,12 @@
         var jsonObj = args.context.item;
         var allowedActions =[];
 
+        if (isAdmin() || jsonObj.state == 'Running') {
+            allowedActions.push("viewConsole");
+        }
+
         if (jsonObj.state == 'Running') {
             allowedActions.push("stop");
-
-            allowedActions.push("viewConsole");
             if (isAdmin())
             allowedActions.push("migrate");
         } else if (jsonObj.state == 'Stopped') {
@@ -22171,6 +22176,10 @@
         var jsonObj = args.context.item;
         var allowedActions =[];
 
+        if (isAdmin() || jsonObj.state == 'Running') {
+            allowedActions.push("viewConsole");
+        }
+
         if (jsonObj.state == 'Running') {
             allowedActions.push("stop");
             allowedActions.push("restart");
@@ -22181,7 +22190,6 @@
                 allowedActions.push("scaleUp");
             }
 
-            allowedActions.push("viewConsole");
             if (isAdmin())
             allowedActions.push("migrate");
         } else if (jsonObj.state == 'Stopped') {


### PR DESCRIPTION
This re-introduces the rebooting of VR after setup of nics/macs in
case of VMware. It also adds a minor enhancement to show the console
esp. for root admins when VRs and systemvms are in starting state.

The issue seen was in Vmware 5.5u3 and older environments where VR does not work unless they are rebooted (reset). In 4.9 systemvm code, it used to reboot after setup of router nic-mac addresses:
https://github.com/apache/cloudstack/blob/4.9/systemvm/patches/debian/config/etc/init.d/cloud-early-config#L914

This PR reintroduces rebooting only in case of VMware where the issue was seen with older hypervisors/vcenter versions. The other change this PR bring is to allow at least the root admins to show console for VMs in starting state.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

On a VMware + ACS 4.9 env, upgraded to ACS 4.11.1.0 it is seen that VR need to be reset to make them work. They fail to work and get network working on its private/control ip for mgmt server to ssh and program the router. This reintroduces a reboot logic which was in 4.9 and may fix the issue for vmware only (esp 5.5u3 and older environments).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

