### PR TITLE
documented host.reserved.mem.mb parameter

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -201,6 +201,13 @@ hypervisor.type=kvm
 # reports to the Management Server
 # Default: 0
 #
+# host.reserved.mem.mb = 0
+# How much host memory to reserve for non-allocation. 
+# A useful parameter if a node uses some other software that requires memory,
+# or in case that OOM Killer kicks in sometimes.
+# If this parameter is used, host.overcommit.mem.mb must be set to 0.
+# Default value: 0
+#
 # vm.watchdog.model=i6300esb
 # The model of Watchdog timer to present to the Guest
 # For all models refer to the libvirt documentation.


### PR DESCRIPTION
## Description

documented "host.reserved.mem.mb" parameter in agent.properties, which exists, but was never documented so far.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
