### PR TITLE
Set integration.api.port to 0 (zero) as default.

### DIFF
--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -228,8 +228,8 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
     private static final ConfigKey<Integer> IntegrationAPIPort = new ConfigKey<Integer>("Advanced"
             , Integer.class
             , "integration.api.port"
-            , "8096"
-            , "Default API port"
+            , "0"
+            , "Integration API port (Unauthenticated)"
             , false
             , ConfigKey.Scope.Global);
     private static final ConfigKey<Long> ConcurrentSnapshotsThresholdPerHost = new ConfigKey<Long>("Advanced"

--- a/server/src/main/java/com/cloud/api/ApiServer.java
+++ b/server/src/main/java/com/cloud/api/ApiServer.java
@@ -229,7 +229,7 @@ public class ApiServer extends ManagerBase implements HttpRequestHandler, ApiSer
             , Integer.class
             , "integration.api.port"
             , "0"
-            , "Integration API port (Unauthenticated)"
+            , "Integration (unauthenticated) API port. To disable set it to 0 or negative."
             , false
             , ConfigKey.Scope.Global);
     private static final ConfigKey<Long> ConcurrentSnapshotsThresholdPerHost = new ConfigKey<Long>("Advanced"


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
CloudStack provides CloudStack API Unauthenticated Access through port
8096. It should not be open to the Internet in any case.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3450

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

**Current behavior**
1. Deploy a fresh CloudStack environment
2. Assert that the port 8096 is enabled by default. 
3. Verify that `integration.api.port` is indeed configured as 8096

**WIth this PR**
1. Deploy a fresh CloudStack environment with packages from this PR
2. Assert that the port 8096 is not enabled by default.
3. Verify that `integration.api.port` is indeed configured as 0

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
