### PR TITLE
vr: Fix vpc router in UNKNOWN state

### DIFF
--- a/systemvm/debian/opt/cloud/bin/checkrouter.sh
+++ b/systemvm/debian/opt/cloud/bin/checkrouter.sh
@@ -27,10 +27,10 @@ fi
 ROUTER_TYPE=$(cat /etc/cloudstack/cmdline.json | grep type | awk '{print $2;}' | sed -e 's/[,\"]//g')
 if [ "$ROUTER_TYPE" = "router" ]
 then
-	ROUTER_STATE=$(ip addr | grep -w eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
+	ROUTER_STATE=$(ip addr show dev eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
 	STATUS=$ROUTER_STATE
 else
-	ROUTER_STATE=$(ip addr | grep -w eth1 | grep state | awk '{print $9;}')
+	ROUTER_STATE=$(ip addr show dev eth1 | grep state | awk '{print $9;}')
 	if [ "$ROUTER_STATE" = "UP" ]
 	then
 	    STATUS=MASTER

--- a/systemvm/debian/opt/cloud/bin/checkrouter.sh
+++ b/systemvm/debian/opt/cloud/bin/checkrouter.sh
@@ -27,10 +27,10 @@ fi
 ROUTER_TYPE=$(cat /etc/cloudstack/cmdline.json | grep type | awk '{print $2;}' | sed -e 's/[,\"]//g')
 if [ "$ROUTER_TYPE" = "router" ]
 then
-	ROUTER_STATE=$(ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
+	ROUTER_STATE=$(ip addr | grep -w eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo "MASTER"; else echo "BACKUP"; fi')
 	STATUS=$ROUTER_STATE
 else
-	ROUTER_STATE=$(ip addr | grep eth1 | grep state | awk '{print $9;}')
+	ROUTER_STATE=$(ip addr | grep -w eth1 | grep state | awk '{print $9;}')
 	if [ "$ROUTER_STATE" = "UP" ]
 	then
 	    STATUS=MASTER


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
If there are more than 10 vpc tiers or public ip subnets in a VPC, eth1X will be added in vpc router.
The redundant state is UNKNOWN in this case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

creaete more than 10 vpc tiers, then vpc router will be UNKNOWN
it can be fixed by this commit.