### PR TITLE
[UI] Improve visibility of dropdown menus on dialogs

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -3866,6 +3866,10 @@ table tr.selected td.actions .action.disabled .icon {
   background-position: -3px -368px;
 }
 
+.ui-dialog select {
+  overflow: scroll;
+}
+
 .ui-dialog.confirm .ui-button {
   margin-top: 0;
   margin-left: 11px;


### PR DESCRIPTION
## Description
It was not possible to display the entire name of items in dropdown menus within dialogs in CloudStack, such as:
- Create compute offering
- Create network offering
- Create VPC offering

## Types of changes
- [x] Enhancement (improves an existing feature and functionality)

## Screenshots (if appropriate):
Before this fix, the entire name of the menu items were not entirely displayed:
![image](https://user-images.githubusercontent.com/5295080/62056332-c8783080-b1f3-11e9-984d-e8ee6b9b1b5a.png)

Scrolling option is added, preserving the dialog's original width:
![image](https://user-images.githubusercontent.com/5295080/62056213-8fd85700-b1f3-11e9-9e10-6ce46ac377ce.png)

## How Has This Been Tested?
Test CloudStack dialogs with dropdown menus
