### PR TITLE
Add back ability to disable backup of snapshot to secondary

### DIFF
--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotInfo.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotInfo.java
@@ -17,6 +17,7 @@
 package org.apache.cloudstack.engine.subsystem.api.storage;
 
 import com.cloud.storage.Snapshot;
+import com.cloud.utils.exception.CloudRuntimeException;
 
 public interface SnapshotInfo extends DataObject, Snapshot {
     SnapshotInfo getParent();
@@ -43,5 +44,5 @@ public interface SnapshotInfo extends DataObject, Snapshot {
 
     long getPhysicalSize();
 
-    boolean markBackedUp();
+    void markBackedUp() throws CloudRuntimeException;
 }

--- a/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotInfo.java
+++ b/engine/api/src/org/apache/cloudstack/engine/subsystem/api/storage/SnapshotInfo.java
@@ -42,4 +42,6 @@ public interface SnapshotInfo extends DataObject, Snapshot {
     boolean isRevertable();
 
     long getPhysicalSize();
+
+    boolean markBackedUp();
 }

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
@@ -150,6 +150,17 @@ public class SnapshotObject implements SnapshotInfo {
     }
 
     @Override
+    public boolean markBackedUp() {
+        try {
+            processEvent(Event.OperationNotPerformed);
+        } catch (NoTransitionException ex) {
+            s_logger.error("no transition error: ", ex);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public VolumeInfo getBaseVolume() {
         return volFactory.getVolume(snapshot.getVolumeId());
     }

--- a/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
+++ b/engine/storage/snapshot/src/org/apache/cloudstack/storage/snapshot/SnapshotObject.java
@@ -150,14 +150,14 @@ public class SnapshotObject implements SnapshotInfo {
     }
 
     @Override
-    public boolean markBackedUp() {
+    public void markBackedUp() throws CloudRuntimeException{
         try {
             processEvent(Event.OperationNotPerformed);
         } catch (NoTransitionException ex) {
             s_logger.error("no transition error: ", ex);
-            return false;
+            throw new CloudRuntimeException("Error marking snapshot backed up: " +
+                    this.snapshot.getId() + " " + ex.getMessage());
         }
-        return true;
     }
 
     @Override

--- a/server/src/com/cloud/storage/snapshot/SnapshotManager.java
+++ b/server/src/com/cloud/storage/snapshot/SnapshotManager.java
@@ -56,6 +56,9 @@ public interface SnapshotManager extends Configurable {
     public static final ConfigKey<Integer> BackupRetryInterval = new ConfigKey<Integer>(Integer.class, "backup.retry.interval", "Advanced", "300",
             "Time in seconds between retries in backing up snapshot to secondary", false, ConfigKey.Scope.Global, null);
 
+    public static final ConfigKey<Boolean> BackupSnapshotAfterTakingSnapshot = new ConfigKey<Boolean>(Boolean.class, "snapshot.backup.to.secondary",  "Snapshots", "true",
+            "Indicates whether to always backup primary storage snapshot to secondary storage", false, ConfigKey.Scope.Global, null);
+
     void deletePoliciesForVolume(Long volumeId);
 
     /**


### PR DESCRIPTION
## Description
The snapshot.backup.rightafter configuration variable was removed by:

SHA: 6bb0ca2f854

This adds it back, though named snapshot.backup.to.secondary now instead.

This global parameter, once set, will allow you to prevent automatic backups of
     snapshots to secondary storage, unless they're actually needed.

Fixes #3096


<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
tested this in our 4.11 lab environment

