### PR TITLE
systemvm: export $TYPE before patching ssvm/cpvm

### DIFF
--- a/engine/schema/src/com/cloud/upgrade/dao/Upgrade41110to41120.java
+++ b/engine/schema/src/com/cloud/upgrade/dao/Upgrade41110to41120.java
@@ -135,12 +135,12 @@ public class Upgrade41110to41120 implements DbUpgrade {
 
         final Map<Hypervisor.HypervisorType, String> newTemplateChecksum = new HashMap<Hypervisor.HypervisorType, String>() {
             {
-                put(Hypervisor.HypervisorType.KVM, "f44242570ae4a0b16c4c2eb2cb71fe45");
-                put(Hypervisor.HypervisorType.XenServer, "afcc31ab9f7635885cd83600eafbbe7f");
-                put(Hypervisor.HypervisorType.VMware, "54449e31530f14af930c80a3155a308f");
-                put(Hypervisor.HypervisorType.Hyperv, "7785df30fdbbacdead5acbfc15ae2c98");
-                put(Hypervisor.HypervisorType.LXC, "f44242570ae4a0b16c4c2eb2cb71fe45");
-                put(Hypervisor.HypervisorType.Ovm3, "81a6cd8d07fad910824f040f73ce03e3");
+                put(Hypervisor.HypervisorType.KVM, "6d12cc764cd7d64112d8c35d70923eb1");
+                put(Hypervisor.HypervisorType.XenServer, "6e8b3ae84ca8145736d1d7d3f7546e65");
+                put(Hypervisor.HypervisorType.VMware, "e981f8cb951688efd93481913198c9cc");
+                put(Hypervisor.HypervisorType.Hyperv, "e9032635ffba021371780307162551b9");
+                put(Hypervisor.HypervisorType.LXC, "6d12cc764cd7d64112d8c35d70923eb1");
+                put(Hypervisor.HypervisorType.Ovm3, "c4a91f8e52e4531a1c2a9a17c530d5fe");
             }
         };
 

--- a/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
+++ b/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
@@ -150,6 +150,10 @@ get_boot_params() {
   esac
 }
 
+get_systemvm_type() {
+  export TYPE=$(grep -Po 'type=\K[a-zA-Z]*' $CMDLINE)
+}
+
 patch() {
   local PATCH_MOUNT=/media/cdrom
   local patchfile=$PATCH_MOUNT/cloud-scripts.tgz
@@ -216,11 +220,11 @@ start() {
 
   config_guest
   get_boot_params
+  get_systemvm_type
   patch
   sync
   sysctl -p
 
-  export TYPE=$(grep -Po 'type=\K[a-zA-Z]*' $CMDLINE)
   log_it "Configuring systemvm type=$TYPE"
 
   if [ -f "/opt/cloud/bin/setup/$TYPE.sh" ]; then

--- a/systemvm/debian/opt/cloud/bin/setup/postinit.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/postinit.sh
@@ -21,7 +21,7 @@
 # Eject cdrom if any
 eject || true
 
-TYPE=$(grep -Po 'type=\K[a-zA-Z]*' $CMDLINE)
+TYPE=$(grep -Po 'type=\K[a-zA-Z]*' /var/cache/cloud/cmdline)
 if [ "$TYPE" == "router" ] || [ "$TYPE" == "vpcrouter" ] || [ "$TYPE" == "dhcpsrvr" ]
 then
   if [ -x /opt/cloud/bin/update_config.py ]

--- a/tools/appliance/systemvmtemplate/scripts/configure_systemvm_services.sh
+++ b/tools/appliance/systemvmtemplate/scripts/configure_systemvm_services.sh
@@ -19,7 +19,7 @@
 set -e
 set -x
 
-CLOUDSTACK_RELEASE=4.11.1
+CLOUDSTACK_RELEASE=4.11.2
 
 function configure_apache2() {
    # Enable ssl, rewrite and auth


### PR DESCRIPTION
This fixes a regression introduced in #2799, by exporting $TYPE
before the `patch` is called to patch/extract archives for ssvm/cpvm.

See comment: https://github.com/apache/cloudstack/pull/2799/files#r218825730

Note: the fix is in cloud-early-config, so we can simply rebuild a new 4.11.2 systemvmtemplate and still continue testing 4.11.2.0 RC1 for end of the week if there are more issues/bugs and try to cut RC2 next week. /cc @PaulAngus 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing integration tests have passed.
- [x] A full integration testsuite with all test that can run on my environment has passed.

