### PR TITLE
console-proxy: fix potential NPE condition

### DIFF
--- a/core/src/main/java/com/cloud/info/ConsoleProxyInfo.java
+++ b/core/src/main/java/com/cloud/info/ConsoleProxyInfo.java
@@ -56,14 +56,12 @@ public class ConsoleProxyInfo {
     private String formatProxyAddress(String consoleProxyUrlDomain, String proxyIpAddress) {
         StringBuffer sb = new StringBuffer();
         // Domain in format *.example.com, proxy IP is 1.2.3.4 --> 1-2-3-4.example.com
-        if (consoleProxyUrlDomain.startsWith("*")) {
+        if (consoleProxyUrlDomain != null && consoleProxyUrlDomain.startsWith("*")) {
             sb.append(proxyIpAddress.replaceAll("\\.", "-"));
             sb.append(consoleProxyUrlDomain.substring(1)); // skip the *
-
         // Otherwise we assume a valid domain if config not blank
         } else if (StringUtils.isNotBlank(consoleProxyUrlDomain)) {
             sb.append(consoleProxyUrlDomain);
-
         // Blank config, we use the proxy IP
         } else {
             sb.append(proxyIpAddress);

--- a/core/src/main/java/com/cloud/info/ConsoleProxyInfo.java
+++ b/core/src/main/java/com/cloud/info/ConsoleProxyInfo.java
@@ -55,16 +55,16 @@ public class ConsoleProxyInfo {
 
     private String formatProxyAddress(String consoleProxyUrlDomain, String proxyIpAddress) {
         StringBuffer sb = new StringBuffer();
-        // Domain in format *.example.com, proxy IP is 1.2.3.4 --> 1-2-3-4.example.com
-        if (consoleProxyUrlDomain != null && consoleProxyUrlDomain.startsWith("*")) {
+        if (StringUtils.isBlank(consoleProxyUrlDomain)) {
+            // Blank config, we use the proxy IP
+            sb.append(proxyIpAddress);
+        } else if (consoleProxyUrlDomain.startsWith("*")) {
+            // Domain in format *.example.com, proxy IP is 1.2.3.4 --> 1-2-3-4.example.com
             sb.append(proxyIpAddress.replaceAll("\\.", "-"));
             sb.append(consoleProxyUrlDomain.substring(1)); // skip the *
-        // Otherwise we assume a valid domain if config not blank
-        } else if (StringUtils.isNotBlank(consoleProxyUrlDomain)) {
-            sb.append(consoleProxyUrlDomain);
-        // Blank config, we use the proxy IP
         } else {
-            sb.append(proxyIpAddress);
+            // Otherwise we assume a valid domain if config not blank
+            sb.append(consoleProxyUrlDomain);
         }
         return sb.toString();
     }


### PR DESCRIPTION
When checking if the console proxy URL domain starts with *, the code
does not check if the provided string is null. When domain is not
configured the IP address should be used.

Fixes #3164

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)