### PR TITLE
Fix removing SRX port forwarding rules, improve add/remove logic

### DIFF
--- a/scripts/network/juniper/dest-nat-rule-add.xml
+++ b/scripts/network/juniper/dest-nat-rule-add.xml
@@ -32,7 +32,7 @@ under the License.
 <dst-addr>%public-address%</dst-addr>
 </destination-address>
 <destination-port>
-<dst-port>%src-port%</dst-port>
+<low>%src-port%</low>
 </destination-port>
 </dest-nat-rule-match>
 <then>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR partially fixes the logic around port forwarding rules on the Juniper SRX plugin.  The code in the plugin is based on JunOS 10, which is very old.  The changes here should not break compatibility, but should enable the plugin to be used on newer devices.  Note that an additional change to a script file is required to be able to add port forwarding rules, but as this PR was targetted for 4.11.3, I thought it best not to include this change as it might break compatibility for anyone still using JunOS 10.

I've made the logic better and consistent for adding/removing static nat and port forwarding rules - these were multi-step processes which did not check each individual step.  This would aid in manually fixing rules in case of further problems.

I've also improved the logging for communication with the SRX by stripping out the Apache header before sending it, and indicating the name of the template filename in use.

To be able to add port forwarding rules, the `<dst-port>` tags in dest-nat-rule-add.xml must be changed to `<low>`.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3379

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [X] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Test environment consisting of simulator CloudStack connected to an SRX345 device.  Test process:

* Add Static NAT Rule
* Confirm rule was added (show | compare rollback 1)
* Remove Static NAT Rule
* Confirm rule was removed (show | compare rollback 1)
* Confirm that Add/Remove left config as before (show | compare rollback2 = empty)
* Add Port Forwarding Rule
* Confirm rule was added (show | compare rollback 1)
* Remove Port Forwarding Rule
* Confirm rule was removed (show | compare rollback 1)
* Confirm that Add/Remove left config as before (show | compare rollback2 = empty)

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
