### PR TITLE
Add resource UUID instead of resource id in resourcedetails api (#2527)

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -153,7 +153,6 @@ import com.cloud.api.query.vo.UserAccountJoinVO;
 import com.cloud.api.query.vo.UserVmJoinVO;
 import com.cloud.api.query.vo.VolumeJoinVO;
 import com.cloud.dc.DedicatedResourceVO;
-import com.cloud.dc.dao.DataCenterDetailsDao;
 import com.cloud.dc.dao.DedicatedResourceDao;
 import com.cloud.domain.Domain;
 import com.cloud.domain.DomainVO;
@@ -205,6 +204,7 @@ import com.cloud.utils.DateUtil;
 import com.cloud.utils.Pair;
 import com.cloud.utils.StringUtils;
 import com.cloud.utils.Ternary;
+import com.cloud.utils.db.EntityManager;
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.JoinBuilder;
 import com.cloud.utils.db.SearchBuilder;
@@ -330,7 +330,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
     private DomainRouterDao _routerDao;
 
     @Inject
-    UserVmDetailsDao _userVmDetailDao;
+    private UserVmDetailsDao _userVmDetailDao;
 
     @Inject
     private HighAvailabilityManager _haMgr;
@@ -342,7 +342,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
     private TemplateJoinDao _templateJoinDao;
 
     @Inject
-    ResourceManager _resourceMgr;
+    private ResourceManager _resourceMgr;
     @Inject
     private ResourceMetaDataService _resourceMetaDataMgr;
 
@@ -350,7 +350,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
     private TaggedResourceService _taggedResourceMgr;
 
     @Inject
-    AffinityGroupVMMapDao _affinityGroupVMMapDao;
+    private AffinityGroupVMMapDao _affinityGroupVMMapDao;
 
     @Inject
     private AffinityGroupJoinDao _affinityGroupJoinDao;
@@ -359,22 +359,22 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
     private DedicatedResourceDao _dedicatedDao;
 
     @Inject
-    DataCenterDetailsDao _dcDetailsDao;
+    private DomainManager _domainMgr;
 
     @Inject
-    DomainManager _domainMgr;
+    private AffinityGroupDomainMapDao _affinityGroupDomainMapDao;
 
     @Inject
-    AffinityGroupDomainMapDao _affinityGroupDomainMapDao;
+    private NetworkDetailsDao _networkDetailsDao;
 
     @Inject
-    NetworkDetailsDao _networkDetailsDao;
+    private ResourceTagDao _resourceTagDao;
 
     @Inject
-    ResourceTagDao _resourceTagDao;
+    private DataStoreManager dataStoreManager;
 
     @Inject
-    DataStoreManager dataStoreManager;
+    private EntityManager _entityMgr;
 
     /*
      * (non-Javadoc)
@@ -3674,7 +3674,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
 
     protected ResourceDetailResponse createResourceDetailsResponse(ResourceDetail requestedDetail, ResourceTag.ResourceObjectType resourceType) {
         ResourceDetailResponse resourceDetailResponse = new ResourceDetailResponse();
-        resourceDetailResponse.setResourceId(String.valueOf(requestedDetail.getResourceId()));
+        resourceDetailResponse.setResourceId(_taggedResourceMgr.getUuid(String.valueOf(requestedDetail.getResourceId()), resourceType));
         resourceDetailResponse.setName(requestedDetail.getName());
         resourceDetailResponse.setValue(requestedDetail.getValue());
         resourceDetailResponse.setForDisplay(requestedDetail.isDisplay());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
List resourcedetails was adding DB ID instead of UUID. This is a security risk and needs fix.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #2527 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Manually added a resource detail for uservm and verified output has uuid and not db id.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
