### PR TITLE
display translation labels as html instead of plain text

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1759,7 +1759,7 @@
             // Translate labels on the fly
             $.each($.find('translate[key]'), function(idx, elem) {
                 var key = $(elem).attr('key');
-                $(elem).text(translate(key));
+                $(elem).html(translate(key));
             });
 
             // Translate element attributes


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

fixes #2575 

In the dictionary internationalization javascript files there are certain label translation descriptions that contain HTML markup to help format the text when it is rendered in the UI. 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

Expected Behaviour:
These HTML markup tags must be rendered as HTML instead of plain text.

Actual Behaviour:
These HTML markup tags are currently rendering as plain text instead of HTML.
For example, the HTML line break tag renders as plain text: '\<br/\>' instead of rendering an actual HTML line break.

To Reproduce:
Create a Zone. In the UI, in the left-hand pane, click on the Infrastructure link and click on Zones.
On the Zones screen, click on the 'Create Zone' button to create a Zone. Follow the Zone creation wizard steps up until the 'HOST' step. Notice that the description contains the '\<br/\>' text instead of rendering it as HTML.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

Fixes: #2575 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30108093/44266035-4f253f00-a229-11e8-8c4b-0579e6b042ef.png)

## How Has This Been Tested?
Manually: (See screenshot above)
<!-- Please describe in detail how you tested your changes. -->
Create a Zone. In the UI, in the left-hand pane, click on the Infrastructure link and click on Zones.
On the Zones screen, click on the 'Create Zone' button to create a Zone. Follow the Zone creation wizard steps up until the 'HOST' step. It now renders the \<br/\> HTML markup as HTML instead of plain text.
<!-- Include details of your testing environment, and the tests you ran to -->
CloudStack version 4.11, KVM hypervisor.
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

