### PR TITLE
Allow password enabled for iso (#2745)

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/iso/RegisterIsoCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/iso/RegisterIsoCmd.java
@@ -113,6 +113,11 @@ public class RegisterIsoCmd extends BaseCmd {
             description = "true if ISO should bypass Secondary Storage and be downloaded to Primary Storage on deployment")
     private Boolean directDownload;
 
+    @Parameter(name = ApiConstants.PASSWORD_ENABLED,
+            type = CommandType.BOOLEAN,
+            description = "true if password reset feature is supported; default is false")
+    private Boolean passwordEnabled;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -175,6 +180,10 @@ public class RegisterIsoCmd extends BaseCmd {
 
     public boolean isDirectDownload() {
         return directDownload == null ? false : directDownload;
+    }
+
+    public Boolean isPasswordEnabled() {
+        return passwordEnabled;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/iso/RegisterIsoCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/iso/RegisterIsoCmd.java
@@ -182,8 +182,8 @@ public class RegisterIsoCmd extends BaseCmd {
         return directDownload == null ? false : directDownload;
     }
 
-    public Boolean isPasswordEnabled() {
-        return passwordEnabled;
+    public boolean isPasswordEnabled() {
+        return passwordEnabled == null ? false : passwordEnabled;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/iso/UpdateIsoCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/iso/UpdateIsoCmd.java
@@ -44,11 +44,6 @@ public class UpdateIsoCmd extends BaseUpdateTemplateOrIsoCmd {
     }
 
     @Override
-    public Boolean getPasswordEnabled() {
-        return null;
-    }
-
-    @Override
     public String getFormat() {
         return null;
     }

--- a/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/TemplateJoinDaoImpl.java
@@ -327,6 +327,7 @@ public class TemplateJoinDaoImpl extends GenericDaoBaseWithTagInformation<Templa
         isoResponse.setOsTypeId(iso.getGuestOSUuid());
         isoResponse.setOsTypeName(iso.getGuestOSName());
         isoResponse.setBits(iso.getBits());
+        isoResponse.setPasswordEnabled(iso.isEnablePassword());
 
         // populate owner.
         ApiResponseHelper.populateOwner(isoResponse, iso);

--- a/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
+++ b/server/src/main/java/com/cloud/template/TemplateAdapterBase.java
@@ -331,7 +331,7 @@ public abstract class TemplateAdapterBase extends AdapterBase implements Templat
             zoneList.add(zoneId);
         }
 
-        return prepare(true, CallContext.current().getCallingUserId(), cmd.getIsoName(), cmd.getDisplayText(), 64, false, true, cmd.getUrl(), cmd.isPublic(),
+        return prepare(true, CallContext.current().getCallingUserId(), cmd.getIsoName(), cmd.getDisplayText(), 64, cmd.isPasswordEnabled(), true, cmd.getUrl(), cmd.isPublic(),
             cmd.isFeatured(), cmd.isExtractable(), ImageFormat.ISO.toString(), cmd.getOsTypeId(), zoneList, HypervisorType.None, cmd.getChecksum(), cmd.isBootable(), null,
             owner, null, false, cmd.getImageStoreUuid(), cmd.isDynamicallyScalable(), TemplateType.USER, cmd.isDirectDownload());
     }

--- a/test/integration/smoke/test_iso.py
+++ b/test/integration/smoke/test_iso.py
@@ -336,7 +336,7 @@ class TestISO(cloudstackTestCase):
 
         self.assertEqual(
             iso_response.passwordenabled,
-            self.services["passwordenabled"],
+            bool(self.services["passwordenabled"]),
             "Check passwordenabled of updated ISO"
         )
 

--- a/test/integration/smoke/test_iso.py
+++ b/test/integration/smoke/test_iso.py
@@ -304,6 +304,7 @@ class TestISO(cloudstackTestCase):
             self.apiclient,
             id=self.iso_1.id
         )
+
         self.assertEqual(
             isinstance(list_iso_response, list),
             True,
@@ -332,6 +333,13 @@ class TestISO(cloudstackTestCase):
             self.services["ostypeid"],
             "Check OSTypeID of updated ISO"
         )
+
+        self.assertEqual(
+            iso_response.passwordenabled,
+            self.services["passwordenabled"],
+            "Check passwordenabled of updated ISO"
+        )
+
         return
 
     @attr(


### PR DESCRIPTION
Both register and update iso commands can allow for allowing password enabled.

Fixes: #2745 

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Ran register iso and update iso API through cloudmonkey. Also added passwordenabled field changes to true after update iso api call through test_iso.py#test_02_edit_iso 

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
