### PR TITLE
vmware: add support for VMware 6.7

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41200to41300.sql
@@ -19,6 +19,10 @@
 -- Schema upgrade from 4.12.0.0 to 4.13.0.0
 --;
 
+-- Add support for VMware 6.7
+INSERT IGNORE INTO `cloud`.`hypervisor_capabilities` (uuid, hypervisor_type, hypervisor_version, max_guests_limit, security_group_enabled, max_data_volumes_limit, max_hosts_per_cluster, storage_motion_supported, vm_snapshot_enabled) values (UUID(), 'VMware', '6.7', 128, 0, 13, 32, 1, 1);
+INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) SELECT UUID(),'VMware', '6.7', guest_os_name, guest_os_id, utc_timestamp(), 0  FROM `cloud`.`guest_os_hypervisor` WHERE hypervisor_type='VMware' AND hypervisor_version='6.5';
+
 -- DPDK client and server mode support
 ALTER TABLE `cloud`.`service_offering_details` CHANGE COLUMN `value` `value` TEXT NOT NULL;
 

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <cs.servlet.version>4.0.0</cs.servlet.version>
         <cs.tomcat-embed-core.version>8.0.30</cs.tomcat-embed-core.version>
         <cs.trilead.version>1.0.0-build221</cs.trilead.version>
-        <cs.vmware.api.version>6.5</cs.vmware.api.version>
+        <cs.vmware.api.version>6.7</cs.vmware.api.version>
         <cs.xapi.version>6.2.0-3.1</cs.xapi.version>
         <cs.xml-apis.version>1.4.01</cs.xml-apis.version>
         <cs.xmlrpc.version>3.1.3</cs.xmlrpc.version>


### PR DESCRIPTION
This adds support for VMware 6.7
Fixes #2700

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

Was able to deploy an advanced zone with VMware vCenter/ESXi 6.7 and see systemvms come up:
![Screenshot from 2019-06-21 03-08-59](https://user-images.githubusercontent.com/95203/59883473-d48df880-93d2-11e9-9a19-af46265c02ae.png)