### PR TITLE
Proposed refactor of memorykbs to memoryusedkbs to reflect description on API docs

### DIFF
--- a/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
+++ b/api/src/org/apache/cloudstack/api/response/UserVmResponse.java
@@ -196,9 +196,9 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     @Param(description = "the write (bytes) of disk on the vm")
     private Long diskKbsWrite;
 
-    @SerializedName("memorykbs")
+    @SerializedName("memoryusedkbs")
     @Param(description = "the memory used by the vm")
-    private Long memoryKBs;
+    private Long memoryUsedKBs;
 
     @SerializedName("memoryintfreekbs")
     @Param(description = "the internal memory thats free in vm")
@@ -475,7 +475,7 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
     }
 
     public Long getMemoryKBs() {
-        return memoryKBs;
+        return memoryUsedKBs;
     }
 
     public Long getMemoryIntFreeKBs() {
@@ -661,8 +661,8 @@ public class UserVmResponse extends BaseResponseWithTagInformation implements Co
         this.diskIORead = diskIORead;
     }
 
-    public void setMemoryKBs(Long memoryKBs) {
-        this.memoryKBs = memoryKBs;
+    public void setMemoryKBs(Long memoryUsedKBs) {
+        this.memoryUsedKBs = memoryUsedKBs;
     }
 
     public void setMemoryIntFreeKBs(Long memoryIntFreeKBs) {

--- a/core/src/com/cloud/agent/api/VmStatsEntry.java
+++ b/core/src/com/cloud/agent/api/VmStatsEntry.java
@@ -30,19 +30,19 @@ public class VmStatsEntry implements VmStats {
     double diskWriteIOs;
     double diskReadKBs;
     double diskWriteKBs;
-    double memoryKBs;
-    double intfreememoryKBs;
-    double targetmemoryKBs;
+    double memoryUsedKBs;
+    double intfreememoryUsedKBs;
+    double targetmemoryUsedKBs;
     int numCPUs;
     String entityType;
 
     public VmStatsEntry() {
     }
 
-    public VmStatsEntry(double memoryKBs,double intfreememoryKBs,double targetmemoryKBs, double cpuUtilization, double networkReadKBs, double networkWriteKBs, int numCPUs, String entityType) {
-        this.memoryKBs = memoryKBs;
-        this.intfreememoryKBs = intfreememoryKBs;
-        this.targetmemoryKBs = targetmemoryKBs;
+    public VmStatsEntry(double memoryUsedKBs,double intfreememoryUsedKBs,double targetmemoryUsedKBs, double cpuUtilization, double networkReadKBs, double networkWriteKBs, int numCPUs, String entityType) {
+        this.memoryUsedKBs = memoryUsedKBs;
+        this.intfreememoryUsedKBs = intfreememoryUsedKBs;
+        this.targetmemoryUsedKBs = targetmemoryUsedKBs;
         this.cpuUtilization = cpuUtilization;
         this.networkReadKBs = networkReadKBs;
         this.networkWriteKBs = networkWriteKBs;
@@ -125,29 +125,29 @@ public class VmStatsEntry implements VmStats {
 
     @Override
     public double getMemoryKBs() {
-        return memoryKBs;
+        return memoryUsedKBs;
     }
 
-    public void setMemoryKBs(double memoryKBs) {
-        this.memoryKBs = memoryKBs;
+    public void setMemoryKBs(double memoryUsedKBs) {
+        this.memoryUsedKBs = memoryUsedKBs;
     }
 
     @Override
     public double getIntFreeMemoryKBs() {
-        return intfreememoryKBs;
+        return intfreememoryUsedKBs;
     }
 
-    public void setIntFreeMemoryKBs(double intfreememoryKBs) {
-        this.intfreememoryKBs = intfreememoryKBs;
+    public void setIntFreeMemoryKBs(double intfreememoryUsedKBs) {
+        this.intfreememoryUsedKBs = intfreememoryUsedKBs;
     }
 
     @Override
     public double getTargetMemoryKBs() {
-        return targetmemoryKBs;
+        return targetmemoryUsedKBs;
     }
 
-    public void setTargetMemoryKBs(double targetmemoryKBs) {
-        this.targetmemoryKBs = targetmemoryKBs;
+    public void setTargetMemoryKBs(double targetmemoryUsedKBs) {
+        this.targetmemoryUsedKBs = targetmemoryUsedKBs;
     }
 
     public int getNumCPUs() {

--- a/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/HypervResourceController.cs
+++ b/plugins/hypervisors/hyperv/DotNet/ServerResource/HypervResource/HypervResourceController.cs
@@ -2242,10 +2242,10 @@ namespace HypervResource
                 strtRouteCmd.cpus = cores;
                 strtRouteCmd.speed = mhz;
                 strtRouteCmd.cpuSockets = sockets;
-                ulong memoryKBs;
+                ulong memoryUsedKBs;
                 ulong freeMemoryKBs;
-                wmiCallsV2.GetMemoryResources(out memoryKBs, out freeMemoryKBs);
-                strtRouteCmd.memory = memoryKBs * 1024;   // Convert to bytes
+                wmiCallsV2.GetMemoryResources(out memoryUsedKBs, out freeMemoryKBs);
+                strtRouteCmd.memory = memoryUsedKBs * 1024;   // Convert to bytes
 
                 // Need 2 Gig for DOM0, see http://technet.microsoft.com/en-us/magazine/hh750394.aspx
                 strtRouteCmd.dom0MinMemory = config.ParentPartitionMinMemoryMb * 1024 * 1024;  // Convert to bytes


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Based on the [API docs](https://cloudstack.apache.org/api/apidocs-4.12/apis/listVirtualMachines.html) this field `memorykbs` has the description `the memory used by the vm` . 
The refactor to `memoryusedkbs` enhances clarity in line with the naming scheme.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

![Screen Shot 2019-07-04 at 9 30 54 AM](https://user-images.githubusercontent.com/20902920/60644380-9c5cd000-9e3e-11e9-8d05-5f105a436803.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Similar to all tests for the `listvirtualmachines` api

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
