### PR TITLE
Fix iops values when creating a compute offering

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -2597,7 +2597,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             isCustomized = true;
         }
 
-        if (Boolean.TRUE.equals(isCustomizedIops)) {
+        if (Boolean.TRUE.equals(isCustomizedIops) || isCustomizedIops == null) {
             minIops = null;
             maxIops = null;
         } else {

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -2376,7 +2376,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 limitResourceUse, volatileVm, displayText, typedProvisioningType, localStorageRequired, false, tags, isSystem, vmType,
                 domainId, hostTag, deploymentPlanner);
 
-        if (Boolean.TRUE.equals(isCustomizedIops)) {
+        if (Boolean.TRUE.equals(isCustomizedIops) || isCustomizedIops == null) {
                 minIops = null;
                 maxIops = null;
         } else {


### PR DESCRIPTION
## Description
When creating a new compute offering over the ui, the isCustomIops parameter is null.
In this case the minIops and maxIops values of the offering gets set to 0 instead of null and when trying to change an instance to this offering an error occurs.
This was introduced in this PR https://github.com/apache/cloudstack/pull/3133/files.
I already opened an issue regarding this. (https://github.com/apache/cloudstack/issues/3332)

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots:
![Bildschirmfoto 2019-05-21 um 13 41 50](https://user-images.githubusercontent.com/6997263/58094720-acdc2280-7bd1-11e9-8bf8-e62f4ff5c33d.png)

![Bildschirmfoto 2019-05-21 um 13 42 18](https://user-images.githubusercontent.com/6997263/58094731-af3e7c80-7bd1-11e9-9e32-0b83ccbe12a2.png)

The marked fields were set to 0 before.

![Bildschirmfoto 2019-05-21 um 14 06 02](https://user-images.githubusercontent.com/6997263/58094818-d006d200-7bd1-11e9-860e-78a212f26482.png)

This to screenshots represent the problem.

<img width="1210" alt="Bildschirmfoto 2019-05-21 um 14 15 29" src="https://user-images.githubusercontent.com/6997263/58095320-0b55d080-7bd3-11e9-8be1-f110b00222d1.png">

<img width="1219" alt="Bildschirmfoto 2019-05-21 um 14 15 43" src="https://user-images.githubusercontent.com/6997263/58095301-042ec280-7bd3-11e9-8033-7696a77a664a.png">


## How Has This Been Tested?
Deployed to local environment and tested functionality.
