### PR TITLE
Allow enable the Java remote Debug for CloudStack Agent

### DIFF
--- a/packaging/systemd/cloudstack-agent.default
+++ b/packaging/systemd/cloudstack-agent.default
@@ -20,3 +20,7 @@ JAVA_HEAP_INITIAL=256m
 JAVA_HEAP_MAX=2048m
 JAVA_CLASS=com.cloud.agent.AgentShell
 JAVA_TMPDIR=/usr/share/cloudstack-agent/tmp
+
+#You can uncomment this if you want to enable Java remote debugging.
+#Feel free to change the parameters at your will. The 'address' field defines the port to be used.
+#JAVA_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"

--- a/packaging/systemd/cloudstack-agent.service
+++ b/packaging/systemd/cloudstack-agent.service
@@ -28,7 +28,7 @@ ExecStart=/bin/sh -ec '\
     export ACP=`ls /usr/share/cloudstack-agent/lib/*.jar /usr/share/cloudstack-agent/plugins/*.jar 2>/dev/null|tr "\\n" ":"`; \
     export CLASSPATH="$ACP:/etc/cloudstack/agent:/usr/share/cloudstack-common/scripts"; \
     mkdir -m 0755 -p ${JAVA_TMPDIR}; \
-    ${JAVA} -Djava.io.tmpdir="${JAVA_TMPDIR}" -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} -cp "$CLASSPATH" $JAVA_CLASS'
+    ${JAVA} -Djava.io.tmpdir="${JAVA_TMPDIR}" -Xms${JAVA_HEAP_INITIAL} -Xmx${JAVA_HEAP_MAX} $JAVA_DEBUG -cp "$CLASSPATH" $JAVA_CLASS'
 Restart=always
 RestartSec=10s
 


### PR DESCRIPTION
The idea is to create a property in /etc/defaults/cloudstack-agent that can be enabled/disabled (uncommented/commented) to control the enabling of Java remote debug in CloudStack's JVM.

This PR is analogous with #2535, which created an easy way to enable Java remote Debug on the CloudStack management; however, this PR creates a variable (JAVA_DEBUG) that helps on enabling remote debug in the CloudStack agent service.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
<!-- If this PR is to fix an issue or another PR on GH, uncomment the section and provide the id of issue/PR -->
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->

<!-- Fixes: # -->

## Screenshots (if appropriate):

## How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

