### PR TITLE
Misc fixes to sharing templates functionality

### DIFF
--- a/ui/scripts/cloudStack.js
+++ b/ui/scripts/cloudStack.js
@@ -318,6 +318,8 @@
                                 g_userProjectsEnabled = json.listcapabilitiesresponse.capability.allowusercreateprojects;
 
                                 g_cloudstackversion = json.listcapabilitiesresponse.capability.cloudstackversion;
+                                // Allow users to see all accounts within a domain
+                                g_allowUserViewAllDomainAccounts = json.listcapabilitiesresponse.capability.allowuserviewalldomainaccounts;
 
                                 if (json.listcapabilitiesresponse.capability.apilimitinterval != null && json.listcapabilitiesresponse.capability.apilimitmax != null) {
                                     var intervalLimit = ((json.listcapabilitiesresponse.capability.apilimitinterval * 1000) / json.listcapabilitiesresponse.capability.apilimitmax) * 3; //multiply 3 to be on safe side
@@ -374,6 +376,7 @@
                         g_kvmsnapshotenabled = null;
                         g_regionsecondaryenabled = null;
                         g_loginCmdText = null;
+                        g_allowUserViewAllDomainAccounts = null;
 
                         // Remove any cookies
                         var cookies = document.cookie.split(";");
@@ -410,6 +413,7 @@
                 g_kvmsnapshotenabled = null;
                 g_regionsecondaryenabled = null;
                 g_loginCmdText = null;
+                g_allowUserViewAllDomainAccounts = null;
 
                 // Remove any cookies
                 var cookies = document.cookie.split(";");

--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -36,7 +36,7 @@ var g_queryAsyncJobResultInterval = 3000;
 var g_idpList = null;
 var g_appendIdpDomain = false;
 var g_sortKeyIsAscending = false;
-var g_allowUserViewAllDomainAccounts= false;
+var g_allowUserViewAllDomainAccounts = false;
 
 //keyboard keycode
 var keycode_Enter = 13;

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -1643,8 +1643,8 @@
                                                         success: function (jsonAccounts) {
                                                             var accountByName = {};
                                                             $.each(jsonAccounts.listaccountsresponse.account, function(idx, account) {
-                                                                // Only add current domain's accounts as update template permissions supports that
-                                                                if (account.domainid === g_domainid) {
+                                                                // Only add current domain's accounts for add as update template permissions supports that
+                                                                if (account.domainid === g_domainid && operation === "add") {
                                                                     accountByName[account.name] = {
                                                                         projName: account.name,
                                                                         hasPermission: false
@@ -1658,7 +1658,9 @@
                                                                 success: function (json) {
                                                                     items = json.listtemplatepermissionsresponse.templatepermission.account;
                                                                     $.each(items, function(idx, accountName) {
-                                                                        accountByName[accountName].hasPermission = true;
+                                                                        if (accountByName[accountName]) {
+                                                                            accountByName[accountName].hasPermission = true;
+                                                                        }
                                                                     });
 
                                                                     var accountObjs = [];
@@ -1707,8 +1709,8 @@
                                                         success: function (jsonProjects) {
                                                             var projectsByIds = {};
                                                             $.each(jsonProjects.listprojectsresponse.project, function(idx, project) {
-                                                                // Only add current domain's projects as update template permissions supports that
-                                                                if (project.domainid === g_domainid) {
+                                                                // Only add current domain's projects for add operation as update template permissions supports that
+                                                                if (project.domainid === g_domainid && operation === "add") {
                                                                     projectsByIds[project.id] = {
                                                                         projName: project.name,
                                                                         hasPermission: false
@@ -1723,7 +1725,9 @@
                                                                 success: function (json) {
                                                                     items = json.listtemplatepermissionsresponse.templatepermission.projectids;
                                                                     $.each(items, function(idx, projectId) {
-                                                                        projectsByIds[projectId].hasPermission = true;
+                                                                        if (projectsByIds[projectId]) {
+                                                                            projectsByIds[projectId].hasPermission = true;
+                                                                        }
                                                                     });
 
                                                                     var projectObjs = [];

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -1710,7 +1710,7 @@
                                                             var projectsByIds = {};
                                                             $.each(jsonProjects.listprojectsresponse.project, function(idx, project) {
                                                                 // Only add current domain's projects for add operation as update template permissions supports that
-                                                                if (project.domainid === g_domainid && operation === "add") {
+                                                                if ((project.domainid === g_domainid && operation === "add") || operation === "remove") {
                                                                     projectsByIds[project.id] = {
                                                                         projName: project.name,
                                                                         hasPermission: false


### PR DESCRIPTION
1. Fix populating g_allowUserViewAllDomainAccounts flag. This was
implemented incorrectly and caused flag's effect to not reflect
directly after login.
2. Filter account/project names only for add operation. update
template permissions API is implemented in such a way that it allows
removal of any account that could have had permissions but allows
only adding accounts/projects which are in caller's domain.
3. Added some checks where null variable could result in crash.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Manual testing has been done on UI locally. 

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
