### PR TITLE
Fix DirectNetworkGuru canHandle checks for lowercase isolation methods

### DIFF
--- a/server/src/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/server/src/com/cloud/network/guru/DirectNetworkGuru.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 
 import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.dc.DataCenter;
@@ -119,10 +120,18 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
         return false;
     }
 
+    /**
+     * Return true if the physical network isolation method contains the expected isolation method for this guru
+     */
     protected boolean isMyIsolationMethod(PhysicalNetwork physicalNetwork) {
         for (IsolationMethod m : _isolationMethods) {
-            if (physicalNetwork.getIsolationMethods().contains(m.toString())) {
-                return true;
+            List<String> isolationMethods = physicalNetwork.getIsolationMethods();
+            if (CollectionUtils.isNotEmpty(isolationMethods)) {
+                for (String method : isolationMethods) {
+                    if (method.equalsIgnoreCase(m.toString())) {
+                        return true;
+                    }
+                }
             }
         }
         return false;

--- a/server/test/com/cloud/network/guru/DirectNetworkGuruTest.java
+++ b/server/test/com/cloud/network/guru/DirectNetworkGuruTest.java
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.network.guru;
+
+import com.cloud.network.PhysicalNetwork;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class DirectNetworkGuruTest {
+
+    DirectNetworkGuru guru = new DirectNetworkGuru();
+
+    @Mock
+    PhysicalNetwork physicalNetwork;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(physicalNetwork.getIsolationMethods()).thenReturn(Arrays.asList("VXLAN", "VLAN"));
+    }
+
+    @Test
+    public void testIsMyIsolationMethodUppercaseMethods() {
+        assertTrue(guru.isMyIsolationMethod(physicalNetwork));
+    }
+
+    @Test
+    public void testIsMyIsolationMethodLowercaseMethods() {
+        when(physicalNetwork.getIsolationMethods()).thenReturn(Arrays.asList("vxlan", "vlan"));
+        assertTrue(guru.isMyIsolationMethod(physicalNetwork));
+    }
+}


### PR DESCRIPTION
## Description

Fixes: #2989 

In upgrade to 4.11 RC4 from 4.9.3 it was found that Shared networks could not be created after the upgrade, failing with: 
![image](https://user-images.githubusercontent.com/5295080/48094758-c26b9b00-e1f1-11e8-8a56-ccc9d0098966.png)

The DirectNetworkGuru refused to design the network due to the isolation method from the physical network was "vlan" and the guru expected "VLAN"

````
2018-11-06 16:21:37,396 TRACE [c.c.n.g.DirectNetworkGuru] (qtp1096283470-28:ctx-bdc0f3b5 ctx-dacb5ddd) (logid:f3094acc) We only take care of Guest networks of type Shared
````

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
