### PR TITLE
api: Set network name as part of the network usage response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UsageRecordResponse.java
@@ -77,8 +77,8 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
     private String virtualMachineId;
 
     @SerializedName(ApiConstants.NAME)
-    @Param(description = "virtual machine name")
-    private String vmName;
+    @Param(description = "resource or virtual machine name")
+    private String resourceName;
 
     @SerializedName("offeringid")
     @Param(description = "offering ID")
@@ -186,8 +186,8 @@ public class UsageRecordResponse extends BaseResponseWithTagInformation implemen
         this.virtualMachineId = virtualMachineId;
     }
 
-    public void setVmName(String vmName) {
-        this.vmName = vmName;
+    public void setResourceName(String name) {
+        this.resourceName = name;
     }
 
     public void setOfferingId(String offeringId) {

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -3309,7 +3309,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                 usageRecResponse.setVirtualMachineId(vm.getUuid());
             }
         }
-        usageRecResponse.setVmName(usageRecord.getVmName());
+        usageRecResponse.setResourceName(usageRecord.getVmName());
         if (usageRecord.getTemplateId() != null) {
             VMTemplateVO template = ApiDBUtils.findTemplateById(usageRecord.getTemplateId());
             if (template != null) {
@@ -3389,6 +3389,7 @@ public class ApiResponseHelper implements ResponseGenerator {
                     resourceType = ResourceObjectType.Network;
                     resourceId = network.getId();
                     usageRecResponse.setNetworkId(network.getUuid());
+                    usageRecResponse.setResourceName(network.getName());
                 }
             }
         } else if (usageRecord.getUsageType() == UsageTypes.VM_DISK_IO_READ || usageRecord.getUsageType() == UsageTypes.VM_DISK_IO_WRITE
@@ -3495,7 +3496,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             resourceType = ResourceObjectType.UserVm;
             if (vm != null) {
                 resourceId = vm.getId();
-                usageRecResponse.setVmName(vm.getInstanceName());
+                usageRecResponse.setResourceName(vm.getInstanceName());
                 usageRecResponse.setUsageId(vm.getUuid());
             }
             usageRecResponse.setSize(usageRecord.getSize());


### PR DESCRIPTION
Problem: Network name is not part of the network usage response
Root Cause: Code does not set the network name
Solution: Set the network name for network usage type usage records in the API response

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)