### PR TITLE
Allowing template owner to download template

### DIFF
--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1499,9 +1499,9 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
         }
 
         if (isExtractable != null) {
-            // Only Root admins allowed to change it for templates
-            if (!template.getFormat().equals(ImageFormat.ISO) && !_accountMgr.isRootAdmin(caller.getId())) {
-                throw new InvalidParameterValueException("Only ROOT admins are allowed to modify isExtractable attribute.");
+            // Only Root admins and owners are allowed to change it for templates
+            if (!template.getFormat().equals(ImageFormat.ISO) && caller.getId() != ownerId && !isAdmin) {
+                throw new InvalidParameterValueException("Only ROOT admins and template owners are allowed to modify isExtractable attribute.");
             } else {
                 // For Isos normal user can change it, as their are no derivatives.
                 updatedTemplate.setExtractable(isExtractable.booleanValue());

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -1378,12 +1378,7 @@
                                     isextractable: {
                                         label: 'label.extractable.lower',
                                         isBoolean: true,
-                                        isEditable: function() {
-                                            if (isAdmin())
-                                                return true;
-                                            else
-                                                return false;
-                                        },
+                                        isEditable: true,
                                         converter: cloudStack.converters.toBooleanText
                                     },
                                     passwordenabled: {
@@ -1822,12 +1817,7 @@
                                                 isextractable: {
                                                     label: 'label.extractable.lower',
                                                     isBoolean: true,
-                                                    isEditable: function() {
-                                                        if (isAdmin())
-                                                            return true;
-                                                        else
-                                                            return false;
-                                                    },
+                                                    isEditable: true,
                                                     converter: cloudStack.converters.toBooleanText
                                                 },
                                                 passwordenabled: {
@@ -2935,12 +2925,7 @@
                                                 isextractable: {
                                                     label: 'label.extractable.lower',
                                                     isBoolean: true,
-                                                    isEditable: function() {
-                                                        if (isAdmin())
-                                                            return true;
-                                                        else
-                                                            return false;
-                                                    },
+                                                    isEditable: true,
                                                     converter: cloudStack.converters.toBooleanText
                                                 },
                                                 bootable: {
@@ -3057,7 +3042,9 @@
             || (jsonObj.isready == false) || jsonObj.templatetype == "SYSTEM") {
             //do nothing
         } else {
-            allowedActions.push("downloadTemplate");
+            if (jsonObj.isextractable){
+                allowedActions.push("downloadTemplate");
+            }
         }
 
         // "Delete Template"


### PR DESCRIPTION
## Description
Removed the download icon when a template is not extractable.

Modified the api to allow a user from the same account as the template, to change the extractable attribute on the template.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #3400

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested using the UI.
Create a user, then login with that user. Navigate to templates, add a template.
Edit the template, click on the extractable checkbox. Save changes. 

At this point, there is no error.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
