### PR TITLE
ca: Fixes #2877 mgmt server cert should have all addrs of default nic

### DIFF
--- a/plugins/ca/root-ca/src/org/apache/cloudstack/ca/provider/RootCAProvider.java
+++ b/plugins/ca/root-ca/src/org/apache/cloudstack/ca/provider/RootCAProvider.java
@@ -359,7 +359,7 @@ public final class RootCAProvider extends AdapterBase implements CAProvider, Con
             return true;
         }
         final Certificate serverCertificate = issueCertificate(Collections.singletonList(NetUtils.getHostName()),
-                Collections.singletonList(NetUtils.getDefaultHostIp()), getCaValidityDays());
+                NetUtils.getAllDefaultNicIps(), getCaValidityDays());
         if (serverCertificate == null || serverCertificate.getPrivateKey() == null) {
             throw new CloudRuntimeException("Failed to generate management server certificate and load management server keystore");
         }

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -225,6 +225,27 @@ public class NetUtils {
         }
     }
 
+    public static List<String> getAllDefaultNicIps() {
+        final List<String> addrs = new ArrayList<>();
+        final String pubNic = getDefaultEthDevice();
+
+        if (pubNic == null) {
+            return addrs;
+        }
+
+        NetworkInterface nic = null;
+        try {
+            nic = NetworkInterface.getByName(pubNic);
+        } catch (final SocketException e) {
+            return addrs;
+        }
+
+        for (InterfaceAddress address : nic.getInterfaceAddresses()) {
+            addrs.add(address.getAddress().getHostAddress().split("%")[0]);
+        }
+        return addrs;
+    }
+
     public static String getDefaultEthDevice() {
         if (SystemUtils.IS_OS_MAC) {
             final String defDev = Script.runSimpleBashScript("/sbin/route -n get default 2> /dev/null | grep interface | awk '{print $2}'");

--- a/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -678,4 +678,10 @@ public class NetUtilsTest {
         assertFalse(NetUtils.isValidPort(-1));
         assertFalse(NetUtils.isValidPort(65536));
     }
+
+    @Test
+    public void testAllIpsOfDefaultNic() {
+        final String defaultHostIp = NetUtils.getDefaultHostIp();
+        assertTrue(NetUtils.getAllDefaultNicIps().stream().anyMatch(defaultHostIp::contains));
+    }
 }


### PR DESCRIPTION
This fixes the default RootCA provider implementation to initiate
and issue certificate for mgmt server on startup for all the IP addresses
on the default nic of that host.

Fixes #2877 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)