### PR TITLE
Display mac address in nic detail view

### DIFF
--- a/ui/l10n/de_DE.js
+++ b/ui/l10n/de_DE.js
@@ -976,6 +976,7 @@ var dictionary = {
     "label.logout": "Abmelden",
     "label.lun": "LUN",
     "label.lxc.traffic.label": "LXC Datenverkehrs-Bezeichnung",
+    "label.mac.address": "MAC Adresse",
     "label.make.project.owner": "Mache Benutzerkonto zum Projekteigentümer",
     "label.make.redundant": "Redundant machen",
     "label.manage": "Verwalten",

--- a/ui/l10n/en.js
+++ b/ui/l10n/en.js
@@ -1014,6 +1014,7 @@ var dictionary = {
 "label.management":"Management",
 "label.management.ips":"Management IP Addresses",
 "label.management.server":"Management Server",
+"label.mac.address": "MAC Address",
 "label.mac.address.changes":"MAC Address Changes",
 "label.max.cpus":"Max. CPU cores",
 "label.max.guest.limit":"Max guest limit",

--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -2865,6 +2865,9 @@
                             type: {
                                 label: 'label.type'
                             },
+                            macaddress: {
+                              label: 'label.mac.address'
+                            },
                             ipaddress: {
                                 label: 'label.ip.address'
                             },


### PR DESCRIPTION
## Description
Adds the MAC address to the NICs detail view of an instance.

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots:

![detailview_with_mac_address](https://user-images.githubusercontent.com/6997263/48567118-a2785d80-e8fc-11e8-9e24-2eda8fcb815a.png)

## How Has This Been Tested?
Tested locally to verify that the correct mac address gets displayed in the detail view.
