### PR TITLE
Increase z-index for install-wizard step

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -784,7 +784,7 @@ body.install-wizard {
 
 .install-wizard .step {
   position: relative;
-  z-index: 10;
+  z-index: 11;
 }
 
 .install-wizard .step .tooltip-info {

--- a/ui/css/src/scss/components/install-wizzard.scss
+++ b/ui/css/src/scss/components/install-wizzard.scss
@@ -194,7 +194,7 @@ body.install-wizard {
 
 .install-wizard .step {
   position: relative;
-  z-index: $z-index-install-wizard2;
+  z-index: $z-index-install-wizard3;
 }
 
 .install-wizard .step .tooltip-info {


### PR DESCRIPTION
Increase z-index for install wizard step to make buttons clickable again.

## Description
After the latest refactoring of the styles there was a slight mistake which caused that the buttons for the initial install wizard in the beginning weren't clickable anymore, because they got overlaid by another box.

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots:
<img width="733" alt="Bildschirmfoto 2019-06-20 um 17 01 55" src="https://user-images.githubusercontent.com/6997263/59914065-d929cf80-9419-11e9-9f3a-6c1945b3216d.png">


## How Has This Been Tested?
Tested on local environment.
