### PR TITLE
UI: Fix SystemVMs public range dedication

### DIFF
--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -493,11 +493,13 @@
                                                 if (args.data.account) {
                                                     if (args.data.account.account)
                                                         array1.push("&account=" + args.data.account.account);
+                                                        if (args.data.account.domainid) {
+                                                            array1.push("&domainid=" + args.data.account.domainid);
+                                                        }
                                                     if (args.data.account.systemvms) {
                                                         systvmsval = args.data.account.systemvms == "on" ? "true" : "false"
                                                         array1.push("&forsystemvms=" + systvmsval);
                                                     }
-                                                    array1.push("&domainid=" + args.data.account.domainid);
                                                 }
 
                                                 array1.push("&forVirtualNetwork=true");


### PR DESCRIPTION
## Description

Fix small UI issue when dedicating public IR range for system VMs:
`Unable to execute API command createvlaniprange due to invalid value. Invalid parameter domainid value=undefined due to incorrect long value format, or entity does not exist or due to incorrect parameter annotation for the field in api cmd class.`

Fixes: #3485 

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
As an administrator, create a new public range, selecting System VMs option