### PR TITLE
[UI] Fix wrap text for accounts on project view

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -8154,7 +8154,6 @@ div.container div.panel div#details-tab-addloadBalancer.detail-group div.loadBal
   display: block;
   float: left;
   max-width: 90%;
-  white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 }


### PR DESCRIPTION
## Description
Fix wrap text for account names on the project view, as it cannot be fully displayed

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Before the fix the account column does not wrap the full text:
![image](https://user-images.githubusercontent.com/5295080/60452526-143fb600-9c05-11e9-8517-631dfbdcdb8b.png)

After the fix:
![image](https://user-images.githubusercontent.com/5295080/60452637-608af600-9c05-11e9-8ae5-55510ec6919c.png)


## How Has This Been Tested?
Create Project
Select Project -> Accounts
