### PR TITLE
Changed SystemVM template to use debian-9.6.0-amd64-netinst.iso

### DIFF
--- a/tools/appliance/systemvmtemplate/template.json
+++ b/tools/appliance/systemvmtemplate/template.json
@@ -38,8 +38,8 @@
       "disk_interface": "virtio",
       "net_device": "virtio-net",
 
-      "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
-      "iso_checksum": "efe75000c066506326c74a97257163b3050d656a5be8708a6826b0f810208d0a58f413c446de09919c580de8fac6d0a47774534725dd9fdd00c94859e370f373",
+      "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-9.6.0-amd64-netinst.iso",
+      "iso_checksum": "fcd77acbd46f33e0a266faf284acc1179ab0a3719e4b8abebac555307aa978aa242d7052c8d41e1a5fc6d1b30bc6ca6d62269e71526b71c9d5199b13339f0e25",
       "iso_checksum_type": "sha512",
 
       "vm_name": "systemvmtemplate",


### PR DESCRIPTION
Hi,

this are the changes to use debian 9.6 instead of 9.5. I tested the build but NOT if the
systemvm is fully working with the changes introduced by 9.6. Also i'm not a
debian guy so I don't really know what's changing there from 9.5. to 9.6.

If there are problems with this I would very much appreciate the feedback.

##  Description
<!--- Describe your changes in detail -->
Changed build script to use debian 9.6 because 9.5 is not available at the link provided in the script.
## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Build new systemvm with it.