### PR TITLE
router: support multi-homed VMs in VPC

### DIFF
--- a/server/src/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/com/cloud/network/element/VirtualRouterElement.java
@@ -895,6 +895,7 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
     @Override
     public boolean release(final Network network, final NicProfile nic, final VirtualMachineProfile vm, final ReservationContext context) throws ConcurrentOperationException,
     ResourceUnavailableException {
+        removeDhcpEntry(network, nic, vm);
         return true;
     }
 

--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -118,7 +118,6 @@ class CsDhcp(CsDataBag):
 
     def delete_leases(self):
         macs_dhcphosts = []
-        interfaces = filter(lambda x: x.startswith('eth'), os.listdir('/sys/class/net'))
         try:
             logging.info("Attempting to delete entries from dnsmasq.leases file for VMs which are not on dhcphosts file")
             for host in open(DHCP_HOSTS):
@@ -130,10 +129,9 @@ class CsDhcp(CsDataBag):
                 mac = lease[1]
                 ip = lease[2]
                 if mac not in macs_dhcphosts:
-                    for interface in interfaces:
-                        cmd = "dhcp_release %s %s %s" % (interface, ip, mac)
-                        logging.info(cmd)
-                        CsHelper.execute(cmd)
+                    cmd = "dhcp_release $(ip route get %s | grep eth | head -1 | awk '{print $3}') %s %s" % (ip, ip, mac)
+                    logging.info(cmd)
+                    CsHelper.execute(cmd)
                     removed = removed + 1
                     self.del_host(ip)
             logging.info("Deleted %s entries from dnsmasq.leases file" % str(removed))

--- a/systemvm/debian/opt/cloud/bin/cs_dhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs_dhcp.py
@@ -28,11 +28,6 @@ def merge(dbag, data):
     else:
         remove_keys = set()
         for key, entry in dbag.iteritems():
-            if key != 'id' and entry['host_name'] == data['host_name']:
-                remove_keys.add(key)
-                break
-
-        for key, entry in dbag.iteritems():
             if key != 'id' and entry['mac_address'] == data['mac_address']:
                 remove_keys.add(key)
                 break


### PR DESCRIPTION
This does not remove VM entries in dbags when hostnames match. The
current codebase already removes entry when a VM is stopped/removed so
we don't need to handle lazy removal. This will allow a VM on
multiple-tiers in a VPC to get dns/dhcp rules as expected.

This also fixes the issue of dhcp_release based on a specific interface.

Fixes #3273

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)