### PR TITLE
Fix "Migrate instance to another host" popup modal

### DIFF
--- a/ui/scripts/ui-custom/migrate.js
+++ b/ui/scripts/ui-custom/migrate.js
@@ -121,7 +121,8 @@
                         });
                     }
                 }]
-            }).parent('.ui-dialog').overlay();
+            });
+            cloudStack.applyDefaultZindexAndOverlayOnJqueryDialogAndRemoveCloseButton($dataList);
         };
     };
 }(cloudStack, jQuery));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
While testing ACS 4.12 (current master) I noticed that the modal popup that appears when migrating VMs is not being displayed properly. The problem is presented in the following picture.
![image](https://user-images.githubusercontent.com/4129005/44053930-7efb8046-9f17-11e8-9621-a44d1b428655.png)

When I apply the change introduced here, the popup starts to work again.
![image](https://user-images.githubusercontent.com/4129005/44053953-9276b00a-9f17-11e8-9297-70ccb5e573c3.png)
 

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Manually

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

