### PR TITLE
server: allow disk offering selection for volume from snapshot

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -682,6 +682,11 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 minIops = snapshotCheck.getMinIops();
                 maxIops = snapshotCheck.getMaxIops();
                 size = snapshotCheck.getSize(); // ; disk offering is used for tags purposes
+            } else {
+                if (size < snapshotCheck.getSize()) {
+                    throw new InvalidParameterValueException(String.format("Invalid size for volume creation: %dGB, snapshot size is: %dGB",
+                            size / (1024 * 1024 * 1024), snapshotCheck.getSize() / (1024 * 1024 * 1024)));
+                }
             }
 
             // check snapshot permissions

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -2042,6 +2042,10 @@
                                                                 });
                                                             }
                                                         });
+                                                        items.unshift({
+                                                            id: undefined,
+                                                            description: ""
+                                                        });
                                                         args.response.success({
                                                             data: items
                                                         });

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -1969,6 +1969,9 @@
                                         } else {
                                             args.$form.find('.form-item[rel=zoneid]').hide();
                                         }
+                                        if(args.context.snapshots[0].volumetype!='ROOT') {
+                                            args.$form.find('.form-item[rel=diskOffering]').hide();
+                                        }
                                     },
                                     fields: {
                                         name: {
@@ -2005,19 +2008,144 @@
                                                     }
                                                 });
                                             }
+                                        },
+                                        diskOffering: {
+                                            label: 'label.disk.offering',
+                                            docID: 'helpVolumeDiskOffering',
+                                            select: function(args) {
+                                                var snapshotSizeInGB = Math.floor(args.context.snapshots[0].virtualsize/(1024 * 1024 * 1024))
+                                                $.ajax({
+                                                    url: createURL("listDiskOfferings"),
+                                                    dataType: "json",
+                                                    async: false,
+                                                    success: function(json) {
+                                                        diskofferingObjs = json.listdiskofferingsresponse.diskoffering;
+                                                        var items = [];
+                                                        // Sort offerings list with size and keep custom offerings at end
+                                                        for(var i=0;i<diskofferingObjs.length;i++) {
+                                                            for(var j=i+1;j<diskofferingObjs.length;j++) {
+                                                                if((diskofferingObjs[i].disksize>diskofferingObjs[j].disksize &&
+                                                                    diskofferingObjs[j].disksize!=0) ||
+                                                                    (diskofferingObjs[i].disksize==0 &&
+                                                                        diskofferingObjs[j].disksize!=0)) {
+                                                                    var temp = diskofferingObjs[i];
+                                                                    diskofferingObjs[i] = diskofferingObjs[j];
+                                                                    diskofferingObjs[j] = temp;
+                                                                }
+                                                            }
+                                                        }
+                                                        $(diskofferingObjs).each(function() {
+                                                            if(this.disksize==0 || this.disksize>=snapshotSizeInGB) {
+                                                                items.push({
+                                                                    id: this.id,
+                                                                    description: this.displaytext
+                                                                });
+                                                            }
+                                                        });
+                                                        args.response.success({
+                                                            data: items
+                                                        });
+                                                    }
+                                                });
+
+                                                args.$select.change(function() {
+                                                    var diskOfferingId = $(this).val();
+                                                    selectedDiskOfferingObj = null;
+                                                    $(diskofferingObjs).each(function() {
+                                                        if (this.id == diskOfferingId) {
+                                                            selectedDiskOfferingObj = this;
+                                                            return false;
+                                                        }
+                                                    });
+
+                                                    if (selectedDiskOfferingObj == null) return;
+
+                                                    var $form = $(this).closest('form');
+                                                    var $diskSize = $form.find('.form-item[rel=diskSize]');
+                                                    if (selectedDiskOfferingObj.iscustomized == true) {
+                                                        $diskSize.css('display', 'inline-block');
+                                                        $form.find('input[name=diskSize]').val(''+snapshotSizeInGB);
+                                                    } else {
+                                                        $diskSize.hide();
+                                                    }
+
+                                                    var $minIops = $form.find('.form-item[rel=minIops]');
+                                                    var $maxIops = $form.find('.form-item[rel=maxIops]');
+                                                    if (selectedDiskOfferingObj.iscustomizediops == true) {
+                                                        $minIops.css('display', 'inline-block');
+                                                        $maxIops.css('display', 'inline-block');
+                                                    } else {
+                                                        $minIops.hide();
+                                                        $maxIops.hide();
+                                                    }
+                                                });
+                                            }
+                                        },
+                                        diskSize: {
+                                            label: 'label.disk.size.gb',
+                                            docID: 'helpVolumeSizeGb',
+                                            validation: {
+                                                required: true,
+                                                number: true
+                                            },
+                                            isHidden: true
+                                        },
+                                        minIops: {
+                                            label: 'label.disk.iops.min',
+                                            validation: {
+                                                required: false,
+                                                number: true
+                                            },
+                                            isHidden: true
+                                        },
+                                        maxIops: {
+                                            label: 'label.disk.iops.max',
+                                            validation: {
+                                                required: false,
+                                                number: true
+                                            },
+                                            isHidden: true
                                         }
                                     }
                                 },
                                 action: function(args) {
                                     var data = {
-                                        snapshotid: args.context.snapshots[0].id,
-                                        name: args.data.name
+                                        name: args.data.name,
+                                        snapshotid: args.context.snapshots[0].id
                                     };
+
+                                    if (args.data.diskOffering) {
+                                        $.extend(data, {
+                                            diskofferingid: args.data.diskOffering
+                                        });
+                                    }
 
                                     if (args.$form.find('.form-item[rel=zoneid]').css("display") != "none" && args.data.zoneid != '') {
                                         $.extend(data, {
                                             zoneId: args.data.zoneid
                                         });
+                                    }
+
+                                    if (selectedDiskOfferingObj) {
+                                        if(selectedDiskOfferingObj.iscustomized == true) {
+                                            $.extend(data, {
+                                                size: args.data.diskSize
+                                            });
+                                        }
+
+                                        if (selectedDiskOfferingObj.iscustomizediops == true) {
+                                            if (args.data.minIops != "" && args.data.minIops > 0) {
+                                                $.extend(data, {
+                                                    miniops: args.data.minIops
+                                                });
+                                            }
+
+                                            if (args.data.maxIops != "" && args.data.maxIops > 0) {
+                                                $.extend(data, {
+                                                    maxiops: args.data.maxIops
+                                                });
+                                            }
+                                        }
                                     }
 
                                     $.ajax({
@@ -2036,6 +2164,9 @@
                                                     }
                                                 }
                                             });
+                                        },
+                                        error: function(json) {
+                                            args.response.error(parseXMLHttpResponse(json));
                                         }
                                     });
                                 },
@@ -2043,7 +2174,6 @@
                                     poll: pollAsyncJobResult
                                 }
                             },
-
                             revertSnapshot: {
                                 label: 'label.action.revert.snapshot',
                                 messages: {

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -2042,10 +2042,6 @@
                                                                 });
                                                             }
                                                         });
-                                                        items.unshift({
-                                                            id: undefined,
-                                                            description: ""
-                                                        });
                                                         args.response.success({
                                                             data: items
                                                         });

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -2114,36 +2114,37 @@
                                         snapshotid: args.context.snapshots[0].id
                                     };
 
-                                    if (args.data.diskOffering) {
-                                        $.extend(data, {
-                                            diskofferingid: args.data.diskOffering
-                                        });
-                                    }
-
                                     if (args.$form.find('.form-item[rel=zoneid]').css("display") != "none" && args.data.zoneid != '') {
                                         $.extend(data, {
                                             zoneId: args.data.zoneid
                                         });
                                     }
 
-                                    if (selectedDiskOfferingObj) {
-                                        if(selectedDiskOfferingObj.iscustomized == true) {
+                                    if (args.$form.find('.form-item[rel=diskOffering]').css("display") != "none") {
+                                        if (args.data.diskOffering) {
                                             $.extend(data, {
-                                                size: args.data.diskSize
+                                                diskofferingid: args.data.diskOffering
                                             });
                                         }
-
-                                        if (selectedDiskOfferingObj.iscustomizediops == true) {
-                                            if (args.data.minIops != "" && args.data.minIops > 0) {
+                                        if (selectedDiskOfferingObj) {
+                                            if(selectedDiskOfferingObj.iscustomized == true) {
                                                 $.extend(data, {
-                                                    miniops: args.data.minIops
+                                                    size: args.data.diskSize
                                                 });
                                             }
 
-                                            if (args.data.maxIops != "" && args.data.maxIops > 0) {
-                                                $.extend(data, {
-                                                    maxiops: args.data.maxIops
-                                                });
+                                            if (selectedDiskOfferingObj.iscustomizediops == true) {
+                                                if (args.data.minIops != "" && args.data.minIops > 0) {
+                                                    $.extend(data, {
+                                                        miniops: args.data.minIops
+                                                    });
+                                                }
+
+                                                if (args.data.maxIops != "" && args.data.maxIops > 0) {
+                                                    $.extend(data, {
+                                                        maxiops: args.data.maxIops
+                                                    });
+                                                }
                                             }
                                         }
                                     }


### PR DESCRIPTION
## Description
**Problem**: Volume created from a snapshot does not show its disk offering.

**Root Cause**: The volume created from a snapshot of a root disk does not have a disk offering therefore the disk offering of the created volume from the snapshot is empty.

**Solution**: Refactored createVolume API and extended UI to allow user to select a disk offering while creating a volume using a root disk volume snapshot. For creating volumes using data disk volume snapshot, the disk offering given by the snapshot will be assigned. Disk offering selection in the UI form for volume creation from snapshot is depicted in screenshot below.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![Screenshot 2019-06-20 at 12 08 15](https://user-images.githubusercontent.com/13551960/59850733-a62d0080-9373-11e9-814e-f450b564a7a3.png)


## How Has This Been Tested?
From UI


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->