### PR TITLE
tools: Added '-B' flag for mvn current version cmd (#2910)

### DIFF
--- a/tools/build/setnextversion.sh
+++ b/tools/build/setnextversion.sh
@@ -124,7 +124,7 @@ echo "checking out correct branch"
 git checkout $branch
 
 echo "determining current POM version"
-export currentversion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`
+export currentversion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version -B | grep -v '\['`
 echo "found $currentversion"
 
 echo "setting new version numbers"


### PR DESCRIPTION
maven command for finding current version might need to download packages and without batch mode it will end in variable. Added '-B' to enable batch mode.

## Description
Added '-B' to enable batch mode in maven command for find current version maven command in cloudstack/tools/build/setnextversion.sh shell script.
