### PR TITLE
Fix PowerReportMissing for new VRs

### DIFF
--- a/engine/orchestration/src/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
+++ b/engine/orchestration/src/com/cloud/vm/VirtualMachinePowerStateSyncImpl.java
@@ -123,8 +123,12 @@ public class VirtualMachinePowerStateSyncImpl implements VirtualMachinePowerStat
 
                 Date vmStateUpdateTime = instance.getPowerStateUpdateTime();
                 if (vmStateUpdateTime == null) {
-                    s_logger.warn("VM state was updated but update time is null?! vm id: " + instance.getId());
-                    vmStateUpdateTime = currentTime;
+                    s_logger.warn("VM power state update time is null, falling back to update time for vm id: " + instance.getId());
+                    vmStateUpdateTime = instance.getUpdateTime();
+                    if (vmStateUpdateTime == null) {
+                        s_logger.warn("VM update time is null, falling back to creation time for vm id: " + instance.getId());
+                        vmStateUpdateTime = instance.getCreated();
+                    }
                 }
 
                 if (s_logger.isDebugEnabled())


### PR DESCRIPTION
## Description
Fallback to update (and creating) time when power state update time is null.
Follow up of CLOUDSTACK-8848 
(also see https://github.com/apache/cloudstack/commit/542880ae76c5e6eefbf61d42364e881495e6f3af#diff-dd162c545fd70c5cf2c4b2fa599c13c9L114)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

Fixes #2845 

## Screenshots (if appropriate):
N/A

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Needs testing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

