### PR TITLE
kvm: when untagged vxlan is used, use the default guest/public bridge

### DIFF
--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -229,7 +229,7 @@ public class BridgeVifDriver extends VifDriverBase {
 
         String vNetId = null;
         String protocol = null;
-        if (nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan || nic.getBroadcastType() == Networks.BroadcastDomainType.Vxlan) {
+        if (isBroadcastTypeVlanOrVxlan(nic)) {
             vNetId = Networks.BroadcastDomainType.getValue(nic.getBroadcastUri());
             protocol = Networks.BroadcastDomainType.getSchemeValue(nic.getBroadcastUri()).scheme();
         } else if (nic.getBroadcastType() == Networks.BroadcastDomainType.Lswitch) {

--- a/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -233,8 +233,8 @@ public class BridgeVifDriver extends VifDriverBase {
         }
 
         if (nic.getType() == Networks.TrafficType.Guest) {
-            if ((nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan) && (vNetId != null) && (protocol != null) && (!vNetId.equalsIgnoreCase("untagged")) ||
-                    (nic.getBroadcastType() == Networks.BroadcastDomainType.Vxlan)) {
+            if ((nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan || nic.getBroadcastType() == Networks.BroadcastDomainType.Vxlan)
+                    && (vNetId != null) && (protocol != null) && (!vNetId.equalsIgnoreCase("untagged"))) {
                     if (trafficLabel != null && !trafficLabel.isEmpty()) {
                         s_logger.debug("creating a vNet dev and bridge for guest traffic per traffic label " + trafficLabel);
                         String brName = createVnetBr(vNetId, trafficLabel, protocol);
@@ -257,8 +257,8 @@ public class BridgeVifDriver extends VifDriverBase {
             createControlNetwork();
             intf.defBridgeNet(_bridges.get("linklocal"), null, nic.getMac(), getGuestNicModel(guestOsType, nicAdapter));
         } else if (nic.getType() == Networks.TrafficType.Public) {
-            if ((nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan) && (vNetId != null) && (protocol != null) && (!vNetId.equalsIgnoreCase("untagged")) ||
-                    (nic.getBroadcastType() == Networks.BroadcastDomainType.Vxlan)) {
+            if ((nic.getBroadcastType() == Networks.BroadcastDomainType.Vlan || nic.getBroadcastType() == Networks.BroadcastDomainType.Vxlan)
+                    && (vNetId != null) && (protocol != null) && (!vNetId.equalsIgnoreCase("untagged"))) {
                 if (trafficLabel != null && !trafficLabel.isEmpty()) {
                     s_logger.debug("creating a vNet dev and bridge for public traffic per traffic label " + trafficLabel);
                     String brName = createVnetBr(vNetId, trafficLabel, protocol);

--- a/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/BridgeVifDriverTest.java
+++ b/plugins/hypervisors/kvm/test/com/cloud/hypervisor/kvm/resource/BridgeVifDriverTest.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.hypervisor.kvm.resource;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.cloud.agent.api.to.NicTO;
+import com.cloud.network.Networks;
+
+public class BridgeVifDriverTest {
+
+    private BridgeVifDriver driver;
+
+    @Before
+    public void setUp() throws Exception {
+        driver = new BridgeVifDriver();
+    }
+
+    @Test
+    public void isBroadcastTypeVlanOrVxlan() {
+        final NicTO nic = new NicTO();
+        nic.setBroadcastType(Networks.BroadcastDomainType.Native);
+        Assert.assertFalse(driver.isBroadcastTypeVlanOrVxlan(null));
+        Assert.assertFalse(driver.isBroadcastTypeVlanOrVxlan(nic));
+        // Test VLAN
+        nic.setBroadcastType(Networks.BroadcastDomainType.Vlan);
+        Assert.assertTrue(driver.isBroadcastTypeVlanOrVxlan(nic));
+        // Test VXLAN
+        nic.setBroadcastType(Networks.BroadcastDomainType.Vxlan);
+        Assert.assertTrue(driver.isBroadcastTypeVlanOrVxlan(nic));
+    }
+
+    @Test
+    public void isValidProtocolAndVnetId() {
+        Assert.assertFalse(driver.isValidProtocolAndVnetId(null, null));
+        Assert.assertFalse(driver.isValidProtocolAndVnetId("123", null));
+        Assert.assertFalse(driver.isValidProtocolAndVnetId(null, "vlan"));
+        Assert.assertFalse(driver.isValidProtocolAndVnetId("untagged", "vxlan"));
+        Assert.assertTrue(driver.isValidProtocolAndVnetId("123", "vlan"));
+        Assert.assertTrue(driver.isValidProtocolAndVnetId("456", "vxlan"));
+    }
+}


### PR DESCRIPTION
When vxlan://untagged is used for public (or guest) network, use the
default public/guest bridge device same as how vlan://untagged works.

![screenshot from 2018-11-18 17-49-36](https://user-images.githubusercontent.com/95203/48672345-b1f4e200-eb5a-11e8-934e-909eb511b15f.png)

Note: currently its possible to use vlan://untagged in the public IP address range for a zone with `vxlan` isolation, which will trick cloudstack-agent (bridge driver) to think the vif/nic to plug is of vlan type and allows `untagged` plugging into the default public/guest bridge device (by default cloudbr0/br1).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

Deploy a KVM advance zone with VXLAN isolation for guest+management+public physical nics/network and pass vxlan://untagged for the public address/range. Agent logs will have exceptions on incorrect `untagged` vnet ID passed error.