### PR TITLE
ui: don't ignore ''mine" when listing "all" templates in projects

### DIFF
--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -1038,7 +1038,6 @@
                                 }
                                 switch (args.filterBy.kind) {
                                     case "all":
-                                        ignoreProject = true;
                                         $.extend(data, {
                                             templatefilter: 'all'
                                         });
@@ -2383,7 +2382,6 @@
                                 }
                                 switch (args.filterBy.kind) {
                                     case "all":
-                                        ignoreProject = true;
                                         $.extend(data, {
                                             isofilter: 'all'
                                         });


### PR DESCRIPTION
Problem: When uploading template or iso in a project, the progress is not seen
Root Cause: When users upload a template/iso in project view, the template/iso is not visible in the all filter. This creates confusion that template/iso has not been uploaded.
Solution: Since the api listtemplates with a projectid acts is a superset of list templates without a project id, we should not ignore the project id when listing templates in all filter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)