### PR TITLE
[WIP DO NOT MERGE] ui: instance settings visibility

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -262,6 +262,10 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     @Param(description = "Vm details in key/value pairs.", since = "4.2.1")
     private Map details;
 
+    @SerializedName("readonlyuidetails")
+    @Param(description = "List of UI read-only Vm details as comma separated string.", since = "4.13.0")
+    private String readOnlyUIDetails;
+
     @SerializedName(ApiConstants.SSH_KEYPAIR)
     @Param(description = "ssh key-pair")
     private String keyPairName;
@@ -810,6 +814,10 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
         this.details = details;
     }
 
+    public void setReadOnlyUIDetails(String readOnlyUIDetails) {
+        this.readOnlyUIDetails = readOnlyUIDetails;
+    }
+
     public void setOsTypeId(String osTypeId) {
         this.osTypeId = osTypeId;
     }
@@ -824,6 +832,10 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
 
     public Map getDetails() {
         return details;
+    }
+
+    public String getReadOnlyUIDetails() {
+        return readOnlyUIDetails;
     }
 
     public Boolean getDynamicallyScalable() {

--- a/api/src/main/java/org/apache/cloudstack/query/QueryService.java
+++ b/api/src/main/java/org/apache/cloudstack/query/QueryService.java
@@ -92,6 +92,10 @@ public interface QueryService {
             "user.vm.blacklisted.details", "rootdisksize, cpuOvercommitRatio, memoryOvercommitRatio, Message.ReservedCapacityFreed.Flag",
             "Determines whether users can view certain VM settings", true);
 
+    static final ConfigKey<String> UserVMReadOnlyUIDetails = new ConfigKey<String>("Advanced", String.class,
+            "user.vm.readonly.ui.details", "dataDiskController, rootDiskController",
+            "List of UI read-only VM settings/details as comma separated string", true);
+
     ListResponse<UserResponse> searchForUsers(ListUsersCmd cmd) throws PermissionDeniedException;
 
     ListResponse<EventResponse> searchForEvents(ListEventsCmd cmd);

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -25,8 +25,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.cloud.cluster.ManagementServerHostVO;
-import com.cloud.cluster.dao.ManagementServerHostDao;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.affinity.AffinityGroupDomainMapVO;
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
@@ -156,6 +154,8 @@ import com.cloud.api.query.vo.TemplateJoinVO;
 import com.cloud.api.query.vo.UserAccountJoinVO;
 import com.cloud.api.query.vo.UserVmJoinVO;
 import com.cloud.api.query.vo.VolumeJoinVO;
+import com.cloud.cluster.ManagementServerHostVO;
+import com.cloud.cluster.dao.ManagementServerHostDao;
 import com.cloud.dc.DedicatedResourceVO;
 import com.cloud.dc.dao.DedicatedResourceDao;
 import com.cloud.domain.Domain;
@@ -3714,6 +3714,6 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {AllowUserViewDestroyedVM, UserVMBlacklistedDetails};
+        return new ConfigKey<?>[] {AllowUserViewDestroyedVM, UserVMBlacklistedDetails, UserVMReadOnlyUIDetails};
     }
 }

--- a/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -321,6 +321,9 @@ public class UserVmJoinDaoImpl extends GenericDaoBaseWithTagInformation<UserVmJo
                 }
             }
             userVmResponse.setDetails(resourceDetails);
+            if (caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
+                userVmResponse.setReadOnlyUIDetails(QueryManagerImpl.UserVMReadOnlyUIDetails.value());
+            }
         }
 
         userVmResponse.setObjectName(objectName);

--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -564,6 +564,21 @@ body.login {
   margin: 0 auto;
 }
 
+.blocking-overlay {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0px;
+  top: 0px;
+  background: #F2F2F2;
+  z-index: 500;
+  /*+opacity:70%;*/
+  filter: alpha(opacity=70);
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=70);
+  -moz-opacity: 0.7;
+  opacity: 0.7;
+}
+
 .loading-overlay {
   opacity: 0.7;
   position: absolute;

--- a/ui/l10n/en.js
+++ b/ui/l10n/en.js
@@ -1944,6 +1944,8 @@ var dictionary = {
 "message.action.restore.instance":"Please confirm that you want to restore this instance.",
 "message.action.revert.snapshot":"Please confirm that you want to revert the owning volume to this snapshot.",
 "message.action.secure.host":"This will restart the host agent and libvirtd process after applying new X509 certificates, please confirm?",
+"message.action.settings.warning.vm.running":"Please stop the virtual machine to access settings",
+"message.action.settings.warning.vm.started":"Virtual machine has been started. It needs to be stopped to access settings",
 "message.action.start.instance":"Please confirm that you want to start this instance.",
 "message.action.start.router":"Please confirm that you want to start this router.",
 "message.action.start.systemvm":"Please confirm that you want to start this system VM.",


### PR DESCRIPTION
## Description
**Problem**: Instance settings tab is visible only for stopped VMs but hidden otherwise. This creates confusion as users may not know that VMs need to be stopped to access settings page. Some VM details need to be read-only for the user.

**Root Cause**: The UI Code hides the settings tab for VMs that are not in stopped state. Instance setting tab should always be visible, but only changeable when VM is stopped. Required instance details are not read-only for the user.

**Solution**: The settings tab is now always visible for VMs. If VM is not in the stopped state, no interactions are allowed in the settings tab view by greying out its content and a popup is shown to advise users for stopping the VM. VM details can be made read-only in UI for the user using “user.vm.readonly.ui.details” which accepts a comma-separated list of details. For user, read-only details will be shown in the settings tab in UI but the action button for them will be disabled and greyed out. Admin can still update such details.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Snapshot when VM is stopped.
![screenshot from 2019-01-09 22-08-03](https://user-images.githubusercontent.com/43956255/50913773-18abc300-145b-11e9-8786-89f91a7508c7.png)
Snapshot when VM is not stopped but Settings tab is clicked and Popup appears
![screenshot from 2019-01-09 17-54-40](https://user-images.githubusercontent.com/43956255/50913775-19445980-145b-11e9-8a25-6c945528cf96.png)
When popup is dismissed
![screenshot from 2019-01-09 17-54-55](https://user-images.githubusercontent.com/43956255/50913774-19445980-145b-11e9-8cdd-a9f450b5af81.png)

VM setting/detail made read-only
![Screenshot from 2019-03-14 14-13-49](https://user-images.githubusercontent.com/153340/54343019-d6258300-4663-11e9-81e7-fd7d9caaaf3a.png)


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->

