### PR TITLE
[WIP DO NOT MERGE] ui: add memory used column in instance metrics view

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -5934,7 +5934,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                         } else if (objProp.getName().contains(instanceNameCustomField)) {
                             if (objProp.getVal() != null)
                                 vmInternalCSName = ((CustomFieldStringValue)objProp.getVal()).getValue();
-                        } else if (objProp.getName().equals(guestMemusage)) {
+                        } else if (objProp.getName().equals(guestMemUseStr)) {
                             guestMemusage = objProp.getVal().toString();
                         } else if (objProp.getName().equals(numCpuStr)) {
                             numberCPUs = objProp.getVal().toString();

--- a/ui/scripts/metrics.js
+++ b/ui/scripts/metrics.js
@@ -478,6 +478,9 @@
                     columns: {
                         memorytotal: {
                             label: 'label.metrics.allocated'
+                        },
+                        memoryused: {
+                            label: 'label.metrics.memory.used.avg'
                         }
                     }
                 },
@@ -525,6 +528,12 @@
                     url: createURL('listVirtualMachinesMetrics'),
                     data: data,
                     success: function(json) {
+                        json.listvirtualmachinesmetricsresponse.virtualmachine.forEach(function(vm) {
+                            var memUsedPercent = (vm.memorykbs && vm.memoryintfreekbs) ? (Math.round((vm.memorykbs - vm.memoryintfreekbs) * 10000 / vm.memorykbs) / 100).toString() + "%" : "";
+                            $.extend(vm,{
+                                memoryused: memUsedPercent
+                            })
+                        });
                         args.response.success({
                             data: json.listvirtualmachinesmetricsresponse.virtualmachine
                         });


### PR DESCRIPTION
**Problem**: The metrics view for instances does not show used memory.
**Root Cause**: Used memory was not added as a column in the metrics view for instances.
**Solution**: Metrics view for instances makes ‘listVirtualMachineMetrics’ API call to gather metrics. The response of this API call contains total and free memory with the instance. These have been used to compute used memory as a percentage of total memory and displayed as a new column in UI. Also fixes
a bug for VMware, due to which incorrect memory usage was returned.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)