### PR TITLE
keystore: don't restart systemvm cloud.service post cert import

### DIFF
--- a/scripts/util/keystore-cert-import
+++ b/scripts/util/keystore-cert-import
@@ -41,6 +41,12 @@ fi
 # Use a new keystore file
 NEW_KS_FILE="$KS_FILE.new"
 
+# Check/store old KS state
+OLD_KS_FILE_EXISTS=false
+if [ -f $KS_FILE ]; then
+    OLD_KS_FILE_EXISTS=true
+fi
+
 # Import certificate
 if [ ! -z "${CERT// }" ]; then
     echo "$CERT" > "$CERT_FILE"
@@ -98,11 +104,10 @@ if [ -f "$SYSTEM_FILE" ]; then
     chmod 755 /usr/local/share/ca-certificates/cloudstack
     chmod 644 /usr/local/share/ca-certificates/cloudstack/ca.crt
     update-ca-certificates > /dev/null 2>&1 || true
-fi
-
-# Restart cloud service if we're in systemvm
-if [ "$MODE" == "ssh" ] && [ -f $SYSTEM_FILE ]; then
-    systemctl restart cloud > /dev/null 2>&1
+    # Restart cloud service if keystore was changed
+    if [ "$MODE" == "ssh" ] && $OLD_KS_FILE_EXISTS; then
+        systemctl restart cloud > /dev/null 2>&1
+    fi
 fi
 
 # Fix file permission

--- a/scripts/util/keystore-cert-import
+++ b/scripts/util/keystore-cert-import
@@ -41,12 +41,6 @@ fi
 # Use a new keystore file
 NEW_KS_FILE="$KS_FILE.new"
 
-# Check/store old KS state
-OLD_KS_FILE_EXISTS=false
-if [ -f $KS_FILE ]; then
-    OLD_KS_FILE_EXISTS=true
-fi
-
 # Import certificate
 if [ ! -z "${CERT// }" ]; then
     echo "$CERT" > "$CERT_FILE"
@@ -104,10 +98,6 @@ if [ -f "$SYSTEM_FILE" ]; then
     chmod 755 /usr/local/share/ca-certificates/cloudstack
     chmod 644 /usr/local/share/ca-certificates/cloudstack/ca.crt
     update-ca-certificates > /dev/null 2>&1 || true
-    # Restart cloud service if keystore was changed
-    if [ "$MODE" == "ssh" ] && $OLD_KS_FILE_EXISTS; then
-        systemctl restart cloud > /dev/null 2>&1
-    fi
 fi
 
 # Fix file permission


### PR DESCRIPTION
This ensures that the systemvm agent (cloud.service) is not restarted
on certificate import. The agent has an inbuilt logic to attempt reconnection.
If the old certificates/keystore is invalid agent will attempt reconnection.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?

Deployed a CPU-bound environment (hypervisor host with limited CPU and 1core), saw that previously irrespective of keystore setup the restart logic would cause agent to restart (sig.kill is the reason seen in logs) and on management server side it would seem agent connects, then disconnects, then connects and is finally in `Up` state. With this fix, the reconnection attempt won't be observed on the management server side. The agent will keep attempting reconnection when certificates are invalid, the cert import script does not need to restart cloud service manually.