### PR TITLE
kvm: fix qemu hook race condition

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -78,7 +78,9 @@ def handleMigrateBegin():
 
 
 def executeCustomScripts(sysArgs):
-    createDirectoryIfNotExists(customDir, customDirPermissions)
+    if not os.path.exists(customDir) or not os.path.isdir(customDir):
+        return
+
     scripts = getCustomScriptsFromDirectory()
 
     for scriptName in scripts:
@@ -125,12 +127,6 @@ def getCustomScriptsFromDirectory():
     return sorted(filter(lambda fileName: (fileName is not None) & (fileName != "") & ('_' in fileName) &
                                           (fileName.startswith((action + '_')) | fileName.startswith(('all' + '_'))),
                          os.listdir(customDir)), key=lambda fileName: substringAfter(fileName, '_'))
-
-
-def createDirectoryIfNotExists(dir, permissions):
-    if not os.path.exists(dir):
-        logger.info('Directory %s does not exist; creating it.' % dir)
-        os.makedirs(dir, permissions)
 
 
 def substringAfter(s, delimiter):


### PR DESCRIPTION
This fixes the qemu hooks `mkdir` race condition which can happen when
too many VMs may launch on a KVM host executing the hooks script that
tries to `mkdir` for the custom directory. On exception (multiple scripts
trying to mkdir), the VM stops. When libvirtd restarts it triggers hooks, and
the issue can be reproduced, which can cause loss of running VMs. 

The custom directory need not be created if it does not exist, instead
the custom hooks should only execute when there is a custom directory.
Admins who want to use the custom scripts feature can create the directory
as per the feature documentation. 

Feature documentation:
http://docs.cloudstack.apache.org/en/4.11.2.0/adminguide/hosts.html#kvm-libvirt-hook-script-include

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)