### PR TITLE
kvm: disable cpu features if feature starts with '-'

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -1360,7 +1360,11 @@ public class LibvirtVMDef {
 
             if (_features != null) {
                 for (String feature : _features) {
-                    modeBuilder.append("<feature policy='require' name='" + feature + "'/>");
+                    if (feature.startsWith("-")) {
+                        modeBuilder.append("<feature policy='disable' name='" + feature.substring(1) + "'/>");
+                    } else {
+                        modeBuilder.append("<feature policy='require' name='" + feature + "'/>");
+                    }
                 }
             }
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
@@ -20,6 +20,8 @@
 package com.cloud.hypervisor.kvm.resource;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Scanner;
 
 import junit.framework.TestCase;
@@ -137,6 +139,31 @@ public class LibvirtVMDefTest extends TestCase {
         String expected3 = "<cpu mode='host-passthrough'></cpu>";
         assertEquals(expected3, cpuModeDef.toString());
 
+    }
+
+    @Test
+    public void testCpuModeDefCpuFeatures() {
+        LibvirtVMDef.CpuModeDef cpuModeDef = new LibvirtVMDef.CpuModeDef();
+        cpuModeDef.setMode("custom");
+        cpuModeDef.setModel("Nehalem");
+
+        String expected_start = "<cpu mode='custom' match='exact'><model fallback='allow'>Nehalem</model>";
+        String expected_end = "</cpu>";
+
+        List<String> features1 = Arrays.asList("feature1", "feature2");
+        cpuModeDef.setFeatures(features1);
+        String expected1 = "<feature policy='require' name='feature1'/><feature policy='require' name='feature2'/>";
+        assertEquals(expected_start + expected1 + expected_end, cpuModeDef.toString());
+
+        List<String> features2 = Arrays.asList("-feature1", "-feature2");
+        cpuModeDef.setFeatures(features2);
+        String expected2 = "<feature policy='disable' name='feature1'/><feature policy='disable' name='feature2'/>";
+        assertEquals(expected_start + expected2 + expected_end, cpuModeDef.toString());
+
+        List<String> features3 = Arrays.asList("-feature1", "feature2");
+        cpuModeDef.setFeatures(features3);
+        String expected3 = "<feature policy='disable' name='feature1'/><feature policy='require' name='feature2'/>";
+        assertEquals(expected_start + expected3 + expected_end, cpuModeDef.toString());
     }
 
     @Test


### PR DESCRIPTION
When I use SandyBridge as custom cpu in my testing, vm failed to start due to following error:
```
org.libvirt.LibvirtException: unsupported configuration: guest and host CPU are not compatible: Host CPU does not provide required features: avx, xsave, aes, tsc-deadline, x2apic, pclmuldq
```

With this patch, it works with the following setting in agent.properties:
```
  guest.cpu.mode=custom
  guest.cpu.model=SandyBridge
  guest.cpu.features=-avx -xsave -aes -tsc-deadline -x2apic -pclmuldq
```

vm cpu is defined as below:
```
  <cpu mode='custom' match='exact'>
    <model fallback='allow'>SandyBridge</model>
    <feature policy='disable' name='avx'/>
    <feature policy='disable' name='xsave'/>
    <feature policy='disable' name='aes'/>
    <feature policy='disable' name='tsc-deadline'/>
    <feature policy='disable' name='x2apic'/>
    <feature policy='disable' name='pclmuldq'/>
  </cpu>
```

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. add agent.properties to server using KVM,  and restart cloudstack-agent

guest.cpu.mode=custom
guest.cpu.model=<cpu model>
guest.cpu.features=<cpu features, seperated by space>

2. create a vm on the server

cpu feature starts with "-" will be disabled, others will be enabled.
```
  <cpu mode='custom' match='exact'>
    <model fallback='allow'><cpu mode></model>
    <feature policy='disable' name='<cpu feature starts with "-">'/>
    <feature policy='require' name='<other cpu feature>'/>
  </cpu>
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
