### PR TITLE
ui: Fix quick view tooltip title on multiselect list views

### DIFF
--- a/ui/scripts/ui/widgets/listView.js
+++ b/ui/scripts/ui/widgets/listView.js
@@ -1585,10 +1585,10 @@
                             $('<span>').html(_l('label.quickview') + ': '),
                             $('<span>').addClass('title').html(
                                 cloudStack.concat(
-                                    $tr.find('td:first span').html(), 30
+                                    $tr.find('td.first span').html(), 30
                                 )
                             ).attr({
-                                title: $tr.find('td:first span').html()
+                                title: $tr.find('td.first span').html()
                             }),
                             $('<span>').addClass('icon').html('&nbsp;')
                         );


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixed an issue, where the quick view tooltip title would not have been displayed properly on list views with a multiselect row.
This was because the html content of the first `td` of a row was used to render the title of the quick view tooltip, which would not work if the first columns content was a checkbox.
Now the `td` with class `first` will be used for this (this will be the second column if there is a multiselect column, otherwise it will remain the first column).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots:
Before
![before](https://user-images.githubusercontent.com/12999459/59413990-f975e080-8dc0-11e9-8a50-b59ba0c45d12.png)
After
![after](https://user-images.githubusercontent.com/12999459/59413999-fda1fe00-8dc0-11e9-9f89-8de92f8c15ac.png)

## How Has This Been Tested?
Deployed to local environment and tested functionality.