### PR TITLE
Unify templates/ISOs checksum API output

### DIFF
--- a/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.cloudstack.utils.security.DigestHelper;
 import org.apache.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -188,7 +189,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
             templateResponse.setPhysicalSize(templatePhysicalSize);
         }
 
-        templateResponse.setChecksum(template.getChecksum());
+        templateResponse.setChecksum(DigestHelper.getHashValueFromChecksumValue(template.getChecksum()));
         if (template.getSourceTemplateId() != null) {
             templateResponse.setSourceTemplateId(template.getSourceTemplateUuid());
         }
@@ -320,7 +321,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         isoResponse.setFeatured(iso.isFeatured());
         isoResponse.setCrossZones(iso.isCrossZones());
         isoResponse.setPublic(iso.isPublicTemplate());
-        isoResponse.setChecksum(iso.getChecksum());
+        isoResponse.setChecksum(DigestHelper.getHashValueFromChecksumValue(iso.getChecksum()));
 
         isoResponse.setOsTypeId(iso.getGuestOSUuid());
         isoResponse.setOsTypeName(iso.getGuestOSName());

--- a/utils/src/main/java/org/apache/cloudstack/utils/security/DigestHelper.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/security/DigestHelper.java
@@ -116,4 +116,19 @@ public class DigestHelper {
             }
         }
     }
+
+    /**
+     * True if the algorithm is present on the checksum value. Format: {ALG}HASH
+     */
+    protected static boolean isAlgorithmPresent(String checksum) {
+        return StringUtils.isNotBlank(checksum) && checksum.contains("{") && checksum.contains("}") &&
+                checksum.indexOf("{") == 0 && checksum.indexOf("}") > checksum.indexOf("{");
+    }
+
+    /**
+     * Returns the checksum HASH from the checksum value which can have the following formats: {ALG}HASH or HASH
+     */
+    public static String getHashValueFromChecksumValue(String checksum) {
+        return isAlgorithmPresent(checksum) ? new ChecksumValue(checksum).getChecksum() : checksum;
+    }
 }

--- a/utils/src/test/java/org/apache/cloudstack/utils/security/DigestHelperTest.java
+++ b/utils/src/test/java/org/apache/cloudstack/utils/security/DigestHelperTest.java
@@ -26,6 +26,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class DigestHelperTest {
 
     private final static String INPUT_STRING = "01234567890123456789012345678901234567890123456789012345678901234567890123456789\n";
@@ -46,17 +49,17 @@ public class DigestHelperTest {
 
     @Test
     public void check_SHA256() throws Exception {
-        Assert.assertTrue(DigestHelper.check(SHA256_CHECKSUM, inputStream));
+        assertTrue(DigestHelper.check(SHA256_CHECKSUM, inputStream));
     }
 
     @Test
     public void check_SHA1() throws Exception {
-        Assert.assertTrue(DigestHelper.check(SHA1_CHECKSUM, inputStream));
+        assertTrue(DigestHelper.check(SHA1_CHECKSUM, inputStream));
     }
 
     @Test
     public void check_MD5() throws Exception {
-        Assert.assertTrue(DigestHelper.check(MD5_CHECKSUM, inputStream));
+        assertTrue(DigestHelper.check(MD5_CHECKSUM, inputStream));
     }
 
     @Test
@@ -126,6 +129,28 @@ public class DigestHelperTest {
     public void testChecksumSanityPrefixWrongChecksumLength() {
         String checksum = SHA256_CHECKSUM + "XXXXX";
         DigestHelper.validateChecksumString(checksum);
+    }
+
+    @Test
+    public void testIsAlgorithmPresentPositiveCase() {
+        assertTrue(DigestHelper.isAlgorithmSupported(SHA256_CHECKSUM));
+    }
+
+    @Test
+    public void testIsAlgorithmPresentnegativeCase() {
+        assertTrue(DigestHelper.isAlgorithmSupported(SHA256_NO_PREFIX_CHECKSUM));
+    }
+
+    @Test
+    public void testGetHashValueFromChecksumValuePrefixPresent() {
+        String checksum = DigestHelper.getHashValueFromChecksumValue(SHA256_CHECKSUM);
+        assertEquals(SHA256_NO_PREFIX_CHECKSUM, checksum);
+    }
+
+    @Test
+    public void testGetHashValueFromChecksumValueNoPrefixPresent() {
+        String checksum = DigestHelper.getHashValueFromChecksumValue(SHA256_NO_PREFIX_CHECKSUM);
+        assertEquals(SHA256_NO_PREFIX_CHECKSUM, checksum);
     }
 }
 


### PR DESCRIPTION
## Description
Unify checksum API output for templates and ISOs: not list the checksum algorithm on:

- KVM direct downloads

- On in progress normal template downloads. The algorithm is shown on the `listtemplates` API, but after it is downloaded it is not shown anymore:
````
(qa11) 🐵 > list templates id=0699767e-ce21-4967-a53a-3c0f37fe9154 templatefilter=all filter=status,checksum
{
  "count": 1,
  "template": [
    {
      "checksum": "{SHA-256}ae490ce8b7a55fa92365f72e7581c3eed651da710794989f263f3816b9dc2ea9",
      "status": "50% Downloaded",
    }
  ]
}
(qa11) 🐵 > list templates id=0699767e-ce21-4967-a53a-3c0f37fe9154 templatefilter=all
{
  "count": 1,
  "template": [
    {
      "checksum": "ae490ce8b7a55fa92365f72e7581c3eed651da710794989f263f3816b9dc2ea9",
      "status": "Download Complete",
    }
  ]
}
````

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

- KVM direct downloads:
````
(local) SBCM5> list templates templatefilter=all id=7713ca67-cf3a-4281-82fb-58b5ddc25d6b filter=status,checksum
{
  "count": 1,
  "template": [
    {
      "checksum": "6952e58f39b470bd166ace11ffd20bf479bed936",
      "status": "Bypassed Secondary Storage"
    }
  ]
}
````

- Non direct downloads:
````
(local) SBCM5> list templates templatefilter=all filter=status,checksum id=c612129c-0fd0-449e-81f6-4d69ab11e5cb
{
  "count": 1,
  "template": [
    {
      "checksum": "6952e58f39b470bd166ace11ffd20bf479bed936",
      "status": "84% Downloaded"
    }
  ]
}
(local) SBCM5> list templates templatefilter=all filter=status,checksum id=c612129c-0fd0-449e-81f6-4d69ab11e5cb
{
  "count": 1,
  "template": [
    {
      "checksum": "6952e58f39b470bd166ace11ffd20bf479bed936",
      "status": "Download Complete"
    }
  ]
}
````

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
