### PR TITLE
travis: fail fast if --with-marvin fails with nose

### DIFF
--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -98,8 +98,6 @@ echo "<settings>
 
 echo -e "\nInstalling some python packages: "
 
-pip install --user --upgrade pip
-
 for ((i=0;i<$RETRY_COUNT;i++))
 do
   pip install --user --upgrade lxml paramiko nose texttable ipmisim pyopenssl mock flask netaddr pylint pycodestyle six astroid > /tmp/piplog

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -100,7 +100,7 @@ echo -e "\nInstalling some python packages: "
 
 for ((i=0;i<$RETRY_COUNT;i++))
 do
-  pip install --user --upgrade lxml paramiko nose texttable ipmisim pyopenssl mock flask netaddr pylint pycodestyle six astroid > /tmp/piplog
+  pip install --user --upgrade lxml paramiko nose texttable ipmisim pyopenssl pycrypto mock flask netaddr pylint pycodestyle six astroid > /tmp/piplog
   if [[ $? -eq 0 ]]; then
     echo -e "\npython packages installed successfully"
     break;

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -26,6 +26,8 @@ mkdir -p integration-test-results/component
 TESTS=($@)
 echo "Running tests: " ${TESTS[@]}
 
+set -e
+
 for suite in "${TESTS[@]}" ; do
   echo "Currently running test: $suite"
   nosetests --with-xunit --xunit-file=integration-test-results/$suite.xml --with-marvin --marvin-config=setup/dev/advanced.cfg test/integration/$suite.py -s -a tags=advanced,required_hardware=false --zone=Sandbox-simulator --hypervisor=simulator || true ;


### PR DESCRIPTION
This fixes issue with recent Travis runs which gave incorrect results
around smoketests with simulator where each test run failed with an
error like "nosetests: error: no such option: --with-marvin".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

We can merge this is Travis actually runs the tests and passes. See all recent travis test runs, they all silently fail.