### PR TITLE
Fix VR bootstrapping/connection state in KVM

### DIFF
--- a/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
@@ -85,9 +85,14 @@ config_guest() {
           sed -i "s/%/ /g" $CMDLINE
           ;;
      kvm)
-          # Configure hot-plug
-          modprobe acpiphp || true
-          modprobe pci_hotplug || true
+          # Configure kvm hotplug support
+          if grep -E 'CONFIG_HOTPLUG_PCI=y|CONFIG_HOTPLUG_PCI_ACPI=y' /boot/config-`uname -r`; then
+            log_it "acpiphp and pci_hotplug module already compiled in"
+          else
+            modprobe acpiphp 2> /dev/null && log_it "acpiphp module loaded" || true
+            modprobe pci_hotplug 2> /dev/null && log_it "pci_hotplug module loaded" || true
+          fi
+
           sed -i -e "/^s0:2345:respawn.*/d" /etc/inittab
           sed -i -e "/6:23:respawn/a\s0:2345:respawn:/sbin/getty -L 115200 ttyS0 vt102" /etc/inittab
           systemctl enable qemu-guest-agent

--- a/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
+++ b/systemvm/debian/opt/cloud/bin/setup/bootstrap.sh
@@ -90,7 +90,8 @@ config_guest() {
           modprobe pci_hotplug || true
           sed -i -e "/^s0:2345:respawn.*/d" /etc/inittab
           sed -i -e "/6:23:respawn/a\s0:2345:respawn:/sbin/getty -L 115200 ttyS0 vt102" /etc/inittab
-          systemctl enable --now qemu-guest-agent
+          systemctl enable qemu-guest-agent
+          systemctl start qemu-guest-agent
 
           # Wait for $CMDLINE file to be written by the qemu-guest-agent
           for i in {1..60}; do


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

* After PR #3278 there was some changes on the channels. this does not seem like the problem. if we look to the VR XML file we see the following. the qemu guest agent must be the problem because the state of the VR is "disconnected".

```xml
   <channel type='unix'>
     <source mode='bind' path='/var/lib/libvirt/qemu/r-1750-VM.org.qemu.guest_agent.0'/>
     <target type='virtio' name='org.qemu.guest_agent.0' state='disconnected'/>
     <alias name='channel0'/>
     <address type='virtio-serial' controller='0' bus='0' port='1'/>
   </channel>
```
after investigation of the bootstrap process i think i found this problem. there is no startup from the qemu-guest-agent. we need them in connected state for the patch.sh script.

![image](https://user-images.githubusercontent.com/5433844/61913361-2d563100-af3d-11e9-9908-d4c2181fee66.png)

the problems seems to be the startup of the "qemu-guest-agent". since this is not an really systemd service more than an sysvinit. the service will be started with "systemctl enable --now qemu-guest agent". this will be redirected to systemd-sysv-install. normally "--now" should enable and start the service. i think with this redirection to systemd-sysv-install there is no option for the startup.

![image](https://user-images.githubusercontent.com/5433844/61913305-fed85600-af3c-11e9-8d89-cdb570b7a046.png)
![image](https://user-images.githubusercontent.com/5433844/61913349-1f081500-af3d-11e9-90b7-6a6d5c719d52.png)

* last one is to capture the error from the module load kvm pci hotplug

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
Use actually master, build a SystemVM and try to deploy them

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
