### PR TITLE
Fix removing static NAT rules with Juniper SRX

### DIFF
--- a/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
+++ b/plugins/network-elements/juniper-srx/src/com/cloud/network/resource/JuniperSrxResource.java
@@ -2078,11 +2078,11 @@ public class JuniperSrxResource implements ServerResource {
                         xml = replaceXmlValue(xml, "rule-set", _privateZone);
                         xml = replaceXmlValue(xml, "from-zone", _privateZone);
                         xml = replaceXmlValue(xml, "rule-name", ruleName_private);
-                    }
 
-                    if (!sendRequestAndCheckResponse(command, xml, "name", ruleName_private))
-                    {
-                        throw new ExecutionException("Failed to delete trust static NAT rule from public IP " + publicIp + " to private IP " + privateIp);
+                        if (!sendRequestAndCheckResponse(command, xml, "name", ruleName_private))
+                        {
+                            throw new ExecutionException("Failed to delete trust static NAT rule from public IP " + publicIp + " to private IP " + privateIp);
+                        }
                     }
                     return true;
                 }
@@ -3568,6 +3568,7 @@ public class JuniperSrxResource implements ServerResource {
 
             case CHECK_IF_EXISTS:
             case CHECK_IF_IN_USE:
+            case CHECK_PRIVATE_IF_EXISTS:
                 assert (keyAndValue != null && keyAndValue.length == 2) : "If the SrxCommand is " + command + ", both a key and value must be specified.";
 
                 key = keyAndValue[0];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixed the logic for deleting static NAT rules on a Juniper SRX device.  Previously the private (trust) rule was not being removed.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3309 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Attached an SRX device to a simulator instance with unfixed code
Create Static NAT rule, verify that rules are added into SRX Config
Remove Static NAT rule, verify that private rule not removed
Apply fixed code
Create Static NAT rule, verify that both rules are present
Remove Static NAT rule, verify that both rules are removed

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
