### PR TITLE
Fix hardcoded max data volumes when VM has been created but not started before

### DIFF
--- a/engine/schema/src/main/java/com/cloud/hypervisor/dao/HypervisorCapabilitiesDao.java
+++ b/engine/schema/src/main/java/com/cloud/hypervisor/dao/HypervisorCapabilitiesDao.java
@@ -35,4 +35,6 @@ public interface HypervisorCapabilitiesDao extends GenericDao<HypervisorCapabili
     Integer getMaxHostsPerCluster(HypervisorType hypervisorType, String hypervisorVersion);
 
     Boolean isVmSnapshotEnabled(HypervisorType hypervisorType, String hypervisorVersion);
+
+    List<HypervisorType> getHypervisorsWithDefaultEntries();
 }

--- a/engine/schema/src/main/java/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/hypervisor/dao/HypervisorCapabilitiesDaoImpl.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.hypervisor.dao;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -105,5 +106,17 @@ public class HypervisorCapabilitiesDaoImpl extends GenericDaoBase<HypervisorCapa
     public Boolean isVmSnapshotEnabled(HypervisorType hypervisorType, String hypervisorVersion) {
         HypervisorCapabilitiesVO result = getCapabilities(hypervisorType, hypervisorVersion);
         return result.getVmSnapshotEnabled();
+    }
+
+    @Override
+    public List<HypervisorType> getHypervisorsWithDefaultEntries() {
+        SearchCriteria<HypervisorCapabilitiesVO> sc = HypervisorTypeAndVersionSearch.create();
+        sc.setParameters("hypervisorVersion", DEFAULT_VERSION);
+        List<HypervisorCapabilitiesVO> hypervisorCapabilitiesVOS = listBy(sc);
+        List<HypervisorType> hvs = new ArrayList<>();
+        for (HypervisorCapabilitiesVO capabilitiesVO : hypervisorCapabilitiesVOS) {
+            hvs.add(capabilitiesVO.getHypervisorType());
+        }
+        return hvs;
     }
 }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -266,6 +266,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     private List<StoragePoolAllocator> _storagePoolAllocators;
 
+    private List<HypervisorType> supportingDefaultHV;
+
     VmWorkJobHandlerProxy _jobHandlerProxy = new VmWorkJobHandlerProxy(this);
 
     static final ConfigKey<Long> VmJobCheckInterval = new ConfigKey<Long>("Advanced", Long.class, "vm.job.check.interval", "3000", "Interval in milliseconds to check if the job is complete", false);
@@ -3010,7 +3012,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             _hostDao.loadDetails(host);
             maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(host.getHypervisorType(), host.getDetail("product_version"));
         } else {
-            List<HypervisorType> supportingDefaultHV = _hypervisorCapabilitiesDao.getHypervisorsWithDefaultEntries();
             HypervisorType hypervisorType = vm.getHypervisorType();
             if (hypervisorType != null && CollectionUtils.isNotEmpty(supportingDefaultHV) && supportingDefaultHV.contains(hypervisorType)) {
                 maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(hypervisorType, "default");
@@ -3062,6 +3063,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     public boolean configure(String name, Map<String, Object> params) {
         String maxVolumeSizeInGbString = _configDao.getValue(Config.MaxVolumeSize.toString());
         _maxVolumeSizeInGb = NumbersUtil.parseLong(maxVolumeSizeInGbString, 2000);
+        supportingDefaultHV = _hypervisorCapabilitiesDao.getHypervisorsWithDefaultEntries();
         return true;
     }
 

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3009,6 +3009,13 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         if (host != null) {
             _hostDao.loadDetails(host);
             maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(host.getHypervisorType(), host.getDetail("product_version"));
+        } else {
+            List<HypervisorType> supportingDefaultHV = Arrays.asList(HypervisorType.XenServer, HypervisorType.VMware,
+                    HypervisorType.KVM, HypervisorType.Ovm, HypervisorType.LXC);
+            HypervisorType hypervisorType = vm.getHypervisorType();
+            if (hypervisorType != null && supportingDefaultHV.contains(hypervisorType)) {
+                maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(hypervisorType, "default");
+            }
         }
         if (maxDataVolumesSupported == null || maxDataVolumesSupported.intValue() <= 0) {
             maxDataVolumesSupported = 6; // 6 data disks by default if nothing

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -3010,10 +3010,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             _hostDao.loadDetails(host);
             maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(host.getHypervisorType(), host.getDetail("product_version"));
         } else {
-            List<HypervisorType> supportingDefaultHV = Arrays.asList(HypervisorType.XenServer, HypervisorType.VMware,
-                    HypervisorType.KVM, HypervisorType.Ovm, HypervisorType.LXC);
+            List<HypervisorType> supportingDefaultHV = _hypervisorCapabilitiesDao.getHypervisorsWithDefaultEntries();
             HypervisorType hypervisorType = vm.getHypervisorType();
-            if (hypervisorType != null && supportingDefaultHV.contains(hypervisorType)) {
+            if (hypervisorType != null && CollectionUtils.isNotEmpty(supportingDefaultHV) && supportingDefaultHV.contains(hypervisorType)) {
                 maxDataVolumesSupported = _hypervisorCapabilitiesDao.getMaxDataVolumesLimit(hypervisorType, "default");
             }
         }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -2861,7 +2861,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             }
         }
 
-        verifyManagedStorage(volumeToAttachStoragePool.getId(), hostId);
+        if (volumeToAttachStoragePool != null) {
+            verifyManagedStorage(volumeToAttachStoragePool.getId(), hostId);
+        }
 
         // volumeToAttachStoragePool should be null if the VM we are attaching the disk to has never been started before
         DataStore dataStore = volumeToAttachStoragePool != null ? dataStoreMgr.getDataStore(volumeToAttachStoragePool.getId(), DataStoreRole.Primary) : null;

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
+import com.cloud.hypervisor.dao.HypervisorCapabilitiesDao;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.command.user.volume.CreateVolumeCmd;
@@ -149,6 +150,8 @@ public class VolumeApiServiceImplTest {
     private HostDao _hostDao;
     @Mock
     private StoragePoolTagsDao storagePoolTagsDao;
+    @Mock
+    private HypervisorCapabilitiesDao hypervisorCapabilitiesDao;
 
     private DetachVolumeCmd detachCmd = new DetachVolumeCmd();
     private Class<?> _detachCmdClass = detachCmd.getClass();


### PR DESCRIPTION
## Description
When VM is created but not started on any host, attaching a volume on it causes the maximum number of allowed volumes to be 6 (hardcoded)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
- Deploy VM with startvm=false parameter
- Attach more than 6 volumes to VM (in case of KVM and VMware)