### PR TITLE
ui: added missing hypervisor options for upload template

### DIFF
--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -296,22 +296,8 @@
 
                                         }
                                     },
-                                    // For KVM only: Direct Download
-                                    directdownload : {
-                                        label: 'label.direct.download',
-                                        docID: 'helpRegisterTemplateDirectDownload',
-                                        isBoolean: true,
-                                        dependsOn: 'hypervisor',
-                                        isHidden: true
-                                    },
-                                    checksum: {
-                                        label: 'label.checksum',
-                                        dependsOn: 'directdownload',
-                                        isHidden: true
-                                    },
-                                    // Direct Download - End
 
-                                    //XenServer only (starts here)
+                                    // fields for hypervisor == XenServer (starts here)
                                     xenserverToolsVersion61plus: {
                                         label: 'label.xenserver.tools.version.61.plus',
                                         isBoolean: true,
@@ -335,9 +321,23 @@
                                         },
                                         isHidden: true
                                     },
-                                    //XenServer only (ends here)
+                                    // fields for hypervisor == XenServer (ends here)
 
-                                    //fields for hypervisor == "KVM" (starts here)
+                                    // fields for hypervisor == "KVM" (starts here)
+                                    // Direct Download
+                                    directdownload : {
+                                        label: 'label.direct.download',
+                                        docID: 'helpRegisterTemplateDirectDownload',
+                                        isBoolean: true,
+                                        dependsOn: 'hypervisor',
+                                        isHidden: true
+                                    },
+                                    checksum: {
+                                        label: 'label.checksum',
+                                        dependsOn: 'directdownload',
+                                        isHidden: true
+                                    },
+                                    // Direct Download - End
                                     rootDiskControllerTypeKVM: {
                                         label: 'label.root.disk.controller',
                                         isHidden: true,
@@ -368,9 +368,9 @@
                                             });
                                         }
                                     },
-                                    //fields for hypervisor == "KVM" (ends here)
+                                    // fields for hypervisor == "KVM" (ends here)
 
-                                    //fields for hypervisor == "VMware" (starts here)
+                                    // fields for hypervisor == "VMware" (starts here)
                                     rootDiskControllerType: {
                                         label: 'label.root.disk.controller',
                                         isHidden: true,
@@ -463,7 +463,7 @@
                                             });
                                         }
                                     },
-                                    //fields for hypervisor == "VMware" (ends here)
+                                    // fields for hypervisor == "VMware" (ends here)
 
                                     format: {
                                         label: 'label.format',
@@ -644,15 +644,15 @@
                                     });
                                 }
 
-                                //XenServer only (starts here)
+                                // for hypervisor == XenServer (starts here)
                                 if (args.$form.find('.form-item[rel=xenserverToolsVersion61plus]').css("display") != "none") {
                                     $.extend(data, {
                                         'details[0].hypervisortoolsversion': (args.data.xenserverToolsVersion61plus == "on") ? "xenserver61" : "xenserver56"
                                     });
                                 }
-                                //XenServer only (ends here)
+                                // for hypervisor == XenServer (ends here)
 
-                                // KVM only (starts here)
+                                // for hypervisor == KVM (starts here)
                                 if (args.$form.find('.form-item[rel=rootDiskControllerTypeKVM]').css("display") != "none" && args.data.rootDiskControllerTypeKVM != "") {
                                     $.extend(data, {
                                         'details[0].rootDiskController': args.data.rootDiskControllerTypeKVM
@@ -665,9 +665,9 @@
                                         'checksum': args.data.checksum
                                     });
                                 }
-                                // KVM only (ends here)
+                                // for hypervisor == KVM (ends here)
 
-                                //VMware only (starts here)
+                                // for hypervisor == VMware (starts here)
                                 if (args.$form.find('.form-item[rel=rootDiskControllerType]').css("display") != "none" && args.data.rootDiskControllerType != "") {
                                     $.extend(data, {
                                         'details[0].rootDiskController': args.data.rootDiskControllerType
@@ -683,7 +683,7 @@
                                         'details[0].keyboard': args.data.keyboardType
                                     });
                                 }
-                                //VMware only (ends here)
+                                // for hypervisor == VMware (ends here)
 
                                 $.ajax({
                                     url: createURL('registerTemplate'),
@@ -735,23 +735,23 @@
                                             hypervisor: args.data.hypervisor
                                         };
 
-                                        //XenServer only (starts here)
+                                        // for hypervisor == XenServer (starts here)
                                         if (args.$form.find('.form-item[rel=xenserverToolsVersion61plus]').css("display") != "none") {
                                             $.extend(data, {
                                                 'details[0].hypervisortoolsversion': (args.data.xenserverToolsVersion61plus == "on") ? "xenserver61" : "xenserver56"
                                             });
                                         }
-                                        //XenServer only (ends here)
+                                        // for hypervisor == XenServer (ends here)
 
-                                        // KVM only (starts here)
+                                        // for hypervisor == KVM (starts here)
                                         if (args.$form.find('.form-item[rel=rootDiskControllerTypeKVM]').css("display") != "none" && args.data.rootDiskControllerTypeKVM != "") {
                                             $.extend(data, {
                                                 'details[0].rootDiskController': args.data.rootDiskControllerTypeKVM
                                             });
                                         }
-                                        // KVM only (ends here)
+                                        // for hypervisor == KVM (ends here)
 
-                                        //VMware only (starts here)
+                                        // for hypervisor == VMware (starts here)
                                         if (args.$form.find('.form-item[rel=rootDiskControllerType]').css("display") != "none" && args.data.rootDiskControllerType != "") {
                                             $.extend(data, {
                                                 'details[0].rootDiskController': args.data.rootDiskControllerType
@@ -767,7 +767,7 @@
                                                 'details[0].keyboard': args.data.keyboardType
                                             });
                                         }
-                                        //VMware only (ends here)
+                                        // for hypervisor == VMware (ends here)
 
                                         if (args.$form.find('.form-item[rel=isPublic]').css("display") != "none") {
                                             $.extend(data, {
@@ -941,7 +941,7 @@
                                         }
                                     },
 
-                                    //XenServer only (starts here)
+                                    // fields for hypervisor == XenServer (starts here)
                                     xenserverToolsVersion61plus: {
                                         label: 'label.xenserver.tools.version.61.plus',
                                         isBoolean: true,
@@ -965,9 +965,9 @@
                                         },
                                         isHidden: true
                                     },
-                                    //XenServer only (ends here)
+                                    // fields for hypervisor == XenServer (ends here)
 
-                                    //fields for hypervisor == "KVM" (starts here)
+                                    // fields for hypervisor == "KVM" (starts here)
                                     rootDiskControllerTypeKVM: {
                                         label: 'label.root.disk.controller',
                                         isHidden: true,
@@ -998,9 +998,9 @@
                                             });
                                         }
                                     },
-                                    //fields for hypervisor == "KVM" (ends here)
+                                    // fields for hypervisor == "KVM" (ends here)
 
-                                    //fields for hypervisor == "VMware" (starts here)
+                                    // fields for hypervisor == "VMware" (starts here)
                                     rootDiskControllerType: {
                                         label: 'label.root.disk.controller',
                                         isHidden: true,
@@ -1093,7 +1093,7 @@
                                             });
                                         }
                                     },
-                                    //fields for hypervisor == "VMware" (ends here)
+                                    // fields for hypervisor == "VMware" (ends here)
 
                                     format: {
                                         label: 'label.format',

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -311,6 +311,7 @@
                                     },
                                     // Direct Download - End
 
+                                    //XenServer only (starts here)
                                     xenserverToolsVersion61plus: {
                                         label: 'label.xenserver.tools.version.61.plus',
                                         isBoolean: true,
@@ -334,6 +335,7 @@
                                         },
                                         isHidden: true
                                     },
+                                    //XenServer only (ends here)
 
                                     //fields for hypervisor == "KVM" (starts here)
                                     rootDiskControllerTypeKVM: {
@@ -366,6 +368,7 @@
                                             });
                                         }
                                     },
+                                    //fields for hypervisor == "KVM" (ends here)
 
                                     //fields for hypervisor == "VMware" (starts here)
                                     rootDiskControllerType: {
@@ -732,6 +735,40 @@
                                             hypervisor: args.data.hypervisor
                                         };
 
+                                        //XenServer only (starts here)
+                                        if (args.$form.find('.form-item[rel=xenserverToolsVersion61plus]').css("display") != "none") {
+                                            $.extend(data, {
+                                                'details[0].hypervisortoolsversion': (args.data.xenserverToolsVersion61plus == "on") ? "xenserver61" : "xenserver56"
+                                            });
+                                        }
+                                        //XenServer only (ends here)
+
+                                        // KVM only (starts here)
+                                        if (args.$form.find('.form-item[rel=rootDiskControllerTypeKVM]').css("display") != "none" && args.data.rootDiskControllerTypeKVM != "") {
+                                            $.extend(data, {
+                                                'details[0].rootDiskController': args.data.rootDiskControllerTypeKVM
+                                            });
+                                        }
+                                        // KVM only (ends here)
+
+                                        //VMware only (starts here)
+                                        if (args.$form.find('.form-item[rel=rootDiskControllerType]').css("display") != "none" && args.data.rootDiskControllerType != "") {
+                                            $.extend(data, {
+                                                'details[0].rootDiskController': args.data.rootDiskControllerType
+                                            });
+                                        }
+                                        if (args.$form.find('.form-item[rel=nicAdapterType]').css("display") != "none" && args.data.nicAdapterType != "") {
+                                            $.extend(data, {
+                                                'details[0].nicAdapter': args.data.nicAdapterType
+                                            });
+                                        }
+                                        if (args.$form.find('.form-item[rel=keyboardType]').css("display") != "none" && args.data.keyboardType != "") {
+                                            $.extend(data, {
+                                                'details[0].keyboard': args.data.keyboardType
+                                            });
+                                        }
+                                        //VMware only (ends here)
+
                                         if (args.$form.find('.form-item[rel=isPublic]').css("display") != "none") {
                                             $.extend(data, {
                                                 ispublic: (args.data.isPublic == "on")
@@ -865,8 +902,198 @@
                                                     });
                                                 }
                                             });
+                                            args.$select.change(function() {
+                                                var $form = $(this).closest('form');
+                                                if ($(this).val() == "VMware") {
+                                                    $form.find('.form-item[rel=rootDiskControllerType]').css('display', 'inline-block');
+                                                    $form.find('.form-item[rel=nicAdapterType]').css('display', 'inline-block');
+                                                    $form.find('.form-item[rel=keyboardType]').css('display', 'inline-block');
+                                                    $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
+                                                    $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
+                                                    $form.find('.form-item[rel=requireshvm]').hide();
+                                                } else if ($(this).val() == "XenServer") {
+                                                    $form.find('.form-item[rel=rootDiskControllerType]').hide();
+                                                    $form.find('.form-item[rel=nicAdapterType]').hide();
+                                                    $form.find('.form-item[rel=keyboardType]').hide();
+                                                    $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
+                                                    $form.find('.form-item[rel=requireshvm]').css('display', 'inline-block');
+                                                    if (isAdmin()) {
+                                                        $form.find('.form-item[rel=xenserverToolsVersion61plus]').css('display', 'inline-block');
+                                                    }
+                                                } else if ($(this).val() == "KVM") {
+                                                    $form.find('.form-item[rel=rootDiskControllerType]').hide();
+                                                    $form.find('.form-item[rel=nicAdapterType]').hide();
+                                                    $form.find('.form-item[rel=keyboardType]').hide();
+                                                    $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
+                                                    $form.find('.form-item[rel=rootDiskControllerTypeKVM]').css('display', 'inline-block');
+                                                    $('#label_root_disk_controller').prop('selectedIndex', 2);
+                                                    $form.find('.form-item[rel=requireshvm]').css('display', 'inline-block');
+                                                } else {
+                                                    $form.find('.form-item[rel=rootDiskControllerType]').hide();
+                                                    $form.find('.form-item[rel=nicAdapterType]').hide();
+                                                    $form.find('.form-item[rel=keyboardType]').hide();
+                                                    $form.find('.form-item[rel=xenserverToolsVersion61plus]').hide();
+                                                    $form.find('.form-item[rel=rootDiskControllerTypeKVM]').hide();
+                                                    $form.find('.form-item[rel=requireshvm]').css('display', 'inline-block');
+                                                }
+                                            });
+                                            args.$select.trigger('change');
                                         }
                                     },
+
+                                    //XenServer only (starts here)
+                                    xenserverToolsVersion61plus: {
+                                        label: 'label.xenserver.tools.version.61.plus',
+                                        isBoolean: true,
+                                        isChecked: function (args) {
+                                             var b = true;
+                                            if (isAdmin()) {
+                                                $.ajax({
+                                                    url: createURL('listConfigurations'),
+                                                    data: {
+                                                        name: 'xenserver.pvdriver.version'
+                                                    },
+                                                    async: false,
+                                                    success: function (json) {
+                                                        if (json.listconfigurationsresponse.configuration != null && json.listconfigurationsresponse.configuration[0].value != 'xenserver61') {
+                                                            b = false;
+                                                        }
+                                                    }
+                                                });
+                                            }
+                                            return b;
+                                        },
+                                        isHidden: true
+                                    },
+                                    //XenServer only (ends here)
+
+                                    //fields for hypervisor == "KVM" (starts here)
+                                    rootDiskControllerTypeKVM: {
+                                        label: 'label.root.disk.controller',
+                                        isHidden: true,
+                                        select: function(args) {
+                                            var items = []
+                                            items.push({
+                                                id: "",
+                                                description: ""
+                                            });
+                                            items.push({
+                                                id: "ide",
+                                                description: "ide"
+                                            });
+                                            items.push({
+                                                id: "osdefault",
+                                                description: "osdefault"
+                                            });
+                                            items.push({
+                                                id: "scsi",
+                                                description: "virtio-scsi"
+                                            });
+                                            items.push({
+                                                id: "virtio",
+                                                description: "virtio"
+                                            });
+                                            args.response.success({
+                                                data: items
+                                            });
+                                        }
+                                    },
+                                    //fields for hypervisor == "KVM" (ends here)
+
+                                    //fields for hypervisor == "VMware" (starts here)
+                                    rootDiskControllerType: {
+                                        label: 'label.root.disk.controller',
+                                        isHidden: true,
+                                        select: function(args) {
+                                            var items = []
+                                            items.push({
+                                                id: "",
+                                                description: ""
+                                            });
+                                            items.push({
+                                                id: "scsi",
+                                                description: "scsi"
+                                            });
+                                            items.push({
+                                                id: "ide",
+                                                description: "ide"
+                                            });
+                                            items.push({
+                                                id: "osdefault",
+                                                description: "osdefault"
+                                            });
+                                            items.push({
+                                                id: "pvscsi",
+                                                description: "pvscsi"
+                                            });
+                                            items.push({
+                                                id: "lsilogic",
+                                                description: "lsilogic"
+                                            });
+                                            items.push({
+                                                id: "lsisas1068",
+                                                description: "lsilogicsas"
+                                            });
+                                            items.push({
+                                                id: "buslogic",
+                                                description: "buslogic"
+                                            });
+                                            args.response.success({
+                                                data: items
+                                            });
+                                        }
+                                    },
+                                    nicAdapterType: {
+                                        label: 'label.nic.adapter.type',
+                                        isHidden: true,
+                                        select: function(args) {
+                                            var items = []
+                                            items.push({
+                                                id: "",
+                                                description: ""
+                                            });
+                                            items.push({
+                                                id: "E1000",
+                                                description: "E1000"
+                                            });
+                                            items.push({
+                                                id: "PCNet32",
+                                                description: "PCNet32"
+                                            });
+                                            items.push({
+                                                id: "Vmxnet2",
+                                                description: "Vmxnet2"
+                                            });
+                                            items.push({
+                                                id: "Vmxnet3",
+                                                description: "Vmxnet3"
+                                            });
+                                            args.response.success({
+                                                data: items
+                                            });
+                                        }
+                                    },
+                                    keyboardType: {
+                                        label: 'label.keyboard.type',
+                                        isHidden: true,
+                                        select: function(args) {
+                                            var items = []
+                                            items.push({
+                                                id: "",
+                                                description: ""
+                                            });
+                                            for (var key in cloudStackOptions.keyboardOptions) {
+                                                items.push({
+                                                    id: key,
+                                                    description: _l(cloudStackOptions.keyboardOptions[key])
+                                                });
+                                            }
+                                            args.response.success({
+                                                data: items
+                                            });
+                                        }
+                                    },
+                                    //fields for hypervisor == "VMware" (ends here)
 
                                     format: {
                                         label: 'label.format',


### PR DESCRIPTION
## Description
Upload template form was missing some hypervisor specific options which can be seen on Register template form.
For XenServer, XenServer tool version added
For VMware, Root disk controller, NIC adapter type, Keyboard type added and HVM is hidden
For KVM, Root disk controller added

Fixes #3363 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![Screenshot from 2019-05-31 15-13-20](https://user-images.githubusercontent.com/153340/58697181-bc6c2000-83b6-11e9-88a6-5c754a826a10.png)
![Screenshot from 2019-05-31 15-12-39](https://user-images.githubusercontent.com/153340/58697189-bfffa700-83b6-11e9-8507-528353888138.png)
![Screenshot from 2019-05-31 15-13-31](https://user-images.githubusercontent.com/153340/58697208-c68e1e80-83b6-11e9-99e8-bfc4c5dae019.png)


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
