### PR TITLE
NioServer: retain links by address string to minimize resource leak

### DIFF
--- a/utils/src/main/java/com/cloud/utils/nio/Link.java
+++ b/utils/src/main/java/com/cloud/utils/nio/Link.java
@@ -489,7 +489,7 @@ public class Link {
             try {
                 sslEngine.closeInbound();
             } catch (SSLException e) {
-                s_logger.warn("This SSL engine was forced to close inbound due to end of stream.");
+                s_logger.warn("This SSL engine was forced to close inbound due to end of stream.", e);
             }
             sslEngine.closeOutbound();
             // After closeOutbound the engine will be set to WRAP state,


### PR DESCRIPTION
Every time a client connects, the NioServer will retain the link against
the InetSocketAddress object. If the same agent/client reconnects, it
will grow older links over time and in case of denial of service attack
or a client/script/monitoring-service reconnecting aggressively against
port 8250 will cause the `_links` weak hashmap to grow over time and
very quickly.

The fix will ensure that only one Link gets weakly retained for an
incoming client based on its address string.

This is what is seen when only one kvm/agent connects to the management server:
![Screenshot from 2019-07-26 16-24-05](https://user-images.githubusercontent.com/95203/61947490-eb6fce00-afc2-11e9-99e1-9d01f64cf969.png)

When I restart the cloudstack-agent couple of times, I see the `_links` grow:
![Screenshot from 2019-07-26 16-24-17](https://user-images.githubusercontent.com/95203/61947523-03475200-afc3-11e9-9a68-5966f1276fda.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)