### PR TITLE
Fix Div overlay problem when PopUp modal with error message is closed

### DIFF
--- a/ui/scripts/ui/dialog.js
+++ b/ui/scripts/ui/dialog.js
@@ -1042,6 +1042,7 @@
                             $(this).dialog('destroy');
                             if (args.clickAction) args.clickAction();
                             $('.hovered-elem').hide();
+                            $('div.overlay').hide();
                         }
                     }]
                 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The error fixed by this PR happens when we have a Pop-up modal with an error message in the latest master. When we close the modal, the overlay div is not being hidden. Therefore, the screen gets locked. 

![image](https://user-images.githubusercontent.com/4129005/43964752-e45eda86-9c93-11e8-8edd-fe00d49e549b.png)

![image](https://user-images.githubusercontent.com/4129005/43964779-f0188dae-9c93-11e8-8bcd-f434fb86fc2b.png)

The solution is quite simple, we should hide the overlay div when closing the modal pop-up.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Manually

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

