### PR TITLE
network: allow icmp code 16 in firewall rules

### DIFF
--- a/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
@@ -545,7 +545,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
         }
         if (icmpCode != null) {
             if (icmpCode.longValue() != -1 && !NetUtils.validateIcmpCode(icmpCode.longValue())) {
-                throw new InvalidParameterValueException(String.format("Invalid icmp code [%d]. It should belong to [0-15] range and can be defined when icmpType belongs to [0-40] range", icmpCode));
+                throw new InvalidParameterValueException(String.format("Invalid icmp code [%d]. It should belong to [0-16] range and can be defined when icmpType belongs to [0-40] range", icmpCode));
             }
         }
     }

--- a/server/src/test/java/com/cloud/network/vpc/NetworkACLServiceImplTest.java
+++ b/server/src/test/java/com/cloud/network/vpc/NetworkACLServiceImplTest.java
@@ -685,7 +685,7 @@ public class NetworkACLServiceImplTest {
     @Test(expected = InvalidParameterValueException.class)
     public void validateIcmpTypeAndCodeTestIcmpTypeValidAndIcmpCodeInvalid() {
         Mockito.when(networkAclItemVoMock.getIcmpType()).thenReturn(255);
-        Mockito.when(networkAclItemVoMock.getIcmpCode()).thenReturn(16);
+        Mockito.when(networkAclItemVoMock.getIcmpCode()).thenReturn(17);
 
         networkAclServiceImpl.validateIcmpTypeAndCode(networkAclItemVoMock);
     }

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -1215,9 +1215,9 @@ public class NetUtils {
 
     public static boolean validateIcmpCode(final long icmpCode) {
 
-        //Source - http://www.erg.abdn.ac.uk/~gorry/course/inet-pages/icmp-code.html
-        if (!(icmpCode >= 0 && icmpCode <= 15)) {
-            s_logger.warn("Icmp code should be within 0-15 range");
+        // Reference: https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-codes-9/#table-icmp-parameters-ext-classes
+        if (!(icmpCode >= 0 && icmpCode <= 16)) {
+            s_logger.warn("Icmp code should be within 0-16 range");
             return false;
         }
 


### PR DESCRIPTION
This allows for icmp code range 0-16.

Type 9 Router advertisement reference:
https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-codes-9/#table-icmp-parameters-ext-classes

Fixes #3349

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)