### PR TITLE
Add missing ConfigDrive entries on existing zones after upgrade

### DIFF
--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
@@ -624,40 +623,9 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
 
         _allowSubdomainNetworkAccess = Boolean.valueOf(_configs.get(Config.SubDomainNetworkAccess.key()));
 
-        verifyConfigDriveEntriesOnZones();
-
         s_logger.info("Network Service is configured.");
 
         return true;
-    }
-
-    /**
-     * Verifies ConfigDrive entries on a zone. Adds Diabled ConfigDrive provider if missing
-     */
-    private void checkConfigDriveEntriesOnZone(DataCenterVO zone) {
-        if (zone.getNetworkType() == NetworkType.Advanced) {
-            List<PhysicalNetworkVO> physicalNetworks = _physicalNetworkDao.listByZoneAndTrafficType(
-                    zone.getId(), TrafficType.Guest);
-            for (PhysicalNetworkVO physicalNetworkVO : physicalNetworks) {
-                PhysicalNetworkServiceProviderVO provider = _pNSPDao.findByServiceProvider(
-                        physicalNetworkVO.getId(), Provider.ConfigDrive.getName());
-                if (provider == null) {
-                    addConfigDriveToPhysicalNetwork(physicalNetworkVO.getId());
-                }
-            }
-        }
-    }
-
-    /**
-     * Verifies ConfigDrive entries on enabled zones. Adds Diabled ConfigDrive provider if missing.
-     */
-    private void verifyConfigDriveEntriesOnZones() {
-        List<DataCenterVO> zones = _dcDao.listEnabledZones();
-        if (CollectionUtils.isNotEmpty(zones)) {
-            for (DataCenterVO zone : zones) {
-                checkConfigDriveEntriesOnZone(zone);
-            }
-        }
     }
 
     @Override

--- a/server/src/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/com/cloud/network/NetworkServiceImpl.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
@@ -623,9 +624,40 @@ public class NetworkServiceImpl extends ManagerBase implements  NetworkService {
 
         _allowSubdomainNetworkAccess = Boolean.valueOf(_configs.get(Config.SubDomainNetworkAccess.key()));
 
+        verifyConfigDriveEntriesOnZones();
+
         s_logger.info("Network Service is configured.");
 
         return true;
+    }
+
+    /**
+     * Verifies ConfigDrive entries on a zone. Adds Diabled ConfigDrive provider if missing
+     */
+    private void checkConfigDriveEntriesOnZone(DataCenterVO zone) {
+        if (zone.getNetworkType() == NetworkType.Advanced) {
+            List<PhysicalNetworkVO> physicalNetworks = _physicalNetworkDao.listByZoneAndTrafficType(
+                    zone.getId(), TrafficType.Guest);
+            for (PhysicalNetworkVO physicalNetworkVO : physicalNetworks) {
+                PhysicalNetworkServiceProviderVO provider = _pNSPDao.findByServiceProvider(
+                        physicalNetworkVO.getId(), Provider.ConfigDrive.getName());
+                if (provider == null) {
+                    addConfigDriveToPhysicalNetwork(physicalNetworkVO.getId());
+                }
+            }
+        }
+    }
+
+    /**
+     * Verifies ConfigDrive entries on enabled zones. Adds Diabled ConfigDrive provider if missing.
+     */
+    private void verifyConfigDriveEntriesOnZones() {
+        List<DataCenterVO> zones = _dcDao.listEnabledZones();
+        if (CollectionUtils.isNotEmpty(zones)) {
+            for (DataCenterVO zone : zones) {
+                checkConfigDriveEntriesOnZone(zone);
+            }
+        }
     }
 
     @Override

--- a/server/test/com/cloud/network/NetworkModelTest.java
+++ b/server/test/com/cloud/network/NetworkModelTest.java
@@ -19,18 +19,32 @@ package com.cloud.network;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.cloud.dc.DataCenter;
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.network.dao.PhysicalNetworkDao;
+import com.cloud.network.dao.PhysicalNetworkServiceProviderDao;
+import com.cloud.network.dao.PhysicalNetworkServiceProviderVO;
+import com.cloud.network.dao.PhysicalNetworkVO;
 import junit.framework.Assert;
 
 import org.junit.Before;
@@ -48,11 +62,64 @@ import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.net.Ip;
 import com.cloud.network.Network.Provider;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 public class NetworkModelTest {
+
+    @Mock
+    private DataCenterDao dataCenterDao;
+    @Mock
+    private PhysicalNetworkDao physicalNetworkDao;
+    @Mock
+    private PhysicalNetworkServiceProviderDao physicalNetworkServiceProviderDao;
+    @Mock
+    private NetworkService networkService;
+
+    @InjectMocks
+    @Spy
+    private NetworkModelImpl networkModel = new NetworkModelImpl();
+
+    @Mock
+    private DataCenterVO zone1;
+    @Mock
+    private DataCenterVO zone2;
+    @Mock
+    private PhysicalNetworkVO physicalNetworkZone1;
+    @Mock
+    private PhysicalNetworkVO physicalNetworkZone2;
+    @Mock
+    private PhysicalNetworkServiceProviderVO providerVO;
+
+    private static final long ZONE_1_ID = 1L;
+    private static final long ZONE_2_ID = 2L;
+    private static final long PHYSICAL_NETWORK_1_ID = 1L;
+    private static final long PHYSICAL_NETWORK_2_ID = 2L;
+
     @Before
     public void setUp() {
+        MockitoAnnotations.initMocks(this);
 
+        when(dataCenterDao.listEnabledZones()).thenReturn(Arrays.asList(zone1, zone2));
+        when(physicalNetworkDao.listByZoneAndTrafficType(ZONE_1_ID, Networks.TrafficType.Guest)).
+                thenReturn(Collections.singletonList(physicalNetworkZone1));
+        when(physicalNetworkDao.listByZoneAndTrafficType(ZONE_2_ID, Networks.TrafficType.Guest)).
+                thenReturn(Collections.singletonList(physicalNetworkZone2));
+        when(physicalNetworkServiceProviderDao.findByServiceProvider(
+                PHYSICAL_NETWORK_1_ID, Network.Provider.ConfigDrive.getName())).thenReturn(null);
+        when(physicalNetworkServiceProviderDao.findByServiceProvider(
+                PHYSICAL_NETWORK_2_ID, Network.Provider.ConfigDrive.getName())).thenReturn(null);
+
+        when(zone1.getNetworkType()).thenReturn(DataCenter.NetworkType.Advanced);
+        when(zone1.getId()).thenReturn(ZONE_1_ID);
+
+        when(zone2.getNetworkType()).thenReturn(DataCenter.NetworkType.Advanced);
+        when(zone2.getId()).thenReturn(ZONE_2_ID);
+
+        when(physicalNetworkZone1.getId()).thenReturn(PHYSICAL_NETWORK_1_ID);
+        when(physicalNetworkZone2.getId()).thenReturn(PHYSICAL_NETWORK_2_ID);
     }
 
     @Test
@@ -69,7 +136,7 @@ public class NetworkModelTest {
         when(fakeVlanDao.findById(anyLong())).thenReturn(mock(VlanVO.class));
         modelImpl._vlanDao = fakeVlanDao;
         when(fakeSearch.create()).thenReturn(mock(SearchCriteria.class));
-        when(ipAddressDao.search(any(SearchCriteria.class), (Filter)org.mockito.Matchers.isNull())).thenReturn(fakeList);
+        when(ipAddressDao.search(any(SearchCriteria.class), (Filter) isNull())).thenReturn(fakeList);
         when(ipAddressDao.findById(anyLong())).thenReturn(fakeIp);
         Account fakeAccount = mock(Account.class);
         when(fakeAccount.getId()).thenReturn(1L);
@@ -134,5 +201,53 @@ public class NetworkModelTest {
         }
     }
 
+    @Test
+    public void testVerifyDisabledConfigDriveEntriesOnZonesBothEnabledZones() {
+        networkModel.verifyDisabledConfigDriveEntriesOnEnabledZones();
+        verify(networkModel, times(2)).addDisabledConfigDriveEntriesOnZone(any(DataCenterVO.class));
+    }
+
+    @Test
+    public void testVerifyDisabledConfigDriveEntriesOnZonesOneEnabledZone() {
+        when(dataCenterDao.listEnabledZones()).thenReturn(Collections.singletonList(zone1));
+
+        networkModel.verifyDisabledConfigDriveEntriesOnEnabledZones();
+        verify(networkModel).addDisabledConfigDriveEntriesOnZone(any(DataCenterVO.class));
+    }
+
+    @Test
+    public void testVerifyDisabledConfigDriveEntriesOnZonesNoEnabledZones() {
+        when(dataCenterDao.listEnabledZones()).thenReturn(null);
+
+        networkModel.verifyDisabledConfigDriveEntriesOnEnabledZones();
+        verify(networkModel, never()).addDisabledConfigDriveEntriesOnZone(any(DataCenterVO.class));
+    }
+
+    @Test
+    public void testAddDisabledConfigDriveEntriesOnZoneBasicZone() {
+        when(zone1.getNetworkType()).thenReturn(DataCenter.NetworkType.Basic);
+
+        networkModel.addDisabledConfigDriveEntriesOnZone(zone1);
+        verify(physicalNetworkDao, never()).listByZoneAndTrafficType(ZONE_1_ID, Networks.TrafficType.Guest);
+        verify(networkService, never()).
+                addProviderToPhysicalNetwork(anyLong(), eq(Provider.ConfigDrive.getName()), isNull(Long.class), isNull(List.class));
+    }
+
+    @Test
+    public void testAddDisabledConfigDriveEntriesOnZoneAdvancedZoneExistingConfigDrive() {
+        when(physicalNetworkServiceProviderDao.findByServiceProvider(
+                PHYSICAL_NETWORK_1_ID, Network.Provider.ConfigDrive.getName())).thenReturn(providerVO);
+
+        networkModel.addDisabledConfigDriveEntriesOnZone(zone1);
+        verify(networkService, never()).
+                addProviderToPhysicalNetwork(anyLong(), eq(Provider.ConfigDrive.getName()), isNull(Long.class), isNull(List.class));
+    }
+
+    @Test
+    public void testAddDisabledConfigDriveEntriesOnZoneAdvancedZoneNonExistingConfigDrive() {
+        networkModel.addDisabledConfigDriveEntriesOnZone(zone1);
+        verify(networkService).
+                addProviderToPhysicalNetwork(anyLong(), eq(Provider.ConfigDrive.getName()), isNull(Long.class), isNull(List.class));
+    }
 
 }


### PR DESCRIPTION
## Description
After upgrade existing environments to 4.11, ConfigDrive cannot be enabled for existing zones due to missing entry on 'physical_network_service_providers' table.

The UI shows:
![image](https://user-images.githubusercontent.com/5295080/48035474-e3c17e00-e142-11e8-8a50-8b685e6564cf.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
