### PR TITLE
kvm/bridge: Allow Link Local Cidr (cloud0 interface) to be configured

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1613,7 +1613,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     _zoneDao.addPrivateIpAddress(zoneId, pod.getId(), startIp, endIpFinal, false, null);
                 }
 
-                final String[] linkLocalIpRanges = getLinkLocalIPRange();
+                final String[] linkLocalIpRanges = NetUtils.getLinkLocalIPRange(_configDao.getValue(Config.ControlCidr.key()));
                 if (linkLocalIpRanges != null) {
                     _zoneDao.addLinkLocalIpAddress(zoneId, pod.getId(), linkLocalIpRanges[0], linkLocalIpRanges[1]);
                 }
@@ -4487,20 +4487,6 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         } else {
             return null;
         }
-    }
-
-    private String[] getLinkLocalIPRange() {
-        final String ipNums = _configDao.getValue("linkLocalIp.nums");
-        final int nums = Integer.parseInt(ipNums);
-        if (nums > 16 || nums <= 0) {
-            throw new InvalidParameterValueException("The linkLocalIp.nums: " + nums + "is wrong, should be 1~16");
-        }
-        /* local link ip address starts from 169.254.0.2 - 169.254.(nums) */
-        final String[] ipRanges = NetUtils.getLinkLocalIPRange(nums);
-        if (ipRanges == null) {
-            throw new InvalidParameterValueException("The linkLocalIp.nums: " + nums + "may be wrong, should be 1~16");
-        }
-        return ipRanges;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/network/guru/ControlNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/ControlNetworkGuru.java
@@ -160,11 +160,16 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
         if (ip == null) {
             throw new InsufficientAddressCapacityException("Insufficient link local address capacity", DataCenter.class, dest.getDataCenter().getId());
         }
+
+        String netmask = NetUtils.cidr2Netmask(_cidr);
+
+        s_logger.debug(String.format("Reserved NIC for %s [ipv4:%s netmask:%s gateway:%s]", vm.getInstanceName(), ip, netmask, _gateway));
+
         nic.setIPv4Address(ip);
         nic.setMacAddress(NetUtils.long2Mac(NetUtils.ip2Long(ip) | (14l << 40)));
-        nic.setIPv4Netmask("255.255.0.0");
+        nic.setIPv4Netmask(netmask);
         nic.setFormat(AddressFormat.Ip4);
-        nic.setIPv4Gateway(NetUtils.getLinkLocalGateway());
+        nic.setIPv4Gateway(_gateway);
     }
 
     @Override
@@ -223,7 +228,7 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
 
         _cidr = dbParams.get(Config.ControlCidr.toString());
         if (_cidr == null) {
-            _cidr = "169.254.0.0/16";
+            _cidr = NetUtils.getLinkLocalCIDR();
         }
 
         _gateway = dbParams.get(Config.ControlGateway.toString());

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -904,12 +904,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
                         throw new InvalidParameterValueException("The linkLocalIp.nums: " + nums + "is wrong, should be 1~16");
                     }
                     /* local link ip address starts from 169.254.0.2 - 169.254.(nums) */
-                    String[] linkLocalIpRanges = NetUtils.getLinkLocalIPRange(nums);
-                    if (linkLocalIpRanges == null) {
-                        throw new InvalidParameterValueException("The linkLocalIp.nums: " + nums + "may be wrong, should be 1~16");
-                    } else {
-                        _zoneDao.addLinkLocalIpAddress(zoneId, pod.getId(), linkLocalIpRanges[0], linkLocalIpRanges[1]);
-                    }
+                    String[] linkLocalIpRanges = NetUtils.getLinkLocalIPRange(_configDao.getValue(Config.ControlCidr.key()));
+                    _zoneDao.addLinkLocalIpAddress(zoneId, pod.getId(), linkLocalIpRanges[0], linkLocalIpRanges[1]);
                 }
             });
         } catch (Exception e) {

--- a/server/src/main/java/com/cloud/test/IPRangeConfig.java
+++ b/server/src/main/java/com/cloud/test/IPRangeConfig.java
@@ -436,7 +436,7 @@ public class IPRangeConfig {
             problemIPs = savePrivateIPRange(txn, startIPLong, endIPLong, podId, zoneId);
         }
 
-        String[] linkLocalIps = NetUtils.getLinkLocalIPRange(10);
+        String[] linkLocalIps = NetUtils.getLinkLocalIPRange("169.254.0.0/16");
         long startLinkLocalIp = NetUtils.ip2Long(linkLocalIps[0]);
         long endLinkLocalIp = NetUtils.ip2Long(linkLocalIps[1]);
 

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -961,27 +961,34 @@ public class NetUtils {
         return "255.255.0.0";
     }
 
+    public static String getLinkLocalGateway(String cidr) {
+        return getLinkLocalFirstAddressFromCIDR(cidr);
+    }
+
     public static String getLinkLocalGateway() {
-        return "169.254.0.1";
+        return getLinkLocalGateway(getLinkLocalCIDR());
     }
 
     public static String getLinkLocalCIDR() {
         return "169.254.0.0/16";
     }
 
-    public static String[] getLinkLocalIPRange(final int size) {
-        if (size > 16 || size <= 0) {
-            return null;
-        }
-        /* reserve gateway */
-        final String[] range = getIpRangeFromCidr(getLinkLocalGateway(), MAX_CIDR - size);
+    public static String getLinkLocalFirstAddressFromCIDR(final String cidr) {
+        SubnetUtils subnetUtils = new SubnetUtils(cidr);
+        return subnetUtils.getInfo().getLowAddress();
+    }
 
-        if (range[0].equalsIgnoreCase(getLinkLocalGateway())) {
-            /* remove the gateway */
-            long ip = ip2Long(range[0]);
-            ip += 1;
-            range[0] = long2Ip(ip);
-        }
+    public static String getLinkLocalAddressFromCIDR(final String cidr) {
+        return getLinkLocalFirstAddressFromCIDR(cidr) + "/" + cidr2Netmask(cidr);
+    }
+
+    public static String[] getLinkLocalIPRange(final String cidr) {
+        final SubnetUtils subnetUtils = new SubnetUtils(cidr);
+        final String[] addresses = subnetUtils.getInfo().getAllAddresses();
+        final String[] range = new String[2];
+        range[0] = addresses[1];
+        range[1] = subnetUtils.getInfo().getHighAddress();
+
         return range;
     }
 

--- a/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -709,4 +709,26 @@ public class NetUtilsTest {
         assertFalse(NetUtils.isIPv6EUI64("2001:db8::100:1"));
         assertFalse(NetUtils.isIPv6EUI64("2a01:4f9:2a:185f::2"));
     }
+
+    @Test
+    public void testLinkLocal() {
+        final String cidr = NetUtils.getLinkLocalCIDR();
+        assertEquals("255.255.0.0", NetUtils.getLinkLocalNetMask());
+        assertEquals("169.254.0.1", NetUtils.getLinkLocalGateway());
+        assertEquals("169.254.0.0/16", cidr);
+        assertEquals("169.254.0.1", NetUtils.getLinkLocalFirstAddressFromCIDR(cidr));
+        assertEquals("169.254.0.1/255.255.0.0", NetUtils.getLinkLocalAddressFromCIDR(cidr));
+        assertEquals("169.254.240.1/255.255.240.0", NetUtils.getLinkLocalAddressFromCIDR("169.254.240.0/20"));
+
+        String[] range = NetUtils.getLinkLocalIPRange("169.254.0.0/16");
+        assertEquals("169.254.0.2", range[0]);
+        assertEquals("169.254.255.254", range[1]);
+    }
+
+    @Test
+    public void testCidrNetmask() {
+        assertEquals("255.255.255.0", NetUtils.cidr2Netmask("192.168.0.0/24"));
+        assertEquals("255.255.0.0", NetUtils.cidr2Netmask("169.254.0.0/16"));
+        assertEquals("255.255.240.0", NetUtils.cidr2Netmask("169.254.240.0/20"));
+    }
 }


### PR DESCRIPTION
## Description
There are certain scenarios where the 169.254.0.0/16 subnet is used for different
purposes then CloudStack on a hypervisor.

Once of such scenarios is a BGP+EVPN+VXLAN setup using BGP Unnumbered where the
169.254.0.1 address is used by Frr/Zebra BGP routing to send traffic to the
neighboring router.

The following settings can be changed in the agent.properties (default values added):

control.cidr=169.254.0.0/16

Make sure the global setting 'control.cidr' matches the values defined in the agent.propeties!

In the future the mgmt server can send this parameter to a KVM Agent on startup, but at the moment
this framework is not in place and thus these values can't be send to the Agent in a proper manner.

Fixes: #3488

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [x] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Ran local test on our cloud environment and verified cloud0 now has a different address.

<pre>
root@hv-138-a05-23:~# ip addr show cloud0
58: cloud0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether fe:00:a9:fe:f0:c9 brd ff:ff:ff:ff:ff:ff
    inet 169.254.240.1/20 scope global cloud0
       valid_lft forever preferred_lft forever
    inet6 fe80::8c3c:82ff:fe5a:77c/64 scope link 
       valid_lft forever preferred_lft forever
root@hv-138-a05-23:~#
</pre>
