### PR TITLE
vmware: fix volume stats logic

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -3612,8 +3612,16 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                                 Pair<VirtualDisk, String> vds = vmMo.getDiskDevice(file.getFileName(), true);
                                 long virtualsize = vds.first().getCapacityInKB() * 1024;
                                 long physicalsize = primaryStorageDatastoreMo.fileDiskSize(file.getPath());
-                                VolumeStatsEntry vse = new VolumeStatsEntry(chainInfo, physicalsize, virtualsize);
-                                statEntry.put(chainInfo, vse);
+                                if (statEntry.containsKey(chainInfo)) {
+                                    VolumeStatsEntry vse = statEntry.get(chainInfo);
+                                    if (vse != null) {
+                                        vse.setPhysicalSize(vse.getPhysicalSize() + physicalsize);
+                                        vse.setVirtualSize(vse.getVirtualSize() + virtualsize);
+                                    }
+                                } else {
+                                    VolumeStatsEntry vse = new VolumeStatsEntry(chainInfo, physicalsize, virtualsize);
+                                    statEntry.put(chainInfo, vse);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
During volume stats calculation, if a volume has more than one disk in
the chain-info it is not used to sum the physical and virtual size
in the loop, instead any previous entry was overwritten by the last disk.

Fixes #3416

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)