### PR TITLE
Fix hostname is localhost in some VRs

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -139,7 +139,8 @@ class CsDhcp(CsDataBag):
             logging.error("Caught error while trying to delete entries from dnsmasq.leases file: %s" % e)
 
     def preseed(self):
-        self.add_host("127.0.0.1", "localhost %s" % CsHelper.get_hostname())
+        self.add_host("127.0.0.1", "localhost")
+        self.add_host("127.0.1.1", "%s" % CsHelper.get_hostname())
         self.add_host("::1", "localhost ip6-localhost ip6-loopback")
         self.add_host("ff02::1", "ip6-allnodes")
         self.add_host("ff02::2", "ip6-allrouters")


### PR DESCRIPTION
## Description

In some virtual routers, 'hostname -f' returns 'localhost'. The hostname is also 'localhost' in /var/log/messages

This change can fix the issue in new VRs.

To fix the issue in running VRs, please execute following commands
```
sed -i "/^127.0.0.1/d" /etc/hosts
sed -i "/^127.0.1.1/d" /etc/hosts
echo -e "127.0.0.1\tlocalhost" >> /etc/hosts
echo -e "127.0.1.1\t$(hostname)" >> /etc/hosts
# restart rsyslog
/etc/init.d/rsyslog restart
```



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
