### PR TITLE
ui: fix computer diagram css margin that blocks down arrow

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -6878,10 +6878,9 @@ label.error {
 .multi-wizard.instance-wizard .diagram .part.zone-plane {
   width: 354px;
   height: 117px;
-  background-position: 0px -55px;
+  background-position: -38px -55px;
   /*+placement:displace -38px 259px;*/
   position: absolute;
-  margin-left: -38px;
   margin-top: 259px;
 }
 


### PR DESCRIPTION
**Problem**: Down arrow key of the vertical scroll bar in the VM deployment wizard does not work.
**Root Cause**: The computer diagram on the right side in the VM deployment wizard spills its margin on the left causing the arrow key to be blocked.
**Solution**: Fix the `background-position` to get the correct position than `margin-left` for the `zone-panel`. With the fix, the left size arrow keys and vertical scrollbars are no longer under the diagram image and press-able now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

Before the fix, as seen from dev tools:
![Screenshot from 2019-03-13 14-51-00](https://user-images.githubusercontent.com/95203/54268578-89797380-45a1-11e9-98dd-1b0a81f8a1de.png)

The layout as seen in dev tools after the fix:
![Screenshot from 2019-03-13 15-00-33](https://user-images.githubusercontent.com/95203/54268624-a0b86100-45a1-11e9-8406-ed67111ca9f1.png)
