### PR TITLE
Console Proxy: Ignore META key mask if control was pressed

### DIFF
--- a/systemvm/agent/js/ajaxviewer.js
+++ b/systemvm/agent/js/ajaxviewer.js
@@ -1431,7 +1431,9 @@ AjaxViewer.prototype = {
 		if(e.shiftLeft)
 			modifiers |= AjaxViewer.LEFT_SHIFT_MASK;
 
-		if(e.metaKey)
+		// Don't pass meta key modifier filter if control key is pressed.
+		// For more details see https://github.com/apache/cloudstack/issues/3229
+		if(e.metaKey && !e.ctrlKey)
 			modifiers |= AjaxViewer.META_KEY_MASK;
 
 		return modifiers;


### PR DESCRIPTION
On VMware Zone, hitting CTRL over Console Proxy will send a mask of Meta key as well. This makes Ctrl+A, Ctrl+E and many functionalities to not work in console.

Read https://github.com/apache/cloudstack/issues/3229 for details

For fixing ignore Meta key flag passed by SDK if Control was pressed. The Jquery implementation sets the meta key to control key to support IE browser.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes #3229 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested the change on KVM, VMWare on Ubuntu based Chrome and MacBook based Chrome. Fix solves the problem.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
