### PR TITLE
Sort list of templates, serviceOfferings, diskOfferings etc in the deploy VM wizard

### DIFF
--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -2531,6 +2531,39 @@ function strOrFunc(arg, args) {
     return arg;
 }
 
+function sortArrayByKey(arrayToSort, sortKey, reverse) {
+
+    if(!arrayToSort){
+        return;
+    }
+    // Move smaller items towards the front
+    // or back of the array depending on if
+    // we want to sort the array in reverse
+    // order or not.
+    var moveSmaller = reverse ? 1 : -1;
+
+    // Move larger items towards the front
+    // or back of the array depending on if
+    // we want to sort the array in reverse
+    // order or not.
+    var moveLarger = reverse ? -1 : 1;
+
+    /**
+     * @param  {*} a
+     * @param  {*} b
+     * @return {Number}
+     */
+    arrayToSort.sort(function(a, b) {
+        if (a[sortKey] < b[sortKey]) {
+            return moveSmaller;
+        }
+        if (a[sortKey] > b[sortKey]) {
+            return moveLarger;
+        }
+        return 0;
+    });
+}
+
 $.validator.addMethod("netmask", function(value, element) {
     if (this.optional(element) && value.length == 0)
         return true;

--- a/ui/scripts/ui-custom/instanceWizard.js
+++ b/ui/scripts/ui-custom/instanceWizard.js
@@ -332,6 +332,9 @@
                                         $step.find('.select-iso').show();
                                     }
                                     var makeIsos = function(type, append) {
+
+                                        sortArrayByKey(args.data.templates[type], 'name');
+
                                         var $selects = makeSelects('templateid', args.data.templates[type], {
                                             name: 'name',
                                             desc: 'displaytext',
@@ -491,6 +494,9 @@
                         return {
                             response: {
                                 success: function(args) {
+
+                                    sortArrayByKey(args.data.serviceOfferings, 'cpuspeed');
+
                                     $step.find('.content .select-container').append(
                                         makeSelects('serviceofferingid', args.data.serviceOfferings, {
                                             name: 'name',
@@ -556,6 +562,8 @@
                                     $step.find('.multi-disk-select-container').remove();
                                     $step.removeClass('custom-disk-size');
                                     $step.find('.main-desc, p.no-datadisk').remove();
+
+                                    sortArrayByKey(args.data.diskOfferings, 'disksize');
 
                                     if (!multiDisk){
                                             if (args.required) {
@@ -749,6 +757,9 @@
                                     $step.find('.main-desc, p.no-affinity-groups').remove();
 
                                     if (args.data.affinityGroups && args.data.affinityGroups.length) {
+
+                                        sortArrayByKey(args.data.affinityGroups, 'name');
+
                                         $step.prepend(
                                             $('<div>').addClass('main-desc').append(
                                                 $('<p>').html(_l('message.select.affinity.groups'))
@@ -795,6 +806,9 @@
                                     $step.find('.main-desc, p.no-sshkey-pairs').remove();
 
                                     if (args.data.sshkeyPairs && args.data.sshkeyPairs.length) {
+
+                                        sortArrayByKey(args.data.sshkeyPairs, 'name');
+
                                         $step.prepend(
                                             $('<div>').addClass('main-desc').append(
                                                 $('<p>').html(_l('message.please.select.ssh.key.pair.use.with.this.vm'))
@@ -964,6 +978,9 @@
 
                                     // Populate VPC drop-down
                                     $vpcSelect.html('');
+
+                                    sortArrayByKey(vpcs, 'name');
+
                                     $(vpcs).map(function(index, vpc) {
                                         var $option = $('<option>');
                                         var id = vpc.id;
@@ -978,6 +995,8 @@
                                     $('<option>').attr('value', '-1').html(_l('ui.listView.filters.all')).prependTo($vpcSelect);
 
                                     $vpcSelect.val(-1);
+
+                                    sortArrayByKey(args.data.networkOfferings, 'name');
 
                                     // Populate network offering drop-down
                                     $(args.data.networkOfferings).each(function() {

--- a/ui/scripts/ui-custom/instanceWizard.js
+++ b/ui/scripts/ui-custom/instanceWizard.js
@@ -332,9 +332,6 @@
                                         $step.find('.select-iso').show();
                                     }
                                     var makeIsos = function(type, append) {
-
-                                        sortArrayByKey(args.data.templates[type], 'name');
-
                                         var $selects = makeSelects('templateid', args.data.templates[type], {
                                             name: 'name',
                                             desc: 'displaytext',
@@ -494,9 +491,6 @@
                         return {
                             response: {
                                 success: function(args) {
-
-                                    sortArrayByKey(args.data.serviceOfferings, 'cpuspeed');
-
                                     $step.find('.content .select-container').append(
                                         makeSelects('serviceofferingid', args.data.serviceOfferings, {
                                             name: 'name',
@@ -562,8 +556,6 @@
                                     $step.find('.multi-disk-select-container').remove();
                                     $step.removeClass('custom-disk-size');
                                     $step.find('.main-desc, p.no-datadisk').remove();
-
-                                    sortArrayByKey(args.data.diskOfferings, 'disksize');
 
                                     if (!multiDisk){
                                             if (args.required) {

--- a/ui/scripts/ui-custom/instanceWizard.js
+++ b/ui/scripts/ui-custom/instanceWizard.js
@@ -988,8 +988,6 @@
 
                                     $vpcSelect.val(-1);
 
-                                    sortArrayByKey(args.data.networkOfferings, 'name');
-
                                     // Populate network offering drop-down
                                     $(args.data.networkOfferings).each(function() {
                                         $('<option>')


### PR DESCRIPTION

## Description
Adds functionality to sort the data that is available on each in the deploy VM wizard's step by their suitable fields i.e
- templates by name
- serviceOfferings by cpuspeed
- diskOfferings by disksize
- affinityGroups by name
- sshkeyPairs by name
- network:
   - vpcs by name
   - networkOfferings by name

Fixes: https://github.com/apache/cloudstack/issues/3050

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

- sorted compute offerings
<img width="480" alt="Screen Shot 2019-05-18 at 02 24 53" src="https://user-images.githubusercontent.com/8104993/57960951-8b9ade00-7914-11e9-8780-cda1593a510a.png">

- sorted disk offerings
<img width="457" alt="Screen Shot 2019-05-18 at 02 24 58" src="https://user-images.githubusercontent.com/8104993/57960967-96ee0980-7914-11e9-86bd-8ac4394e0336.png">

- sorted networks
<img width="446" alt="Screen Shot 2019-05-18 at 02 25 09" src="https://user-images.githubusercontent.com/8104993/57960972-9b1a2700-7914-11e9-8232-90b4a6670c67.png">

## How Has This Been Tested?
Run client
Instances > Add Instance
See previous non sorted data in the browser's console
After sort function run see sorted data in the browser's console
See sorted results in the deploy VM wizard as well
