### PR TITLE
ApiServer: signature v3 to accept more formats

### DIFF
--- a/utils/src/main/java/com/cloud/utils/DateUtil.java
+++ b/utils/src/main/java/com/cloud/utils/DateUtil.java
@@ -31,7 +31,7 @@ import com.cloud.utils.exception.CloudRuntimeException;
 public class DateUtil {
     public static final TimeZone GMT_TIMEZONE = TimeZone.getTimeZone("GMT");
     public static final String YYYYMMDD_FORMAT = "yyyyMMddHHmmss";
-    private static final DateFormat s_outputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+    private static final DateFormat s_outputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
 
     public static Date currentGMTTime() {
         // Date object always stores miliseconds offset based on GMT internally
@@ -43,7 +43,7 @@ public class DateUtil {
         try {
             return s_outputFormat.parse(str);
         } catch (ParseException e) {
-            final DateFormat dfParse = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'Z");
+            final DateFormat dfParse = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSX");
             return dfParse.parse(str);
         }
     }

--- a/utils/src/test/java/com/cloud/utils/DateUtilTest.java
+++ b/utils/src/test/java/com/cloud/utils/DateUtilTest.java
@@ -52,7 +52,7 @@ public class DateUtilTest {
     @Test
     public void zonedTimeFormatLegacy() throws ParseException {
         Date time = new Date();
-        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'Z");
+        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         String str = dfDate.format(time);
         Date dtParsed = DateUtil.parseTZDateString(str);
 
@@ -60,11 +60,51 @@ public class DateUtilTest {
     }
 
     @Test
-    public void zonedTimeFormat() throws ParseException {
+    public void zonedTimeFormatNoColon() throws ParseException {
         Date time = new Date();
         DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         String str = dfDate.format(time);
-        Date dtParsed = DateUtil.parseTZDateString(str);
+        Date dtParsed = DateUtil.parseTZDateString(str + "+0100");
+
+        assertEquals(time.toString(), dtParsed.toString());
+    }
+
+    @Test
+    public void zonedTimeFormatWithColon() throws ParseException {
+        Date time = new Date();
+        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        String str = dfDate.format(time);
+        Date dtParsed = DateUtil.parseTZDateString(str + "+01:00");
+
+        assertEquals(time.toString(), dtParsed.toString());
+    }
+
+    @Test
+    public void zonedTimeFormatWithMilliseconds() throws ParseException {
+        Date time = new Date();
+        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        String str = dfDate.format(time);
+        Date dtParsed = DateUtil.parseTZDateString(str + ".000Z");
+
+        assertEquals(time.toString(), dtParsed.toString());
+    }
+
+    @Test
+    public void zonedTimeFormatWithMillisecondsAndColon() throws ParseException {
+        Date time = new Date();
+        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        String str = dfDate.format(time);
+        Date dtParsed = DateUtil.parseTZDateString(str + ".000000+01:00");
+
+        assertEquals(time.toString(), dtParsed.toString());
+    }
+
+    @Test
+    public void zonedTimeFormatWithMillisecondsNoColon() throws ParseException {
+        Date time = new Date();
+        DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        String str = dfDate.format(time)
+        Date dtParsed = DateUtil.parseTZDateString(str + ".000000+0100");
 
         assertEquals(time.toString(), dtParsed.toString());
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

The format expected by `signatureVersion=3&expires=....` is [quite limited](http://docs.cloudstack.apache.org/en/4.11.1.0/developersguide/dev.html?#enabling-api-call-expiration
).

It should accepts the following formats that are containing a timezone and/or milliseconds.

- 2018-10-01T08:12:14Z
- 2018-10-01T08:12:14+01:00
- 2018-10-01T08:12:14+0100
- 2018-10-01T08:12:14.000Z
- 2018-10-01T08:12:14.000+01:00
- 2018-10-01T08:12:14.000+0100

afaik only `2018-10-01T08:12:14+0100` is accepted by the current codebase.

This PR echoes another pull requests I made earlier this year. https://github.com/apache/cloudstack/pull/2392

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

n/a

## Screenshots (if appropriate):

n/a

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

__todo__

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [x] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

