### PR TITLE
ui: use executable template filter for users

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -1024,7 +1024,7 @@
                                     label: 'label.select.a.template',
                                     select: function(args) {
                                         var data = {
-                                            templatefilter: 'featured'
+                                            templatefilter: 'executable'
                                         };
                                         $.ajax({
                                             url: createURL('listTemplates'),


### PR DESCRIPTION
**Problem**: When reinstalling a VM, the UI only shows featured templates and not all possible list of allowed templates.
**Root Cause**: The list of templates for reinstall used `featured` as filter in ‘listTemplates’ API which did not include all available options.
**Solution**: The issue is fixed by using the `executable` template filter of the ‘listTemplates’ API to list all
possible templates that a user is allowed to use to deploy a VM.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)