### PR TITLE
utils: reverse ip addresses of a nic returned by java to get the first ip address

### DIFF
--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -34,6 +34,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Collections;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedSet;
@@ -394,10 +395,11 @@ public class NetUtils {
     }
 
     public static String[] getNetworkParams(final NetworkInterface nic) {
-        final List<InterfaceAddress> addrs = nic.getInterfaceAddresses();
+        List<InterfaceAddress> addrs = nic.getInterfaceAddresses();
         if (addrs == null || addrs.size() == 0) {
             return null;
         }
+        Collections.reverse(addrs); // reverse addresses because it has reverse order as "ip addr show"
         InterfaceAddress addr = null;
         for (final InterfaceAddress iaddr : addrs) {
             final InetAddress inet = iaddr.getAddress();


### PR DESCRIPTION

## Description

Java methods getInterfaceAddresses()  returns ip addresses in reverse order as "ip addr show"
If there are multiple IPs assigned to a management interface, the last ip will be used as management ip in cloudstack. We need to reverse the ip addresses to get the first ip that makes more sense.
 
Fixes: #3311 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Add a secondary ip to management interface in kvm hypervisor, and restart cloudstack-agent
In the past the hypervisor will use the new ip in cloudstack database.
If the new ip does not work, we are not able to access the console of vm on the hypervisor.

With this change, the ip in database will not be changed. cloudstack will still use primary ip.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
