### PR TITLE
network: on rolling restart force stop old routers

### DIFF
--- a/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2959,6 +2959,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
         // Destroy old routers
         for (final DomainRouterVO oldRouter : oldRouters) {
+            _routerService.stopRouter(oldRouter.getId(), true);
             _routerService.destroyRouter(oldRouter.getId(), context.getAccount(), context.getCaller().getId());
         }
 

--- a/server/src/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2490,6 +2490,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         // Destroy old routers
         for (final DomainRouterVO oldRouter : oldRouters) {
+            _routerService.stopRouter(oldRouter.getId(), true);
             _routerService.destroyRouter(oldRouter.getId(), context.getAccount(), context.getCaller().getId());
         }
 


### PR DESCRIPTION
This force stops old VRs when performing rolling restart with
cleanup=true. This will ensure that VRs are powered off quickly than
wait longer for the normal ACPI shutdown. During testing, it was found
on VMware where VM stops are slow compared to XenServer and KVM.

This could likely fix #2880 /cc @resmo 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

Restart an isolated network or VPC with cleanup=true, see actions in vCenter. With this changes, it should now refer to powering off the VR.