### PR TITLE
Use IDE as the bus type for root disks and VIRTIO for data disks on platforms without support for para virtualization when using managed storage

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2330,9 +2330,13 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
             // if params contains a rootDiskController key, use its value (this is what other HVs are doing)
             DiskDef.DiskBus diskBusType = getDiskModelFromVMDetail(vmSpec);
-
             if (diskBusType == null) {
-                diskBusType = getGuestDiskModel(vmSpec.getPlatformEmulator());
+                // always use bus type ide for windows root volumes unless specified in vmspec
+                if (volume.getType() == Volume.Type.ROOT && vmSpec.getPlatformEmulator().startsWith("Windows")){
+                    diskBusType = DiskDef.DiskBus.IDE;
+                } else {
+                    diskBusType = getGuestDiskModel(vmSpec.getPlatformEmulator());
+                }
             }
 
             // I'm not sure why previously certain DATADISKs were hard-coded VIRTIO and others not, however this
@@ -3205,7 +3209,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
                 platformEmulator.startsWith("Debian GNU/Linux") ||
                 platformEmulator.startsWith("FreeBSD") ||
                 platformEmulator.startsWith("Oracle") ||
-                platformEmulator.startsWith("Windows") ||
+                platformEmulator.startsWith("Windows PV") ||
                 platformEmulator.startsWith("Other PV")) {
             return DiskDef.DiskBus.VIRTIO;
         } else {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2331,8 +2331,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             // if params contains a rootDiskController key, use its value (this is what other HVs are doing)
             DiskDef.DiskBus diskBusType = getDiskModelFromVMDetail(vmSpec);
             if (diskBusType == null) {
-                // always use bus type ide for windows root volumes unless specified in vmspec
-                if (volume.getType() == Volume.Type.ROOT && vmSpec.getPlatformEmulator().startsWith("Windows")){
+                // always use bus type ide for windows root volumes unless specified in vm details or windows pv is selected
+                if (volume.getType() == Volume.Type.ROOT && vmSpec.getPlatformEmulator().startsWith("Windows") && !vmSpec.getPlatformEmulator().startsWith("Windows PV")){
                     diskBusType = DiskDef.DiskBus.IDE;
                 } else {
                     diskBusType = getGuestDiskModel(vmSpec.getPlatformEmulator());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3202,14 +3202,13 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             return DiskDef.DiskBus.IDE;
         } else if (platformEmulator.startsWith("Other PV Virtio-SCSI")) {
             return DiskDef.DiskBus.SCSI;
-        } else if (platformEmulator.startsWith("Ubuntu") ||
+        } else if (platformEmulator.contains("Ubuntu") ||
                 platformEmulator.startsWith("Fedora") ||
                 platformEmulator.startsWith("CentOS") ||
                 platformEmulator.startsWith("Red Hat Enterprise Linux") ||
                 platformEmulator.startsWith("Debian GNU/Linux") ||
                 platformEmulator.startsWith("FreeBSD") ||
                 platformEmulator.startsWith("Oracle") ||
-                platformEmulator.startsWith("Windows PV") ||
                 platformEmulator.startsWith("Other PV")) {
             return DiskDef.DiskBus.VIRTIO;
         } else {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2331,9 +2331,11 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             // if params contains a rootDiskController key, use its value (this is what other HVs are doing)
             DiskDef.DiskBus diskBusType = getDiskModelFromVMDetail(vmSpec);
             if (diskBusType == null) {
-                // always use bus type ide for windows root volumes unless specified in vm details or windows pv is selected
+                // always use bus type ide for windows root volumes and virtio for data volumes unless specified in vm details or windows pv is selected
                 if (volume.getType() == Volume.Type.ROOT && vmSpec.getPlatformEmulator().startsWith("Windows") && !vmSpec.getPlatformEmulator().startsWith("Windows PV")){
                     diskBusType = DiskDef.DiskBus.IDE;
+                } else if (volume.getType() == Volume.Type.DATADISK && vmSpec.getPlatformEmulator().startsWith("Windows")) {
+                    diskBusType = DiskDef.DiskBus.VIRTIO;
                 } else {
                     diskBusType = getGuestDiskModel(vmSpec.getPlatformEmulator());
                 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3198,12 +3198,15 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
             return DiskDef.DiskBus.IDE;
         } else if (platformEmulator.startsWith("Other PV Virtio-SCSI")) {
             return DiskDef.DiskBus.SCSI;
-        } else if (platformEmulator.startsWith("Ubuntu") || platformEmulator.startsWith("Fedora 13") || platformEmulator.startsWith("Fedora 12") || platformEmulator.startsWith("Fedora 11") ||
-                platformEmulator.startsWith("Fedora 10") || platformEmulator.startsWith("Fedora 9") || platformEmulator.startsWith("CentOS 5.3") || platformEmulator.startsWith("CentOS 5.4") ||
-                platformEmulator.startsWith("CentOS 5.5") || platformEmulator.startsWith("CentOS") || platformEmulator.startsWith("Fedora") ||
-                platformEmulator.startsWith("Red Hat Enterprise Linux 5.3") || platformEmulator.startsWith("Red Hat Enterprise Linux 5.4") ||
-                platformEmulator.startsWith("Red Hat Enterprise Linux 5.5") || platformEmulator.startsWith("Red Hat Enterprise Linux 6") || platformEmulator.startsWith("Debian GNU/Linux") ||
-                platformEmulator.startsWith("FreeBSD 10") || platformEmulator.startsWith("Oracle") || platformEmulator.startsWith("Other PV")) {
+        } else if (platformEmulator.startsWith("Ubuntu") ||
+                platformEmulator.startsWith("Fedora") ||
+                platformEmulator.startsWith("CentOS") ||
+                platformEmulator.startsWith("Red Hat Enterprise Linux") ||
+                platformEmulator.startsWith("Debian GNU/Linux") ||
+                platformEmulator.startsWith("FreeBSD") ||
+                platformEmulator.startsWith("Oracle") ||
+                platformEmulator.startsWith("Windows") ||
+                platformEmulator.startsWith("Other PV")) {
             return DiskDef.DiskBus.VIRTIO;
         } else {
             return DiskDef.DiskBus.IDE;


### PR DESCRIPTION
## Description
This change addresses #3089. There was an issue when disks were being added with bus type IDE when creating windows VMs from ISOs. It is not possible to select bus type when creating a VM with an ISO. The bus type is inferred based on the platform emulator string provided to the KVM agent. Currently when creating a VM with managed storage (ex: Solidfire) and OS type string Windows*, all disks are added as IDE. Qemu currently does not support multiple IDE controllers and this configuration results in VMs that cannot be started. This issue does not occur when using NFS as the storage provider due to logic in that KVM agent that makes all data volumes (non root) use a virtio controller for file based disk. Similar logic was added for raw physical disks so that managed storage has the same behavior as NFS. In addition specific versions were removed from the code that guesses the disk controller to be used based on the platform emulator string since most modern operating systems support virtio.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
steps to reproduce are described in #3089

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

<!-- ## Screenshots (if appropriate): -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

In a Cloudstack system with Solidfire managed primary storage and a KVM host the following steps were performed:
1. Register to an ISO template with OS set to Windows 2016
2. Create a VM using this template with Solidfire Storage
3. Verify that the VM starts successfully
4. Verify that disks are attached on the virtio bus and only the cdrom device is ide by executing `virsh dumpxml <id>` on the KVM host

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
