### PR TITLE
ssvm: use secstorage.ssl.cert.domain as hostname if it does not start with '*' when upload a template or volume from local

### DIFF
--- a/utils/src/main/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtil.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtil.java
@@ -30,9 +30,11 @@ public class ImageStoreUtil {
 
         //if ssvm url domain is present, use it to construct hostname in the format 1-2-3-4.domain
         // if the domain name is not present, ssl validation fails and has to be ignored
-        if(StringUtils.isNotBlank(ssvmUrlDomain)) {
+        if(StringUtils.isNotBlank(ssvmUrlDomain) && ssvmUrlDomain.startsWith("*")) {
             hostname = ipAddress.replace(".", "-");
             hostname = hostname + ssvmUrlDomain.substring(1);
+        } else if (StringUtils.isNotBlank(ssvmUrlDomain)) {
+            hostname = ssvmUrlDomain;
         }
 
         //only https works with postupload and url format is fixed


### PR DESCRIPTION
## Description

If secstorage.ssl.cert.domain does not start with '*', we should use it as host name in url when upload template/volume from local

Fixes: #3305

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
