### PR TITLE
base64 userdata encoding fix

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -557,7 +557,7 @@
                                             <span><translate key="label.add.userdata"/> (<translate key="label.optional"/>)</span>
                                         </div>
                                         <div class="value">
-                                            <textarea name="userdata" class="disallowSpecialCharacters"></textarea>
+                                            <textarea name="userdata"></textarea>
                                         </div>
                                     </div>
                                 </div>

--- a/ui/scripts/instanceWizard.js
+++ b/ui/scripts/instanceWizard.js
@@ -1094,8 +1094,9 @@
 
             var userdata = args.data.userdata;
             if (userdata != null && userdata.length > 0) {
+
                 $.extend(deployVmData, {
-                    userdata : encodeURIComponent(btoa(userdata))
+                    userdata : encodeURIComponent(btoa(cloudStack.sanitizeReverse(userdata)))
                 });
             }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
  In the cloudstack UI fields get '<', '>' and '&' replaced by xml-entities
  these are generic for all fields and hurt us in the case of userdata
  this fix calls the existing method to reverse character replacements.
  it also removes the ccs class that pretends to prevent special chars

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #3202

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested by creating VMs in the simulator and checking the user_vm.user_data field contents 

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
