### PR TITLE
Count Starting along with Running VMs for user dispersing planner

### DIFF
--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDao.java
@@ -122,7 +122,7 @@ public interface VMInstanceDao extends GenericDao<VMInstanceVO, Long>, StateDao<
 
     List<Long> listHostIdsByVmCount(long dcId, Long podId, Long clusterId, long accountId);
 
-    Long countRunningByAccount(long accountId);
+    Long countRunningAndStartingByAccount(long accountId);
 
     Long countByZoneAndState(long zoneId, State state);
 

--- a/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/VMInstanceDaoImpl.java
@@ -87,7 +87,7 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
     protected SearchBuilder<VMInstanceVO> HostNameAndZoneSearch;
     protected GenericSearchBuilder<VMInstanceVO, Long> FindIdsOfVirtualRoutersByAccount;
     protected GenericSearchBuilder<VMInstanceVO, Long> CountActiveByHost;
-    protected GenericSearchBuilder<VMInstanceVO, Long> CountRunningByAccount;
+    protected GenericSearchBuilder<VMInstanceVO, Long> CountRunningAndStartingByAccount;
     protected GenericSearchBuilder<VMInstanceVO, Long> CountByZoneAndState;
     protected SearchBuilder<VMInstanceVO> NetworkTypeSearch;
     protected GenericSearchBuilder<VMInstanceVO, String> DistinctHostNameSearch;
@@ -245,11 +245,11 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
         CountActiveByHost.and("state", CountActiveByHost.entity().getState(), SearchCriteria.Op.IN);
         CountActiveByHost.done();
 
-        CountRunningByAccount = createSearchBuilder(Long.class);
-        CountRunningByAccount.select(null, Func.COUNT, null);
-        CountRunningByAccount.and("account", CountRunningByAccount.entity().getAccountId(), SearchCriteria.Op.EQ);
-        CountRunningByAccount.and("state", CountRunningByAccount.entity().getState(), SearchCriteria.Op.EQ);
-        CountRunningByAccount.done();
+        CountRunningAndStartingByAccount = createSearchBuilder(Long.class);
+        CountRunningAndStartingByAccount.select(null, Func.COUNT, null);
+        CountRunningAndStartingByAccount.and("account", CountRunningAndStartingByAccount.entity().getAccountId(), SearchCriteria.Op.EQ);
+        CountRunningAndStartingByAccount.and("states", CountRunningAndStartingByAccount.entity().getState(), SearchCriteria.Op.IN);
+        CountRunningAndStartingByAccount.done();
 
         CountByZoneAndState = createSearchBuilder(Long.class);
         CountByZoneAndState.select(null, Func.COUNT, null);
@@ -749,10 +749,10 @@ public class VMInstanceDaoImpl extends GenericDaoBase<VMInstanceVO, Long> implem
     }
 
     @Override
-    public Long countRunningByAccount(long accountId) {
-        SearchCriteria<Long> sc = CountRunningByAccount.create();
+    public Long countRunningAndStartingByAccount(long accountId) {
+        SearchCriteria<Long> sc = CountRunningAndStartingByAccount.create();
         sc.setParameters("account", accountId);
-        sc.setParameters("state", State.Running);
+        sc.setParameters("states", new Object[] {State.Starting, State.Running});
         return customSearch(sc, null).get(0);
     }
 

--- a/plugins/deployment-planners/user-dispersing/src/main/java/com/cloud/deploy/UserDispersingPlanner.java
+++ b/plugins/deployment-planners/user-dispersing/src/main/java/com/cloud/deploy/UserDispersingPlanner.java
@@ -146,7 +146,7 @@ public class UserDispersingPlanner extends FirstFitPlanner implements Deployment
         //normalize the vmCountMap
         LinkedHashMap<Long, Double> normalisedVmCountIdMap = new LinkedHashMap<Long, Double>();
 
-        Long totalVmsOfAccount = vmInstanceDao.countRunningByAccount(accountId);
+        Long totalVmsOfAccount = vmInstanceDao.countRunningAndStartingByAccount(accountId);
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("Total VMs for account: " + totalVmsOfAccount);
         }


### PR DESCRIPTION
Consider running and starting VMs when considering load ona host for VM deployement for more accurate dispersion.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3442 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Deploy VMs quickly through CMK on a 2 host environment.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
