### PR TITLE
Bug fix for distinting between string and map type tags in forms

### DIFF
--- a/ui/scripts/ui/dialog.js
+++ b/ui/scripts/ui/dialog.js
@@ -778,7 +778,7 @@
 
             var complete = function($formContainer) {
                 var $form = $formContainer.find('form');
-                var data = cloudStack.serializeForm($form));
+                var data = cloudStack.serializeForm($form);
                 if (!data.tags) {
                     // Some APIs consume tags as a string (such as disk offering creation).
                     // The UI of those use a tagger that is not a custom cloudStack.tagger

--- a/ui/scripts/ui/dialog.js
+++ b/ui/scripts/ui/dialog.js
@@ -778,7 +778,14 @@
 
             var complete = function($formContainer) {
                 var $form = $formContainer.find('form');
-                var data = $.extend(cloudStack.serializeForm($form), {'tags' : cloudStack.getTagsFromForm($form)});
+                var data = cloudStack.serializeForm($form));
+                if (!data.tags) {
+                    // Some APIs consume tags as a string (such as disk offering creation).
+                    // The UI of those use a tagger that is not a custom cloudStack.tagger
+                    // but rather a string. That case is handled by usual serialization. We
+                    // only need to check extract tags when the string tags are not present.
+                    $.extend(data, {'tags' : cloudStack.getTagsFromForm($form)});
+                }
 
                 if (!$formContainer.find('form').valid()) {
                     // Ignore hidden field validation


### PR DESCRIPTION
Some APIs consume 'tags' param as string and some consume as maps.
Since each API can have at most one 'tags' param the extraction of
map based tags should only happen when strings based tags are not
extracted from the form serialization.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Try tagging in 2 different places -
1. Snapshot , Snapshot policies
2. Disk offering creation

Both places should work. Without this patch only former would work.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
