### PR TITLE
Fix set initial reservation on public IP ranges

### DIFF
--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -126,13 +126,16 @@
                                 var $systemvmsCb = $systemvms.find('input[type=checkbox]');
                                 var $account = args.$form.find('.form-item[rel=account]');
                                 var $accountTxt = args.$form.find('input[name=account]');
+                                var $domainid = args.$form.find('select[name=domainid]');
                                 $systemvmsCb.change(function() {
                                     if ($systemvmsCb.is(':checked')) {
                                         $accountTxt.val('');
                                         $accountTxt.attr('disabled', true);
+                                        $domainid.attr('disabled', true);
                                     }
                                     else {
                                         $accountTxt.attr('disabled', false);
+                                        $domainid.attr('disabled', false);
                                     }
                                 });
                             }
@@ -526,7 +529,8 @@
                                         },
                                         actionPreFilter: function (args) {
                                             var actionsToShow =[ 'destroy'];
-                                            if (args.context.multiRule[0].domain == 'ROOT' && args.context.multiRule[0].account != null && args.context.multiRule[0].account.account == 'system')
+                                            if (args.context.multiRule[0].domain == 'ROOT' &&args.context.multiRule[0].account != null &&
+                                                args.context.multiRule[0].account.account == 'system' && !args.context.multiRule[0].forsystemvms)
                                             actionsToShow.push('addAccount'); else
                                             actionsToShow.push('releaseFromAccount');
                                             return actionsToShow;


### PR DESCRIPTION
## Description
Fix initial reservation on public IP range addition. Also, if the range is dedicated for system VMs do not allow dedicating it to any account

Fixes: #2929 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
- Set reservation to a domain, add range. Verify domain is set to the domain.