### PR TITLE
ssvm: apply MTU value on storage/management nic if available

### DIFF
--- a/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
+++ b/services/secondary-storage/server/src/org/apache/cloudstack/storage/resource/NfsSecondaryStorageResource.java
@@ -258,6 +258,30 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
     }
 
     /**
+     * Applies MTU per the "mtu" value from params
+     * @param params
+     */
+    public static void applyMtu(Map<String, Object> params) {
+        if (params == null || params.get("mtu") == null) {
+            return;
+        }
+        final Integer mtu = NumbersUtil.parseInt((String) params.get("mtu"), 0);
+        if (mtu > 0) {
+            final Script command = new Script("/sbin/ip", s_logger);
+            command.add("link");
+            command.add("set");
+            command.add("dev");
+            command.add("eth1");
+            command.add("mtu");
+            command.add(String.valueOf(mtu));
+            final String result = command.execute();
+            if (result != null) {
+                s_logger.warn("Error in setting MTU on storage/management nic: " + result);
+            }
+        }
+    }
+
+    /**
      * Retrieve converted "nfsVersion" value from params
      * @param params
      * @return nfsVersion value if exists, null in other case
@@ -2605,6 +2629,7 @@ public class NfsSecondaryStorageResource extends ServerResourceBase implements S
             }
 
             startAdditionalServices();
+            applyMtu(params);
             _params.put("install.numthreads", "50");
             _params.put("secondary.storage.vm", "true");
             _nfsVersion = retrieveNfsVersionFromParams(params);


### PR DESCRIPTION
If mtu= value is defined in the parameters received by the SSVM agent
per the secstorage.vm.mtu.size setting, it applies the MTU setting on
eth1 which is the storage/management nic.

Fixes #3369

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)