### PR TITLE
marvin: add missing test data for test_migration smoketest

### DIFF
--- a/test/integration/smoke/test_service_offerings.py
+++ b/test/integration/smoke/test_service_offerings.py
@@ -31,7 +31,7 @@ from marvin.lib.common import (list_service_offering,
                                list_virtual_machines,
                                get_domain,
                                get_zone,
-                               get_template,
+                               get_test_template,
                                list_hosts)
 from nose.plugins.attrib import attr
 
@@ -167,13 +167,13 @@ class TestServiceOfferings(cloudstackTestCase):
             cls.apiclient,
             cls.services["service_offerings"]["tiny"]
         )
-        template = get_template(
+        template = get_test_template(
             cls.apiclient,
             cls.zone.id,
             cls.hypervisor
         )
         if template == FAILED:
-            assert False, "get_template() failed to return template"
+            assert False, "get_test_template() failed to return template"
 
         # Set Zones and disk offerings
         cls.services["small"]["zoneid"] = cls.zone.id
@@ -458,9 +458,9 @@ class TestCpuCapServiceOfferings(cloudstackTestCase):
         cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
         cls.services['mode'] = cls.zone.networktype
 
-        template = get_template(cls.apiclient, cls.zone.id, cls.hypervisor)
+        template = get_test_template(cls.apiclient, cls.zone.id, cls.hypervisor)
         if template == FAILED:
-            assert False, "get_template() failed to return template"
+            assert False, "get_test_template() failed to return template"
 
         cls.services["small"]["zoneid"] = cls.zone.id
         cls.services["small"]["template"] = template.id

--- a/tools/marvin/marvin/config/test_data.py
+++ b/tools/marvin/marvin/config/test_data.py
@@ -644,6 +644,26 @@ test_data = {
             "Lb": "VpcVirtualRouter"
         }
     },
+    "nw_offering_reduced_vpc": {
+        "name": 'Reduced Network for VPC',
+        "displaytext": 'Reduced Network for VPC',
+        "guestiptype": 'Isolated',
+        "supportedservices": 'Dhcp,StaticNat,SourceNat,NetworkACL,UserData,'
+                             'Dns',
+        "traffictype": 'GUEST',
+        "availability": 'Optional',
+        "tags": "native",
+        "useVpc": 'on',
+        "ispersistent": 'True',
+        "serviceProviderList": {
+            "Dhcp": "VpcVirtualRouter",
+            "StaticNat": "VpcVirtualRouter",
+            "SourceNat": "VpcVirtualRouter",
+            "NetworkACL": "VpcVirtualRouter",
+            "UserData": "VpcVirtualRouter",
+            "Dns": "VpcVirtualRouter"
+        }
+    },
     "nw_off_persistent_VPCVR_LB": {
         "name": "Persistent Network VPC with LB",
         "displaytext": "Persistent Network VPC No LB",


### PR DESCRIPTION
Adds missing test data for test/integration/smoke/test_migration.py

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

This is fixed in Trillian codebase but not in cloudstack's test_data.py. Test run result:
```
=== TestName: test_01_native_to_native_network_migration | Status : SUCCESS ===

=== TestName: test_02_native_to_native_vpc_migration | Status : SUCCESS ===

===final results are now copied to: /tmp//MarvinLogs/test_migration_3B7NX2===
```