### PR TITLE
Keep iotune section in the VM's XML after live migration

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -352,7 +352,7 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
     //   * The value of the 'type' of the disk (ex. file, block)
     //   * The value of the 'type' of the driver of the disk (ex. qcow2, raw)
     //   * The source of the disk needs an attribute that is either 'file' or 'dev' as well as its corresponding value.
-    private String replaceStorage(String xmlDesc, Map<String, MigrateCommand.MigrateDiskInfo> migrateStorage)
+    protected String replaceStorage(String xmlDesc, Map<String, MigrateCommand.MigrateDiskInfo> migrateStorage)
             throws IOException, ParserConfigurationException, SAXException, TransformerException {
         InputStream in = IOUtils.toInputStream(xmlDesc);
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -411,8 +411,6 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
                                     diskNode.appendChild(newChildSourceNode);
                                 } else if ("auth".equals(diskChildNode.getNodeName())) {
                                     diskNode.removeChild(diskChildNode);
-                                } else if ("iotune".equals(diskChildNode.getNodeName())) {
-                                    diskNode.removeChild(diskChildNode);
                                 }
                             }
                         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtMigrateCommandWrapper.java
@@ -346,12 +346,16 @@ public final class LibvirtMigrateCommandWrapper extends CommandWrapper<MigrateCo
         return xmlDesc;
     }
 
-    // Pass in a list of the disks to update in the XML (xmlDesc). Each disk passed in needs to have a serial number. If any disk's serial number in the
-    // list does not match a disk in the XML, an exception should be thrown.
-    // In addition to the serial number, each disk in the list needs the following info:
-    //   * The value of the 'type' of the disk (ex. file, block)
-    //   * The value of the 'type' of the driver of the disk (ex. qcow2, raw)
-    //   * The source of the disk needs an attribute that is either 'file' or 'dev' as well as its corresponding value.
+    /**
+     * Pass in a list of the disks to update in the XML (xmlDesc). Each disk passed in needs to have a serial number. If any disk's serial number in the
+     * list does not match a disk in the XML, an exception should be thrown.
+     * In addition to the serial number, each disk in the list needs the following info:
+     * <ul>
+     *  <li>The value of the 'type' of the disk (ex. file, block)
+     *  <li>The value of the 'type' of the driver of the disk (ex. qcow2, raw)
+     *  <li>The source of the disk needs an attribute that is either 'file' or 'dev' as well as its corresponding value.
+     * </ul>
+     */
     protected String replaceStorage(String xmlDesc, Map<String, MigrateCommand.MigrateDiskInfo> migrateStorage)
             throws IOException, ParserConfigurationException, SAXException, TransformerException {
         InputStream in = IOUtils.toInputStream(xmlDesc);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When live migrating a KVM VM among local storages, the VM loses the
 `<iotune> ... </iotune>` section on its XML, therefore, having no IO limitations.

```
 <iotune>
    <read_iops_sec>5000</read_iops_sec>
    <write_iops_sec>5000</write_iops_sec>
</iotune>
```
This commit removes the piece of code that deletes the  `<iotune> ... </iotune>` section in the XML.

@rhtyd @mike-tutkowski @wido @DaanHoogland @nvazquez @kiwiflyer @rafaelweingartner do any of you guys know a reason for keeping the conditional that I removed? It looks like it can be removed without breaking anything.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
**Bug:**
- Start a VM running on KVM, with local storage and service offering limiting the VM's IOPS;
- verify that the VM's XML file contains `<iotune> ... </iotune>`;
- live migrate to another host (with local storage);
- verify that the `<iotune> ... </iotune>` section **has been removed** in the VM's XML;

**With the fix:**
- Start a VM running on KVM, with local storage and service offering limiting the VM's IOPS;
- verify that the VM's XML file contains `<iotune> ... </iotune>`;
- live migrate to another host (with local storage);
- verify that the `<iotune> ... </iotune>` section **stayed** in the VM's XML

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
