### PR TITLE
 storage: publish delete usage event for snapshot deletion

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/vmsnapshot/DefaultVMSnapshotStrategy.java
@@ -423,6 +423,12 @@ public class DefaultVMSnapshotStrategy extends ManagerBase implements VMSnapshot
             s_logger.debug("Failed to change vm snapshot state with event ExpungeRequested");
             throw new CloudRuntimeException("Failed to change vm snapshot state with event ExpungeRequested: " + e.getMessage());
         }
+        UserVm userVm = userVmDao.findById(vmSnapshot.getVmId());
+        List<VolumeObjectTO> volumeTOs = vmSnapshotHelper.getVolumeTOList(userVm.getId());
+        for (VolumeObjectTO volumeTo: volumeTOs) {
+            volumeTo.setSize(0);
+            publishUsageEvent(EventTypes.EVENT_VM_SNAPSHOT_DELETE, vmSnapshot, userVm, volumeTo);
+        }
         return vmSnapshotDao.remove(vmSnapshot.getId());
     }
 }


### PR DESCRIPTION
**Problem**: Users are billed for destroyed VMs with VM snapshots because usage records don't get that the VM and VM snapshots are removed.
**Root Cause**: The destroyVirtualMachine and expungeVirtualMachine APIs were removing VM snapshots but not generating VMSNAPSHOT.DELETE usage event due to which the VM snapshots were not marked as removed in the usage_vmsnapshot table.
**Solution**: The issue was fixed by emitting the proper usage event for all the VM snapshots of a VM that is destroyed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)