### PR TITLE
ui: show complete domain for accounts (#2994)

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -110,6 +110,7 @@ public class ApiConstants {
     public static final String IP6_DNS1 = "ip6dns1";
     public static final String IP6_DNS2 = "ip6dns2";
     public static final String DOMAIN = "domain";
+    public static final String DOMAIN_PATH = "domainpath";
     public static final String DOMAIN_ID = "domainid";
     public static final String DOMAIN__ID = "domainId";
     public static final String DURATION = "duration";

--- a/api/src/main/java/org/apache/cloudstack/api/response/AccountResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/AccountResponse.java
@@ -19,8 +19,6 @@ package org.apache.cloudstack.api.response;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gson.annotations.SerializedName;
-
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
@@ -28,6 +26,7 @@ import org.apache.cloudstack.api.EntityReference;
 
 import com.cloud.serializer.Param;
 import com.cloud.user.Account;
+import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = Account.class)
 public class AccountResponse extends BaseResponse implements ResourceLimitAndCountResponse {
@@ -62,6 +61,10 @@ public class AccountResponse extends BaseResponse implements ResourceLimitAndCou
     @SerializedName(ApiConstants.DOMAIN)
     @Param(description = "name of the Domain the account belongs too")
     private String domainName;
+
+    @SerializedName(ApiConstants.DOMAIN_PATH)
+    @Param(description = "name of the Domain the account belongs too", since = "4.13")
+    private String domainPath;
 
     @SerializedName(ApiConstants.DEFAULT_ZONE_ID)
     @Param(description = "the default zone of the account")
@@ -292,6 +295,10 @@ public class AccountResponse extends BaseResponse implements ResourceLimitAndCou
 
     public void setDomainName(String domainName) {
         this.domainName = domainName;
+    }
+
+    public void setDomainPath(String domainPath) {
+        this.domainPath = domainPath;
     }
 
     public void setBytesReceived(Long bytesReceived) {

--- a/server/src/main/java/com/cloud/api/query/dao/AccountJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/AccountJoinDaoImpl.java
@@ -64,6 +64,9 @@ public class AccountJoinDaoImpl extends GenericDaoBase<AccountJoinVO, Long> impl
         accountResponse.setAccountType(account.getType());
         accountResponse.setDomainId(account.getDomainUuid());
         accountResponse.setDomainName(account.getDomainName());
+        StringBuilder domainPath = new StringBuilder("ROOT");
+        (domainPath.append(account.getDomainPath())).deleteCharAt(domainPath.length() - 1);
+        accountResponse.setDomainPath(domainPath.toString());
         accountResponse.setState(account.getState().toString());
         accountResponse.setNetworkDomain(account.getNetworkDomain());
         accountResponse.setDefaultZone(account.getDataCenterUuid());

--- a/ui/scripts/accounts.js
+++ b/ui/scripts/accounts.js
@@ -45,7 +45,7 @@
                         roletype: {
                             label: 'label.roletype'
                         },
-                        domain: {
+                        domainpath: {
                             label: 'label.domain'
                         },
                         state: {
@@ -697,7 +697,7 @@
                                     roletype: {
                                         label: 'label.roletype'
                                     },
-                                    domain: {
+                                    domainpath: {
                                         label: 'label.domain'
                                     },
                                     state: {


### PR DESCRIPTION
Fixes #2994 
This PR allows showing complete domain, ie, domain path for accounts list view and account detail.
Added a new key, domainpath, in AccountResponse for accounts API to facilitate this in UI.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Original behavior  in UI
![Screenshot from 2019-04-03 11-30-18](https://user-images.githubusercontent.com/153340/55456171-0083b400-5604-11e9-8afb-7678bf80138b.png)

After changes,
![Screenshot from 2019-04-03 11-04-33](https://user-images.githubusercontent.com/153340/55455277-b0572280-5600-11e9-8112-a62ae2fb9f4c.png)
![Screenshot from 2019-04-03 11-04-50](https://user-images.githubusercontent.com/153340/55455286-b3521300-5600-11e9-8098-e5a8e283f06e.png)
![Screenshot from 2019-04-03 11-07-00](https://user-images.githubusercontent.com/153340/55455290-b5b46d00-5600-11e9-8290-f07fde8150f1.png)


## How Has This Been Tested?
UI and cmk

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
