### PR TITLE
when destroy the vms, delete the tags from virtual router

### DIFF
--- a/server/src/test/java/com/cloud/user/AccountManagerImplVolumeDeleteEventTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplVolumeDeleteEventTest.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.cloud.server.ResourceTag;
+import com.cloud.tags.TaggedResourceManagerImpl;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.engine.cloud.entity.api.VirtualMachineEntity;
@@ -68,6 +70,8 @@ public class AccountManagerImplVolumeDeleteEventTest extends AccountManagetImplT
     UserVmManagerImpl _vmMgr;
     Map<String, Object> oldFields = new HashMap<>();
     UserVmVO vm = mock(UserVmVO.class);
+    TaggedResourceManagerImpl taggedResourceManager = mock(TaggedResourceManagerImpl.class);
+
 
     // Configures the static fields of the UsageEventUtils class, Storing the
     // previous values to be restored during the cleanup phase, to avoid
@@ -138,6 +142,9 @@ public class AccountManagerImplVolumeDeleteEventTest extends AccountManagetImplT
         when(_serviceOfferingDao.findByIdIncludingRemoved(anyLong(), anyLong())).thenReturn(offering);
 
         when(_domainMgr.getDomain(anyLong())).thenReturn(domain);
+        Mockito.when(vm.getUuid()).thenReturn("1l");
+        Mockito.when(taggedResourceManager.getResourceId("123", ResourceTag.ResourceObjectType.UserVm)).thenReturn(Long.valueOf(123));
+
 
         Mockito.doReturn(true).when(_vmMgr).expunge(any(UserVmVO.class), anyLong(), any(Account.class));
 

--- a/server/src/test/java/com/cloud/user/AccountManagetImplTestBase.java
+++ b/server/src/test/java/com/cloud/user/AccountManagetImplTestBase.java
@@ -198,6 +198,7 @@ public class AccountManagetImplTestBase {
     @Mock
     UsageEventDao _usageEventDao;
 
+
     @Before
     public void setup() {
         accountManagerImpl.setUserAuthenticators(Arrays.asList(userAuthenticator));


### PR DESCRIPTION
## Description
When tags are placed in the vms and after we delete them, they remain in the virtual router generating problems for other vms that gain the same ip in the virtual router.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
I put the tags in the vms and after that I deleted them and accessed the virtual router to verify that they were deleted correctly. 