### PR TITLE
server: publish volume resize event for volumes

### DIFF
--- a/engine/schema/src/main/java/com/cloud/event/UsageEventVO.java
+++ b/engine/schema/src/main/java/com/cloud/event/UsageEventVO.java
@@ -70,7 +70,7 @@ public class UsageEventVO implements UsageEvent {
     private String resourceType;
 
     @Column(name = "processed")
-    boolean processed;
+    private boolean processed;
 
     @Column(name = "virtual_size")
     private Long virtualSize;

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -719,10 +719,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
         String userSpecifiedName = getVolumeNameFromCommand(cmd);
 
-        VolumeVO volume = commitVolume(cmd, caller, owner, displayVolume, zoneId, diskOfferingId, provisioningType, size, minIops, maxIops, parentVolume, userSpecifiedName,
+        return commitVolume(cmd, caller, owner, displayVolume, zoneId, diskOfferingId, provisioningType, size, minIops, maxIops, parentVolume, userSpecifiedName,
                 _uuidMgr.generateUuid(Volume.class, cmd.getCustomId()));
-
-        return volume;
     }
 
     private VolumeVO commitVolume(final CreateVolumeCmd cmd, final Account caller, final Account owner, final Boolean displayVolume, final Long zoneId, final Long diskOfferingId,
@@ -1044,6 +1042,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         // the requested change
 
         /* If this volume has never been beyond allocated state, short circuit everything and simply update the database. */
+        // We need to publish this event to usage_volume table
         if (volume.getState() == Volume.State.Allocated) {
             s_logger.debug("Volume is in the allocated state, but has never been created. Simply updating database with new size and IOPS.");
 
@@ -1057,7 +1056,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
 
             _volsDao.update(volume.getId(), volume);
-
+            UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VOLUME_RESIZE, volume.getAccountId(), volume.getDataCenterId(), volume.getId(), volume.getName(),
+                    volume.getDiskOfferingId(), volume.getTemplateId(), volume.getSize(), Volume.class.getName(), volume.getUuid());
             return volume;
         }
 
@@ -1134,7 +1134,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     private VolumeVO orchestrateResizeVolume(long volumeId, long currentSize, long newSize, Long newMinIops, Long newMaxIops, Integer newHypervisorSnapshotReserve, Long newDiskOfferingId,
             boolean shrinkOk) {
-        VolumeVO volume = _volsDao.findById(volumeId);
+        final VolumeVO volume = _volsDao.findById(volumeId);
         UserVmVO userVm = _userVmDao.findById(volume.getInstanceId());
         StoragePoolVO storagePool = _storagePoolDao.findById(volume.getPoolId());
         boolean isManaged = storagePool.isManaged();
@@ -1210,13 +1210,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                         volService.resizeVolumeOnHypervisor(volumeId, newSize, hosts[0], instanceName);
                     }
                 }
-
-                volume.setSize(newSize);
-
-                _volsDao.update(volume.getId(), volume);
             }
-
-            volume = _volsDao.findById(volume.getId());
 
             if (newDiskOfferingId != null) {
                 volume.setDiskOfferingId(newDiskOfferingId);
@@ -1230,20 +1224,18 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
             /* Update resource count for the account on primary storage resource */
             if (!shrinkOk) {
-                _resourceLimitMgr.incrementResourceCount(volume.getAccountId(), ResourceType.primary_storage, volume.isDisplayVolume(), new Long(newSize - currentSize));
+                _resourceLimitMgr.incrementResourceCount(volume.getAccountId(), ResourceType.primary_storage, volume.isDisplayVolume(), newSize - currentSize);
             } else {
-                _resourceLimitMgr.decrementResourceCount(volume.getAccountId(), ResourceType.primary_storage, volume.isDisplayVolume(), new Long(currentSize - newSize));
+                _resourceLimitMgr.decrementResourceCount(volume.getAccountId(), ResourceType.primary_storage, volume.isDisplayVolume(), currentSize - newSize);
             }
+
+            UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VOLUME_RESIZE, volume.getAccountId(), volume.getDataCenterId(), volume.getId(), volume.getName(),
+                    volume.getDiskOfferingId(), volume.getTemplateId(), volume.getSize(), Volume.class.getName(), volume.getUuid());
+
             return volume;
-        } catch (InterruptedException e) {
-            s_logger.warn("failed get resize volume result", e);
-            throw new CloudRuntimeException(e.getMessage());
-        } catch (ExecutionException e) {
-            s_logger.warn("failed get resize volume result", e);
-            throw new CloudRuntimeException(e.getMessage());
+
         } catch (Exception e) {
-            s_logger.warn("failed get resize volume result", e);
-            throw new CloudRuntimeException(e.getMessage());
+            throw new CloudRuntimeException("Exception caught during resize volume operation of volume UUID: " + volume.getUuid(), e);
         }
     }
 

--- a/server/src/main/java/com/cloud/storage/listener/VolumeStateListener.java
+++ b/server/src/main/java/com/cloud/storage/listener/VolumeStateListener.java
@@ -76,8 +76,7 @@ public class VolumeStateListener implements StateListener<State, Event, Volume> 
           if (transition.getToState() == State.Ready) {
             if (transition.getCurrentState() == State.Resizing) {
               // Log usage event for volumes belonging user VM's only
-              UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VOLUME_RESIZE, vol.getAccountId(), vol.getDataCenterId(), vol.getId(), vol.getName(),
-                      vol.getDiskOfferingId(), vol.getTemplateId(), vol.getSize(), Volume.class.getName(), vol.getUuid());
+              // For the Resize Volume Event, this  publishes an event with an incorrect disk offering ID, so do nothing for now
             } else {
               UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VOLUME_CREATE, vol.getAccountId(), vol.getDataCenterId(), vol.getId(), vol.getName(), vol.getDiskOfferingId(), null, vol.getSize(),
                       Volume.class.getName(), vol.getUuid(), vol.isDisplayVolume());

--- a/usage/src/main/java/com/cloud/usage/parser/VolumeUsageParser.java
+++ b/usage/src/main/java/com/cloud/usage/parser/VolumeUsageParser.java
@@ -166,8 +166,7 @@ public class VolumeUsageParser {
             usageDesc += " (DiskOffering: " + doId + ")";
         }
 
-        UsageVO usageRecord =
-            new UsageVO(zoneId, account.getId(), account.getDomainId(), usageDesc, usageDisplay + " Hrs", type, new Double(usage), null, null, doId, templateId, volId,
+        UsageVO usageRecord = new UsageVO(zoneId, account.getId(), account.getDomainId(), usageDesc, usageDisplay + " Hrs", type, new Double(usage), null, null, doId, templateId, volId,
                 size, startDate, endDate);
         s_usageDao.persist(usageRecord);
     }


### PR DESCRIPTION
**Problem**: The disk offering change is not reflected in cloud_usage database table.
**Root Cause**: The resizeVolume API does not publish the volume disk offering change event to the
cloud_usage database table.
**Solution**: This issue has been fixed by refactoring the resizeVolume API to publish this disk offering change for volumes that either in Allocated or Ready state.

Moves the method that published events for volumes in Ready state from
the VolumeStateListener class to the orchestrateResizeVolume method in
the VolumeApiService.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)