### PR TITLE
systemvm: Ensure cloud service reboots after failure

### DIFF
--- a/systemvm/debian/etc/systemd/system/cloud-postinit.service
+++ b/systemvm/debian/etc/systemd/system/cloud-postinit.service
@@ -2,7 +2,6 @@
 Description=CloudStack post-patching init script
 After=cloud-early-config.service network.target local-fs.target
 Before=ssh.service
-Requires=networking.service
 
 [Install]
 WantedBy=multi-user.target

--- a/systemvm/debian/etc/systemd/system/cloud.service
+++ b/systemvm/debian/etc/systemd/system/cloud.service
@@ -9,5 +9,4 @@ WantedBy=multi-user.target
 Type=simple
 WorkingDirectory=/usr/local/cloud/systemvm
 ExecStart=/usr/local/cloud/systemvm/_run.sh
-Restart=always
-RestartSec=5
+Restart=on-failure


### PR DESCRIPTION
This fixes an issue for systemvms (CPVM and SSVM) on VMware, as eth0
is not programmed (link-local) the networking.service fails to start
which is a dependency for cloud-postinit service. When cloud-postinit
service fails to start/run, it fails to start the agent (cloud) process.
This fixes the smoketest failures we saw in case of VMware 6.5 with
4.11.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

On a VMware 6.5 env, restart any SSVM/CPVM. Post restart, the agent will never connect.
With the changes, once systemvm is restarted the agent will reconnect.