### PR TITLE
Fix UI bug: Create Network Offering Popup has no fields

### DIFF
--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -3001,9 +3001,9 @@
                                                                                 });
                                                                             }
                                                                         } else { //canenableindividualservice == true
-                                                                            if ($thisProviderDropdown.context.name in providerDropdownsForciblyChangedTogether) { //if this provider dropdown is one of provider dropdowns forcibly changed together earlier, make other forcibly changed provider dropdowns restore default option (i.e. 1st option in dropdown)
+                                                                            if (this.name in providerDropdownsForciblyChangedTogether) { //if this provider dropdown is one of provider dropdowns forcibly changed together earlier, make other forcibly changed provider dropdowns restore default option (i.e. 1st option in dropdown)
                                                                                 for (var key in providerDropdownsForciblyChangedTogether) {
-                                                                                    if (key == $thisProviderDropdown.context.name)
+                                                                                    if (key == this.name)
                                                                                         continue; //skip to next item in for loop
                                                                                     else
                                                                                         $("select[name='" + key + "'] option:first").attr("selected", "selected");


### PR DESCRIPTION
Upgrade to jquery 3.3.1: $('selector').context was deprecated,
and has been removed. See: https://api.jquery.com/context/

Fixes: #3148

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
