### PR TITLE
kvm: Set amount of queues for Virtio SCSI driver to vCPU of Instance

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2214,7 +2214,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         // If we're using virtio scsi, then we need to add a virtual scsi controller
         if (busT == DiskDef.DiskBus.SCSI) {
-            final SCSIDef sd = new SCSIDef((short)0, 0, 0, 9, 0);
+            final SCSIDef sd = new SCSIDef((short)0, 0, 0, 9, 0, vcpus);
             devices.addDevice(sd);
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1501,13 +1501,15 @@ public class LibvirtVMDef {
         private int bus = 0;
         private int slot = 9;
         private int function = 0;
+        private int queues = 0;
 
-        public SCSIDef(short index, int domain, int bus, int slot, int function) {
+        public SCSIDef(short index, int domain, int bus, int slot, int function, int queues) {
             this.index = index;
             this.domain = domain;
             this.bus = bus;
             this.slot = slot;
             this.function = function;
+            this.queues = queues;
         }
 
         public SCSIDef() {
@@ -1518,9 +1520,12 @@ public class LibvirtVMDef {
         public String toString() {
             StringBuilder scsiBuilder = new StringBuilder();
 
-            scsiBuilder.append(String.format("<controller type='scsi' index='%d' model='virtio-scsi'>\n", this.index ));
+            scsiBuilder.append(String.format("<controller type='scsi' index='%d' model='virtio-scsi'>\n", this.index));
             scsiBuilder.append(String.format("<address type='pci' domain='0x%04X' bus='0x%02X' slot='0x%02X' function='0x%01X'/>\n",
                     this.domain, this.bus, this.slot, this.function ) );
+            if (this.queues > 0) {
+                scsiBuilder.append(String.format("<driver queues='%d'/>\n", this.queues));
+            }
             scsiBuilder.append("</controller>\n");
             return scsiBuilder.toString();
         }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
@@ -196,10 +196,11 @@ public class LibvirtVMDefTest extends TestCase {
     }
 
     public void testSCSIDef() {
-        SCSIDef def = new SCSIDef();
+        SCSIDef def = new SCSIDef((short)0, 0, 0, 9, 0, 4);
         String str = def.toString();
         String expected = "<controller type='scsi' index='0' model='virtio-scsi'>\n" +
                 "<address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>\n" +
+                "<driver queues='4'/>\n" +
                 "</controller>\n";
         assertEquals(str, expected);
     }


### PR DESCRIPTION
## Description
The additional queues can enhance the performance of the VirtIO SCSI disk
and it is recommended to set this to the amount of vCPUs a Instance is assigned.

  The optional queues attribute specifies the number of queues for the
  controller. For best performance, it's recommended to specify a value matching
  the number of vCPUs. Since 1.0.5 (QEMU and KVM only)

Source: https://libvirt.org/formatdomain.html#elementsVirtio

## Types of changes
- [x] Enhancement (improves an existing feature and functionality)

## Screenshots (if appropriate):

## How Has This Been Tested?
Tested on local Cloud and Unit Tests have been extended.
