### PR TITLE
Deactivate ehcache

### DIFF
--- a/client/conf/ehcache.xml.in
+++ b/client/conf/ehcache.xml.in
@@ -163,14 +163,6 @@ under the License.
      used.
 
     -->
-    <cacheManagerPeerProviderFactory
-            class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
-            properties="peerDiscovery=automatic,
-                        multicastGroupAddress=230.0.0.1,
-                        multicastGroupPort=4446, timeToLive=1"
-            propertySeparator=","
-            />
-
 
     <!--
     CacheManagerPeerListener
@@ -209,9 +201,6 @@ under the License.
       If not specified it defaults 120000ms.
 
     -->
-    <cacheManagerPeerListenerFactory
-            class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"/>
-
 
     <!--
     Cache configuration

--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -28,91 +28,17 @@
                       >
 
   <!--
-    DAO with customized configuration
-  -->
-  <bean id="serviceOfferingDaoImpl" class="com.cloud.service.dao.ServiceOfferingDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="50" />
-        <entry key="cache.time.to.live" value="600" />
-      </map>
-    </property>
-  </bean>
-
-  <bean id="diskOfferingDaoImpl" class="com.cloud.storage.dao.DiskOfferingDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="50" />
-        <entry key="cache.time.to.live" value="600" />
-      </map>
-    </property>
-  </bean>
-
-  <bean id="dataCenterDaoImpl" class="com.cloud.dc.dao.DataCenterDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="50" />
-        <entry key="cache.time.to.live" value="600" />
-      </map>
-    </property>
-  </bean>
-
-  <bean id="hostPodDaoImpl" class="com.cloud.dc.dao.HostPodDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="50" />
-        <entry key="cache.time.to.live" value="600" />
-      </map>
-    </property>
-  </bean>
-
-  <bean id="vlanDaoImpl" class="com.cloud.dc.dao.VlanDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="30" />
-        <entry key="cache.time.to.live" value="3600" />
-      </map>
-    </property>
-  </bean>
-
-  <bean id="userDaoImpl" class="com.cloud.user.dao.UserDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="5000" />
-        <entry key="cache.time.to.live" value="300" />
-      </map>
-    </property>
-  </bean>
-
-  <bean id="VMTemplateDaoImpl" class="com.cloud.storage.dao.VMTemplateDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="100" />
-        <entry key="cache.time.to.live" value="600" />
-      </map>
-    </property>
-  </bean>
-
-  <bean id="hypervisorCapabilitiesDaoImpl" class="com.cloud.hypervisor.dao.HypervisorCapabilitiesDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="100" />
-        <entry key="cache.time.to.live" value="600" />
-      </map>
-    </property>
-  </bean>
-  <bean id="dedicatedResourceDaoImpl" class="com.cloud.dc.dao.DedicatedResourceDaoImpl">
-    <property name="configParams">
-      <map>
-        <entry key="cache.size" value="30" />
-        <entry key="cache.time.to.live" value="3600" />
-      </map>
-    </property>
-  </bean>
-
-  <!--
     DAOs with default configuration
   -->
+  <bean id="serviceOfferingDaoImpl" class="com.cloud.service.dao.ServiceOfferingDaoImpl" />
+  <bean id="diskOfferingDaoImpl" class="com.cloud.storage.dao.DiskOfferingDaoImpl" />
+  <bean id="dataCenterDaoImpl" class="com.cloud.dc.dao.DataCenterDaoImpl" />
+  <bean id="hostPodDaoImpl" class="com.cloud.dc.dao.HostPodDaoImpl" />
+  <bean id="vlanDaoImpl" class="com.cloud.dc.dao.VlanDaoImpl" />
+  <bean id="userDaoImpl" class="com.cloud.user.dao.UserDaoImpl" />
+  <bean id="VMTemplateDaoImpl" class="com.cloud.storage.dao.VMTemplateDaoImpl" />
+  <bean id="hypervisorCapabilitiesDaoImpl" class="com.cloud.hypervisor.dao.HypervisorCapabilitiesDaoImpl" />
+  <bean id="dedicatedResourceDaoImpl" class="com.cloud.dc.dao.DedicatedResourceDaoImpl" />
   <bean id="roleDaoImpl" class="org.apache.cloudstack.acl.dao.RoleDaoImpl" />
   <bean id="rolePermissionsDaoImpl" class="org.apache.cloudstack.acl.dao.RolePermissionsDaoImpl" />
   <bean id="accountDaoImpl" class="com.cloud.user.dao.AccountDaoImpl" />


### PR DESCRIPTION
## Description

This PR is for deactivating Ehcache in CloudStack since it is not usable. The first commit remove the default RMI cache peering configured for multicast which most of the time cannot work. It also requires to have an interface up which is not always the case while developing offline.
The second commits remove the configuration to activate caching on some DAOs.

### Problems
The code in CS does not seem to fit any caching mechanism especially due to the homemade DAO code. The main 3 flaws are the following:

#### Entities are not expected to be shared
There is quite a lot of code with method calls passing entity IDs value as `long`, which does some object fetching. Without caching, this behavior will create distinct objects each time an entity with the same ID is fetched. With the cache enabled, the same object will be shared among those methods. It has been seen that it does generate some side effects where code still expected unchanged entity attributes after calling different methods thus generating exception/bugs.

#### DAO update operations are using search queries
Some part of the code are updating entities based on a search query, therefore the whole cache must be invalidated (see GenericDaoBase: `public int update(UpdateBuilder ub, final SearchCriteria<?> sc, Integer rows);`).

#### Entities based on views joining multiple tables
There are quite a lot of entities based on SQL views joining multiple entities in a same object. Enabling caching on those would require a mechanism to link and cross-remove related objects whenever one of the sub-entity is changed.

### Final word
Based on the previously discussed points, the best approach IMHO would be to move out of the custom DAO framework in CS and use a well known one (out of scope of this change of course). It will handle caching well and the joins made by the views in the code. It's not an easy change, but it will fix along a lot of issues and add a proven / robust framework to an important part of the code.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
A cluster of management servers with a manual ehcache RMI configuration has been setup to test different changes in the caching. The RMI cache setup has been verified though cache invalidation being propagated to the other server. A series of integration tests have been run, while figuring out the reason for (random) errors.
