### PR TITLE
api: include tags in listvmsnapshots response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/VMSnapshotResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VMSnapshotResponse.java
@@ -18,18 +18,19 @@
 package org.apache.cloudstack.api.response;
 
 import java.util.Date;
-
-import com.google.gson.annotations.SerializedName;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseResponse;
+import org.apache.cloudstack.api.BaseResponseWithTagInformation;
 import org.apache.cloudstack.api.EntityReference;
 
 import com.cloud.serializer.Param;
 import com.cloud.vm.snapshot.VMSnapshot;
+import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = VMSnapshot.class)
-public class VMSnapshotResponse extends BaseResponse implements ControlledEntityResponse {
+public class VMSnapshotResponse extends BaseResponseWithTagInformation implements ControlledEntityResponse {
 
     @SerializedName(ApiConstants.ID)
     @Param(description = "the ID of the vm snapshot")
@@ -98,6 +99,10 @@ public class VMSnapshotResponse extends BaseResponse implements ControlledEntity
     @SerializedName(ApiConstants.DOMAIN)
     @Param(description = "the domain associated with the disk volume")
     private String domainName;
+
+    public VMSnapshotResponse() {
+        tags = new LinkedHashSet<ResourceTagResponse>();
+    }
 
     @Override
     public String getObjectId() {
@@ -226,6 +231,9 @@ public class VMSnapshotResponse extends BaseResponse implements ControlledEntity
     @Override
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
 
+    public void setTags(Set<ResourceTagResponse> tags) {
+        this.tags = tags;
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -619,6 +619,14 @@ public class ApiResponseHelper implements ResponseGenerator {
             vmSnapshotResponse.setDomainName(domain.getName());
         }
 
+        List<? extends ResourceTag> tags = _resourceTagDao.listBy(vmSnapshot.getId(), ResourceObjectType.VMSnapshot);
+        List<ResourceTagResponse> tagResponses = new ArrayList<ResourceTagResponse>();
+        for (ResourceTag tag : tags) {
+            ResourceTagResponse tagResponse = createResourceTagResponse(tag, false);
+            CollectionUtils.addIgnoreNull(tagResponses, tagResponse);
+        }
+        vmSnapshotResponse.setTags(new HashSet<>(tagResponses));
+
         vmSnapshotResponse.setCurrent(vmSnapshot.getCurrent());
         vmSnapshotResponse.setType(vmSnapshot.getType().toString());
         vmSnapshotResponse.setObjectName("vmsnapshot");


### PR DESCRIPTION
**Problem**: Tags of VM snapshots are not returned as part of the listVMSnapshots API and therefore was not shown in the UI.
**Root Cause**: The API response creator was not setting the tags in the API response.
**Solution**: The issue was fixed to return tags of a VM snapshot as part of the listVMSnapshots API response and now it is possible to list/add/remove tags using the UI. The tags are also included for VMSnapshot usage records in the listUsageRecords API response when `includetags=true` parameter is passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)