### PR TITLE
server: make snapshotting on KVM non-blocking

### DIFF
--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -126,6 +126,10 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
 
     @Override
     public Pair<Boolean, Long> getCommandHostDelegation(long hostId, Command cmd) {
+        if (cmd instanceof StorageSubSystemCommand) {
+            StorageSubSystemCommand c = (StorageSubSystemCommand)cmd;
+            c.setExecuteInSequence(false);
+        }
         if (cmd instanceof CopyCommand) {
             CopyCommand c = (CopyCommand) cmd;
             boolean inSeq = true;
@@ -140,10 +144,6 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
             if (c.getSrcTO().getHypervisorType() == HypervisorType.KVM) {
                 return new Pair<>(true, hostId);
             }
-        }
-        if (cmd instanceof StorageSubSystemCommand) {
-            StorageSubSystemCommand c = (StorageSubSystemCommand)cmd;
-            c.setExecuteInSequence(false);
         }
         return new Pair<>(false, hostId);
     }

--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -137,12 +137,15 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
                 inSeq = false;
             }
             c.setExecuteInSequence(inSeq);
+            if (c.getSrcTO().getHypervisorType() == HypervisorType.KVM) {
+                return new Pair<>(true, hostId);
+            }
         }
         if (cmd instanceof StorageSubSystemCommand) {
             StorageSubSystemCommand c = (StorageSubSystemCommand)cmd;
             c.setExecuteInSequence(false);
         }
-        return new Pair<Boolean, Long>(false, new Long(hostId));
+        return new Pair<>(false, hostId);
     }
 
     @Override


### PR DESCRIPTION
This references and uses an already fixed solution from
https://github.com/MissionCriticalCloud/cosmic/pull/68 to make
snapshotting on KVM non-blocking.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)