### PR TITLE
vr: defer was broken in VR because of json name change

### DIFF
--- a/systemvm/debian/opt/cloud/bin/update_config.py
+++ b/systemvm/debian/opt/cloud/bin/update_config.py
@@ -52,7 +52,7 @@ def process_file():
     qf.setFile(sys.argv[1])
     qf.load(None)
     # These can be safely deferred, dramatically speeding up loading times
-    if not (os.environ.get('DEFER_CONFIG', False) and sys.argv[1] in ('vm_dhcp_entry.json', 'vm_metadata.json')):
+    if not (os.environ.get('DEFER_CONFIG', False) and ('vm_dhcp_entry.json' in sys.argv[1] or 'vm_metadata.json' in sys.argv[1])):
         # Converge
         finish_config()
 


### PR DESCRIPTION
After upgrade from CS 4.10 to CS 4.11, multiple VRs did not start through.
It did not properly defer the finalize config in update_config.py.
Apparently, the json files are now called differently: where it used to
be vm_dhcp_entry.json it now has a uuid added, for example
vm_metadata.json.4d727b6e-2b48-49df-81c3-b8532f3d6745.
The if statement that checks if the finalize can be safely deferred
therefore no longer matches. This PR contains a fix so finalize is
defered again.

Rohit: I made a boo-boo by force pushing and trying to rebash on @RPDiep 's repo/branch. Submitting his commit on his behalf against 4.11 branch. Sorry @RPDiep /cc @wido.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)