### PR TITLE
kvm: Use libvirtd as service name for libvirt for Debian (#2909)

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPostCertificateRenewalCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPostCertificateRenewalCommandWrapper.java
@@ -38,7 +38,7 @@ public final class LibvirtPostCertificateRenewalCommandWrapper extends CommandWr
         if (command != null) {
             final int timeout = 30000;
             Script script = new Script(true, "service", timeout, s_logger);
-            if ("Ubuntu".equals(serverResource.getHostDistro()) || "Debian".equals(serverResource.getHostDistro())) {
+            if ("Ubuntu".equals(serverResource.getHostDistro())) {
                 script.add("libvirt-bin");
             } else {
                script.add("libvirtd");


### PR DESCRIPTION
Debian does not have libvirt-bin package. Therefore, only for Ubuntu host distro process name libvirt-bin is used, otherwise libvirtd will be used

## Description
As discussed in #2909 libvirt-bin is not resent in Debian but it is in Ubuntu. Host check should only be for Ubuntu and not for Debian.
cloudstack/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtPostCertificateRenewalCommandWrapper.java is changed to fix this.