### PR TITLE
Fix bug in counting items for search query

### DIFF
--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import com.google.common.base.Strings;
+
 import javax.naming.ConfigurationException;
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -54,16 +54,6 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
-
-import net.sf.cglib.proxy.Callback;
-import net.sf.cglib.proxy.CallbackFilter;
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.Factory;
-import net.sf.cglib.proxy.MethodInterceptor;
-import net.sf.cglib.proxy.NoOp;
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.Element;
 
 import org.apache.log4j.Logger;
 
@@ -79,6 +69,17 @@ import com.cloud.utils.db.SearchCriteria.SelectType;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.Ip;
 import com.cloud.utils.net.NetUtils;
+import com.google.common.base.Strings;
+
+import net.sf.cglib.proxy.Callback;
+import net.sf.cglib.proxy.CallbackFilter;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.Factory;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.NoOp;
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
 
 /**
  *  GenericDaoBase is a simple way to implement DAOs.  It DOES NOT
@@ -2014,8 +2015,6 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
         }
 
-        // we have to disable group by in getting count, since count for groupBy clause will be different.
-        //List<Object> groupByValues = addGroupBy(str, sc);
         final TransactionLegacy txn = TransactionLegacy.currentTxn();
         final String sql = str.toString();
 
@@ -2033,14 +2032,6 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
                 i = addJoinAttributes(i, pstmt, joins);
             }
 
-            /*
-            if (groupByValues != null) {
-                for (Object value : groupByValues) {
-                    pstmt.setObject(i++, value);
-                }
-            }
-             */
-
             final ResultSet rs = pstmt.executeQuery();
             while (rs.next()) {
                 return rs.getInt(1);
@@ -2055,7 +2046,17 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
 
     @DB()
     protected StringBuilder createCountSelect(SearchCriteria<?> sc, final boolean whereClause) {
-        StringBuilder sql = new StringBuilder(_count);
+        if (sc == null)
+            return null;
+
+        StringBuilder sql;
+        Pair<GroupBy<?, ?, ?>, List<Object>> groupBys = sc.getGroupBy();
+        if (groupBys != null) {
+            final SqlGenerator generator = new SqlGenerator(_entityBeanType);
+            sql = new StringBuilder(generator.buildCountSqlWithGroupBy(groupBys.first()));
+        } else {
+            sql = new StringBuilder(_count);
+        }
 
         if (!whereClause) {
             sql.delete(sql.length() - (_discriminatorClause == null ? 6 : 4), sql.length());

--- a/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -2046,16 +2046,13 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
 
     @DB()
     protected StringBuilder createCountSelect(SearchCriteria<?> sc, final boolean whereClause) {
-        if (sc == null)
-            return null;
-
-        StringBuilder sql;
-        Pair<GroupBy<?, ?, ?>, List<Object>> groupBys = sc.getGroupBy();
-        if (groupBys != null) {
-            final SqlGenerator generator = new SqlGenerator(_entityBeanType);
-            sql = new StringBuilder(generator.buildCountSqlWithGroupBy(groupBys.first()));
-        } else {
-            sql = new StringBuilder(_count);
+        StringBuilder sql = new StringBuilder(_count);
+        if (sc != null) {
+            Pair<GroupBy<?, ?, ?>, List<Object>> groupBys = sc.getGroupBy();
+            if (groupBys != null) {
+                final SqlGenerator generator = new SqlGenerator(_entityBeanType);
+                sql = new StringBuilder(generator.buildCountSqlWithGroupBy(groupBys.first()));
+            }
         }
 
         if (!whereClause) {

--- a/framework/db/src/main/java/com/cloud/utils/db/GroupBy.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/GroupBy.java
@@ -63,6 +63,13 @@ public class GroupBy<J extends SearchBase<?, T, R>, T, R> {
 
     public void toSql(final StringBuilder builder) {
         builder.append(" GROUP BY ");
+        appendGroupByAttributes(builder);
+        if (_having != null) {
+            _having.toSql(builder);
+        }
+    }
+
+    public void appendGroupByAttributes(final StringBuilder builder) {
         for (final Pair<Func, Attribute> groupBy : _groupBys) {
             if (groupBy.first() != null) {
                 String func = groupBy.first().toString();
@@ -71,14 +78,9 @@ public class GroupBy<J extends SearchBase<?, T, R>, T, R> {
             } else {
                 builder.append(groupBy.second().table + "." + groupBy.second().columnName);
             }
-
             builder.append(", ");
         }
-
         builder.delete(builder.length() - 2, builder.length());
-        if (_having != null) {
-            _having.toSql(builder);
-        }
     }
 
     protected class Having {

--- a/framework/db/src/main/java/com/cloud/utils/db/SqlGenerator.java
+++ b/framework/db/src/main/java/com/cloud/utils/db/SqlGenerator.java
@@ -675,6 +675,14 @@ public class SqlGenerator {
         return sql.append("SELECT COUNT(*) FROM ").append(buildTableReferences()).append(" WHERE ").append(buildDiscriminatorClause().first()).toString();
     }
 
+    public String buildCountSqlWithGroupBy(final GroupBy groupBy) {
+        StringBuilder sql = new StringBuilder();
+        sql.append("SELECT COUNT(DISTINCT ");
+        groupBy.appendGroupByAttributes(sql);
+        sql.append(") FROM ").append(buildTableReferences()).append(" WHERE ").append(buildDiscriminatorClause().first());
+        return sql.toString();
+    }
+
     public String buildDistinctIdSql() {
         StringBuilder sql = new StringBuilder();
 


### PR DESCRIPTION
The implementation of GenericBaseDao#searchAndCount() can result in incorrect count. This happens because the implementation of the GenericBaseDao#getCount method ingores the groupBy components of the search queries completely. This means the count returned will always be larger than
the actual count when not considering pagination.

The change to ignore the group by components was brought in b0ce8fd which also fails to explain the rationale. This was probably because the groupby would be executed after select count(*) has finished.

Further investigation of the getCount usage reveal they are always accompanied by search queries which include groupBy components via GenericBaseDao#searchIncludingRemoved method.

Current code diff between search and count methods is as follows -
```diff --git a/framework/db/src/main/java/com/cloud/uddtils/db/GenericDaoBase.java b/framework/db/src/main/java/com/cloud/utils/db/GenericDaoBase.java
@@ -371,7 +371,7 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             clause = null;
         }

-        final StringBuilder str = createPartialSelectSql(sc, clause != null, enableQueryCache);
+        final StringBuilder str = createCountSelect(sc, clause != null);
@@ -384,19 +384,12 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone
             }
         }

-        List<Object> groupByValues = addGroupBy(str, sc);
-        addFilter(str, filter);
-
+        // we have to disable group by in getting count, since count for groupBy clause will be different.
+        //List<Object> groupByValues = addGroupBy(str, sc);
         final TransactionLegacy txn = TransactionLegacy.currentTxn();
-        if (lock != null) {
-            assert (txn.dbTxnStarted() == true) : "As nice as I can here now....how do you lock when there's no DB transaction?  Review your db 101 course from college.";
-            str.append(lock ? FOR_UPDATE_CLAUSE : SHARE_MODE_CLAUSE);
-        }
-
@@ -410,20 +403,19 @@ public abstract class GenericDaoBase<T, ID extends Serializable> extends Compone

+            /*
             if (groupByValues != null) {
                 for (Object value : groupByValues) {
                     pstmt.setObject(i++, value);
                 }
             }
+             */

-            if (s_logger.isDebugEnabled() && lock != null) {
-                txn.registerLock(pstmt.toString());
-            }
             final ResultSet rs = pstmt.executeQuery();
             while (rs.next()) {
-                result.add(toEntityBean(rs, cache));
+                return rs.getInt(1);
             }
-            return result;
+            return 0;
--
2.17.1
```

The fix is to update the way we setup query for counting with group by params. We need to do the below query to get accurate count -
`SELECT COUNT(DISTINCT GROUP_ROW1...) FROM.......`
## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #2874
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Example API call - `http://localhost:8080/client/api?command=listPublicIpAddresses&response=json&associatednetworkid=72954e98-7fa5-41a0-85f1-97b719f8ff0a&forloadbalancing=true&listall=true&_=1561816856393`
Here is it's response -
```
{
  "listpublicipaddressesresponse": {
    "count": 2,
    "publicipaddress": [
      {
        "id": "b65b9d02-9135-4f3a-89c7-c6d1948ad3ce",
        "ipaddress": "172.20.20.107",
        "allocated": "2019-06-29T19:21:01+0530",
        "zoneid": "c3476f05-69ea-4b4a-a38c-c7436188a727",
        "zonename": "KVM-advzone1",
        "issourcenat": false,
        "account": "admin",
        "domainid": "96fb4917-97e5-11e9-8e69-34e12d5f623e",
        "domain": "ROOT",
        "forvirtualnetwork": true,
        "vlanid": "8f7413bc-3d85-423e-b685-60910b91a819",
        "vlanname": "vlan://untagged",
        "isstaticnat": false,
        "issystem": false,
        "associatednetworkid": "72954e98-7fa5-41a0-85f1-97b719f8ff0a",
        "associatednetworkname": "tier1",
        "networkid": "5a0679dc-1f52-4e40-a7aa-1253848e4886",
        "state": "Allocated",
        "physicalnetworkid": "ac5912b6-6461-4d4a-b137-f730f29ef241",
        "vpcid": "89195bd2-28b1-4afa-b67f-6c8b468ac3f6",
        "tags": [
          
        ],
        "isportable": false,
        "fordisplay": true
      }
    ]
  }
}
```
After fix the correct count is returned.

An example at database level : 
Here is an SQL Query below for fetching data for ipaddresses for lb in an environment -
```
SELECT user_ip_address.id, user_ip_address.account_id, user_ip_address.domain_id, 
    user_ip_address.public_ip_address, user_ip_address.data_center_id, user_ip_address.source_nat, 
    user_ip_address.allocated, user_ip_address.vlan_db_id, user_ip_address.one_to_one_nat, 
    user_ip_address.vm_id, user_ip_address.state, user_ip_address.mac_address, 
    user_ip_address.source_network_id, user_ip_address.network_id, user_ip_address.uuid, 
    user_ip_address.physical_network_id, user_ip_address.is_system, user_ip_address.vpc_id, 
    user_ip_address.dnat_vmip, user_ip_address.is_portable, user_ip_address.display, 
    user_ip_address.rule_state, user_ip_address.forsystemvms, user_ip_address.removed, 
    user_ip_address.created 
FROM user_ip_address  
    INNER JOIN vlan ON user_ip_address.vlan_db_id=vlan.id  
    INNER JOIN account ON user_ip_address.account_id=account.id  
    INNER JOIN firewall_rules ON user_ip_address.id=firewall_rules.ip_address_id 
WHERE user_ip_address.account_id=2 AND user_ip_address.network_id = 207  AND 
    user_ip_address.display = 1  AND user_ip_address.allocated IS NOT NULL  AND 
    user_ip_address.removed IS NULL  AND  (vlan.vlan_type = 'VirtualNetwork' ) AND (account.type != 5 ) 
GROUP BY user_ip_address.id ORDER BY user_ip_address.public_ip_address DESC  LIMIT 0, 500;
```
Corresponding to the above query, the count query executed was -
```
SELECT COUNT(*)
FROM user_ip_address 
    INNER JOIN vlan ON user_ip_address.vlan_db_id=vlan.id  
    INNER JOIN account ON user_ip_address.account_id=account.id  
    INNER JOIN firewall_rules ON user_ip_address.id=firewall_rules.ip_address_id 
WHERE user_ip_address.network_id = 207  AND user_ip_address.display = 1  AND user_ip_address.allocated IS NOT NULL  AND user_ip_address.removed IS NULL  AND  (vlan.vlan_type = 'VirtualNetwork' ) AND (account.type != 5 )
```
As evident the queries don't match when grouping is involved. After change the query executed is -
```
SELECT COUNT(DISTINCT  user_ip_address.id)
FROM user_ip_address 
    INNER JOIN vlan ON user_ip_address.vlan_db_id=vlan.id  
    INNER JOIN account ON user_ip_address.account_id=account.id  
    INNER JOIN firewall_rules ON user_ip_address.id=firewall_rules.ip_address_id 
WHERE user_ip_address.network_id = 207  AND user_ip_address.display = 1  AND user_ip_address.allocated IS NOT NULL  AND user_ip_address.removed IS NULL  AND  (vlan.vlan_type = 'VirtualNetwork' ) AND (account.type != 5 )
```
For queries without grouping we proceed as before.
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
