### PR TITLE
systemd: Fix -Dpid arg passing to systemd usage service

### DIFF
--- a/packaging/systemd/cloudstack-usage.default
+++ b/packaging/systemd/cloudstack-usage.default
@@ -15,8 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-JAVA_OPTS="-Dpid=$$ -Xms256m -Xmx2048m"
+JAVA_OPTS="-Xms256m -Xmx2048m"
 
 CLASSPATH="/usr/share/cloudstack-usage/*:/usr/share/cloudstack-usage/lib/*:/usr/share/cloudstack-mysql-ha/lib/*:/etc/cloudstack/usage:/usr/share/java/mysql-connector-java.jar"
 
 JAVA_CLASS=com.cloud.usage.UsageServer
+
+# Enable the following to enable remote socket based debugging:
+#JAVA_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=n"

--- a/packaging/systemd/cloudstack-usage.service
+++ b/packaging/systemd/cloudstack-usage.service
@@ -24,7 +24,8 @@ After=network.target network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/default/cloudstack-usage
-ExecStart=/usr/bin/java $JAVA_OPTS -cp $CLASSPATH $JAVA_CLASS
+Environment=JAVA_PID=$$
+ExecStart=/usr/bin/java -Dpid=$JAVA_PID $JAVA_OPTS $JAVA_DEBUG -cp $CLASSPATH $JAVA_CLASS
 Restart=always
 RestartSec=10s
 

--- a/packaging/systemd/cloudstack-usage.service
+++ b/packaging/systemd/cloudstack-usage.service
@@ -25,7 +25,7 @@ After=network.target network-online.target
 Type=simple
 EnvironmentFile=/etc/default/cloudstack-usage
 Environment=JAVA_PID=$$
-ExecStart=/usr/bin/java -Dpid=$JAVA_PID $JAVA_OPTS $JAVA_DEBUG -cp $CLASSPATH $JAVA_CLASS
+ExecStart=/bin/sh -ec '/usr/bin/java -Dpid=${JAVA_PID} $JAVA_OPTS $JAVA_DEBUG -cp $CLASSPATH $JAVA_CLASS'
 Restart=always
 RestartSec=10s
 

--- a/usage/src/com/cloud/usage/UsageServer.java
+++ b/usage/src/com/cloud/usage/UsageServer.java
@@ -51,11 +51,7 @@ public class UsageServer implements Daemon {
 
         appContext = new ClassPathXmlApplicationContext("usageApplicationContext.xml");
 
-        try {
-            ComponentContext.initComponentsLifeCycle();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        ComponentContext.initComponentsLifeCycle();
 
         mgr = appContext.getBean(UsageManager.class);
 


### PR DESCRIPTION
This fixes regression introduced by refactoring PR #3163 where `-Dpid`
was incorrectly passed string `$$` instead of parent PID integer.

Fixes #3203

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)