### PR TITLE
kvm: Use 'ip route show default 0.0.0.0/0' to find the default gateway

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1015,21 +1015,21 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         */
 
         if (_pifs.get("private") == null) {
-            s_logger.debug("Failed to get private nic name");
+            s_logger.error("Failed to get private nic name");
             throw new ConfigurationException("Failed to get private nic name");
         }
 
         if (_pifs.get("public") == null) {
-            s_logger.debug("Failed to get public nic name");
+            s_logger.error("Failed to get public nic name");
             throw new ConfigurationException("Failed to get public nic name");
         }
         s_logger.debug("Found pif: " + _pifs.get("private") + " on " + _privBridgeName + ", pif: " + _pifs.get("public") + " on " + _publicBridgeName);
 
         _canBridgeFirewall = canBridgeFirewall(_pifs.get("public"));
 
-        _localGateway = Script.runSimpleBashScript("ip route |grep default|awk '{print $3}'");
+        _localGateway = Script.runSimpleBashScript("ip route show default 0.0.0.0/0|head -1|awk '{print $3}'");
         if (_localGateway == null) {
-            s_logger.debug("Failed to found the local gateway");
+            s_logger.warn("No default IPv4 gateway found");
         }
 
         _mountPoint = (String)params.get("mount.path");


### PR DESCRIPTION
If a host has many routes this can be a magnitude faster then printing
all the routes and grepping for the default.

In some situations the host might have a large amount of routes due to
dynamic routing being used like OSPF or BGP.

In addition fix a couple of loglines which were throwing messages on
DEBUG while WARN and ERROR should be used there.

Signed-off-by: Wido den Hollander <wido@widodh.nl>

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
