### PR TITLE
Fix for Vmware full clones update

### DIFF
--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -1399,7 +1399,7 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
                 if (cloneSettingVO != null) {
                     if (!cloneSettingVO.getCloneType().equals(cloneType.toString())) {
                         cloneSettingVO.setCloneType(cloneType.toString());
-                        _vmCloneSettingDao.update(cloneSettingVO.getVmId(), cloneSettingVO);
+                        _vmCloneSettingDao.update(cloneSettingVO.getId(), cloneSettingVO);
                     }
                 } else {
                     UserVmCloneSettingVO vmCloneSettingVO = new UserVmCloneSettingVO(vm.getId(), cloneType.toString());

--- a/engine/schema/resources/META-INF/db/schema-41110to41120.sql
+++ b/engine/schema/resources/META-INF/db/schema-41110to41120.sql
@@ -22,3 +22,9 @@
 -- XenServer 7.5
 INSERT IGNORE INTO `cloud`.`hypervisor_capabilities`(uuid, hypervisor_type, hypervisor_version, max_guests_limit, max_data_volumes_limit, storage_motion_supported) values (UUID(), 'XenServer', '7.5.0', 500, 13, 1);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) SELECT UUID(),'Xenserver', '7.5.0', guest_os_name, guest_os_id, utc_timestamp(), 0  FROM `cloud`.`guest_os_hypervisor` WHERE hypervisor_type='Xenserver' AND hypervisor_version='7.4.0';
+
+-- Fix Vmware full clones issue
+ALTER TABLE `cloud`.`user_vm_clone_setting`
+ADD COLUMN `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT FIRST,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (`id`);

--- a/engine/schema/src/com/cloud/vm/UserVmCloneSettingVO.java
+++ b/engine/schema/src/com/cloud/vm/UserVmCloneSettingVO.java
@@ -16,13 +16,23 @@
 // under the License.
 package com.cloud.vm;
 
+import org.apache.cloudstack.api.InternalIdentity;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
 @Table(name = "user_vm_clone_setting")
-public class UserVmCloneSettingVO {
+public class UserVmCloneSettingVO implements InternalIdentity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private long id;
 
     @Column(name = "vm_id")
     private Long vmId;
@@ -49,5 +59,10 @@ public class UserVmCloneSettingVO {
 
     public void setCloneType(String cloneType) {
         this.cloneType = cloneType;
+    }
+
+    @Override
+    public long getId() {
+        return id;
     }
 }


### PR DESCRIPTION
## Description
The use of full/linked clones on Vmware caused some VMs not starting due to ArrayIndexOutOfBoundsException

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
#2838 BLOCKER: 4.11.1: VMware: VM start fails with ArrayIndexOutOfBoundsException

## Screenshots (if appropriate):

## How Has This Been Tested?
On Vmware environment:
- Set configuration vmware.create.full.clone = true
- Create VM
- Set configuration vmware.create.full.clone = false
- Stop/start the same VM 

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

