### PR TITLE
vr: memory and swap optimizations

### DIFF
--- a/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalKickStartServiceImpl.java
+++ b/plugins/hypervisors/baremetal/src/com/cloud/baremetal/networkservice/BaremetalKickStartServiceImpl.java
@@ -226,11 +226,16 @@ public class BaremetalKickStartServiceImpl extends BareMetalPxeServiceBase imple
             throw new CloudRuntimeException(String.format("please specify 'baremetal.internal.storage.server.ip', which is the http server/nfs server storing kickstart files and ISO files, in global setting"));
         }
 
+        Pair<Boolean, String> ret = SshHelper.sshExecute(mgmtNic.getIPv4Address(), 3922, "root", getSystemVMKeyFile(), null, "systemctl start baremetal-vr");
+        if (!ret.first()) {
+            throw new CloudRuntimeException(String.format("failed to start baremetal agent in virtual router[id:%s]", vr.getId()));
+        }
+
         List<String> tuple =  parseKickstartUrl(profile);
         String cmd =  String.format("/opt/cloud/bin/prepare_pxe.sh %s %s %s %s %s %s", tuple.get(1), tuple.get(2), profile.getTemplate().getUuid(),
                 String.format("01-%s", nic.getMacAddress().replaceAll(":", "-")).toLowerCase(), tuple.get(0), nic.getMacAddress().toLowerCase());
         s_logger.debug(String.format("prepare pxe on virtual router[ip:%s], cmd: %s", mgmtNic.getIPv4Address(), cmd));
-        Pair<Boolean, String> ret = SshHelper.sshExecute(mgmtNic.getIPv4Address(), 3922, "root", getSystemVMKeyFile(), null, cmd);
+        ret = SshHelper.sshExecute(mgmtNic.getIPv4Address(), 3922, "root", getSystemVMKeyFile(), null, cmd);
         if (!ret.first()) {
             throw new CloudRuntimeException(String.format("failed preparing PXE in virtual router[id:%s], because %s", vr.getId(), ret.second()));
         }

--- a/systemvm/debian/etc/sysctl.conf
+++ b/systemvm/debian/etc/sysctl.conf
@@ -62,4 +62,4 @@ net.ipv6.conf.all.accept_redirects = 0
 net.ipv6.conf.all.autoconf = 0
 
 # Minimum swappiness without disabling it
-vm.swappiness=5
+vm.swappiness=1

--- a/systemvm/debian/etc/sysctl.conf
+++ b/systemvm/debian/etc/sysctl.conf
@@ -60,3 +60,6 @@ net.ipv6.conf.all.forwarding = 0
 net.ipv6.conf.all.accept_ra = 0
 net.ipv6.conf.all.accept_redirects = 0
 net.ipv6.conf.all.autoconf = 0
+
+# Minimum swappiness without disabling it
+vm.swappiness=5

--- a/systemvm/debian/etc/systemd/journald.conf
+++ b/systemvm/debian/etc/systemd/journald.conf
@@ -1,5 +1,5 @@
 [Journal]
 Compress=yes
-SystemMaxUse=50M
+SystemMaxUse=40M
 SystemMaxFileSize=10M
-RuntimeMaxUse=50M
+RuntimeMaxUse=20M

--- a/systemvm/debian/etc/systemd/journald.conf
+++ b/systemvm/debian/etc/systemd/journald.conf
@@ -1,0 +1,5 @@
+[Journal]
+Compress=yes
+SystemMaxUse=50M
+SystemMaxFileSize=10M
+RuntimeMaxUse=50M

--- a/systemvm/debian/etc/systemd/system/baremetal-vr.service
+++ b/systemvm/debian/etc/systemd/system/baremetal-vr.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=CloudStack Baremetal VR service
+After=network.target local-fs.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/cloud/bin
+ExecStart=/usr/bin/python /opt/cloud/bin/baremetal-vr.py

--- a/systemvm/debian/etc/systemd/system/baremetal-vr.service
+++ b/systemvm/debian/etc/systemd/system/baremetal-vr.service
@@ -9,3 +9,4 @@ WantedBy=multi-user.target
 Type=simple
 WorkingDirectory=/opt/cloud/bin
 ExecStart=/usr/bin/python /opt/cloud/bin/baremetal-vr.py
+Restart=on-failure

--- a/systemvm/debian/etc/systemd/system/cloud-postinit.service
+++ b/systemvm/debian/etc/systemd/system/cloud-postinit.service
@@ -2,7 +2,7 @@
 Description=CloudStack post-patching init script
 After=cloud-early-config.service network.target local-fs.target
 Before=ssh.service
-Requires=network.service
+Requires=networking.service
 
 [Install]
 WantedBy=multi-user.target

--- a/systemvm/debian/opt/cloud/bin/setup/postinit.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/postinit.sh
@@ -59,8 +59,3 @@ fi
 systemctl enable --now --no-block ssh
 
 date > /var/cache/cloud/boot_up_done
-
-if [ "$TYPE" == "router" ]
-then
-    python /opt/cloud/bin/baremetal-vr.py &
-fi

--- a/systemvm/debian/opt/cloud/bin/setup/postinit.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/postinit.sh
@@ -21,6 +21,9 @@
 # Eject cdrom if any
 eject || true
 
+# Restart journald for setting changes to apply
+systemctl restart systemd-journald
+
 TYPE=$(grep -Po 'type=\K[a-zA-Z]*' /var/cache/cloud/cmdline)
 if [ "$TYPE" == "router" ] || [ "$TYPE" == "vpcrouter" ] || [ "$TYPE" == "dhcpsrvr" ]
 then


### PR DESCRIPTION
This tries to provide a threshold based fix for #2873 where swappinness of VR is not used until last resort. By limiting swappiness unless actually needed, the VR system degradation can be avoided for most cases. The other change is around not starting `baremetal-vr` by default on all VRs, according to the spec https://cwiki.apache.org/confluence/display/CLOUDSTACK/Baremetal+Advanced+Networking+Support only vmware VRs need to run it and that too only as the last step of the setup/completion, so we don't need to run it all the time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

The default swapiness on VRs is 60, by reducing the value swapiness it is anticipated that swappiness will not be normally seen. I could not reproduce the swapping so could not test it.