### PR TITLE
Fix quick view tooltip loading overlay offset

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -1505,10 +1505,7 @@ div.list-view td.state.notsuitable-storage-migration-required span {
 
 .quick-view-tooltip .loading-overlay {
   opacity: 0.35;
-  top: 94px;
-  left: 1px;
   /*+opacity:35%;*/
-  height: 57px;
   filter: alpha(opacity=35);
   -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=35);
   -moz-opacity: 0.35;
@@ -1516,6 +1513,7 @@ div.list-view td.state.notsuitable-storage-migration-required span {
 
 .quick-view-tooltip .container {
   display: inline-block;
+  position: relative;
   width: 471px;
   height: auto;
   min-height: 100px;

--- a/ui/css/src/scss/components/quick-view-tooltip.scss
+++ b/ui/css/src/scss/components/quick-view-tooltip.scss
@@ -42,10 +42,7 @@
 
 .quick-view-tooltip .loading-overlay {
   opacity: 0.35;
-  top: 94px;
-  left: 1px;
   /*+opacity:35%;*/
-  height: 57px;
   filter: alpha(opacity=35);
   -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=35);
   -moz-opacity: 0.35;
@@ -53,6 +50,7 @@
 
 .quick-view-tooltip .container {
   display: inline-block;
+  position: relative;
   width: 471px;
   height: auto;
   min-height: 100px;


### PR DESCRIPTION
## Description
Fixed the styling of the quick view tooltip loading overlay. Before it would have a top offset to the quick view tooltip and stick out of the tooltip. Afterwards it just overlays the tooltip.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots:
Before:
![CS1](https://user-images.githubusercontent.com/12999459/59586801-04dc4b00-90e4-11e9-8d12-feb0731f0ce1.png)
After:
![CS2](https://user-images.githubusercontent.com/12999459/59586808-09a0ff00-90e4-11e9-89c5-156956c80539.png)

## How Has This Been Tested?
Deployed to local environment and tested functionality.
