### PR TITLE
systemvm: don't fork to curl to save password

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -21,6 +21,8 @@ import logging
 import os
 import re
 import sys
+import urllib
+import urllib2
 import time
 
 from collections import OrderedDict
@@ -62,10 +64,15 @@ class CsPassword(CsDataBag):
             server_ip = ip.split('/')[0]
             proc = CsProcess(['/opt/cloud/bin/passwd_server_ip.py', server_ip])
             if proc.find():
-                update_command = 'curl --header "DomU_Request: save_password" "http://{SERVER_IP}:8080/" -F "ip={VM_IP}" -F "password={PASSWORD}" ' \
-                                 '-F "token={TOKEN}" >/dev/null 2>/dev/null &'.format(SERVER_IP=server_ip, VM_IP=vm_ip, PASSWORD=password, TOKEN=token)
-                result = CsHelper.execute(update_command)
-                logging.debug("Update password server result ==> %s" % result)
+                url = "http://%s:8080/" % server_ip
+                payload = {"ip": vm_ip, "password": password, "token": token}
+                data = urllib.urlencode(payload)
+                request = urllib2.Request(url, data=data, headers={"DomU_Request" : "save_password"})
+                try:
+                    resp = urllib2.urlopen(request, data)
+                    logging.debug("Update password server result: http:%s, content:%s" % resp.code, resp.read())
+                except Exception as e:
+                    logging.error("Failed to update password server due to: %s" % e)
 
 
 class CsAcl(CsDataBag):

--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -70,7 +70,7 @@ class CsPassword(CsDataBag):
                 request = urllib2.Request(url, data=data, headers={"DomU_Request" : "save_password"})
                 try:
                     resp = urllib2.urlopen(request, data)
-                    logging.debug("Update password server result: http:%s, content:%s" % resp.code, resp.read())
+                    logging.debug("Update password server result: http:%s, content:%s" % (resp.code, resp.read()))
                 except Exception as e:
                     logging.error("Failed to update password server due to: %s" % e)
 


### PR DESCRIPTION
This fixes to avoid forking curl to save password but instead call
a HTTP POST url directly within Python code. This may reduce bottleneck
during high VM launches that require passwords.

Fixes #3182

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)