### PR TITLE
ipv6: Do not allow Secondary IPv6 addresses to be EUI-64

### DIFF
--- a/server/src/main/java/com/cloud/network/Ipv6AddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/Ipv6AddressManagerImpl.java
@@ -104,6 +104,11 @@ public class Ipv6AddressManagerImpl extends ManagerBase implements Ipv6AddressMa
                     network.getDataCenterId());
         }
 
+        if (NetUtils.isIPv6EUI64(requestedIpv6)) {
+            throw new InsufficientAddressCapacityException(String.format("Requested IPv6 address [%s] may not be a EUI-64 address", requestedIpv6), DataCenter.class,
+                    network.getDataCenterId());
+        }
+
         checkIfCanAllocateIpv6Address(network, requestedIpv6);
 
         IpAddresses requestedIpPair = new IpAddresses(null, requestedIpv6);

--- a/server/src/test/java/com/cloud/network/Ipv6AddressManagerTest.java
+++ b/server/src/test/java/com/cloud/network/Ipv6AddressManagerTest.java
@@ -248,4 +248,11 @@ public class Ipv6AddressManagerTest {
 
         Assert.assertEquals(expected, nic.getIPv6Address());
     }
+
+    @Test(expected = InsufficientAddressCapacityException.class)
+    public void acquireGuestIpv6AddressEUI64Test() throws InsufficientAddressCapacityException {
+        setAcquireGuestIpv6AddressTest(true, State.Free);
+        String requestedIpv6 = setCheckIfCanAllocateIpv6AddresscTest("2001:db8:13f::1c00:4aff:fe00:fe", false, false);
+        ip6Manager.acquireGuestIpv6Address(network, requestedIpv6);
+    }
 }

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -88,6 +88,10 @@ public class NetUtils {
     private final static Random s_rand = new Random(System.currentTimeMillis());
     private final static long prefix = 0x1e;
 
+    // RFC4291 IPv6 EUI-64
+    public final static int IPV6_EUI64_11TH_BYTE = -1;
+    public final static int IPV6_EUI64_12TH_BYTE = -2;
+
     public static long createSequenceBasedMacAddress(final long macAddress, long globalConfig) {
         /*
             Logic for generating MAC address:
@@ -1580,6 +1584,29 @@ public class NetUtils {
 
     public static IPv6Address ipv6LinkLocal(final String macAddress) {
         return EUI64Address(IPv6Network.LINK_LOCAL_NETWORK, macAddress);
+    }
+
+    /**
+     * When using StateLess Address AutoConfiguration (SLAAC) for IPv6 the addresses
+     * choosen by hosts in a network are based on the 48-bit MAC address and this is expanded to 64-bits
+     * with EUI-64
+     * FFFE is inserted into the address and these can be identified
+     *
+     * By converting the IPv6 Address to a byte array we can check the 11th and 12th byte to see if the
+     * address is EUI064.
+     *
+     * See RFC4291 for more information
+     *
+     * @param address IPv6Address to be checked
+     * @return True if Address is EUI-64 IPv6
+     */
+    public static boolean isIPv6EUI64(final IPv6Address address) {
+        byte[] bytes = address.toByteArray();
+        return (bytes[11] == IPV6_EUI64_11TH_BYTE && bytes[12] == IPV6_EUI64_12TH_BYTE);
+    }
+
+    public static boolean isIPv6EUI64(final String address) {
+        return NetUtils.isIPv6EUI64(IPv6Address.fromString(address));
     }
 
     /**

--- a/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -701,4 +701,12 @@ public class NetUtilsTest {
             assertTrue(NetUtils.getAllDefaultNicIps().stream().anyMatch(defaultHostIp::contains));
         }
     }
+
+    @Test
+    public void testIsIPv6EUI64() {
+        assertTrue(NetUtils.isIPv6EUI64("fe80::5054:8fff:fe9f:af61"));
+        assertTrue(NetUtils.isIPv6EUI64("2a00:f10:305:0:464:64ff:fe00:4e0"));
+        assertFalse(NetUtils.isIPv6EUI64("2001:db8::100:1"));
+        assertFalse(NetUtils.isIPv6EUI64("2a01:4f9:2a:185f::2"));
+    }
 }


### PR DESCRIPTION
## Description
When requesting a secondary IPv6 address the address specified by the requester should not be a EUI-64 (SLAAC) address.

This can be seen by looking at *ff:fe* which is always in the same position in a IPv6 address when using SLAAC/EUI-64.

<pre>2001:db8:13f:0:1c00:4aff:fe00:fe</pre>

That is an IPv6 EUI-64 address for example.

See: https://community.cisco.com/t5/networking-documents/understanding-ipv6-eui-64-bit-address/ta-p/3116953

  Extended Unique Identifier (EUI), as per RFC2373, allows a host to assign iteslf a unique 64-Bit IP 
  Version 6 interface identifier (EUI-64). This feature is a key benefit over IPv4 as it eliminates the need of manual configuration or DHCP as in the world of IPv4. The IPv6 EUI-64 format address is obtained 
  through the 48-bit MAC address. The MAC address is first separated into two 24-bits, with one being 
  OUI (Organizationally Unique Identifier) and the other being NIC specific. The 16-bit 0xFFFE is then 
  inserted between these two 24-bits for the 64-bit EUI address. IEEE has chosen FFFE as a reserved 
  value which can only appear in EUI-64 generated from the an EUI-48 MAC address.


![image](https://user-images.githubusercontent.com/326786/51250495-d4f31500-1996-11e9-85e4-1c2049851206.png)


## Types of changes
- [ ] Enhancement (improves an existing feature and functionality)

## How Has This Been Tested?
Tested this locally
