### PR TITLE
server: fix public IP association/disassociation to new network

### DIFF
--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -29,9 +29,6 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
-import com.cloud.dc.DomainVlanMapVO;
-import org.apache.log4j.Logger;
-
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.response.AcquirePodIpCmdResponse;
@@ -44,6 +41,7 @@ import org.apache.cloudstack.region.PortableIp;
 import org.apache.cloudstack.region.PortableIpDao;
 import org.apache.cloudstack.region.PortableIpVO;
 import org.apache.cloudstack.region.Region;
+import org.apache.log4j.Logger;
 
 import com.cloud.agent.AgentManager;
 import com.cloud.alert.AlertManager;
@@ -54,6 +52,7 @@ import com.cloud.dc.AccountVlanMapVO;
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenter.NetworkType;
 import com.cloud.dc.DataCenterIpAddressVO;
+import com.cloud.dc.DomainVlanMapVO;
 import com.cloud.dc.HostPodVO;
 import com.cloud.dc.Pod;
 import com.cloud.dc.PodVlanMapVO;
@@ -1429,12 +1428,6 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         if (!sharedSourceNat) {
             if (getExistingSourceNatInNetwork(owner.getId(), network.getId()) == null) {
                 if (network.getGuestType() == GuestType.Isolated && network.getVpcId() == null && !ipToAssoc.isPortable()) {
-                    if (network.getState() == Network.State.Allocated) {
-                        //prevent associating an ip address to an allocated (unimplemented network).
-                        //it will cause the ip to become source nat, and it can't be disassociated later on.
-                        String msg = String.format("Network with UUID:%s is in allocated and needs to be implemented first before acquiring an IP address", network.getUuid());
-                        throw new InvalidParameterValueException(msg);
-                    }
                     isSourceNat = true;
                 }
             }

--- a/server/src/test/java/com/cloud/network/IpAddressManagerTest.java
+++ b/server/src/test/java/com/cloud/network/IpAddressManagerTest.java
@@ -36,8 +36,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
 
-import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.network.Network.Service;
 import com.cloud.network.dao.IPAddressDao;
@@ -50,7 +50,6 @@ import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.net.Ip;
-import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IpAddressManagerTest {
@@ -170,7 +169,7 @@ public class IpAddressManagerTest {
         assertTrue("Source NAT should be true", isSourceNat);
     }
 
-    @Test(expected = InvalidParameterValueException.class)
+    @Test
     public void assertSourceNatAllocatedNetwork() {
 
         NetworkVO networkAllocated = Mockito.mock(NetworkVO.class);
@@ -184,7 +183,7 @@ public class IpAddressManagerTest {
         Mockito.when(networkDao.findById(2L)).thenReturn(networkAllocated);
         doReturn(null).when(ipAddressManager).getExistingSourceNatInNetwork(1L, 2L);
 
-        ipAddressManager.isSourceNatAvailableForNetwork(account, ipAddressVO, networkAllocated);
+        assertTrue(ipAddressManager.isSourceNatAvailableForNetwork(account, ipAddressVO, networkAllocated));
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes #3321 

This changes removes exception throwing while associating an IP address to a new isolated network which is in `Allocated` state. And it allows disassociating an IP address when it is used for source NAT purpose but network is in allocated state.
Refer, https://github.com/apache/cloudstack/issues/3321#issuecomment-510389806

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Using cmk,
```
(localcloud) 🐱 > list networks filter=id,name,state
{
  "count": 1,
  "network": [
    {
      "id": "6838a64f-2f55-4097-af9f-c0cdff805737",
      "name": "Test",
      "state": "Allocated"
    }
  ]
}
(localcloud) 🐱 > associate ipaddress networkid=6838a64f-2f55-4097-af9f-c0cdff805737 
{
  "ipaddress": {
    "account": "admin",
    "allocated": "2019-07-12T15:29:07+0530",
    "associatednetworkid": "6838a64f-2f55-4097-af9f-c0cdff805737",
    "associatednetworkname": "Test",
    "domain": "ROOT",
    "domainid": "5b4d6fd0-a486-11e9-a980-645d8651f45a",
    "fordisplay": true,
    "forvirtualnetwork": true,
    "id": "8e8593dd-b38c-4272-8748-bdd87de5997f",
    "ipaddress": "192.168.2.4",
    "isportable": false,
    "issourcenat": true,
    "isstaticnat": false,
    "issystem": false,
    "networkid": "09e7940c-a642-41c1-9bad-47d9d97fb1d5",
    "physicalnetworkid": "e964a192-5883-4e07-afdb-a30ef5ea69fe",
    "state": "Allocating",
    "tags": [],
    "vlanid": "3421057d-5a58-45cd-b451-e26de05f7417",
    "vlanname": "vlan://50",
    "zoneid": "c9db52ce-6425-4460-aed4-cb00b67b02e8",
    "zonename": "Sandbox-simulator"
  }
}
(localcloud) 🐱 > disassociate ipaddress id=8e8593dd-b38c-4272-8748-bdd87de5997f
{
  "success": true
}

```


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
