### PR TITLE
network: Allow ability to disable rolling restart feature

### DIFF
--- a/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -93,6 +93,9 @@ public interface NetworkOrchestrationService {
     ConfigKey<Boolean> ForgedTransmits = new ConfigKey<Boolean>("Advanced", Boolean.class, "network.forged.transmits", "true",
             "Whether to allow or deny forged transmits on nics for applicable network elements such as for vswitch/dvswitch portgroups.", true);
 
+    ConfigKey<Boolean> RollingRestartEnabled = new ConfigKey<Boolean>("Advanced", Boolean.class, "network.rolling.restart", "true",
+            "Whether to allow or deny rolling restart of network routers.", true);
+
     List<? extends Network> setupNetwork(Account owner, NetworkOffering offering, DeploymentPlan plan, String name, String displayText, boolean isDefault)
         throws ConcurrentOperationException;
 

--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2860,7 +2860,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         s_logger.debug("Implementing the network " + network + " elements and resources as a part of network restart without cleanup");
         try {
             implementNetworkElementsAndResources(dest, context, network, offering);
-            setRestartRequired(network, true);
+            setRestartRequired(network, false);
             return true;
         } catch (final Exception ex) {
             s_logger.warn("Failed to implement network " + network + " elements and resources as a part of network restart due to ", ex);
@@ -2927,6 +2927,14 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
      * @throws InsufficientCapacityException
      */
     private boolean rollingRestartRouters(final NetworkVO network, final NetworkOffering offering, final DeployDestination dest, final ReservationContext context) throws ResourceUnavailableException, ConcurrentOperationException, InsufficientCapacityException {
+        if (!NetworkOrchestrationService.RollingRestartEnabled.value()) {
+            if (shutdownNetworkElementsAndResources(context, true, network)) {
+                implementNetworkElementsAndResources(dest, context, network, offering);
+                return true;
+            }
+            s_logger.debug("Failed to shutdown the network elements and resources as a part of network restart: " + network.getState());
+            return false;
+        }
         s_logger.debug("Performing rolling restart of routers of network " + network);
         destroyExpendableRouters(_routerDao.findByNetwork(network.getId()), context);
 
@@ -3831,6 +3839,6 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[] {NetworkGcWait, NetworkGcInterval, NetworkLockTimeout,
                 GuestDomainSuffix, NetworkThrottlingRate, MinVRVersion,
-                PromiscuousMode, MacAddressChanges, ForgedTransmits};
+                PromiscuousMode, MacAddressChanges, ForgedTransmits, RollingRestartEnabled};
     }
 }

--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2458,6 +2458,13 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
      * @throws InsufficientCapacityException
      */
     private boolean rollingRestartVpc(final Vpc vpc, final ReservationContext context) throws ResourceUnavailableException, ConcurrentOperationException, InsufficientCapacityException {
+        if (!NetworkOrchestrationService.RollingRestartEnabled.value()) {
+            if (shutdownVpc(vpc.getId())) {
+                return startVpc(vpc.getId(), false);
+            }
+            s_logger.warn("Failed to shutdown vpc as a part of VPC " + vpc + " restart process");
+            return false;
+        }
         s_logger.debug("Performing rolling restart of routers of VPC " + vpc);
         _ntwkMgr.destroyExpendableRouters(_routerDao.listByVpcId(vpc.getId()), context);
 


### PR DESCRIPTION
This adds a global setting for admins who may want the lebacy behaviour of network restart with cleanup=true. In future, this setting may be removed.

The examples of error are in #2880, by having this toggle switch a temporary relief may be possible for such environments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

The global settings ships as 'true', so rolling restart feature is shipped as the default behaviour. If somebody wants legacy behaviour they can set the value to false and try to restart an isolated network or redundant network with cleanup enabled.