### PR TITLE
ubuntu16:  fix three issues with ubuntu 16.04 hosts

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -72,6 +72,7 @@ import org.libvirt.DomainInterfaceStats;
 import org.libvirt.DomainSnapshot;
 import org.libvirt.LibvirtException;
 import org.libvirt.MemoryStatistic;
+import org.libvirt.Network;
 import org.libvirt.NodeInfo;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -923,6 +924,20 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             }
         } catch (final LibvirtException e) {
             throw new CloudRuntimeException(e.getMessage());
+        }
+
+        // destroy default network, see https://libvirt.org/sources/java/javadoc/org/libvirt/Network.html
+        try {
+            Network network = conn.networkLookupByName("default");
+            s_logger.debug("Found libvirt default network, destroying it and setting autostart to false");
+            if (network.isActive() == 1) {
+                network.destroy();
+            }
+            if (network.getAutostart()) {
+                network.setAutostart(false);
+            }
+        } catch (final LibvirtException e) {
+            s_logger.warn("Ignoring libvirt error.", e);
         }
 
         if (HypervisorType.KVM == _hypervisorType) {

--- a/python/lib/cloudutils/networkConfig.py
+++ b/python/lib/cloudutils/networkConfig.py
@@ -103,6 +103,9 @@ class networkConfig:
 
     @staticmethod
     def isOvsBridge(devName):
+        cmd = bash("which ovs-vsctl")
+        if not cmd.isSuccess():
+            return False
         try:
             return 0==subprocess.check_call(("ovs-vsctl", "br-exists", devName))
         except subprocess.CalledProcessError:

--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -581,6 +581,8 @@ class libvirtConfigUbuntu(serviceCfgBase):
 
             self.syscfg.svo.stopService("libvirt-bin")
             self.syscfg.svo.enableService("libvirt-bin")
+            if os.path.exists("/lib/systemd/system/libvirt-bin.socket"):
+                bash("systemctl stop libvirt-bin.socket")
             return True
         except:
             raise


### PR DESCRIPTION
## Description

This fixes three issues with ubuntu 16.04 hosts

1. fix unable to add host if cloudbrX is not configured
2. Stop service libvirt-bin.socket while add a host
3. Diable libvirt default network

Details can be found in each commit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
