### PR TITLE
ipv6: Calculate IPv6 address instead of fetching one from a pool

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2257,8 +2257,8 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
             }
         }
 
-        if (ipv6 && !NetUtils.isValidIp6Cidr(ip6Cidr)) {
-            throw new InvalidParameterValueException("Invalid IPv6 cidr specified");
+        if (ipv6 && NetUtils.getIp6CidrSize(ip6Cidr) != 64) {
+            throw new InvalidParameterValueException("IPv6 subnet should be exactly 64-bits in size");
         }
 
         //TODO(VXLAN): Support VNI specified

--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -57,7 +57,6 @@ import com.cloud.dc.DataCenterIpAddressVO;
 import com.cloud.dc.HostPodVO;
 import com.cloud.dc.Pod;
 import com.cloud.dc.PodVlanMapVO;
-import com.cloud.dc.Vlan;
 import com.cloud.dc.Vlan.VlanType;
 import com.cloud.dc.VlanVO;
 import com.cloud.dc.dao.AccountVlanMapDao;
@@ -2014,7 +2013,6 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
 
                 if (network.getGateway() != null) {
                     if (nic.getIPv4Address() == null) {
-                        ipv4 = true;
                         PublicIp ip = null;
 
                         //Get ip address from the placeholder and don't allocate a new one
@@ -2050,30 +2048,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
                     nic.setIPv4Dns2(dc.getDns2());
                 }
 
-                //FIXME - get ipv6 address from the placeholder if it's stored there
-                if (network.getIp6Gateway() != null) {
-                    if (nic.getIPv6Address() == null) {
-                        UserIpv6Address ip = _ipv6Mgr.assignDirectIp6Address(dc.getId(), vm.getOwner(), network.getId(), requestedIpv6);
-                        Vlan vlan = _vlanDao.findById(ip.getVlanId());
-                        nic.setIPv6Address(ip.getAddress().toString());
-                        nic.setIPv6Gateway(vlan.getIp6Gateway());
-                        nic.setIPv6Cidr(vlan.getIp6Cidr());
-                        if (ipv4) {
-                            nic.setFormat(AddressFormat.DualStack);
-                        } else {
-                            nic.setIsolationUri(IsolationType.Vlan.toUri(vlan.getVlanTag()));
-                            nic.setBroadcastType(BroadcastDomainType.Vlan);
-                            nic.setBroadcastUri(BroadcastDomainType.Vlan.toUri(vlan.getVlanTag()));
-                            nic.setFormat(AddressFormat.Ip6);
-                            nic.setReservationId(String.valueOf(vlan.getVlanTag()));
-                            if(nic.getMacAddress() == null) {
-                                nic.setMacAddress(ip.getMacAddress());
-                            }
-                        }
-                    }
-                    nic.setIPv6Dns1(dc.getIp6Dns1());
-                    nic.setIPv6Dns2(dc.getIp6Dns2());
-                }
+                _ipv6Mgr.setNicIp6Address(nic, dc, network);
             }
         });
     }
@@ -2123,29 +2098,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
                     nic.setIPv4Dns2(dc.getDns2());
                 }
 
-                // TODO: the IPv6 logic is not changed.
-                //FIXME - get ipv6 address from the placeholder if it's stored there
-                if (network.getIp6Gateway() != null) {
-                    if (nic.getIPv6Address() == null) {
-                        UserIpv6Address ip = _ipv6Mgr.assignDirectIp6Address(dc.getId(), vm.getOwner(), network.getId(), requestedIpv6);
-                        Vlan vlan = _vlanDao.findById(ip.getVlanId());
-                        nic.setIPv6Address(ip.getAddress().toString());
-                        nic.setIPv6Gateway(vlan.getIp6Gateway());
-                        nic.setIPv6Cidr(vlan.getIp6Cidr());
-                        if (ipv4) {
-                            nic.setFormat(AddressFormat.DualStack);
-                        } else {
-                            nic.setIsolationUri(IsolationType.Vlan.toUri(vlan.getVlanTag()));
-                            nic.setBroadcastType(BroadcastDomainType.Vlan);
-                            nic.setBroadcastUri(BroadcastDomainType.Vlan.toUri(vlan.getVlanTag()));
-                            nic.setFormat(AddressFormat.Ip6);
-                            nic.setReservationId(String.valueOf(vlan.getVlanTag()));
-                            nic.setMacAddress(ip.getMacAddress());
-                        }
-                    }
-                    nic.setIPv6Dns1(dc.getIp6Dns1());
-                    nic.setIPv6Dns2(dc.getIp6Dns2());
-                }
+                _ipv6Mgr.setNicIp6Address(nic, dc, network);
             }
         });
     }

--- a/server/src/main/java/com/cloud/network/Ipv6AddressManager.java
+++ b/server/src/main/java/com/cloud/network/Ipv6AddressManager.java
@@ -17,20 +17,20 @@
 
 package com.cloud.network;
 
+import com.cloud.dc.DataCenter;
 import com.cloud.exception.InsufficientAddressCapacityException;
 import com.cloud.user.Account;
 import com.cloud.utils.component.Manager;
+import com.cloud.vm.NicProfile;
 
 public interface Ipv6AddressManager extends Manager {
-
-    public UserIpv6Address assignDirectIp6Address(long dcId, Account owner, Long networkId, String requestedIp6) throws InsufficientAddressCapacityException;
-
-    public void revokeDirectIpv6Address(long networkId, String ip6Address);
 
     public String allocateGuestIpv6(Network network, String requestedIpv6) throws InsufficientAddressCapacityException;
 
     public String allocatePublicIp6ForGuestNic(Network network, Long podId, Account ipOwner, String requestedIp) throws InsufficientAddressCapacityException;
 
     public String acquireGuestIpv6Address(Network network, String requestedIpv6) throws InsufficientAddressCapacityException;
+
+    public void setNicIp6Address(final NicProfile nic, final DataCenter dc, final Network network);
 
 }

--- a/server/src/main/java/com/cloud/network/guru/DirectNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/DirectNetworkGuru.java
@@ -39,7 +39,6 @@ import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.network.dao.PhysicalNetworkDao;
 import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.network.IpAddressManager;
-import com.cloud.network.Ipv6AddressManager;
 import com.cloud.network.Network;
 import com.cloud.network.Network.GuestType;
 import com.cloud.network.Network.Service;
@@ -55,9 +54,7 @@ import com.cloud.network.PhysicalNetwork.IsolationMethod;
 import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkVO;
-import com.cloud.network.dao.UserIpv6AddressDao;
 import com.cloud.offering.NetworkOffering;
-import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.user.Account;
 import com.cloud.utils.component.AdapterBase;
 import com.cloud.utils.db.DB;
@@ -93,12 +90,6 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
     NetworkOrchestrationService _networkMgr;
     @Inject
     IPAddressDao _ipAddressDao;
-    @Inject
-    NetworkOfferingDao _networkOfferingDao;
-    @Inject
-    UserIpv6AddressDao _ipv6Dao;
-    @Inject
-    Ipv6AddressManager _ipv6Mgr;
     @Inject
     NicSecondaryIpDao _nicSecondaryIpDao;
     @Inject
@@ -367,9 +358,6 @@ public class DirectNetworkGuru extends AdapterBase implements NetworkGuru {
             }
         }
 
-        if (nic.getIPv6Address() != null) {
-            _ipv6Mgr.revokeDirectIpv6Address(nic.getNetworkId(), nic.getIPv6Address());
-        }
         nic.deallocate();
     }
 

--- a/server/src/test/java/com/cloud/network/Ipv6AddressManagerTest.java
+++ b/server/src/test/java/com/cloud/network/Ipv6AddressManagerTest.java
@@ -19,6 +19,8 @@ package com.cloud.network;
 
 import static org.mockito.Mockito.mock;
 
+import com.cloud.dc.DataCenter;
+import com.cloud.vm.NicProfile;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -226,4 +228,24 @@ public class Ipv6AddressManagerTest {
         Mockito.when(ipVo.getState()).thenReturn(state);
     }
 
+    @Test
+    public void setNICIPv6AddressTest() {
+        NicProfile nic = new NicProfile();
+        Network network = mock(Network.class);
+        DataCenter dc = mock(DataCenter.class);
+
+        nic.setMacAddress("1e:00:b1:00:0a:f6");
+
+        Mockito.when(network.getIp6Cidr()).thenReturn("2001:db8:100::/64");
+        Mockito.when(network.getIp6Gateway()).thenReturn("2001:db8:100::1");
+
+        Mockito.when(dc.getIp6Dns1()).thenReturn("2001:db8::53:1");
+        Mockito.when(dc.getIp6Dns1()).thenReturn("2001:db8::53:2");
+
+        String expected = "2001:db8:100:0:1c00:b1ff:fe00:af6";
+
+        ip6Manager.setNicIp6Address(nic, dc, network);
+
+        Assert.assertEquals(expected, nic.getIPv6Address());
+    }
 }


### PR DESCRIPTION
## Description
With IPv6 we are not using DHCP to allocate addresses, but using
StateLess Address Auto Configuration (SLAAC) a Instance will calculate
it's own address based on the Router Advertisements send out by the
routers in the network.

This Advertisement contains the IPv6 Subnet in use in that subnet and
allows to calculate the stable Address the Instance will obtain based
on it's MAC Address.

The existing code is 'dead code' as it has been written, but was never
used by any production code.

SLAAC only works properly with subnets of exactly 64-bits large.

## Types of changes
- [x] Enhancement (improves an existing feature and functionality)

## Screenshots (if appropriate):
![screenshot from 2018-12-03 15-34-52](https://user-images.githubusercontent.com/326786/49380082-1003f680-f711-11e8-8665-60dafe4313ca.png)

![screenshot from 2018-12-03 15-35-10](https://user-images.githubusercontent.com/326786/49380078-0da19c80-f711-11e8-94b9-86722150a9af.png)

## How Has This Been Tested?
On a CloudStack test setup running from master (4.12) and trying manually.

The zone is running with Advanced Networking and Guest Networks have been provided a IPv6 64-bits subnet:

- Advanced Networking
- Shared VXLAN network
- Ubuntu 18.04 hypervisors

UnitTesting has also been added to check that the code calculates the IPv6 Address as it should.