### PR TITLE
Add checksum sanity validation on template registration

### DIFF
--- a/server/src/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/com/cloud/template/HypervisorTemplateAdapter.java
@@ -39,6 +39,7 @@ import org.apache.cloudstack.api.command.user.template.GetUploadParamsForTemplat
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
 import org.apache.cloudstack.storage.command.TemplateOrVolumePostUploadCommand;
+import org.apache.cloudstack.utils.security.DigestHelper;
 import org.apache.log4j.Logger;
 import org.apache.cloudstack.storage.datastore.db.TemplateDataStoreDao;
 import org.apache.cloudstack.api.command.user.iso.DeleteIsoCmd;
@@ -155,6 +156,7 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
         String url = profile.getUrl();
         UriUtils.validateUrl(ImageFormat.ISO.getFileExtension(), url);
         if (cmd.isDirectDownload()) {
+            DigestHelper.checksumSanity(cmd.getChecksum());
             Long templateSize = performDirectDownloadUrlValidation(url);
             profile.setSize(templateSize);
         }
@@ -170,6 +172,7 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
         String url = profile.getUrl();
         UriUtils.validateUrl(cmd.getFormat(), url);
         if (cmd.isDirectDownload()) {
+            DigestHelper.checksumSanity(cmd.getChecksum());
             Long templateSize = performDirectDownloadUrlValidation(url);
             profile.setSize(templateSize);
         }

--- a/utils/src/test/java/org/apache/cloudstack/utils/security/DigestHelperTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/security/DigestHelperTest.java
@@ -97,6 +97,30 @@ public class DigestHelperTest {
     public void reset() throws IOException {
         inputStream.reset();
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testChecksumSanityNoPrefix() {
+        String checksum = "177adf7019cf04933ccb9f0cff784b5b737de2b5f92a43c60c362f646dfee816";
+        DigestHelper.checksumSanity(checksum);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testChecksumSanityPrefixEmptyAlgorithm() {
+        String checksum = "{}177adf7019cf04933ccb9f0cff784b5b737de2b5f92a43c60c362f646dfee816";
+        DigestHelper.checksumSanity(checksum);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testChecksumSanityPrefixWrongAlgorithm() {
+        String checksum = "{MD5}177adf7019cf04933ccb9f0cff784b5b737de2b5f92a43c60c362f646dfee816";
+        DigestHelper.checksumSanity(checksum);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testChecksumSanityPrefixWrongChecksumLength() {
+        String checksum = "{SHA-256}177adf7019cf04933ccb9f0cff784b5b737de2b5f92a43c60c362f646dfee816XXXXX";
+        DigestHelper.checksumSanity(checksum);
+    }
 }
 
 //Generated with love by TestMe :) Please report issues and submit feature requests at: http://weirddev.com/forum#!/testme


### PR DESCRIPTION
## Description
Add a checksum sanity check on template/ISO registration for direct downloads on KVM.
Assert that:
- Algorithm is provided as a prefix between braces on the checksum parameter: `Format: {ALG}HASH`
- Hash length matches the expected one for the provided algorithm

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## GitHub Issue/PRs

## Screenshots (if appropriate):

## How Has This Been Tested?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Testing
- [ ] I have added tests to cover my changes.
- [ ] All relevant new and existing integration tests have passed.
- [ ] A full integration testsuite with all test that can run on my environment has passed.

