### PR TITLE
Add influxdb to statscollector

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.cloudstack</groupId>
+            <artifactId>cloud-engine-schema</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cloudstack</groupId>
             <artifactId>cloud-framework-security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/core/src/main/java/com/cloud/agent/api/HostStatsEntry.java
+++ b/core/src/main/java/com/cloud/agent/api/HostStatsEntry.java
@@ -20,10 +20,12 @@
 package com.cloud.agent.api;
 
 import com.cloud.host.HostStats;
+import com.cloud.host.HostVO;
 
 public class HostStatsEntry implements HostStats {
 
     long hostId;
+    HostVO hostVo;
     String entityType;
     double cpuUtilization;
     double networkReadKBs;
@@ -111,5 +113,17 @@ public class HostStatsEntry implements HostStats {
 
     public void setHostId(long hostId) {
         this.hostId = hostId;
+    }
+
+    public long getHostId() {
+        return hostId;
+    }
+
+    public HostVO getHostVo() {
+        return hostVo;
+    }
+
+    public void setHostVo(HostVO hostVo) {
+        this.hostVo = hostVo;
     }
 }

--- a/core/src/main/java/com/cloud/agent/api/VmStatsEntry.java
+++ b/core/src/main/java/com/cloud/agent/api/VmStatsEntry.java
@@ -19,22 +19,25 @@
 
 package com.cloud.agent.api;
 
+import com.cloud.vm.UserVmVO;
 import com.cloud.vm.VmStats;
 
 public class VmStatsEntry implements VmStats {
 
-    double cpuUtilization;
-    double networkReadKBs;
-    double networkWriteKBs;
-    double diskReadIOs;
-    double diskWriteIOs;
-    double diskReadKBs;
-    double diskWriteKBs;
-    double memoryKBs;
-    double intfreememoryKBs;
-    double targetmemoryKBs;
-    int numCPUs;
-    String entityType;
+    private long vmId;
+    private UserVmVO userVmVO;
+    private double cpuUtilization;
+    private double networkReadKBs;
+    private double networkWriteKBs;
+    private double diskReadIOs;
+    private double diskWriteIOs;
+    private double diskReadKBs;
+    private double diskWriteKBs;
+    private double memoryKBs;
+    private double intfreememoryKBs;
+    private double targetmemoryKBs;
+    private int numCPUs;
+    private String entityType;
 
     public VmStatsEntry() {
     }
@@ -50,14 +53,12 @@ public class VmStatsEntry implements VmStats {
         this.entityType = entityType;
     }
 
-    public VmStatsEntry(double cpuUtilization, double networkReadKBs, double networkWriteKBs, double diskReadKBs, double diskWriteKBs, int numCPUs, String entityType) {
-        this.cpuUtilization = cpuUtilization;
-        this.networkReadKBs = networkReadKBs;
-        this.networkWriteKBs = networkWriteKBs;
-        this.diskReadKBs = diskReadKBs;
-        this.diskWriteKBs = diskWriteKBs;
-        this.numCPUs = numCPUs;
-        this.entityType = entityType;
+    public long getVmId() {
+        return vmId;
+    }
+
+    public void setVmId(long vmId) {
+        this.vmId = vmId;
     }
 
     @Override
@@ -164,6 +165,14 @@ public class VmStatsEntry implements VmStats {
 
     public void setEntityType(String entityType) {
         this.entityType = entityType;
+    }
+
+    public UserVmVO getUserVmVO() {
+        return userVmVO;
+    }
+
+    public void setUserVmVO(UserVmVO userVmVO) {
+        this.userVmVO = userVmVO;
     }
 
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -158,10 +158,10 @@
             <artifactId>opensaml</artifactId>
         </dependency>
         <dependency>
-			<groupId>org.influxdb</groupId>
-			<artifactId>influxdb-java</artifactId>
-			<version>2.8</version>
-		</dependency>
+            <groupId>org.influxdb</groupId>
+            <artifactId>influxdb-java</artifactId>
+            <version>2.8</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -157,6 +157,11 @@
             <groupId>org.opensaml</groupId>
             <artifactId>opensaml</artifactId>
         </dependency>
+        <dependency>
+			<groupId>org.influxdb</groupId>
+			<artifactId>influxdb-java</artifactId>
+			<version>2.8</version>
+		</dependency>
     </dependencies>
     <build>
         <plugins>

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -195,16 +195,17 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     private static final String INFLUXDB_HOST_MEASUREMENT = "host_stats";
     private static final String INFLUXDB_VM_MEASUREMENT = "vm_stats";
 
-    static final ConfigKey<Integer> vmDiskStatsInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval", "0",
+    private static final ConfigKey<Integer> vmDiskStatsInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval", "0",
             "Interval (in seconds) to report vm disk statistics. Vm disk statistics will be disabled if this is set to 0 or less than 0.", false);
-    static final ConfigKey<Integer> vmDiskStatsIntervalMin = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval.min", "300",
+    private static final ConfigKey<Integer> vmDiskStatsIntervalMin = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval.min", "300",
             "Minimal interval (in seconds) to report vm disk statistics. If vm.disk.stats.interval is smaller than this, use this to report vm disk statistics.", false);
-    static final ConfigKey<Integer> vmNetworkStatsInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vm.network.stats.interval", "0",
+    private static final ConfigKey<Integer> vmNetworkStatsInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vm.network.stats.interval", "0",
             "Interval (in seconds) to report vm network statistics (for Shared networks). Vm network statistics will be disabled if this is set to 0 or less than 0.", false);
-    static final ConfigKey<Integer> vmNetworkStatsIntervalMin = new ConfigKey<Integer>("Advanced", Integer.class, "vm.network.stats.interval.min", "300",
+    private static final ConfigKey<Integer> vmNetworkStatsIntervalMin = new ConfigKey<Integer>("Advanced", Integer.class, "vm.network.stats.interval.min", "300",
             "Minimal Interval (in seconds) to report vm network statistics (for Shared networks). If vm.network.stats.interval is smaller than this, use this to report vm network statistics.",
             false);
-    static final ConfigKey<Integer> StatsTimeout = new ConfigKey<Integer>("Advanced", Integer.class, "stats.timeout", "60000", "The timeout for stats call in milli seconds.", true,
+    private static final ConfigKey<Integer> StatsTimeout = new ConfigKey<Integer>("Advanced", Integer.class, "stats.timeout", "60000",
+            "The timeout for stats call in milli seconds.", true,
             ConfigKey.Scope.Cluster);
     private static final ConfigKey<String> statsOutputUri = new ConfigKey<String>("Advanced", String.class, "stats.output.uri", "",
             "URI to send StatsCollector statistics to. The collector is defined on the URI scheme. Example: graphite://graphite-hostaddress:port or influxdb://influxdb-hostaddress/dbname. Note that the port is optional, if not added the default port for the respective collector (graphite or influxdb) will be used. Additionally, the database name '/dbname' is  also optional; default db name is 'cloudstack'. You must create and configure the database if using influxdb.",
@@ -280,18 +281,18 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     private ConcurrentHashMap<Long, StorageStats> _storageStats = new ConcurrentHashMap<Long, StorageStats>();
     private ConcurrentHashMap<Long, StorageStats> _storagePoolStats = new ConcurrentHashMap<Long, StorageStats>();
 
-    long hostStatsInterval = -1L;
-    long hostAndVmStatsInterval = -1L;
-    long storageStatsInterval = -1L;
-    long volumeStatsInterval = -1L;
-    long autoScaleStatsInterval = -1L;
+    private long hostStatsInterval = -1L;
+    private long hostAndVmStatsInterval = -1L;
+    private long storageStatsInterval = -1L;
+    private long volumeStatsInterval = -1L;
+    private long autoScaleStatsInterval = -1L;
 
     private double _imageStoreCapacityThreshold = 0.90;
 
-    String externalStatsPrefix = "";
+    private String externalStatsPrefix = "";
     String externalStatsHost = null;
     int externalStatsPort = -1;
-    String externalStatsScheme;
+    private String externalStatsScheme;
     ExternalStatsProtocol externalStatsType = ExternalStatsProtocol.NONE;
     private String databaseName = DEFAULT_DATABASE_NAME;
 

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +49,10 @@ import org.apache.cloudstack.utils.graphite.GraphiteException;
 import org.apache.cloudstack.utils.usage.UsageUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
 import org.springframework.stereotype.Component;
 
 import com.cloud.agent.AgentManager;
@@ -121,6 +126,7 @@ import com.cloud.utils.db.SearchCriteria;
 import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionStatus;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.MacAddress;
 import com.cloud.vm.NicVO;
 import com.cloud.vm.UserVmManager;
@@ -140,7 +146,7 @@ import com.cloud.vm.dao.VMInstanceDao;
 public class StatsCollector extends ManagerBase implements ComponentMethodInterceptable, Configurable {
 
     public static enum ExternalStatsProtocol {
-        NONE("none"), GRAPHITE("graphite");
+        NONE("none"), GRAPHITE("graphite"), INFLUXDB("influxdb");
         String _type;
 
         ExternalStatsProtocol(String type) {
@@ -155,6 +161,42 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
     public static final Logger s_logger = Logger.getLogger(StatsCollector.class.getName());
 
+    private static final int UNDEFINED_PORT_VALUE = -1;
+
+    /**
+     * Default value for the Graphite connection port: {@value}
+     */
+    private static final int GRAPHITE_DEFAULT_PORT = 2003;
+
+    /**
+     * Default value for the InfluxDB connection port: {@value}
+     */
+    private static final int INFLUXDB_DEFAULT_PORT = 8086;
+
+    private static final String HOST_ID_TAG = "host_id";
+    private static final String VM_ID_TAG = "vm_id";
+    private static final String INSTANCE_NAME_TAG = "instance_name";
+    private static final String UUID_TAG = "uuid";
+    private static final String POD_ID_TAG = "pod_id";
+    private static final String DATA_CENTER_ID_TAG = "data_center_id";
+
+    private static final String TOTAL_MEMORY_KBS_FIELD = "total_memory_kb";
+    private static final String FREE_MEMORY_KBS_FIELD = "free_memory_kb";
+    private static final String CPU_UTILIZATION_FIELD = "cpu_utilization";
+    private static final String CPUS_FIELD = "cpus";
+    private static final String CPU_SOCKETS_FIELD = "cpu_sockets";
+    private static final String NETWORK_READ_KBS_FIELD = "network_read_kbs";
+    private static final String NETWORK_WRITE_KBS_FIELD = "network_write_kbs";
+    private static final String MEMORY_TARGET_KBS_FIELD = "memory_target_kbs";
+    private static final String DISK_READ_IOPS_FIELD = "disk_read_iops";
+    private static final String DISK_READ_KBS_FIELD = "disk_read_kbs";
+    private static final String DISK_WRITE_IOPS_FIELD = "disk_write_iops";
+    private static final String DISK_WRITE_KBS_FIELD = "disk_write_kbs";
+
+    private static final String DEFAULT_DATABASE_NAME = "cloudstack";
+    private static final String INFLUXDB_HOST_MEASUREMENT = "host_stats";
+    private static final String INFLUXDB_VM_MEASUREMENT = "vm_stats";
+
     static final ConfigKey<Integer> vmDiskStatsInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval", "0",
             "Interval (in seconds) to report vm disk statistics. Vm disk statistics will be disabled if this is set to 0 or less than 0.", false);
     static final ConfigKey<Integer> vmDiskStatsIntervalMin = new ConfigKey<Integer>("Advanced", Integer.class, "vm.disk.stats.interval.min", "300",
@@ -162,9 +204,13 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     static final ConfigKey<Integer> vmNetworkStatsInterval = new ConfigKey<Integer>("Advanced", Integer.class, "vm.network.stats.interval", "0",
             "Interval (in seconds) to report vm network statistics (for Shared networks). Vm network statistics will be disabled if this is set to 0 or less than 0.", false);
     static final ConfigKey<Integer> vmNetworkStatsIntervalMin = new ConfigKey<Integer>("Advanced", Integer.class, "vm.network.stats.interval.min", "300",
-            "Minimal Interval (in seconds) to report vm network statistics (for Shared networks). If vm.network.stats.interval is smaller than this, use this to report vm network statistics.", false);
-    static final ConfigKey<Integer> StatsTimeout = new ConfigKey<Integer>("Advanced", Integer.class, "stats.timeout", "60000",
-            "The timeout for stats call in milli seconds.", true, ConfigKey.Scope.Cluster);
+            "Minimal Interval (in seconds) to report vm network statistics (for Shared networks). If vm.network.stats.interval is smaller than this, use this to report vm network statistics.",
+            false);
+    static final ConfigKey<Integer> StatsTimeout = new ConfigKey<Integer>("Advanced", Integer.class, "stats.timeout", "60000", "The timeout for stats call in milli seconds.", true,
+            ConfigKey.Scope.Cluster);
+    private static final ConfigKey<String> statsOutputUri = new ConfigKey<String>("Advanced", String.class, "stats.output.uri", "",
+            "URI to send StatsCollector statistics to. The collector is defined on the URI scheme. Example: graphite://graphite-hostaddress:port or influxdb://influxdb-hostaddress/dbname. Note that the port is optional, if not added the default port for the respective collector (graphite or influxdb) will be used. Additionally, the database name '/dbname' is  also optional; default db name is 'cloudstack'. You must create and configure the database if using influxdb.",
+            true);
 
     private static StatsCollector s_instance = null;
 
@@ -248,8 +294,8 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
     String externalStatsPrefix = "";
     String externalStatsHost = null;
     int externalStatsPort = -1;
-    boolean externalStatsEnabled = false;
     ExternalStatsProtocol externalStatsType = ExternalStatsProtocol.NONE;
+    private String databaseName = DEFAULT_DATABASE_NAME;
 
     private ScheduledExecutorService _diskStatsUpdateExecutor;
     private int _usageAggregationRange = 1440;
@@ -279,7 +325,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         return true;
     }
 
-    private void init(Map<String, String> configs) {
+    protected void init(Map<String, String> configs) {
         _executor = Executors.newScheduledThreadPool(6, new NamedThreadFactory("StatsCollector"));
 
         hostStatsInterval = NumbersUtil.parseLong(configs.get("host.stats.interval"), 60000L);
@@ -288,11 +334,10 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         volumeStatsInterval = NumbersUtil.parseLong(configs.get("volume.stats.interval"), 600000L);
         autoScaleStatsInterval = NumbersUtil.parseLong(configs.get("autoscale.stats.interval"), 60000L);
 
-        /* URI to send statistics to. Currently only Graphite is supported */
-        String externalStatsUri = configs.get("stats.output.uri");
-        if (externalStatsUri != null && !externalStatsUri.equals("")) {
+        String statsUri = statsOutputUri.value();
+        if (StringUtils.isNotBlank(statsUri)) {
             try {
-                URI uri = new URI(externalStatsUri);
+                URI uri = new URI(statsUri);
                 String scheme = uri.getScheme();
 
                 try {
@@ -305,7 +350,9 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                     externalStatsHost = uri.getHost();
                 }
 
-                externalStatsPort = uri.getPort();
+                externalStatsPort = configureExternalStatsPort(uri);
+
+                databaseName = configureDatabaseName(uri);
 
                 if (!StringUtils.isEmpty(uri.getPath())) {
                     externalStatsPrefix = uri.getPath().substring(1);
@@ -318,7 +365,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                     externalStatsPrefix = "";
                 }
 
-                externalStatsEnabled = true;
             } catch (URISyntaxException e) {
                 s_logger.debug("Failed to parse external statistics URI: " + e.getMessage());
             }
@@ -342,7 +388,8 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
         if (vmDiskStatsInterval.value() > 0) {
             if (vmDiskStatsInterval.value() < vmDiskStatsIntervalMin.value()) {
-                s_logger.debug("vm.disk.stats.interval - " + vmDiskStatsInterval.value() + " is smaller than vm.disk.stats.interval.min - " + vmDiskStatsIntervalMin.value() + ", so use vm.disk.stats.interval.min");
+                s_logger.debug("vm.disk.stats.interval - " + vmDiskStatsInterval.value() + " is smaller than vm.disk.stats.interval.min - " + vmDiskStatsIntervalMin.value()
+                        + ", so use vm.disk.stats.interval.min");
                 _executor.scheduleAtFixedRate(new VmDiskStatsTask(), vmDiskStatsIntervalMin.value(), vmDiskStatsIntervalMin.value(), TimeUnit.SECONDS);
             } else {
                 _executor.scheduleAtFixedRate(new VmDiskStatsTask(), vmDiskStatsInterval.value(), vmDiskStatsInterval.value(), TimeUnit.SECONDS);
@@ -353,7 +400,8 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
         if (vmNetworkStatsInterval.value() > 0) {
             if (vmNetworkStatsInterval.value() < vmNetworkStatsIntervalMin.value()) {
-                s_logger.debug("vm.network.stats.interval - " + vmNetworkStatsInterval.value() + " is smaller than vm.network.stats.interval.min - " + vmNetworkStatsIntervalMin.value() + ", so use vm.network.stats.interval.min");
+                s_logger.debug("vm.network.stats.interval - " + vmNetworkStatsInterval.value() + " is smaller than vm.network.stats.interval.min - "
+                        + vmNetworkStatsIntervalMin.value() + ", so use vm.network.stats.interval.min");
                 _executor.scheduleAtFixedRate(new VmNetworkStatsTask(), vmNetworkStatsIntervalMin.value(), vmNetworkStatsIntervalMin.value(), TimeUnit.SECONDS);
             } else {
                 _executor.scheduleAtFixedRate(new VmNetworkStatsTask(), vmNetworkStatsInterval.value(), vmNetworkStatsInterval.value(), TimeUnit.SECONDS);
@@ -411,7 +459,39 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
     }
 
-    class HostCollector extends ManagedContextRunnable {
+    /**
+     * Configures the database name according to the URI path. For instance, if the URI is as influxdb://address:port/dbname, the database name will be 'dbname'.
+     */
+    protected String configureDatabaseName(URI uri) {
+        String dbname = StringUtils.removeStart(uri.getPath(), "/");
+        if (StringUtils.isBlank(dbname)) {
+            return DEFAULT_DATABASE_NAME;
+        } else {
+            return dbname;
+        }
+    }
+
+    /**
+     * Configures the port to be used when connecting with the stats collector service.
+     * Default values are 8086 for influx DB and 2003 for GraphiteDB
+     */
+    protected int configureExternalStatsPort(URI uri) {
+        int port = uri.getPort();
+        if (port != UNDEFINED_PORT_VALUE) {
+            return port;
+        }
+        if (externalStatsType == ExternalStatsProtocol.GRAPHITE) {
+            return GRAPHITE_DEFAULT_PORT;
+        }
+        if (externalStatsType == ExternalStatsProtocol.INFLUXDB) {
+            return INFLUXDB_DEFAULT_PORT;
+        }
+        throw new CloudRuntimeException("Cannot define a port for the Stats Collector service. The configured URI in stats.output.uri is not supported. "
+                + "Please configure as the following examples: graphite://graphite-hostaddress:port, or influxdb://influxdb-hostaddress:port. "
+                + "Note that the port is optional, if not added the default port for the respective collector (graphite or influxdb) will be used.");
+    }
+
+    class HostCollector extends AbstractStatsCollector {
         @Override
         protected void runInContext() {
             try {
@@ -420,55 +500,63 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                 SearchCriteria<HostVO> sc = _hostDao.createSearchCriteria();
                 sc.addAnd("status", SearchCriteria.Op.EQ, Status.Up.toString());
                 sc.addAnd("resourceState", SearchCriteria.Op.NIN, ResourceState.Maintenance, ResourceState.PrepareForMaintenance, ResourceState.ErrorInMaintenance);
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.Storage.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.ConsoleProxy.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.SecondaryStorage.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.LocalSecondaryStorage.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.TrafficMonitor.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.SecondaryStorageVM.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.ExternalFirewall.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.ExternalLoadBalancer.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.NetScalerControlCenter.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.L2Networking.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.BaremetalDhcp.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.BaremetalPxe.toString());
+                sc.addAnd("type", SearchCriteria.Op.EQ, Host.Type.Routing.toString());
+
                 ConcurrentHashMap<Long, HostStats> hostStats = new ConcurrentHashMap<Long, HostStats>();
+                Map<Object, Object> metrics = new HashMap<>();
                 List<HostVO> hosts = _hostDao.search(sc, null);
+
                 for (HostVO host : hosts) {
-                    HostStatsEntry stats = (HostStatsEntry)_resourceMgr.getHostStatistics(host.getId());
-                    if (stats != null) {
-                        hostStats.put(host.getId(), stats);
+                    HostStatsEntry hostStatsEntry = (HostStatsEntry)_resourceMgr.getHostStatistics(host.getId());
+                    if (hostStatsEntry != null) {
+                        hostStatsEntry.setHostVo(host);
+                        metrics.put(hostStatsEntry.getHostId(), hostStatsEntry);
+                        _hostStats.put(host.getId(), hostStatsEntry);
                     } else {
                         s_logger.warn("Received invalid host stats for host: " + host.getId());
                     }
                 }
-                _hostStats = hostStats;
-                // Get a subset of hosts with GPU support from the list of "hosts"
-                List<HostVO> gpuEnabledHosts = new ArrayList<HostVO>();
-                if (hostIds != null) {
-                    for (HostVO host : hosts) {
-                        if (hostIds.contains(host.getId())) {
-                            gpuEnabledHosts.add(host);
-                        }
-                    }
-                } else {
-                    // Check for all the hosts managed by CloudStack.
-                    gpuEnabledHosts = hosts;
-                }
-                for (HostVO host : gpuEnabledHosts) {
-                    HashMap<String, HashMap<String, VgpuTypesInfo>> groupDetails = _resourceMgr.getGPUStatistics(host);
-                    if (groupDetails != null) {
-                        _resourceMgr.updateGPUDetails(host.getId(), groupDetails);
-                    }
-                }
-                hostIds = _hostGpuGroupsDao.listHostIds();
+
+                sendMetricsToInfluxdb(metrics);
+
+                updateGpuEnabledHostsDetails(hosts);
             } catch (Throwable t) {
                 s_logger.error("Error trying to retrieve host stats", t);
             }
         }
+
+        /**
+         * Updates GPU details on hosts supporting GPU.
+         */
+        private void updateGpuEnabledHostsDetails(List<HostVO> hosts) {
+            // Get a subset of hosts with GPU support from the list of "hosts"
+            List<HostVO> gpuEnabledHosts = new ArrayList<HostVO>();
+            if (hostIds != null) {
+                for (HostVO host : hosts) {
+                    if (hostIds.contains(host.getId())) {
+                        gpuEnabledHosts.add(host);
+                    }
+                }
+            } else {
+                // Check for all the hosts managed by CloudStack.
+                gpuEnabledHosts = hosts;
+            }
+            for (HostVO host : gpuEnabledHosts) {
+                HashMap<String, HashMap<String, VgpuTypesInfo>> groupDetails = _resourceMgr.getGPUStatistics(host);
+                if (groupDetails != null) {
+                    _resourceMgr.updateGPUDetails(host.getId(), groupDetails);
+                }
+            }
+            hostIds = _hostGpuGroupsDao.listHostIds();
+        }
+
+        @Override
+        protected Point creteInfluxDbPoint(Object metricsObject) {
+            return createInfluxDbPointForHostMetrics(metricsObject);
+        }
     }
 
-    class VmStatsCollector extends ManagedContextRunnable {
+    class VmStatsCollector extends AbstractStatsCollector {
         @Override
         protected void runInContext() {
             try {
@@ -477,16 +565,10 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                 SearchCriteria<HostVO> sc = _hostDao.createSearchCriteria();
                 sc.addAnd("status", SearchCriteria.Op.EQ, Status.Up.toString());
                 sc.addAnd("resourceState", SearchCriteria.Op.NIN, ResourceState.Maintenance, ResourceState.PrepareForMaintenance, ResourceState.ErrorInMaintenance);
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.Storage.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.ConsoleProxy.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.SecondaryStorage.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.LocalSecondaryStorage.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.TrafficMonitor.toString());
-                sc.addAnd("type", SearchCriteria.Op.NEQ, Host.Type.SecondaryStorageVM.toString());
+                sc.addAnd("type", SearchCriteria.Op.EQ, Host.Type.Routing.toString());
                 List<HostVO> hosts = _hostDao.search(sc, null);
 
-                /* HashMap for metrics to be send to Graphite */
-                HashMap metrics = new HashMap<String, Integer>();
+                Map<Object, Object> metrics = new HashMap<>();
 
                 for (HostVO host : hosts) {
                     List<UserVmVO> vms = _userVmDao.listRunningByHostId(host.getId());
@@ -497,86 +579,35 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                     }
 
                     try {
-                        HashMap<Long, VmStatsEntry> vmStatsById = _userVmMgr.getVirtualMachineStatistics(host.getId(), host.getName(), vmIds);
+                        Map<Long, VmStatsEntry> vmStatsById = _userVmMgr.getVirtualMachineStatistics(host.getId(), host.getName(), vmIds);
 
                         if (vmStatsById != null) {
-                            VmStatsEntry statsInMemory = null;
-
                             Set<Long> vmIdSet = vmStatsById.keySet();
                             for (Long vmId : vmIdSet) {
                                 VmStatsEntry statsForCurrentIteration = vmStatsById.get(vmId);
-                                statsInMemory = (VmStatsEntry)_VmStats.get(vmId);
+                                statsForCurrentIteration.setVmId(vmId);
+                                UserVmVO userVmVo = _userVmDao.findById(vmId);
+                                statsForCurrentIteration.setUserVmVO(userVmVo);
 
-                                if (statsInMemory == null) {
-                                    //no stats exist for this vm, directly persist
-                                    _VmStats.put(vmId, statsForCurrentIteration);
+                                storeVirtualMachineStatsInMemory(statsForCurrentIteration);
+
+                                if (externalStatsType == ExternalStatsProtocol.GRAPHITE) {
+                                    prepareVmMetricsForGraphite(metrics, statsForCurrentIteration);
                                 } else {
-                                    //update each field
-                                    statsInMemory.setCPUUtilization(statsForCurrentIteration.getCPUUtilization());
-                                    statsInMemory.setNumCPUs(statsForCurrentIteration.getNumCPUs());
-                                    statsInMemory.setNetworkReadKBs(statsInMemory.getNetworkReadKBs() + statsForCurrentIteration.getNetworkReadKBs());
-                                    statsInMemory.setNetworkWriteKBs(statsInMemory.getNetworkWriteKBs() + statsForCurrentIteration.getNetworkWriteKBs());
-                                    statsInMemory.setDiskWriteKBs(statsInMemory.getDiskWriteKBs() + statsForCurrentIteration.getDiskWriteKBs());
-                                    statsInMemory.setDiskReadIOs(statsInMemory.getDiskReadIOs() + statsForCurrentIteration.getDiskReadIOs());
-                                    statsInMemory.setDiskWriteIOs(statsInMemory.getDiskWriteIOs() + statsForCurrentIteration.getDiskWriteIOs());
-                                    statsInMemory.setDiskReadKBs(statsInMemory.getDiskReadKBs() + statsForCurrentIteration.getDiskReadKBs());
-                                    statsInMemory.setMemoryKBs(statsForCurrentIteration.getMemoryKBs());
-                                    statsInMemory.setIntFreeMemoryKBs(statsForCurrentIteration.getIntFreeMemoryKBs());
-                                    statsInMemory.setTargetMemoryKBs(statsForCurrentIteration.getTargetMemoryKBs());
-
-                                    _VmStats.put(vmId, statsInMemory);
+                                    metrics.put(statsForCurrentIteration.getVmId(), statsForCurrentIteration);
                                 }
-
-                                /**
-                                 * Add statistics to HashMap only when they should be send to a external stats collector
-                                 * Performance wise it seems best to only append to the HashMap when needed
-                                 */
-                                if (externalStatsEnabled) {
-                                    VMInstanceVO vmVO = _vmInstance.findById(vmId);
-                                    String vmName = vmVO.getUuid();
-
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".cpu.num", statsForCurrentIteration.getNumCPUs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".cpu.utilization", statsForCurrentIteration.getCPUUtilization());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".network.read_kbs", statsForCurrentIteration.getNetworkReadKBs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".network.write_kbs", statsForCurrentIteration.getNetworkWriteKBs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.write_kbs", statsForCurrentIteration.getDiskWriteKBs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.read_kbs", statsForCurrentIteration.getDiskReadKBs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.write_iops", statsForCurrentIteration.getDiskWriteIOs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.read_iops", statsForCurrentIteration.getDiskReadIOs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".memory.total_kbs", statsForCurrentIteration.getMemoryKBs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".memory.internalfree_kbs", statsForCurrentIteration.getIntFreeMemoryKBs());
-                                    metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".memory.target_kbs", statsForCurrentIteration.getTargetMemoryKBs());
-
-                                }
-
                             }
 
-                            /**
-                             * Send the metrics to a external stats collector
-                             * We send it on a per-host basis to prevent that we flood the host
-                             * Currently only Graphite is supported
-                             */
                             if (!metrics.isEmpty()) {
-                                if (externalStatsType != null && externalStatsType == ExternalStatsProtocol.GRAPHITE) {
-
-                                    if (externalStatsPort == -1) {
-                                        externalStatsPort = 2003;
-                                    }
-
-                                    s_logger.debug("Sending VmStats of host " + host.getId() + " to Graphite host " + externalStatsHost + ":" + externalStatsPort);
-
-                                    try {
-                                        GraphiteClient g = new GraphiteClient(externalStatsHost, externalStatsPort);
-                                        g.sendMetrics(metrics);
-                                    } catch (GraphiteException e) {
-                                        s_logger.debug("Failed sending VmStats to Graphite host " + externalStatsHost + ":" + externalStatsPort + ": " + e.getMessage());
-                                    }
-
-                                    metrics.clear();
+                                if (externalStatsType == ExternalStatsProtocol.GRAPHITE) {
+                                    sendVmMetricsToGraphiteHost(metrics, host);
+                                } else if (externalStatsType == ExternalStatsProtocol.INFLUXDB) {
+                                    sendMetricsToInfluxdb(metrics);
                                 }
                             }
-                        }
 
+                            metrics.clear();
+                        }
                     } catch (Exception e) {
                         s_logger.debug("Failed to get VM stats for host with ID: " + host.getId());
                         continue;
@@ -586,6 +617,11 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             } catch (Throwable t) {
                 s_logger.error("Error trying to retrieve VM stats", t);
             }
+        }
+
+        @Override
+        protected Point creteInfluxDbPoint(Object metricsObject) {
+            return createInfluxDbPointForVmMetrics(metricsObject);
         }
     }
 
@@ -646,7 +682,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             //Check for ownership
             //msHost in UP state with min id should run the job
             ManagementServerHostVO msHost = _msHostDao.findOneInUpState(new Filter(ManagementServerHostVO.class, "id", true, 0L, 1L));
-            if(msHost == null || (msHost.getMsid() != mgmtSrvrId)){
+            if (msHost == null || (msHost.getMsid() != mgmtSrvrId)) {
                 s_logger.debug("Skipping collect vm disk stats from hosts");
                 return;
             }
@@ -660,8 +696,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
                         SearchCriteria<HostVO> sc = _hostDao.createSearchCriteria();
                         sc.addAnd("status", SearchCriteria.Op.EQ, Status.Up.toString());
-                        sc.addAnd("resourceState", SearchCriteria.Op.NIN, ResourceState.Maintenance, ResourceState.PrepareForMaintenance,
-                                ResourceState.ErrorInMaintenance);
+                        sc.addAnd("resourceState", SearchCriteria.Op.NIN, ResourceState.Maintenance, ResourceState.PrepareForMaintenance, ResourceState.ErrorInMaintenance);
                         sc.addAnd("type", SearchCriteria.Op.EQ, Host.Type.Routing.toString());
                         sc.addAnd("hypervisorType", SearchCriteria.Op.EQ, HypervisorType.KVM); // support KVM only util 2013.06.25
                         List<HostVO> hosts = _hostDao.search(sc, null);
@@ -692,64 +727,62 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                     if ((volumes == null) || (volumes.size() == 0))
                                         break;
                                     VolumeVO volume = volumes.get(0);
-                                    VmDiskStatisticsVO previousVmDiskStats =
-                                            _vmDiskStatsDao.findBy(userVm.getAccountId(), userVm.getDataCenterId(), vmId, volume.getId());
+                                    VmDiskStatisticsVO previousVmDiskStats = _vmDiskStatsDao.findBy(userVm.getAccountId(), userVm.getDataCenterId(), vmId, volume.getId());
                                     VmDiskStatisticsVO vmDiskStat_lock = _vmDiskStatsDao.lock(userVm.getAccountId(), userVm.getDataCenterId(), vmId, volume.getId());
 
-                                    if ((vmDiskStat.getBytesRead() == 0) && (vmDiskStat.getBytesWrite() == 0) && (vmDiskStat.getIORead() == 0) &&
-                                            (vmDiskStat.getIOWrite() == 0)) {
+                                    if ((vmDiskStat.getBytesRead() == 0) && (vmDiskStat.getBytesWrite() == 0) && (vmDiskStat.getIORead() == 0) && (vmDiskStat.getIOWrite() == 0)) {
                                         s_logger.debug("IO/bytes read and write are all 0. Not updating vm_disk_statistics");
                                         continue;
                                     }
 
                                     if (vmDiskStat_lock == null) {
-                                        s_logger.warn("unable to find vm disk stats from host for account: " + userVm.getAccountId() + " with vmId: " + userVm.getId() +
-                                                " and volumeId:" + volume.getId());
+                                        s_logger.warn("unable to find vm disk stats from host for account: " + userVm.getAccountId() + " with vmId: " + userVm.getId()
+                                                + " and volumeId:" + volume.getId());
                                         continue;
                                     }
 
-                                    if (previousVmDiskStats != null &&
-                                            ((previousVmDiskStats.getCurrentBytesRead() != vmDiskStat_lock.getCurrentBytesRead()) ||
-                                                    (previousVmDiskStats.getCurrentBytesWrite() != vmDiskStat_lock.getCurrentBytesWrite()) ||
-                                                    (previousVmDiskStats.getCurrentIORead() != vmDiskStat_lock.getCurrentIORead()) || (previousVmDiskStats.getCurrentIOWrite() != vmDiskStat_lock.getCurrentIOWrite()))) {
-                                        s_logger.debug("vm disk stats changed from the time GetVmDiskStatsCommand was sent. " + "Ignoring current answer. Host: " +
-                                                host.getName() + " . VM: " + vmDiskStat.getVmName() + " Read(Bytes): " + vmDiskStat.getBytesRead() + " write(Bytes): " +
-                                                vmDiskStat.getBytesWrite() + " Read(IO): " + vmDiskStat.getIORead() + " write(IO): " + vmDiskStat.getIOWrite());
+                                    if (previousVmDiskStats != null && ((previousVmDiskStats.getCurrentBytesRead() != vmDiskStat_lock.getCurrentBytesRead())
+                                            || (previousVmDiskStats.getCurrentBytesWrite() != vmDiskStat_lock.getCurrentBytesWrite())
+                                            || (previousVmDiskStats.getCurrentIORead() != vmDiskStat_lock.getCurrentIORead())
+                                            || (previousVmDiskStats.getCurrentIOWrite() != vmDiskStat_lock.getCurrentIOWrite()))) {
+                                        s_logger.debug("vm disk stats changed from the time GetVmDiskStatsCommand was sent. " + "Ignoring current answer. Host: " + host.getName()
+                                                + " . VM: " + vmDiskStat.getVmName() + " Read(Bytes): " + vmDiskStat.getBytesRead() + " write(Bytes): " + vmDiskStat.getBytesWrite()
+                                                + " Read(IO): " + vmDiskStat.getIORead() + " write(IO): " + vmDiskStat.getIOWrite());
                                         continue;
                                     }
 
                                     if (vmDiskStat_lock.getCurrentBytesRead() > vmDiskStat.getBytesRead()) {
                                         if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Read # of bytes that's less than the last one.  " +
-                                                    "Assuming something went wrong and persisting it. Host: " + host.getName() + " . VM: " + vmDiskStat.getVmName() +
-                                                    " Reported: " + vmDiskStat.getBytesRead() + " Stored: " + vmDiskStat_lock.getCurrentBytesRead());
+                                            s_logger.debug("Read # of bytes that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: "
+                                                    + host.getName() + " . VM: " + vmDiskStat.getVmName() + " Reported: " + vmDiskStat.getBytesRead() + " Stored: "
+                                                    + vmDiskStat_lock.getCurrentBytesRead());
                                         }
                                         vmDiskStat_lock.setNetBytesRead(vmDiskStat_lock.getNetBytesRead() + vmDiskStat_lock.getCurrentBytesRead());
                                     }
                                     vmDiskStat_lock.setCurrentBytesRead(vmDiskStat.getBytesRead());
                                     if (vmDiskStat_lock.getCurrentBytesWrite() > vmDiskStat.getBytesWrite()) {
                                         if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Write # of bytes that's less than the last one.  " +
-                                                    "Assuming something went wrong and persisting it. Host: " + host.getName() + " . VM: " + vmDiskStat.getVmName() +
-                                                    " Reported: " + vmDiskStat.getBytesWrite() + " Stored: " + vmDiskStat_lock.getCurrentBytesWrite());
+                                            s_logger.debug("Write # of bytes that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: "
+                                                    + host.getName() + " . VM: " + vmDiskStat.getVmName() + " Reported: " + vmDiskStat.getBytesWrite() + " Stored: "
+                                                    + vmDiskStat_lock.getCurrentBytesWrite());
                                         }
                                         vmDiskStat_lock.setNetBytesWrite(vmDiskStat_lock.getNetBytesWrite() + vmDiskStat_lock.getCurrentBytesWrite());
                                     }
                                     vmDiskStat_lock.setCurrentBytesWrite(vmDiskStat.getBytesWrite());
                                     if (vmDiskStat_lock.getCurrentIORead() > vmDiskStat.getIORead()) {
                                         if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Read # of IO that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: " +
-                                                    host.getName() + " . VM: " + vmDiskStat.getVmName() + " Reported: " + vmDiskStat.getIORead() + " Stored: " +
-                                                    vmDiskStat_lock.getCurrentIORead());
+                                            s_logger.debug("Read # of IO that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: "
+                                                    + host.getName() + " . VM: " + vmDiskStat.getVmName() + " Reported: " + vmDiskStat.getIORead() + " Stored: "
+                                                    + vmDiskStat_lock.getCurrentIORead());
                                         }
                                         vmDiskStat_lock.setNetIORead(vmDiskStat_lock.getNetIORead() + vmDiskStat_lock.getCurrentIORead());
                                     }
                                     vmDiskStat_lock.setCurrentIORead(vmDiskStat.getIORead());
                                     if (vmDiskStat_lock.getCurrentIOWrite() > vmDiskStat.getIOWrite()) {
                                         if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Write # of IO that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: " +
-                                                    host.getName() + " . VM: " + vmDiskStat.getVmName() + " Reported: " + vmDiskStat.getIOWrite() + " Stored: " +
-                                                    vmDiskStat_lock.getCurrentIOWrite());
+                                            s_logger.debug("Write # of IO that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: "
+                                                    + host.getName() + " . VM: " + vmDiskStat.getVmName() + " Reported: " + vmDiskStat.getIOWrite() + " Stored: "
+                                                    + vmDiskStat_lock.getCurrentIOWrite());
                                         }
                                         vmDiskStat_lock.setNetIOWrite(vmDiskStat_lock.getNetIOWrite() + vmDiskStat_lock.getCurrentIOWrite());
                                     }
@@ -781,7 +814,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             //Check for ownership
             //msHost in UP state with min id should run the job
             ManagementServerHostVO msHost = _msHostDao.findOneInUpState(new Filter(ManagementServerHostVO.class, "id", true, 0L, 1L));
-            if(msHost == null || (msHost.getMsid() != mgmtSrvrId)){
+            if (msHost == null || (msHost.getMsid() != mgmtSrvrId)) {
                 s_logger.debug("Skipping collect vm network stats from hosts");
                 return;
             }
@@ -798,8 +831,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         sc.addAnd("type", SearchCriteria.Op.EQ, Host.Type.Routing.toString());
                         List<HostVO> hosts = _hostDao.search(sc, null);
 
-                        for (HostVO host : hosts)
-                        {
+                        for (HostVO host : hosts) {
                             List<UserVmVO> vms = _userVmDao.listRunningByHostId(host.getId());
                             List<Long> vmIds = new ArrayList<Long>();
 
@@ -813,8 +845,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                 continue;
 
                             Set<Long> vmIdSet = vmNetworkStatsById.keySet();
-                            for(Long vmId : vmIdSet)
-                            {
+                            for (Long vmId : vmIdSet) {
                                 List<VmNetworkStatsEntry> vmNetworkStats = vmNetworkStatsById.get(vmId);
                                 if (vmNetworkStats == null)
                                     continue;
@@ -823,20 +854,24 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                     s_logger.debug("Cannot find uservm with id: " + vmId + " , continue");
                                     continue;
                                 }
-                                s_logger.debug("Now we are updating the user_statistics table for VM: " + userVm.getInstanceName() + " after collecting vm network statistics from host: " + host.getName());
-                                for (VmNetworkStatsEntry vmNetworkStat:vmNetworkStats) {
+                                s_logger.debug("Now we are updating the user_statistics table for VM: " + userVm.getInstanceName()
+                                        + " after collecting vm network statistics from host: " + host.getName());
+                                for (VmNetworkStatsEntry vmNetworkStat : vmNetworkStats) {
                                     SearchCriteria<NicVO> sc_nic = _nicDao.createSearchCriteria();
                                     sc_nic.addAnd("macAddress", SearchCriteria.Op.EQ, vmNetworkStat.getMacAddress());
                                     NicVO nic = _nicDao.search(sc_nic, null).get(0);
                                     List<VlanVO> vlan = _vlanDao.listVlansByNetworkId(nic.getNetworkId());
                                     if (vlan == null || vlan.size() == 0 || vlan.get(0).getVlanType() != VlanType.DirectAttached)
                                         continue; // only get network statistics for DirectAttached network (shared networks in Basic zone and Advanced zone with/without SG)
-                                    UserStatisticsVO previousvmNetworkStats = _userStatsDao.findBy(userVm.getAccountId(), userVm.getDataCenterId(), nic.getNetworkId(), nic.getIPv4Address(), vmId, "UserVm");
+                                    UserStatisticsVO previousvmNetworkStats = _userStatsDao.findBy(userVm.getAccountId(), userVm.getDataCenterId(), nic.getNetworkId(),
+                                            nic.getIPv4Address(), vmId, "UserVm");
                                     if (previousvmNetworkStats == null) {
-                                        previousvmNetworkStats = new UserStatisticsVO(userVm.getAccountId(), userVm.getDataCenterId(),nic.getIPv4Address(), vmId, "UserVm", nic.getNetworkId());
+                                        previousvmNetworkStats = new UserStatisticsVO(userVm.getAccountId(), userVm.getDataCenterId(), nic.getIPv4Address(), vmId, "UserVm",
+                                                nic.getNetworkId());
                                         _userStatsDao.persist(previousvmNetworkStats);
                                     }
-                                    UserStatisticsVO vmNetworkStat_lock = _userStatsDao.lock(userVm.getAccountId(), userVm.getDataCenterId(), nic.getNetworkId(), nic.getIPv4Address(), vmId, "UserVm");
+                                    UserStatisticsVO vmNetworkStat_lock = _userStatsDao.lock(userVm.getAccountId(), userVm.getDataCenterId(), nic.getNetworkId(),
+                                            nic.getIPv4Address(), vmId, "UserVm");
 
                                     if ((vmNetworkStat.getBytesSent() == 0) && (vmNetworkStat.getBytesReceived() == 0)) {
                                         s_logger.debug("bytes sent and received are all 0. Not updating user_statistics");
@@ -844,24 +879,24 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                     }
 
                                     if (vmNetworkStat_lock == null) {
-                                        s_logger.warn("unable to find vm network stats from host for account: " + userVm.getAccountId() + " with vmId: " + userVm.getId()+ " and nicId:" + nic.getId());
+                                        s_logger.warn("unable to find vm network stats from host for account: " + userVm.getAccountId() + " with vmId: " + userVm.getId()
+                                                + " and nicId:" + nic.getId());
                                         continue;
                                     }
 
-                                    if (previousvmNetworkStats != null
-                                            && ((previousvmNetworkStats.getCurrentBytesSent() != vmNetworkStat_lock.getCurrentBytesSent())
+                                    if (previousvmNetworkStats != null && ((previousvmNetworkStats.getCurrentBytesSent() != vmNetworkStat_lock.getCurrentBytesSent())
                                             || (previousvmNetworkStats.getCurrentBytesReceived() != vmNetworkStat_lock.getCurrentBytesReceived()))) {
-                                        s_logger.debug("vm network stats changed from the time GetNmNetworkStatsCommand was sent. " +
-                                                "Ignoring current answer. Host: " + host.getName()  + " . VM: " + vmNetworkStat.getVmName() +
-                                                " Sent(Bytes): " + vmNetworkStat.getBytesSent() + " Received(Bytes): " + vmNetworkStat.getBytesReceived());
+                                        s_logger.debug("vm network stats changed from the time GetNmNetworkStatsCommand was sent. " + "Ignoring current answer. Host: "
+                                                + host.getName() + " . VM: " + vmNetworkStat.getVmName() + " Sent(Bytes): " + vmNetworkStat.getBytesSent() + " Received(Bytes): "
+                                                + vmNetworkStat.getBytesReceived());
                                         continue;
                                     }
 
                                     if (vmNetworkStat_lock.getCurrentBytesSent() > vmNetworkStat.getBytesSent()) {
                                         if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Sent # of bytes that's less than the last one.  " +
-                                                    "Assuming something went wrong and persisting it. Host: " + host.getName() + " . VM: " + vmNetworkStat.getVmName() +
-                                                    " Reported: " + vmNetworkStat.getBytesSent() + " Stored: " + vmNetworkStat_lock.getCurrentBytesSent());
+                                            s_logger.debug("Sent # of bytes that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: "
+                                                    + host.getName() + " . VM: " + vmNetworkStat.getVmName() + " Reported: " + vmNetworkStat.getBytesSent() + " Stored: "
+                                                    + vmNetworkStat_lock.getCurrentBytesSent());
                                         }
                                         vmNetworkStat_lock.setNetBytesSent(vmNetworkStat_lock.getNetBytesSent() + vmNetworkStat_lock.getCurrentBytesSent());
                                     }
@@ -869,15 +904,15 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
                                     if (vmNetworkStat_lock.getCurrentBytesReceived() > vmNetworkStat.getBytesReceived()) {
                                         if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Received # of bytes that's less than the last one.  " +
-                                                    "Assuming something went wrong and persisting it. Host: " + host.getName() + " . VM: " + vmNetworkStat.getVmName() +
-                                                    " Reported: " + vmNetworkStat.getBytesReceived() + " Stored: " + vmNetworkStat_lock.getCurrentBytesReceived());
+                                            s_logger.debug("Received # of bytes that's less than the last one.  " + "Assuming something went wrong and persisting it. Host: "
+                                                    + host.getName() + " . VM: " + vmNetworkStat.getVmName() + " Reported: " + vmNetworkStat.getBytesReceived() + " Stored: "
+                                                    + vmNetworkStat_lock.getCurrentBytesReceived());
                                         }
                                         vmNetworkStat_lock.setNetBytesReceived(vmNetworkStat_lock.getNetBytesReceived() + vmNetworkStat_lock.getCurrentBytesReceived());
                                     }
                                     vmNetworkStat_lock.setCurrentBytesReceived(vmNetworkStat.getBytesReceived());
 
-                                    if (! _dailyOrHourly) {
+                                    if (!_dailyOrHourly) {
                                         //update agg bytes
                                         vmNetworkStat_lock.setAggBytesReceived(vmNetworkStat_lock.getNetBytesReceived() + vmNetworkStat_lock.getCurrentBytesReceived());
                                         vmNetworkStat_lock.setAggBytesSent(vmNetworkStat_lock.getNetBytesSent() + vmNetworkStat_lock.getCurrentBytesSent());
@@ -895,7 +930,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         }
     }
 
-
     class VolumeStatsTask extends ManagedContextRunnable {
         @Override
         protected void runInContext() {
@@ -905,18 +939,15 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                 for (StoragePoolVO pool : pools) {
                     List<VolumeVO> volumes = _volsDao.findByPoolId(pool.getId(), null);
                     List<String> volumeLocators = new ArrayList<String>();
-                    for (VolumeVO volume: volumes){
+                    for (VolumeVO volume : volumes) {
                         if (volume.getFormat() == ImageFormat.QCOW2) {
                             volumeLocators.add(volume.getUuid());
-                        }
-                        else if (volume.getFormat() == ImageFormat.VHD){
+                        } else if (volume.getFormat() == ImageFormat.VHD) {
                             volumeLocators.add(volume.getPath());
-                        }
-                        else if (volume.getFormat() == ImageFormat.OVA){
+                        } else if (volume.getFormat() == ImageFormat.OVA) {
                             volumeLocators.add(volume.getChainInfo());
-                        }
-                        else {
-                            s_logger.warn("Volume stats not implemented for this format type " + volume.getFormat() );
+                        } else {
+                            s_logger.warn("Volume stats not implemented for this format type " + volume.getFormat());
                             break;
                         }
                     }
@@ -924,8 +955,9 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         Map<String, VolumeStatsEntry> volumeStatsByUuid;
                         if (pool.getScope() == ScopeType.ZONE) {
                             volumeStatsByUuid = new HashMap<>();
-                            for (final Cluster cluster: _clusterDao.listByZoneId(pool.getDataCenterId())) {
-                                final Map<String, VolumeStatsEntry> volumeStatsForCluster = _userVmMgr.getVolumeStatistics(cluster.getId(), pool.getUuid(), pool.getPoolType(), volumeLocators, StatsTimeout.value());
+                            for (final Cluster cluster : _clusterDao.listByZoneId(pool.getDataCenterId())) {
+                                final Map<String, VolumeStatsEntry> volumeStatsForCluster = _userVmMgr.getVolumeStatistics(cluster.getId(), pool.getUuid(), pool.getPoolType(),
+                                        volumeLocators, StatsTimeout.value());
                                 if (volumeStatsForCluster != null) {
                                     volumeStatsByUuid.putAll(volumeStatsForCluster);
                                 }
@@ -933,7 +965,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         } else {
                             volumeStatsByUuid = _userVmMgr.getVolumeStatistics(pool.getClusterId(), pool.getUuid(), pool.getPoolType(), volumeLocators, StatsTimeout.value());
                         }
-                        if (volumeStatsByUuid != null){
+                        if (volumeStatsByUuid != null) {
                             for (final Map.Entry<String, VolumeStatsEntry> entry : volumeStatsByUuid.entrySet()) {
                                 if (entry == null || entry.getKey() == null || entry.getValue() == null) {
                                     continue;
@@ -985,8 +1017,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                     Answer answer = ssAhost.sendMessage(command);
                     if (answer != null && answer.getResult()) {
                         storageStats.put(storeId, (StorageStats)answer);
-                        s_logger.trace("HostId: " + storeId + " Used: " + ((StorageStats)answer).getByteUsed() + " Total Available: " +
-                                ((StorageStats)answer).getCapacityBytes());
+                        s_logger.trace("HostId: " + storeId + " Used: " + ((StorageStats)answer).getByteUsed() + " Total Available: " + ((StorageStats)answer).getCapacityBytes());
                     }
                 }
                 _storageStats = storageStats;
@@ -1047,8 +1078,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                         //check interval
                         long now = (new Date()).getTime();
                         if (asGroup.getLastInterval() != null)
-                            if ((now - asGroup.getLastInterval().getTime()) < asGroup
-                                    .getInterval()) {
+                            if ((now - asGroup.getLastInterval().getTime()) < asGroup.getInterval()) {
                                 continue;
                             }
 
@@ -1213,7 +1243,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                                 long thresholdValue = conditionVO.getThreshold();
                                 Double thresholdPercent = (double)thresholdValue / 100;
                                 CounterVO counterVO = _asCounterDao.findById(conditionVO.getCounterid());
-//Double sum = avgCounter.get(conditionVO.getCounterid());
                                 long counter_count = 1;
                                 do {
                                     String counter_param = params.get("counter" + String.valueOf(counter_count));
@@ -1260,8 +1289,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
             return lstResult;
         }
 
-        public List<Pair<String, Integer>> getPairofCounternameAndDuration(
-                long groupId) {
+        public List<Pair<String, Integer>> getPairofCounternameAndDuration(long groupId) {
             AutoScaleVmGroupVO groupVo = _asGroupDao.findById(groupId);
             if (groupVo == null)
                 return null;
@@ -1307,12 +1335,188 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
         }
     }
 
+    /**
+     * This class allows to writing metrics in InfluxDB for the table that matches the Collector extending it.
+     * Thus, VmStatsCollector and HostCollector can use same method to write on different measures (host_stats or vm_stats table).
+     */
+    abstract class AbstractStatsCollector extends ManagedContextRunnable {
+        /**
+         * Sends metrics to influxdb host. This method supports both VM and Host metrics
+         */
+        protected void sendMetricsToInfluxdb(Map<Object, Object> metrics) {
+            InfluxDB influxDbConnection = createInfluxDbConnection();
+            Collection<Object> metricsObjects = metrics.values();
+            List<Point> points = new ArrayList<>();
+
+            s_logger.debug(String.format("Sending stats to %s host %s:%s", externalStatsType, externalStatsHost, externalStatsPort));
+
+            for (Object metricsObject : metricsObjects) {
+                Point vmPoint = creteInfluxDbPoint(metricsObject);
+                points.add(vmPoint);
+            }
+            writeBatches(influxDbConnection, databaseName, points);
+        }
+
+        /**
+         * Creates a InfluxDB point for the given stats collector (VmStatsCollector, or HostCollector).
+         */
+        protected abstract Point creteInfluxDbPoint(Object metricsObject);
+    }
+
     public boolean imageStoreHasEnoughCapacity(DataStore imageStore) {
         StorageStats imageStoreStats = _storageStats.get(imageStore.getId());
-        if (imageStoreStats != null && (imageStoreStats.getByteUsed()/(imageStoreStats.getCapacityBytes()*1.0)) <= _imageStoreCapacityThreshold) {
+        if (imageStoreStats != null && (imageStoreStats.getByteUsed() / (imageStoreStats.getCapacityBytes() * 1.0)) <= _imageStoreCapacityThreshold) {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Sends VMs metrics to the configured graphite host.
+     */
+    protected void sendVmMetricsToGraphiteHost(Map<Object, Object> metrics, HostVO host) {
+        s_logger.debug(String.format("Sending VmStats of host %s to %s host %s:%s", host.getId(), externalStatsType, externalStatsHost, externalStatsPort));
+        try {
+            GraphiteClient g = new GraphiteClient(externalStatsHost, externalStatsPort);
+            g.sendMetrics(metrics);
+        } catch (GraphiteException e) {
+            s_logger.debug("Failed sending VmStats to Graphite host " + externalStatsHost + ":" + externalStatsPort + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Prepares metrics for Graphite.
+     * @note this method must only be executed in case the configured stats collector is a Graphite host;
+     * otherwise, it will compromise the map of metrics used by another type of collector (e.g. InfluxDB).
+     */
+    private void prepareVmMetricsForGraphite(Map<Object, Object> metrics, VmStatsEntry statsForCurrentIteration) {
+        VMInstanceVO vmVO = _vmInstance.findById(statsForCurrentIteration.getVmId());
+        String vmName = vmVO.getUuid();
+
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".cpu.num", statsForCurrentIteration.getNumCPUs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".cpu.utilization", statsForCurrentIteration.getCPUUtilization());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".network.read_kbs", statsForCurrentIteration.getNetworkReadKBs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".network.write_kbs", statsForCurrentIteration.getNetworkWriteKBs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.write_kbs", statsForCurrentIteration.getDiskWriteKBs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.read_kbs", statsForCurrentIteration.getDiskReadKBs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.write_iops", statsForCurrentIteration.getDiskWriteIOs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".disk.read_iops", statsForCurrentIteration.getDiskReadIOs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".memory.total_kbs", statsForCurrentIteration.getMemoryKBs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".memory.internalfree_kbs", statsForCurrentIteration.getIntFreeMemoryKBs());
+        metrics.put(externalStatsPrefix + "cloudstack.stats.instances." + vmName + ".memory.target_kbs", statsForCurrentIteration.getTargetMemoryKBs());
+    }
+
+    /**
+     * Stores virtual machine stats in memory (map of {@link VmStatsEntry}).
+     */
+    private void storeVirtualMachineStatsInMemory(VmStatsEntry statsForCurrentIteration) {
+        VmStatsEntry statsInMemory = (VmStatsEntry)_VmStats.get(statsForCurrentIteration.getVmId());
+
+        if (statsInMemory == null) {
+            //no stats exist for this vm, directly persist
+            _VmStats.put(statsForCurrentIteration.getVmId(), statsForCurrentIteration);
+        } else {
+            //update each field
+            statsInMemory.setCPUUtilization(statsForCurrentIteration.getCPUUtilization());
+            statsInMemory.setNumCPUs(statsForCurrentIteration.getNumCPUs());
+            statsInMemory.setNetworkReadKBs(statsInMemory.getNetworkReadKBs() + statsForCurrentIteration.getNetworkReadKBs());
+            statsInMemory.setNetworkWriteKBs(statsInMemory.getNetworkWriteKBs() + statsForCurrentIteration.getNetworkWriteKBs());
+            statsInMemory.setDiskWriteKBs(statsInMemory.getDiskWriteKBs() + statsForCurrentIteration.getDiskWriteKBs());
+            statsInMemory.setDiskReadIOs(statsInMemory.getDiskReadIOs() + statsForCurrentIteration.getDiskReadIOs());
+            statsInMemory.setDiskWriteIOs(statsInMemory.getDiskWriteIOs() + statsForCurrentIteration.getDiskWriteIOs());
+            statsInMemory.setDiskReadKBs(statsInMemory.getDiskReadKBs() + statsForCurrentIteration.getDiskReadKBs());
+            statsInMemory.setMemoryKBs(statsForCurrentIteration.getMemoryKBs());
+            statsInMemory.setIntFreeMemoryKBs(statsForCurrentIteration.getIntFreeMemoryKBs());
+            statsInMemory.setTargetMemoryKBs(statsForCurrentIteration.getTargetMemoryKBs());
+
+            _VmStats.put(statsForCurrentIteration.getVmId(), statsInMemory);
+        }
+    }
+
+    /**
+     * Sends host metrics to a configured InfluxDB host. The metrics respects the following specification.</br>
+     * <b>Tags:</b>vm_id, uuid, instance_name, data_center_id, host_id</br>
+     * <b>Fields:</b>memory_total_kb, memory_internal_free_kbs, memory_target_kbs, cpu_utilization, cpus, network_write_kb, disk_read_iops, disk_read_kbs, disk_write_iops, disk_write_kbs
+     */
+    protected Point createInfluxDbPointForHostMetrics(Object metricsObject) {
+        HostStatsEntry hostStatsEntry = (HostStatsEntry)metricsObject;
+
+        Map<String, String> tagsToAdd = new HashMap<>();
+        tagsToAdd.put(HOST_ID_TAG, new Long(hostStatsEntry.getHostId()).toString());
+        tagsToAdd.put(UUID_TAG, hostStatsEntry.getHostVo().getUuid());
+        tagsToAdd.put(POD_ID_TAG, new Long(hostStatsEntry.getHostVo().getPodId()).toString());
+        tagsToAdd.put(DATA_CENTER_ID_TAG, new Long(hostStatsEntry.getHostVo().getDataCenterId()).toString());
+
+        Map<String, Object> fieldsToAdd = new HashMap<>();
+        fieldsToAdd.put(TOTAL_MEMORY_KBS_FIELD, hostStatsEntry.getTotalMemoryKBs());
+        fieldsToAdd.put(FREE_MEMORY_KBS_FIELD, hostStatsEntry.getFreeMemoryKBs());
+        fieldsToAdd.put(CPU_UTILIZATION_FIELD, hostStatsEntry.getCpuUtilization());
+        fieldsToAdd.put(CPUS_FIELD, hostStatsEntry.getHostVo().getCpus());
+        fieldsToAdd.put(CPU_SOCKETS_FIELD, hostStatsEntry.getHostVo().getCpuSockets());
+        fieldsToAdd.put(NETWORK_READ_KBS_FIELD, hostStatsEntry.getNetworkReadKBs());
+        fieldsToAdd.put(NETWORK_WRITE_KBS_FIELD, hostStatsEntry.getNetworkWriteKBs());
+
+        return Point.measurement(INFLUXDB_HOST_MEASUREMENT).tag(tagsToAdd).time(System.currentTimeMillis(), TimeUnit.MILLISECONDS).fields(fieldsToAdd).build();
+    }
+
+    /**
+     * Sends VMs metrics to a configured InfluxDB host. The metrics respects the following specification.</br>
+     * <b>Tags:</b>vm_id, uuid, instance_name, data_center_id, host_id</br>
+     * <b>Fields:</b>memory_total_kb, memory_internal_free_kbs, memory_target_kbs, cpu_utilization, cpus, network_write_kb, disk_read_iops, disk_read_kbs, disk_write_iops, disk_write_kbs
+     */
+    protected Point createInfluxDbPointForVmMetrics(Object metricsObject) {
+        VmStatsEntry vmStatsEntry = (VmStatsEntry)metricsObject;
+        UserVmVO userVmVO = vmStatsEntry.getUserVmVO();
+
+        Map<String, String> tagsToAdd = new HashMap<>();
+        tagsToAdd.put(VM_ID_TAG, new Long(vmStatsEntry.getVmId()).toString());
+        tagsToAdd.put(UUID_TAG, userVmVO.getUuid());
+        tagsToAdd.put(INSTANCE_NAME_TAG, userVmVO.getInstanceName());
+        tagsToAdd.put(DATA_CENTER_ID_TAG, new Long(userVmVO.getDataCenterId()).toString());
+        tagsToAdd.put(HOST_ID_TAG, new Long(userVmVO.getHostId()).toString());
+
+        Map<String, Object> fieldsToAdd = new HashMap<>();
+        fieldsToAdd.put(TOTAL_MEMORY_KBS_FIELD, vmStatsEntry.getMemoryKBs());
+        fieldsToAdd.put(FREE_MEMORY_KBS_FIELD, vmStatsEntry.getIntFreeMemoryKBs());
+        fieldsToAdd.put(MEMORY_TARGET_KBS_FIELD, vmStatsEntry.getTargetMemoryKBs());
+        fieldsToAdd.put(CPU_UTILIZATION_FIELD, vmStatsEntry.getCPUUtilization());
+        fieldsToAdd.put(CPUS_FIELD, vmStatsEntry.getNumCPUs());
+        fieldsToAdd.put(NETWORK_READ_KBS_FIELD, vmStatsEntry.getNetworkReadKBs());
+        fieldsToAdd.put(NETWORK_WRITE_KBS_FIELD, vmStatsEntry.getNetworkWriteKBs());
+        fieldsToAdd.put(DISK_READ_IOPS_FIELD, vmStatsEntry.getDiskReadIOs());
+        fieldsToAdd.put(DISK_READ_KBS_FIELD, vmStatsEntry.getDiskReadKBs());
+        fieldsToAdd.put(DISK_WRITE_IOPS_FIELD, vmStatsEntry.getDiskWriteIOs());
+        fieldsToAdd.put(DISK_WRITE_KBS_FIELD, vmStatsEntry.getDiskWriteKBs());
+
+        return Point.measurement(INFLUXDB_VM_MEASUREMENT).tag(tagsToAdd).time(System.currentTimeMillis(), TimeUnit.MILLISECONDS).fields(fieldsToAdd).build();
+    }
+
+    /**
+     * Creates connection to InfluxDB. If the database does not exist, it throws a CloudRuntimeException. </br>
+     * @note the user can configure the database name on parameter 'stats.output.influxdb.database.name'; such database must be yet created and configured by the user.
+     * The Default name for the database is 'cloudstack_stats'.
+     */
+    protected InfluxDB createInfluxDbConnection() {
+        String influxDbQueryUrl = String.format("http://%s:%s/", externalStatsHost, INFLUXDB_DEFAULT_PORT);
+        InfluxDB influxDbConnection = InfluxDBFactory.connect(influxDbQueryUrl);
+
+        if (!influxDbConnection.databaseExists(databaseName)) {
+            throw new CloudRuntimeException(String.format("Database with name %s does not exist in influxdb host %s:%s", databaseName, externalStatsHost, externalStatsPort));
+        }
+        return influxDbConnection;
+    }
+
+    /**
+     * Writes batches of InfluxDB database points into a given database.
+     */
+    protected void writeBatches(InfluxDB influxDbConnection, String dbName, List<Point> points) {
+        BatchPoints batchPoints = BatchPoints.database(dbName).build();
+
+        for (Point point : points) {
+            batchPoints.point(point);
+        }
+
+        influxDbConnection.write(batchPoints);
     }
 
     public StorageStats getStorageStats(long id) {
@@ -1334,6 +1538,6 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] { vmDiskStatsInterval, vmDiskStatsIntervalMin, vmNetworkStatsInterval, vmNetworkStatsIntervalMin, StatsTimeout };
+        return new ConfigKey<?>[] {vmDiskStatsInterval, vmDiskStatsIntervalMin, vmNetworkStatsInterval, vmNetworkStatsIntervalMin, StatsTimeout, statsOutputUri};
     }
 }

--- a/server/src/test/java/com/cloud/server/StatsCollectorTest.java
+++ b/server/src/test/java/com/cloud/server/StatsCollectorTest.java
@@ -1,0 +1,217 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.server;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.BatchPoints.Builder;
+import org.influxdb.dto.Point;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cloud.agent.api.HostStatsEntry;
+import com.cloud.host.HostVO;
+import com.cloud.server.StatsCollector.ExternalStatsProtocol;
+import com.cloud.utils.exception.CloudRuntimeException;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({InfluxDBFactory.class, BatchPoints.class})
+public class StatsCollectorTest {
+    private StatsCollector statsCollector = Mockito.spy(new StatsCollector());
+
+    private static final int GRAPHITE_DEFAULT_PORT = 2003;
+    private static final int INFLUXDB_DEFAULT_PORT = 8086;
+    private static final String HOST_ADDRESS = "192.168.16.10";
+    private static final String URL = String.format("http://%s:%s/", HOST_ADDRESS, INFLUXDB_DEFAULT_PORT);
+
+    private static final String DEFAULT_DATABASE_NAME = "cloudstack";
+    private static final String INFLUXDB_HOST_MEASUREMENT = "host_stats";
+    private static final String INFLUXDB_VM_MEASUREMENT = "vm_stats";
+
+    @Test
+    public void createInfluxDbConnectionTest() {
+        configureAndTestCreateInfluxDbConnection(true);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void createInfluxDbConnectionTestExpectException() {
+        configureAndTestCreateInfluxDbConnection(false);
+    }
+
+    private void configureAndTestCreateInfluxDbConnection(boolean databaseExists) {
+        statsCollector.externalStatsHost = HOST_ADDRESS;
+        InfluxDB influxDbConnection = Mockito.mock(InfluxDB.class);
+        Mockito.when(influxDbConnection.databaseExists(DEFAULT_DATABASE_NAME)).thenReturn(databaseExists);
+        PowerMockito.mockStatic(InfluxDBFactory.class);
+        PowerMockito.when(InfluxDBFactory.connect(URL)).thenReturn(influxDbConnection);
+
+        InfluxDB returnedConnection = statsCollector.createInfluxDbConnection();
+
+        Assert.assertEquals(influxDbConnection, returnedConnection);
+    }
+
+    @Test
+    public void writeBatchesTest() {
+        InfluxDB influxDbConnection = Mockito.mock(InfluxDB.class);
+        Mockito.doNothing().when(influxDbConnection).write(Mockito.any(Point.class));
+        Builder builder = Mockito.mock(Builder.class);
+        BatchPoints batchPoints = Mockito.mock(BatchPoints.class);
+        PowerMockito.mockStatic(BatchPoints.class);
+        PowerMockito.when(BatchPoints.database(DEFAULT_DATABASE_NAME)).thenReturn(builder);
+        Mockito.when(builder.build()).thenReturn(batchPoints);
+        Map<String, String> tagsToAdd = new HashMap<>();
+        tagsToAdd.put("hostId", "1");
+        Map<String, Object> fieldsToAdd = new HashMap<>();
+        fieldsToAdd.put("total_memory_kbs", 10000000);
+        Point point = Point.measurement("measure").tag(tagsToAdd).time(System.currentTimeMillis(), TimeUnit.MILLISECONDS).fields(fieldsToAdd).build();
+        List<Point> points = new ArrayList<>();
+        points.add(point);
+        Mockito.when(batchPoints.point(point)).thenReturn(batchPoints);
+
+        statsCollector.writeBatches(influxDbConnection, DEFAULT_DATABASE_NAME, points);
+
+        Mockito.verify(influxDbConnection).write(batchPoints);
+    }
+
+    @Test
+    public void sendVmMetricsToExternalStatsCollectorTestVmStatsMetricsEmpty() {
+        configureAndTestSendVmMetricsToExternalStatsCollector(new HashMap<>(), ExternalStatsProtocol.INFLUXDB, 0, 0);
+    }
+
+    @Test
+    public void sendVmMetricsToExternalStatsCollectorTestVmStatsMetricsInfluxdb() {
+        Map<Object, Object> metrics = new HashMap<>();
+        metrics.put(0l, 0l);
+        configureAndTestSendVmMetricsToExternalStatsCollector(metrics, ExternalStatsProtocol.INFLUXDB, 0, 1);
+    }
+
+    @Test
+    public void sendVmMetricsToExternalStatsCollectorTestVmStatsMetricsGraphit() {
+        Map<Object, Object> metrics = new HashMap<>();
+        metrics.put(0l, 0l);
+        configureAndTestSendVmMetricsToExternalStatsCollector(metrics, ExternalStatsProtocol.GRAPHITE, 1, 0);
+    }
+
+    private void configureAndTestSendVmMetricsToExternalStatsCollector(Map<Object, Object> metrics, ExternalStatsProtocol externalStatsType, int timesGraphite, int timesInflux) {
+        HostVO host = new HostVO("guid");
+        statsCollector.externalStatsType = externalStatsType;
+        Mockito.doNothing().when(statsCollector).sendVmMetricsToGraphiteHost(Mockito.anyMap(), Mockito.any());
+//        Mockito.doNothing().when(statsCollector).sendMetricsToInfluxdb(Mockito.anyMap(), Mockito.anyString());
+
+//        statsCollector.sendVmMetricsToExternalStatsCollector(metrics, host); TODO review
+
+        Mockito.verify(statsCollector, Mockito.times(timesGraphite)).sendVmMetricsToGraphiteHost(metrics, host);
+//        Mockito.verify(statsCollector, Mockito.times(timesInflux)).sendMetricsToInfluxdb(metrics, "abc");
+    }
+
+    @Test
+    public void configureExternalStatsPortTestGraphitePort() throws URISyntaxException {
+        URI uri = new URI(HOST_ADDRESS);
+        statsCollector.externalStatsType = ExternalStatsProtocol.GRAPHITE;
+        int port = statsCollector.configureExternalStatsPort(uri);
+        Assert.assertEquals(GRAPHITE_DEFAULT_PORT, port);
+    }
+
+    @Test
+    public void configureExternalStatsPortTestInfluxdbPort() throws URISyntaxException {
+        URI uri = new URI(HOST_ADDRESS);
+        statsCollector.externalStatsType = ExternalStatsProtocol.INFLUXDB;
+        int port = statsCollector.configureExternalStatsPort(uri);
+        Assert.assertEquals(INFLUXDB_DEFAULT_PORT, port);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void configureExternalStatsPortTestExpectException() throws URISyntaxException {
+        statsCollector.externalStatsType = ExternalStatsProtocol.NONE;
+        URI uri = new URI(HOST_ADDRESS);
+        statsCollector.configureExternalStatsPort(uri);
+    }
+
+    @Test
+    public void configureExternalStatsPortTestCustomized() throws URISyntaxException {
+        URI uri = new URI("test://" + HOST_ADDRESS + ":1234");
+        int port = statsCollector.configureExternalStatsPort(uri);
+        Assert.assertEquals(1234, port);
+    }
+
+    @Test
+    public void sendMetricsToInfluxdbTestHostMeasure() {
+        configureTestAndVerifySendMetricsToInfluxdb(2, 0, INFLUXDB_HOST_MEASUREMENT);
+    }
+
+    @Test
+    public void sendMetricsToInfluxdbTestVmMeasure() {
+        configureTestAndVerifySendMetricsToInfluxdb(0, 2, INFLUXDB_VM_MEASUREMENT);
+    }
+
+    private void configureTestAndVerifySendMetricsToInfluxdb(int timesPointForHost, int timesPointForVm, String measure) {
+        HostStatsEntry hostStatsEntry = Mockito.mock(HostStatsEntry.class);
+        Point point = Mockito.mock(Point.class);
+        List<Point> points = new ArrayList<>();
+        points.add(point);
+        points.add(point);
+        InfluxDB influxDbConnection = Mockito.mock(InfluxDB.class);
+        Map<Object, Object> metrics = new HashMap<>();
+        metrics.put(0l, hostStatsEntry);
+        metrics.put(1l, hostStatsEntry);
+
+        Mockito.doReturn(point).when(statsCollector).createInfluxDbPointForHostMetrics(Mockito.any());
+        Mockito.doReturn(point).when(statsCollector).createInfluxDbPointForVmMetrics(Mockito.any());
+        Mockito.doReturn(influxDbConnection).when(statsCollector).createInfluxDbConnection();
+        Mockito.doNothing().when(statsCollector).writeBatches(influxDbConnection, DEFAULT_DATABASE_NAME, points);
+
+//        statsCollector.sendMetricsToInfluxdb(metrics, measure); TODO review
+
+        InOrder inOrder = Mockito.inOrder(statsCollector);
+        inOrder.verify(statsCollector, Mockito.times(1)).createInfluxDbConnection();
+        inOrder.verify(statsCollector, Mockito.times(timesPointForHost)).createInfluxDbPointForHostMetrics(Mockito.any());
+        inOrder.verify(statsCollector, Mockito.times(timesPointForVm)).createInfluxDbPointForVmMetrics(Mockito.any());
+        inOrder.verify(statsCollector, Mockito.times(1)).writeBatches(influxDbConnection, DEFAULT_DATABASE_NAME, points);
+    }
+
+    @Test
+    public void configureDatabaseNameTestDefaultDbName() throws URISyntaxException {
+        URI uri = new URI(URL);
+        String dbName = statsCollector.configureDatabaseName(uri);
+        Assert.assertEquals(DEFAULT_DATABASE_NAME, dbName);
+    }
+
+    @Test
+    public void configureDatabaseNameTestCustomDbName() throws URISyntaxException {
+        String configuredDbName = "dbName";
+        URI uri = new URI(URL + configuredDbName);
+        String dbName = statsCollector.configureDatabaseName(uri);
+        Assert.assertEquals(configuredDbName, dbName);
+    }
+}

--- a/utils/src/main/java/org/apache/cloudstack/utils/graphite/GraphiteClient.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/graphite/GraphiteClient.java
@@ -67,7 +67,7 @@ public class GraphiteClient {
      *
      * @param metrics the metrics as key-value-pairs
      */
-    public void sendMetrics(Map<String, Integer> metrics) {
+    public void sendMetrics(Map<Object, Object> metrics) {
         sendMetrics(metrics, getCurrentSystemTime());
     }
 
@@ -77,12 +77,12 @@ public class GraphiteClient {
      * @param metrics the metrics as key-value-pairs
      * @param timeStamp the timestamp
      */
-    public void sendMetrics(Map<String, Integer> metrics, long timeStamp) {
+    public void sendMetrics(Map<Object, Object> metrics, long timeStamp) {
         try (DatagramSocket sock = new DatagramSocket()){
             java.security.Security.setProperty("networkaddress.cache.ttl", "0");
             InetAddress addr = InetAddress.getByName(this.graphiteHost);
 
-            for (Map.Entry<String, Integer> metric: metrics.entrySet()) {
+            for (Map.Entry<Object, Object> metric : metrics.entrySet()) {
                 byte[] message = new String(metric.getKey() + " " + metric.getValue() + " " + timeStamp + "\n").getBytes();
                 DatagramPacket packet = new DatagramPacket(message, message.length, addr, graphitePort);
                 sock.send(packet);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add Support for InfluxDB on StatsCollector.

The collector is defined on the URI scheme. The _Global Settings_ configuration with the name `stats.output.uri` is used to set the URI to send StatsCollector statistics to.

Example: `graphite://graphite-hostaddress:port` or `influxdb://influxdb-hostaddress:port/dbname`. Note that the port is optional, if not added the default port for the respective collector (graphite or influxdb) will be used. Additionally, the database name `dbname` is also optional; default db name is `cloudstack`. Note that one must create and configure the database if using influxdb.

- Host stats
For the host metrics it creates an InfluxDB point with the measure `host_stats` and containing the following tags and fields:
Tags:
-- host_id
-- uuid
-- pod_id
-- data_center_id
Fields:
-- total_memory_kbs
-- free_memory_kbs
-- cpu_utilization
-- cpus
-- cpu_sockets
-- network_read_kbs
-- network_write_kbs

- VM stats
It creates an InfluxDB point with the measure `vm_stats` and containing the following tags and fields:
Tags:
-- vm_id
-- uuid
-- pod_id
-- data_center_id
-- host_id
Fields:
-- total_memory_kbs
-- free_memory_kbs
-- memory_target_kbs
-- cpu_utilization
-- cpus
-- network_read_kbs
-- network_write_kbs
-- disk_read_kbs
-- disk_read_iops
-- disk_write_kbs
-- disk_write_iops

**Note:** As the current stats collector supports only KVM, this extension supports only KVM. I am planning on enhance and refactor the StatsCollector architecture on the future. Due to the inner class structure, test case for some methods will not be implemented. On the future it will be necessary to refactor the whole StatsCOllector architecture and extract inner classes.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Apart from the JUnit tests, the following tests have been manually done, asserting the expected behavior.
Test 1: correct scheme and address, database "cloudstack" exists, default port 8086 is open and listening  (influxdb://172.16.0.10, influxdb://172.16.0.10/cloudstack, or influxdb://172.16.0.10:8086/cloudstack)
- Result: CloudStack starts correctly, data are stored in the database cloudstack (the "cloudstack" is already configured on the influxdb before testing) and no error/warning logs.

Test 2: `stats.output.uri` has wrong URI scheme (http://172.16.0.10 or influxd://172.16.0.10)
 - Result: Cannot store data on the InfluxDB host, logs the following Errors
```
ERROR  [c.c.s.StatsCollector] (main:null) (logid:) influxd is not a valid protocol for external statistics. No statistics will be send.
(...)
ERROR [c.c.s.StatsCollector] (main:null) (logid:) Failed to parse external statistics URI: Cannot define a port for the Stats Collector service. The configured URI in stats.output.uri is not supported. Please configure as the following examples: graphite://graphite-hostaddress:port, or influxdb://influxdb-hostaddress:port. Note that the port is optional, if not added the default port for the respective collector (graphite or influxdb) will be used.: influxd://172.16.0.10
```

Test 3: correct URI scheme but wrong address (influxdb://172.16.0.11)
- Result: Cannot store data on the InfluxDB host, logs the following error
```
ERROR [c.c.s.StatsCollector] (StatsCollector-6:ctx-bf6d551c) (logid:d5c92b19) Error trying to retrieve host stats
org.influxdb.InfluxDBIOException: java.net.NoRouteToHostException: No route to host (Host unreachable)
```

Test 4: correct URI scheme and address, database does not exist (influxdb://172.16.0.10/nonexistingdb)
- Result: Cannot store data on the InfluxDB host, logs the following Errors
```
ERROR [c.c.s.StatsCollector] (StatsCollector-1:ctx-5921793c) (logid:d4bab167) Error trying to retrieve host stats
com.cloud.utils.exception.CloudRuntimeException: Database with name nonexistingdb does not exist in influxdb host 172.16.0.10:8086

```
Test 5: correct URI scheme and address, database exists, customized port is not correctily configured (influxdb://172.16.0.10:8888/)
- Result: Cannot store data on the InfluxDB host, logs the following Errors
```
ERROR [c.c.s.StatsCollector] (StatsCollector-1:ctx-b2371dde) (logid:209a4b10) Error trying to retrieve host stats
org.influxdb.InfluxDBIOException: java.net.ConnectException: Failed to connect to /172.16.0.10:8888

```
Test 6: set stats.output.uri to null/empty
- Result: it does not write in the external stats collector and does not log exceptions, as expected.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
