### PR TITLE
Make the API documentation version not *hardcoded* to v4.9.0

### DIFF
--- a/tools/apidoc/build-apidoc.sh
+++ b/tools/apidoc/build-apidoc.sh
@@ -20,6 +20,8 @@
 # cloud-build-api-doc.sh -- builds api documentation.
 #set -x
 #set -u
+ACS_RELEASE="$1"
+shift
 TARGETJARDIR="$1"
 shift
 DEPSDIR="$1"
@@ -59,6 +61,8 @@ set -e
  cp "$thisdir"/*.java .
  cp "$thisdir"/*.xsl .
  sed -e 's,%API_HEADER%,All APIs,g' "$thisdir/generatetoc_header.xsl" >generatetoc.xsl
+ sed -i "s/%ACS_RELEASE%/${ACS_RELEASE}/g" generatetoc.xsl
+ sed -i "s/%ACS_RELEASE%/${ACS_RELEASE}/g" generatecommands.xsl
 
  PLATFORM=`uname -s`
  if [[ "$PLATFORM" =~ .*WIN.* ]]

--- a/tools/apidoc/generatecommands.xsl
+++ b/tools/apidoc/generatecommands.xsl
@@ -55,13 +55,12 @@ version="1.0">
 			<div class="api_titlebox">
 				<div class="api_titlebox_left">
 				<xsl:for-each select="command/command">
-					<!-- Modify this line for the release version -->
 					<span>
-									Apache CloudStack %ACS_RELEASE% Root Admin API Reference
-								</span>
-								<p></p>
-                                <h1><xsl:value-of select="name"/></h1>
-                                <p><xsl:value-of select="description"/></p>
+						Apache CloudStack %ACS_RELEASE% Root Admin API Reference
+					</span>
+					<p></p>
+					<h1><xsl:value-of select="name"/></h1>
+					<p><xsl:value-of select="description"/></p>
 				</xsl:for-each>
                             </div>
 

--- a/tools/apidoc/generatecommands.xsl
+++ b/tools/apidoc/generatecommands.xsl
@@ -57,7 +57,7 @@ version="1.0">
 				<xsl:for-each select="command/command">
 					<!-- Modify this line for the release version -->
 					<span>
-									Apache CloudStack v4.9.0 Root Admin API Reference
+									Apache CloudStack %ACS_RELEASE% Root Admin API Reference
 								</span>
 								<p></p>
                                 <h1><xsl:value-of select="name"/></h1>

--- a/tools/apidoc/generatetoc_header.xsl
+++ b/tools/apidoc/generatetoc_header.xsl
@@ -51,7 +51,6 @@ version="1.0">
              	
                 <div class="inside_apileftpanel">
                 	<div class="inside_contentpanel" style="width:930px;">
-              		  	<!-- Modify this line for the release version -->
                       <h1>Apache CloudStack API Documentation (%ACS_RELEASE%)</h1>
                       <a class="api_backbutton" href="http://cloudstack.apache.org/docs/api/"></a>
                         <div class="apiannouncement_box">

--- a/tools/apidoc/generatetoc_header.xsl
+++ b/tools/apidoc/generatetoc_header.xsl
@@ -52,7 +52,7 @@ version="1.0">
                 <div class="inside_apileftpanel">
                 	<div class="inside_contentpanel" style="width:930px;">
               		  	<!-- Modify this line for the release version -->
-                      <h1>Apache CloudStack API Documentation (v4.9.0)</h1>
+                      <h1>Apache CloudStack API Documentation (%ACS_RELEASE%)</h1>
                       <a class="api_backbutton" href="http://cloudstack.apache.org/docs/api/"></a>
                         <div class="apiannouncement_box">
                         	<div class="apiannouncement_contentarea">

--- a/tools/apidoc/pom.xml
+++ b/tools/apidoc/pom.xml
@@ -63,6 +63,7 @@
                             <executable>bash</executable>
                             <arguments>
                                 <argument>./build-apidoc.sh</argument>
+                                <armument>${project.version}</armument>
                                 <argument>${client.config.jars}</argument>
                                 <argument>${client.config.jars}</argument>
                                 <argument>./target</argument>


### PR DESCRIPTION
Currently, the API documentation is hardcoded to _v4.9.0_. This commit makes the API documentation automatically updated to the current project version. If one wants to set another version, it is possible by just editing the `ACS_RELEASE` variable in _build-apidoc.sh_.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Prior to the changes proposed in this PR the generated API documentaion was labeled as '4.9.0':
![image](https://user-images.githubusercontent.com/5025148/55164448-7393b300-514a-11e9-95d5-a8c99b71b486.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Project API documentation page:
![image](https://user-images.githubusercontent.com/5025148/55164220-0d0e9500-514a-11e9-8fac-db7d75e64ff4.png)

Example of an API command documentation page:
![image](https://user-images.githubusercontent.com/5025148/55164328-37f8e900-514a-11e9-88b0-86858e08a4c4.png)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
