### PR TITLE
filter volumes by host when refreshing stats

### DIFF
--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDao.java
@@ -46,6 +46,8 @@ public interface VolumeDao extends GenericDao<VolumeVO, Long>, StateDao<Volume.S
 
     List<VolumeVO> findByInstanceAndType(long id, Volume.Type vType);
 
+    List<VolumeVO> findByInstanceIdAndPoolId(long instanceId, long poolId);
+
     List<VolumeVO> findByInstanceIdDestroyed(long vmId);
 
     List<VolumeVO> findByPod(long podId);

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VolumeDaoImpl.java
@@ -128,6 +128,15 @@ public class VolumeDaoImpl extends GenericDaoBase<VolumeVO, Long> implements Vol
     }
 
     @Override
+    public List<VolumeVO> findByInstanceIdAndPoolId(long instanceId, long poolId) {
+        SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
+        sc.setParameters("instanceId", instanceId);
+        sc.setParameters("poolId", poolId);
+        sc.setParameters("notDestroyed", Volume.State.Destroy);
+        return listBy(sc);
+    }
+
+    @Override
     public VolumeVO findByPoolIdName(long poolId, String name) {
         SearchCriteria<VolumeVO> sc = AllFieldsSearch.create();
         sc.setParameters("poolId", poolId);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiAdmStorageAdaptor.java
@@ -242,7 +242,7 @@ public class IscsiAdmStorageAdaptor implements StorageAdaptor {
         String result = iScsiAdmCmd.execute(parser);
 
         if (result != null) {
-            s_logger.warn("Unable to retrieve the size of device " + deviceByPath);
+            s_logger.warn("Unable to retrieve the size of device (resource may have moved to a different host)" + deviceByPath);
 
             return 0;
         }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1911,7 +1911,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             List<String> volumeLocatorsForHost;
             if (storagePool.isManaged()) {
                 List<UserVmVO> vmsPerHost = _vmDao.listByHostId(neighbor.getId());
-                volumeLocatorsForHost = vmsPerHost.stream().flatMap(vm -> _volsDao.findByInstance(vm.getId()).stream().map(vol -> vol.getUuid())).collect(Collectors.toList());
+                volumeLocatorsForHost = vmsPerHost.stream().flatMap(vm -> _volsDao.findByInstance(vm.getId()).stream().map(vol -> vol.getPath())).collect(Collectors.toList());
             } else {
                 volumeLocatorsForHost = volumeLocators;
             }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1911,7 +1911,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             List<String> volumeLocatorsForHost;
             if (storagePool.isManaged()) {
                 List<UserVmVO> vmsPerHost = _vmDao.listByHostId(neighbor.getId());
-                volumeLocatorsForHost = vmsPerHost.stream().flatMap(vm -> _volsDao.findByInstance(vm.getId()).stream().map(vol -> vol.getPath())).collect(Collectors.toList());
+                volumeLocatorsForHost = vmsPerHost.stream().flatMap(vm -> _volsDao.findByInstance(vm.getId()).stream()
+                        .filter(vol -> vol.getPoolType().equals(storagePool.getPoolType())).map(vol -> vol.getPath()))
+                        .collect(Collectors.toList());
             } else {
                 volumeLocatorsForHost = volumeLocators;
             }

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1912,7 +1912,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             if (storagePool.isManaged()) {
                 List<UserVmVO> vmsPerHost = _vmDao.listByHostId(neighbor.getId());
                 volumeLocatorsForHost = vmsPerHost.stream().flatMap(vm -> _volsDao.findByInstance(vm.getId()).stream()
-                        .filter(vol -> vol.getPoolType().equals(storagePool.getPoolType())).map(vol -> vol.getPath()))
+                        .filter(vol -> vol.getPoolType().equals(poolType)).map(vol -> vol.getPath()))
                         .collect(Collectors.toList());
             } else {
                 volumeLocatorsForHost = volumeLocators;

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1912,7 +1912,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             if (storagePool.isManaged()) {
                 List<UserVmVO> vmsPerHost = _vmDao.listByHostId(neighbor.getId());
                 volumeLocatorsForHost = vmsPerHost.stream().flatMap(vm -> _volsDao.findByInstance(vm.getId()).stream()
-                        .filter(vol -> vol.getPoolType().equals(poolType)).map(vol -> vol.getPath()))
+                        .filter(vol -> vol.getPoolType().toString().equals(poolType.toString())).map(vol -> vol.getPath()))
                         .collect(Collectors.toList());
             } else {
                 volumeLocatorsForHost = volumeLocators;

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1911,8 +1911,9 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
             List<String> volumeLocatorsForHost;
             if (storagePool.isManaged()) {
                 List<UserVmVO> vmsPerHost = _vmDao.listByHostId(neighbor.getId());
-                volumeLocatorsForHost = vmsPerHost.stream().flatMap(vm -> _volsDao.findByInstance(vm.getId()).stream()
-                        .filter(vol -> vol.getPoolType().toString().equals(poolType.toString())).map(vol -> vol.getPath()))
+                volumeLocatorsForHost = vmsPerHost.stream()
+                        .flatMap(vm -> _volsDao.findByInstanceIdAndPoolId(vm.getId(),storagePool.getId()).stream()
+                        .map(vol -> vol.getPath()))
                         .collect(Collectors.toList());
             } else {
                 volumeLocatorsForHost = volumeLocators;


### PR DESCRIPTION
## Description
Currently when refreshing disk usage stats all kvm agents are asked to collect stats for all volumes. In setups with multiple kvm hosts where managed storage is used, not all volumes are attached to all kvm hosts, this results in a large number of warnings in the kvm agent logs. This change introduces a filter step in case managed storage is used so that the management server only requests kvm agents for stats about volumes that are connected to each kvm host.
 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
