### PR TITLE
KVM: Propagating changes on host parameters to the agents

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/agent/AgentManager.java
+++ b/engine/components-api/src/main/java/com/cloud/agent/AgentManager.java
@@ -152,4 +152,6 @@ public interface AgentManager {
     void notifyMonitorsOfHostAboutToBeRemoved(long hostId);
 
     void notifyMonitorsOfRemovedHost(long hostId, long clusterId);
+
+    void propagateChangeToAgents();
 }

--- a/framework/agent-lb/src/main/java/org/apache/cloudstack/agent/lb/IndirectAgentLB.java
+++ b/framework/agent-lb/src/main/java/org/apache/cloudstack/agent/lb/IndirectAgentLB.java
@@ -50,4 +50,7 @@ public interface IndirectAgentLB {
      * @return returns interval in seconds
      */
     Long getLBPreferredHostCheckInterval(Long clusterId);
+
+    void propagateMSListToAgents();
+
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -1104,9 +1104,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         // Save configurations in agent.properties
         PropertiesStorage storage = new PropertiesStorage();
         storage.configure("Storage", new HashMap<String, Object>());
-        if (params.get("router.aggregation.command.each.timeout") == null) {
+        if (params.get("router.aggregation.command.each.timeout") != null) {
             String value = (String)params.get("router.aggregation.command.each.timeout");
-            Integer intValue = NumbersUtil.parseInt(value, 10);
+            Integer intValue = NumbersUtil.parseInt(value, 600);
             storage.persist("router.aggregation.command.each.timeout", String.valueOf(intValue));
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -106,6 +106,7 @@ import com.cloud.agent.api.to.IpAddressTO;
 import com.cloud.agent.api.to.NfsTO;
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.agent.dao.impl.PropertiesStorage;
 import com.cloud.agent.resource.virtualnetwork.VRScripts;
 import com.cloud.agent.resource.virtualnetwork.VirtualRouterDeployer;
 import com.cloud.agent.resource.virtualnetwork.VirtualRoutingResource;
@@ -1090,6 +1091,24 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         IscsiStorageCleanupMonitor isciCleanupMonitor = new IscsiStorageCleanupMonitor();
         final Thread cleanupMonitor = new Thread(isciCleanupMonitor);
         cleanupMonitor.start();
+
+        return true;
+    }
+
+    public boolean configureHostParams(final Map<String, String> params) {
+        final File file = PropertiesUtil.findConfigFile("agent.properties");
+        if (file == null) {
+            s_logger.error("Unable to find the file agent.properties");
+            return false;
+        }
+        // Save configurations in agent.properties
+        PropertiesStorage storage = new PropertiesStorage();
+        storage.configure("Storage", new HashMap<String, Object>());
+        if (params.get("router.aggregation.command.each.timeout") == null) {
+            String value = (String)params.get("router.aggregation.command.each.timeout");
+            Integer intValue = NumbersUtil.parseInt(value, 10);
+            storage.persist("router.aggregation.command.each.timeout", String.valueOf(intValue));
+        }
 
         return true;
     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtSetHostParamsCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtSetHostParamsCommandWrapper.java
@@ -35,6 +35,7 @@ public final class LibvirtSetHostParamsCommandWrapper extends CommandWrapper<Set
 
         final Map<String, String> params = command.getParams();
         boolean success = libvirtComputingResource.getVirtRouterResource().configureHostParams(params);
+        success = success && libvirtComputingResource.configureHostParams(params);
 
         if (!success) {
             return new Answer(command, false, "Failed to set host parameters");

--- a/server/src/test/java/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImplTest.java
@@ -95,7 +95,6 @@ public class IndirectAgentLBServiceImplTest {
             id++;
         }
         addField(agentMSLB, "hostDao", hostDao);
-        addField(agentMSLB, "messageBus", messageBus);
         addField(agentMSLB, "agentManager", agentManager);
 
         when(hostDao.listAll()).thenReturn(Arrays.asList(host4, host2, host1, host3));

--- a/server/src/test/resources/createNetworkOffering.xml
+++ b/server/src/test/resources/createNetworkOffering.xml
@@ -58,4 +58,5 @@
     <bean id="DiskOfferingDetailsDaoImpl" class="org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDaoImpl" />
     <bean id="networkOfferingJoinDaoImpl" class="com.cloud.api.query.dao.NetworkOfferingJoinDaoImpl" />
     <bean id="networkOfferingDetailsDaoImpl" class="com.cloud.offerings.dao.NetworkOfferingDetailsDaoImpl" />
+    <bean id="indirectAgentLBImpl" class="org.apache.cloudstack.agent.lb.IndirectAgentLBServiceImpl" />
 </beans>


### PR DESCRIPTION
## Description

When we change a global setting and it needs to be applied to all kvm agents, it would be nice that the new value can be propagated to all kvm agents (and save in agent.properties if needed) so we do not need to manually restart cloudstack agent or change agent.properties.

it supports only "router.aggregation.command.each.timeout" for now.

In the future, it would be good to add a new column in "configurations" table to determine whether the configuration needs to be propagated to kvm agents.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

(1) change router.aggregation.command.each.timeout in global setting
(2) check agent.properties to see if the value is changed as well.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
