### PR TITLE
server: add newline to the SSH key content

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtStartCommandWrapper.java
@@ -116,7 +116,7 @@ public final class LibvirtStartCommandWrapper extends CommandWrapper<StartComman
                     }
                 }
                 // try to patch and SSH into the systemvm for up to 5 minutes
-                for (int count = 0; count < 10; count++) {
+                for (int count = 0; count < 30; count++) {
                     // wait and try passCmdLine for 30 seconds at most for CLOUDSTACK-2823
                     libvirtComputingResource.passCmdLine(vmName, vmSpec.getBootArgs());
                     // check router is up?

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -620,7 +620,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 s_logger.error("Cannot read the private key file", e);
                 throw new CloudRuntimeException("Cannot read the private key file");
             }
-            String privateKey = new String(arr1).trim();
+            String privateKey = new String(arr1).trim() + "\n";
             byte[] arr2 = new byte[4094]; // configuration table column value size
             try (DataInputStream dis = new DataInputStream(new FileInputStream(pubkeyfile))) {
                 dis.readFully(arr2);
@@ -630,7 +630,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                 s_logger.warn("Cannot read the public key file", e);
                 throw new CloudRuntimeException("Cannot read the public key file");
             }
-            String publicKey = new String(arr2).trim();
+            String publicKey = new String(arr2).trim() + "\n";
 
             final String insertSql1 =
                     "INSERT INTO `cloud`.`configuration` (category, instance, component, name, value, description) " +


### PR DESCRIPTION
On first startup, the management server instantiates and saves random
ssh keys in the database by calling a `trim()` on the string data. On
latest CentOS7 release (CentOS Linux release 7.6.1810 (Core)) I could
reproduce the issue where router_proxy (ssh) failed and kept
prompting for passphrase. By adding a newline to the id_rsa.cloud private
key it did not prompt the same. This may likely be an environmental bug.

The patch fixes the issue by adding a newline at the end of the generated
SSH public/private keys in the DB.

SSH packages details:
libssh2.x86_64                             1.4.3-12.el7_6.2            @updates
openssh.x86_64                             7.4p1-16.el7                @anaconda
openssh-askpass.x86_64                     7.4p1-16.el7                @base
openssh-clients.x86_64                     7.4p1-16.el7                @anaconda
openssh-server.x86_64                      7.4p1-16.el7                @anaconda

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)