### PR TITLE
KVM Volumes: Limit migration of volumes within the same storage pool.

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2034,7 +2034,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
         
         if (vol.getPoolId() == storagePoolId) {
-            throw new InvalidParameterValueException("Volume "+ vol +" current storage pool is same as the the destination storage pool " + destPool.getName());
+            throw new InvalidParameterValueException("Volume " + vol + " current storage pool is same as the the destination storage pool " + destPool.getName());
         }
 
         boolean liveMigrateVolume = false;

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2034,7 +2034,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         }
 
         if (vol.getPoolId() == storagePoolId) {
-            throw new InvalidParameterValueException("Volume " + vol + " current storage pool is same as the the destination storage pool " + destPool.getName());
+            throw new InvalidParameterValueException("Volume " + vol + " is already on the destination storage pool");
         }
 
         boolean liveMigrateVolume = false;

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2032,7 +2032,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (vol.getState() != Volume.State.Ready) {
             throw new InvalidParameterValueException("Volume must be in ready state");
         }
-        
+
         if (vol.getPoolId() == storagePoolId) {
             throw new InvalidParameterValueException("Volume " + vol + " current storage pool is same as the the destination storage pool " + destPool.getName());
         }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2032,6 +2032,10 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (vol.getState() != Volume.State.Ready) {
             throw new InvalidParameterValueException("Volume must be in ready state");
         }
+        
+        if (vol.getPoolId() == storagePoolId) {
+            throw new InvalidParameterValueException("Volume "+ vol +" current storage pool is same as the the destination storage pool " + destPool.getName());
+        }
 
         boolean liveMigrateVolume = false;
         Long instanceId = vol.getInstanceId();
@@ -2083,8 +2087,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new InvalidParameterValueException("Failed to find the destination storage pool: " + storagePoolId);
         } else if (destPool.isInMaintenance()) {
             throw new InvalidParameterValueException("Cannot migrate volume " + vol + "to the destination storage pool " + destPool.getName() + " as the storage pool is in maintenance mode.");
-        }else if(storagePoolId == vol.poolId){
-            throw new InvalidParameterValueException("Cannot migrate volume "+ vol.name +" to the destination storage pool " +storagePoolId+ " as the current storage pool and the destination pool are the same.");
         }
 
         if (!storageMgr.storagePoolHasEnoughSpace(Collections.singletonList(vol), destPool)) {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2083,6 +2083,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new InvalidParameterValueException("Failed to find the destination storage pool: " + storagePoolId);
         } else if (destPool.isInMaintenance()) {
             throw new InvalidParameterValueException("Cannot migrate volume " + vol + "to the destination storage pool " + destPool.getName() + " as the storage pool is in maintenance mode.");
+        }else if(storagePoolId == vol.poolId){
+            throw new InvalidParameterValueException("Cannot migrate volume "+ vol.name +" to the destination storage pool " +storagePoolId+ " as the current storage pool and the destination pool are the same.");
         }
 
         if (!storageMgr.storagePoolHasEnoughSpace(Collections.singletonList(vol), destPool)) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes #3291

**ENVIRONMENT**
`KVM on CentOS7`

**SUMMARY**
Added an if statement that catches the destination poolid as an invalid parameter if it is similer to the current poolid

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
