### PR TITLE
server: fix the subnet overlap checking logic for tagged and untagged vlans when adding ipranges

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3568,19 +3568,19 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 } else {
                     // For tagged or non-overlapping URIs we need to ensure there is no Public traffic type
                     boolean overlapped = false;
-                    if( network.getTrafficType() == TrafficType.Public ) {
+                    if (network.getTrafficType() == TrafficType.Public) {
                         overlapped = true;
                     } else {
                         final Long nwId = vlan.getNetworkId();
-                        if ( nwId != null ) {
+                        if (nwId != null) {
                             final Network nw = _networkModel.getNetwork(nwId);
-                            if ( nw != null && nw.getTrafficType() == TrafficType.Public ) {
+                            if (nw != null && nw.getTrafficType() == TrafficType.Public) {
                                 overlapped = true;
                             }
                         }
 
                     }
-                    if ( overlapped ) {
+                    if (overlapped) {
                         throw new InvalidParameterValueException("The IP range with tag: " + vlan.getVlanTag()
                                 + " in zone " + zone.getName()
                                 + " has overlapped with the subnet. Please specify a different gateway/netmask.");

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3566,7 +3566,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                         }
                     }
                 } else {
-                    // For untagged or non-overlapping URIs we need to ensure there is no Public traffic type
+                    // For tagged or non-overlapping URIs we need to ensure there is no Public traffic type
                     boolean overlapped = false;
                     if( network.getTrafficType() == TrafficType.Public ) {
                         overlapped = true;

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -209,7 +209,6 @@ import com.cloud.user.dao.UserDao;
 import com.cloud.utils.NumbersUtil;
 import com.cloud.utils.Pair;
 import com.cloud.utils.StringUtils;
-import com.cloud.utils.UriUtils;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.db.DB;
 import com.cloud.utils.db.EntityManager;
@@ -3542,9 +3541,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     continue;
                 }
                 // from here, subnet overlaps
-                if (!UriUtils.checkVlanUriOverlap(
-                        BroadcastDomainType.getValue(BroadcastDomainType.fromString(vlanId)),
-                        BroadcastDomainType.getValue(BroadcastDomainType.fromString(vlan.getVlanTag())))) {
+                if (!vlanId.equals(vlan.getVlanTag())) {
                     boolean overlapped = false;
                     if( network.getTrafficType() == TrafficType.Public ) {
                         overlapped = true;


### PR DESCRIPTION
When adding iprange for VLANs there are 3 cases -
1) VLAN under consideration has a tag (like 101)
2) VLAN under consideration has a tag but as a range (like 101-124)
3) VLAN is untagged (i.e. id is "untagged")

Before adding iprange we have to check for possible overlaps and throw exception. This needs to be done as follows -
1) If VLAN Tag ID is numeric or a range we need to call `UriUtils.checkVlanUriOverlap`method which internally tries to expand the range as verifies if there are overlaps. If URI overlaps (i.e. there are overlapping VLAN tags) we then need to verify if the iprange being added overlaps with previously added ranges.
2) If there are no overlapping tags we simply need to test for public networks being present in the VLAN.

A Regression was introduced in https://github.com/apache/cloudstack/commit/41fdb88970d1a33d57ff08a3ecc239ec898956dc#diff-6e2b61984e8fa2823bb47da3caafa4eeR3174 which caused comparing 'untagged' string as a numeric VLAN Tag range and and attempted expanding it to test overlap in `UriUtils.checkVlanUriOverlap`.

To fix the bug in the issue, we need to handle the untagged case separately as it's non-numeric tag in code. For untagged VLANs and overlapping VLAN URIs we need to check for ipranges and gateways which happens naturally after this change. For tagged VLANs with non-overlapping URIs we need to check if there is a public network.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3114
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Cloudmonkey-
```
(local) 🐵 > create vlaniprange zoneid=c3476f05-69ea-4b4a-a38c-c7436188a727 vlan=untagged gateway=10.99.0.254 netmask=255.255.255.0 startip=10.99.0.1 endip=10.99.0.100 forsystemvms=false forVirtualNetwork=true
{
  "vlan": {
    "account": "system",
    "domain": "ROOT",
    "domainid": "96fb4917-97e5-11e9-8e69-34e12d5f623e",
    "endip": "10.99.0.100",
    "forsystemvms": false,
    "forvirtualnetwork": true,
    "gateway": "10.99.0.254",
    "id": "8f249bce-8210-4e79-bc02-7c9723970137",
    "netmask": "255.255.255.0",
    "networkid": "5a0679dc-1f52-4e40-a7aa-1253848e4886",
    "physicalnetworkid": "ac5912b6-6461-4d4a-b137-f730f29ef241",
    "startip": "10.99.0.1",
    "vlan": "vlan://untagged",
    "zoneid": "c3476f05-69ea-4b4a-a38c-c7436188a727"
  }
}
(local) 🐵 > create vlaniprange zoneid=c3476f05-69ea-4b4a-a38c-c7436188a727 vlan=untagged gateway=10.99.0.254 netmask=255.255.255.0 startip=10.99.0.101 endip=10.99.0.200 forsystemvms=false forVirtualNetwork=true
{
  "vlan": {
    "account": "system",
    "domain": "ROOT",
    "domainid": "96fb4917-97e5-11e9-8e69-34e12d5f623e",
    "endip": "10.99.0.200",
    "forsystemvms": false,
    "forvirtualnetwork": true,
    "gateway": "10.99.0.254",
    "id": "34d0b59b-4494-44cd-932e-c33f8f979b16",
    "netmask": "255.255.255.0",
    "networkid": "5a0679dc-1f52-4e40-a7aa-1253848e4886",
    "physicalnetworkid": "ac5912b6-6461-4d4a-b137-f730f29ef241",
    "startip": "10.99.0.101",
    "vlan": "vlan://untagged",
    "zoneid": "c3476f05-69ea-4b4a-a38c-c7436188a727"
  }
}
(local) 🐵 > create vlaniprange zoneid=c3476f05-69ea-4b4a-a38c-c7436188a727 vlan=untagged gateway=10.99.0.254 netmask=255.255.255.0 startip=10.99.0.190 endip=10.99.0.210 forsystemvms=false forVirtualNetwork=true
Error 431: The IP range already has IPs that overlap with the new range. Please specify a different start IP/end IP.
(local) 🐵 > create vlaniprange zoneid=c3476f05-69ea-4b4a-a38c-c7436188a727 vlan=untagged gateway=10.99.0.254 netmask=255.255.255.0 startip=10.99.0.201 endip=10.99.0.210 forsystemvms=false forVirtualNetwork=true
{
  "vlan": {
    "account": "system",
    "domain": "ROOT",
    "domainid": "96fb4917-97e5-11e9-8e69-34e12d5f623e",
    "endip": "10.99.0.210",
    "forsystemvms": false,
    "forvirtualnetwork": true,
    "gateway": "10.99.0.254",
    "id": "92abf2b6-44b3-416c-abd5-f331d718d8dc",
    "netmask": "255.255.255.0",
    "networkid": "5a0679dc-1f52-4e40-a7aa-1253848e4886",
    "physicalnetworkid": "ac5912b6-6461-4d4a-b137-f730f29ef241",
    "startip": "10.99.0.201",
    "vlan": "vlan://untagged",
    "zoneid": "c3476f05-69ea-4b4a-a38c-c7436188a727"
  }
}
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
