### PR TITLE
Fixed Issue 2868, libvirt resize notify failure

### DIFF
--- a/scripts/storage/qcow2/resizevolume.sh
+++ b/scripts/storage/qcow2/resizevolume.sh
@@ -92,7 +92,7 @@ notifyqemu() {
     if `virsh domstate $vmname >/dev/null 2>&1`
     then
       sizeinkb=$(($newsize/1024))
-      devicepath=$(virsh domblklist $vmname|grep $path|tr -s ' ' | cut -d' ' -f1)
+      devicepath=$(virsh domblklist $vmname|grep $path|awk '{print $1}')
       virsh blockresize --path $devicepath --size $sizeinkb $vmname >/dev/null 2>&1
       retval=$?
       if [ -z $retval ] || [ $retval -ne 0 ]

--- a/scripts/storage/qcow2/resizevolume.sh
+++ b/scripts/storage/qcow2/resizevolume.sh
@@ -92,7 +92,8 @@ notifyqemu() {
     if `virsh domstate $vmname >/dev/null 2>&1`
     then
       sizeinkb=$(($newsize/1024))
-      virsh blockresize --domain $vmname --path $path --size $sizeinkb >/dev/null 2>&1
+      devicepath=$(virsh domblklist $vmname|grep $path|tr -s ' ' | cut -d' ' -f1)
+      virsh blockresize --path $devicepath --size $sizeinkb $vmname >/dev/null 2>&1
       retval=$?
       if [ -z $retval ] || [ $retval -ne 0 ]
       then

--- a/scripts/storage/qcow2/resizevolume.sh
+++ b/scripts/storage/qcow2/resizevolume.sh
@@ -92,7 +92,7 @@ notifyqemu() {
     if `virsh domstate $vmname >/dev/null 2>&1`
     then
       sizeinkb=$(($newsize/1024))
-      devicepath=$(virsh domblklist $vmname|grep $path|awk '{print $1}')
+      devicepath=$(virsh domblklist $vmname | grep $path | awk '{print $1}')
       virsh blockresize --path $devicepath --size $sizeinkb $vmname >/dev/null 2>&1
       retval=$?
       if [ -z $retval ] || [ $retval -ne 0 ]


### PR DESCRIPTION
## Description
Fixed for https://github.com/apache/cloudstack/issues/2868
Incorrect diskpath information was being sent to virsh blockresize, so the block device size was never refreshed to reflect the new disk size.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
Fixes: #2868 
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):
This was tested on Centos 7 with Ceph backend storage. Virtio-blk driver was used in the VM. Ubuntu 16.04 and Centos 7 VMs were tested.

Disk was 106GB:
![before_106gb](https://user-images.githubusercontent.com/17278194/46509153-aea1d300-c806-11e8-9677-d9e3e6251222.png)
Resize was used via the ACS GUI to resize the block device on ceph to 150GB.
The VM picks up the change immediately:
![after_150gb](https://user-images.githubusercontent.com/17278194/46509169-c4af9380-c806-11e8-80eb-7b3ea1046a1b.png)


## How Has This Been Tested?
Yes, see above.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

