### PR TITLE
Fix rule duplication with static NAT rules

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -922,11 +922,11 @@ class CsForwardingRules(CsDataBag):
         if device is None:
             raise Exception("Ip address %s has no device in the ips databag" % rule["public_ip"])
 
-        self.fw.append(["mangle", "",
-                        "-I PREROUTING -s %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
+        self.fw.append(["mangle", "front",
+                        "-A PREROUTING -s %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
                         rule["internal_ip"]])
-        self.fw.append(["mangle", "",
-                        "-I PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
+        self.fw.append(["mangle", "front",
+                        "-A PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
                         (rule["internal_ip"], hex(100 + int(device[len("eth"):])))])
         self.fw.append(["nat", "front",
                         "-A PREROUTING -d %s/32 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The VR code has provision for inserting rules at the top or bottom by specifying "front" as the second parameter to `self.fw.append`.  However, there are a number of cases where someone has been unaware of this and added a rule with the pattern `self.fw.append(["mangle", "", "-I PREROUTING"...`.  This causes the code to check for the rule already being present to fail, and duplicate rules end up being added.

This PR fixes two of these cases which apply to adding static NAT rules.  I am aware of more of these cases, but I don't have the ability to easily test the outcome of fixing them.  I'm happy to add these in if you're confident that the automated tests will be sufficient.  Searching for "-I (case sensitive) finds these.

The [code for dealing with "front"](https://github.com/apache/cloudstack/blob/master/systemvm/debian/opt/cloud/bin/cs/CsNetfilter.py#L166) is included below to show that this shouldn't have any ill effects:

~~~
if fw[1] == "front":
    cpy = cpy.replace('-A', '-I')
~~~
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3177 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Local tests were performed (see #3177 for details of symptoms), and we have had this fix deployed in production on advanced networks for a couple of months.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
