### PR TITLE
ui: fix enable static nat only towards first nic and not on any other interface

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -91,7 +91,7 @@
                 url: createURL('listNics'),
                 data: {
                     virtualmachineid: instance.id,
-                    networkId: network.id
+                    networkid: (args.context.networkid != undefined) ? args.context.networkid : network.id
                 },
                 success: function(json) {
                     var nic = json.listnicsresponse.nic[0];
@@ -2462,6 +2462,10 @@
 
                                                     if ('vpc' in args.context) {
                                                         $.extend(data, {
+                                                            networkid: $tierSelect.val(),
+                                                            vpcid: args.context.vpc[0].id
+                                                        });
+                                                        $.extend(args.context, {
                                                             networkid: $tierSelect.val(),
                                                             vpcid: args.context.vpc[0].id
                                                         });

--- a/ui/scripts/vpc.js
+++ b/ui/scripts/vpc.js
@@ -39,7 +39,7 @@
                             url: createURL('listNics'),
                             data: {
                                 virtualmachineid: instance.id,
-                                nicId: instance.nic[0].id
+                                networkId: network.id
                             },
                             success: function(json) {
                                 var nic = json.listnicsresponse.nic[0];


### PR DESCRIPTION
## Description
When enable static nat in a vpc on UI, it only lists the primary and secondary ips of first nic of a vm, no matter which vpc tier is selected. 
The same issue happens when add a vm to load balancer.

Fixes: #3334

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
