### PR TITLE
[4.11] Fix set initial reservation on public IP ranges

### DIFF
--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3569,10 +3569,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     }
                     // increment resource count for dedicated public ip's
                     _resourceLimitMgr.incrementResourceCount(vlanOwner.getId(), ResourceType.public_ip, new Long(ips.size()));
-                } else if (domain != null) {
+                } else if (domain != null && !forSystemVms) {
                     // This VLAN is domain-wide, so create a DomainVlanMapVO entry
-                    //final DomainVlanMapVO domainVlanMapVO = new DomainVlanMapVO(domain.getId(), vlan.getId());
-                    //_domainVlanMapDao.persist(domainVlanMapVO);
+                    final DomainVlanMapVO domainVlanMapVO = new DomainVlanMapVO(domain.getId(), vlan.getId());
+                    _domainVlanMapDao.persist(domainVlanMapVO);
                 } else if (podId != null) {
                     // This VLAN is pod-wide, so create a PodVlanMapVO entry
                     final PodVlanMapVO podVlanMapVO = new PodVlanMapVO(podId, vlan.getId());

--- a/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3754,8 +3754,10 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
         // Check if any of the Public IP addresses is allocated to another
         // account
+        boolean forSystemVms = false;
         final List<IPAddressVO> ips = _publicIpAddressDao.listByVlanId(vlanDbId);
         for (final IPAddressVO ip : ips) {
+            forSystemVms = ip.isForSystemVms();
             final Long allocatedToAccountId = ip.getAllocatedToAccountId();
             if (allocatedToAccountId != null) {
                 final Account accountAllocatedTo = _accountMgr.getActiveAccountById(allocatedToAccountId);
@@ -3779,7 +3781,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 UsageEventUtils.publishUsageEvent(EventTypes.EVENT_NET_IP_ASSIGN, vlanOwner.getId(), ip.getDataCenterId(), ip.getId(), ip.getAddress().toString(), ip.isSourceNat(),
                         vlan.getVlanType().toString(), ip.getSystem(), ip.getClass().getName(), ip.getUuid());
             }
-        } else if (domain != null) {
+        } else if (domain != null && !forSystemVms) {
             // Create an DomainVlanMapVO entry
             DomainVlanMapVO domainVlanMapVO = new DomainVlanMapVO(domain.getId(), vlan.getId());
             _domainVlanMapDao.persist(domainVlanMapVO);

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -126,13 +126,16 @@
                                 var $systemvmsCb = $systemvms.find('input[type=checkbox]');
                                 var $account = args.$form.find('.form-item[rel=account]');
                                 var $accountTxt = args.$form.find('input[name=account]');
+                                var $domainid = args.$form.find('select[name=domainid]');
                                 $systemvmsCb.change(function() {
                                     if ($systemvmsCb.is(':checked')) {
                                         $accountTxt.val('');
                                         $accountTxt.attr('disabled', true);
+                                        $domainid.attr('disabled', true);
                                     }
                                     else {
                                         $accountTxt.attr('disabled', false);
+                                        $domainid.attr('disabled', false);
                                     }
                                 });
                             }

--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -527,7 +527,8 @@
                                         },
                                         actionPreFilter: function (args) {
                                             var actionsToShow =[ 'destroy'];
-                                            if (args.context.multiRule[0].domain == 'ROOT' && args.context.multiRule[0].account != null && args.context.multiRule[0].account.account == 'system')
+                                            if (args.context.multiRule[0].domain == 'ROOT' && args.context.multiRule[0].account != null &&
+                                                args.context.multiRule[0].account.account == 'system' && !args.context.multiRule[0].forsystemvms)
                                             actionsToShow.push('addAccount'); else
                                             actionsToShow.push('releaseFromAccount');
                                             return actionsToShow;


### PR DESCRIPTION
## Description
Fix initial reservation on public IP range addition. Also, if the range is dedicated for system VMs do not allow dedicating it to any account

Fixes: #2929 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
- Set reservation to a domain, add range. Verify domain is set to the domain.
