### PR TITLE
KVM: Enhancements for direct download feature

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/RevokeTemplateDirectDownloadCertificateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/RevokeTemplateDirectDownloadCertificateCmd.java
@@ -1,0 +1,88 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package org.apache.cloudstack.api.command.admin.direct.download;
+
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.SuccessResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.direct.download.DirectDownloadManager;
+import org.apache.log4j.Logger;
+
+import javax.inject.Inject;
+
+@APICommand(name = RevokeTemplateDirectDownloadCertificateCmd.APINAME,
+        description = "Revoke a certificate alias from a KVM host",
+        responseObject = SuccessResponse.class,
+        requestHasSensitiveInfo = true,
+        responseHasSensitiveInfo = true,
+        since = "4.13",
+        authorized = {RoleType.Admin})
+public class RevokeTemplateDirectDownloadCertificateCmd extends BaseCmd {
+
+    @Inject
+    DirectDownloadManager directDownloadManager;
+
+    private static final Logger LOG = Logger.getLogger(RevokeTemplateDirectDownloadCertificateCmd.class);
+    public static final String APINAME = "revokeTemplateDirectDownloadCertificate";
+
+    @Parameter(name = ApiConstants.NAME, type = BaseCmd.CommandType.STRING, required = true,
+            description = "alias of the SSL certificate")
+    private String certificateAlias;
+
+    @Parameter(name = ApiConstants.HYPERVISOR, type = BaseCmd.CommandType.STRING, required = true,
+            description = "Hypervisor type")
+    private String hypervisor;
+
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        if (!hypervisor.equalsIgnoreCase("kvm")) {
+            throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Currently supporting KVM hosts only");
+        }
+        SuccessResponse response = new SuccessResponse(getCommandName());
+        try {
+            LOG.debug("Revoking certificate " + certificateAlias + " from " + hypervisor + " hosts");
+            boolean result = directDownloadManager.revokeCertificateAlias(certificateAlias, hypervisor);
+            response.setSuccess(result);
+            setResponseObject(response);
+        } catch (Exception e) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, e.getMessage());
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return APINAME.toLowerCase() + BaseCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return CallContext.current().getCallingAccount().getId();
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/RevokeTemplateDirectDownloadCertificateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/RevokeTemplateDirectDownloadCertificateCmd.java
@@ -30,6 +30,7 @@ import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.context.CallContext;
@@ -58,12 +59,16 @@ public class RevokeTemplateDirectDownloadCertificateCmd extends BaseCmd {
     private String certificateAlias;
 
     @Parameter(name = ApiConstants.HYPERVISOR, type = BaseCmd.CommandType.STRING, required = true,
-            description = "Hypervisor type")
+            description = "hypervisor type")
     private String hypervisor;
 
     @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class,
-            description = "Zone to upload certificate", required = true)
+            description = "zone to revoke certificate", required = true)
     private Long zoneId;
+
+    @Parameter(name = ApiConstants.HOST_ID, type = CommandType.UUID, entityType = HostResponse.class,
+            description = "(optional) the host ID to revoke certificate")
+    private Long hostId;
 
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
@@ -73,7 +78,7 @@ public class RevokeTemplateDirectDownloadCertificateCmd extends BaseCmd {
         SuccessResponse response = new SuccessResponse(getCommandName());
         try {
             LOG.debug("Revoking certificate " + certificateAlias + " from " + hypervisor + " hosts");
-            boolean result = directDownloadManager.revokeCertificateAlias(certificateAlias, hypervisor, zoneId);
+            boolean result = directDownloadManager.revokeCertificateAlias(certificateAlias, hypervisor, zoneId, hostId);
             response.setSuccess(result);
             setResponseObject(response);
         } catch (Exception e) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/RevokeTemplateDirectDownloadCertificateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/RevokeTemplateDirectDownloadCertificateCmd.java
@@ -31,6 +31,7 @@ import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.SuccessResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.direct.download.DirectDownloadManager;
 import org.apache.log4j.Logger;
@@ -60,6 +61,10 @@ public class RevokeTemplateDirectDownloadCertificateCmd extends BaseCmd {
             description = "Hypervisor type")
     private String hypervisor;
 
+    @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class,
+            description = "Zone to upload certificate", required = true)
+    private Long zoneId;
+
     @Override
     public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
         if (!hypervisor.equalsIgnoreCase("kvm")) {
@@ -68,7 +73,7 @@ public class RevokeTemplateDirectDownloadCertificateCmd extends BaseCmd {
         SuccessResponse response = new SuccessResponse(getCommandName());
         try {
             LOG.debug("Revoking certificate " + certificateAlias + " from " + hypervisor + " hosts");
-            boolean result = directDownloadManager.revokeCertificateAlias(certificateAlias, hypervisor);
+            boolean result = directDownloadManager.revokeCertificateAlias(certificateAlias, hypervisor, zoneId);
             response.setSuccess(result);
             setResponseObject(response);
         } catch (Exception e) {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/UploadTemplateDirectDownloadCertificateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/UploadTemplateDirectDownloadCertificateCmd.java
@@ -23,6 +23,7 @@ import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.SuccessResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.context.CallContext;
@@ -61,6 +62,10 @@ public class UploadTemplateDirectDownloadCertificateCmd extends BaseCmd {
             description = "Zone to upload certificate", required = true)
     private Long zoneId;
 
+    @Parameter(name = ApiConstants.HOST_ID, type = CommandType.UUID, entityType = HostResponse.class,
+            description = "(optional) the host ID to revoke certificate")
+    private Long hostId;
+
     @Override
     public void execute() {
         if (!hypervisor.equalsIgnoreCase("kvm")) {
@@ -69,7 +74,7 @@ public class UploadTemplateDirectDownloadCertificateCmd extends BaseCmd {
 
         try {
             LOG.debug("Uploading certificate " + name + " to agents for Direct Download");
-            boolean result = directDownloadManager.uploadCertificateToHosts(certificate, name, hypervisor, zoneId);
+            boolean result = directDownloadManager.uploadCertificateToHosts(certificate, name, hypervisor, zoneId, hostId);
             SuccessResponse response = new SuccessResponse(getCommandName());
             response.setSuccess(result);
             setResponseObject(response);

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/UploadTemplateDirectDownloadCertificateCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/direct/download/UploadTemplateDirectDownloadCertificateCmd.java
@@ -24,6 +24,7 @@ import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.response.SuccessResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.direct.download.DirectDownloadManager;
 import org.apache.log4j.Logger;
@@ -56,6 +57,10 @@ public class UploadTemplateDirectDownloadCertificateCmd extends BaseCmd {
     @Parameter(name = ApiConstants.HYPERVISOR, type = BaseCmd.CommandType.STRING, required = true, description = "Hypervisor type")
     private String hypervisor;
 
+    @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class,
+            description = "Zone to upload certificate", required = true)
+    private Long zoneId;
+
     @Override
     public void execute() {
         if (!hypervisor.equalsIgnoreCase("kvm")) {
@@ -64,7 +69,7 @@ public class UploadTemplateDirectDownloadCertificateCmd extends BaseCmd {
 
         try {
             LOG.debug("Uploading certificate " + name + " to agents for Direct Download");
-            boolean result = directDownloadManager.uploadCertificateToHosts(certificate, name, hypervisor);
+            boolean result = directDownloadManager.uploadCertificateToHosts(certificate, name, hypervisor, zoneId);
             SuccessResponse response = new SuccessResponse(getCommandName());
             response.setSuccess(result);
             setResponseObject(response);

--- a/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificate.java
+++ b/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificate.java
@@ -14,23 +14,16 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+package org.apache.cloudstack.direct.download;
 
-package org.apache.cloudstack.framework.agent.direct.download;
+import com.cloud.hypervisor.Hypervisor;
+import org.apache.cloudstack.api.Identity;
+import org.apache.cloudstack.api.InternalIdentity;
 
-public interface DirectDownloadService {
+public interface DirectDownloadCertificate extends InternalIdentity, Identity {
 
-    /**
-     * Download template/ISO into poolId bypassing secondary storage. Download performed by hostId
-     */
-    void downloadTemplate(long templateId, long poolId, long hostId);
+    String getCertificate();
+    String getAlias();
+    Hypervisor.HypervisorType getHypervisorType();
 
-    /**
-     * Upload client certificate to each running host
-     */
-    boolean uploadCertificateToHosts(String certificateCer, String certificateName, String hypervisor, Long zoneId);
-
-    /**
-     * Upload a stored certificate on database with id 'certificateId' to host with id 'hostId'
-     */
-    boolean uploadCertificate(long certificateId, long hostId);
 }

--- a/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
+++ b/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
@@ -26,12 +26,14 @@ public interface DirectDownloadManager extends DirectDownloadService, PluggableS
 
     ConfigKey<Long> DirectDownloadCertificateUploadInterval = new ConfigKey<>("Advanced", Long.class,
             "direct.download.certificate.background.task.interval",
-            "24",
-            "The Direct Download framework background interval in hours.",
-            true);
+            "0",
+            "This interval (in hours) controls a background task to sync hosts within enabled zones " +
+                    "missing uploaded certificates for direct download." +
+                    "Only certificates which have not been revoked from hosts are uploaded",
+            false);
 
     /**
      * Revoke direct download certificate with alias 'alias' from hosts of hypervisor type 'hypervisor'
      */
-    boolean revokeCertificateAlias(String certificateAlias, String hypervisor, Long zoneId);
+    boolean revokeCertificateAlias(String certificateAlias, String hypervisor, Long zoneId, Long hostId);
 }

--- a/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
+++ b/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
@@ -19,11 +19,19 @@ package org.apache.cloudstack.direct.download;
 
 import com.cloud.utils.component.PluggableService;
 import org.apache.cloudstack.framework.agent.direct.download.DirectDownloadService;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
 
-public interface DirectDownloadManager extends DirectDownloadService, PluggableService {
+public interface DirectDownloadManager extends DirectDownloadService, PluggableService, Configurable {
+
+    ConfigKey<Long> DirectDownloadCertificateUploadInterval = new ConfigKey<>("Advanced", Long.class,
+            "direct.download.certificate.background.task.interval",
+            "24",
+            "The Direct Download framework background interval in hours.",
+            true);
 
     /**
      * Revoke direct download certificate with alias 'alias' from hosts of hypervisor type 'hypervisor'
      */
-    boolean revokeCertificateAlias(String certificateAlias, String hypervisor);
+    boolean revokeCertificateAlias(String certificateAlias, String hypervisor, Long zoneId);
 }

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/RevokeDirectDownloadCertificateCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/RevokeDirectDownloadCertificateCommand.java
@@ -1,3 +1,4 @@
+//
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -14,16 +15,25 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+//
+package org.apache.cloudstack.agent.directdownload;
 
-package org.apache.cloudstack.direct.download;
+import com.cloud.agent.api.Command;
 
-import com.cloud.utils.component.PluggableService;
-import org.apache.cloudstack.framework.agent.direct.download.DirectDownloadService;
+public class RevokeDirectDownloadCertificateCommand extends Command {
 
-public interface DirectDownloadManager extends DirectDownloadService, PluggableService {
+    private String certificateAlias;
 
-    /**
-     * Revoke direct download certificate with alias 'alias' from hosts of hypervisor type 'hypervisor'
-     */
-    boolean revokeCertificateAlias(String certificateAlias, String hypervisor);
+    public RevokeDirectDownloadCertificateCommand(final String alias) {
+        this.certificateAlias = alias;
+    }
+
+    public String getCertificateAlias() {
+        return certificateAlias;
+    }
+
+    @Override
+    public boolean executeInSequence() {
+        return false;
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDao.java
@@ -107,4 +107,6 @@ public interface HostDao extends GenericDao<HostVO, Long>, StateDao<Status, Stat
      * Side note: this method is currently only used in XenServerGuru; therefore, it was designed to meet XenServer deployment scenarios requirements.
      */
     HostVO findHostInZoneToExecuteCommand(long zoneId, HypervisorType hypervisorType);
+
+    List<HostVO> listAllHostsUpByZoneAndHypervisor(long zoneId, HypervisorType hypervisorType);
 }

--- a/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/host/dao/HostDaoImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -1188,6 +1189,15 @@ public class HostDaoImpl extends GenericDaoBase<HostVO, Long> implements HostDao
         } catch (SQLException e) {
             throw new CloudRuntimeException(e);
         }
+    }
+
+    @Override
+    public List<HostVO> listAllHostsUpByZoneAndHypervisor(long zoneId, HypervisorType hypervisorType) {
+        return listByDataCenterIdAndHypervisorType(zoneId, hypervisorType)
+                .stream()
+                .filter(x -> x.getStatus().equals(Status.Up) &&
+                        x.getType() == Host.Type.Routing)
+                .collect(Collectors.toList());
     }
 
     private ResultSet executeSqlGetResultsetForMethodFindHostInZoneToExecuteCommand(HypervisorType hypervisorType, long zoneId, TransactionLegacy tx, String sql) throws SQLException {

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDao.java
@@ -14,23 +14,15 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+package org.apache.cloudstack.direct.download;
 
-package org.apache.cloudstack.framework.agent.direct.download;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.utils.db.GenericDao;
 
-public interface DirectDownloadService {
+import java.util.List;
 
-    /**
-     * Download template/ISO into poolId bypassing secondary storage. Download performed by hostId
-     */
-    void downloadTemplate(long templateId, long poolId, long hostId);
-
-    /**
-     * Upload client certificate to each running host
-     */
-    boolean uploadCertificateToHosts(String certificateCer, String certificateName, String hypervisor, Long zoneId);
-
-    /**
-     * Upload a stored certificate on database with id 'certificateId' to host with id 'hostId'
-     */
-    boolean uploadCertificate(long certificateId, long hostId);
+public interface DirectDownloadCertificateDao extends GenericDao<DirectDownloadCertificateVO, Long> {
+    DirectDownloadCertificateVO findByAlias(String alias);
+    List<DirectDownloadCertificateVO> listByHypervisorType(Hypervisor.HypervisorType hypervisorType);
+    List<DirectDownloadCertificateVO> listByZone(long zoneId);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDao.java
@@ -22,7 +22,6 @@ import com.cloud.utils.db.GenericDao;
 import java.util.List;
 
 public interface DirectDownloadCertificateDao extends GenericDao<DirectDownloadCertificateVO, Long> {
-    DirectDownloadCertificateVO findByAlias(String alias);
-    List<DirectDownloadCertificateVO> listByHypervisorType(Hypervisor.HypervisorType hypervisorType);
+    DirectDownloadCertificateVO findByAlias(String alias, Hypervisor.HypervisorType hypervisorType, long zoneId);
     List<DirectDownloadCertificateVO> listByZone(long zoneId);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDaoImpl.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.direct.download;
+
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.utils.db.GenericDaoBase;
+import com.cloud.utils.db.SearchBuilder;
+import com.cloud.utils.db.SearchCriteria;
+
+import java.util.List;
+
+public class DirectDownloadCertificateDaoImpl extends GenericDaoBase<DirectDownloadCertificateVO, Long> implements DirectDownloadCertificateDao {
+
+    private final SearchBuilder<DirectDownloadCertificateVO> certificateSearchBuilder;
+
+    public DirectDownloadCertificateDaoImpl() {
+        certificateSearchBuilder = createSearchBuilder();
+        certificateSearchBuilder.and("alias", certificateSearchBuilder.entity().getAlias(), SearchCriteria.Op.EQ);
+        certificateSearchBuilder.and("hypervisor_type", certificateSearchBuilder.entity().getHypervisorType(), SearchCriteria.Op.EQ);
+        certificateSearchBuilder.and("zone_id", certificateSearchBuilder.entity().getZoneId(), SearchCriteria.Op.EQ);
+        certificateSearchBuilder.done();
+    }
+
+    @Override
+    public DirectDownloadCertificateVO findByAlias(String alias) {
+        SearchCriteria<DirectDownloadCertificateVO> sc = certificateSearchBuilder.create();
+        sc.setParameters("alias", alias);
+        return findOneBy(sc);
+    }
+
+    @Override
+    public List<DirectDownloadCertificateVO> listByHypervisorType(Hypervisor.HypervisorType hypervisorType) {
+        SearchCriteria<DirectDownloadCertificateVO> sc = certificateSearchBuilder.create();
+        sc.setParameters("hypervisor_type", hypervisorType);
+        return listBy(sc);
+    }
+
+    @Override
+    public List<DirectDownloadCertificateVO> listByZone(long zoneId) {
+        SearchCriteria<DirectDownloadCertificateVO> sc = certificateSearchBuilder.create();
+        sc.setParameters("zone_id", zoneId);
+        return listBy(sc);
+    }
+}

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateDaoImpl.java
@@ -36,17 +36,12 @@ public class DirectDownloadCertificateDaoImpl extends GenericDaoBase<DirectDownl
     }
 
     @Override
-    public DirectDownloadCertificateVO findByAlias(String alias) {
+    public DirectDownloadCertificateVO findByAlias(String alias, Hypervisor.HypervisorType hypervisorType, long zoneId) {
         SearchCriteria<DirectDownloadCertificateVO> sc = certificateSearchBuilder.create();
         sc.setParameters("alias", alias);
-        return findOneBy(sc);
-    }
-
-    @Override
-    public List<DirectDownloadCertificateVO> listByHypervisorType(Hypervisor.HypervisorType hypervisorType) {
-        SearchCriteria<DirectDownloadCertificateVO> sc = certificateSearchBuilder.create();
         sc.setParameters("hypervisor_type", hypervisorType);
-        return listBy(sc);
+        sc.setParameters("zone_id", zoneId);
+        return findOneBy(sc);
     }
 
     @Override

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDao.java
@@ -14,23 +14,10 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+package org.apache.cloudstack.direct.download;
 
-package org.apache.cloudstack.framework.agent.direct.download;
+import com.cloud.utils.db.GenericDao;
 
-public interface DirectDownloadService {
-
-    /**
-     * Download template/ISO into poolId bypassing secondary storage. Download performed by hostId
-     */
-    void downloadTemplate(long templateId, long poolId, long hostId);
-
-    /**
-     * Upload client certificate to each running host
-     */
-    boolean uploadCertificateToHosts(String certificateCer, String certificateName, String hypervisor, Long zoneId);
-
-    /**
-     * Upload a stored certificate on database with id 'certificateId' to host with id 'hostId'
-     */
-    boolean uploadCertificate(long certificateId, long hostId);
+public interface DirectDownloadCertificateHostMapDao extends GenericDao<DirectDownloadCertificateHostMapVO, Long> {
+    DirectDownloadCertificateHostMapVO findByCertificateAndHost(long certificateId, long hostId);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDao.java
@@ -18,6 +18,9 @@ package org.apache.cloudstack.direct.download;
 
 import com.cloud.utils.db.GenericDao;
 
+import java.util.List;
+
 public interface DirectDownloadCertificateHostMapDao extends GenericDao<DirectDownloadCertificateHostMapVO, Long> {
     DirectDownloadCertificateHostMapVO findByCertificateAndHost(long certificateId, long hostId);
+    List<DirectDownloadCertificateHostMapVO> listByCertificateId(long certificateId);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDaoImpl.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.direct.download;
+
+import com.cloud.utils.db.GenericDaoBase;
+import com.cloud.utils.db.SearchBuilder;
+import com.cloud.utils.db.SearchCriteria;
+
+public class DirectDownloadCertificateHostMapDaoImpl extends GenericDaoBase<DirectDownloadCertificateHostMapVO, Long> implements DirectDownloadCertificateHostMapDao {
+    private final SearchBuilder<DirectDownloadCertificateHostMapVO> mapSearchBuilder;
+
+    public DirectDownloadCertificateHostMapDaoImpl() {
+        mapSearchBuilder = createSearchBuilder();
+        mapSearchBuilder.and("certificate_id", mapSearchBuilder.entity().getCertificateId(), SearchCriteria.Op.EQ);
+        mapSearchBuilder.and("host_id", mapSearchBuilder.entity().getHostId(), SearchCriteria.Op.EQ);
+        mapSearchBuilder.done();
+    }
+    @Override
+    public DirectDownloadCertificateHostMapVO findByCertificateAndHost(long certificateId, long hostId) {
+        SearchCriteria<DirectDownloadCertificateHostMapVO> sc = mapSearchBuilder.create();
+        sc.setParameters("certificate_id", certificateId);
+        sc.setParameters("host_id", hostId);
+        return findOneBy(sc);
+    }
+}

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapDaoImpl.java
@@ -20,6 +20,8 @@ import com.cloud.utils.db.GenericDaoBase;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
 
+import java.util.List;
+
 public class DirectDownloadCertificateHostMapDaoImpl extends GenericDaoBase<DirectDownloadCertificateHostMapVO, Long> implements DirectDownloadCertificateHostMapDao {
     private final SearchBuilder<DirectDownloadCertificateHostMapVO> mapSearchBuilder;
 
@@ -35,5 +37,12 @@ public class DirectDownloadCertificateHostMapDaoImpl extends GenericDaoBase<Dire
         sc.setParameters("certificate_id", certificateId);
         sc.setParameters("host_id", hostId);
         return findOneBy(sc);
+    }
+
+    @Override
+    public List<DirectDownloadCertificateHostMapVO> listByCertificateId(long certificateId) {
+        SearchCriteria<DirectDownloadCertificateHostMapVO> sc = mapSearchBuilder.create();
+        sc.setParameters("certificate_id", certificateId);
+        return listBy(sc);
     }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapVO.java
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.direct.download;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "direct_download_certificate_host_map")
+public class DirectDownloadCertificateHostMapVO {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "host_id")
+    private Long hostId;
+
+    @Column(name = "certificate_id")
+    private Long certificateId;
+
+    public DirectDownloadCertificateHostMapVO() {
+    }
+
+    public DirectDownloadCertificateHostMapVO(Long certificateId, Long hostId) {
+        this.certificateId = certificateId;
+        this.hostId = hostId;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getHostId() {
+        return hostId;
+    }
+
+    public void setHostId(Long hostId) {
+        this.hostId = hostId;
+    }
+
+    public Long getCertificateId() {
+        return certificateId;
+    }
+
+    public void setCertificateId(Long certificateId) {
+        this.certificateId = certificateId;
+    }
+}

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateHostMapVO.java
@@ -38,12 +38,16 @@ public class DirectDownloadCertificateHostMapVO {
     @Column(name = "certificate_id")
     private Long certificateId;
 
+    @Column(name = "revoked")
+    private Boolean revoked;
+
     public DirectDownloadCertificateHostMapVO() {
     }
 
     public DirectDownloadCertificateHostMapVO(Long certificateId, Long hostId) {
         this.certificateId = certificateId;
         this.hostId = hostId;
+        this.revoked = false;
     }
 
     public Long getId() {
@@ -68,5 +72,13 @@ public class DirectDownloadCertificateHostMapVO {
 
     public void setCertificateId(Long certificateId) {
         this.certificateId = certificateId;
+    }
+
+    public Boolean isRevoked() {
+        return revoked;
+    }
+
+    public void setRevoked(Boolean revoked) {
+        this.revoked = revoked;
     }
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateVO.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadCertificateVO.java
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.direct.download;
+
+import com.cloud.hypervisor.Hypervisor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Entity
+@Table(name = "direct_download_certificate")
+public class DirectDownloadCertificateVO implements DirectDownloadCertificate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "uuid")
+    private String uuid;
+
+    @Column(name = "alias")
+    private String alias;
+
+    @Column(name = "certificate", length = 65535)
+    private String certificate;
+
+    @Column(name = "hypervisor_type")
+    private Hypervisor.HypervisorType hypervisorType;
+
+    @Column(name = "zone_id")
+    private Long zoneId;
+
+    public DirectDownloadCertificateVO() {
+        this.uuid = UUID.randomUUID().toString();
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    public void setHypervisorType(Hypervisor.HypervisorType hypervisorType) {
+        this.hypervisorType = hypervisorType;
+    }
+
+    public DirectDownloadCertificateVO(String alias, String certificate,
+                                       Hypervisor.HypervisorType hypervisorType, Long zoneId) {
+        this();
+        this.alias = alias;
+        this.certificate = certificate;
+        this.hypervisorType = hypervisorType;
+        this.zoneId = zoneId;
+    }
+
+    @Override
+    public String getCertificate() {
+        return certificate;
+    }
+
+    @Override
+    public String getAlias() {
+        return alias;
+    }
+
+    @Override
+    public Hypervisor.HypervisorType getHypervisorType() {
+        return hypervisorType;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public String getUuid() {
+        return uuid;
+    }
+
+    public Long getZoneId() {
+        return zoneId;
+    }
+
+    public void setZoneId(Long zoneId) {
+        this.zoneId = zoneId;
+    }
+
+}

--- a/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
+++ b/engine/schema/src/main/resources/META-INF/cloudstack/core/spring-engine-schema-core-daos-context.xml
@@ -285,4 +285,6 @@
   <bean id="outOfBandManagementDaoImpl" class="org.apache.cloudstack.outofbandmanagement.dao.OutOfBandManagementDaoImpl" />
   <bean id="GuestOsDetailsDaoImpl" class="org.apache.cloudstack.resourcedetail.dao.GuestOsDetailsDaoImpl" />
   <bean id="annotationDaoImpl" class="org.apache.cloudstack.annotation.dao.AnnotationDaoImpl" />
+  <bean id="directDownloadCertificateDaoImpl" class="org.apache.cloudstack.direct.download.DirectDownloadCertificateDaoImpl" />
+  <bean id="directDownloadCertificateHostMapDaoImpl" class="org.apache.cloudstack.direct.download.DirectDownloadCertificateHostMapDaoImpl" />
 </beans>

--- a/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
@@ -378,6 +378,7 @@ CREATE TABLE `cloud`.`direct_download_certificate_host_map` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `certificate_id` bigint(20) unsigned NOT NULL,
   `host_id` bigint(20) unsigned NOT NULL,
+  `revoked` int(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `fk_direct_download_certificate_host_map__host_id` (`host_id`),
   KEY `fk_direct_download_certificate_host_map__certificate_id` (`certificate_id`),

--- a/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
@@ -359,3 +359,29 @@ CREATE VIEW `cloud`.`project_view` AS
         `cloud`.`account` ON account.id = project_account.account_id
             left join
         `cloud`.`project_account` pacct ON projects.id = pacct.project_id;
+
+-- KVM: Add background task to upload certificates for direct download
+CREATE TABLE `cloud`.`direct_download_certificate` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `uuid` varchar(40) NOT NULL,
+  `alias` varchar(255) NOT NULL,
+  `certificate` text NOT NULL,
+  `hypervisor_type` varchar(45) NOT NULL,
+  `zone_id` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `i_direct_download_certificate_alias` (`alias`),
+  KEY `fk_direct_download_certificate__zone_id` (`zone_id`),
+  CONSTRAINT `fk_direct_download_certificate__zone_id` FOREIGN KEY (`zone_id`) REFERENCES `data_center` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `cloud`.`direct_download_certificate_host_map` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `certificate_id` bigint(20) unsigned NOT NULL,
+  `host_id` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_direct_download_certificate_host_map__host_id` (`host_id`),
+  KEY `fk_direct_download_certificate_host_map__certificate_id` (`certificate_id`),
+  CONSTRAINT `fk_direct_download_certificate_host_map__host_id` FOREIGN KEY (`host_id`) REFERENCES `host` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_direct_download_certificate_host_map__certificate_id` FOREIGN KEY (`certificate_id`) REFERENCES `direct_download_certificate` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/framework/direct-download/src/main/java/org/apache/cloudstack/framework/agent/direct/download/DirectDownloadService.java
+++ b/framework/direct-download/src/main/java/org/apache/cloudstack/framework/agent/direct/download/DirectDownloadService.java
@@ -27,7 +27,7 @@ public interface DirectDownloadService {
     /**
      * Upload client certificate to each running host
      */
-    boolean uploadCertificateToHosts(String certificateCer, String certificateName, String hypervisor, Long zoneId);
+    boolean uploadCertificateToHosts(String certificateCer, String certificateName, String hypervisor, Long zoneId, Long hostId);
 
     /**
      * Upload a stored certificate on database with id 'certificateId' to host with id 'hostId'

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRevokeDirectDownloadCertificateWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRevokeDirectDownloadCertificateWrapper.java
@@ -1,0 +1,106 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import com.cloud.agent.api.Answer;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+import com.cloud.utils.PropertiesUtil;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
+import org.apache.cloudstack.agent.directdownload.RevokeDirectDownloadCertificateCommand;
+import org.apache.cloudstack.utils.security.KeyStoreUtils;
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+@ResourceWrapper(handles =  RevokeDirectDownloadCertificateCommand.class)
+public class LibvirtRevokeDirectDownloadCertificateWrapper extends CommandWrapper<RevokeDirectDownloadCertificateCommand, Answer, LibvirtComputingResource> {
+
+    private static final Logger s_logger = Logger.getLogger(LibvirtRevokeDirectDownloadCertificateWrapper.class);
+
+    /**
+     * Retrieve agent.properties file
+     */
+    private File getAgentPropertiesFile() throws FileNotFoundException {
+        final File agentFile = PropertiesUtil.findConfigFile("agent.properties");
+        if (agentFile == null) {
+            throw new FileNotFoundException("Failed to find agent.properties file");
+        }
+        return agentFile;
+    }
+
+    /**
+     * Get the property 'keystore.passphrase' value from agent.properties file
+     */
+    private String getKeystorePassword(File agentFile) {
+        String pass = null;
+        if (agentFile != null) {
+            try {
+                pass = PropertiesUtil.loadFromFile(agentFile).getProperty(KeyStoreUtils.KS_PASSPHRASE_PROPERTY);
+            } catch (IOException e) {
+                s_logger.error("Could not get 'keystore.passphrase' property value due to: " + e.getMessage());
+            }
+        }
+        return pass;
+    }
+
+    /**
+     * Get keystore path
+     */
+    private String getKeyStoreFilePath(File agentFile) {
+        return agentFile.getParent() + "/" + KeyStoreUtils.KS_FILENAME;
+    }
+
+    @Override
+    public Answer execute(RevokeDirectDownloadCertificateCommand command, LibvirtComputingResource serverResource) {
+        String certificateAlias = command.getCertificateAlias();
+        try {
+            File agentFile = getAgentPropertiesFile();
+            String privatePassword = getKeystorePassword(agentFile);
+            if (isBlank(privatePassword)) {
+                return new Answer(command, false, "No password found for keystore: " + KeyStoreUtils.KS_FILENAME);
+            }
+
+            final String keyStoreFile = getKeyStoreFilePath(agentFile);
+
+            String checkCmd = String.format("keytool -list -alias %s -keystore %s -storepass %s",
+                    certificateAlias, keyStoreFile, privatePassword);
+            int existsCmdResult = Script.runSimpleBashScriptForExitValue(checkCmd);
+            if (existsCmdResult == 1) {
+                s_logger.error("Certificate alias " + certificateAlias + " does not exist, no need to revoke it");
+            } else {
+                String revokeCmd = String.format("keytool -delete -alias %s -keystore %s -storepass %s",
+                        certificateAlias, keyStoreFile, privatePassword);
+                s_logger.debug("Revoking certificate alias " + certificateAlias + " from keystore " + keyStoreFile);
+                Script.runSimpleBashScriptForExitValue(revokeCmd);
+            }
+        } catch (FileNotFoundException | CloudRuntimeException e) {
+            s_logger.error("Error while setting up certificate " + certificateAlias, e);
+            return new Answer(command, false, e.getMessage());
+        }
+        return new Answer(command);
+    }
+}

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -67,6 +67,7 @@ import org.apache.cloudstack.api.command.admin.config.ListDeploymentPlannersCmd;
 import org.apache.cloudstack.api.command.admin.config.ListHypervisorCapabilitiesCmd;
 import org.apache.cloudstack.api.command.admin.config.UpdateCfgCmd;
 import org.apache.cloudstack.api.command.admin.config.UpdateHypervisorCapabilitiesCmd;
+import org.apache.cloudstack.api.command.admin.direct.download.RevokeTemplateDirectDownloadCertificateCmd;
 import org.apache.cloudstack.api.command.admin.direct.download.UploadTemplateDirectDownloadCertificateCmd;
 import org.apache.cloudstack.api.command.admin.domain.CreateDomainCmd;
 import org.apache.cloudstack.api.command.admin.domain.DeleteDomainCmd;
@@ -3100,6 +3101,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(CreateManagementNetworkIpRangeCmd.class);
         cmdList.add(DeleteManagementNetworkIpRangeCmd.class);
         cmdList.add(UploadTemplateDirectDownloadCertificateCmd.class);
+        cmdList.add(RevokeTemplateDirectDownloadCertificateCmd.class);
         cmdList.add(ListMgmtsCmd.class);
         cmdList.add(GetUploadParamsForIsoCmd.class);
 

--- a/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
@@ -25,6 +25,8 @@ import com.cloud.agent.api.Answer;
 import com.cloud.event.ActionEventUtils;
 import com.cloud.event.EventTypes;
 import com.cloud.event.EventVO;
+import com.cloud.exception.AgentUnavailableException;
+import com.cloud.exception.OperationTimedoutException;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
@@ -62,6 +64,7 @@ import org.apache.cloudstack.agent.directdownload.HttpDirectDownloadCommand;
 import org.apache.cloudstack.agent.directdownload.MetalinkDirectDownloadCommand;
 import org.apache.cloudstack.agent.directdownload.NfsDirectDownloadCommand;
 import org.apache.cloudstack.agent.directdownload.HttpsDirectDownloadCommand;
+import org.apache.cloudstack.agent.directdownload.RevokeDirectDownloadCertificateCommand;
 import org.apache.cloudstack.agent.directdownload.SetupDirectDownloadCertificateCommand;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
@@ -411,4 +414,31 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
         return true;
     }
 
+    @Override
+    public boolean revokeCertificateAlias(String certificateAlias, String hypervisor) {
+        HypervisorType hypervisorType = HypervisorType.getType(hypervisor);
+        List<HostVO> hosts = getRunningHostsToUploadCertificate(hypervisorType);
+        s_logger.info("Attempting to revoke certificate alias: " + certificateAlias + " from " + hosts.size() + " hosts");
+        if (CollectionUtils.isNotEmpty(hosts)) {
+            for (HostVO host : hosts) {
+                if (!revokeCertificateAliasFromHost(certificateAlias, host.getId())) {
+                    String msg = "Could not revoke certificate from host: " + host.getName() + " (" + host.getUuid() + ")";
+                    s_logger.error(msg);
+                    throw new CloudRuntimeException(msg);
+                }
+            }
+        }
+        return true;
+    }
+
+    protected boolean revokeCertificateAliasFromHost(String alias, Long hostId) {
+        RevokeDirectDownloadCertificateCommand cmd = new RevokeDirectDownloadCertificateCommand(alias);
+        try {
+            Answer answer = agentManager.send(hostId, cmd);
+            return answer != null && answer.getResult();
+        } catch (AgentUnavailableException | OperationTimedoutException e) {
+            s_logger.error("Error revoking certificate " + alias + " from host " + hostId, e);
+        }
+        return false;
+    }
 }

--- a/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
@@ -395,7 +395,7 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
         if (certificateVO != null) {
             throw new CloudRuntimeException("Certificate alias " + alias + " has been already created");
         }
-        certificateVO = new DirectDownloadCertificateVO(alias, certificateCer, hypervisorType, zoneId);
+        certificateVO = new DirectDownloadCertificateVO(alias, certificatePem, hypervisorType, zoneId);
         directDownloadCertificateDao.persist(certificateVO);
 
         s_logger.info("Attempting to upload certificate: " + alias + " to " + hosts.size() + " hosts on zone " + zoneId);

--- a/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
@@ -22,6 +22,8 @@ import static com.cloud.storage.Storage.ImageFormat;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.event.ActionEventUtils;
 import com.cloud.event.EventTypes;
 import com.cloud.event.EventVO;
@@ -71,12 +73,18 @@ import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
 import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStore;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.cloudstack.poll.BackgroundPollManager;
+import org.apache.cloudstack.poll.BackgroundPollTask;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import sun.security.x509.X509CertImpl;
 
 public class DirectDownloadManagerImpl extends ManagerBase implements DirectDownloadManager {
@@ -99,6 +107,14 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
     private VMTemplatePoolDao vmTemplatePoolDao;
     @Inject
     private DataStoreManager dataStoreManager;
+    @Inject
+    private DirectDownloadCertificateDao directDownloadCertificateDao;
+    @Inject
+    private DirectDownloadCertificateHostMapDao directDownloadCertificateHostMapDao;
+    @Inject
+    private BackgroundPollManager backgroundPollManager;
+    @Inject
+    private DataCenterDao dataCenterDao;
 
     @Override
     public List<Class<?>> getCommands() {
@@ -314,12 +330,8 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
     /**
      * Return the list of running hosts to which upload certificates for Direct Download
      */
-    private List<HostVO> getRunningHostsToUploadCertificate(HypervisorType hypervisorType) {
-        return hostDao.listAllHostsByType(Host.Type.Routing)
-                .stream()
-                .filter(x -> x.getStatus().equals(Status.Up) &&
-                        x.getHypervisorType().equals(hypervisorType))
-                .collect(Collectors.toList());
+    private List<HostVO> getRunningHostsToUploadCertificate(Long zoneId, HypervisorType hypervisorType) {
+        return hostDao.listAllHostsUpByZoneAndHypervisor(zoneId, hypervisorType);
     }
 
     /**
@@ -368,22 +380,29 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
     }
 
     @Override
-    public boolean uploadCertificateToHosts(String certificateCer, String alias, String hypervisor) {
+    public boolean uploadCertificateToHosts(String certificateCer, String alias, String hypervisor, Long zoneId) {
         if (alias != null && (alias.equalsIgnoreCase("cloud") || alias.startsWith("cloudca"))) {
             throw new CloudRuntimeException("Please provide a different alias name for the certificate");
         }
 
         HypervisorType hypervisorType = HypervisorType.getType(hypervisor);
-        List<HostVO> hosts = getRunningHostsToUploadCertificate(hypervisorType);
+        List<HostVO> hosts = getRunningHostsToUploadCertificate(zoneId, hypervisorType);
 
         String certificatePem = getPretifiedCertificate(certificateCer);
         certificateSanity(certificatePem);
 
-        s_logger.info("Attempting to upload certificate: " + alias + " to " + hosts.size() + " hosts");
+        DirectDownloadCertificateVO certificateVO = directDownloadCertificateDao.findByAlias(alias);
+        if (certificateVO != null) {
+            throw new CloudRuntimeException("Certificate alias " + alias + " has been already created");
+        }
+        certificateVO = new DirectDownloadCertificateVO(alias, certificateCer, hypervisorType, zoneId);
+        directDownloadCertificateDao.persist(certificateVO);
+
+        s_logger.info("Attempting to upload certificate: " + alias + " to " + hosts.size() + " hosts on zone " + zoneId);
         int hostCount = 0;
         if (CollectionUtils.isNotEmpty(hosts)) {
             for (HostVO host : hosts) {
-                if (!uploadCertificate(certificatePem, alias, host.getId())) {
+                if (!uploadCertificate(certificateVO.getId(), host.getId())) {
                     String msg = "Could not upload certificate " + alias + " on host: " + host.getName() + " (" + host.getUuid() + ")";
                     s_logger.error(msg);
                     throw new CloudRuntimeException(msg);
@@ -398,26 +417,43 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
     /**
      * Upload and import certificate to hostId on keystore
      */
-    protected boolean uploadCertificate(String certificate, String certificateName, long hostId) {
-        s_logger.debug("Uploading certificate: " + certificateName + " to host " + hostId);
-        SetupDirectDownloadCertificateCommand cmd = new SetupDirectDownloadCertificateCommand(certificate, certificateName);
+    public boolean uploadCertificate(long certificateId, long hostId) {
+        DirectDownloadCertificateHostMapVO map = directDownloadCertificateHostMapDao.findByCertificateAndHost(certificateId, hostId);
+        if (map != null) {
+            s_logger.debug("Certificate " + certificateId + " is already uploaded on host " + hostId);
+            return true;
+        }
+
+        DirectDownloadCertificateVO certificateVO = directDownloadCertificateDao.findById(certificateId);
+        if (certificateVO == null) {
+            throw new CloudRuntimeException("Could not find certificate with id " + certificateId + " to upload to host: " + hostId);
+        }
+
+        String certificate = certificateVO.getCertificate();
+        String alias = certificateVO.getAlias();
+
+            s_logger.debug("Uploading certificate: " + certificateVO.getAlias() + " to host " + hostId);
+        SetupDirectDownloadCertificateCommand cmd = new SetupDirectDownloadCertificateCommand(certificate, alias);
         Answer answer = agentManager.easySend(hostId, cmd);
         if (answer == null || !answer.getResult()) {
-            String msg = "Certificate " + certificateName + " could not be added to host " + hostId;
+            String msg = "Certificate " + alias + " could not be added to host " + hostId;
             if (answer != null) {
                 msg += " due to: " + answer.getDetails();
             }
             s_logger.error(msg);
             return false;
         }
-        s_logger.info("Certificate " + certificateName + " successfully uploaded to host: " + hostId);
+
+        DirectDownloadCertificateHostMapVO mapVO = new DirectDownloadCertificateHostMapVO(certificateId, hostId);
+        directDownloadCertificateHostMapDao.persist(mapVO);
+        s_logger.info("Certificate " + alias + " successfully uploaded to host: " + hostId);
         return true;
     }
 
     @Override
-    public boolean revokeCertificateAlias(String certificateAlias, String hypervisor) {
+    public boolean revokeCertificateAlias(String certificateAlias, String hypervisor, Long zoneId) {
         HypervisorType hypervisorType = HypervisorType.getType(hypervisor);
-        List<HostVO> hosts = getRunningHostsToUploadCertificate(hypervisorType);
+        List<HostVO> hosts = getRunningHostsToUploadCertificate(zoneId, hypervisorType);
         s_logger.info("Attempting to revoke certificate alias: " + certificateAlias + " from " + hosts.size() + " hosts");
         if (CollectionUtils.isNotEmpty(hosts)) {
             for (HostVO host : hosts) {
@@ -440,5 +476,80 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
             s_logger.error("Error revoking certificate " + alias + " from host " + hostId, e);
         }
         return false;
+    }
+
+    @Override
+    public String getConfigComponentName() {
+        return DirectDownloadManager.class.getSimpleName();
+    }
+
+    @Override
+    public ConfigKey<?>[] getConfigKeys() {
+        return new ConfigKey<?>[]{
+                DirectDownloadCertificateUploadInterval
+        };
+    }
+
+    public static final class DirectDownloadCertificateUploadBackgroundTask extends ManagedContextRunnable implements BackgroundPollTask {
+
+        private DirectDownloadManager directDownloadManager;
+        private HostDao hostDao;
+        private DirectDownloadCertificateDao directDownloadCertificateDao;
+        private DirectDownloadCertificateHostMapDao directDownloadCertificateHostMapDao;
+        private DataCenterDao dataCenterDao;
+
+        public DirectDownloadCertificateUploadBackgroundTask(
+                final DirectDownloadManager caManager,
+                final HostDao hostDao,
+                final DataCenterDao dataCenterDao,
+                final DirectDownloadCertificateDao directDownloadCertificateDao,
+                final DirectDownloadCertificateHostMapDao directDownloadCertificateHostMapDao) {
+            this.directDownloadManager = caManager;
+            this.hostDao = hostDao;
+            this.dataCenterDao = dataCenterDao;
+            this.directDownloadCertificateDao = directDownloadCertificateDao;
+            this.directDownloadCertificateHostMapDao = directDownloadCertificateHostMapDao;
+        }
+
+        @Override
+        protected void runInContext() {
+            try {
+                if (s_logger.isTraceEnabled()) {
+                    s_logger.trace("Direct Download Manager background task is running...");
+                }
+                final DateTime now = DateTime.now(DateTimeZone.UTC);
+                List<DataCenterVO> enabledZones = dataCenterDao.listEnabledZones();
+                for (DataCenterVO zone : enabledZones) {
+                    List<DirectDownloadCertificateVO> zoneCertificates = directDownloadCertificateDao.listByZone(zone.getId());
+                    if (CollectionUtils.isNotEmpty(zoneCertificates)) {
+                        for (DirectDownloadCertificateVO certificateVO : zoneCertificates) {
+                            List<HostVO> hostsToUpload = hostDao.listAllHostsUpByZoneAndHypervisor(certificateVO.getZoneId(), certificateVO.getHypervisorType());
+                            if (CollectionUtils.isNotEmpty(hostsToUpload)) {
+                                for (HostVO hostVO : hostsToUpload) {
+                                    DirectDownloadCertificateHostMapVO mapping = directDownloadCertificateHostMapDao.findByCertificateAndHost(certificateVO.getId(), hostVO.getId());
+                                    if (mapping == null) {
+                                        s_logger.debug("Certificate " + certificateVO.getId() +
+                                                " (" + certificateVO.getAlias() + ") was not uploaded to host: " + hostVO.getId() +
+                                                " uploading it");
+                                        boolean result = directDownloadManager.uploadCertificate(certificateVO.getId(), hostVO.getId());
+                                        s_logger.debug("Certificate " + certificateVO.getAlias() + " " +
+                                                (result ? "uploaded" : "could not be uploaded") +
+                                                " to host " + hostVO.getId());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (final Throwable t) {
+                s_logger.error("Error trying to run Direct Download background task", t);
+            }
+        }
+
+        @Override
+        public Long getDelay() {
+            return DirectDownloadCertificateUploadInterval.value()
+                    * 60L * 60L * 1000L; //From hours to milliseconds
+        }
     }
 }

--- a/test/integration/smoke/test_direct_download.py
+++ b/test/integration/smoke/test_direct_download.py
@@ -92,6 +92,7 @@ class TestUploadDirectDownloadCertificates(cloudstackTestCase):
         cmd.hypervisor = self.hypervisor
         cmd.name = "marvin-test-verify-certs"
         cmd.certificate = self.certificates["invalid"]
+        cmd.zoneid = self.zone.id
 
         invalid_cert_uploadFails = False
         expired_cert_upload_fails = False
@@ -126,6 +127,7 @@ class TestUploadDirectDownloadCertificates(cloudstackTestCase):
         cmd.hypervisor = self.hypervisor
         cmd.name = "marvin-test-verify-certs"
         cmd.certificate = self.certificates["valid"]
+        cmd.zoneid = self.zone.id
 
         try:
             self.apiclient.uploadTemplateDirectDownloadCertificate(cmd)
@@ -135,9 +137,10 @@ class TestUploadDirectDownloadCertificates(cloudstackTestCase):
         revokecmd = revokeTemplateDirectDownloadCertificate.revokeTemplateDirectDownloadCertificateCmd()
         revokecmd.hypervisor = self.hypervisor
         revokecmd.name = cmd.name
+        revokecmd.zoneid = self.zone.id
 
         try:
-            self.apiclient.revokeTemplateDirectDownloadCertificate(cmd)
+            self.apiclient.revokeTemplateDirectDownloadCertificate(revokecmd)
         except Exception as e:
             self.fail("Uploaded certificates should be revoked when needed")
 

--- a/test/integration/smoke/test_direct_download.py
+++ b/test/integration/smoke/test_direct_download.py
@@ -27,7 +27,7 @@ from marvin.lib.base import (ServiceOffering,
 from marvin.lib.common import (get_pod,
                                get_zone)
 from nose.plugins.attrib import attr
-from marvin.cloudstackAPI import uploadTemplateDirectDownloadCertificate
+from marvin.cloudstackAPI import (uploadTemplateDirectDownloadCertificate, revokeTemplateDirectDownloadCertificate)
 from marvin.lib.decoratorGenerators import skipTestIf
 
 
@@ -120,6 +120,7 @@ class TestUploadDirectDownloadCertificates(cloudstackTestCase):
 
         # Validate the following
         # 1. Valid certificates are uploaded to hosts
+        # 2. Revoke uploaded certificate from host
 
         cmd = uploadTemplateDirectDownloadCertificate.uploadTemplateDirectDownloadCertificateCmd()
         cmd.hypervisor = self.hypervisor
@@ -130,6 +131,15 @@ class TestUploadDirectDownloadCertificates(cloudstackTestCase):
             self.apiclient.uploadTemplateDirectDownloadCertificate(cmd)
         except Exception as e:
             self.fail("Valid certificate must be uploaded")
+
+        revokecmd = revokeTemplateDirectDownloadCertificate.revokeTemplateDirectDownloadCertificateCmd()
+        revokecmd.hypervisor = self.hypervisor
+        revokecmd.name = cmd.name
+
+        try:
+            self.apiclient.revokeTemplateDirectDownloadCertificate(cmd)
+        except Exception as e:
+            self.fail("Uploaded certificates should be revoked when needed")
 
         return
 


### PR DESCRIPTION
## Description
Extend improvements on PR #2995 and #3075 

- Add an API method to revoke certificates from hosts
- Add a background task to sync missing certificates to hosts (which for some reason could not be uploaded before)

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?