### PR TITLE
Fix some LGTM alerts

### DIFF
--- a/api/src/main/java/com/cloud/deploy/DeployDestination.java
+++ b/api/src/main/java/com/cloud/deploy/DeployDestination.java
@@ -78,6 +78,10 @@ public class DeployDestination implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        if (!(obj instanceof DeployDestination))
+            return false;
         DeployDestination that = (DeployDestination)obj;
         if (_dc == null || that._dc == null) {
             return false;

--- a/api/src/main/java/com/cloud/deploy/DeployDestination.java
+++ b/api/src/main/java/com/cloud/deploy/DeployDestination.java
@@ -78,33 +78,35 @@ public class DeployDestination implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null)
+        if (obj == null) {
             return false;
-        if (!(obj instanceof DeployDestination))
+        }
+        if (!(obj instanceof DeployDestination)) {
             return false;
+        }
         DeployDestination that = (DeployDestination)obj;
-        if (_dc == null || that._dc == null) {
+        if (this._dc == null || that._dc == null) {
             return false;
         }
-        if (_dc.getId() != that._dc.getId()) {
+        if (this._dc.getId() != that._dc.getId()) {
             return false;
         }
-        if (_pod == null || that._pod == null) {
+        if (this._pod == null || that._pod == null) {
             return false;
         }
-        if (_pod.getId() != that._pod.getId()) {
+        if (this._pod.getId() != that._pod.getId()) {
             return false;
         }
-        if (_cluster == null || that._cluster == null) {
+        if (this._cluster == null || that._cluster == null) {
             return false;
         }
-        if (_cluster.getId() != that._cluster.getId()) {
+        if (this._cluster.getId() != that._cluster.getId()) {
             return false;
         }
-        if (_host == null || that._host == null) {
+        if (this._host == null || that._host == null) {
             return false;
         }
-        return _host.getId() == that._host.getId();
+        return this._host.getId() == that._host.getId();
     }
 
     @Override

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -780,7 +780,7 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
                         }
 
                         final int devId = vmNic.getDeviceId();
-                        if (devId > deviceIds.length) {
+                        if (devId >= deviceIds.length) {
                             throw new IllegalArgumentException("Device id for nic is too large: " + vmNic);
                         }
                         if (deviceIds[devId]) {

--- a/plugins/hypervisors/hyperv/src/main/java/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
+++ b/plugins/hypervisors/hyperv/src/main/java/com/cloud/hypervisor/hyperv/resource/HypervDirectConnectResource.java
@@ -439,50 +439,10 @@ public class HypervDirectConnectResource extends ServerResourceBase implements S
             return _vrResource.executeRequest((NetworkElementCommand)cmd);
         }if (clazz == CheckSshCommand.class) {
             answer = execute((CheckSshCommand)cmd);
-        } else if (clazz == GetDomRVersionCmd.class) {
-            answer = execute((GetDomRVersionCmd)cmd);
         } else if (cmd instanceof NetworkUsageCommand) {
             answer = execute((NetworkUsageCommand)cmd);
-        } else if (clazz == IpAssocCommand.class) {
-            answer = execute((IpAssocCommand)cmd);
-        } else if (clazz == DnsMasqConfigCommand.class) {
-            return execute((DnsMasqConfigCommand)cmd);
-        } else if (clazz == CreateIpAliasCommand.class) {
-            return execute((CreateIpAliasCommand)cmd);
-        } else if (clazz == DhcpEntryCommand.class) {
-            answer = execute((DhcpEntryCommand)cmd);
-        } else if (clazz == VmDataCommand.class) {
-            answer = execute((VmDataCommand)cmd);
-        } else if (clazz == SavePasswordCommand.class) {
-            answer = execute((SavePasswordCommand)cmd);
-        } else if (clazz == SetFirewallRulesCommand.class) {
-            answer = execute((SetFirewallRulesCommand)cmd);
-        } else if (clazz == LoadBalancerConfigCommand.class) {
-            answer = execute((LoadBalancerConfigCommand)cmd);
-        } else if (clazz == DeleteIpAliasCommand.class) {
-            return execute((DeleteIpAliasCommand)cmd);
         } else if (clazz == PingTestCommand.class) {
             answer = execute((PingTestCommand)cmd);
-        } else if (clazz == SetStaticNatRulesCommand.class) {
-            answer = execute((SetStaticNatRulesCommand)cmd);
-        } else if (clazz == CheckRouterCommand.class) {
-            answer = execute((CheckRouterCommand)cmd);
-        } else if (clazz == SetPortForwardingRulesCommand.class) {
-            answer = execute((SetPortForwardingRulesCommand)cmd);
-        } else if (clazz == SetSourceNatCommand.class) {
-            answer = execute((SetSourceNatCommand)cmd);
-        } else if (clazz == Site2SiteVpnCfgCommand.class) {
-            answer = execute((Site2SiteVpnCfgCommand)cmd);
-        } else if (clazz == CheckS2SVpnConnectionsCommand.class) {
-            answer = execute((CheckS2SVpnConnectionsCommand) cmd);
-        } else if (clazz == RemoteAccessVpnCfgCommand.class) {
-            answer = execute((RemoteAccessVpnCfgCommand) cmd);
-        } else if (clazz == VpnUsersCfgCommand.class) {
-            answer = execute((VpnUsersCfgCommand) cmd);
-        } else if (clazz == SetStaticRouteCommand.class) {
-            answer = execute((SetStaticRouteCommand) cmd);
-        } else if (clazz == SetMonitorServiceCommand.class) {
-            answer = execute((SetMonitorServiceCommand) cmd);
         } else if (clazz == PlugNicCommand.class) {
             answer = execute((PlugNicCommand)cmd);
         } else if (clazz == UnPlugNicCommand.class) {

--- a/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorResource.java
+++ b/plugins/hypervisors/ovm3/src/main/java/com/cloud/hypervisor/ovm3/resources/Ovm3HypervisorResource.java
@@ -27,8 +27,6 @@ import javax.naming.ConfigurationException;
 import org.apache.cloudstack.storage.command.AttachCommand;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.CreateObjectCommand;
-import org.apache.cloudstack.storage.command.DeleteCommand;
-import org.apache.cloudstack.storage.command.DettachCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
 import org.apache.log4j.Logger;
 
@@ -195,18 +193,12 @@ public class Ovm3HypervisorResource extends ServerResourceBase implements Hyperv
             return storageprocessor.execute((CopyCommand)cmd);
         } else if (cmd instanceof StorageSubSystemCommand) {
             return storageHandler.handleStorageCommands((StorageSubSystemCommand)cmd);
-        } else if (clazz == DeleteCommand.class) {
-            return storageprocessor.execute((DeleteCommand)cmd);
         } else if (clazz == CreateCommand.class) {
             return storageprocessor.execute((CreateCommand)cmd);
         } else if (clazz == CreateObjectCommand.class) {
             return storageprocessor.execute((CreateObjectCommand)cmd);
         } else if (clazz == AttachIsoCommand.class) {
             return storageprocessor.attachIso((AttachCommand)cmd);
-        } else if (clazz == DettachCommand.class) {
-            return storageprocessor.execute((DettachCommand)cmd);
-        } else if (clazz == AttachCommand.class) {
-            return storageprocessor.execute((AttachCommand)cmd);
         } else if (clazz == CreatePrivateTemplateFromVolumeCommand.class) {
             return storageprocessor.execute((CreatePrivateTemplateFromVolumeCommand)cmd);
         } else if (clazz == DestroyCommand.class) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -980,7 +980,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 endIp.add(((existingPodIpRange.length > 1) && (existingPodIpRange[1] != null)) ? existingPodIpRange[1] : "");
                 forSystemVms.add((existingPodIpRange.length > 2) && (existingPodIpRange[2] != null) ? existingPodIpRange[2] : "0");
                 vlanIds.add((existingPodIpRange.length > 3) &&
-                        (existingPodIpRange[3] != null && !existingPodIpRange.equals("untagged")) ?
+                        (existingPodIpRange[3] != null && !existingPodIpRange[3].equals("untagged")) ?
                         BroadcastDomainType.Vlan.toUri(existingPodIpRange[3]).toString() :
                         BroadcastDomainType.Vlan.toUri(Vlan.UNTAGGED).toString());
             }

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -74,14 +74,10 @@ import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.auth.APIAuthenticationManager;
-import org.apache.cloudstack.api.command.admin.account.ListAccountsCmdByAdmin;
 import org.apache.cloudstack.api.command.admin.host.ListHostsCmd;
 import org.apache.cloudstack.api.command.admin.router.ListRoutersCmd;
 import org.apache.cloudstack.api.command.admin.storage.ListStoragePoolsCmd;
 import org.apache.cloudstack.api.command.admin.user.ListUsersCmd;
-import org.apache.cloudstack.api.command.admin.vm.ListVMsCmdByAdmin;
-import org.apache.cloudstack.api.command.admin.volume.ListVolumesCmdByAdmin;
-import org.apache.cloudstack.api.command.admin.zone.ListZonesCmdByAdmin;
 import org.apache.cloudstack.api.command.user.account.ListAccountsCmd;
 import org.apache.cloudstack.api.command.user.account.ListProjectAccountsCmd;
 import org.apache.cloudstack.api.command.user.event.ListEventsCmd;
@@ -732,14 +728,13 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             // if the command is of the listXXXCommand, we will need to also return the
             // the job id and status if possible
             // For those listXXXCommand which we have already created DB views, this step is not needed since async job is joined in their db views.
-            if (cmdObj instanceof BaseListCmd && !(cmdObj instanceof ListVMsCmd) && !(cmdObj instanceof ListVMsCmdByAdmin) && !(cmdObj instanceof ListRoutersCmd)
+            if (cmdObj instanceof BaseListCmd && !(cmdObj instanceof ListVMsCmd) && !(cmdObj instanceof ListRoutersCmd)
                     && !(cmdObj instanceof ListSecurityGroupsCmd) &&
                     !(cmdObj instanceof ListTagsCmd) && !(cmdObj instanceof ListEventsCmd) && !(cmdObj instanceof ListVMGroupsCmd) && !(cmdObj instanceof ListProjectsCmd) &&
                     !(cmdObj instanceof ListProjectAccountsCmd) && !(cmdObj instanceof ListProjectInvitationsCmd) && !(cmdObj instanceof ListHostsCmd) &&
-                    !(cmdObj instanceof ListVolumesCmd) && !(cmdObj instanceof ListVolumesCmdByAdmin) && !(cmdObj instanceof ListUsersCmd) && !(cmdObj instanceof ListAccountsCmd)
-                    && !(cmdObj instanceof ListAccountsCmdByAdmin) &&
-                    !(cmdObj instanceof ListStoragePoolsCmd) && !(cmdObj instanceof ListDiskOfferingsCmd) && !(cmdObj instanceof ListServiceOfferingsCmd) &&
-                    !(cmdObj instanceof ListZonesCmd) && !(cmdObj instanceof ListZonesCmdByAdmin)) {
+                    !(cmdObj instanceof ListVolumesCmd) && !(cmdObj instanceof ListUsersCmd) && !(cmdObj instanceof ListAccountsCmd)
+                    && !(cmdObj instanceof ListStoragePoolsCmd) && !(cmdObj instanceof ListDiskOfferingsCmd) && !(cmdObj instanceof ListServiceOfferingsCmd) &&
+                    !(cmdObj instanceof ListZonesCmd)) {
                 buildAsyncListResponse((BaseListCmd)cmdObj, caller);
             }
 


### PR DESCRIPTION
## Description
LGTM has raised a number of alerts from analysis of apache/cloudstack (https://lgtm.com/projects/g/apache/cloudstack/alerts/?mode=tree).
This pull request is to fix some of the problems raised. Specifically,
- 2 `Array index out of bounds` errors in NetworkOrchestrator
- 1 `Equals method does not inspect argument type` in DeployDestination
- 1 `Equals on incomparable types` in ApiResponseHelper
- 28 `Contradictory type checks` in ApiServer, HypervDirectConnectResource and Ovm3HypervisorResource

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


