### PR TITLE
template: copy md5 mismatch

### DIFF
--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -1045,8 +1045,6 @@ public class TemplateServiceImpl implements TemplateService {
         }
         tmplForCopy.setUrl(url);
 
-        tmplForCopy.getImage().setChecksum("");
-
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Mark template_store_ref entry as Creating");
         }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -1045,6 +1045,8 @@ public class TemplateServiceImpl implements TemplateService {
         }
         tmplForCopy.setUrl(url);
 
+        tmplForCopy.getImage().setChecksum("");
+
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Mark template_store_ref entry as Creating");
         }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -1052,6 +1052,9 @@ public class TemplateServiceImpl implements TemplateService {
         DataObject templateOnStore = destStore.create(tmplForCopy);
         templateOnStore.processEvent(Event.CreateOnlyRequested);
 
+        // I am the big assumer^Wpretender
+        ((TemplateObject)templateOnStore).getImage().setChecksum(null);
+
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Invoke datastore driver createAsync to create template on destination store");
         }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -1052,8 +1052,9 @@ public class TemplateServiceImpl implements TemplateService {
         DataObject templateOnStore = destStore.create(tmplForCopy);
         templateOnStore.processEvent(Event.CreateOnlyRequested);
 
-        // I am the big assumer^Wpretender
-        ((TemplateObject)templateOnStore).getImage().setChecksum(null);
+        if (templateOnStore instanceof TemplateObject) {
+            ((TemplateObject)templateOnStore).getImage().setChecksum(null);
+        } // else we don't know what to do.
 
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Invoke datastore driver createAsync to create template on destination store");

--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -927,8 +927,6 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
                     }
                 }
             }
-
-
         }
 
         if ((destZoneIds != null) && (destZoneIds.size() > failedZones.size())){

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -506,7 +506,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         if (StringUtils.isNotBlank(dnld.getChecksum()) && !oldValue.equals(newValue)) {
             return "checksum \"" + newValue + "\" didn't match the given value, \"" + oldValue + "\"";
         }
-        String checksum = newValue.getChecksum();
+        String checksum = newValue.toString();
         if (checksum == null) {
             LOGGER.warn("Something wrong happened when try to calculate the checksum of downloaded template!");
         }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -231,7 +231,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         }
     }
 
-    public static final Logger s_logger = Logger.getLogger(DownloadManagerImpl.class);
+    public static final Logger LOGGER = Logger.getLogger(DownloadManagerImpl.class);
     private String _templateDir;
     private String _volumeDir;
     private String createTmpltScr;
@@ -264,12 +264,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     public void setDownloadStatus(String jobId, Status status) {
         DownloadJob dj = jobs.get(jobId);
         if (dj == null) {
-            s_logger.warn("setDownloadStatus for jobId: " + jobId + ", status=" + status + " no job found");
+            LOGGER.warn("setDownloadStatus for jobId: " + jobId + ", status=" + status + " no job found");
             return;
         }
         TemplateDownloader td = dj.getTemplateDownloader();
-        s_logger.info("Download Completion for jobId: " + jobId + ", status=" + status);
-        s_logger.info("local: " + td.getDownloadLocalPath() + ", bytes=" + td.getDownloadedBytes() + ", error=" + td.getDownloadError() + ", pct=" +
+        LOGGER.info("Download Completion for jobId: " + jobId + ", status=" + status);
+        LOGGER.info("local: " + td.getDownloadLocalPath() + ", bytes=" + td.getDownloadedBytes() + ", error=" + td.getDownloadError() + ", pct=" +
                 td.getDownloadPercent());
 
         switch (status) {
@@ -282,7 +282,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         case UNKNOWN:
             return;
         case IN_PROGRESS:
-            s_logger.info("Resuming jobId: " + jobId + ", status=" + status);
+            LOGGER.info("Resuming jobId: " + jobId + ", status=" + status);
             td.setResume(true);
             threadPool.execute(td);
             break;
@@ -297,7 +297,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                 td.setDownloadError("Download success, starting install ");
                 String result = postRemoteDownload(jobId);
                 if (result != null) {
-                    s_logger.error("Failed post download install: " + result);
+                    LOGGER.error("Failed post download install: " + result);
                     td.setStatus(Status.UNRECOVERABLE_ERROR);
                     td.setDownloadError("Failed post download install: " + result);
                     ((S3TemplateDownloader) td).cleanupAfterError();
@@ -312,7 +312,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                 td.setDownloadError("Download success, starting install ");
                 String result = postLocalDownload(jobId);
                 if (result != null) {
-                    s_logger.error("Failed post download script: " + result);
+                    LOGGER.error("Failed post download script: " + result);
                     td.setStatus(Status.UNRECOVERABLE_ERROR);
                     td.setDownloadError("Failed post download script: " + result);
                 } else {
@@ -392,8 +392,8 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                 return checksumErrorMessage;
             }
         } else {
-            if(s_logger.isInfoEnabled()) {
-                s_logger.info(String.format("No checksum available for '%s'",originalTemplate.getName()));
+            if(LOGGER.isInfoEnabled()) {
+                LOGGER.info(String.format("No checksum available for '%s'",originalTemplate.getName()));
             }
         }
 
@@ -417,7 +417,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         try {
             loc.create(dnld.getId(), true, dnld.getTmpltName());
         } catch (IOException e) {
-            s_logger.warn("Something is wrong with template location " + resourcePath, e);
+            LOGGER.warn("Something is wrong with template location " + resourcePath, e);
             loc.purge();
             return "Unable to download due to " + e.getMessage();
         }
@@ -433,8 +433,8 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             if (checksumErrorMessage != null) {
                 return checksumErrorMessage;
             }
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug(String.format("created new checksum (%s) for '%s'",dnld.getChecksum(), downloadedTemplate));
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(String.format("created new checksum (%s) for '%s'",dnld.getChecksum(), downloadedTemplate));
             }
         }
         return null;
@@ -447,7 +447,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         long timeout = (long)imgSizeGigs * installTimeoutPerGig;
         Script scr = null;
         String script = resourceType == ResourceType.TEMPLATE ? createTmpltScr : createVolScr;
-        scr = new Script(script, timeout, s_logger);
+        scr = new Script(script, timeout, LOGGER);
         scr.add("-s", Integer.toString(imgSizeGigs));
         scr.add("-S", Long.toString(td.getMaxTemplateSizeInBytes()));
         if (dnld.getDescription() != null && dnld.getDescription().length() > 1) {
@@ -497,8 +497,8 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         ChecksumValue newValue = null;
         try {
             newValue = computeCheckSum(oldValue.getAlgorithm(), originalTemplate);
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug(String.format("computed checksum: %s", newValue));
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(String.format("computed checksum: %s", newValue));
             }
         } catch (NoSuchAlgorithmException e) {
             return "checksum algorithm not recognised: " + oldValue.getAlgorithm();
@@ -508,7 +508,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         }
         String checksum = newValue.getChecksum();
         if (checksum == null) {
-            s_logger.warn("Something wrong happened when try to calculate the checksum of downloaded template!");
+            LOGGER.warn("Something wrong happened when try to calculate the checksum of downloaded template!");
         }
         dnld.setCheckSum(checksum);
         return null;
@@ -523,7 +523,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             try {
                 info = processor.process(resourcePath, null, templateName, this._processTimeout);
             } catch (InternalErrorException e) {
-                s_logger.error("Template process exception ", e);
+                LOGGER.error("Template process exception ", e);
                 return e.toString();
             }
             if (info != null) {
@@ -541,7 +541,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         }
 
         if (!loc.save()) {
-            s_logger.warn("Cleaning up because we're unable to save the formats");
+            LOGGER.warn("Cleaning up because we're unable to save the formats");
             loc.purge();
         }
 
@@ -600,7 +600,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         try {
 
             if (!_storage.mkdirs(tmpDir)) {
-                s_logger.warn("Unable to create " + tmpDir);
+                LOGGER.warn("Unable to create " + tmpDir);
                 return "Unable to create " + tmpDir;
             }
             // TO DO - define constant for volume properties.
@@ -609,12 +609,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                             "volume.properties");
                     if (file.exists()) {
                         if(! file.delete()) {
-                            s_logger.warn("Deletion of file '" + file.getAbsolutePath() + "' failed.");
+                            LOGGER.warn("Deletion of file '" + file.getAbsolutePath() + "' failed.");
                         }
                     }
 
                     if (!file.createNewFile()) {
-                        s_logger.warn("Unable to create new file: " + file.getAbsolutePath());
+                        LOGGER.warn("Unable to create new file: " + file.getAbsolutePath());
                         return "Unable to create new file: " + file.getAbsolutePath();
                     }
 
@@ -656,7 +656,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
                     return jobId;
         } catch (IOException e) {
-            s_logger.warn("Unable to download to " + tmpDir, e);
+            LOGGER.warn("Unable to download to " + tmpDir, e);
             return null;
         }
     }
@@ -859,24 +859,24 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     private List<String> listVolumes(String rootdir) {
         List<String> result = new ArrayList<String>();
 
-        Script script = new Script(listVolScr, s_logger);
+        Script script = new Script(listVolScr, LOGGER);
         script.add("-r", rootdir);
         ZfsPathParser zpp = new ZfsPathParser(rootdir);
         script.execute(zpp);
         result.addAll(zpp.getPaths());
-        s_logger.info("found " + zpp.getPaths().size() + " volumes" + zpp.getPaths());
+        LOGGER.info("found " + zpp.getPaths().size() + " volumes" + zpp.getPaths());
         return result;
     }
 
     private List<String> listTemplates(String rootdir) {
         List<String> result = new ArrayList<String>();
 
-        Script script = new Script(listTmpltScr, s_logger);
+        Script script = new Script(listTmpltScr, LOGGER);
         script.add("-r", rootdir);
         ZfsPathParser zpp = new ZfsPathParser(rootdir);
         script.execute(zpp);
         result.addAll(zpp.getPaths());
-        s_logger.info("found " + zpp.getPaths().size() + " templates" + zpp.getPaths());
+        LOGGER.info("found " + zpp.getPaths().size() + " templates" + zpp.getPaths());
         return result;
     }
 
@@ -895,13 +895,13 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             TemplateLocation loc = new TemplateLocation(_storage, path);
             try {
                 if (!loc.load()) {
-                    s_logger.warn("Post download installation was not completed for " + path);
+                    LOGGER.warn("Post download installation was not completed for " + path);
                     // loc.purge();
                     _storage.cleanup(path, templateDir);
                     continue;
                 }
             } catch (IOException e) {
-                s_logger.warn("Unable to load template location " + path, e);
+                LOGGER.warn("Unable to load template location " + path, e);
                 continue;
             }
 
@@ -916,12 +916,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                     loc.updateVirtualSize(vSize);
                     loc.save();
                 } catch (Exception e) {
-                    s_logger.error("Unable to get the virtual size of the template: " + tInfo.getInstallPath() + " due to " + e.getMessage());
+                    LOGGER.error("Unable to get the virtual size of the template: " + tInfo.getInstallPath() + " due to " + e.getMessage());
                 }
             }
 
             result.put(tInfo.getTemplateName(), tInfo);
-            s_logger.debug("Added template name: " + tInfo.getTemplateName() + ", path: " + tmplt);
+            LOGGER.debug("Added template name: " + tInfo.getTemplateName() + ", path: " + tmplt);
         }
         return result;
     }
@@ -941,13 +941,13 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             TemplateLocation loc = new TemplateLocation(_storage, path);
             try {
                 if (!loc.load()) {
-                    s_logger.warn("Post download installation was not completed for " + path);
+                    LOGGER.warn("Post download installation was not completed for " + path);
                     // loc.purge();
                     _storage.cleanup(path, volumeDir);
                     continue;
                 }
             } catch (IOException e) {
-                s_logger.warn("Unable to load volume location " + path, e);
+                LOGGER.warn("Unable to load volume location " + path, e);
                 continue;
             }
 
@@ -962,12 +962,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
                     loc.updateVirtualSize(vSize);
                     loc.save();
                 } catch (Exception e) {
-                    s_logger.error("Unable to get the virtual size of the volume: " + vInfo.getInstallPath() + " due to " + e.getMessage());
+                    LOGGER.error("Unable to get the virtual size of the volume: " + vInfo.getInstallPath() + " due to " + e.getMessage());
                 }
             }
 
             result.put(vInfo.getId(), vInfo);
-            s_logger.debug("Added volume name: " + vInfo.getTemplateName() + ", path: " + vol);
+            LOGGER.debug("Added volume name: " + vInfo.getTemplateName() + ", path: " + vol);
         }
         return result;
     }
@@ -1031,7 +1031,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
         String inSystemVM = (String)params.get("secondary.storage.vm");
         if (inSystemVM != null && "true".equalsIgnoreCase(inSystemVM)) {
-            s_logger.info("DownloadManager: starting additional services since we are inside system vm");
+            LOGGER.info("DownloadManager: starting additional services since we are inside system vm");
             _nfsVersion = NfsSecondaryStorageResource.retrieveNfsVersionFromParams(params);
             startAdditionalServices();
             blockOutgoingOnPrivate();
@@ -1052,25 +1052,25 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         if (listTmpltScr == null) {
             throw new ConfigurationException("Unable to find the listvmtmplt.sh");
         }
-        s_logger.info("listvmtmplt.sh found in " + listTmpltScr);
+        LOGGER.info("listvmtmplt.sh found in " + listTmpltScr);
 
         createTmpltScr = Script.findScript(scriptsDir, "createtmplt.sh");
         if (createTmpltScr == null) {
             throw new ConfigurationException("Unable to find createtmplt.sh");
         }
-        s_logger.info("createtmplt.sh found in " + createTmpltScr);
+        LOGGER.info("createtmplt.sh found in " + createTmpltScr);
 
         listVolScr = Script.findScript(scriptsDir, "listvolume.sh");
         if (listVolScr == null) {
             throw new ConfigurationException("Unable to find the listvolume.sh");
         }
-        s_logger.info("listvolume.sh found in " + listVolScr);
+        LOGGER.info("listvolume.sh found in " + listVolScr);
 
         createVolScr = Script.findScript(scriptsDir, "createvolume.sh");
         if (createVolScr == null) {
             throw new ConfigurationException("Unable to find createvolume.sh");
         }
-        s_logger.info("createvolume.sh found in " + createVolScr);
+        LOGGER.info("createvolume.sh found in " + createVolScr);
 
         _processors = new HashMap<String, Processor>();
 
@@ -1114,7 +1114,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     }
 
     private void blockOutgoingOnPrivate() {
-        Script command = new Script("/bin/bash", s_logger);
+        Script command = new Script("/bin/bash", LOGGER);
         String intf = "eth1";
         command.add("-c");
         command.add("iptables -A OUTPUT -o " + intf + " -p tcp -m state --state NEW -m tcp --dport " + "80" + " -j REJECT;" + "iptables -A OUTPUT -o " + intf +
@@ -1122,7 +1122,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
         String result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in blocking outgoing to port 80/443 err=" + result);
+            LOGGER.warn("Error in blocking outgoing to port 80/443 err=" + result);
             return;
         }
     }
@@ -1143,37 +1143,37 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
     }
 
     private void startAdditionalServices() {
-        Script command = new Script("/bin/systemctl", s_logger);
+        Script command = new Script("/bin/systemctl", LOGGER);
         command.add("stop");
         command.add("apache2");
         String result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in stopping httpd service err=" + result);
+            LOGGER.warn("Error in stopping httpd service err=" + result);
         }
         String port = Integer.toString(TemplateConstants.DEFAULT_TMPLT_COPY_PORT);
         String intf = TemplateConstants.DEFAULT_TMPLT_COPY_INTF;
 
-        command = new Script("/bin/bash", s_logger);
+        command = new Script("/bin/bash", LOGGER);
         command.add("-c");
         command.add("iptables -I INPUT -i " + intf + " -p tcp -m state --state NEW -m tcp --dport " + port + " -j ACCEPT;" + "iptables -I INPUT -i " + intf +
                 " -p tcp -m state --state NEW -m tcp --dport " + "443" + " -j ACCEPT;");
 
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in opening up apache2 port err=" + result);
+            LOGGER.warn("Error in opening up apache2 port err=" + result);
             return;
         }
 
-        command = new Script("/bin/systemctl", s_logger);
+        command = new Script("/bin/systemctl", LOGGER);
         command.add("start");
         command.add("apache2");
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in starting apache2 service err=" + result);
+            LOGGER.warn("Error in starting apache2 service err=" + result);
             return;
         }
 
-        command = new Script("/bin/su", s_logger);
+        command = new Script("/bin/su", LOGGER);
         command.add("-s");
         command.add("/bin/bash");
         command.add("-c");
@@ -1181,7 +1181,7 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         command.add("www-data");
         result = command.execute();
         if (result != null) {
-            s_logger.warn("Error in creating directory =" + result);
+            LOGGER.warn("Error in creating directory =" + result);
             return;
         }
     }

--- a/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
+++ b/services/secondary-storage/server/src/main/java/org/apache/cloudstack/storage/template/DownloadManagerImpl.java
@@ -391,6 +391,10 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
             if (checksumErrorMessage != null) {
                 return checksumErrorMessage;
             }
+        } else {
+            if(s_logger.isInfoEnabled()) {
+                s_logger.info(String.format("No checksum available for '%s'",originalTemplate.getName()));
+            }
         }
 
         String result;
@@ -425,9 +429,12 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
 
         // if we don't have a checksum let's create one now
         if(StringUtils.isBlank(dnld.getChecksum())) {
-            String checksumErrorMessage = doTheChecksum(dnld, originalTemplate);
+            String checksumErrorMessage = doTheChecksum(dnld, downloadedTemplate);
             if (checksumErrorMessage != null) {
                 return checksumErrorMessage;
+            }
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(String.format("created new checksum (%s) for '%s'",dnld.getChecksum(), downloadedTemplate));
             }
         }
         return null;
@@ -490,6 +497,9 @@ public class DownloadManagerImpl extends ManagerBase implements DownloadManager 
         ChecksumValue newValue = null;
         try {
             newValue = computeCheckSum(oldValue.getAlgorithm(), originalTemplate);
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(String.format("computed checksum: %s", newValue));
+            }
         } catch (NoSuchAlgorithmException e) {
             return "checksum algorithm not recognised: " + oldValue.getAlgorithm();
         }

--- a/utils/src/main/java/org/apache/cloudstack/utils/security/ChecksumValue.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/security/ChecksumValue.java
@@ -82,6 +82,6 @@ public class ChecksumValue {
             } // else if no algoritm
             return "MD5";
         } // or if no digest at all
-        return "SHA512";
+        return "SHA-512";
     }
 }

--- a/utils/src/main/java/org/apache/cloudstack/utils/security/ChecksumValue.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/security/ChecksumValue.java
@@ -80,7 +80,8 @@ public class ChecksumValue {
             if (s == 0 && e > s+1) { // we have an algorithm name of at least 1 char
                 return digest.substring(s+1,e);
             } // else if no algoritm
+            return "MD5";
         } // or if no digest at all
-        return "MD5";
+        return "SHA512";
     }
 }


### PR DESCRIPTION
## Description
Fixes #3191 

When a template is registered, code stores md5sum of the downloaded file in the `vm_template` table. However, this downloaded file could be deleted after template installation if it is not an actual (`.qcow2`, `.ova`, etc.) file. When the user copies a template using copyTemplate API, the actual template file will be copied across the image stores. Matching checksum for the copied templated file and the stored value from the `vm_template` table will result in a mismatch.
Changes will set an empty checksum value for the copied template while passing to download service which allows skipping wrong checksum check for the copied while install.
However, this results in a change in checksum value for concerned template entry in `vm_template` table post template install.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![template-md5-mismatch-1](https://user-images.githubusercontent.com/153340/59089736-766c0a80-8928-11e9-9372-c190e946bba9.png)

![template-md5-mismatch-2](https://user-images.githubusercontent.com/153340/59089744-7b30be80-8928-11e9-9a73-92322f12cc9a.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
cmk


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
