### PR TITLE
client: mgmt server listen default to 0.0.0.0

### DIFF
--- a/client/conf/server.properties.in
+++ b/client/conf/server.properties.in
@@ -16,7 +16,7 @@
 # under the License.
 
 # The binding interface for the management server
-bind.interface=0.0.0.0
+# bind.interface=::
 
 # The service context path where URL requests should be served
 context.path=/client

--- a/client/conf/server.properties.in
+++ b/client/conf/server.properties.in
@@ -16,7 +16,7 @@
 # under the License.
 
 # The binding interface for the management server
-bind.interface=::
+bind.interface=0.0.0.0
 
 # The service context path where URL requests should be served
 context.path=/client

--- a/client/conf/server.properties.in
+++ b/client/conf/server.properties.in
@@ -16,6 +16,7 @@
 # under the License.
 
 # The binding interface for the management server
+# The management server will listen on all interfaces by default
 # bind.interface=::
 
 # The service context path where URL requests should be served

--- a/client/src/org/apache/cloudstack/ServerDaemon.java
+++ b/client/src/org/apache/cloudstack/ServerDaemon.java
@@ -85,7 +85,7 @@ public class ServerDaemon implements Daemon {
     private int sessionTimeout = 30;
     private boolean httpsEnable = false;
     private String accessLogFile = "access.log";
-    private String bindInterface = "";
+    private String bindInterface = null;
     private String contextPath = "/client";
     private String keystoreFile;
     private String keystorePassword;
@@ -117,7 +117,7 @@ public class ServerDaemon implements Daemon {
             if (properties == null) {
                 return;
             }
-            setBindInterface(properties.getProperty(BIND_INTERFACE, ""));
+            setBindInterface(properties.getProperty(BIND_INTERFACE, null));
             setContextPath(properties.getProperty(CONTEXT_PATH, "/client"));
             setHttpPort(Integer.valueOf(properties.getProperty(HTTP_PORT, "8080")));
             setHttpsEnable(Boolean.valueOf(properties.getProperty(HTTPS_ENABLE, "false")));


### PR DESCRIPTION
This makes the management server listen 0.0.0.0 by default as we cannot
always assume that the host where management server will be installed
will have ipv6 enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

@blueorangutan package