### PR TITLE
ui: fix for disk offering quickview details, actions

### DIFF
--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -2403,16 +2403,19 @@
 
                                 dataProvider: function(args) {
                                     var data = {
+                                        isrecursive: true,
                                         id: args.context.diskOfferings[0].id
                                     };
-                                    var listDiskOfferingsOptions = {
-                                        isRecursive: true,
-                                        data: data
-                                    };
-                                    var diskOfferings = cloudStack.listDiskOfferings(listDiskOfferingsOptions);
-                                    args.response.success({
-                                        actionFilter: diskOfferingActionfilter,
-                                        data: diskOfferings[0]
+                                    $.ajax({
+                                        url: createURL('listDiskOfferings'),
+                                        dataType: "json",
+                                        data: data,
+                                        success: function(json) {
+                                            var item = json.listdiskofferingsresponse.diskoffering[0];
+                                            args.response.success({
+                                                data: item
+                                            });
+                                        }
                                     });
                                 }
                             }


### PR DESCRIPTION
## Description

Fixes #2741 

Quickview widget for disk offerings list in the UI was missing offering details and action items. `cloudStack.listDiskOfferings` method call for the details view data provider was not working, therefore, it has been replaced with direct ajax API call.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Existing UI behaviour:
![Screenshot from 2019-06-10 14-37-30](https://user-images.githubusercontent.com/153340/59185165-61dc7c00-8b8d-11e9-8426-a8597803c8e8.png)

After changes:
![Screenshot from 2019-06-10 14-33-21](https://user-images.githubusercontent.com/153340/59185384-f941cf00-8b8d-11e9-8b2e-96b8a6bda8a5.png)


## How Has This Been Tested?
UI


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
