### PR TITLE
Remove unused StrategyPriority.PLUGIN

### DIFF
--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/StrategyPriority.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/StrategyPriority.java
@@ -17,5 +17,5 @@
 package org.apache.cloudstack.engine.subsystem.api.storage;
 
 public enum StrategyPriority {
-    CANT_HANDLE, DEFAULT, HYPERVISOR, PLUGIN, HIGHEST
+    CANT_HANDLE, DEFAULT, HYPERVISOR, HIGHEST
 }

--- a/engine/storage/src/test/java/org/apache/cloudstack/engine/subsystem/api/storage/StrategyPriorityTest.java
+++ b/engine/storage/src/test/java/org/apache/cloudstack/engine/subsystem/api/storage/StrategyPriorityTest.java
@@ -40,13 +40,11 @@ public class StrategyPriorityTest {
         SnapshotStrategy cantHandleStrategy = mock(SnapshotStrategy.class);
         SnapshotStrategy defaultStrategy = mock(SnapshotStrategy.class);
         SnapshotStrategy hyperStrategy = mock(SnapshotStrategy.class);
-        SnapshotStrategy pluginStrategy = mock(SnapshotStrategy.class);
         SnapshotStrategy highestStrategy = mock(SnapshotStrategy.class);
 
         doReturn(StrategyPriority.CANT_HANDLE).when(cantHandleStrategy).canHandle(any(Snapshot.class), any(SnapshotOperation.class));
         doReturn(StrategyPriority.DEFAULT).when(defaultStrategy).canHandle(any(Snapshot.class), any(SnapshotOperation.class));
         doReturn(StrategyPriority.HYPERVISOR).when(hyperStrategy).canHandle(any(Snapshot.class), any(SnapshotOperation.class));
-        doReturn(StrategyPriority.PLUGIN).when(pluginStrategy).canHandle(any(Snapshot.class), any(SnapshotOperation.class));
         doReturn(StrategyPriority.HIGHEST).when(highestStrategy).canHandle(any(Snapshot.class), any(SnapshotOperation.class));
 
         List<SnapshotStrategy> strategies = new ArrayList<SnapshotStrategy>(5);
@@ -67,10 +65,6 @@ public class StrategyPriorityTest {
         strategy = factory.getSnapshotStrategy(mock(Snapshot.class), SnapshotOperation.TAKE);
         assertEquals("Hypervisor strategy was not picked.", hyperStrategy, strategy);
 
-        strategies.add(pluginStrategy);
-        strategy = factory.getSnapshotStrategy(mock(Snapshot.class), SnapshotOperation.TAKE);
-        assertEquals("Plugin strategy was not picked.", pluginStrategy, strategy);
-
         strategies.add(highestStrategy);
         strategy = factory.getSnapshotStrategy(mock(Snapshot.class), SnapshotOperation.TAKE);
         assertEquals("Highest strategy was not picked.", highestStrategy, strategy);
@@ -81,13 +75,11 @@ public class StrategyPriorityTest {
         DataMotionStrategy cantHandleStrategy = mock(DataMotionStrategy.class);
         DataMotionStrategy defaultStrategy = mock(DataMotionStrategy.class);
         DataMotionStrategy hyperStrategy = mock(DataMotionStrategy.class);
-        DataMotionStrategy pluginStrategy = mock(DataMotionStrategy.class);
         DataMotionStrategy highestStrategy = mock(DataMotionStrategy.class);
 
         doReturn(StrategyPriority.CANT_HANDLE).when(cantHandleStrategy).canHandle(any(DataObject.class), any(DataObject.class));
         doReturn(StrategyPriority.DEFAULT).when(defaultStrategy).canHandle(any(DataObject.class), any(DataObject.class));
         doReturn(StrategyPriority.HYPERVISOR).when(hyperStrategy).canHandle(any(DataObject.class), any(DataObject.class));
-        doReturn(StrategyPriority.PLUGIN).when(pluginStrategy).canHandle(any(DataObject.class), any(DataObject.class));
         doReturn(StrategyPriority.HIGHEST).when(highestStrategy).canHandle(any(DataObject.class), any(DataObject.class));
 
         List<DataMotionStrategy> strategies = new ArrayList<DataMotionStrategy>(5);
@@ -108,10 +100,6 @@ public class StrategyPriorityTest {
         strategy = factory.getDataMotionStrategy(mock(DataObject.class), mock(DataObject.class));
         assertEquals("Hypervisor strategy was not picked.", hyperStrategy, strategy);
 
-        strategies.add(pluginStrategy);
-        strategy = factory.getDataMotionStrategy(mock(DataObject.class), mock(DataObject.class));
-        assertEquals("Plugin strategy was not picked.", pluginStrategy, strategy);
-
         strategies.add(highestStrategy);
         strategy = factory.getDataMotionStrategy(mock(DataObject.class), mock(DataObject.class));
         assertEquals("Highest strategy was not picked.", highestStrategy, strategy);
@@ -123,13 +111,11 @@ public class StrategyPriorityTest {
         DataMotionStrategy cantHandleStrategy = mock(DataMotionStrategy.class);
         DataMotionStrategy defaultStrategy = mock(DataMotionStrategy.class);
         DataMotionStrategy hyperStrategy = mock(DataMotionStrategy.class);
-        DataMotionStrategy pluginStrategy = mock(DataMotionStrategy.class);
         DataMotionStrategy highestStrategy = mock(DataMotionStrategy.class);
 
         doReturn(StrategyPriority.CANT_HANDLE).when(cantHandleStrategy).canHandle(any(Map.class), any(Host.class), any(Host.class));
         doReturn(StrategyPriority.DEFAULT).when(defaultStrategy).canHandle(any(Map.class), any(Host.class), any(Host.class));
         doReturn(StrategyPriority.HYPERVISOR).when(hyperStrategy).canHandle(any(Map.class), any(Host.class), any(Host.class));
-        doReturn(StrategyPriority.PLUGIN).when(pluginStrategy).canHandle(any(Map.class), any(Host.class), any(Host.class));
         doReturn(StrategyPriority.HIGHEST).when(highestStrategy).canHandle(any(Map.class), any(Host.class), any(Host.class));
 
         List<DataMotionStrategy> strategies = new ArrayList<DataMotionStrategy>(5);
@@ -149,10 +135,6 @@ public class StrategyPriorityTest {
         strategies.add(hyperStrategy);
         strategy = factory.getDataMotionStrategy(mock(Map.class), mock(Host.class), mock(Host.class));
         assertEquals("Hypervisor strategy was not picked.", hyperStrategy, strategy);
-
-        strategies.add(pluginStrategy);
-        strategy = factory.getDataMotionStrategy(mock(Map.class), mock(Host.class), mock(Host.class));
-        assertEquals("Plugin strategy was not picked.", pluginStrategy, strategy);
 
         strategies.add(highestStrategy);
         strategy = factory.getDataMotionStrategy(mock(Map.class), mock(Host.class), mock(Host.class));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove unused `StrategyPriority.PLUGIN` enum. The **PLUGIN** Strategy priority is not used, except by three JUnit test methods.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
