### PR TITLE
Fix sorting order bug in UI Code with usage of sortkey.algorithm global config

### DIFF
--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -2419,7 +2419,7 @@ cloudStack.api = {
                     url: createURL(updateCommand),
                     data: {
                         id: args.context[objType].id,
-                        sortKey: g_sortKeyIsAscending ? (-1 * args.index) : args.index
+                        sortKey: args.sortKey
                     },
                     success: function(json) {
                         args.response.success();

--- a/ui/scripts/ui/widgets/listView.js
+++ b/ui/scripts/ui/widgets/listView.js
@@ -1335,13 +1335,18 @@
                         true, {},
                         $tr.closest('.list-view').data('view-args').context
                     );
-                    var rowIndex = $tr.closest('tbody').find('tr').length - ($tr.index());
+                    var sortKey;
+                    if (g_sortKeyIsAscending) {
+                        sortKey = $tr.index() + 1;
+                    } else {
+                        sortKey = ($tr.closest('tbody').find('tr').length - ($tr.index()));
+                    }
 
                     context[viewArgs.activeSection] = $tr.data('json-obj');
 
                     action.action({
                         context: context,
-                        index: rowIndex,
+                        sortKey: sortKey,
                         response: {
                             success: function(args) {},
                             error: function(args) {


### PR DESCRIPTION
Current master has sorting broken and the order reverses as opposed to
what is set if sortkey.algorithm is set to true. The problem lies in the
way the update APIs were being called by the UI. The code was agnostic
to a global config that backend uses to set the order of the entities
in the corresponding list APIs.

We need to make UI aware of the global config and instead of changing
sign of sort key pass proper numbers so that DB isn't confusing when
some tables have positive sortkey and some have negative.

The fix is in 2 steps-
1) Make use of sortkey name in place where it's relevant. Mere row index
is not sufficient.
2) Reverse the sortkey if we are sorting by descending (when global
config is false)
Fix is general bugfix but I also verified that #2724 is also fixed after this change and verifiable. The DB support already existed.
## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Flip the config sortkey.algorithm and verify the templates and offerings order is retained as the UI sets in either case.
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
