### PR TITLE
Fix delete domain button in the UI to update only after deleteDomain job finishes

### DIFF
--- a/ui/scripts/domains.js
+++ b/ui/scripts/domains.js
@@ -69,11 +69,23 @@
                                 async: false,
                                 success: function(json) {
                                     var jid = json.deletedomainresponse.jobid;
+                                    var wasDomainDeletedWithSuccess = false;
+                                    $.ajax({
+                                        url: createURL("queryAsyncJobResult&jobId=" + jid),
+                                        dataType: "json",
+                                        async: false,
+                                        success: function(json) {
+                                            wasDomainDeletedWithSuccess = json.queryasyncjobresultresponse.jobresultcode ==  0;
+                                        }
+                                    });
                                     args.response.success({
                                         _custom: {
                                             jobId: jid
                                         }
                                     });
+                                    if(!wasDomainDeletedWithSuccess){
+                                        return;
+                                    }
 
                                     // Quick fix for proper UI reaction to delete domain
                                     var $item = $('.name.selected').closest('li');


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When the “deleteDomain” command is sent via UI, the HTML is already updated assuming that the “deleteDomain” command will actually delete it. However, there are cases (domain with allocated resources) that will not allow ACS to remove the command; as a consequence, the UI will not be in sync with ACS state, which can lead to misunderstandings.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Manually

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
