### PR TITLE
  add date to usage server logs

### DIFF
--- a/usage/conf/log4j-cloud_usage.xml.in
+++ b/usage/conf/log4j-cloud_usage.xml.in
@@ -48,7 +48,7 @@ under the License.
       </rollingPolicy>
 
       <layout class="org.apache.log4j.EnhancedPatternLayout">
-         <param name="ConversionPattern" value="%-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%n"/>
+         <param name="ConversionPattern" value="%d{ISO8601} %-5p [%c{3}] (%t:%x) (logid:%X{logcontextid}) %m%n"/>
       </layout>
    </appender>
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When logging operations of the usage server, a timestamp is not included, making the usage logs hard to interpret.
The same timestamp as used by them management log has been added to the usage server logging output.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

Timestamp added to the log4j.xml description of output.
Output now looks like:

2018-10-07 00:15:00,001 INFO  [cloud.usage.UsageManagerImpl] (Usage-Job-1:null) (logid:) starting usage job...
2018-10-07 00:15:00,016 INFO  [cloud.usage.UsageManagerImpl] (Usage-Job-1:null) (logid:) Parsing usage records between Sat Oct 06 00:00:00 UTC 2018 and Sat Oct 06 23:59:59 UTC 2018
2018-10-07 00:15:00,151 DEBUG [event.dao.UsageEventDaoImpl] (Usage-Job-1:null) (logid:) no recent event date, copying all events

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This has been tested by building RPMs, installing the usage service and checking the log output.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ x ] All relevant new and existing integration tests have passed.
- [ x ] A full integration testsuite with all test that can run on my environment has passed.

