### PR TITLE
server: reduce execution time while listing project if projects have many resource tags

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
@@ -74,3 +74,33 @@ CREATE VIEW `cloud`.`data_center_view` AS
         `cloud`.`dedicated_resources` ON data_center.id = dedicated_resources.data_center_id
             left join
         `cloud`.`affinity_group` ON dedicated_resources.affinity_group_id = affinity_group.id;
+
+-- Remove key/value tags from project_view
+DROP VIEW IF EXISTS `cloud`.`project_view`;
+CREATE VIEW `cloud`.`project_view` AS
+    select
+        projects.id,
+        projects.uuid,
+        projects.name,
+        projects.display_text,
+        projects.state,
+        projects.removed,
+        projects.created,
+        projects.project_account_id,
+        account.account_name owner,
+        pacct.account_id,
+        domain.id domain_id,
+        domain.uuid domain_uuid,
+        domain.name domain_name,
+        domain.path domain_path
+    from
+        `cloud`.`projects`
+            inner join
+        `cloud`.`domain` ON projects.domain_id = domain.id
+            inner join
+        `cloud`.`project_account` ON projects.id = project_account.project_id
+            and project_account.account_role = 'Admin'
+            inner join
+        `cloud`.`account` ON account.id = project_account.account_id
+            left join
+        `cloud`.`project_account` pacct ON projects.id = pacct.project_id;

--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -1771,10 +1771,6 @@ public class ApiDBUtils {
         return s_projectJoinDao.newProjectResponse(proj);
     }
 
-    public static ProjectResponse fillProjectDetails(ProjectResponse rsp, ProjectJoinVO proj) {
-        return s_projectJoinDao.setProjectResponse(rsp, proj);
-    }
-
     public static List<ProjectJoinVO> newProjectView(Project proj) {
         return s_projectJoinDao.newProjectView(proj);
     }

--- a/server/src/main/java/com/cloud/api/query/ViewResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/query/ViewResponseHelper.java
@@ -203,11 +203,8 @@ public class ViewResponseHelper {
             if (pData == null) {
                 // first time encountering this vm
                 pData = ApiDBUtils.newProjectResponse(p);
-            } else {
-                // update those  1 to many mapping fields
-                pData = ApiDBUtils.fillProjectDetails(pData, p);
+                prjDataList.put(p.getId(), pData);
             }
-            prjDataList.put(p.getId(), pData);
         }
         return new ArrayList<ProjectResponse>(prjDataList.values());
     }

--- a/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDao.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDao.java
@@ -28,8 +28,6 @@ public interface ProjectJoinDao extends GenericDao<ProjectJoinVO, Long> {
 
     ProjectResponse newProjectResponse(ProjectJoinVO proj);
 
-    ProjectResponse setProjectResponse(ProjectResponse rsp, ProjectJoinVO proj);
-
     List<ProjectJoinVO> newProjectView(Project proj);
 
     List<ProjectJoinVO> searchByIds(Long... ids);

--- a/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
@@ -32,6 +32,7 @@ import com.cloud.api.query.vo.AccountJoinVO;
 import com.cloud.api.query.vo.ProjectJoinVO;
 import com.cloud.api.query.vo.ResourceTagJoinVO;
 import com.cloud.projects.Project;
+import com.cloud.server.ResourceTag.ResourceObjectType;
 import com.cloud.user.Account;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.db.GenericDaoBase;
@@ -81,12 +82,9 @@ public class ProjectJoinDaoImpl extends GenericDaoBase<ProjectJoinVO, Long> impl
         response.setOwner(proj.getOwner());
 
         // update tag information
-        Long tag_id = proj.getTagId();
-        if (tag_id != null && tag_id.longValue() > 0) {
-            ResourceTagJoinVO vtag = ApiDBUtils.findResourceTagViewById(tag_id);
-            if (vtag != null) {
-                response.addTag(ApiDBUtils.newResourceTagResponse(vtag, false));
-            }
+        List<ResourceTagJoinVO> tags = ApiDBUtils.listResourceTagViewByResourceUUID(proj.getUuid(), ResourceObjectType.Project);
+        for (ResourceTagJoinVO vtag : tags) {
+            response.addTag(ApiDBUtils.newResourceTagResponse(vtag, false));
         }
 
         //set resource limit/count information for the project (by getting the info of the project's account)
@@ -101,14 +99,6 @@ public class ProjectJoinDaoImpl extends GenericDaoBase<ProjectJoinVO, Long> impl
 
     @Override
     public ProjectResponse setProjectResponse(ProjectResponse rsp, ProjectJoinVO proj) {
-        // update tag information
-        Long tag_id = proj.getTagId();
-        if (tag_id != null && tag_id.longValue() > 0) {
-            ResourceTagJoinVO vtag = ApiDBUtils.findResourceTagViewById(tag_id);
-            if (vtag != null) {
-                rsp.addTag(ApiDBUtils.newResourceTagResponse(vtag, false));
-            }
-        }
         return rsp;
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/ProjectJoinDaoImpl.java
@@ -98,11 +98,6 @@ public class ProjectJoinDaoImpl extends GenericDaoBase<ProjectJoinVO, Long> impl
     }
 
     @Override
-    public ProjectResponse setProjectResponse(ProjectResponse rsp, ProjectJoinVO proj) {
-        return rsp;
-    }
-
-    @Override
     public List<ProjectJoinVO> newProjectView(Project proj) {
         SearchCriteria<ProjectJoinVO> sc = prjIdSearch.create();
         sc.setParameters("id", proj.getId());

--- a/server/src/main/java/com/cloud/api/query/vo/ProjectJoinVO.java
+++ b/server/src/main/java/com/cloud/api/query/vo/ProjectJoinVO.java
@@ -29,7 +29,6 @@ import org.apache.cloudstack.api.Identity;
 import org.apache.cloudstack.api.InternalIdentity;
 
 import com.cloud.projects.Project.State;
-import com.cloud.server.ResourceTag.ResourceObjectType;
 import com.cloud.utils.db.GenericDao;
 
 @Entity
@@ -76,37 +75,6 @@ public class ProjectJoinVO extends BaseViewVO implements InternalIdentity, Ident
 
     @Column(name = "domain_path")
     private String domainPath;
-
-    @Column(name = "tag_id")
-    private long tagId;
-
-    @Column(name = "tag_uuid")
-    private String tagUuid;
-
-    @Column(name = "tag_key")
-    private String tagKey;
-
-    @Column(name = "tag_value")
-    private String tagValue;
-
-    @Column(name = "tag_domain_id")
-    private long tagDomainId;
-
-    @Column(name = "tag_account_id")
-    private long tagAccountId;
-
-    @Column(name = "tag_resource_id")
-    private long tagResourceId;
-
-    @Column(name = "tag_resource_uuid")
-    private String tagResourceUuid;
-
-    @Column(name = "tag_resource_type")
-    @Enumerated(value = EnumType.STRING)
-    private ResourceObjectType tagResourceType;
-
-    @Column(name = "tag_customer")
-    private String tagCustomer;
 
     @Column(name = "project_account_id")
     private long projectAccountId;
@@ -162,46 +130,6 @@ public class ProjectJoinVO extends BaseViewVO implements InternalIdentity, Ident
 
     public String getOwner() {
         return owner;
-    }
-
-    public long getTagId() {
-        return tagId;
-    }
-
-    public String getTagUuid() {
-        return tagUuid;
-    }
-
-    public String getTagKey() {
-        return tagKey;
-    }
-
-    public String getTagValue() {
-        return tagValue;
-    }
-
-    public long getTagDomainId() {
-        return tagDomainId;
-    }
-
-    public long getTagAccountId() {
-        return tagAccountId;
-    }
-
-    public long getTagResourceId() {
-        return tagResourceId;
-    }
-
-    public String getTagResourceUuid() {
-        return tagResourceUuid;
-    }
-
-    public ResourceObjectType getTagResourceType() {
-        return tagResourceType;
-    }
-
-    public String getTagCustomer() {
-        return tagCustomer;
     }
 
     public long getAccountId() {


### PR DESCRIPTION

## Description

If projects have many resource tags, it will take long time to list projects.
Remove resource tags information from project_view will fix it the issue.

Fixes: #3178

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

create project,
add resource tags to project,
listprojects  lists all resouce tags.
