### PR TITLE
docker: add compose file for database

### DIFF
--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  db:
+    image: mariadb:10.0
+    volumes:
+      - db:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: cloud
+#      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_USER: cloud
+      MYSQL_PASSWORD: cloud
+    ports:
+      - "3306:3306"
+
+volumes:
+  db:

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 version: '2'
 services:
   db:

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   db:
     image: mariadb:10.0
     volumes:
+      - ./mariadb-docker:/etc/mysql/conf.d
       - db:/var/lib/mysql
     environment:
       MYSQL_DATABASE: cloud

--- a/tools/docker/mariadb-docker/cloudstack-docker.cnf
+++ b/tools/docker/mariadb-docker/cloudstack-docker.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+server-id=master-dev
+innodb_rollback_on_timeout=1
+innodb_lock_wait_timeout=600
+max_connections=1000
+log-bin=mysql-bin
+binlog-format = 'ROW'

--- a/tools/docker/mariadb-docker/cloudstack-docker.cnf
+++ b/tools/docker/mariadb-docker/cloudstack-docker.cnf
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [mysqld]
 server-id=master-dev
 innodb_rollback_on_timeout=1


### PR DESCRIPTION
## Description
A docker-compose file to setup quickly the database for CS. This helps during local development and remove the need to install a local MariaDB/MySQL.

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs
None

## Screenshots (if appropriate):

## How Has This Been Tested?
`docker-compose up` starts the MariaDB 10.0 database for local development.

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

