### PR TITLE
Add KVM Guest OS mapping for Windows Server 2019

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41120to41200.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41120to41200.sql
@@ -38,3 +38,7 @@ UPDATE `cloud`.`async_job` SET `removed` = now() WHERE `removed` IS NULL;
 
 -- PR#1448 update description of 'execute.in.sequence.network.element.commands' parameter to reflect an unused command that has been removed. The removed class command is 'UserDataCommand'.
 update `cloud`.`configuration` set description = 'If set to true, DhcpEntryCommand, SavePasswordCommand, VmDataCommand will be synchronized on the agent side. If set to false, these commands become asynchronous. Default value is false.' where name = 'execute.in.sequence.network.element.commands'; 
+
+-- add KVM Guest OS mapping for Windows Server 2019
+INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, created) VALUES (276, UUID(), 6, 'Windows Server 2019 (64-bit)', now());
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid, hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(), 'KVM', 'default', 'Windows Server 2019', 276, now(), 0);


### PR DESCRIPTION
## Description

Add KVM guest OS type for Windows Server 2019 x64 (there is no x86 version)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

Tested on 4.11.2 RC4 - by manually executing SQL lines from PR, uploading latest Windows Server 2019 Preview ISO to CloudStack, spinning new VM from ISO with using new OS type "Windows Server 2019 (x64)". Also tested spinning Win2019 using Windows PV OS Type with latest VirtIO drivers - all work fine.

Successfully booted VM after install and did some IO with decent performance.

Unrelated note for testing: Qemu CPU model is not supported starting from Windows Server 2016, CPU must have specific CPU extensions, so SandyBridge CPU model was used - nothing new to 2019...