### PR TITLE
Project drop-down refresh data fix

### DIFF
--- a/ui/scripts/ui-custom/projectSelect.js
+++ b/ui/scripts/ui-custom/projectSelect.js
@@ -24,33 +24,35 @@
         );
         var $label = $('<label>').html(_l('label.project'));
 
-        // Get project list
-        cloudStack.projects.dataProvider({
-            context: cloudStack.context,
-            response: {
-                success: function(args) {
-                    var projects = args.data;
-                    var arrayOfProjs = [];
+        var populateProjectSelect = function() {
+            // Get project list
+            cloudStack.projects.dataProvider({
+                context: cloudStack.context,
+                response: {
+                    success: function(args) {
+                        var projects = args.data;
+                        var arrayOfProjs = [];
 
-                    $(projects).map(function(index, project) {
-                        var proj = {id: _s(project.id), html: _s(project.displaytext ? project.displaytext : project.name)};
-                        arrayOfProjs.push(proj);
-                    });
+                        $(projects).map(function(index, project) {
+                            var proj = {id: _s(project.id), html: _s(project.displaytext ? project.displaytext : project.name)};
+                            arrayOfProjs.push(proj);
+                        });
 
-                    arrayOfProjs.sort(function(a,b) {
-                        return a.html.localeCompare(b.html);
-                    });
+                        arrayOfProjs.sort(function(a,b) {
+                            return a.html.localeCompare(b.html);
+                        });
 
-                    $(arrayOfProjs).map(function(index, project) {
-                        var $option = $('<option>').val(_s(project.id));
+                        $(arrayOfProjs).map(function(index, project) {
+                            var $option = $('<option>').val(_s(project.id));
 
-                        $option.html(_s(project.html));
-                        $option.appendTo($projectSelect);
-                    });
-                },
-                error: function() {}
-            }
-        });
+                            $option.html(_s(project.html));
+                            $option.appendTo($projectSelect);
+                        });
+                    },
+                    error: function() {}
+                }
+            });
+        }
 
         $projectSwitcher.append($label, $projectSelect);
         $projectSwitcher.insertBefore($header.find('.region-switcher'));
@@ -72,6 +74,13 @@
                 $('#cloudStack3-container').removeClass('project-view');
                 $('#navigation li.dashboard').click();
             }
+        });
+
+        $projectSelect.mousedown(function() {
+           var projectID = $projectSelect.val();
+           $('.project-switcher option:not(:first)').remove();
+           populateProjectSelect();
+           $projectSelect.val(projectID);
         });
     });
 }(jQuery, cloudStack));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In the UI, the 'Project' drop-down displays all the projects that the logged in user is a member of.
A regular user can add other accounts to a project when creating the project. 
An Admin user can also add other accounts to an existing project.
When user 'x' adds account 'y' to a project 'z' and user 'y' is logged in to another session at the same time, the 'Project' drop-down in user 'y' session does not display project 'z' to which he/she has just been added as a member in the other session. 
The latest project addition will only display in the drop-down if the user refreshes the HTML page.

Expected Behaviour:
Whenever user 'y' clicks on the drop-down to display the projects, it must include the newly added project 'z' without having to refresh the HTML page.
Whenever a user clicks on the 'Project' drop-down to display the projects he/she is a member of, Cloudstack must fetch the latest projects data from the database and repopulate the drop-down so that it displays all the up-to-date projects including projects that this user has been added to in other user sessions.

Current Behaviour:
Whenever user 'y' clicks on the drop-down to display the projects, it does not include the newly added project 'z' unless the HTML page is refreshed.

To Reproduce:
In the UI, log in as an Admin User. While logged in as an Admin User, also log in to another session as a different user. 
Go back to the Admin User session and on the lefthand side, select the Projects link.
Create a new project or select an existing project. Add to the project the account belonging to the user that you used to log in to the other session. 
After adding the account to the project in the Admin User session, go back to the added account user's session and click on the 'Project' drop-down in the top left corner. The drop-down will display all the projects that the user is a part of, except the project that he/she has just been added to in the Admin user's session.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30108093/44208008-71eb2100-a15f-11e8-8654-565d270e6136.png)
![image](https://user-images.githubusercontent.com/30108093/44208045-8af3d200-a15f-11e8-9c69-337334e79ca9.png)

## How Has This Been Tested?
Manually (See screenshots above):
<!-- Please describe in detail how you tested your changes. -->
In the UI, log in as an Admin User. While logged in as an Admin User, also log in to another session as a different user. 
Go back to the Admin User session and on the lefthand side, select the Projects link.
Create a new project or select an existing project. Add to the project the account belonging to the user that you used to log in to the other session. 
After adding the account to the project in the Admin User session, go back to the added account user's session and click on the 'Project' drop-down in the top left corner. The drop-down will now display all the projects that the user is a part including the project that he/she has just been added to in the Admin user's session.
<!-- Include details of your testing environment, and the tests you ran to -->
CloudStack version 4.11, KVM hypervisor.
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

