### PR TITLE
CLOUDSTACK-10365: Change the "getXXX" boolean-related method names to…

### DIFF
--- a/api/src/main/java/com/cloud/agent/api/to/S3TO.java
+++ b/api/src/main/java/com/cloud/agent/api/to/S3TO.java
@@ -201,7 +201,7 @@ public final class S3TO implements ClientOptions, DataStoreTO {
         return DataStoreRole.Image;
     }
 
-    public boolean getEnableRRS() {
+    public boolean isEnableRRS() {
         return enableRRS;
     }
 

--- a/api/src/main/java/com/cloud/offering/DiskOffering.java
+++ b/api/src/main/java/com/cloud/offering/DiskOffering.java
@@ -57,13 +57,13 @@ public interface DiskOffering extends InfrastructureEntity, Identity, InternalId
 
     String getUniqueName();
 
-    boolean getUseLocalStorage();
+    boolean isUseLocalStorage();
 
     Long getDomainId();
 
     String getName();
 
-    boolean getSystemUse();
+    boolean isSystemUse();
 
     String getDisplayText();
 

--- a/api/src/main/java/com/cloud/offering/NetworkOffering.java
+++ b/api/src/main/java/com/cloud/offering/NetworkOffering.java
@@ -82,11 +82,11 @@ public interface NetworkOffering extends InfrastructureEntity, InternalIdentity,
      */
     Integer getMulticastRateMbps();
 
-    boolean getForVpc();
+    boolean isForVpc();
 
     TrafficType getTrafficType();
 
-    boolean getSpecifyVlan();
+    boolean isSpecifyVlan();
 
     String getTags();
 
@@ -106,39 +106,39 @@ public interface NetworkOffering extends InfrastructureEntity, InternalIdentity,
 
     Long getServiceOfferingId();
 
-    boolean getDedicatedLB();
+    boolean isDedicatedLB();
 
-    boolean getSharedSourceNat();
+    boolean isSharedSourceNat();
 
-    boolean getRedundantRouter();
+    boolean isRedundantRouter();
 
     boolean isConserveMode();
 
-    boolean getElasticIp();
+    boolean isElasticIp();
 
-    boolean getAssociatePublicIP();
+    boolean isAssociatePublicIP();
 
-    boolean getElasticLb();
+    boolean isElasticLb();
 
-    boolean getSpecifyIpRanges();
+    boolean isSpecifyIpRanges();
 
     boolean isInline();
 
-    boolean getIsPersistent();
+    boolean isPersistent();
 
-    boolean getInternalLb();
+    boolean isInternalLb();
 
-    boolean getPublicLb();
+    boolean isPublicLb();
 
-    boolean getEgressDefaultPolicy();
+    boolean isEgressDefaultPolicy();
 
     Integer getConcurrentConnections();
 
     boolean isKeepAliveEnabled();
 
-    boolean getSupportsStrechedL2();
+    boolean isSupportingStrechedL2();
 
-    boolean getSupportsPublicAccess();
+    boolean isSupportingPublicAccess();
 
     String getServicePackage();
 }

--- a/api/src/main/java/com/cloud/offering/ServiceOffering.java
+++ b/api/src/main/java/com/cloud/offering/ServiceOffering.java
@@ -56,7 +56,7 @@ public interface ServiceOffering extends DiskOffering, InfrastructureEntity, Int
      * @return is this a system service offering
      */
     @Override
-    boolean getSystemUse();
+    boolean isSystemUse();
 
     /**
      * @return # of cpu.
@@ -76,7 +76,7 @@ public interface ServiceOffering extends DiskOffering, InfrastructureEntity, Int
     /**
      * @return Does this service plan offer HA?
      */
-    boolean getOfferHA();
+    boolean isOfferHA();
 
     /**
      * @return Does this service plan offer VM to use CPU resources beyond the service offering limits?
@@ -86,7 +86,7 @@ public interface ServiceOffering extends DiskOffering, InfrastructureEntity, Int
     /**
      * @return Does this service plan support Volatile VM that is, discard VM's root disk and create a new one on reboot?
      */
-    boolean getVolatileVm();
+    boolean isVolatileVm();
 
     /**
      * @return the rate in megabits per sec to which a VM's network interface is throttled to
@@ -102,7 +102,7 @@ public interface ServiceOffering extends DiskOffering, InfrastructureEntity, Int
      * @return whether or not the service offering requires local storage
      */
     @Override
-    boolean getUseLocalStorage();
+    boolean isUseLocalStorage();
 
     @Override
     Long getDomainId();

--- a/api/src/main/java/com/cloud/storage/GuestOS.java
+++ b/api/src/main/java/com/cloud/storage/GuestOS.java
@@ -33,5 +33,5 @@ public interface GuestOS extends InternalIdentity, Identity {
 
     Date getRemoved();
 
-    boolean getIsUserDefined();
+    boolean isUserDefined();
 }

--- a/api/src/main/java/com/cloud/template/VirtualMachineTemplate.java
+++ b/api/src/main/java/com/cloud/template/VirtualMachineTemplate.java
@@ -101,9 +101,9 @@ public interface VirtualMachineTemplate extends ControlledEntity, Identity, Inte
 
     String getDisplayText();
 
-    boolean getEnablePassword();
+    boolean isEnablePassword();
 
-    boolean getEnableSshKey();
+    boolean isEnableSshKey();
 
     boolean isCrossZones();
 

--- a/api/src/main/java/com/cloud/vm/DiskProfile.java
+++ b/api/src/main/java/com/cloud/vm/DiskProfile.java
@@ -68,7 +68,7 @@ public class DiskProfile {
             offering.getId(),
             vol.getSize(),
             offering.getTagsArray(),
-            offering.getUseLocalStorage(),
+            offering.isUseLocalStorage(),
             offering.isCustomized(),
             null);
         this.hyperType = hyperType;

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/address/AssociateIPAddrCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/address/AssociateIPAddrCmd.java
@@ -238,7 +238,7 @@ public class AssociateIPAddrCmd extends BaseAsyncCreateCmd {
             NetworkOffering offering = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
 
             DataCenter zone = _entityMgr.findById(DataCenter.class, network.getDataCenterId());
-            if (zone.getNetworkType() == NetworkType.Basic && offering.getElasticIp() && offering.getElasticLb()) {
+            if (zone.getNetworkType() == NetworkType.Basic && offering.isElasticIp() && offering.isElasticLb()) {
                 // Since the basic zone network is owned by 'Root' domain, domain access checkers will fail for the
                 // accounts in non-root domains while acquiring public IP. So add an exception for the 'Basic' zone
                 // shared network with EIP/ELB service.

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/volume/ResizeVolumeCmd.java
@@ -107,7 +107,7 @@ public class ResizeVolumeCmd extends BaseAsyncCmd {
         return size;
     }
 
-    public boolean getShrinkOk() {
+    public boolean isShrinkOk() {
         return shrinkOk;
     }
 

--- a/core/src/main/java/com/cloud/storage/template/S3TemplateDownloader.java
+++ b/core/src/main/java/com/cloud/storage/template/S3TemplateDownloader.java
@@ -184,7 +184,7 @@ public class S3TemplateDownloader extends ManagedContextRunnable implements Temp
         PutObjectRequest putObjectRequest = new PutObjectRequest(s3TO.getBucketName(), s3Key, inputStream, objectMetadata);
 
         // If reduced redundancy is enabled, set it.
-        if (s3TO.getEnableRRS()) {
+        if (s3TO.isEnableRRS()) {
             putObjectRequest.withStorageClass(StorageClass.ReducedRedundancy);
         }
 

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -3214,14 +3214,14 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         // Check that the service offering being upgraded to has the same storage pool preference as the VM's current service
         // offering
-        if (currentServiceOffering.getUseLocalStorage() != newServiceOffering.getUseLocalStorage()) {
+        if (currentServiceOffering.isUseLocalStorage() != newServiceOffering.isUseLocalStorage()) {
             throw new InvalidParameterValueException("Unable to upgrade virtual machine " + vmInstance.toString() +
                     ", cannot switch between local storage and shared storage service offerings.  Current offering " + "useLocalStorage=" +
-                    currentServiceOffering.getUseLocalStorage() + ", target offering useLocalStorage=" + newServiceOffering.getUseLocalStorage());
+                    currentServiceOffering.isUseLocalStorage() + ", target offering useLocalStorage=" + newServiceOffering.isUseLocalStorage());
         }
 
         // if vm is a system vm, check if it is a system service offering, if yes return with error as it cannot be used for user vms
-        if (currentServiceOffering.getSystemUse() != newServiceOffering.getSystemUse()) {
+        if (currentServiceOffering.isSystemUse() != newServiceOffering.isSystemUse()) {
             throw new InvalidParameterValueException("isSystem property is different for current service offering and new service offering");
         }
 
@@ -3245,7 +3245,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         final VMInstanceVO vmForUpdate = _vmDao.createForUpdate();
         vmForUpdate.setServiceOfferingId(serviceOfferingId);
         final ServiceOffering newSvcOff = _entityMgr.findById(ServiceOffering.class, serviceOfferingId);
-        vmForUpdate.setHaEnabled(newSvcOff.getOfferHA());
+        vmForUpdate.setHaEnabled(newSvcOff.isOfferHA());
         vmForUpdate.setLimitCpuUse(newSvcOff.getLimitCpuUse());
         vmForUpdate.setServiceOfferingId(newSvcOff.getId());
         return _vmDao.update(vmId, vmForUpdate);

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -690,10 +690,10 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                     @Override
                     public void doInTransactionWithoutResult(final TransactionStatus status) {
                         final NetworkVO vo = new NetworkVO(id, network, offering.getId(), guru.getName(), owner.getDomainId(), owner.getId(), relatedFile, name, displayText, predefined
-                                .getNetworkDomain(), offering.getGuestType(), plan.getDataCenterId(), plan.getPhysicalNetworkId(), aclType, offering.getSpecifyIpRanges(),
-                                vpcId, offering.getRedundantRouter(), predefined.getExternalId());
+                                .getNetworkDomain(), offering.getGuestType(), plan.getDataCenterId(), plan.getPhysicalNetworkId(), aclType, offering.isSpecifyIpRanges(),
+                                vpcId, offering.isRedundantRouter(), predefined.getExternalId());
                         vo.setDisplayNetwork(isDisplayNetworkEnabled == null ? true : isDisplayNetworkEnabled);
-                        vo.setStrechedL2Network(offering.getSupportsStrechedL2());
+                        vo.setStrechedL2Network(offering.isSupportingStrechedL2());
                         final NetworkVO networkPersisted = _networksDao.persist(vo, vo.getGuestType() == Network.GuestType.Isolated,
                                 finalizeServicesAndProvidersForNetwork(offering, plan.getPhysicalNetworkId()));
                         networks.add(networkPersisted);
@@ -1110,7 +1110,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         //     2) network has sourceNat service
         //     3) network offering does not support a shared source NAT rule
 
-        final boolean sharedSourceNat = offering.getSharedSourceNat();
+        final boolean sharedSourceNat = offering.isSharedSourceNat();
         final DataCenter zone = _dcDao.findById(network.getDataCenterId());
 
         if (!sharedSourceNat && _networkModel.areServicesSupportedInNetwork(network.getId(), Service.SourceNat)
@@ -1220,7 +1220,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         if (_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Firewall) && _networkModel.areServicesSupportedInNetwork(network.getId(), Service.Firewall)
                 && (network.getGuestType() == Network.GuestType.Isolated || network.getGuestType() == Network.GuestType.Shared && zone.getNetworkType() == NetworkType.Advanced)) {
             // add default egress rule to accept the traffic
-            _firewallMgr.applyDefaultEgressFirewallRule(network.getId(), offering.getEgressDefaultPolicy(), true);
+            _firewallMgr.applyDefaultEgressFirewallRule(network.getId(), offering.isEgressDefaultPolicy(), true);
         }
         if (!_firewallMgr.applyFirewallRules(firewallEgressRulesToApply, false, caller)) {
             s_logger.warn("Failed to reapply firewall Egress rule(s) as a part of network id=" + networkId + " restart");
@@ -2171,7 +2171,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             }
 
             //don't allow eip/elb networks in Advance zone
-            if (ntwkOff.getElasticIp() || ntwkOff.getElasticLb()) {
+            if (ntwkOff.isElasticIp() || ntwkOff.isElasticLb()) {
                 throw new InvalidParameterValueException("Elastic IP and Elastic LB services are supported in zone of type " + NetworkType.Basic);
             }
         }
@@ -2183,7 +2183,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         //TODO(VXLAN): Support VNI specified
         // VlanId can be specified only when network offering supports it
         final boolean vlanSpecified = vlanId != null;
-        if (vlanSpecified != ntwkOff.getSpecifyVlan()) {
+        if (vlanSpecified != ntwkOff.isSpecifyVlan()) {
             if (vlanSpecified) {
                 throw new InvalidParameterValueException("Can't specify vlan; corresponding offering says specifyVlan=false");
             } else {

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -225,7 +225,7 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
         // Find a destination storage pool with the specified criteria
         DiskOffering diskOffering = _entityMgr.findById(DiskOffering.class, volume.getDiskOfferingId());
         DiskProfile dskCh = new DiskProfile(volume.getId(), volume.getVolumeType(), volume.getName(), diskOffering.getId(), diskOffering.getDiskSize(), diskOffering.getTagsArray(),
-                diskOffering.getUseLocalStorage(), diskOffering.isRecreatable(), null);
+                diskOffering.isUseLocalStorage(), diskOffering.isRecreatable(), null);
         dskCh.setHyperType(dataDiskHyperType);
         storageMgr.setDiskProfileThrottling(dskCh, null, diskOffering);
 
@@ -469,11 +469,11 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
                 throw new CloudRuntimeException("Template " + template.getName() + " has not been completely downloaded to zone " + dc.getId());
             }
 
-            return new DiskProfile(volume.getId(), volume.getVolumeType(), volume.getName(), diskOffering.getId(), ss.getSize(), diskOffering.getTagsArray(), diskOffering.getUseLocalStorage(),
+            return new DiskProfile(volume.getId(), volume.getVolumeType(), volume.getName(), diskOffering.getId(), ss.getSize(), diskOffering.getTagsArray(), diskOffering.isUseLocalStorage(),
                     diskOffering.isRecreatable(), Storage.ImageFormat.ISO != template.getFormat() ? template.getId() : null);
         } else {
             return new DiskProfile(volume.getId(), volume.getVolumeType(), volume.getName(), diskOffering.getId(), diskOffering.getDiskSize(), diskOffering.getTagsArray(),
-                    diskOffering.getUseLocalStorage(), diskOffering.isRecreatable(), null);
+                    diskOffering.isUseLocalStorage(), diskOffering.isRecreatable(), null);
         }
     }
 
@@ -648,7 +648,7 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
     }
 
     protected DiskProfile toDiskProfile(Volume vol, DiskOffering offering) {
-        return new DiskProfile(vol.getId(), vol.getVolumeType(), vol.getName(), offering.getId(), vol.getSize(), offering.getTagsArray(), offering.getUseLocalStorage(), offering.isRecreatable(),
+        return new DiskProfile(vol.getId(), vol.getVolumeType(), vol.getName(), offering.getId(), vol.getSize(), offering.getTagsArray(), offering.isUseLocalStorage(), offering.isRecreatable(),
                 vol.getTemplateId());
     }
 
@@ -1174,7 +1174,7 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
                                 s_logger.debug("Mismatch in storage pool " + assignedPool + " assigned by deploymentPlanner and the one associated with volume " + vol);
                             }
                             DiskOffering diskOffering = _entityMgr.findById(DiskOffering.class, vol.getDiskOfferingId());
-                            if (diskOffering.getUseLocalStorage()) {
+                            if (diskOffering.isUseLocalStorage()) {
                                 // Currently migration of local volume is not supported so bail out
                                 if (s_logger.isDebugEnabled()) {
                                     s_logger.debug("Local volume " + vol + " cannot be recreated on storagepool " + assignedPool + " assigned by deploymentPlanner");

--- a/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
+++ b/engine/orchestration/src/test/java/com/cloud/vm/VirtualMachineManagerImplTest.java
@@ -213,10 +213,10 @@ public class VirtualMachineManagerImplTest {
         ServiceOfferingVO mockCurrentServiceOffering = mock(ServiceOfferingVO.class);
 
         when(serviceOfferingDaoMock.findByIdIncludingRemoved(anyLong(), anyLong())).thenReturn(mockCurrentServiceOffering);
-        when(mockCurrentServiceOffering.getUseLocalStorage()).thenReturn(true);
-        when(serviceOfferingMock.getUseLocalStorage()).thenReturn(true);
-        when(mockCurrentServiceOffering.getSystemUse()).thenReturn(true);
-        when(serviceOfferingMock.getSystemUse()).thenReturn(true);
+        when(mockCurrentServiceOffering.isUseLocalStorage()).thenReturn(true);
+        when(serviceOfferingMock.isUseLocalStorage()).thenReturn(true);
+        when(mockCurrentServiceOffering.isSystemUse()).thenReturn(true);
+        when(serviceOfferingMock.isSystemUse()).thenReturn(true);
         when(mockCurrentServiceOffering.getTags()).thenReturn("x,y");
         when(serviceOfferingMock.getTags()).thenReturn("z,x,y");
 

--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkDaoImpl.java
@@ -119,7 +119,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
         AllFieldsSearch.and("redundant", AllFieldsSearch.entity().isRedundant(), Op.EQ);
         final SearchBuilder<NetworkOfferingVO> join1 = _ntwkOffDao.createSearchBuilder();
         join1.and("isSystem", join1.entity().isSystemOnly(), Op.EQ);
-        join1.and("isRedundant", join1.entity().getRedundantRouter(), Op.EQ);
+        join1.and("isRedundant", join1.entity().isRedundantRouter(), Op.EQ);
         AllFieldsSearch.join("offerings", join1, AllFieldsSearch.entity().getNetworkOfferingId(), join1.entity().getId(), JoinBuilder.JoinType.INNER);
         AllFieldsSearch.done();
 
@@ -196,7 +196,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
         NetworksRegularUserCanCreateSearch.join("accounts", join4, NetworksRegularUserCanCreateSearch.entity().getId(), join4.entity().getNetworkId(),
                 JoinBuilder.JoinType.INNER);
         final SearchBuilder<NetworkOfferingVO> join5 = _ntwkOffDao.createSearchBuilder();
-        join5.and("specifyVlan", join5.entity().getSpecifyVlan(), Op.EQ);
+        join5.and("specifyVlan", join5.entity().isSpecifyVlan(), Op.EQ);
         NetworksRegularUserCanCreateSearch.join("ntwkOff", join5, NetworksRegularUserCanCreateSearch.entity().getNetworkOfferingId(), join5.entity().getId(),
                 JoinBuilder.JoinType.INNER);
         NetworksRegularUserCanCreateSearch.done();
@@ -242,7 +242,7 @@ public class NetworkDaoImpl extends GenericDaoBase<NetworkVO, Long>implements Ne
         join7.and("check", join7.entity().isCheckForGc(), Op.EQ);
         GarbageCollectedSearch.join("ntwkOpGC", join7, GarbageCollectedSearch.entity().getId(), join7.entity().getId(), JoinBuilder.JoinType.INNER);
         final SearchBuilder<NetworkOfferingVO> join8 = _ntwkOffDao.createSearchBuilder();
-        join8.and("isPersistent", join8.entity().getIsPersistent(), Op.EQ);
+        join8.and("isPersistent", join8.entity().isPersistent(), Op.EQ);
         GarbageCollectedSearch.join("ntwkOffGC", join8, GarbageCollectedSearch.entity().getNetworkOfferingId(), join8.entity().getId(), JoinBuilder.JoinType.INNER);
         GarbageCollectedSearch.done();
 

--- a/engine/schema/src/main/java/com/cloud/network/vpc/PrivateIpVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/PrivateIpVO.java
@@ -97,7 +97,7 @@ public class PrivateIpVO implements InternalIdentity {
         return vpcId;
     }
 
-    public boolean getSourceNat() {
+    public boolean isSourceNat() {
         return sourceNat;
     }
 

--- a/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/offerings/NetworkOfferingVO.java
@@ -172,7 +172,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getForVpc() {
+    public boolean isForVpc() {
         return forVpc;
     }
 
@@ -249,7 +249,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getSpecifyVlan() {
+    public boolean isSpecifyVlan() {
         return specifyVlan;
     }
 
@@ -292,7 +292,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getDedicatedLB() {
+    public boolean isDedicatedLB() {
         return dedicatedLB;
     }
 
@@ -301,7 +301,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getSharedSourceNat() {
+    public boolean isSharedSourceNat() {
         return sharedSourceNat;
     }
 
@@ -310,7 +310,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getRedundantRouter() {
+    public boolean isRedundantRouter() {
         return redundantRouter;
     }
 
@@ -319,7 +319,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getEgressDefaultPolicy() {
+    public boolean isEgressDefaultPolicy() {
         return egressdefaultpolicy;
     }
 
@@ -456,22 +456,22 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getElasticIp() {
+    public boolean isElasticIp() {
         return elasticIp;
     }
 
     @Override
-    public boolean getAssociatePublicIP() {
+    public boolean isAssociatePublicIP() {
         return eipAssociatePublicIp;
     }
 
     @Override
-    public boolean getElasticLb() {
+    public boolean isElasticLb() {
         return elasticLb;
     }
 
     @Override
-    public boolean getSpecifyIpRanges() {
+    public boolean isSpecifyIpRanges() {
         return specifyIpRanges;
     }
 
@@ -485,17 +485,17 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getIsPersistent() {
+    public boolean isPersistent() {
         return isPersistent;
     }
 
     @Override
-    public boolean getInternalLb() {
+    public boolean isInternalLb() {
         return internalLb;
     }
 
     @Override
-    public boolean getPublicLb() {
+    public boolean isPublicLb() {
         return publicLb;
     }
 
@@ -517,7 +517,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getSupportsStrechedL2() {
+    public boolean isSupportingStrechedL2() {
         return supportsStrechedL2;
     }
 
@@ -526,7 +526,7 @@ public class NetworkOfferingVO implements NetworkOffering {
     }
 
     @Override
-    public boolean getSupportsPublicAccess() {
+    public boolean isSupportingPublicAccess() {
         return supportsPublicAccess;
     }
 

--- a/engine/schema/src/main/java/com/cloud/offerings/dao/NetworkOfferingDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/offerings/dao/NetworkOfferingDaoImpl.java
@@ -162,7 +162,7 @@ public class NetworkOfferingDaoImpl extends GenericDaoBase<NetworkOfferingVO, Lo
         sc.addAnd("state", SearchCriteria.Op.EQ, NetworkOffering.State.Enabled);
 
         //specify Vlan should be the same
-        sc.addAnd("specifyVlan", SearchCriteria.Op.EQ, originalOffering.getSpecifyVlan());
+        sc.addAnd("specifyVlan", SearchCriteria.Op.EQ, originalOffering.isSpecifyVlan());
 
         return customSearch(sc, null);
     }

--- a/engine/schema/src/main/java/com/cloud/service/ServiceOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/service/ServiceOfferingVO.java
@@ -173,8 +173,8 @@ public class ServiceOfferingVO extends DiskOfferingVO implements ServiceOffering
             false,
             offering.getTags(),
             offering.isRecreatable(),
-            offering.getUseLocalStorage(),
-            offering.getSystemUse(),
+            offering.isUseLocalStorage(),
+            offering.isSystemUse(),
             true,
             offering.isCustomizedIops()== null ? false:offering.isCustomizedIops(),
             offering.getDomainId(),
@@ -185,15 +185,15 @@ public class ServiceOfferingVO extends DiskOfferingVO implements ServiceOffering
         speed = offering.getSpeed();
         rateMbps = offering.getRateMbps();
         multicastRateMbps = offering.getMulticastRateMbps();
-        offerHA = offering.getOfferHA();
+        offerHA = offering.isOfferHA();
         limitCpuUse = offering.getLimitCpuUse();
-        volatileVm = offering.getVolatileVm();
+        volatileVm = offering.isVolatileVm();
         hostTag = offering.getHostTag();
         vmType = offering.getSystemVmType();
     }
 
     @Override
-    public boolean getOfferHA() {
+    public boolean isOfferHA() {
         return offerHA;
     }
 
@@ -296,7 +296,7 @@ public class ServiceOfferingVO extends DiskOfferingVO implements ServiceOffering
     }
 
     @Override
-    public boolean getVolatileVm() {
+    public boolean isVolatileVm() {
         return volatileVm;
     }
 

--- a/engine/schema/src/main/java/com/cloud/service/dao/ServiceOfferingDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/service/dao/ServiceOfferingDaoImpl.java
@@ -60,7 +60,7 @@ public class ServiceOfferingDaoImpl extends GenericDaoBase<ServiceOfferingVO, Lo
 
         UniqueNameSearch = createSearchBuilder();
         UniqueNameSearch.and("name", UniqueNameSearch.entity().getUniqueName(), SearchCriteria.Op.EQ);
-        UniqueNameSearch.and("system", UniqueNameSearch.entity().getSystemUse(), SearchCriteria.Op.EQ);
+        UniqueNameSearch.and("system", UniqueNameSearch.entity().isSystemUse(), SearchCriteria.Op.EQ);
         UniqueNameSearch.done();
 
         ServiceOfferingsByDomainIdSearch = createSearchBuilder();
@@ -69,14 +69,14 @@ public class ServiceOfferingDaoImpl extends GenericDaoBase<ServiceOfferingVO, Lo
 
         SystemServiceOffering = createSearchBuilder();
         SystemServiceOffering.and("domainId", SystemServiceOffering.entity().getDomainId(), SearchCriteria.Op.EQ);
-        SystemServiceOffering.and("system", SystemServiceOffering.entity().getSystemUse(), SearchCriteria.Op.EQ);
+        SystemServiceOffering.and("system", SystemServiceOffering.entity().isSystemUse(), SearchCriteria.Op.EQ);
         SystemServiceOffering.and("vm_type", SystemServiceOffering.entity().getSpeed(), SearchCriteria.Op.EQ);
         SystemServiceOffering.and("removed", SystemServiceOffering.entity().getRemoved(), SearchCriteria.Op.NULL);
         SystemServiceOffering.done();
 
         PublicServiceOfferingSearch = createSearchBuilder();
         PublicServiceOfferingSearch.and("domainId", PublicServiceOfferingSearch.entity().getDomainId(), SearchCriteria.Op.NULL);
-        PublicServiceOfferingSearch.and("system", PublicServiceOfferingSearch.entity().getSystemUse(), SearchCriteria.Op.EQ);
+        PublicServiceOfferingSearch.and("system", PublicServiceOfferingSearch.entity().isSystemUse(), SearchCriteria.Op.EQ);
         PublicServiceOfferingSearch.and("removed", PublicServiceOfferingSearch.entity().getRemoved(), SearchCriteria.Op.NULL);
         PublicServiceOfferingSearch.done();
 
@@ -111,7 +111,7 @@ public class ServiceOfferingDaoImpl extends GenericDaoBase<ServiceOfferingVO, Lo
                 update(vo.getId(), vo);
             }
             if (!vo.getUniqueName().endsWith("-Local")) {
-                if (vo.getUseLocalStorage()) {
+                if (vo.isUseLocalStorage()) {
                     vo.setUniqueName(vo.getUniqueName() + "-Local");
                     vo.setName(vo.getName() + " - Local Storage");
                     update(vo.getId(), vo);
@@ -260,7 +260,7 @@ public class ServiceOfferingDaoImpl extends GenericDaoBase<ServiceOfferingVO, Lo
         }
 
         boolean useLocal = true;
-        if (offering.getUseLocalStorage()) { // if 1st one is already local then 2nd needs to be shared
+        if (offering.isUseLocalStorage()) { // if 1st one is already local then 2nd needs to be shared
             useLocal = false;
         }
 

--- a/engine/schema/src/main/java/com/cloud/storage/DiskOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/DiskOfferingVO.java
@@ -299,7 +299,7 @@ public class DiskOfferingVO implements DiskOffering {
     }
 
     @Override
-    public boolean getUseLocalStorage() {
+    public boolean isUseLocalStorage() {
         return useLocalStorage;
     }
 
@@ -332,7 +332,7 @@ public class DiskOfferingVO implements DiskOffering {
     }
 
     @Override
-    public boolean getSystemUse() {
+    public boolean isSystemUse() {
         return systemUse;
     }
 

--- a/engine/schema/src/main/java/com/cloud/storage/GuestOSVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/GuestOSVO.java
@@ -113,7 +113,7 @@ public class GuestOSVO implements GuestOS {
     }
 
     @Override
-    public boolean getIsUserDefined() {
+    public boolean isUserDefined() {
         return isUserDefined;
     }
 

--- a/engine/schema/src/main/java/com/cloud/storage/VMTemplateVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/VMTemplateVO.java
@@ -284,7 +284,7 @@ public class VMTemplateVO implements VirtualMachineTemplate {
     }
 
     @Override
-    public boolean getEnablePassword() {
+    public boolean isEnablePassword() {
         return enablePassword;
     }
 
@@ -573,7 +573,7 @@ public class VMTemplateVO implements VirtualMachineTemplate {
     }
 
     @Override
-    public boolean getEnableSshKey() {
+    public boolean isEnableSshKey() {
         return enableSshKey;
     }
 

--- a/engine/schema/src/main/java/com/cloud/storage/dao/DiskOfferingDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/DiskOfferingDaoImpl.java
@@ -52,7 +52,7 @@ public class DiskOfferingDaoImpl extends GenericDaoBase<DiskOfferingVO, Long> im
 
         PublicDiskOfferingSearch = createSearchBuilder();
         PublicDiskOfferingSearch.and("domainId", PublicDiskOfferingSearch.entity().getDomainId(), SearchCriteria.Op.NULL);
-        PublicDiskOfferingSearch.and("system", PublicDiskOfferingSearch.entity().getSystemUse(), SearchCriteria.Op.EQ);
+        PublicDiskOfferingSearch.and("system", PublicDiskOfferingSearch.entity().isSystemUse(), SearchCriteria.Op.EQ);
         PublicDiskOfferingSearch.and("removed", PublicDiskOfferingSearch.entity().getRemoved(), SearchCriteria.Op.NULL);
         PublicDiskOfferingSearch.done();
 

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/store/TemplateObject.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/store/TemplateObject.java
@@ -403,13 +403,13 @@ public class TemplateObject implements TemplateInfo {
     }
 
     @Override
-    public boolean getEnablePassword() {
-        return imageVO.getEnablePassword();
+    public boolean isEnablePassword() {
+        return imageVO.isEnablePassword();
     }
 
     @Override
-    public boolean getEnableSshKey() {
-        return imageVO.getEnableSshKey();
+    public boolean isEnableSshKey() {
+        return imageVO.isEnableSshKey();
     }
 
     @Override

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/image/TemplateEntityImpl.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/image/TemplateEntityImpl.java
@@ -179,13 +179,13 @@ public class TemplateEntityImpl implements TemplateEntity {
     }
 
     @Override
-    public boolean getEnablePassword() {
+    public boolean isEnablePassword() {
         // TODO Auto-generated method stub
         return false;
     }
 
     @Override
-    public boolean getEnableSshKey() {
+    public boolean isEnableSshKey() {
         // TODO Auto-generated method stub
         return false;
     }

--- a/framework/quota/src/main/java/org/apache/cloudstack/quota/vo/ServiceOfferingVO.java
+++ b/framework/quota/src/main/java/org/apache/cloudstack/quota/vo/ServiceOfferingVO.java
@@ -133,22 +133,22 @@ public class ServiceOfferingVO extends DiskOfferingVO implements ServiceOffering
 
     public ServiceOfferingVO(ServiceOfferingVO offering) {
         super(offering.getId(), offering.getName(), offering.getDisplayText(), offering.getProvisioningType(), false, offering.getTags(), offering.isRecreatable(),
-                offering.getUseLocalStorage(), offering.getSystemUse(), true, offering.isCustomizedIops() == null ? false : offering.isCustomizedIops(), offering.getDomainId(),
+                offering.isUseLocalStorage(), offering.isSystemUse(), true, offering.isCustomizedIops() == null ? false : offering.isCustomizedIops(), offering.getDomainId(),
                 offering.getMinIops(), offering.getMaxIops());
         cpu = offering.getCpu();
         ramSize = offering.getRamSize();
         speed = offering.getSpeed();
         rateMbps = offering.getRateMbps();
         multicastRateMbps = offering.getMulticastRateMbps();
-        offerHA = offering.getOfferHA();
+        offerHA = offering.isOfferHA();
         limitCpuUse = offering.getLimitCpuUse();
-        volatileVm = offering.getVolatileVm();
+        volatileVm = offering.isVolatileVm();
         hostTag = offering.getHostTag();
         vmType = offering.getSystemVmType();
     }
 
     @Override
-    public boolean getOfferHA() {
+    public boolean isOfferHA() {
         return offerHA;
     }
 
@@ -251,7 +251,7 @@ public class ServiceOfferingVO extends DiskOfferingVO implements ServiceOffering
     }
 
     @Override
-    public boolean getVolatileVm() {
+    public boolean isVolatileVm() {
         return volatileVm;
     }
 

--- a/plugins/network-elements/elastic-loadbalancer/src/main/java/com/cloud/network/lb/LoadBalanceRuleHandler.java
+++ b/plugins/network-elements/elastic-loadbalancer/src/main/java/com/cloud/network/lb/LoadBalanceRuleHandler.java
@@ -289,7 +289,7 @@ public class LoadBalanceRuleHandler {
                 ServiceOfferingVO elasticLbVmOffering = _serviceOfferingDao.findDefaultSystemOffering(ServiceOffering.elbVmDefaultOffUniqueName, ConfigurationManagerImpl.SystemVMUseLocalStorage.valueIn(dest.getDataCenter().getId()));
                 elbVm = new DomainRouterVO(id, elasticLbVmOffering.getId(), vrProvider.getId(), VirtualMachineName.getSystemVmName(id, _instance, ELB_VM_NAME_PREFIX),
                         template.getId(), template.getHypervisorType(), template.getGuestOSId(), owner.getDomainId(), owner.getId(), userId, false, RedundantState.UNKNOWN,
-                        elasticLbVmOffering.getOfferHA(), false, null);
+                        elasticLbVmOffering.isOfferHA(), false, null);
                 elbVm.setRole(Role.LB);
                 elbVm = _routerDao.persist(elbVm);
                 _itMgr.allocate(elbVm.getInstanceName(), template, elasticLbVmOffering, networks, plan, null);

--- a/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/management/ContrailGuru.java
+++ b/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/management/ContrailGuru.java
@@ -129,7 +129,7 @@ public class ContrailGuru extends AdapterBase implements NetworkGuru {
         }
         NetworkVO network =
                 new NetworkVO(offering.getTrafficType(), Mode.Dhcp, BroadcastDomainType.Lswitch, offering.getId(), State.Allocated, plan.getDataCenterId(),
-                        plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                        plan.getPhysicalNetworkId(), offering.isRedundantRouter());
         if (userSpecified.getCidr() != null) {
             network.setCidr(userSpecified.getCidr());
             network.setGateway(userSpecified.getGateway());

--- a/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/management/ManagementNetworkGuru.java
+++ b/plugins/network-elements/juniper-contrail/src/main/java/org/apache/cloudstack/network/contrail/management/ManagementNetworkGuru.java
@@ -118,7 +118,7 @@ public class ManagementNetworkGuru extends ContrailGuru {
         }
         NetworkVO network =
             new NetworkVO(offering.getTrafficType(), Mode.Dhcp, BroadcastDomainType.Lswitch, offering.getId(), Network.State.Allocated, plan.getDataCenterId(),
-                plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                plan.getPhysicalNetworkId(), offering.isRedundantRouter());
         if (_mgmtCidr != null) {
             network.setCidr(_mgmtCidr);
             network.setGateway(_mgmtGateway);

--- a/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuru.java
+++ b/plugins/network-elements/nicira-nvp/src/main/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuru.java
@@ -182,7 +182,7 @@ public class NiciraNvpGuestNetworkGuru extends GuestNetworkGuru implements Netwo
         }
 
         final NetworkVO implemented = new NetworkVO(network.getTrafficType(), network.getMode(), network.getBroadcastDomainType(), network.getNetworkOfferingId(),
-                State.Allocated, network.getDataCenterId(), physicalNetworkId, offering.getRedundantRouter());
+                State.Allocated, network.getDataCenterId(), physicalNetworkId, offering.isRedundantRouter());
 
         if (network.getGateway() != null) {
             implemented.setGateway(network.getGateway());

--- a/plugins/network-elements/nicira-nvp/src/test/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuruTest.java
+++ b/plugins/network-elements/nicira-nvp/src/test/java/com/cloud/network/guru/NiciraNvpGuestNetworkGuruTest.java
@@ -469,7 +469,7 @@ public class NiciraNvpGuestNetworkGuruTest {
         final NetworkProfile implementednetwork = mock(NetworkProfile.class);
         when(implementednetwork.getId()).thenReturn(NETWORK_ID);
         when(implementednetwork.getBroadcastUri()).thenReturn(new URI("lswitch:aaaa"));
-        when(offering.getSpecifyVlan()).thenReturn(false);
+        when(offering.isSpecifyVlan()).thenReturn(false);
 
         guru.shutdown(implementednetwork, offering);
         verify(agentmgr, times(1)).easySend(eq(NETWORK_ID), (Command)any());

--- a/plugins/network-elements/nuage-vsp/src/main/java/com/cloud/network/element/NuageVspElement.java
+++ b/plugins/network-elements/nuage-vsp/src/main/java/com/cloud/network/element/NuageVspElement.java
@@ -481,14 +481,14 @@ public class NuageVspElement extends AdapterBase implements ConnectivityProvider
             return false;
         }
 
-        if (networkOffering.getSpecifyVlan()) {
+        if (networkOffering.isSpecifyVlan()) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("NuageVsp doesn't support VLAN values for networks");
             }
             return false;
         }
 
-        if (network.getVpcId() != null && !networkOffering.getIsPersistent()) {
+        if (network.getVpcId() != null && !networkOffering.isPersistent()) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("NuageVsp can't handle VPC tiers which use a network offering which are not persistent");
             }

--- a/plugins/network-elements/nuage-vsp/src/main/java/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
+++ b/plugins/network-elements/nuage-vsp/src/main/java/com/cloud/network/guru/NuageVspGuestNetworkGuru.java
@@ -297,7 +297,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
 
             implemented = new NetworkVO(network.getId(), network, network.getNetworkOfferingId(), network.getGuruName(), network.getDomainId(), network.getAccountId(),
                     network.getRelated(), network.getName(), network.getDisplayText(), network.getNetworkDomain(), network.getGuestType(), network.getDataCenterId(),
-                    physicalNetworkId, network.getAclType(), network.getSpecifyIpRanges(), network.getVpcId(), offering.getRedundantRouter(), network.getExternalId());
+                    physicalNetworkId, network.getAclType(), network.getSpecifyIpRanges(), network.getVpcId(), offering.isRedundantRouter(), network.getExternalId());
             implemented.setUuid(network.getUuid());
             implemented.setState(State.Allocated);
             if (network.getGateway() != null) {
@@ -652,7 +652,7 @@ public class NuageVspGuestNetworkGuru extends GuestNetworkGuru implements Networ
                 && isMyIsolationMethod(physicalNetwork)
                 && (offering.getGuestType() == GuestType.Isolated || offering.getGuestType() == GuestType.Shared)
                 && hasRequiredServices(offering)) {
-            if (_configMgr.isOfferingForVpc(offering) && !offering.getIsPersistent()) {
+            if (_configMgr.isOfferingForVpc(offering) && !offering.isPersistent()) {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("NuageVsp can't handle VPC tiers which use a network offering which are not persistent");
                 }

--- a/plugins/network-elements/nuage-vsp/src/main/java/com/cloud/util/NuageVspEntityBuilder.java
+++ b/plugins/network-elements/nuage-vsp/src/main/java/com/cloud/util/NuageVspEntityBuilder.java
@@ -178,8 +178,8 @@ public class NuageVspEntityBuilder {
         }
 
         NetworkOfferingVO networkOffering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        vspNetworkBuilder.egressDefaultPolicy(networkOffering.getEgressDefaultPolicy())
-                         .publicAccess(networkOffering.getSupportsPublicAccess());
+        vspNetworkBuilder.egressDefaultPolicy(networkOffering.isEgressDefaultPolicy())
+                         .publicAccess(networkOffering.isSupportingPublicAccess());
 
         Map<String, String> networkDetails = _networkDetailsDao.listDetailsKeyPairs(network.getId(), false);
 
@@ -381,7 +381,7 @@ public class NuageVspEntityBuilder {
                 .trafficType(getEnumValue(firewallRule.getTrafficType(), VspAclRule.ACLTrafficType.class));
 
         NetworkOfferingVO networkOffering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        if (firewallRule.getTrafficType() == FirewallRule.TrafficType.Egress && networkOffering.getEgressDefaultPolicy()) {
+        if (firewallRule.getTrafficType() == FirewallRule.TrafficType.Egress && networkOffering.isEgressDefaultPolicy()) {
             vspAclRuleBuilder.deny();
         } else {
             vspAclRuleBuilder.allow();

--- a/plugins/network-elements/nuage-vsp/src/test/java/com/cloud/network/element/NuageVspElementTest.java
+++ b/plugins/network-elements/nuage-vsp/src/test/java/com/cloud/network/element/NuageVspElementTest.java
@@ -137,7 +137,7 @@ public class NuageVspElementTest extends NuageTest {
 
         final NetworkOfferingVO ntwkoffer = mock(NetworkOfferingVO.class);
         when(ntwkoffer.getId()).thenReturn(NETWORK_ID);
-        when(ntwkoffer.getIsPersistent()).thenReturn(true);
+        when(ntwkoffer.isPersistent()).thenReturn(true);
         when(_networkOfferingDao.findById(NETWORK_ID)).thenReturn(ntwkoffer);
 
         // Golden path
@@ -162,7 +162,7 @@ public class NuageVspElementTest extends NuageTest {
         assertFalse(_nuageVspElement.canHandle(net, Service.Dhcp));
 
         // Can't handle network offerings with specify vlan = true
-        when(ntwkoffer.getSpecifyVlan()).thenReturn(true);
+        when(ntwkoffer.isSpecifyVlan()).thenReturn(true);
         assertFalse(_nuageVspElement.canHandle(net, Service.Connectivity));
     }
 
@@ -277,7 +277,7 @@ public class NuageVspElementTest extends NuageTest {
 
         final NetworkOfferingVO ntwkoffer = mock(NetworkOfferingVO.class);
         when(ntwkoffer.getId()).thenReturn(NETWORK_ID);
-        when(ntwkoffer.getEgressDefaultPolicy()).thenReturn(true);
+        when(ntwkoffer.isEgressDefaultPolicy()).thenReturn(true);
         when(_networkOfferingDao.findById(NETWORK_ID)).thenReturn(ntwkoffer);
 
         final HostVO host = mock(HostVO.class);
@@ -307,7 +307,7 @@ public class NuageVspElementTest extends NuageTest {
 
         final NetworkOfferingVO ntwkoffer = mock(NetworkOfferingVO.class);
         when(ntwkoffer.getId()).thenReturn(NETWORK_ID);
-        when(ntwkoffer.getEgressDefaultPolicy()).thenReturn(true);
+        when(ntwkoffer.isEgressDefaultPolicy()).thenReturn(true);
         when(_networkOfferingDao.findById(NETWORK_ID)).thenReturn(ntwkoffer);
 
         final HostVO host = mock(HostVO.class);

--- a/plugins/network-elements/nuage-vsp/src/test/java/com/cloud/network/guru/NuageVspGuestNetworkGuruTest.java
+++ b/plugins/network-elements/nuage-vsp/src/test/java/com/cloud/network/guru/NuageVspGuestNetworkGuruTest.java
@@ -224,7 +224,7 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
     @Test
     public void testDesign() {
         final NetworkOffering offering = mockNetworkOffering(false);
-        when(offering.getIsPersistent()).thenReturn(false);
+        when(offering.isPersistent()).thenReturn(false);
 
         final DeploymentPlan plan = mockDeploymentPlan();
         final Network network = mock(Network.class);
@@ -383,10 +383,10 @@ public class NuageVspGuestNetworkGuruTest extends NuageTest {
         when(offering.getUuid()).thenReturn(OFFERING_UUID);
         when(offering.getTrafficType()).thenReturn(TrafficType.Guest);
         when(offering.getGuestType()).thenReturn(GuestType.Isolated);
-        when(offering.getForVpc()).thenReturn(forVpc);
-        when(offering.getIsPersistent()).thenReturn(false);
+        when(offering.isForVpc()).thenReturn(forVpc);
+        when(offering.isPersistent()).thenReturn(false);
         when(offering.getTags()).thenReturn("aaaa");
-        when(offering.getEgressDefaultPolicy()).thenReturn(true);
+        when(offering.isEgressDefaultPolicy()).thenReturn(true);
 
         when(_networkOfferingDao.findById(OFFERING_ID)).thenReturn(offering);
 

--- a/plugins/network-elements/nuage-vsp/src/test/java/com/cloud/util/NuageVspEntityBuilderTest.java
+++ b/plugins/network-elements/nuage-vsp/src/test/java/com/cloud/util/NuageVspEntityBuilderTest.java
@@ -319,7 +319,7 @@ public class NuageVspEntityBuilderTest extends NuageTest {
     }
 
     private void setUpMockedNetworkOffering(NetworkOfferingVO networkOfferingToMock, Network.GuestType guestType) {
-        when(networkOfferingToMock.getEgressDefaultPolicy()).thenReturn(true);
+        when(networkOfferingToMock.isEgressDefaultPolicy()).thenReturn(true);
         when(networkOfferingToMock.getGuestType()).thenReturn(guestType);
     }
 

--- a/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightGuestNetworkGuru.java
+++ b/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/OpendaylightGuestNetworkGuru.java
@@ -140,7 +140,7 @@ public class OpendaylightGuestNetworkGuru extends GuestNetworkGuru {
         }
 
         NetworkVO implemented = new NetworkVO(network.getTrafficType(), network.getMode(), network.getBroadcastDomainType(), network.getNetworkOfferingId(), State.Allocated,
-                network.getDataCenterId(), physicalNetworkId, offering.getRedundantRouter());
+                network.getDataCenterId(), physicalNetworkId, offering.isRedundantRouter());
 
         if (network.getGateway() != null) {
             implemented.setGateway(network.getGateway());

--- a/plugins/network-elements/vxlan/src/main/java/com/cloud/network/guru/VxlanGuestNetworkGuru.java
+++ b/plugins/network-elements/vxlan/src/main/java/com/cloud/network/guru/VxlanGuestNetworkGuru.java
@@ -122,7 +122,7 @@ public class VxlanGuestNetworkGuru extends GuestNetworkGuru {
 
         NetworkVO implemented =
             new NetworkVO(network.getTrafficType(), network.getMode(), network.getBroadcastDomainType(), network.getNetworkOfferingId(), State.Allocated,
-                network.getDataCenterId(), physicalNetworkId, offering.getRedundantRouter());
+                network.getDataCenterId(), physicalNetworkId, offering.isRedundantRouter());
 
         allocateVnet(network, implemented, dcId, physicalNetworkId, context.getReservationId());
 

--- a/plugins/network-elements/vxlan/src/test/java/com/cloud/network/guru/VxlanGuestNetworkGuruTest.java
+++ b/plugins/network-elements/vxlan/src/test/java/com/cloud/network/guru/VxlanGuestNetworkGuruTest.java
@@ -272,7 +272,7 @@ public class VxlanGuestNetworkGuruTest {
         NetworkProfile implementednetwork = mock(NetworkProfile.class);
         when(implementednetwork.getId()).thenReturn(42L);
         when(implementednetwork.getBroadcastUri()).thenReturn(new URI("vxlan:12345"));
-        when(offering.getSpecifyVlan()).thenReturn(false);
+        when(offering.isSpecifyVlan()).thenReturn(false);
 
         guru.shutdown(implementednetwork, offering);
         verify(implementednetwork, times(1)).setBroadcastUri(null);

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1391,7 +1391,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                           * IP allocated for EIP. So return the guest/public IP accordingly.
                           * */
                         NetworkOffering networkOffering = ApiDBUtils.findNetworkOfferingById(network.getNetworkOfferingId());
-                        if (networkOffering.getElasticIp()) {
+                        if (networkOffering.isElasticIp()) {
                             IpAddress ip = ApiDBUtils.findIpByAssociatedVmId(vm.getId());
                             if (ip != null) {
                                 Vlan vlan = ApiDBUtils.findVlanById(ip.getVlanId());
@@ -1908,16 +1908,16 @@ public class ApiResponseHelper implements ResponseGenerator {
         response.setTags(offering.getTags());
         response.setTrafficType(offering.getTrafficType().toString());
         response.setIsDefault(offering.isDefault());
-        response.setSpecifyVlan(offering.getSpecifyVlan());
+        response.setSpecifyVlan(offering.isSpecifyVlan());
         response.setConserveMode(offering.isConserveMode());
-        response.setSpecifyIpRanges(offering.getSpecifyIpRanges());
+        response.setSpecifyIpRanges(offering.isSpecifyIpRanges());
         response.setAvailability(offering.getAvailability().toString());
-        response.setIsPersistent(offering.getIsPersistent());
+        response.setIsPersistent(offering.isPersistent());
         response.setNetworkRate(ApiDBUtils.getNetworkRate(offering.getId()));
-        response.setEgressDefaultPolicy(offering.getEgressDefaultPolicy());
+        response.setEgressDefaultPolicy(offering.isEgressDefaultPolicy());
         response.setConcurrentConnections(offering.getConcurrentConnections());
-        response.setSupportsStrechedL2Subnet(offering.getSupportsStrechedL2());
-        response.setSupportsPublicAccess(offering.getSupportsPublicAccess());
+        response.setSupportsStrechedL2Subnet(offering.isSupportingStrechedL2());
+        response.setSupportsPublicAccess(offering.isSupportingPublicAccess());
         Long so = null;
         if (offering.getServiceOfferingId() != null) {
             so = offering.getServiceOfferingId();
@@ -1963,12 +1963,12 @@ public class ApiResponseHelper implements ResponseGenerator {
 
                 CapabilityResponse lbIsoaltion = new CapabilityResponse();
                 lbIsoaltion.setName(Capability.SupportedLBIsolation.getName());
-                lbIsoaltion.setValue(offering.getDedicatedLB() ? "dedicated" : "shared");
+                lbIsoaltion.setValue(offering.isDedicatedLB() ? "dedicated" : "shared");
                 lbCapResponse.add(lbIsoaltion);
 
                 CapabilityResponse eLb = new CapabilityResponse();
                 eLb.setName(Capability.ElasticLb.getName());
-                eLb.setValue(offering.getElasticLb() ? "true" : "false");
+                eLb.setValue(offering.isElasticLb() ? "true" : "false");
                 lbCapResponse.add(eLb);
 
                 CapabilityResponse inline = new CapabilityResponse();
@@ -1981,12 +1981,12 @@ public class ApiResponseHelper implements ResponseGenerator {
                 List<CapabilityResponse> capabilities = new ArrayList<CapabilityResponse>();
                 CapabilityResponse sharedSourceNat = new CapabilityResponse();
                 sharedSourceNat.setName(Capability.SupportedSourceNatTypes.getName());
-                sharedSourceNat.setValue(offering.getSharedSourceNat() ? "perzone" : "peraccount");
+                sharedSourceNat.setValue(offering.isSharedSourceNat() ? "perzone" : "peraccount");
                 capabilities.add(sharedSourceNat);
 
                 CapabilityResponse redundantRouter = new CapabilityResponse();
                 redundantRouter.setName(Capability.RedundantRouter.getName());
-                redundantRouter.setValue(offering.getRedundantRouter() ? "true" : "false");
+                redundantRouter.setValue(offering.isRedundantRouter() ? "true" : "false");
                 capabilities.add(redundantRouter);
 
                 svcRsp.setCapabilities(capabilities);
@@ -1995,12 +1995,12 @@ public class ApiResponseHelper implements ResponseGenerator {
 
                 CapabilityResponse eIp = new CapabilityResponse();
                 eIp.setName(Capability.ElasticIp.getName());
-                eIp.setValue(offering.getElasticIp() ? "true" : "false");
+                eIp.setValue(offering.isElasticIp() ? "true" : "false");
                 staticNatCapResponse.add(eIp);
 
                 CapabilityResponse associatePublicIp = new CapabilityResponse();
                 associatePublicIp.setName(Capability.AssociatePublicIP.getName());
-                associatePublicIp.setValue(offering.getAssociatePublicIP() ? "true" : "false");
+                associatePublicIp.setValue(offering.isAssociatePublicIP() ? "true" : "false");
                 staticNatCapResponse.add(associatePublicIp);
 
                 svcRsp.setCapabilities(staticNatCapResponse);
@@ -2127,7 +2127,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             response.setNetworkOfferingConserveMode(networkOffering.isConserveMode());
             response.setIsSystem(networkOffering.isSystemOnly());
             response.setNetworkOfferingAvailability(networkOffering.getAvailability().toString());
-            response.setIsPersistent(networkOffering.getIsPersistent());
+            response.setIsPersistent(networkOffering.isPersistent());
         }
 
         if (network.getAclType() != null) {
@@ -3204,7 +3204,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         GuestOSResponse response = new GuestOSResponse();
         response.setDescription(guestOS.getDisplayName());
         response.setId(guestOS.getUuid());
-        response.setIsUserDefined(guestOS.getIsUserDefined());
+        response.setIsUserDefined(guestOS.isUserDefined());
         GuestOSCategoryVO category = ApiDBUtils.findGuestOsCategoryById(guestOS.getCategoryId());
         if (category != null) {
             response.setOsCategoryId(category.getUuid());

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -2688,7 +2688,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             sc.addAnd("id", SearchCriteria.Op.NEQ, currentVmOffering.getId());
 
             // 1. Only return offerings with the same storage type
-            sc.addAnd("useLocalStorage", SearchCriteria.Op.EQ, currentVmOffering.getUseLocalStorage());
+            sc.addAnd("useLocalStorage", SearchCriteria.Op.EQ, currentVmOffering.isUseLocalStorage());
 
             // 2.In case vm is running return only offerings greater than equal to current offering compute.
             if (vmInstance.getState() == VirtualMachine.State.Running) {

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -5105,7 +5105,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
     @Override
     public boolean isOfferingForVpc(final NetworkOffering offering) {
-        return offering.getForVpc();
+        return offering.isForVpc();
     }
 
     @DB

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -773,7 +773,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
         }
         ConsoleProxyVO proxy =
             new ConsoleProxyVO(id, serviceOffering.getId(), name, template.getId(), template.getHypervisorType(), template.getGuestOSId(), dataCenterId,
-                systemAcct.getDomainId(), systemAcct.getId(), _accountMgr.getSystemUser().getId(), 0, serviceOffering.getOfferHA());
+                systemAcct.getDomainId(), systemAcct.getId(), _accountMgr.getSystemUser().getId(), 0, serviceOffering.isOfferHA());
         proxy.setDynamicallyScalable(template.isDynamicallyScalable());
         proxy = _consoleProxyDao.persist(proxy);
         try {
@@ -1315,7 +1315,7 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
             }
         }
 
-        if (_serviceOffering == null || !_serviceOffering.getSystemUse()) {
+        if (_serviceOffering == null || !_serviceOffering.isSystemUse()) {
             int ramSize = NumbersUtil.parseInt(_configDao.getValue("console.ram.size"), DEFAULT_PROXY_VM_RAMSIZE);
             int cpuFreq = NumbersUtil.parseInt(_configDao.getValue("console.cpu.mhz"), DEFAULT_PROXY_VM_CPUMHZ);
             List<ServiceOfferingVO> offerings = _offeringDao.createSystemServiceOfferings("System Offering For Console Proxy",

--- a/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
+++ b/server/src/main/java/com/cloud/deploy/DeploymentPlanningManagerImpl.java
@@ -1206,7 +1206,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
             DiskOfferingVO diskOffering = _diskOfferingDao.findById(toBeCreated.getDiskOfferingId());
 
             if (diskOffering != null) {
-                if (diskOffering.getUseLocalStorage()) {
+                if (diskOffering.isUseLocalStorage()) {
                     requiresLocal = true;
                 } else {
                     requiresShared = true;
@@ -1448,7 +1448,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                     s_logger.debug("System VMs will use " + (useLocalStorage ? "local" : "shared") + " storage for zone id=" + plan.getDataCenterId());
                 }
             } else {
-                useLocalStorage = diskOffering.getUseLocalStorage();
+                useLocalStorage = diskOffering.isUseLocalStorage();
 
                 // TODO: this is a hacking fix for the problem of deploy
                 // ISO-based VM on local storage
@@ -1457,7 +1457,7 @@ StateListener<State, VirtualMachine.Event, VirtualMachine> {
                 // actually
                 // saved in service offering, override the flag from service
                 // offering when it is a ROOT disk
-                if (!useLocalStorage && vmProfile.getServiceOffering().getUseLocalStorage()) {
+                if (!useLocalStorage && vmProfile.getServiceOffering().isUseLocalStorage()) {
                     if (toBeCreated.getVolumeType() == Volume.Type.ROOT) {
                         useLocalStorage = true;
                     }

--- a/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -266,7 +266,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements HighAvai
 
         for (VMInstanceVO vm : reorderedVMList) {
             ServiceOfferingVO vmOffering = _serviceOfferingDao.findById(vm.getServiceOfferingId());
-            if (vmOffering.getUseLocalStorage()) {
+            if (vmOffering.isUseLocalStorage()) {
                 if (s_logger.isDebugEnabled()){
                     s_logger.debug("Skipping HA on vm " + vm + ", because it uses local storage. Its fate is tied to the host.");
                 }

--- a/server/src/main/java/com/cloud/network/ExternalFirewallDeviceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/ExternalFirewallDeviceManagerImpl.java
@@ -463,7 +463,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         Account account = _accountDao.findByIdIncludingRemoved(network.getAccountId());
 
         NetworkOffering offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        boolean sharedSourceNat = offering.getSharedSourceNat();
+        boolean sharedSourceNat = offering.isSharedSourceNat();
 
         IPAddressVO sourceNatIp = null;
         if (!sharedSourceNat) {
@@ -582,7 +582,7 @@ public abstract class ExternalFirewallDeviceManagerImpl extends AdapterBase impl
         List<FirewallRuleTO> rulesTO = new ArrayList<FirewallRuleTO>();
         NetworkVO networkVO = _networkDao.findById(network.getId());
         NetworkOfferingVO offering = _networkOfferingDao.findById(networkVO.getNetworkOfferingId());
-        Boolean defaultEgressPolicy = offering.getEgressDefaultPolicy();
+        Boolean defaultEgressPolicy = offering.isEgressDefaultPolicy();
 
         for (FirewallRule rule : rules) {
             if (rule.getSourceCidrList() == null && (rule.getPurpose() == Purpose.Firewall || rule.getPurpose() == Purpose.NetworkACL)) {

--- a/server/src/main/java/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/ExternalLoadBalancerDeviceManagerImpl.java
@@ -445,7 +445,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
             try {
                 if (deviceMapLock.lock(120)) {
                     try {
-                        final boolean dedicatedLB = offering.getDedicatedLB(); // does network offering supports a dedicated load balancer?
+                        final boolean dedicatedLB = offering.isDedicatedLB(); // does network offering supports a dedicated load balancer?
 
                         try {
                             lbDevice = Transaction.execute(new TransactionCallbackWithException<ExternalLoadBalancerDeviceVO, InsufficientCapacityException>() {
@@ -532,7 +532,7 @@ public abstract class ExternalLoadBalancerDeviceManagerImpl extends AdapterBase 
                             String privateIf = createLbAnswer.getPrivateInterface();
 
                             // we have provisioned load balancer so add the appliance as cloudstack provisioned external load balancer
-                            String dedicatedLb = offering.getDedicatedLB() ? "true" : "false";
+                            String dedicatedLb = offering.isDedicatedLB() ? "true" : "false";
                             String capacity = Long.toString(lbProviderDevice.getCapacity());
 
                             // acquire a public IP to associate with lb appliance (used as subnet IP to make the appliance part of private network)

--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -1379,7 +1379,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         }
 
         NetworkOffering offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        boolean sharedSourceNat = offering.getSharedSourceNat();
+        boolean sharedSourceNat = offering.isSharedSourceNat();
         boolean isSourceNat = false;
         if (!sharedSourceNat) {
             if (getExistingSourceNatInNetwork(owner.getId(), networkId) == null) {
@@ -1737,7 +1737,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         Network guestNetwork = pair.third();
 
         // if the network offering has persistent set to true, implement the network
-        if (createNetwork && requiredOfferings.get(0).getIsPersistent()) {
+        if (createNetwork && requiredOfferings.get(0).isPersistent()) {
             DataCenter zone = _dcDao.findById(zoneId);
             DeployDestination dest = new DeployDestination(zone, null, null, null);
             Account callerAccount = CallContext.current().getCallingAccount();
@@ -1959,7 +1959,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         Network guestNetwork = _networksDao.findById(networkId);
         NetworkOffering off = _entityMgr.findById(NetworkOffering.class, guestNetwork.getNetworkOfferingId());
         IpAddress ip = null;
-        if ((off.getElasticLb() && forElasticLb) || (off.getElasticIp() && forElasticIp)) {
+        if ((off.isElasticLb() && forElasticLb) || (off.isElasticIp() && forElasticIp)) {
 
             try {
                 s_logger.debug("Allocating system IP address for load balancer rule...");

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2337,7 +2337,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
 
         if (network != null) {
             NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-            return offering.getEgressDefaultPolicy();
+            return offering.isEgressDefaultPolicy();
         } else {
             InvalidParameterValueException ex = new InvalidParameterValueException("network with network id does not exist");
             throw ex;

--- a/server/src/main/java/com/cloud/network/as/AutoScaleManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/as/AutoScaleManagerImpl.java
@@ -1314,7 +1314,7 @@ public class AutoScaleManagerImpl<Type> extends ManagerBase implements AutoScale
             }
 
             if (!zone.isLocalStorageEnabled()) {
-                if (serviceOffering.getUseLocalStorage()) {
+                if (serviceOffering.isUseLocalStorage()) {
                     throw new InvalidParameterValueException("Zone is not configured to use local storage but service offering " + serviceOffering.getName() + " uses it");
                 }
             }

--- a/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
@@ -231,7 +231,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
         final List<DomainRouterVO> routers = routerDeploymentDefinition.deployVirtualRouter();
 
         int expectedRouters = 1;
-        if (offering.getRedundantRouter() || network.isRollingRestart()) {
+        if (offering.isRedundantRouter() || network.isRollingRestart()) {
             expectedRouters = 2;
         }
         if (routers == null || routers.size() < expectedRouters) {

--- a/server/src/main/java/com/cloud/network/guru/ControlNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/ControlNetworkGuru.java
@@ -97,7 +97,7 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
 
         NetworkVO config =
             new NetworkVO(offering.getTrafficType(), Mode.Static, BroadcastDomainType.LinkLocal, offering.getId(), Network.State.Setup, plan.getDataCenterId(),
-                plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                plan.getPhysicalNetworkId(), offering.isRedundantRouter());
         config.setCidr(_cidr);
         config.setGateway(_gateway);
 

--- a/server/src/main/java/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/DirectNetworkGuru.java
@@ -179,7 +179,7 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
 
         NetworkVO config =
             new NetworkVO(offering.getTrafficType(), Mode.Dhcp, BroadcastDomainType.Vlan, offering.getId(), state, plan.getDataCenterId(),
-                    plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                    plan.getPhysicalNetworkId(), offering.isRedundantRouter());
 
         if (userSpecified != null) {
             if ((userSpecified.getCidr() == null && userSpecified.getGateway() != null) || (userSpecified.getCidr() != null && userSpecified.getGateway() == null)) {

--- a/server/src/main/java/com/cloud/network/guru/ExternalGuestNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/ExternalGuestNetworkGuru.java
@@ -135,7 +135,7 @@ public class ExternalGuestNetworkGuru extends GuestNetworkGuru {
         DataCenter zone = dest.getDataCenter();
         NetworkVO implemented =
             new NetworkVO(config.getTrafficType(), config.getMode(), config.getBroadcastDomainType(), config.getNetworkOfferingId(), State.Allocated,
-                config.getDataCenterId(), config.getPhysicalNetworkId(), offering.getRedundantRouter());
+                config.getDataCenterId(), config.getPhysicalNetworkId(), offering.isRedundantRouter());
 
         // Get a vlan tag
         int vlanTag;

--- a/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -191,7 +191,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
 
         final NetworkVO network =
                 new NetworkVO(offering.getTrafficType(), Mode.Dhcp, BroadcastDomainType.Vlan, offering.getId(), State.Allocated, plan.getDataCenterId(),
-                        plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                        plan.getPhysicalNetworkId(), offering.isRedundantRouter());
         if (userSpecified != null) {
             if (userSpecified.getCidr() == null && userSpecified.getGateway() != null || userSpecified.getCidr() != null && userSpecified.getGateway() == null) {
                 throw new InvalidParameterValueException("cidr and gateway must be specified together.");
@@ -211,7 +211,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
                 }
             }
 
-            if (offering.getSpecifyVlan()) {
+            if (offering.isSpecifyVlan()) {
                 network.setBroadcastUri(userSpecified.getBroadcastUri());
                 network.setState(State.Setup);
             }
@@ -315,7 +315,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
 
         final NetworkVO implemented =
                 new NetworkVO(network.getTrafficType(), network.getMode(), network.getBroadcastDomainType(), network.getNetworkOfferingId(), State.Allocated,
-                        network.getDataCenterId(), physicalNetworkId, offering.getRedundantRouter());
+                        network.getDataCenterId(), physicalNetworkId, offering.isRedundantRouter());
 
         allocateVnet(network, implemented, dcId, physicalNetworkId, context.getReservationId());
 
@@ -430,7 +430,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
             return; // Nothing to do here if the uri is null already
         }
 
-        if ((profile.getBroadcastDomainType() == BroadcastDomainType.Vlan || profile.getBroadcastDomainType() == BroadcastDomainType.Vxlan) && !offering.getSpecifyVlan()) {
+        if ((profile.getBroadcastDomainType() == BroadcastDomainType.Vlan || profile.getBroadcastDomainType() == BroadcastDomainType.Vxlan) && !offering.isSpecifyVlan()) {
             s_logger.debug("Releasing vnet for the network id=" + profile.getId());
             _dcDao.releaseVnet(BroadcastDomainType.getValue(profile.getBroadcastUri()), profile.getDataCenterId(), profile.getPhysicalNetworkId(), profile.getAccountId(),
                     profile.getReservationId());

--- a/server/src/main/java/com/cloud/network/guru/PodBasedNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/PodBasedNetworkGuru.java
@@ -85,7 +85,7 @@ public class PodBasedNetworkGuru extends AdapterBase implements NetworkGuru {
 
         NetworkVO config =
             new NetworkVO(type, Mode.Static, BroadcastDomainType.Native, offering.getId(), Network.State.Setup, plan.getDataCenterId(),
-                    plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                    plan.getPhysicalNetworkId(), offering.isRedundantRouter());
         return config;
     }
 

--- a/server/src/main/java/com/cloud/network/guru/PrivateNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/PrivateNetworkGuru.java
@@ -111,7 +111,7 @@ public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
         }
         NetworkVO network =
             new NetworkVO(offering.getTrafficType(), Mode.Static, broadcastType, offering.getId(), State.Allocated, plan.getDataCenterId(),
-                    plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                    plan.getPhysicalNetworkId(), offering.isRedundantRouter());
         if (userSpecified != null) {
             if ((userSpecified.getCidr() == null && userSpecified.getGateway() != null) || (userSpecified.getCidr() != null && userSpecified.getGateway() == null)) {
                 throw new InvalidParameterValueException("cidr and gateway must be specified together.");
@@ -124,7 +124,7 @@ public class PrivateNetworkGuru extends AdapterBase implements NetworkGuru {
                 throw new InvalidParameterValueException("Can't design network " + network + "; netmask/gateway must be passed in");
             }
 
-            if (offering.getSpecifyVlan()) {
+            if (offering.isSpecifyVlan()) {
                 network.setBroadcastUri(userSpecified.getBroadcastUri());
                 network.setState(State.Setup);
             }

--- a/server/src/main/java/com/cloud/network/guru/PublicNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/PublicNetworkGuru.java
@@ -101,7 +101,7 @@ public class PublicNetworkGuru extends AdapterBase implements NetworkGuru {
         if (offering.getTrafficType() == TrafficType.Public) {
             NetworkVO ntwk =
                 new NetworkVO(offering.getTrafficType(), Mode.Static, network.getBroadcastDomainType(), offering.getId(), State.Setup, plan.getDataCenterId(),
-                    plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                    plan.getPhysicalNetworkId(), offering.isRedundantRouter());
             return ntwk;
         } else {
             return null;

--- a/server/src/main/java/com/cloud/network/guru/StorageNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/StorageNetworkGuru.java
@@ -89,7 +89,7 @@ public class StorageNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
 
         NetworkVO config =
             new NetworkVO(offering.getTrafficType(), Mode.Static, BroadcastDomainType.Native, offering.getId(), Network.State.Setup, plan.getDataCenterId(),
-                plan.getPhysicalNetworkId(), offering.getRedundantRouter());
+                plan.getPhysicalNetworkId(), offering.isRedundantRouter());
         return config;
     }
 

--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -1601,7 +1601,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         if (result == null) {
             IpAddress systemIp = null;
             NetworkOffering off = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
-            if (off.getElasticLb() && ipVO == null && network.getVpcId() == null) {
+            if (off.isElasticLb() && ipVO == null && network.getVpcId() == null) {
                 systemIp = _ipAddrMgr.assignSystemIp(networkId, lbOwner, true, false);
                 if (systemIp != null) {
                     ipVO = _ipAddressDao.findById(systemIp.getId());
@@ -2507,11 +2507,11 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         //2) Check if the Scheme is supported\
         NetworkOffering off = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
         if (scheme == Scheme.Public) {
-            if (!off.getPublicLb()) {
+            if (!off.isPublicLb()) {
                 throw new InvalidParameterValueException("Scheme " + scheme + " is not supported by the network offering " + off);
             }
         } else {
-            if (!off.getInternalLb()) {
+            if (!off.isInternalLb()) {
                 throw new InvalidParameterValueException("Scheme " + scheme + " is not supported by the network offering " + off);
             }
         }

--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -406,7 +406,7 @@ public class CommandSetupHelper {
                 } else if (rule.getTrafficType() == FirewallRule.TrafficType.Egress) {
                     final NetworkVO network = _networkDao.findById(guestNetworkId);
                     final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-                    defaultEgressPolicy = offering.getEgressDefaultPolicy();
+                    defaultEgressPolicy = offering.isEgressDefaultPolicy();
                     assert rule.getSourceIpAddressId() == null : "ipAddressId should be null for egress firewall rule. ";
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, "", Purpose.Firewall, traffictype, defaultEgressPolicy);
                     rulesTO.add(ruleTO);
@@ -450,7 +450,7 @@ public class CommandSetupHelper {
                 } else if (rule.getTrafficType() == FirewallRule.TrafficType.Egress) {
                     final NetworkVO network = _networkDao.findById(guestNetworkId);
                     final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-                    defaultEgressPolicy = offering.getEgressDefaultPolicy();
+                    defaultEgressPolicy = offering.isEgressDefaultPolicy();
                     assert rule.getSourceIpAddressId() == null : "ipAddressId should be null for egress firewall rule. ";
                     final FirewallRuleTO ruleTO = new FirewallRuleTO(rule, null, "", Purpose.Firewall, traffictype, defaultEgressPolicy);
                     rulesTO.add(ruleTO);
@@ -1066,7 +1066,7 @@ public class CommandSetupHelper {
         }
 
         final NetworkOffering offering = _networkOfferingDao.findById(_networkDao.findById(defaultNic.getNetworkId()).getNetworkOfferingId());
-        if (offering.getRedundantRouter()) {
+        if (offering.isRedundantRouter()) {
             return findGatewayIp(userVmId);
         }
 

--- a/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -479,7 +479,7 @@ public class NetworkHelperImpl implements NetworkHelper {
                     continue;
                 }
 
-                final boolean offerHA = routerOffering.getOfferHA();
+                final boolean offerHA = routerOffering.isOfferHA();
 
                 // routerDeploymentDefinition.getVpc().getId() ==> do not use
                 // VPC because it is not a VPC offering.

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -376,7 +376,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
 
         // check if it is a system service offering, if yes return with error as
         // it cannot be used for user vms
-        if (!newServiceOffering.getSystemUse()) {
+        if (!newServiceOffering.isSystemUse()) {
             throw new InvalidParameterValueException("Cannot upgrade router vm to a non system service offering " + serviceOfferingId);
         }
 
@@ -392,9 +392,9 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
         // Check that the service offering being upgraded to has the same
         // storage pool preference as the VM's current service
         // offering
-        if (currentServiceOffering.getUseLocalStorage() != newServiceOffering.getUseLocalStorage()) {
-            throw new InvalidParameterValueException("Can't upgrade, due to new local storage status : " + newServiceOffering.getUseLocalStorage() + " is different from "
-                    + "curruent local storage status: " + currentServiceOffering.getUseLocalStorage());
+        if (currentServiceOffering.isUseLocalStorage() != newServiceOffering.isUseLocalStorage()) {
+            throw new InvalidParameterValueException("Can't upgrade, due to new local storage status : " + newServiceOffering.isUseLocalStorage() + " is different from "
+                    + "curruent local storage status: " + currentServiceOffering.isUseLocalStorage());
         }
 
         router.setServiceOfferingId(serviceOfferingId);
@@ -1670,7 +1670,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
 
                 final NetworkOffering offering = _networkOfferingDao.findById(_networkDao.findById(guestNetworkId).getNetworkOfferingId());
                 // service monitoring is currently not added in RVR
-                if (!offering.getRedundantRouter()) {
+                if (!offering.isRedundantRouter()) {
                     final String serviceMonitringSet = _configDao.getValue(Config.EnableServiceMonitoring.key());
 
                     if (serviceMonitringSet != null && serviceMonitringSet.equalsIgnoreCase("true")) {
@@ -1947,7 +1947,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     private void createDefaultEgressFirewallRule(final List<FirewallRule> rules, final long networkId) {
         final NetworkVO network = _networkDao.findById(networkId);
         final NetworkOfferingVO offering = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        final Boolean defaultEgressPolicy = offering.getEgressDefaultPolicy();
+        final Boolean defaultEgressPolicy = offering.isEgressDefaultPolicy();
 
         // The default on the router is set to Deny all. So, if the default configuration in the offering is set to true (Allow), we change the Egress here
         if (defaultEgressPolicy) {

--- a/server/src/main/java/com/cloud/network/rules/RulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/rules/RulesManagerImpl.java
@@ -391,7 +391,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
 
         Network network = _networkModel.getNetwork(networkId);
         NetworkOffering off = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
-        if (off.getElasticIp()) {
+        if (off.isElasticIp()) {
             throw new InvalidParameterValueException("Can't create ip forwarding rules for the network where elasticIP service is enabled");
         }
 
@@ -653,7 +653,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
             if (networkId != null) {
                 Network guestNetwork = _networkModel.getNetwork(networkId);
                 NetworkOffering offering = _entityMgr.findById(NetworkOffering.class, guestNetwork.getNetworkOfferingId());
-                if (offering.getElasticIp()) {
+                if (offering.isElasticIp()) {
                     reassignStaticNat = true;
                 }
             }
@@ -1235,8 +1235,8 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         // re-enable it on the new one enable static nat takes care of that
         Network guestNetwork = _networkModel.getNetwork(ipAddress.getAssociatedWithNetworkId());
         NetworkOffering offering = _entityMgr.findById(NetworkOffering.class, guestNetwork.getNetworkOfferingId());
-        if (offering.getElasticIp()) {
-            if (offering.getAssociatePublicIP()) {
+        if (offering.isElasticIp()) {
+            if (offering.isAssociatePublicIP()) {
                 getSystemIpAndEnableStaticNatForVm(_vmDao.findById(vmId), true);
                 return true;
             }
@@ -1434,10 +1434,10 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
         for (Nic nic : nics) {
             Network guestNetwork = _networkModel.getNetwork(nic.getNetworkId());
             NetworkOffering offering = _entityMgr.findById(NetworkOffering.class, guestNetwork.getNetworkOfferingId());
-            if (offering.getElasticIp()) {
+            if (offering.isElasticIp()) {
                 boolean isSystemVM = (vm.getType() == Type.ConsoleProxy || vm.getType() == Type.SecondaryStorageVm);
                 // for user VM's associate public IP only if offering is marked to associate a public IP by default on start of VM
-                if (!isSystemVM && !offering.getAssociatePublicIP()) {
+                if (!isSystemVM && !offering.isAssociatePublicIP()) {
                     continue;
                 }
                 // check if there is already static nat enabled

--- a/server/src/main/java/com/cloud/network/vpc/PrivateIpAddress.java
+++ b/server/src/main/java/com/cloud/network/vpc/PrivateIpAddress.java
@@ -41,7 +41,7 @@ public class PrivateIpAddress implements PrivateIp {
         this.netmask = netmask;
         this.macAddress = macAddress;
         this.networkId = privateIp.getNetworkId();
-        this.sourceNat = privateIp.getSourceNat();
+        this.sourceNat = privateIp.isSourceNat();
     }
 
     @Override

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1262,7 +1262,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         // 4) Only one network in the VPC can support public LB inside the VPC.
         // Internal LB can be supported on multiple VPC tiers
-        if (_ntwkModel.areServicesSupportedByNetworkOffering(guestNtwkOff.getId(), Service.Lb) && guestNtwkOff.getPublicLb()) {
+        if (_ntwkModel.areServicesSupportedByNetworkOffering(guestNtwkOff.getId(), Service.Lb) && guestNtwkOff.isPublicLb()) {
             final List<? extends Network> networks = getVpcNetworks(vpc.getId());
             for (final Network network : networks) {
                 if (networkId != null && network.getId() == networkId.longValue()) {
@@ -1272,7 +1272,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                     final NetworkOffering otherOff = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
                     // throw only if networks have different offerings with
                     // public lb support
-                    if (_ntwkModel.areServicesSupportedInNetwork(network.getId(), Service.Lb) && otherOff.getPublicLb() && guestNtwkOff.getId() != otherOff.getId()) {
+                    if (_ntwkModel.areServicesSupportedInNetwork(network.getId(), Service.Lb) && otherOff.isPublicLb() && guestNtwkOff.getId() != otherOff.getId()) {
                         throw new InvalidParameterValueException("Public LB service is already supported " + "by network " + network + " in VPC " + vpc);
                     }
                 }
@@ -1319,7 +1319,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         }
 
         // 5) If Netscaler is LB provider make sure it is in dedicated mode
-        if (providers.contains(Provider.Netscaler) && !guestNtwkOff.getDedicatedLB()) {
+        if (providers.contains(Provider.Netscaler) && !guestNtwkOff.isDedicatedLB()) {
             throw new InvalidParameterValueException("Netscaler only with Dedicated LB can belong to VPC");
         }
         return;

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -1234,7 +1234,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                     if (broadcastDomainType != null) {
                         NetworkVO network =
                                 new NetworkVO(id, trafficType, mode, broadcastDomainType, networkOfferingId, domainId, accountId, related, null, null, networkDomain,
-                                        Network.GuestType.Shared, zoneId, null, null, specifyIpRanges, null, offering.getRedundantRouter());
+                                        Network.GuestType.Shared, zoneId, null, null, specifyIpRanges, null, offering.isRedundantRouter());
                         network.setGuruName(guruNames.get(network.getTrafficType()));
                         network.setDns1(zone.getDns1());
                         network.setDns2(zone.getDns2());

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -2180,7 +2180,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             throw new InvalidParameterValueException("Guest OS not found. Please specify a valid ID for the Guest OS");
         }
 
-        if (!guestOsHandle.getIsUserDefined()) {
+        if (!guestOsHandle.isUserDefined()) {
             throw new InvalidParameterValueException("Unable to modify system defined guest OS");
         }
 
@@ -2222,7 +2222,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
             throw new InvalidParameterValueException("Guest OS not found. Please specify a valid ID for the Guest OS");
         }
 
-        if (!guestOs.getIsUserDefined()) {
+        if (!guestOs.isUserDefined()) {
             throw new InvalidParameterValueException("Unable to remove system defined guest OS");
         }
 

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -2421,7 +2421,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             return diskOffering.getBytesReadRate();
         } else {
             Long bytesReadRate = Long.parseLong(_configDao.getValue(Config.VmDiskThrottlingBytesReadRate.key()));
-            if ((bytesReadRate > 0) && ((offering == null) || (!offering.getSystemUse()))) {
+            if ((bytesReadRate > 0) && ((offering == null) || (!offering.isSystemUse()))) {
                 return bytesReadRate;
             }
         }
@@ -2437,7 +2437,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             return diskOffering.getBytesWriteRate();
         } else {
             Long bytesWriteRate = Long.parseLong(_configDao.getValue(Config.VmDiskThrottlingBytesWriteRate.key()));
-            if ((bytesWriteRate > 0) && ((offering == null) || (!offering.getSystemUse()))) {
+            if ((bytesWriteRate > 0) && ((offering == null) || (!offering.isSystemUse()))) {
                 return bytesWriteRate;
             }
         }
@@ -2453,7 +2453,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             return diskOffering.getIopsReadRate();
         } else {
             Long iopsReadRate = Long.parseLong(_configDao.getValue(Config.VmDiskThrottlingIopsReadRate.key()));
-            if ((iopsReadRate > 0) && ((offering == null) || (!offering.getSystemUse()))) {
+            if ((iopsReadRate > 0) && ((offering == null) || (!offering.isSystemUse()))) {
                 return iopsReadRate;
             }
         }
@@ -2469,7 +2469,7 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
             return diskOffering.getIopsWriteRate();
         } else {
             Long iopsWriteRate = Long.parseLong(_configDao.getValue(Config.VmDiskThrottlingIopsWriteRate.key()));
-            if ((iopsWriteRate > 0) && ((offering == null) || (!offering.getSystemUse()))) {
+            if ((iopsWriteRate > 0) && ((offering == null) || (!offering.isSystemUse()))) {
                 return iopsWriteRate;
             }
         }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -712,7 +712,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         // If local storage is disabled then creation of volume with local disk
         // offering not allowed
-        if (!zone.isLocalStorageEnabled() && diskOffering.getUseLocalStorage()) {
+        if (!zone.isLocalStorageEnabled() && diskOffering.isUseLocalStorage()) {
             throw new InvalidParameterValueException("Zone is not configured to use local storage but volume's disk offering " + diskOffering.getName() + " uses it");
         }
 
@@ -853,7 +853,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         Long newMinIops;
         Long newMaxIops;
         Integer newHypervisorSnapshotReserve;
-        boolean shrinkOk = cmd.getShrinkOk();
+        boolean shrinkOk = cmd.isShrinkOk();
 
         VolumeVO volume = _volsDao.findById(cmd.getEntityId());
         if (volume == null) {
@@ -1540,7 +1540,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         DataCenterVO dataCenter = _dcDao.findById(volumeToAttach.getDataCenterId());
         if (!dataCenter.isLocalStorageEnabled()) {
             DiskOfferingVO diskOffering = _diskOfferingDao.findById(volumeToAttach.getDiskOfferingId());
-            if (diskOffering.getUseLocalStorage()) {
+            if (diskOffering.isUseLocalStorage()) {
                 throw new InvalidParameterValueException("Zone is not configured to use local storage but volume's disk offering " + diskOffering.getName() + " uses it");
             }
         }
@@ -2185,7 +2185,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (newDiskOffering == null) {
             return;
         }
-        if ((destPool.isShared() && newDiskOffering.getUseLocalStorage()) || destPool.isLocal() && newDiskOffering.isShared()) {
+        if ((destPool.isShared() && newDiskOffering.isUseLocalStorage()) || destPool.isLocal() && newDiskOffering.isShared()) {
             throw new InvalidParameterValueException("You cannot move the volume to a shared storage and assing a disk offering for local storage and vice versa.");
         }
         if (!doesTargetStorageSupportNewDiskOffering(destPool, newDiskOffering)) {

--- a/server/src/main/java/org/apache/cloudstack/network/topology/BasicNetworkVisitor.java
+++ b/server/src/main/java/org/apache/cloudstack/network/topology/BasicNetworkVisitor.java
@@ -216,7 +216,7 @@ public class BasicNetworkVisitor extends NetworkTopologyVisitor {
         final NicVO nicVo = sshkey.getNicVo();
         final VMTemplateVO template = sshkey.getTemplate();
 
-        if (template != null && template.getEnablePassword()) {
+        if (template != null && template.isEnablePassword()) {
             _commandSetupHelper.createPasswordCommand(router, profile, nicVo, commands);
         }
 

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -559,7 +559,7 @@ public class VolumeApiServiceImplTest {
     @Test(expected = InvalidParameterValueException.class)
     public void validateConditionsToReplaceDiskOfferingOfVolumeTestTargetPoolSharedDiskOfferingLocal() {
         Mockito.when(volumeVoMock.getVolumeType()).thenReturn(Type.DATADISK);
-        Mockito.when(newDiskOfferingMock.getUseLocalStorage()).thenReturn(true);
+        Mockito.when(newDiskOfferingMock.isUseLocalStorage()).thenReturn(true);
         Mockito.when(storagePoolMock.isShared()).thenReturn(true);
 
         volumeApiServiceImpl.validateConditionsToReplaceDiskOfferingOfVolume(volumeVoMock, newDiskOfferingMock, storagePoolMock);
@@ -578,7 +578,7 @@ public class VolumeApiServiceImplTest {
     public void validateConditionsToReplaceDiskOfferingOfVolumeTestTagsDoNotMatch() {
         Mockito.when(volumeVoMock.getVolumeType()).thenReturn(Type.DATADISK);
 
-        Mockito.when(newDiskOfferingMock.getUseLocalStorage()).thenReturn(false);
+        Mockito.when(newDiskOfferingMock.isUseLocalStorage()).thenReturn(false);
         Mockito.when(storagePoolMock.isShared()).thenReturn(true);
 
         Mockito.when(newDiskOfferingMock.isShared()).thenReturn(true);
@@ -595,7 +595,7 @@ public class VolumeApiServiceImplTest {
     public void validateConditionsToReplaceDiskOfferingOfVolumeTestEverythingWorking() {
         Mockito.when(volumeVoMock.getVolumeType()).thenReturn(Type.DATADISK);
 
-        Mockito.when(newDiskOfferingMock.getUseLocalStorage()).thenReturn(false);
+        Mockito.when(newDiskOfferingMock.isUseLocalStorage()).thenReturn(false);
         Mockito.when(storagePoolMock.isShared()).thenReturn(true);
 
         Mockito.when(newDiskOfferingMock.isShared()).thenReturn(true);
@@ -609,7 +609,7 @@ public class VolumeApiServiceImplTest {
 
         InOrder inOrder = Mockito.inOrder(volumeVoMock, newDiskOfferingMock, storagePoolMock, volumeApiServiceImpl);
         inOrder.verify(storagePoolMock).isShared();
-        inOrder.verify(newDiskOfferingMock).getUseLocalStorage();
+        inOrder.verify(newDiskOfferingMock).isUseLocalStorage();
         inOrder.verify(storagePoolMock).isLocal();
         inOrder.verify(newDiskOfferingMock, times(0)).isShared();
         inOrder.verify(volumeApiServiceImpl).getStoragePoolTags(storagePoolMock);

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -653,7 +653,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
         }
         SecondaryStorageVmVO secStorageVm =
             new SecondaryStorageVmVO(id, serviceOffering.getId(), name, template.getId(), template.getHypervisorType(), template.getGuestOSId(), dataCenterId,
-                systemAcct.getDomainId(), systemAcct.getId(), _accountMgr.getSystemUser().getId(), role, serviceOffering.getOfferHA());
+                systemAcct.getDomainId(), systemAcct.getId(), _accountMgr.getSystemUser().getId(), role, serviceOffering.isOfferHA());
         secStorageVm.setDynamicallyScalable(template.isDynamicallyScalable());
         secStorageVm = _secStorageVmDao.persist(secStorageVm);
         try {
@@ -950,7 +950,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
             }
         }
 
-        if (_serviceOffering == null || !_serviceOffering.getSystemUse()) {
+        if (_serviceOffering == null || !_serviceOffering.isSystemUse()) {
             int ramSize = NumbersUtil.parseInt(_configDao.getValue("ssvm.ram.size"), DEFAULT_SS_VM_RAMSIZE);
             int cpuFreq = NumbersUtil.parseInt(_configDao.getValue("ssvm.cpu.mhz"), DEFAULT_SS_VM_CPUMHZ);
             List<ServiceOfferingVO> offerings = _offeringDao.createSystemServiceOfferings("System Offering For Secondary Storage VM",


### PR DESCRIPTION
… "isXXX".

These boolean-return methods are named as "getXXX".
Other boolean-return methods are named as "isXXX".
Considering there methods will return boolean values, it should be more clear and consistent to rename them as "isXXX".
(rebase #2602 and #2816)
