### PR TITLE
Discover tags field on superclass of API responses

### DIFF
--- a/plugins/api/discovery/src/org/apache/cloudstack/api/response/ApiDiscoveryResponse.java
+++ b/plugins/api/discovery/src/org/apache/cloudstack/api/response/ApiDiscoveryResponse.java
@@ -16,15 +16,13 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.cloud.serializer.Param;
 import com.google.gson.annotations.SerializedName;
-
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 
-import com.cloud.serializer.Param;
+import java.util.HashSet;
+import java.util.Set;
 
 @SuppressWarnings("unused")
 public class ApiDiscoveryResponse extends BaseResponse {
@@ -120,5 +118,9 @@ public class ApiDiscoveryResponse extends BaseResponse {
 
     public void addApiResponse(ApiResponseResponse apiResponse) {
         this.apiResponse.add(apiResponse);
+    }
+
+    public Set<ApiResponseResponse> getApiResponse() {
+        return apiResponse;
     }
 }

--- a/plugins/api/discovery/src/org/apache/cloudstack/api/response/ApiResponseResponse.java
+++ b/plugins/api/discovery/src/org/apache/cloudstack/api/response/ApiResponseResponse.java
@@ -16,15 +16,13 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.cloud.serializer.Param;
 import com.google.gson.annotations.SerializedName;
-
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 
-import com.cloud.serializer.Param;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ApiResponseResponse extends BaseResponse {
     @SerializedName(ApiConstants.NAME)
@@ -60,5 +58,21 @@ public class ApiResponseResponse extends BaseResponse {
             this.apiResponse = new HashSet<ApiResponseResponse>();
         }
         this.apiResponse.add(childApiResponse);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Set<ApiResponseResponse> getApiResponse() {
+        return apiResponse;
     }
 }

--- a/plugins/api/discovery/test/org/apache/cloudstack/discovery/ApiDiscoveryTest.java
+++ b/plugins/api/discovery/test/org/apache/cloudstack/discovery/ApiDiscoveryTest.java
@@ -16,34 +16,36 @@
 // under the License.
 package org.apache.cloudstack.discovery;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.cloud.user.User;
+import com.cloud.user.UserVO;
+import com.cloud.utils.component.PluggableService;
+import org.apache.cloudstack.acl.APIChecker;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.command.user.discovery.ListApisCmd;
+import org.apache.cloudstack.api.command.user.vm.ListVMsCmd;
+import org.apache.cloudstack.api.response.ApiDiscoveryResponse;
+import org.apache.cloudstack.api.response.ApiResponseResponse;
+import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.commons.lang.StringUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
+import javax.naming.ConfigurationException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import javax.naming.ConfigurationException;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import org.apache.cloudstack.acl.APIChecker;
-import org.apache.cloudstack.api.APICommand;
-import org.apache.cloudstack.api.command.user.discovery.ListApisCmd;
-import org.apache.cloudstack.api.response.ApiDiscoveryResponse;
-import org.apache.cloudstack.api.response.ListResponse;
-
-import com.cloud.user.User;
-import com.cloud.user.UserVO;
-import com.cloud.utils.component.PluggableService;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ApiDiscoveryTest {
     private static APIChecker s_apiChecker = mock(APIChecker.class);
@@ -51,14 +53,19 @@ public class ApiDiscoveryTest {
     private static ApiDiscoveryServiceImpl s_discoveryService = new ApiDiscoveryServiceImpl();
 
     private static Class<?> testCmdClass = ListApisCmd.class;
+    private static Class<?> listVMsCmdClass = ListVMsCmd.class;
     private static User testUser;
     private static String testApiName;
+    private static String listVmsCmdName;
     private static String testApiDescription;
     private static String testApiSince;
     private static boolean testApiAsync;
 
     @BeforeClass
     public static void setUp() throws ConfigurationException {
+
+        listVmsCmdName = listVMsCmdClass.getAnnotation(APICommand.class).name();
+
         testApiName = testCmdClass.getAnnotation(APICommand.class).name();
         testApiDescription = testCmdClass.getAnnotation(APICommand.class).description();
         testApiSince = testCmdClass.getAnnotation(APICommand.class).since();
@@ -75,6 +82,7 @@ public class ApiDiscoveryTest {
 
         Set<Class<?>> cmdClasses = new HashSet<Class<?>>();
         cmdClasses.add(ListApisCmd.class);
+        cmdClasses.add(ListVMsCmd.class);
         s_discoveryService.start();
         s_discoveryService.cacheResponseMap(cmdClasses);
     }
@@ -82,6 +90,7 @@ public class ApiDiscoveryTest {
     @Test
     public void verifyListSingleApi() throws Exception {
         ListResponse<ApiDiscoveryResponse> responses = (ListResponse<ApiDiscoveryResponse>)s_discoveryService.listApis(testUser, testApiName);
+        assertNotNull("Responses should not be null", responses);
         if (responses != null) {
             ApiDiscoveryResponse response = responses.getResponses().get(0);
             assertTrue("No. of response items should be one", responses.getCount() == 1);
@@ -95,12 +104,25 @@ public class ApiDiscoveryTest {
     @Test
     public void verifyListApis() throws Exception {
         ListResponse<ApiDiscoveryResponse> responses = (ListResponse<ApiDiscoveryResponse>)s_discoveryService.listApis(testUser, null);
+        assertNotNull("Responses should not be null", responses);
         if (responses != null) {
-            assertTrue("No. of response items > 1", responses.getCount().intValue() == 1);
+            assertTrue("No. of response items > 2", responses.getCount().intValue() == 2);
             for (ApiDiscoveryResponse response : responses.getResponses()) {
                 assertFalse("API name is empty", response.getName().isEmpty());
                 assertFalse("API description is empty", response.getDescription().isEmpty());
             }
+        }
+    }
+
+    @Test
+    public void verifyListVirtualMachinesTagsField() throws Exception {
+        ListResponse<ApiDiscoveryResponse> responses = (ListResponse<ApiDiscoveryResponse>)s_discoveryService.listApis(testUser, listVmsCmdName);
+        assertNotNull("Response should not be null", responses);
+        if (responses != null) {
+            assertEquals("No. of response items should be one", 1, (int) responses.getCount());
+            ApiDiscoveryResponse response = responses.getResponses().get(0);
+            List<ApiResponseResponse> tagsResponse = response.getApiResponse().stream().filter(resp -> StringUtils.equals(resp.getName(), "tags")).collect(Collectors.toList());
+            assertEquals("Tags field should be present in listVirtualMachines response fields", tagsResponse.size(), 1);
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated `ApiServiceDiscoveryImpl` to check superclasses of API responses for fields.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3002 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Additional unit test and tested locally to verify the tags field was present in the output of listApis response for listVirtualMachines API.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
