### PR TITLE
NioConnection: When packet is incomplete, ask selector to read again

### DIFF
--- a/utils/src/main/java/com/cloud/utils/nio/NioConnection.java
+++ b/utils/src/main/java/com/cloud/utils/nio/NioConnection.java
@@ -273,6 +273,7 @@ public abstract class NioConnection implements Callable<Boolean> {
             }
             final byte[] data = link.read(socketChannel);
             if (data == null) {
+                key.interestOps(SelectionKey.OP_READ);
                 if (s_logger.isTraceEnabled()) {
                     s_logger.trace("Packet is incomplete.  Waiting for more.");
                 }


### PR DESCRIPTION
In CPU bound environments, it is observed that the ssvm/cpvm agent
connect to the management server then go into Alert state. From trace
logs it is seen that it thinks that packet is incomplete. It was further
observed that if any client would connect to management server's port
8250 it would kick the previous (stuck) connections and the agent would
go into Up state.

This is an experimental fix which would force selector to try reading
again when it thinks that packet is incomplete on reading.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)