### PR TITLE
travis: use openjdk8 and xenial (ubuntu 16.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 sudo: required
-dist: trusty
+dist: xenial
 group: edge
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 python:
   - "2.7"
 cache:


### PR DESCRIPTION
This fixes Travis to use openjdk8 and Xenial (Ubuntu 16.04) as base
distro.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

This only changes Travis config and does not require smoketests. PR may be merged solely when Travis passes.