### PR TITLE
Bigger partiton table for SVM & ambigous redirect bugfix

### DIFF
--- a/tools/appliance/shar_cloud_scripts.sh
+++ b/tools/appliance/shar_cloud_scripts.sh
@@ -44,7 +44,7 @@ cd ${CLOUDSTACK_DIR}/systemvm/debian
 tar -cf ${TEMP_DIR}/cloud_scripts/usr/share/cloud/cloud-scripts.tar *
 
 cd ${TEMP_DIR}
-shar `find . -print` > ${CURR_DIR}/cloud_scripts_shar_archive.sh
+shar `find . -print` > "${CURR_DIR}"/cloud_scripts_shar_archive.sh
 
 cd ${CURR_DIR}
 rm -rf ${TEMP_DIR}

--- a/tools/appliance/systemvmtemplate/http/preseed.cfg
+++ b/tools/appliance/systemvmtemplate/http/preseed.cfg
@@ -54,13 +54,13 @@ d-i partman-auto/disk string /dev/vda
 d-i partman-auto/method string regular
 d-i partman-auto/expert_recipe string                         \
       boot-root ::                                            \
-              80 60 80 ext2                                   \
+              100 60 100 ext2                                 \
                       $primary{ } $bootable{ }                \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext2 }    \
                       mountpoint{ /boot }                     \
               .                                               \
-              1175 40 1200 ext4                                \
+              1175 40 1200 ext4                               \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext4 }    \
                       mountpoint{ / }                         \

--- a/tools/appliance/systemvmtemplate/http/preseed.cfg
+++ b/tools/appliance/systemvmtemplate/http/preseed.cfg
@@ -60,7 +60,7 @@ d-i partman-auto/expert_recipe string                         \
                       use_filesystem{ } filesystem{ ext2 }    \
                       mountpoint{ /boot }                     \
               .                                               \
-              975 40 1000 ext4                                \
+              1175 40 1200 ext4                                \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext4 }    \
                       mountpoint{ / }                         \

--- a/tools/appliance/systemvmtemplate/http/preseed.cfg
+++ b/tools/appliance/systemvmtemplate/http/preseed.cfg
@@ -54,7 +54,7 @@ d-i partman-auto/disk string /dev/vda
 d-i partman-auto/method string regular
 d-i partman-auto/expert_recipe string                         \
       boot-root ::                                            \
-              60 60 60 ext2                                   \
+              80 60 80 ext2                                   \
                       $primary{ } $bootable{ }                \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext2 }    \

--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -32,7 +32,7 @@
         [ "-m", "512M" ],
         [ "-smp", "cpus=1,maxcpus=1,cores=1" ]
       ],
-      "disk_size": 1800,
+      "disk_size": 2000,
       "format": "qcow2",
 
       "disk_interface": "virtio",


### PR DESCRIPTION
## Description
build.sh systemvmtemplate failed while pulling updates. Reason was ‘No Space Left on Device’ Error on the root partition.
So I went on and increased the partition size and it built succesfully.

Testing revealed, that the boot partition has to be bigger than 60MB to allow installing updates.

Also I had bash ambiguous redirect error in shar_cloud_scripts.sh wich I fixed by placing quotes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Built successfully via:
bash build.sh systemvmtemplate

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
Testing
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

