### PR TITLE
Fix SystemVMs running in Xen HVM mode are not configured (#2760)

### DIFF
--- a/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
+++ b/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
@@ -35,6 +35,16 @@ log_it() {
 }
 
 hypervisor() {
+  if [ -d /proc/xen ]; then
+    mount -t xenfs none /proc/xen
+    $(dmesg | grep -q "Xen HVM")
+    if [ $? -eq 0 ]; then  # 1=PV,0=HVM
+      echo "xen-hvm" && return 0
+    else
+      echo "xen-pv" && return 0
+    fi
+  fi
+
   [ -x /usr/sbin/virt-what ] && local facts=( $(virt-what) )
   if [ "$facts" != "" ]; then
     # Xen HVM is recognized as Hyperv when Viridian extensions are enabled
@@ -47,16 +57,6 @@ hypervisor() {
 
   grep -q QEMU /proc/cpuinfo  && echo "kvm" && return 0
   grep -q QEMU /var/log/messages && echo "kvm" && return 0
-
-  [ -d /proc/xen ] && mount -t xenfs none /proc/xen
-  if [ -d /proc/xen ]; then
-    $(dmesg | grep -q "Xen HVM")
-    if [ $? -eq 0 ]; then  # 1=PV,0=HVM
-      echo "xen-hvm" && return 0
-    else
-      echo "xen-pv" && return 0
-    fi
-  fi
 
   vmware-checkvm &> /dev/null && echo "vmware" && return 0
 

--- a/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
+++ b/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
@@ -35,8 +35,15 @@ log_it() {
 }
 
 hypervisor() {
-  local try=$([ -x /usr/sbin/virt-what ] && virt-what | tail -1)
-  [ "$try" != "" ] && echo $try && return 0
+  [ -x /usr/sbin/virt-what ] && local facts=( $(virt-what) )
+  if [ "$facts" != "" ]; then
+    # Xen HVM is recognized as Hyperv when Viridian extensions are enabled
+    if [ "${facts[-1]}" == "xen-domU" ] && [ "${facts[0]}" == "hyperv" ]; then
+      echo "xen-hvm" && return 0
+    else
+      echo ${facts[-1]} && return 0
+    fi
+  fi
 
   grep -q QEMU /proc/cpuinfo  && echo "kvm" && return 0
   grep -q QEMU /var/log/messages && echo "kvm" && return 0


### PR DESCRIPTION
Set hypervisor to xen-hvm when virt-what detects both HyperV cpuid and xen-domU

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

Fixes: #2760 

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested on Cloudstack 4.11.1 + XenServer 7.1.1 with a patched systemvm template.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

