### PR TITLE
Support copy tags from template/iso image to VM from deploy vm command

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -50,6 +50,7 @@ public class ApiConstants {
     public static final String CERTIFICATE_CHAIN = "certchain";
     public static final String CERTIFICATE_FINGERPRINT = "fingerprint";
     public static final String CERTIFICATE_ID = "certid";
+    public static final String COPY_IMAGE_TAGS = "copyimagetags";
     public static final String CSR = "csr";
     public static final String PRIVATE_KEY = "privatekey";
     public static final String DOMAIN_SUFFIX = "domainsuffix";

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -203,6 +203,10 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = ApiConstants.EXTRA_CONFIG, type = CommandType.STRING, since = "4.12", description = "an optional URL encoded string that can be passed to the virtual machine upon successful deployment", length = 5120)
     private String extraConfig;
 
+    @Parameter(name = "copyimagetagstovm", type = CommandType.BOOLEAN, description = "if true we copy the image tags to the deployed Vm; defaulted to false if not specified")
+    private Boolean copyImageTagsToVm;
+
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -487,6 +491,10 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
 
     public String getExtraConfig() {
         return extraConfig;
+    }
+
+    public boolean getCopyImageTagsToVm() {
+        return copyImageTagsToVm == null ? false : copyImageTagsToVm;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -203,8 +203,8 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = ApiConstants.EXTRA_CONFIG, type = CommandType.STRING, since = "4.12", description = "an optional URL encoded string that can be passed to the virtual machine upon successful deployment", length = 5120)
     private String extraConfig;
 
-    @Parameter(name = "copyimagetagstovm", type = CommandType.BOOLEAN, since = "4.13", description = "if true we copy the image tags to the deployed Vm; defaulted to false if not specified")
-    private Boolean copyImageTagsToVm;
+    @Parameter(name = ApiConstants.COPY_IMAGE_TAGS, type = CommandType.BOOLEAN, since = "4.13", description = "if true the image tags (if any) will be copied to the VM, default value is false")
+    private Boolean copyImageTags;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -492,8 +492,8 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
         return extraConfig;
     }
 
-    public boolean getCopyImageTagsToVm() {
-        return copyImageTagsToVm == null ? false : copyImageTagsToVm;
+    public boolean getCopyImageTags() {
+        return copyImageTags == null ? false : copyImageTags;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -203,7 +203,7 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = ApiConstants.EXTRA_CONFIG, type = CommandType.STRING, since = "4.12", description = "an optional URL encoded string that can be passed to the virtual machine upon successful deployment", length = 5120)
     private String extraConfig;
 
-    @Parameter(name = "copyimagetagstovm", type = CommandType.BOOLEAN, description = "if true we copy the image tags to the deployed Vm; defaulted to false if not specified")
+    @Parameter(name = "copyimagetagstovm", type = CommandType.BOOLEAN, since = "4.13", description = "if true we copy the image tags to the deployed Vm; defaulted to false if not specified")
     private Boolean copyImageTagsToVm;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vm/DeployVMCmd.java
@@ -206,7 +206,6 @@ public class DeployVMCmd extends BaseAsyncCreateCustomIdCmd implements SecurityG
     @Parameter(name = "copyimagetagstovm", type = CommandType.BOOLEAN, description = "if true we copy the image tags to the deployed Vm; defaulted to false if not specified")
     private Boolean copyImageTagsToVm;
 
-
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -4936,12 +4936,15 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             addExtraConfig(vm, caller, extraConfig);
         }
 
-        if (cmd.getCopyImageTagsToVm()) {
-            final ResourceTag.ResourceObjectType templateType = (_templateDao.findById(templateId).getFormat() == ImageFormat.ISO) ? ResourceTag.ResourceObjectType.ISO : ResourceTag.ResourceObjectType.Template;
-            final List<? extends ResourceTag> resourceTags = resourceTagDao.listBy(templateId, templateType);
-            for (ResourceTag resourceTag : resourceTags) {
-                final ResourceTagVO copyTag = new ResourceTagVO(resourceTag.getKey(), resourceTag.getValue(), resourceTag.getAccountId(), resourceTag.getDomainId(), vm.getId(), ResourceTag.ResourceObjectType.UserVm, resourceTag.getCustomer(), vm.getUuid());
-                resourceTagDao.persist(copyTag);
+        if (cmd.getCopyImageTags()) {
+            VMTemplateVO templateOrIso = _templateDao.findById(templateId);
+            if (templateOrIso != null) {
+                final ResourceTag.ResourceObjectType templateType = (templateOrIso.getFormat() == ImageFormat.ISO) ? ResourceTag.ResourceObjectType.ISO : ResourceTag.ResourceObjectType.Template;
+                final List<? extends ResourceTag> resourceTags = resourceTagDao.listBy(templateId, templateType);
+                for (ResourceTag resourceTag : resourceTags) {
+                    final ResourceTagVO copyTag = new ResourceTagVO(resourceTag.getKey(), resourceTag.getValue(), resourceTag.getAccountId(), resourceTag.getDomainId(), vm.getId(), ResourceTag.ResourceObjectType.UserVm, resourceTag.getCustomer(), vm.getUuid());
+                    resourceTagDao.persist(copyTag);
+                }
             }
         }
 


### PR DESCRIPTION
Support copy tags from template/iso image to VM from deploy vm command.

## Description
<!--- Describe your changes in detail -->
Allow creation of tags from the source template/iso image to vm when deploy vm command creates virtual machine. 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
Fixes: #3048 
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Cloudmonkey can be used to launch a VM with template containing tags.
1) Created tags in template
2) deployed VM
3) Verify tags were present in the deployed VM
```
(local) 🐵 > deploy virtualmachine zoneid=3d0dff25-be49-487f-b7ed-ff898b4dc560 templateid=1637451e-86b9-11e9-949e-34e12d5f623e hypervisor=KVM serviceofferingid=8d60c39b-3bb4-461c-8639-5f5b5a66fe6b iptonetworklist[0].networkid=fe2e98b0-ccb2-48e9-b607-3335b4857bf8 displayname=vm1 name=vm2 copyimagetagstovm=true
 
{
  "accountid": "16441a0f-86b9-11e9-949e-34e12d5f623e",
  "cmd": "org.apache.cloudstack.api.command.admin.vm.DeployVMCmdByAdmin",
  "completed": "2019-06-04T17:38:02+0530",
  "created": "2019-06-04T17:37:57+0530",
  "jobid": "deabc7d4-69ba-443e-8679-2efb5ea59cce",
  "jobinstanceid": "04112f23-3c1a-4932-b8df-a1526b058c2e",
  "jobinstancetype": "VirtualMachine",
  "jobprocstatus": 0,
  "jobresult": {
    "virtualmachine": {
      "account": "admin",
      "affinitygroup": [],
      "cpunumber": 1,
      "cpuspeed": 500,
      "created": "2019-06-04T17:37:57+0530",
      "details": {},
      "displayname": "vm1",
      "displayvm": true,
      "domain": "ROOT",
      "domainid": "1644063b-86b9-11e9-949e-34e12d5f623e",
      "guestosid": "163ae1db-86b9-11e9-949e-34e12d5f623e",
      "haenable": false,
      "hostid": "83ba2001-ce1a-40c3-a183-856808c5d6ab",
      "hostname": "localhost.localdomain",
      "hypervisor": "KVM",
      "id": "04112f23-3c1a-4932-b8df-a1526b058c2e",
      "instancename": "i-2-5-VM",
      "isdynamicallyscalable": false,
      "jobid": "deabc7d4-69ba-443e-8679-2efb5ea59cce",
      "jobstatus": 0,
      "memory": 512,
      "name": "vm2",
      "nic": [
        {
          "broadcasturi": "vlan://127",
          "extradhcpoption": [],
          "gateway": "10.1.1.1",
          "id": "b7d38f54-5dc2-481d-b205-a791207f6e67",
          "ipaddress": "10.1.1.177",
          "isdefault": true,
          "isolationuri": "vlan://127",
          "macaddress": "02:00:78:74:00:03",
          "netmask": "255.255.255.0",
          "networkid": "fe2e98b0-ccb2-48e9-b607-3335b4857bf8",
          "networkname": "net",
          "secondaryip": [],
          "traffictype": "Guest",
          "type": "Isolated"
        }
      ],
      "ostypeid": "163ae1db-86b9-11e9-949e-34e12d5f623e",
      "passwordenabled": false,
      "rootdeviceid": 0,
      "rootdevicetype": "ROOT",
      "securitygroup": [],
      "serviceofferingid": "8d60c39b-3bb4-461c-8639-5f5b5a66fe6b",
      "serviceofferingname": "Small Instance",
      "state": "Running",
      "tags": [
        {
          "account": "admin",
          "domain": "ROOT",
          "domainid": "1644063b-86b9-11e9-949e-34e12d5f623e",
          "key": "key",
          "resourceid": "04112f23-3c1a-4932-b8df-a1526b058c2e",
          "resourcetype": "UserVm",
          "value": "val"
        }
      ],
      "templatedisplaytext": "CentOS 5.5(64-bit) no GUI (KVM)",
      "templateid": "1637451e-86b9-11e9-949e-34e12d5f623e",
      "templatename": "CentOS 5.5(64-bit) no GUI (KVM)",
      "userid": "16442cca-86b9-11e9-949e-34e12d5f623e",
      "username": "admin",
      "zoneid": "3d0dff25-be49-487f-b7ed-ff898b4dc560",
      "zonename": "KVM-advzone1"
    }
  },
  "jobresultcode": 0,
  "jobresulttype": "object",
  "jobstatus": 1,
  "userid": "16442cca-86b9-11e9-949e-34e12d5f623e"
}
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
