### PR TITLE
Prevent error on GroupAnswers on VR creation

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -524,15 +524,16 @@ class CsIP:
                     CsHelper.execute("sudo ip route add throw " + self.config.address().dbag['eth1'][0]['network'] + " table " + tableName + " proto static")
 
                 # add 'defaul via gateway' rule in the device specific routing table
-                if "gateway" in self.address and self.address["gateway"] != "None":
+                if "gateway" in self.address and self.address["gateway"] and self.address["gateway"] != "None":
                     route.add_route(self.dev, self.address["gateway"])
-                route.add_network_route(self.dev, str(self.address["network"]))
+                if "network" in self.address and self.address["network"]:
+                    route.add_network_route(self.dev, str(self.address["network"]))
 
                 if self.get_type() in ["public"]:
                     CsRule(self.dev).addRule("from " + str(self.address["network"]))
 
             if self.config.is_vpc():
-                if self.get_type() in ["public"] and "gateway" in self.address and self.address["gateway"] != "None":
+                if self.get_type() in ["public"] and "gateway" in self.address and self.address["gateway"] and self.address["gateway"] != "None":
                     route.add_route(self.dev, self.address["gateway"])
                     for inf, addresses in self.config.address().dbag.iteritems():
                         if not inf.startswith("eth"):

--- a/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
@@ -50,20 +50,29 @@ class CsRoute:
         """ Wrapper method that adds table name and device to route statement """
         # ip route add dev eth1 table Table_eth1 10.0.2.0/24
         table = self.get_tablename(dev)
-        logging.info("Adding route: dev " + dev + " table: " +
-                     table + " network: " + address + " if not present")
-        cmd = "dev %s table %s %s" % (dev, table, address)
-        cmd = "default via %s table %s proto static" % (address, table)
-        self.set_route(cmd)
+
+        if not table or not address:
+            empty_param = "table" if not table else "address"
+            logging.info("Empty parameter received %s while trying to add route, skipping" % empty_param)
+        else:
+            logging.info("Adding route: dev " + dev + " table: " +
+                         table + " network: " + address + " if not present")
+            cmd = "default via %s table %s proto static" % (address, table)
+            self.set_route(cmd)
 
     def add_network_route(self, dev, address):
         """ Wrapper method that adds table name and device to route statement """
         # ip route add dev eth1 table Table_eth1 10.0.2.0/24
         table = self.get_tablename(dev)
-        logging.info("Adding route: dev " + dev + " table: " +
-                     table + " network: " + address + " if not present")
-        cmd = "throw %s table %s proto static" % (address, table)
-        self.set_route(cmd)
+
+        if not table or not address:
+            empty_param = "table" if not table else "address"
+            logging.info("Empty parameter received %s while trying to add network route, skipping" % empty_param)
+        else:
+            logging.info("Adding route: dev " + dev + " table: " +
+                         table + " network: " + address + " if not present")
+            cmd = "throw %s table %s proto static" % (address, table)
+            self.set_route(cmd)
 
     def set_route(self, cmd, method="add"):
         """ Add a route if it is not already defined """


### PR DESCRIPTION
## Description
On VR creation it has been noticed that management server receives these answers:

````
{ Ans: , MgmtId: 7206518937063, via: 11, Ver: v1, Flags: 10, [{"com.cloud.agent.api.routing.GroupAnswer":{"results":["null - success: Creating file in VR, with ip: 169.254.3.212, file: vm_password.json.2b0e06a0-821f-41f1-bf8f-b9805f490a6c","null - success: Error: inet prefix is expected rather than \"table\".\nError: inet address is expected rather than \"table\".\n"],"result":true,"wait":0}},{"com.cloud.agent.api.routing.GroupAnswer":{"results":["null - success: Creating file in VR, with ip: 169.254.3.212, file: vm_metadata.json.01da0832-2dd7-451b-a526-1de81d737a80","null - success: Error: inet prefix is expected rather than \"table\".\nError: inet address is expected rather than \"table\".\n"],"result":true,"wait":0}}] }
````

This has been originated by empty parameters on VR commands: (cloud.log)
````
2018-11-05 16:50:59,260  CsHelper.py execute:188 Executing: ip route show default via  table Table_eth0 proto static
Error: inet prefix is expected rather than "table"

2018-11-05 16:50:59,269  CsHelper.py execute:188 Executing: ip route add default via  table Table_eth0 proto static
Error: inet address is expected rather than "table"
````

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Deploy VM on Isolated or Shared network - VR created