### PR TITLE
KVM hook script include

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -6,9 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-#
 #   http://www.apache.org/licenses/LICENSE-2.0
-#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,6 +17,9 @@
 import logging
 import re
 import sys
+import os
+import subprocess
+from threading import Timer
 from xml.dom.minidom import parse
 from cloudutils.configFileOps import configFileOps
 from cloudutils.networkConfig import networkConfig
@@ -30,19 +31,24 @@ logging.basicConfig(filename='/var/log/libvirt/qemu-hook.log',
                     level=logging.INFO)
 logger = logging.getLogger('qemu-hook')
 
+customDir = "/etc/libvirt/hooks/custom"
+customDirPermissions = 0744
+timeoutSeconds = 10 * 60
+validQemuActions = ['prepare', 'start', 'started', 'stopped', 'release', 'migrate', 'restore', 'reconnect', 'attach']
+
 def isOldStyleBridge(brName):
     if brName.find("cloudVirBr") == 0:
-       return True
+        return True
     else:
-       return False
+        return False
 
 def isNewStyleBridge(brName):
     if brName.startswith('brvx-'):
         return False
     if re.match(r"br(\w+)-(\d+)", brName) == None:
-       return False
+        return False
     else:
-       return True
+        return True
 
 def getGuestNetworkDevice():
     netlib = networkConfig()
@@ -71,6 +77,66 @@ def handleMigrateBegin():
         pass
 
 
+def executeCustomScripts(sysArgs):
+    createDirectoryIfNotExists(customDir, customDirPermissions)
+    scripts = getCustomScriptsFromDirectory()
+
+    for scriptName in scripts:
+        executeScript(scriptName, sysArgs)
+
+
+def executeScript(scriptName, sysArgs):
+    logger.info('Executing custom script: %s, parameters: %s' % (scriptName, ' '.join(map(str, sysArgs))))
+    path = customDir + os.path.sep + scriptName
+
+    if not os.access(path, os.X_OK):
+        logger.warning('Custom script: %s is not executable; skipping execution.' % scriptName)
+        return
+
+    try:
+        process = subprocess.Popen([path] + sysArgs, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, shell=False)
+        try:
+            timer = Timer(timeoutSeconds, terminateProcess, [process, scriptName])
+            timer.start()
+            output, error = process.communicate()
+
+            if process.returncode == -15:
+                logger.error('Custom script: %s terminated after timeout of %s second[s].'
+                             % (scriptName, timeoutSeconds))
+                return
+            if process.returncode != 0:
+                logger.info('return code: %s' % str(process.returncode))
+                raise Exception(error)
+            logger.info('Custom script: %s finished successfully; output: \n%s' %
+                        (scriptName, str(output)))
+        finally:
+            timer.cancel()
+    except (OSError, Exception) as e:
+        logger.exception("Custom script: %s finished with error: \n%s" % (scriptName, e))
+
+
+def terminateProcess(process, scriptName):
+    logger.warning('Custom script: %s taking longer than %s second[s]; terminating..' % (scriptName, str(timeoutSeconds)))
+    process.terminate()
+
+
+def getCustomScriptsFromDirectory():
+    return sorted(filter(lambda fileName: (fileName is not None) & (fileName != "") & ('_' in fileName) &
+                                          (fileName.startswith((action + '_')) | fileName.startswith(('all' + '_'))),
+                         os.listdir(customDir)), key=lambda fileName: substringAfter(fileName, '_'))
+
+
+def createDirectoryIfNotExists(dir, permissions):
+    if not os.path.exists(dir):
+        logger.info('Directory %s does not exist; creating it.' % dir)
+        os.makedirs(dir, permissions)
+
+
+def substringAfter(s, delimiter):
+    return s.partition(delimiter)[2]
+
+
 if __name__ == '__main__':
     if len(sys.argv) != 5:
         sys.exit(0)
@@ -79,5 +145,11 @@ if __name__ == '__main__':
     logger.debug("Executing qemu hook with args: %s" % sys.argv)
     action, status = sys.argv[2:4]
 
+    if action not in validQemuActions:
+        logger.error('The given action: %s, is not a valid libvirt qemu operation.' % action)
+        sys.exit(0)
+
     if action == "migrate" and status == "begin":
         handleMigrateBegin()
+
+    executeCustomScripts(sys.argv[1:])


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
KVM utilised under CloudStack uses the standard libvirt hook script behaviour. During the install of the KVM CloudStack agent the script "/etc/libvirt/hooks/qemu" is populated based on the CloudStack-provided file "libvirtqemuhook.in". This is a python script that carries out network management every time a VM is started, stopped or migrated (as per the qemu script specification). Please note that CloudStack does not provide any scripts for other libvirt actions – and the scope of this feature request is limited to the "qemu" script itself.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
Design Document page:
https://cwiki.apache.org/confluence/display/CLOUDSTACK/KVM+hook+script+include
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?
Regression and Functional Tests.
<!-- Please describe in detail how you tested your changes. -->
Preconditions:
* Advanced zone configuration with 1 zones, 1 pods
* 2x hosts running KVM CentOS 6.9 
* Create custom scripts in the /etc/libvirt/hooks/custom:
1) all_custom.sh and all_custom.py
2) created custom scripts [action]_custom.sh 
3) created custom scripts [action]_custom.py

Functional Test steps:
* Verify python and shell scripts are able to be executed: Create .py and .sh scripts under the custom dir and verify they can be executed when having the right permissions.
* Scripts with non-executable permissions could not be executed: chmod 644 one of the scripts and run the libvirt action that invokes it.
* Execution order for all and [action]_scripts: Check that order of execution will be: • stopped_123.sh • all_234.sh • stopped_456.sh • stopped_abc.py
* Execution order sorting: Create scripts named: stopped_123.sh, s topped_456.sh, stopped_abc.py. Then stop a VM. Check that order of execution will be as follows: • stopped_123.sh • all_234.sh • stopped_456.sh • stopped_abc.py
* Output of stderr and stdout is logged: Create a stopped_error.sh that will return an error. Stop a VM Error log is logged in the qemu-hook.log as well as stdout.
* Prepare action: Start an instance. Observe that prepare action is part of starting a VM and it executes all prepare_* scripts.
* Start action: Start an instance. Observe that when starting a VM it executes all start_* scripts.
* Started action: Start an instance Observe that started action is part of starting a VM and it executes all started _* scripts.
* Stopped action: Stop an instance. When an instance is stopped all s topped_* scripts are executed.
* Release action: Stop an instance. Observe that release action is part of stopping a VM and it executes all release_* scripts.
* Migrate action: Migrate an instance to another host. All migrate_* scripts are executed.
* Restore action: Restore action is not available to be invoked by cloudstack - agent but it still is available within the limits of this feature. It can be run manually with the following syntax: restore <file> [ -- bypass - cache] [ -- xml <string>] [ - - running] [ -- paused]. All restore_* scripts are executed.
* Reconnect action: Restart libvirt. All reconnect_* scripts are executed.
* Attach action: Restore action is not available to be invoked by cloudstack - agent but it still is available wit hin the limits of this feature. It can be run manually with the following syntax: attach - disk <domain> <source> <target> [ -- driver <string>] [ -- subdriver <string>] [ -- cache <string>] [ -- type <string>] [ -- mode <string>] [ -- sourcetype <string>] [ --serial <st ring>] [ -- shareable] [ -- rawio] [ -- address <string>] [ -- multifunction] [ -- persistent] [ -- config] [ -- live] [ -- current]. All attach_* scripts are executed.
* Invalid action: Call libvirthook.in with 'invalid' action parameter Error message of invalid act ion is logged in the qemu – hook.log.
* Invalid file name: Create a 123.py script without any action prefix and underscore 123.py script is not executed.
* Arguments passing: Create start_args.sh script capturing input parameters and start VM. S tart_ args.sh is executed and captures same input parameters as t he qemu script.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

