### PR TITLE
[WIP DO NOT MERGE] VM ingestion

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -19,6 +19,13 @@ package com.cloud.event;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.cloudstack.acl.Role;
+import org.apache.cloudstack.acl.RolePermission;
+import org.apache.cloudstack.annotation.Annotation;
+import org.apache.cloudstack.config.Configuration;
+import org.apache.cloudstack.ha.HAConfig;
+import org.apache.cloudstack.usage.Usage;
+
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.Pod;
 import com.cloud.dc.StorageNetworkIpRange;
@@ -69,12 +76,6 @@ import com.cloud.user.User;
 import com.cloud.vm.Nic;
 import com.cloud.vm.NicSecondaryIp;
 import com.cloud.vm.VirtualMachine;
-import org.apache.cloudstack.acl.Role;
-import org.apache.cloudstack.acl.RolePermission;
-import org.apache.cloudstack.annotation.Annotation;
-import org.apache.cloudstack.config.Configuration;
-import org.apache.cloudstack.ha.HAConfig;
-import org.apache.cloudstack.usage.Usage;
 
 public class EventTypes {
 
@@ -96,6 +97,7 @@ public class EventTypes {
     public static final String EVENT_VM_MOVE = "VM.MOVE";
     public static final String EVENT_VM_RESTORE = "VM.RESTORE";
     public static final String EVENT_VM_EXPUNGE = "VM.EXPUNGE";
+    public static final String EVENT_VM_IMPORT = "VM.IMPORT";
 
     // Domain Router
     public static final String EVENT_ROUTER_CREATE = "ROUTER.CREATE";
@@ -594,6 +596,7 @@ public class EventTypes {
         entityEventDetails.put(EVENT_VM_MOVE, VirtualMachine.class);
         entityEventDetails.put(EVENT_VM_RESTORE, VirtualMachine.class);
         entityEventDetails.put(EVENT_VM_EXPUNGE, VirtualMachine.class);
+        entityEventDetails.put(EVENT_VM_IMPORT, VirtualMachine.class);
 
         entityEventDetails.put(EVENT_ROUTER_CREATE, VirtualRouter.class);
         entityEventDetails.put(EVENT_ROUTER_DESTROY, VirtualRouter.class);

--- a/api/src/main/java/com/cloud/vm/UserVmService.java
+++ b/api/src/main/java/com/cloud/vm/UserVmService.java
@@ -513,4 +513,8 @@ public interface UserVmService {
 
     void collectVmNetworkStatistics (UserVm userVm);
 
+    UserVm importVM(final DataCenter zone, final Host host, final VirtualMachineTemplate template, final String instanceName, final String displayName, final Account owner, final String userData, final Account caller, final Boolean isDisplayVm, final String keyboard,
+                    final long accountId, final long userId, final ServiceOffering serviceOffering, final DiskOffering rootDiskOffering, final String sshPublicKey,
+                    final String hostName, final HypervisorType hypervisorType, final Map<String, String> customParameters, final VirtualMachine.PowerState powerState) throws InsufficientCapacityException;
+
 }

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -43,6 +43,7 @@ public class ApiConstants {
     public static final String BYTES_WRITE_RATE_MAX = "byteswriteratemax";
     public static final String BYTES_WRITE_RATE_MAX_LENGTH = "byteswriteratemaxlength";
     public static final String BYPASS_VLAN_OVERLAP_CHECK = "bypassvlanoverlapcheck";
+    public static final String CAPACITY = "capacity";
     public static final String CATEGORY = "category";
     public static final String CAN_REVERT = "canrevert";
     public static final String CA_CERTIFICATES = "cacertificates";
@@ -50,6 +51,8 @@ public class ApiConstants {
     public static final String CERTIFICATE_CHAIN = "certchain";
     public static final String CERTIFICATE_FINGERPRINT = "fingerprint";
     public static final String CERTIFICATE_ID = "certid";
+    public static final String CONTROLLER = "controller";
+    public static final String CONTROLLER_UNIT = "controllerunit";
     public static final String COPY_IMAGE_TAGS = "copyimagetags";
     public static final String CSR = "csr";
     public static final String PRIVATE_KEY = "privatekey";
@@ -69,6 +72,7 @@ public class ApiConstants {
     public static final String COMMAND = "command";
     public static final String CMD_EVENT_TYPE = "cmdeventtype";
     public static final String COMPONENT = "component";
+    public static final String CPU_CORE_PER_SOCKET = "cpucorepersocket";
     public static final String CPU_NUMBER = "cpunumber";
     public static final String CPU_SPEED = "cpuspeed";
     public static final String CREATED = "created";
@@ -90,6 +94,7 @@ public class ApiConstants {
     public static final String DETAILS = "details";
     public static final String DEVICE_ID = "deviceid";
     public static final String DIRECT_DOWNLOAD = "directdownload";
+    public static final String DISK = "disk";
     public static final String DISK_OFFERING_ID = "diskofferingid";
     public static final String NEW_DISK_OFFERING_ID = "newdiskofferingid";
     public static final String DISK_KBS_READ = "diskkbsread";
@@ -169,6 +174,7 @@ public class ApiConstants {
     public static final String PREVIOUS_ACL_RULE_ID = "previousaclruleid";
     public static final String NEXT_ACL_RULE_ID = "nextaclruleid";
     public static final String MOVE_ACL_CONSISTENCY_HASH = "aclconsistencyhash";
+    public static final String IMAGE_PATH = "imagepath";
     public static final String INTERNAL_DNS1 = "internaldns1";
     public static final String INTERNAL_DNS2 = "internaldns2";
     public static final String INTERVAL_TYPE = "intervaltype";
@@ -222,6 +228,9 @@ public class ApiConstants {
     public static final String NETWORK_DOMAIN = "networkdomain";
     public static final String NETMASK = "netmask";
     public static final String NEW_NAME = "newname";
+    public static final String NIC = "nic";
+    public static final String NIC_NETWORK_LIST = "nicnetworklist";
+    public static final String NIC_IP_ADDRESS_LIST = "nicipaddresslist";
     public static final String NUM_RETRIES = "numretries";
     public static final String OFFER_HA = "offerha";
     public static final String IS_SYSTEM_OFFERING = "issystem";
@@ -253,6 +262,7 @@ public class ApiConstants {
     public static final String PORTAL = "portal";
     public static final String PORTABLE_IP_ADDRESS = "portableipaddress";
     public static final String PORT_FORWARDING_SERVICE_ID = "portforwardingserviceid";
+    public static final String POSITION = "position";
     public static final String POST_URL = "postURL";
     public static final String POWER_STATE = "powerstate";
     public static final String PRIVATE_INTERFACE = "privateinterface";

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/ingestion/ImportUnmanageInstanceCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/ingestion/ImportUnmanageInstanceCmd.java
@@ -1,0 +1,328 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.admin.ingestion;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.ACL;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseAsyncCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ResponseObject;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.ClusterResponse;
+import org.apache.cloudstack.api.response.DiskOfferingResponse;
+import org.apache.cloudstack.api.response.DomainResponse;
+import org.apache.cloudstack.api.response.ProjectResponse;
+import org.apache.cloudstack.api.response.ServiceOfferingResponse;
+import org.apache.cloudstack.api.response.TemplateResponse;
+import org.apache.cloudstack.api.response.UserVmResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.vm.VmImportService;
+import org.apache.log4j.Logger;
+
+import com.cloud.event.EventTypes;
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.network.Network;
+import com.cloud.offering.DiskOffering;
+import com.cloud.offering.ServiceOffering;
+import com.cloud.org.Cluster;
+import com.cloud.user.Account;
+import com.cloud.utils.net.NetUtils;
+import com.google.common.base.Strings;
+
+@APICommand(name = ImportUnmanageInstanceCmd.API_NAME,
+        description = "Import unmanaged virtual machine from a given cluster.",
+        responseObject = UserVmResponse.class,
+        responseView = ResponseObject.ResponseView.Full,
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = true,
+        authorized = {RoleType.Admin})
+public class ImportUnmanageInstanceCmd extends BaseAsyncCmd {
+    public static final Logger s_logger = Logger.getLogger(ImportUnmanageInstanceCmd.class);
+    public static final String API_NAME = "importUnmanagedInstance";
+
+    @Inject
+    public VmImportService vmImportService;
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.CLUSTER_ID,
+            type = CommandType.UUID,
+            entityType = ClusterResponse.class,
+            required = true,
+            description = "the cluster ID")
+    private Long clusterId;
+
+    @Parameter(name = ApiConstants.NAME,
+            type = CommandType.STRING,
+            required = true,
+            description = "the hypervisor name of the instance")
+    private String name;
+
+    @Parameter(name = ApiConstants.DISPLAY_NAME,
+            type = CommandType.STRING,
+            description = "the display name of the instance")
+    private String displayName;
+
+    @Parameter(name = ApiConstants.HOST_NAME,
+            type = CommandType.STRING,
+            description = "the host name of the instance")
+    private String hostName;
+
+    @Parameter(name = ApiConstants.ACCOUNT,
+            type = CommandType.STRING,
+            description = "an optional account for the virtual machine. Must be used with domainId.")
+    private String accountName;
+
+    @Parameter(name = ApiConstants.DOMAIN_ID,
+            type = CommandType.UUID,
+            entityType = DomainResponse.class,
+            description = "import instance to the domain specified")
+    private Long domainId;
+
+    @Parameter(name = ApiConstants.PROJECT_ID,
+            type = CommandType.UUID,
+            entityType = ProjectResponse.class,
+            description = "import instance for the project")
+    private Long projectId;
+
+    @ACL
+    @Parameter(name = ApiConstants.TEMPLATE_ID,
+            type = CommandType.UUID,
+            entityType = TemplateResponse.class,
+            required = true,
+            description = "the ID of the template for the virtual machine")
+    private Long templateId;
+
+    @ACL
+    @Parameter(name = ApiConstants.SERVICE_OFFERING_ID,
+            type = CommandType.UUID,
+            entityType = ServiceOfferingResponse.class,
+            required = true,
+            description = "the ID of the service offering for the virtual machine")
+    private Long serviceOfferingId;
+
+    @ACL
+    @Parameter(name = ApiConstants.DISK_OFFERING_ID,
+            type = CommandType.UUID,
+            entityType = DiskOfferingResponse.class,
+            required = true,
+            description = "the ID of the root disk offering for the virtual machine")
+    private Long diskOfferingId;
+
+    @Parameter(name = ApiConstants.NIC_NETWORK_LIST,
+            type = CommandType.MAP,
+            description = "VM nic to network id mapping")
+    private Map nicNetworkList;
+
+    @Parameter(name = ApiConstants.NIC_IP_ADDRESS_LIST,
+            type = CommandType.MAP,
+            description = "VM nic to ip address mapping")
+    private Map nicIpAddressList;
+
+    @Parameter(name = ApiConstants.DATADISK_OFFERING_LIST,
+            type = CommandType.MAP,
+            description = "datadisk template to disk-offering mapping")
+    private Map dataDiskToDiskOfferingList;
+
+    @Parameter(name = ApiConstants.DETAILS,
+            type = CommandType.MAP,
+            description = "used to specify the custom parameters.")
+    private Map<String, String> details;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getClusterId() {
+        return clusterId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public Long getDomainId() {
+        return domainId;
+    }
+
+    public Long getTemplateId() {
+        return templateId;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public Long getServiceOfferingId() {
+        return serviceOfferingId;
+    }
+
+    public Long getDiskOfferingId() {
+        return diskOfferingId;
+    }
+
+    public Map<String, Long> getNicNetworkList() {
+        Map<String, Long> nicNetworkMap = new HashMap<>();
+        if (nicNetworkList != null && !nicNetworkList.isEmpty()) {
+            Collection parameterCollection = nicNetworkList.values();
+            Iterator iter = parameterCollection.iterator();
+            while (iter.hasNext()) {
+                HashMap<String, String> value = (HashMap<String, String>)iter.next();
+                String nic = value.get("nic");
+                String networkUuid = value.get("network");
+                if (_entityMgr.findByUuid(Network.class, networkUuid) != null) {
+                    nicNetworkMap.put(nic, _entityMgr.findByUuid(Network.class, networkUuid).getId());
+                } else {
+                    throw new InvalidParameterValueException(String.format("Unable to find network ID: %s for NIC ID: %s", networkUuid, nic));
+                }
+            }
+        }
+        return nicNetworkMap;
+    }
+
+    public Map<String, String> getNicIpAddressList() {
+        Map<String, String> nicIpAddressMap = new HashMap<>();
+        if (nicIpAddressList != null && !nicIpAddressList.isEmpty()) {
+            Collection parameterCollection = nicIpAddressList.values();
+            Iterator iter = parameterCollection.iterator();
+            while (iter.hasNext()) {
+                HashMap<String, String> value = (HashMap<String, String>)iter.next();
+                String nic = value.get("nic");
+                String ipAddress = value.get("ipAddress");
+                if (!Strings.isNullOrEmpty(ipAddress) && NetUtils.isValidIp4(ipAddress)) {
+                    nicIpAddressMap.put(nic, ipAddress);
+                } else {
+                    throw new InvalidParameterValueException(String.format("IP Address: %s for NIC ID: %s is invalid", ipAddress, nic));
+                }
+            }
+        }
+        return nicIpAddressMap;
+    }
+
+    public Map<String, Long> getDataDiskToDiskOfferingList() {
+        Map<String, Long> dataDiskToDiskOfferingMap = new HashMap<>();
+        if (dataDiskToDiskOfferingList != null && !dataDiskToDiskOfferingList.isEmpty()) {
+            Collection parameterCollection = dataDiskToDiskOfferingList.values();
+            Iterator iter = parameterCollection.iterator();
+            while (iter.hasNext()) {
+                HashMap<String, String> value = (HashMap<String, String>)iter.next();
+                String disk = value.get("disk");
+                String offeringUuid = value.get("diskOffering");
+                if (_entityMgr.findByUuid(DiskOffering.class, offeringUuid) != null) {
+                    dataDiskToDiskOfferingMap.put(disk, _entityMgr.findByUuid(DiskOffering.class, offeringUuid).getId());
+                } else {
+                    throw new InvalidParameterValueException(String.format("Unable to find disk offering ID: %s for data disk ID: %s", offeringUuid, disk));
+                }
+            }
+        }
+        return dataDiskToDiskOfferingMap;
+    }
+
+    public Map<String, String> getDetails() {
+        Map<String, String> customParameterMap = new HashMap<String, String>();
+        if (details != null && details.size() != 0) {
+            Collection parameterCollection = details.values();
+            Iterator iter = parameterCollection.iterator();
+            while (iter.hasNext()) {
+                HashMap<String, String> value = (HashMap<String, String>)iter.next();
+                for (Map.Entry<String,String> entry: value.entrySet()) {
+                    customParameterMap.put(entry.getKey(),entry.getValue());
+                }
+            }
+        }
+        return customParameterMap;
+    }
+
+    @Override
+    public String getEventType() {
+        return EventTypes.EVENT_VM_IMPORT;
+    }
+
+    @Override
+    public String getEventDescription() {
+        return "Importing unmanaged VM";
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+    private void validateInput() {
+        if (_entityMgr.findById(Cluster.class, clusterId) == null) {
+            throw new InvalidParameterValueException(String.format("Unable to find cluster with ID: %d", clusterId));
+        }
+        if (_entityMgr.findById(ServiceOffering.class, serviceOfferingId) == null) {
+            throw new InvalidParameterValueException(String.format("Unable to find service offering with ID: %d", serviceOfferingId));
+        }
+    }
+
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        validateInput();
+        UserVmResponse response = vmImportService.importUnmanagedInstance(this);
+        response.setResponseName(getCommandName());
+        setResponseObject(response);
+    }
+
+    @Override
+    public String getCommandName() {
+        return API_NAME.toLowerCase() + BaseAsyncCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        Long accountId = _accountService.finalyzeAccountId(accountName, domainId, projectId, true);
+        if (accountId == null) {
+            Account account = CallContext.current().getCallingAccount();
+            if (account != null) {
+                accountId = account.getId();
+            } else {
+                accountId = Account.ACCOUNT_ID_SYSTEM;
+            }
+        }
+        return accountId;
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/ingestion/ListUnmanagedInstancesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/ingestion/ListUnmanagedInstancesCmd.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.admin.ingestion;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseAsyncCmd;
+import org.apache.cloudstack.api.BaseListCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ResponseObject;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.ClusterResponse;
+import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.api.response.UnmanagedInstanceResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.vm.UnmanagedInstance;
+import org.apache.cloudstack.vm.VmImportService;
+import org.apache.log4j.Logger;
+
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.user.Account;
+
+@APICommand(name = ListUnmanagedInstancesCmd.API_NAME,
+        description = "Lists unmanaged virtual machines for a given cluster.",
+        responseObject = UnmanagedInstanceResponse.class,
+        responseView = ResponseObject.ResponseView.Full,
+        entityType = {UnmanagedInstance.class},
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = true,
+        authorized = {RoleType.Admin})
+public class ListUnmanagedInstancesCmd extends BaseListCmd {
+    public static final Logger s_logger = Logger.getLogger(ListUnmanagedInstancesCmd.class.getName());
+    public static final String API_NAME = "listUnmanagedInstances";
+
+    @Inject
+    public VmImportService vmIngestionService;
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.CLUSTER_ID,
+            type = CommandType.UUID,
+            entityType = ClusterResponse.class,
+            required = true,
+            description = "the cluster ID")
+    private Long clusterId;
+
+    @Parameter(name = ApiConstants.NAME,
+            type = CommandType.UUID,
+            description = "the hypervisor name of the instance")
+    private String name;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getClusterId() {
+        return clusterId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        ListResponse<UnmanagedInstanceResponse> response = vmIngestionService.listUnmanagedInstances(this);
+        response.setResponseName(getCommandName());
+        setResponseObject(response);
+    }
+
+    @Override
+    public String getCommandName() {
+        return API_NAME.toLowerCase() + BaseAsyncCmd.RESPONSE_SUFFIX;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        Account account = CallContext.current().getCallingAccount();
+        if (account != null) {
+            return account.getId();
+        }
+        return Account.ACCOUNT_ID_SYSTEM;
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/response/DomainRouterResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/DomainRouterResponse.java
@@ -20,8 +20,6 @@ import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import com.google.gson.annotations.SerializedName;
-
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.EntityReference;
@@ -29,6 +27,7 @@ import org.apache.cloudstack.api.EntityReference;
 import com.cloud.serializer.Param;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.State;
+import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = VirtualMachine.class)
 @SuppressWarnings("unused")
@@ -256,6 +255,10 @@ public class DomainRouterResponse extends BaseResponse implements ControlledView
 
     public void setGateway(String gateway) {
         this.gateway = gateway;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public void setName(String name) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/NicResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/NicResponse.java
@@ -16,14 +16,15 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.cloud.serializer.Param;
-import com.cloud.vm.Nic;
-import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
 import org.apache.cloudstack.api.EntityReference;
 
-import java.util.List;
+import com.cloud.serializer.Param;
+import com.cloud.vm.Nic;
+import com.google.gson.annotations.SerializedName;
 
 @SuppressWarnings("unused")
 @EntityReference(value = Nic.class)
@@ -112,6 +113,10 @@ public class NicResponse extends BaseResponse {
     @SerializedName(ApiConstants.NSX_LOGICAL_SWITCH_PORT)
     @Param(description = "Id of the NSX Logical Switch Port (if NSX based), null otherwise", since="4.6.0")
     private String nsxLogicalSwitchPort;
+
+    @SerializedName(ApiConstants.VLAN_ID)
+    @Param(description = "ID of the VLAN/VNI if available", since="4.14.0")
+    private Integer vlanId;
 
     public void setVmId(String vmId) {
         this.vmId = vmId;
@@ -302,5 +307,13 @@ public class NicResponse extends BaseResponse {
 
     public String getNsxLogicalSwitchPort() {
         return nsxLogicalSwitchPort;
+    }
+
+    public Integer getVlanId() {
+        return vlanId;
+    }
+
+    public void setVlanId(Integer vlanId) {
+        this.vlanId = vlanId;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/UnmanagedInstanceDiskResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UnmanagedInstanceDiskResponse.java
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.response;
+
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseResponse;
+
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
+
+public class UnmanagedInstanceDiskResponse extends BaseResponse {
+
+    @SerializedName(ApiConstants.ID)
+    @Param(description = "the ID of the disk")
+    private String diskId;
+
+    @SerializedName(ApiConstants.LABEL)
+    @Param(description = "the label of the disk")
+    private String label;
+
+    @SerializedName(ApiConstants.CAPACITY)
+    @Param(description = "the capacity in KB of the disk")
+    private Long capacity;
+
+    @SerializedName(ApiConstants.IMAGE_PATH)
+    @Param(description = "the file path of the disk image")
+    private String imagePath;
+
+    @SerializedName(ApiConstants.CONTROLLER)
+    @Param(description = "the controller of the disk")
+    private String controller;
+
+    @SerializedName(ApiConstants.CONTROLLER_UNIT)
+    @Param(description = "the controller unit of the disk")
+    private Integer controllerUnit;
+
+    @SerializedName(ApiConstants.POSITION)
+    @Param(description = "the position of the disk")
+    private Integer position;
+
+    public String getDiskId() {
+        return diskId;
+    }
+
+    public void setDiskId(String diskId) {
+        this.diskId = diskId;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public Long getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(Long capacity) {
+        this.capacity = capacity;
+    }
+
+    public String getImagePath() {
+        return imagePath;
+    }
+
+    public void setImagePath(String imagePath) {
+        this.imagePath = imagePath;
+    }
+
+    public String getController() {
+        return controller;
+    }
+
+    public void setController(String controller) {
+        this.controller = controller;
+    }
+
+    public Integer getControllerUnit() {
+        return controllerUnit;
+    }
+
+    public void setControllerUnit(Integer controllerUnit) {
+        this.controllerUnit = controllerUnit;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+
+    public void setPosition(Integer position) {
+        this.position = position;
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/api/response/UnmanagedInstanceResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/UnmanagedInstanceResponse.java
@@ -1,0 +1,178 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.response;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseResponse;
+import org.apache.cloudstack.api.EntityReference;
+import org.apache.cloudstack.vm.UnmanagedInstance;
+
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
+
+@EntityReference(value = UnmanagedInstance.class)
+public class UnmanagedInstanceResponse extends BaseResponse {
+
+    @SerializedName(ApiConstants.NAME)
+    @Param(description = "the name of the virtual machine")
+    private String name;
+
+    @SerializedName(ApiConstants.CLUSTER_ID)
+    @Param(description = "the ID of the cluster to which virtual machine belongs")
+    private String clusterId;
+
+    @SerializedName(ApiConstants.HOST_ID)
+    @Param(description = "the ID of the host to which virtual machine belongs")
+    private String hostId;
+
+    @SerializedName(ApiConstants.POWER_STATE)
+    @Param(description = "the power state of the virtual machine")
+    private String  powerState;
+
+    @SerializedName(ApiConstants.CPU_NUMBER)
+    @Param(description = "the CPU cores of the virtual machine")
+    private Integer cpuCores;
+
+    @SerializedName(ApiConstants.CPU_CORE_PER_SOCKET)
+    @Param(description = "the CPU cores per socket for the virtual machine. VMware specific")
+    private Integer cpuCoresPerSocket;
+
+    @SerializedName(ApiConstants.CPU_SPEED)
+    @Param(description = "the CPU speed of the virtual machine")
+    private Integer cpuSpeed;
+
+    @SerializedName(ApiConstants.MEMORY)
+    @Param(description = "the memory of the virtual machine in MB")
+    private Integer memory;
+
+    @SerializedName(ApiConstants.OS_DISPLAY_NAME)
+    @Param(description = "the operating system of the virtual machine")
+    private String operatingSystem;
+
+    @SerializedName(ApiConstants.DISK)
+    @Param(description = "the list of disks associated with the virtual machine", responseObject = UnmanagedInstanceDiskResponse.class)
+    private Set<UnmanagedInstanceDiskResponse> disks;
+
+    @SerializedName(ApiConstants.NIC)
+    @Param(description = "the list of nics associated with the virtual machine", responseObject = NicResponse.class)
+    private Set<NicResponse> nics;
+
+    public UnmanagedInstanceResponse() {
+        disks = new LinkedHashSet<UnmanagedInstanceDiskResponse>();
+        nics = new LinkedHashSet<NicResponse>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(String clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    public String getHostId() {
+        return hostId;
+    }
+
+    public void setHostId(String hostId) {
+        this.hostId = hostId;
+    }
+
+    public String getPowerState() {
+        return powerState;
+    }
+
+    public void setPowerState(String powerState) {
+        this.powerState = powerState;
+    }
+
+    public Integer getCpuCores() {
+        return cpuCores;
+    }
+
+    public void setCpuCores(Integer cpuCores) {
+        this.cpuCores = cpuCores;
+    }
+
+    public Integer getCpuCoresPerSocket() {
+        return cpuCoresPerSocket;
+    }
+
+    public void setCpuCoresPerSocket(Integer cpuCoresPerSocket) {
+        this.cpuCoresPerSocket = cpuCoresPerSocket;
+    }
+
+    public Integer getCpuSpeed() {
+        return cpuSpeed;
+    }
+
+    public void setCpuSpeed(Integer cpuSpeed) {
+        this.cpuSpeed = cpuSpeed;
+    }
+
+    public Integer getMemory() {
+        return memory;
+    }
+
+    public void setMemory(Integer memory) {
+        this.memory = memory;
+    }
+
+    public String getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    public void setOperatingSystem(String operatingSystem) {
+        this.operatingSystem = operatingSystem;
+    }
+
+    public Set<UnmanagedInstanceDiskResponse> getDisks() {
+        return disks;
+    }
+
+    public void setDisks(Set<UnmanagedInstanceDiskResponse> disks) {
+        this.disks = disks;
+    }
+
+    public void addDisk(UnmanagedInstanceDiskResponse disk) {
+        this.disks.add(disk);
+    }
+
+    public Set<NicResponse> getNics() {
+        return nics;
+    }
+
+    public void setNics(Set<NicResponse> nics) {
+        this.nics = nics;
+    }
+
+    public void addNic(NicResponse nic) {
+        this.nics.add(nic);
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/vm/UnmanagedInstance.java
+++ b/api/src/main/java/org/apache/cloudstack/vm/UnmanagedInstance.java
@@ -1,0 +1,257 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.vm;
+
+import java.util.List;
+
+public class UnmanagedInstance {
+
+    private String name;
+
+    private String  powerState;
+
+    private Integer cpuCores;
+
+    private Integer cpuCoresPerSocket;
+
+    private Integer memory;
+
+    private Integer cpuSpeed;
+
+    private String operatingSystem;
+
+    private List<Disk> disks;
+
+    private List<Nic> nics;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPowerState() {
+        return powerState;
+    }
+
+    public void setPowerState(String powerState) {
+        this.powerState = powerState;
+    }
+
+    public Integer getCpuCores() {
+        return cpuCores;
+    }
+
+    public void setCpuCores(Integer cpuCores) {
+        this.cpuCores = cpuCores;
+    }
+
+    public Integer getCpuCoresPerSocket() {
+        return cpuCoresPerSocket;
+    }
+
+    public void setCpuCoresPerSocket(Integer cpuCoresPerSocket) {
+        this.cpuCoresPerSocket = cpuCoresPerSocket;
+    }
+
+    public Integer getMemory() {
+        return memory;
+    }
+
+    public void setMemory(Integer memory) {
+        this.memory = memory;
+    }
+
+    public Integer getCpuSpeed() {
+        return cpuSpeed;
+    }
+
+    public void setCpuSpeed(Integer cpuSpeed) {
+        this.cpuSpeed = cpuSpeed;
+    }
+
+    public String getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    public void setOperatingSystem(String operatingSystem) {
+        this.operatingSystem = operatingSystem;
+    }
+
+    public List<Disk> getDisks() {
+        return disks;
+    }
+
+    public void setDisks(List<Disk> disks) {
+        this.disks = disks;
+    }
+
+    public List<Nic> getNics() {
+        return nics;
+    }
+
+    public void setNics(List<Nic> nics) {
+        this.nics = nics;
+    }
+
+    public static class Disk {
+        private String diskId;
+
+        private String label;
+
+        private Long capacity;
+
+        private String imagePath;
+
+        private String controller;
+
+        private Integer controllerUnit;
+
+        private Integer position;
+
+        public String getDiskId() {
+            return diskId;
+        }
+
+        public void setDiskId(String diskId) {
+            this.diskId = diskId;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public Long getCapacity() {
+            return capacity;
+        }
+
+        public void setCapacity(Long capacity) {
+            this.capacity = capacity;
+        }
+
+        public String getImagePath() {
+            return imagePath;
+        }
+
+        public void setImagePath(String imagePath) {
+            this.imagePath = imagePath;
+        }
+
+        public String getController() {
+            return controller;
+        }
+
+        public void setController(String controller) {
+            this.controller = controller;
+        }
+
+        public Integer getControllerUnit() {
+            return controllerUnit;
+        }
+
+        public void setControllerUnit(Integer controllerUnit) {
+            this.controllerUnit = controllerUnit;
+        }
+
+        public Integer getPosition() {
+            return position;
+        }
+
+        public void setPosition(Integer position) {
+            this.position = position;
+        }
+    }
+
+    public static class Nic {
+        private String nicId;
+
+        private String adapterType;
+
+        private String macAddress;
+
+        private String network;
+
+        private Integer vlan;
+
+        private String ipAddress;
+
+        private String pciSlot;
+
+        public String getNicId() {
+            return nicId;
+        }
+
+        public void setNicId(String nicId) {
+            this.nicId = nicId;
+        }
+
+        public String getAdapterType() {
+            return adapterType;
+        }
+
+        public void setAdapterType(String adapterType) {
+            this.adapterType = adapterType;
+        }
+
+        public String getMacAddress() {
+            return macAddress;
+        }
+
+        public void setMacAddress(String macAddress) {
+            this.macAddress = macAddress;
+        }
+
+        public String getNetwork() {
+            return network;
+        }
+
+        public void setNetwork(String network) {
+            this.network = network;
+        }
+
+        public Integer getVlan() {
+            return vlan;
+        }
+
+        public void setVlan(Integer vlan) {
+            this.vlan = vlan;
+        }
+
+        public String getIpAddress() {
+            return ipAddress;
+        }
+
+        public void setIpAddress(String ipAddress) {
+            this.ipAddress = ipAddress;
+        }
+
+        public String getPciSlot() {
+            return pciSlot;
+        }
+
+        public void setPciSlot(String pciSlot) {
+            this.pciSlot = pciSlot;
+        }
+    }
+}

--- a/api/src/main/java/org/apache/cloudstack/vm/VmImportService.java
+++ b/api/src/main/java/org/apache/cloudstack/vm/VmImportService.java
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.vm;
+
+import org.apache.cloudstack.api.command.admin.ingestion.ImportUnmanageInstanceCmd;
+import org.apache.cloudstack.api.command.admin.ingestion.ListUnmanagedInstancesCmd;
+import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.api.response.UnmanagedInstanceResponse;
+import org.apache.cloudstack.api.response.UserVmResponse;
+
+import com.cloud.utils.component.PluggableService;
+
+public interface VmImportService extends PluggableService {
+    ListResponse<UnmanagedInstanceResponse> listUnmanagedInstances(ListUnmanagedInstancesCmd cmd);
+    UserVmResponse importUnmanagedInstance(ImportUnmanageInstanceCmd cmd);
+}

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <repositories>
         <repository>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesAnswer.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.cloud.agent.api;
+
+import java.util.HashMap;
+
+import org.apache.cloudstack.vm.UnmanagedInstance;
+
+@LogLevel(LogLevel.Log4jLevel.Trace)
+public class GetUnmanagedInstancesAnswer extends Answer {
+
+    private String instanceName;
+    private HashMap<String, UnmanagedInstance> unmanagedInstances;
+
+    GetUnmanagedInstancesAnswer() {
+    }
+
+    public GetUnmanagedInstancesAnswer(GetUnmanagedInstancesCommand cmd, String details, HashMap<String, UnmanagedInstance> unmanagedInstances) {
+        super(cmd, true, details);
+        this.instanceName = cmd.getInstanceName();
+        this.unmanagedInstances = unmanagedInstances;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public void setInstanceName(String instanceName) {
+        this.instanceName = instanceName;
+    }
+
+    public HashMap<String, UnmanagedInstance> getUnmanagedInstances() {
+        return unmanagedInstances;
+    }
+
+    public void setUnmanagedInstances(HashMap<String, UnmanagedInstance> unmanagedInstances) {
+        this.unmanagedInstances = unmanagedInstances;
+    }
+
+    public String getString() {
+        return "GetUnmanagedInstancesAnswer [instanceName=" + instanceName + "]";
+    }
+}

--- a/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/GetUnmanagedInstancesCommand.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.cloud.agent.api;
+
+import java.util.List;
+
+@LogLevel(LogLevel.Log4jLevel.Trace)
+public class GetUnmanagedInstancesCommand extends Command {
+
+    String instanceName;
+
+    List<String> managedInstancesNames;
+
+    public GetUnmanagedInstancesCommand() {
+    }
+
+    public GetUnmanagedInstancesCommand(String instanceName) {
+        this.instanceName = instanceName;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public void setInstanceName(String instanceName) {
+        this.instanceName = instanceName;
+    }
+
+    public List<String> getManagedInstancesNames() {
+        return managedInstancesNames;
+    }
+
+    public void setManagedInstancesNames(List<String> managedInstancesNames) {
+        this.managedInstancesNames = managedInstancesNames;
+    }
+
+    public boolean hasManagedInstance(String name) {
+        if (managedInstancesNames!=null && !managedInstancesNames.isEmpty()) {
+            return managedInstancesNames.contains(name);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean executeInSequence() {
+        return false;
+    }
+
+    public String getString() {
+        return "GetUnmanagedInstancesCommand [instanceName=" + instanceName + "]";
+    }
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloudstack (4.13.0.0) unstable; urgency=low
+
+  * Update the version to 4.13.0.0
+
+ -- the Apache CloudStack project <dev@cloudstack.apache.org>  Wed, 28 Aug 2019 19:58:13 +0100
+
 cloudstack (4.13.0.0-SNAPSHOT) unstable; urgency=low
 
   * Update the version to 4.13.0.0-SNAPSHOT

--- a/developer/pom.xml
+++ b/developer/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/engine/api/pom.xml
+++ b/engine/api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -313,4 +313,6 @@ public interface NetworkOrchestrationService {
      * Remove entry from /etc/dhcphosts and /etc/hosts on virtual routers
      */
     void cleanupNicDhcpDnsEntry(Network network, VirtualMachineProfile vmProfile, NicProfile nicProfile);
+
+    Pair<NicProfile, Integer> importNic(final String macAddress, int deviceId, final Network network, final Boolean isDefaultNic, final VirtualMachine vm, final String ipAddress);
 }

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
@@ -127,4 +127,24 @@ public interface VolumeOrchestrationService {
     StoragePool findStoragePool(DiskProfile dskCh, DataCenter dc, Pod pod, Long clusterId, Long hostId, VirtualMachine vm, Set<StoragePool> avoid);
 
     void updateVolumeDiskChain(long volumeId, String path, String chainInfo);
+
+    /**
+     * Imports an existing volume for a VM into database. Useful while ingesting an unmanaged VM.
+     * @param type Type of the volume - ROOT, DATADISK, etc
+     * @param name Name of the volume
+     * @param offering DiskOffering for the volume
+     * @param size DiskOffering for the volume
+     * @param minIops minimum IOPS for the disk, if not passed DiskOffering value will be used
+     * @param maxIops maximum IOPS for the disk, if not passed DiskOffering value will be used
+     * @param vm VirtualMachine this volume is attached to
+     * @param template Template of the VM of the volume
+     * @param owner owner Account for the volume
+     * @param deviceId device ID of the virtual disk
+     * @param poolId ID of pool in which volume is stored
+     * @param path image path of the volume
+     * @param chainInfo chain info for the volume. Hypervisor specific.
+     * @return  DiskProfile of imported volume
+     */
+    DiskProfile importVolume(Type type, String name, DiskOffering offering, Long size, Long minIops, Long maxIops, VirtualMachine vm, VirtualMachineTemplate template,
+                             Account owner, Long deviceId, Long poolId, String path, String chainInfo);
 }

--- a/engine/components-api/pom.xml
+++ b/engine/components-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/network/pom.xml
+++ b/engine/network/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/orchestration/pom.xml
+++ b/engine/orchestration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -3941,6 +3941,40 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         return _nicDao.persist(nic);
     }
 
+    @DB
+    @Override
+    public Pair<NicProfile, Integer> importNic(final String macAddress, int deviceId, final Network network, final Boolean isDefaultNic, final VirtualMachine vm, final String ipAddress)
+            throws ConcurrentOperationException {
+        s_logger.debug("Allocating nic for vm " + vm.getUuid() + " in network " + network + " during ingestion");
+
+        NicVO vo = Transaction.execute(new TransactionCallback<NicVO>() {
+            @Override
+            public NicVO doInTransaction(TransactionStatus status) {
+                NicVO vo = new NicVO(network.getGuruName(), vm.getId(), network.getId(), vm.getType());
+                vo.setMacAddress(macAddress);
+                vo.setAddressFormat(Networks.AddressFormat.Ip4);
+                vo.setIPv4Address(ipAddress);
+                vo.setBroadcastUri(network.getBroadcastUri());
+                vo.setMode(network.getMode());
+                vo.setState(Nic.State.Reserved);
+                vo.setReservationStrategy(ReservationStrategy.Start);
+                vo.setReservationId(UUID.randomUUID().toString());
+                vo.setDeviceId(deviceId);
+                vo.setIsolationUri(network.getBroadcastUri());
+                vo.setDeviceId(deviceId);
+                vo.setDefaultNic(isDefaultNic);
+                vo = _nicDao.persist(vo);
+                return vo;
+            }
+        });
+
+        final Integer networkRate = _networkModel.getNetworkRate(network.getId(), vm.getId());
+        final NicProfile vmNic = new NicProfile(vo, network, vo.getBroadcastUri(), vo.getIsolationUri(), networkRate, _networkModel.isSecurityGroupSupportedInNetwork(network),
+                _networkModel.getNetworkTag(vm.getHypervisorType(), network));
+
+        return new Pair<NicProfile, Integer>(vmNic, Integer.valueOf(deviceId));
+    }
+
     @Override
     public String getConfigComponentName() {
         return NetworkOrchestrationService.class.getSimpleName();

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/engine/schema/pom.xml
+++ b/engine/schema/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/service/pom.xml
+++ b/engine/service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <artifactId>cloud-engine-service</artifactId>
     <packaging>war</packaging>

--- a/engine/storage/cache/pom.xml
+++ b/engine/storage/cache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/storage/configdrive/pom.xml
+++ b/engine/storage/configdrive/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/storage/datamotion/pom.xml
+++ b/engine/storage/datamotion/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/storage/image/pom.xml
+++ b/engine/storage/image/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/storage/integration-test/pom.xml
+++ b/engine/storage/integration-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/storage/pom.xml
+++ b/engine/storage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/storage/snapshot/pom.xml
+++ b/engine/storage/snapshot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/engine/storage/volume/pom.xml
+++ b/engine/storage/volume/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-engine</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/agent-lb/pom.xml
+++ b/framework/agent-lb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>cloudstack-framework</artifactId>
         <groupId>org.apache.cloudstack</groupId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/framework/ca/pom.xml
+++ b/framework/ca/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/framework/cluster/pom.xml
+++ b/framework/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/config/pom.xml
+++ b/framework/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/db/pom.xml
+++ b/framework/db/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/direct-download/pom.xml
+++ b/framework/direct-download/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>cloudstack-framework</artifactId>
         <groupId>org.apache.cloudstack</groupId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/framework/events/pom.xml
+++ b/framework/events/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/ipc/pom.xml
+++ b/framework/ipc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/jobs/pom.xml
+++ b/framework/jobs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/managed-context/pom.xml
+++ b/framework/managed-context/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <build>
         <plugins>

--- a/framework/quota/pom.xml
+++ b/framework/quota/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/rest/pom.xml
+++ b/framework/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>cloud-framework-rest</artifactId>

--- a/framework/security/pom.xml
+++ b/framework/security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-framework</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/spring/lifecycle/pom.xml
+++ b/framework/spring/lifecycle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/framework/spring/module/pom.xml
+++ b/framework/spring/module/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/acl/dynamic-role-based/pom.xml
+++ b/plugins/acl/dynamic-role-based/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/acl/static-role-based/pom.xml
+++ b/plugins/acl/static-role-based/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/affinity-group-processors/explicit-dedication/pom.xml
+++ b/plugins/affinity-group-processors/explicit-dedication/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/affinity-group-processors/host-affinity/pom.xml
+++ b/plugins/affinity-group-processors/host-affinity/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/affinity-group-processors/host-anti-affinity/pom.xml
+++ b/plugins/affinity-group-processors/host-anti-affinity/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/alert-handlers/snmp-alerts/pom.xml
+++ b/plugins/alert-handlers/snmp-alerts/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>cloudstack-plugins</artifactId>
         <groupId>org.apache.cloudstack</groupId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/alert-handlers/syslog-alerts/pom.xml
+++ b/plugins/alert-handlers/syslog-alerts/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>cloudstack-plugins</artifactId>
         <groupId>org.apache.cloudstack</groupId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/api/discovery/pom.xml
+++ b/plugins/api/discovery/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/api/rate-limit/pom.xml
+++ b/plugins/api/rate-limit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <build>

--- a/plugins/api/solidfire-intg-test/pom.xml
+++ b/plugins/api/solidfire-intg-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/api/vmware-sioc/pom.xml
+++ b/plugins/api/vmware-sioc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/ca/root-ca/pom.xml
+++ b/plugins/ca/root-ca/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/database/mysql-ha/pom.xml
+++ b/plugins/database/mysql-ha/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/database/quota/pom.xml
+++ b/plugins/database/quota/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/dedicated-resources/pom.xml
+++ b/plugins/dedicated-resources/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/deployment-planners/implicit-dedication/pom.xml
+++ b/plugins/deployment-planners/implicit-dedication/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/deployment-planners/user-concentrated-pod/pom.xml
+++ b/plugins/deployment-planners/user-concentrated-pod/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/deployment-planners/user-dispersing/pom.xml
+++ b/plugins/deployment-planners/user-dispersing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/event-bus/inmemory/pom.xml
+++ b/plugins/event-bus/inmemory/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/event-bus/kafka/pom.xml
+++ b/plugins/event-bus/kafka/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/event-bus/rabbitmq/pom.xml
+++ b/plugins/event-bus/rabbitmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/ha-planners/skip-heurestics/pom.xml
+++ b/plugins/ha-planners/skip-heurestics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/host-allocators/random/pom.xml
+++ b/plugins/host-allocators/random/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/hypervisors/baremetal/pom.xml
+++ b/plugins/hypervisors/baremetal/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>cloud-plugin-hypervisor-baremetal</artifactId>

--- a/plugins/hypervisors/hyperv/pom.xml
+++ b/plugins/hypervisors/hyperv/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <properties>

--- a/plugins/hypervisors/kvm/pom.xml
+++ b/plugins/hypervisors/kvm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/hypervisors/ovm/pom.xml
+++ b/plugins/hypervisors/ovm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/hypervisors/ovm3/pom.xml
+++ b/plugins/hypervisors/ovm3/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/hypervisors/simulator/pom.xml
+++ b/plugins/hypervisors/simulator/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>cloud-plugin-hypervisor-simulator</artifactId>

--- a/plugins/hypervisors/ucs/pom.xml
+++ b/plugins/hypervisors/ucs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>cloud-plugin-hypervisor-ucs</artifactId>

--- a/plugins/hypervisors/vmware/pom.xml
+++ b/plugins/hypervisors/vmware/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -44,20 +44,8 @@ import java.util.UUID;
 import javax.naming.ConfigurationException;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import com.cloud.agent.api.storage.OVFPropertyTO;
-import com.cloud.utils.crypt.DBEncryptionUtil;
-import com.vmware.vim25.ArrayUpdateOperation;
-import com.vmware.vim25.VAppOvfSectionInfo;
-import com.vmware.vim25.VAppOvfSectionSpec;
-import com.vmware.vim25.VAppProductInfo;
-import com.vmware.vim25.VAppProductSpec;
-import com.vmware.vim25.VAppPropertyInfo;
-import com.vmware.vim25.VAppPropertySpec;
-import com.vmware.vim25.VmConfigInfo;
-import com.vmware.vim25.VmConfigSpec;
-import org.apache.commons.collections.CollectionUtils;
-
 import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.vm.UnmanagedInstance;
 import org.apache.cloudstack.storage.command.CopyCommand;
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
 import org.apache.cloudstack.storage.configdrive.ConfigDrive;
@@ -66,6 +54,7 @@ import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
 import org.apache.cloudstack.utils.volume.VirtualMachineDiskInfo;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.log4j.Logger;
@@ -101,6 +90,8 @@ import com.cloud.agent.api.GetHostStatsAnswer;
 import com.cloud.agent.api.GetHostStatsCommand;
 import com.cloud.agent.api.GetStorageStatsAnswer;
 import com.cloud.agent.api.GetStorageStatsCommand;
+import com.cloud.agent.api.GetUnmanagedInstancesAnswer;
+import com.cloud.agent.api.GetUnmanagedInstancesCommand;
 import com.cloud.agent.api.GetVmDiskStatsAnswer;
 import com.cloud.agent.api.GetVmDiskStatsCommand;
 import com.cloud.agent.api.GetVmIpAddressCommand;
@@ -184,6 +175,7 @@ import com.cloud.agent.api.storage.CreatePrivateTemplateAnswer;
 import com.cloud.agent.api.storage.DestroyCommand;
 import com.cloud.agent.api.storage.MigrateVolumeAnswer;
 import com.cloud.agent.api.storage.MigrateVolumeCommand;
+import com.cloud.agent.api.storage.OVFPropertyTO;
 import com.cloud.agent.api.storage.PrimaryStorageDownloadAnswer;
 import com.cloud.agent.api.storage.PrimaryStorageDownloadCommand;
 import com.cloud.agent.api.storage.ResizeVolumeAnswer;
@@ -255,6 +247,7 @@ import com.cloud.utils.ExecutionResult;
 import com.cloud.utils.NumbersUtil;
 import com.cloud.utils.Pair;
 import com.cloud.utils.Ternary;
+import com.cloud.utils.crypt.DBEncryptionUtil;
 import com.cloud.utils.db.DB;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.exception.ExceptionUtil;
@@ -268,8 +261,10 @@ import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachine.PowerState;
 import com.cloud.vm.VirtualMachineName;
 import com.cloud.vm.VmDetailConstants;
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.vmware.vim25.AboutInfo;
+import com.vmware.vim25.ArrayUpdateOperation;
 import com.vmware.vim25.BoolPolicy;
 import com.vmware.vim25.ComputeResourceSummary;
 import com.vmware.vim25.CustomFieldStringValue;
@@ -282,9 +277,11 @@ import com.vmware.vim25.DistributedVirtualSwitchPortConnection;
 import com.vmware.vim25.DistributedVirtualSwitchPortCriteria;
 import com.vmware.vim25.DynamicProperty;
 import com.vmware.vim25.GuestInfo;
+import com.vmware.vim25.GuestNicInfo;
 import com.vmware.vim25.HostCapability;
 import com.vmware.vim25.HostHostBusAdapter;
 import com.vmware.vim25.HostInternetScsiHba;
+import com.vmware.vim25.HostPortGroupSpec;
 import com.vmware.vim25.ManagedObjectReference;
 import com.vmware.vim25.ObjectContent;
 import com.vmware.vim25.OptionValue;
@@ -297,6 +294,12 @@ import com.vmware.vim25.PerfMetricSeries;
 import com.vmware.vim25.PerfQuerySpec;
 import com.vmware.vim25.RuntimeFaultFaultMsg;
 import com.vmware.vim25.ToolsUnavailableFaultMsg;
+import com.vmware.vim25.VAppOvfSectionInfo;
+import com.vmware.vim25.VAppOvfSectionSpec;
+import com.vmware.vim25.VAppProductInfo;
+import com.vmware.vim25.VAppProductSpec;
+import com.vmware.vim25.VAppPropertyInfo;
+import com.vmware.vim25.VAppPropertySpec;
 import com.vmware.vim25.VMwareDVSPortSetting;
 import com.vmware.vim25.VimPortType;
 import com.vmware.vim25.VirtualDevice;
@@ -309,6 +312,7 @@ import com.vmware.vim25.VirtualEthernetCard;
 import com.vmware.vim25.VirtualEthernetCardDistributedVirtualPortBackingInfo;
 import com.vmware.vim25.VirtualEthernetCardNetworkBackingInfo;
 import com.vmware.vim25.VirtualEthernetCardOpaqueNetworkBackingInfo;
+import com.vmware.vim25.VirtualIDEController;
 import com.vmware.vim25.VirtualMachineConfigSpec;
 import com.vmware.vim25.VirtualMachineFileInfo;
 import com.vmware.vim25.VirtualMachineFileLayoutEx;
@@ -320,7 +324,10 @@ import com.vmware.vim25.VirtualMachineRelocateSpecDiskLocator;
 import com.vmware.vim25.VirtualMachineRuntimeInfo;
 import com.vmware.vim25.VirtualMachineToolsStatus;
 import com.vmware.vim25.VirtualMachineVideoCard;
+import com.vmware.vim25.VirtualSCSIController;
 import com.vmware.vim25.VirtualUSBController;
+import com.vmware.vim25.VmConfigInfo;
+import com.vmware.vim25.VmConfigSpec;
 import com.vmware.vim25.VmwareDistributedVirtualSwitchVlanIdSpec;
 
 public class VmwareResource implements StoragePoolResource, ServerResource, VmwareHostService, VirtualRouterDeployer {
@@ -378,6 +385,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     protected VirtualRoutingResource _vrResource;
 
     protected final static HashMap<VirtualMachinePowerState, PowerState> s_powerStatesTable = new HashMap<VirtualMachinePowerState, PowerState>();
+
     static {
         s_powerStatesTable.put(VirtualMachinePowerState.POWERED_ON, PowerState.PowerOn);
         s_powerStatesTable.put(VirtualMachinePowerState.POWERED_OFF, PowerState.PowerOff);
@@ -430,118 +438,120 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             Class<? extends Command> clz = cmd.getClass();
             if (cmd instanceof NetworkElementCommand) {
-                return _vrResource.executeRequest((NetworkElementCommand)cmd);
+                return _vrResource.executeRequest((NetworkElementCommand) cmd);
             } else if (clz == ReadyCommand.class) {
-                answer = execute((ReadyCommand)cmd);
+                answer = execute((ReadyCommand) cmd);
             } else if (clz == GetHostStatsCommand.class) {
-                answer = execute((GetHostStatsCommand)cmd);
+                answer = execute((GetHostStatsCommand) cmd);
             } else if (clz == GetVmStatsCommand.class) {
-                answer = execute((GetVmStatsCommand)cmd);
+                answer = execute((GetVmStatsCommand) cmd);
             } else if (clz == GetVmNetworkStatsCommand.class) {
                 answer = execute((GetVmNetworkStatsCommand) cmd);
             } else if (clz == GetVmDiskStatsCommand.class) {
-                answer = execute((GetVmDiskStatsCommand)cmd);
+                answer = execute((GetVmDiskStatsCommand) cmd);
             } else if (cmd instanceof GetVolumeStatsCommand) {
-                return execute((GetVolumeStatsCommand)cmd);
+                return execute((GetVolumeStatsCommand) cmd);
             } else if (clz == CheckHealthCommand.class) {
-                answer = execute((CheckHealthCommand)cmd);
+                answer = execute((CheckHealthCommand) cmd);
             } else if (clz == StopCommand.class) {
-                answer = execute((StopCommand)cmd);
+                answer = execute((StopCommand) cmd);
             } else if (clz == RebootRouterCommand.class) {
-                answer = execute((RebootRouterCommand)cmd);
+                answer = execute((RebootRouterCommand) cmd);
             } else if (clz == RebootCommand.class) {
-                answer = execute((RebootCommand)cmd);
+                answer = execute((RebootCommand) cmd);
             } else if (clz == CheckVirtualMachineCommand.class) {
-                answer = execute((CheckVirtualMachineCommand)cmd);
+                answer = execute((CheckVirtualMachineCommand) cmd);
             } else if (clz == PrepareForMigrationCommand.class) {
-                answer = execute((PrepareForMigrationCommand)cmd);
+                answer = execute((PrepareForMigrationCommand) cmd);
             } else if (clz == MigrateCommand.class) {
-                answer = execute((MigrateCommand)cmd);
+                answer = execute((MigrateCommand) cmd);
             } else if (clz == MigrateVmToPoolCommand.class) {
-                answer = execute((MigrateVmToPoolCommand)cmd);
+                answer = execute((MigrateVmToPoolCommand) cmd);
             } else if (clz == MigrateWithStorageCommand.class) {
-                answer = execute((MigrateWithStorageCommand)cmd);
+                answer = execute((MigrateWithStorageCommand) cmd);
             } else if (clz == MigrateVolumeCommand.class) {
-                answer = execute((MigrateVolumeCommand)cmd);
+                answer = execute((MigrateVolumeCommand) cmd);
             } else if (clz == DestroyCommand.class) {
-                answer = execute((DestroyCommand)cmd);
+                answer = execute((DestroyCommand) cmd);
             } else if (clz == CreateStoragePoolCommand.class) {
-                return execute((CreateStoragePoolCommand)cmd);
+                return execute((CreateStoragePoolCommand) cmd);
             } else if (clz == ModifyTargetsCommand.class) {
-                answer = execute((ModifyTargetsCommand)cmd);
+                answer = execute((ModifyTargetsCommand) cmd);
             } else if (clz == ModifyStoragePoolCommand.class) {
-                answer = execute((ModifyStoragePoolCommand)cmd);
+                answer = execute((ModifyStoragePoolCommand) cmd);
             } else if (clz == DeleteStoragePoolCommand.class) {
-                answer = execute((DeleteStoragePoolCommand)cmd);
+                answer = execute((DeleteStoragePoolCommand) cmd);
             } else if (clz == CopyVolumeCommand.class) {
-                answer = execute((CopyVolumeCommand)cmd);
+                answer = execute((CopyVolumeCommand) cmd);
             } else if (clz == AttachIsoCommand.class) {
-                answer = execute((AttachIsoCommand)cmd);
+                answer = execute((AttachIsoCommand) cmd);
             } else if (clz == ValidateSnapshotCommand.class) {
-                answer = execute((ValidateSnapshotCommand)cmd);
+                answer = execute((ValidateSnapshotCommand) cmd);
             } else if (clz == ManageSnapshotCommand.class) {
-                answer = execute((ManageSnapshotCommand)cmd);
+                answer = execute((ManageSnapshotCommand) cmd);
             } else if (clz == BackupSnapshotCommand.class) {
-                answer = execute((BackupSnapshotCommand)cmd);
+                answer = execute((BackupSnapshotCommand) cmd);
             } else if (clz == CreateVolumeFromSnapshotCommand.class) {
-                answer = execute((CreateVolumeFromSnapshotCommand)cmd);
+                answer = execute((CreateVolumeFromSnapshotCommand) cmd);
             } else if (clz == CreatePrivateTemplateFromVolumeCommand.class) {
-                answer = execute((CreatePrivateTemplateFromVolumeCommand)cmd);
+                answer = execute((CreatePrivateTemplateFromVolumeCommand) cmd);
             } else if (clz == CreatePrivateTemplateFromSnapshotCommand.class) {
-                answer = execute((CreatePrivateTemplateFromSnapshotCommand)cmd);
+                answer = execute((CreatePrivateTemplateFromSnapshotCommand) cmd);
             } else if (clz == UpgradeSnapshotCommand.class) {
-                answer = execute((UpgradeSnapshotCommand)cmd);
+                answer = execute((UpgradeSnapshotCommand) cmd);
             } else if (clz == GetStorageStatsCommand.class) {
-                answer = execute((GetStorageStatsCommand)cmd);
+                answer = execute((GetStorageStatsCommand) cmd);
             } else if (clz == PrimaryStorageDownloadCommand.class) {
-                answer = execute((PrimaryStorageDownloadCommand)cmd);
+                answer = execute((PrimaryStorageDownloadCommand) cmd);
             } else if (clz == GetVncPortCommand.class) {
-                answer = execute((GetVncPortCommand)cmd);
+                answer = execute((GetVncPortCommand) cmd);
             } else if (clz == SetupCommand.class) {
-                answer = execute((SetupCommand)cmd);
+                answer = execute((SetupCommand) cmd);
             } else if (clz == MaintainCommand.class) {
-                answer = execute((MaintainCommand)cmd);
+                answer = execute((MaintainCommand) cmd);
             } else if (clz == PingTestCommand.class) {
-                answer = execute((PingTestCommand)cmd);
+                answer = execute((PingTestCommand) cmd);
             } else if (clz == CheckOnHostCommand.class) {
-                answer = execute((CheckOnHostCommand)cmd);
+                answer = execute((CheckOnHostCommand) cmd);
             } else if (clz == ModifySshKeysCommand.class) {
-                answer = execute((ModifySshKeysCommand)cmd);
+                answer = execute((ModifySshKeysCommand) cmd);
             } else if (clz == NetworkUsageCommand.class) {
-                answer = execute((NetworkUsageCommand)cmd);
+                answer = execute((NetworkUsageCommand) cmd);
             } else if (clz == StartCommand.class) {
-                answer = execute((StartCommand)cmd);
+                answer = execute((StartCommand) cmd);
             } else if (clz == CheckSshCommand.class) {
-                answer = execute((CheckSshCommand)cmd);
+                answer = execute((CheckSshCommand) cmd);
             } else if (clz == CheckNetworkCommand.class) {
-                answer = execute((CheckNetworkCommand)cmd);
+                answer = execute((CheckNetworkCommand) cmd);
             } else if (clz == PlugNicCommand.class) {
-                answer = execute((PlugNicCommand)cmd);
+                answer = execute((PlugNicCommand) cmd);
             } else if (clz == ReplugNicCommand.class) {
-                answer = execute((ReplugNicCommand)cmd);
+                answer = execute((ReplugNicCommand) cmd);
             } else if (clz == UnPlugNicCommand.class) {
-                answer = execute((UnPlugNicCommand)cmd);
+                answer = execute((UnPlugNicCommand) cmd);
             } else if (cmd instanceof CreateVMSnapshotCommand) {
-                return execute((CreateVMSnapshotCommand)cmd);
+                return execute((CreateVMSnapshotCommand) cmd);
             } else if (cmd instanceof DeleteVMSnapshotCommand) {
-                return execute((DeleteVMSnapshotCommand)cmd);
+                return execute((DeleteVMSnapshotCommand) cmd);
             } else if (cmd instanceof RevertToVMSnapshotCommand) {
-                return execute((RevertToVMSnapshotCommand)cmd);
+                return execute((RevertToVMSnapshotCommand) cmd);
             } else if (clz == ResizeVolumeCommand.class) {
-                return execute((ResizeVolumeCommand)cmd);
+                return execute((ResizeVolumeCommand) cmd);
             } else if (clz == UnregisterVMCommand.class) {
-                return execute((UnregisterVMCommand)cmd);
+                return execute((UnregisterVMCommand) cmd);
             } else if (cmd instanceof StorageSubSystemCommand) {
-                checkStorageProcessorAndHandlerNfsVersionAttribute((StorageSubSystemCommand)cmd);
-                return storageHandler.handleStorageCommands((StorageSubSystemCommand)cmd);
+                checkStorageProcessorAndHandlerNfsVersionAttribute((StorageSubSystemCommand) cmd);
+                return storageHandler.handleStorageCommands((StorageSubSystemCommand) cmd);
             } else if (clz == ScaleVmCommand.class) {
-                return execute((ScaleVmCommand)cmd);
+                return execute((ScaleVmCommand) cmd);
             } else if (clz == PvlanSetupCommand.class) {
-                return execute((PvlanSetupCommand)cmd);
+                return execute((PvlanSetupCommand) cmd);
             } else if (clz == GetVmIpAddressCommand.class) {
-                return execute((GetVmIpAddressCommand)cmd);
+                return execute((GetVmIpAddressCommand) cmd);
             } else if (clz == UnregisterNicCommand.class) {
-                answer = execute((UnregisterNicCommand)cmd);
+                answer = execute((UnregisterNicCommand) cmd);
+            } else if (clz == GetUnmanagedInstancesCommand.class) {
+                answer = execute((GetUnmanagedInstancesCommand) cmd);
             } else {
                 answer = Answer.createUnsupportedCommandAnswer(cmd);
             }
@@ -587,6 +597,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
      * If _storageNfsVersion is not null -> nothing to do, version already set.<br>
      * If _storageNfsVersion is null -> examine StorageSubSystemCommand to get NFS version and set it
      * to the storage processor and storage handler.
+     *
      * @param cmd command to execute
      */
     protected void checkStorageProcessorAndHandlerNfsVersionAttribute(StorageSubSystemCommand cmd) {
@@ -595,18 +606,19 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         if (cmd instanceof CopyCommand) {
             EnumMap<VmwareStorageProcessorConfigurableFields, Object> params = new EnumMap<VmwareStorageProcessorConfigurableFields, Object>(
                     VmwareStorageProcessorConfigurableFields.class);
-            examineStorageSubSystemCommandNfsVersion((CopyCommand)cmd, params);
-            params = examineStorageSubSystemCommandFullCloneFlagForVmware((CopyCommand)cmd, params);
+            examineStorageSubSystemCommandNfsVersion((CopyCommand) cmd, params);
+            params = examineStorageSubSystemCommandFullCloneFlagForVmware((CopyCommand) cmd, params);
             reconfigureProcessorByHandler(params);
         }
     }
 
     /**
      * Reconfigure processor by handler
+     *
      * @param params params
      */
     protected void reconfigureProcessorByHandler(EnumMap<VmwareStorageProcessorConfigurableFields, Object> params) {
-        VmwareStorageSubsystemCommandHandler handler = (VmwareStorageSubsystemCommandHandler)storageHandler;
+        VmwareStorageSubsystemCommandHandler handler = (VmwareStorageSubsystemCommandHandler) storageHandler;
         boolean success = handler.reconfigureStorageProcessor(params);
         if (success) {
             s_logger.info("VmwareStorageProcessor and VmwareStorageSubsystemCommandHandler successfully reconfigured");
@@ -617,18 +629,19 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     /**
      * Examine StorageSubSystem command to get full clone flag, if provided
-     * @param cmd command to execute
+     *
+     * @param cmd    command to execute
      * @param params params
      * @return copy of params including new values, if suitable
      */
     protected EnumMap<VmwareStorageProcessorConfigurableFields, Object> examineStorageSubSystemCommandFullCloneFlagForVmware(CopyCommand cmd,
-            EnumMap<VmwareStorageProcessorConfigurableFields, Object> params) {
+                                                                                                                             EnumMap<VmwareStorageProcessorConfigurableFields, Object> params) {
         EnumMap<VmwareStorageProcessorConfigurableFields, Object> paramsCopy = new EnumMap<VmwareStorageProcessorConfigurableFields, Object>(params);
         HypervisorType hypervisor = cmd.getDestTO().getHypervisorType();
         if (hypervisor != null && hypervisor.equals(HypervisorType.VMware)) {
             DataStoreTO destDataStore = cmd.getDestTO().getDataStore();
             if (destDataStore instanceof PrimaryDataStoreTO) {
-                PrimaryDataStoreTO dest = (PrimaryDataStoreTO)destDataStore;
+                PrimaryDataStoreTO dest = (PrimaryDataStoreTO) destDataStore;
                 if (dest.isFullCloneFlag() != null) {
                     paramsCopy.put(VmwareStorageProcessorConfigurableFields.FULL_CLONE_FLAG, dest.isFullCloneFlag().booleanValue());
                 }
@@ -639,7 +652,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     /**
      * Examine StorageSubSystem command to get storage NFS version, if provided
-     * @param cmd command to execute
+     *
+     * @param cmd    command to execute
      * @param params params
      */
     protected void examineStorageSubSystemCommandNfsVersion(CopyCommand cmd, EnumMap<VmwareStorageProcessorConfigurableFields, Object> params) {
@@ -647,7 +661,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         boolean nfsVersionFound = false;
 
         if (srcDataStore instanceof NfsTO) {
-            nfsVersionFound = getStorageNfsVersionFromNfsTO((NfsTO)srcDataStore);
+            nfsVersionFound = getStorageNfsVersionFromNfsTO((NfsTO) srcDataStore);
         }
 
         if (nfsVersionFound) {
@@ -657,6 +671,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     /**
      * Get storage NFS version from NfsTO
+     *
      * @param nfsTO nfsTO
      * @return true if NFS version was found and not null, false in other case
      */
@@ -743,7 +758,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                     // OfflineVmwareMigration: 3. attach the disk to the worker
                     vmdkDataStorePath = VmwareStorageLayoutHelper.getLegacyDatastorePathFromVmdkFileName(dsMo, path + VMDK_EXTENSION);
 
-                    vmMo.attachDisk(new String[] { vmdkDataStorePath }, morDS);
+                    vmMo.attachDisk(new String[]{vmdkDataStorePath}, morDS);
                 }
             }
 
@@ -773,7 +788,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // IDE virtual disk cannot be re-sized if VM is running
             if (vdisk.second() != null && vdisk.second().contains("ide")) {
                 throw new Exception("Re-sizing a virtual disk over an IDE controller is not supported in the VMware hypervisor. " +
-                            "Please re-try when virtual disk is attached to a VM using a SCSI controller.");
+                        "Please re-try when virtual disk is attached to a VM using a SCSI controller.");
             }
 
             if (cmd.isManaged()) {
@@ -799,16 +814,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 _storageProcessor.expandDatastore(hostDatastoreSystem, dsMo);
             }
 
-            if (vdisk.second() != null && !vdisk.second().toLowerCase().startsWith("scsi"))
-            {
-                s_logger.error("Unsupported disk device bus "+ vdisk.second());
-                throw new Exception("Unsupported disk device bus "+ vdisk.second());
+            if (vdisk.second() != null && !vdisk.second().toLowerCase().startsWith("scsi")) {
+                s_logger.error("Unsupported disk device bus " + vdisk.second());
+                throw new Exception("Unsupported disk device bus " + vdisk.second());
             }
             VirtualDisk disk = vdisk.first();
-            if ((VirtualDiskFlatVer2BackingInfo)disk.getBacking() != null && ((VirtualDiskFlatVer2BackingInfo)disk.getBacking()).getParent() != null)
-            {
-                s_logger.error("Resize is not supported because Disk device has Parent "+ ((VirtualDiskFlatVer2BackingInfo)disk.getBacking()).getParent().getUuid());
-                throw new Exception("Resize is not supported because Disk device has Parent "+ ((VirtualDiskFlatVer2BackingInfo)disk.getBacking()).getParent().getUuid());
+            if ((VirtualDiskFlatVer2BackingInfo) disk.getBacking() != null && ((VirtualDiskFlatVer2BackingInfo) disk.getBacking()).getParent() != null) {
+                s_logger.error("Resize is not supported because Disk device has Parent " + ((VirtualDiskFlatVer2BackingInfo) disk.getBacking()).getParent().getUuid());
+                throw new Exception("Resize is not supported because Disk device has Parent " + ((VirtualDiskFlatVer2BackingInfo) disk.getBacking()).getParent().getUuid());
             }
             String vmdkAbsFile = getAbsoluteVmdkFile(disk);
 
@@ -946,15 +959,15 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         assert cmd.getRouterAccessIp() != null;
 
         if (cmd instanceof IpAssocVpcCommand) {
-            return prepareNetworkElementCommand((IpAssocVpcCommand)cmd);
+            return prepareNetworkElementCommand((IpAssocVpcCommand) cmd);
         } else if (cmd instanceof IpAssocCommand) {
-            return prepareNetworkElementCommand((IpAssocCommand)cmd);
+            return prepareNetworkElementCommand((IpAssocCommand) cmd);
         } else if (cmd instanceof SetSourceNatCommand) {
-            return prepareNetworkElementCommand((SetSourceNatCommand)cmd);
+            return prepareNetworkElementCommand((SetSourceNatCommand) cmd);
         } else if (cmd instanceof SetupGuestNetworkCommand) {
-            return prepareNetworkElementCommand((SetupGuestNetworkCommand)cmd);
+            return prepareNetworkElementCommand((SetupGuestNetworkCommand) cmd);
         } else if (cmd instanceof SetNetworkACLCommand) {
-            return prepareNetworkElementCommand((SetNetworkACLCommand)cmd);
+            return prepareNetworkElementCommand((SetNetworkACLCommand) cmd);
         }
         return new ExecutionResult(true, null);
     }
@@ -1027,7 +1040,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         VirtualDevice[] nics = vmMo.getNicDevices();
         for (VirtualDevice nic : nics) {
             if (nic instanceof VirtualEthernetCard) {
-                if (((VirtualEthernetCard)nic).getMacAddress().equals(mac))
+                if (((VirtualEthernetCard) nic).getMacAddress().equals(mac))
                     return nic;
             }
         }
@@ -1125,7 +1138,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             if (vmMo == null) {
                 if (hyperHost instanceof HostMO) {
-                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO)hyperHost).getParentMor());
+                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO) hyperHost).getParentMor());
                     vmMo = clusterMo.findVmOnHyperHost(vmName);
                 }
             }
@@ -1147,7 +1160,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             VirtualEthernetCardType nicDeviceType = VirtualEthernetCardType.E1000;
             Map<String, String> details = cmd.getDetails();
             if (details != null) {
-                nicDeviceType = VirtualEthernetCardType.valueOf((String)details.get("nicAdapter"));
+                nicDeviceType = VirtualEthernetCardType.valueOf((String) details.get("nicAdapter"));
             }
 
             // find a usable device number in VMware environment
@@ -1209,7 +1222,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             if (vmMo == null) {
                 if (hyperHost instanceof HostMO) {
-                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO)hyperHost).getParentMor());
+                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO) hyperHost).getParentMor());
                     vmMo = clusterMo.findVmOnHyperHost(vmName);
                 }
             }
@@ -1288,7 +1301,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             if (vmMo == null) {
                 if (hyperHost instanceof HostMO) {
-                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO)hyperHost).getParentMor());
+                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO) hyperHost).getParentMor());
                     vmMo = clusterMo.findVmOnHyperHost(vmName);
                 }
             }
@@ -1353,7 +1366,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         try {
             VirtualDevice[] nicDevices = vmMo.getNicDevices();
 
-            VirtualEthernetCard device = (VirtualEthernetCard)nicDevices[nicIndex];
+            VirtualEthernetCard device = (VirtualEthernetCard) nicDevices[nicIndex];
 
             if (VirtualSwitchType.StandardVirtualSwitch == vSwitchType) {
                 VirtualEthernetCardNetworkBackingInfo nicBacking = new VirtualEthernetCardNetworkBackingInfo();
@@ -1423,7 +1436,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // the check and will try to find it within cluster
             if (vmMo == null) {
                 if (hyperHost instanceof HostMO) {
-                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO)hyperHost).getParentMor());
+                    ClusterMO clusterMo = new ClusterMO(hyperHost.getContext(), ((HostMO) hyperHost).getParentMor());
                     vmMo = clusterMo.findVmOnHyperHost(routerName);
                 }
             }
@@ -1549,13 +1562,13 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
         for (DiskTO vol : disks) {
             if (vol.getType() != Volume.Type.ISO) {
-                VolumeObjectTO volumeTO = (VolumeObjectTO)vol.getData();
+                VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
                 DataStoreTO primaryStore = volumeTO.getDataStore();
                 if (primaryStore.getUuid() != null && !primaryStore.getUuid().isEmpty()) {
                     validatedDisks.add(vol);
                 }
             } else if (vol.getType() == Volume.Type.ISO) {
-                TemplateObjectTO templateTO = (TemplateObjectTO)vol.getData();
+                TemplateObjectTO templateTO = (TemplateObjectTO) vol.getData();
                 if (templateTO.getPath() != null && !templateTO.getPath().isEmpty()) {
                     validatedDisks.add(vol);
                 }
@@ -1612,7 +1625,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             // Check if license supports the feature
             VmwareHelper.isFeatureLicensed(hyperHost, FeatureKeyConstants.HOTPLUG);
-            VmwareHelper.setVmScaleUpConfig(vmConfigSpec, vmSpec.getCpus(), vmSpec.getMaxSpeed(), vmSpec.getMinSpeed(), (int)requestedMaxMemoryInMb, ramMb,
+            VmwareHelper.setVmScaleUpConfig(vmConfigSpec, vmSpec.getCpus(), vmSpec.getMaxSpeed(), vmSpec.getMinSpeed(), (int) requestedMaxMemoryInMb, ramMb,
                     vmSpec.getLimitCpuUse());
 
             if (!vmMo.configureVm(vmConfigSpec)) {
@@ -1772,9 +1785,9 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 diskInfoBuilder = vmMo.getDiskInfoBuilder();
                 hasSnapshot = vmMo.hasSnapshot();
                 if (!hasSnapshot)
-                    vmMo.tearDownDevices(new Class<?>[] {VirtualDisk.class, VirtualEthernetCard.class});
+                    vmMo.tearDownDevices(new Class<?>[]{VirtualDisk.class, VirtualEthernetCard.class});
                 else
-                    vmMo.tearDownDevices(new Class<?>[] {VirtualEthernetCard.class});
+                    vmMo.tearDownDevices(new Class<?>[]{VirtualEthernetCard.class});
                 if (systemVm) {
                     ensureScsiDiskControllers(vmMo, systemVmScsiControllerType.toString(), numScsiControllerForSystemVm, firstScsiControllerBusNum);
                 } else {
@@ -1798,9 +1811,9 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                     diskInfoBuilder = vmMo.getDiskInfoBuilder();
                     hasSnapshot = vmMo.hasSnapshot();
                     if (!hasSnapshot)
-                        vmMo.tearDownDevices(new Class<?>[] {VirtualDisk.class, VirtualEthernetCard.class});
+                        vmMo.tearDownDevices(new Class<?>[]{VirtualDisk.class, VirtualEthernetCard.class});
                     else
-                        vmMo.tearDownDevices(new Class<?>[] {VirtualEthernetCard.class});
+                        vmMo.tearDownDevices(new Class<?>[]{VirtualEthernetCard.class});
 
                     if (systemVm) {
                         // System volumes doesn't require more than 1 SCSI controller as there is no requirement for data volumes.
@@ -1855,7 +1868,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                         }
                         tearDownVm(vmMo);
                     } else if (!hyperHost.createBlankVm(vmNameOnVcenter, vmInternalCSName, vmSpec.getCpus(), vmSpec.getMaxSpeed().intValue(), getReservedCpuMHZ(vmSpec),
-                            vmSpec.getLimitCpuUse(), (int)(vmSpec.getMaxRam() / ResourceType.bytesToMiB), getReservedMemoryMb(vmSpec), guestOsId, rootDiskDataStoreDetails.first(), false,
+                            vmSpec.getLimitCpuUse(), (int) (vmSpec.getMaxRam() / ResourceType.bytesToMiB), getReservedMemoryMb(vmSpec), guestOsId, rootDiskDataStoreDetails.first(), false,
                             controllerInfo, systemVm)) {
                         throw new Exception("Failed to create VM. vmName: " + vmInternalCSName);
                     }
@@ -1881,7 +1894,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             VirtualMachineConfigSpec vmConfigSpec = new VirtualMachineConfigSpec();
 
-            VmwareHelper.setBasicVmConfig(vmConfigSpec, vmSpec.getCpus(), vmSpec.getMaxSpeed(), getReservedCpuMHZ(vmSpec), (int)(vmSpec.getMaxRam() / (1024 * 1024)),
+            VmwareHelper.setBasicVmConfig(vmConfigSpec, vmSpec.getCpus(), vmSpec.getMaxSpeed(), getReservedCpuMHZ(vmSpec), (int) (vmSpec.getMaxRam() / (1024 * 1024)),
                     getReservedMemoryMb(vmSpec), guestOsId, vmSpec.getLimitCpuUse());
 
             // Check for multi-cores per socket settings
@@ -1899,7 +1912,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // Check for hotadd settings
             vmConfigSpec.setMemoryHotAddEnabled(vmMo.isMemoryHotAddSupported(guestOsId));
 
-            String hostApiVersion = ((HostMO)hyperHost).getHostAboutInfo().getApiVersion();
+            String hostApiVersion = ((HostMO) hyperHost).getHostAboutInfo().getApiVersion();
             if (numCoresPerSocket > 1 && hostApiVersion.compareTo("5.0") < 0) {
                 s_logger.warn("Dynamic scaling of CPU is not supported for Virtual Machines with multi-core vCPUs in case of ESXi hosts 4.1 and prior. Hence CpuHotAdd will not be"
                         + " enabled for Virtual Machine: " + vmInternalCSName);
@@ -2012,7 +2025,6 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             }
 
 
-
             //
             // Setup ROOT/DATA disk devices
             //
@@ -2051,7 +2063,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 if (!hasSnapshot) {
                     deviceConfigSpecArray[i] = new VirtualDeviceConfigSpec();
 
-                    VolumeObjectTO volumeTO = (VolumeObjectTO)vol.getData();
+                    VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
                     DataStoreTO primaryStore = volumeTO.getDataStore();
                     Map<String, String> details = vol.getDetails();
                     boolean managed = false;
@@ -2097,7 +2109,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // Setup USB devices
             //
             if (guestOsId.startsWith("darwin")) { //Mac OS
-                VirtualDevice[] devices = vmMo.getMatchedDevices(new Class<?>[] {VirtualUSBController.class});
+                VirtualDevice[] devices = vmMo.getMatchedDevices(new Class<?>[]{VirtualUSBController.class});
                 if (devices.length == 0) {
                     s_logger.debug("No USB Controller device on VM Start. Add USB Controller device for Mac OS VM " + vmInternalCSName);
 
@@ -2140,7 +2152,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                         for (int nicIndex = nics.length - extraPublicNics; nicIndex < nics.length; nicIndex++) {
                             VirtualDevice nicDevice = peerVmMo.getNicDeviceByIndex(nics[nicIndex].getDeviceId());
                             if (nicDevice != null) {
-                                String mac = ((VirtualEthernetCard)nicDevice).getMacAddress();
+                                String mac = ((VirtualEthernetCard) nicDevice).getMacAddress();
                                 if (mac != null) {
                                     s_logger.info("Use same MAC as previous RvR, the MAC is " + mac + " for extra NIC with device id: " + nics[nicIndex].getDeviceId());
                                     nics[nicIndex].setMac(mac);
@@ -2413,8 +2425,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
      * and seting properties values from ovfProperties
      */
     protected void copyVAppConfigsFromTemplate(VmConfigInfo vAppConfig,
-                                                   List<OVFPropertyTO> ovfProperties,
-                                                   VirtualMachineConfigSpec vmConfig) throws Exception {
+                                               List<OVFPropertyTO> ovfProperties,
+                                               VirtualMachineConfigSpec vmConfig) throws Exception {
         VmConfigSpec vmConfigSpec = new VmConfigSpec();
         vmConfigSpec.getEula().addAll(vAppConfig.getEula());
         vmConfigSpec.setInstallBootStopDelay(vAppConfig.getInstallBootStopDelay());
@@ -2437,10 +2449,10 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     private void resizeRootDiskOnVMStart(VirtualMachineMO vmMo, DiskTO rootDiskTO, VmwareHypervisorHost hyperHost, VmwareContext context) throws Exception {
         final Pair<VirtualDisk, String> vdisk = getVirtualDiskInfo(vmMo, appendFileType(rootDiskTO.getPath(), VMDK_EXTENSION));
-        assert(vdisk != null);
+        assert (vdisk != null);
 
         Long reqSize = 0L;
-        final VolumeObjectTO volumeTO = ((VolumeObjectTO)rootDiskTO.getData());
+        final VolumeObjectTO volumeTO = ((VolumeObjectTO) rootDiskTO.getData());
         if (volumeTO != null) {
             reqSize = volumeTO.getSize() / 1024;
         }
@@ -2452,7 +2464,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             if (diskChain != null && diskChain.length > 1) {
                 s_logger.warn("Disk chain length for the VM is greater than one, this is not supported");
-                throw new CloudRuntimeException("Unsupported VM disk chain length: "+ diskChain.length);
+                throw new CloudRuntimeException("Unsupported VM disk chain length: " + diskChain.length);
             }
 
             boolean resizingSupported = false;
@@ -2462,7 +2474,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             }
             if (!resizingSupported) {
                 s_logger.warn("Resizing of root disk is only support for scsi device/bus, the provide VM's disk device bus name is " + diskInfo.getDiskDeviceBusName());
-                throw new CloudRuntimeException("Unsupported VM root disk device bus: "+ diskInfo.getDiskDeviceBusName());
+                throw new CloudRuntimeException("Unsupported VM root disk device bus: " + diskInfo.getDiskDeviceBusName());
             }
 
             disk.setCapacityInKB(reqSize);
@@ -2512,8 +2524,9 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
      * Sets video card memory to the one provided in detail svga.vramSize (if provided) on {@code vmConfigSpec}.
      * 64MB was always set before.
      * Size must be in KB.
-     * @param vmMo virtual machine mo
-     * @param vmSpec virtual machine specs
+     *
+     * @param vmMo         virtual machine mo
+     * @param vmSpec       virtual machine specs
      * @param vmConfigSpec virtual machine config spec
      * @throws Exception exception
      */
@@ -2531,14 +2544,15 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     /**
      * Search for vm video card iterating through vm device list
-     * @param vmMo virtual machine mo
+     *
+     * @param vmMo          virtual machine mo
      * @param svgaVmramSize new svga vram size (in KB)
-     * @param vmConfigSpec virtual machine config spec
+     * @param vmConfigSpec  virtual machine config spec
      */
     protected void setNewVRamSizeVmVideoCard(VirtualMachineMO vmMo, long svgaVmramSize, VirtualMachineConfigSpec vmConfigSpec) throws Exception {
         for (VirtualDevice device : vmMo.getAllDeviceList()) {
             if (device instanceof VirtualMachineVideoCard) {
-                VirtualMachineVideoCard videoCard = (VirtualMachineVideoCard)device;
+                VirtualMachineVideoCard videoCard = (VirtualMachineVideoCard) device;
                 modifyVmVideoCardVRamSize(videoCard, vmMo, svgaVmramSize, vmConfigSpec);
             }
         }
@@ -2546,10 +2560,11 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     /**
      * Modifies vm vram size if it was set to a different size to the one provided in svga.vramSize (user_vm_details or template_vm_details) on {@code vmConfigSpec}
-     * @param videoCard vm's video card device
-     * @param vmMo virtual machine mo
+     *
+     * @param videoCard     vm's video card device
+     * @param vmMo          virtual machine mo
      * @param svgaVmramSize new svga vram size (in KB)
-     * @param vmConfigSpec virtual machine config spec
+     * @param vmConfigSpec  virtual machine config spec
      */
     protected void modifyVmVideoCardVRamSize(VirtualMachineVideoCard videoCard, VirtualMachineMO vmMo, long svgaVmramSize, VirtualMachineConfigSpec vmConfigSpec) {
         if (videoCard.getVideoRamSizeInKB().longValue() != svgaVmramSize) {
@@ -2560,9 +2575,10 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     /**
      * Add edit spec on {@code vmConfigSpec} to modify svga vram size
-     * @param videoCard video card device to edit providing the svga vram size
+     *
+     * @param videoCard     video card device to edit providing the svga vram size
      * @param svgaVmramSize new svga vram size (in KB)
-     * @param vmConfigSpec virtual machine spec
+     * @param vmConfigSpec  virtual machine spec
      */
     protected void configureSpecVideoCardNewVRamSize(VirtualMachineVideoCard videoCard, long svgaVmramSize, VirtualMachineConfigSpec vmConfigSpec) {
         videoCard.setVideoRamSizeInKB(svgaVmramSize);
@@ -2583,15 +2599,15 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         boolean hasSnapshot = false;
         hasSnapshot = vmMo.hasSnapshot();
         if (!hasSnapshot)
-            vmMo.tearDownDevices(new Class<?>[] {VirtualDisk.class, VirtualEthernetCard.class});
+            vmMo.tearDownDevices(new Class<?>[]{VirtualDisk.class, VirtualEthernetCard.class});
         else
-            vmMo.tearDownDevices(new Class<?>[] {VirtualEthernetCard.class});
+            vmMo.tearDownDevices(new Class<?>[]{VirtualEthernetCard.class});
         vmMo.ensureScsiDeviceController();
     }
 
     int getReservedMemoryMb(VirtualMachineTO vmSpec) {
         if (vmSpec.getDetails().get(VMwareGuru.VmwareReserveMemory.key()).equalsIgnoreCase("true")) {
-            return (int)(vmSpec.getMinRam() / ResourceType.bytesToMiB);
+            return (int) (vmSpec.getMinRam() / ResourceType.bytesToMiB);
         }
         return 0;
     }
@@ -2605,9 +2621,9 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     // return the finalized disk chain for startup, from top to bottom
     private String[] syncDiskChain(DatacenterMO dcMo, VirtualMachineMO vmMo, VirtualMachineTO vmSpec, DiskTO vol, VirtualMachineDiskInfo diskInfo,
-            HashMap<String, Pair<ManagedObjectReference, DatastoreMO>> dataStoresDetails) throws Exception {
+                                   HashMap<String, Pair<ManagedObjectReference, DatastoreMO>> dataStoresDetails) throws Exception {
 
-        VolumeObjectTO volumeTO = (VolumeObjectTO)vol.getData();
+        VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
         DataStoreTO primaryStore = volumeTO.getDataStore();
         Map<String, String> details = vol.getDetails();
         boolean isManaged = false;
@@ -2653,8 +2669,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 }
 
                 datastoreDiskPath = VmwareStorageLayoutHelper.syncVolumeToVmDefaultFolder(dcMo, vmMo.getName(), dsMo, vmdkPath);
-            }
-            else {
+            } else {
                 if (vmdkPath == null) {
                     vmdkPath = dsMo.getName();
                 }
@@ -2669,7 +2684,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             s_logger.warn("Volume " + volumeTO.getId() + " does not seem to exist on datastore, out of sync? path: " + datastoreDiskPath);
         }
 
-        return new String[] {datastoreDiskPath};
+        return new String[]{datastoreDiskPath};
     }
 
     // Pair<internal CS name, vCenter display name>
@@ -2773,7 +2788,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 VirtualDeviceBackingInfo backing = nicVirtualDevice.getBacking();
                 if (backing instanceof VirtualEthernetCardDistributedVirtualPortBackingInfo) {
                     // This NIC is connected to a Distributed Virtual Switch
-                    VirtualEthernetCardDistributedVirtualPortBackingInfo portInfo = (VirtualEthernetCardDistributedVirtualPortBackingInfo)backing;
+                    VirtualEthernetCardDistributedVirtualPortBackingInfo portInfo = (VirtualEthernetCardDistributedVirtualPortBackingInfo) backing;
                     DistributedVirtualSwitchPortConnection port = portInfo.getPort();
                     String portKey = port.getPortKey();
                     String portGroupKey = port.getPortgroupKey();
@@ -2797,8 +2812,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                         if (portKey.equals(dvPort.getKey())) {
                             vmDvPort = dvPort;
                         }
-                        VMwareDVSPortSetting settings = (VMwareDVSPortSetting)dvPort.getConfig().getSetting();
-                        VmwareDistributedVirtualSwitchVlanIdSpec vlanId = (VmwareDistributedVirtualSwitchVlanIdSpec)settings.getVlan();
+                        VMwareDVSPortSetting settings = (VMwareDVSPortSetting) dvPort.getConfig().getSetting();
+                        VmwareDistributedVirtualSwitchVlanIdSpec vlanId = (VmwareDistributedVirtualSwitchVlanIdSpec) settings.getVlan();
                         s_logger.trace("Found port " + dvPort.getKey() + " with vlan " + vlanId.getVlanId());
                         if (vlanId.getVlanId() > 0 && vlanId.getVlanId() < 4095) {
                             usedVlans.add(vlanId.getVlanId());
@@ -2810,9 +2825,9 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                     }
 
                     DVPortConfigInfo dvPortConfigInfo = vmDvPort.getConfig();
-                    VMwareDVSPortSetting settings = (VMwareDVSPortSetting)dvPortConfigInfo.getSetting();
+                    VMwareDVSPortSetting settings = (VMwareDVSPortSetting) dvPortConfigInfo.getSetting();
 
-                    VmwareDistributedVirtualSwitchVlanIdSpec vlanId = (VmwareDistributedVirtualSwitchVlanIdSpec)settings.getVlan();
+                    VmwareDistributedVirtualSwitchVlanIdSpec vlanId = (VmwareDistributedVirtualSwitchVlanIdSpec) settings.getVlan();
                     BoolPolicy blocked = settings.getBlocked();
                     if (blocked.isValue() == Boolean.TRUE) {
                         s_logger.trace("Port is blocked, set a vlanid and unblock");
@@ -2864,7 +2879,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     private VirtualMachineDiskInfo getMatchingExistingDisk(VirtualMachineDiskInfoBuilder diskInfoBuilder, DiskTO vol, VmwareHypervisorHost hyperHost, VmwareContext context)
             throws Exception {
         if (diskInfoBuilder != null) {
-            VolumeObjectTO volume = (VolumeObjectTO)vol.getData();
+            VolumeObjectTO volume = (VolumeObjectTO) vol.getData();
 
             String dsName = null;
             String diskBackingFileBaseName = null;
@@ -2993,14 +3008,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     }
 
     private void postDiskConfigBeforeStart(VirtualMachineMO vmMo, VirtualMachineTO vmSpec, DiskTO[] sortedDisks, int ideControllerKey,
-            int scsiControllerKey, Map<String, Map<String, String>> iqnToData, VmwareHypervisorHost hyperHost, VmwareContext context) throws Exception {
+                                           int scsiControllerKey, Map<String, Map<String, String>> iqnToData, VmwareHypervisorHost hyperHost, VmwareContext context) throws Exception {
         VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();
 
         for (DiskTO vol : sortedDisks) {
             if (vol.getType() == Volume.Type.ISO)
                 continue;
 
-            VolumeObjectTO volumeTO = (VolumeObjectTO)vol.getData();
+            VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
 
             VirtualMachineDiskInfo diskInfo = getMatchingExistingDisk(diskInfoBuilder, vol, hyperHost, context);
             assert (diskInfo != null);
@@ -3185,14 +3200,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     }
 
     private HashMap<String, Pair<ManagedObjectReference, DatastoreMO>> inferDatastoreDetailsFromDiskInfo(VmwareHypervisorHost hyperHost, VmwareContext context,
-            DiskTO[] disks, Command cmd) throws Exception {
+                                                                                                         DiskTO[] disks, Command cmd) throws Exception {
         HashMap<String, Pair<ManagedObjectReference, DatastoreMO>> mapIdToMors = new HashMap<>();
 
         assert (hyperHost != null) && (context != null);
 
         for (DiskTO vol : disks) {
             if (vol.getType() != Volume.Type.ISO) {
-                VolumeObjectTO volumeTO = (VolumeObjectTO)vol.getData();
+                VolumeObjectTO volumeTO = (VolumeObjectTO) vol.getData();
                 DataStoreTO primaryStore = volumeTO.getDataStore();
                 String poolUuid = primaryStore.getUuid();
 
@@ -3227,8 +3242,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
                             if (vmdkPath != null) {
                                 datastoreVolumePath = dsMo.getDatastorePath(vmdkPath + VMDK_EXTENSION);
-                            }
-                            else {
+                            } else {
                                 datastoreVolumePath = dsMo.getDatastorePath(dsMo.getName() + VMDK_EXTENSION);
                             }
 
@@ -3237,8 +3251,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                         }
 
                         mapIdToMors.put(datastoreName, new Pair<>(morDatastore, new DatastoreMO(context, morDatastore)));
-                    }
-                    else {
+                    } else {
                         ManagedObjectReference morDatastore = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, poolUuid);
 
                         if (morDatastore == null) {
@@ -3350,8 +3363,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             networkInfo = HypervisorHostHelper.prepareNetwork(switchName, namePrefix, hostMo,
                     getVlanInfo(nicTo, vlanToken), nicTo.getNetworkRateMbps(), nicTo.getNetworkRateMulticastMbps(),
                     _opsTimeout, true, nicTo.getBroadcastType(), nicTo.getUuid(), nicTo.getDetails());
-        }
-        else {
+        } else {
             String vlanId = getVlanInfo(nicTo, vlanToken);
             String svlanId = null;
             boolean pvlannetwork = (getPvlanInfo(nicTo) == null) ? false : true;
@@ -3372,7 +3384,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     // return Ternary <switch name, switch tyep, vlan tagging>
     private Ternary<String, String, String> getTargetSwitch(NicTO nicTo) throws CloudException {
-        TrafficType[] supportedTrafficTypes = new TrafficType[] {TrafficType.Guest, TrafficType.Public, TrafficType.Control, TrafficType.Management, TrafficType.Storage};
+        TrafficType[] supportedTrafficTypes = new TrafficType[]{TrafficType.Guest, TrafficType.Public, TrafficType.Control, TrafficType.Management, TrafficType.Storage};
 
         TrafficType trafficType = nicTo.getType();
         if (!Arrays.asList(supportedTrafficTypes).contains(trafficType)) {
@@ -3471,7 +3483,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
         int templateRootPos = isoUrl.indexOf("template/tmpl");
         templateRootPos = (templateRootPos < 0 ? isoUrl.indexOf(ConfigDrive.CONFIGDRIVEDIR) : templateRootPos);
-        if (templateRootPos < 0 ) {
+        if (templateRootPos < 0) {
             throw new Exception("Invalid ISO path info");
         }
 
@@ -3653,7 +3665,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                             if (!(perfValue instanceof PerfEntityMetric)) {
                                 continue;
                             }
-                            final List<PerfMetricSeries> values = ((PerfEntityMetric)perfValue).getValue();
+                            final List<PerfMetricSeries> values = ((PerfEntityMetric) perfValue).getValue();
                             if (values == null || values.isEmpty()) {
                                 continue;
                             }
@@ -3661,7 +3673,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                                 if (!(value instanceof PerfMetricIntSeries) || !value.getId().getInstance().equals(diskBusName)) {
                                     continue;
                                 }
-                                final List<Long> perfStats = ((PerfMetricIntSeries)value).getValue();
+                                final List<Long> perfStats = ((PerfMetricIntSeries) value).getValue();
                                 if (perfStats.size() > 0) {
                                     long sum = 0;
                                     for (long val : perfStats) {
@@ -3711,7 +3723,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             DatacenterMO dcMo = new DatacenterMO(getServiceContext(), dcMor);
             HashMap<String, VolumeStatsEntry> statEntry = new HashMap<String, VolumeStatsEntry>();
 
-            for (String chainInfo : cmd.getVolumeUuids()){
+            for (String chainInfo : cmd.getVolumeUuids()) {
                 if (chainInfo != null) {
                     VirtualMachineDiskInfo infoInChain = _gson.fromJson(chainInfo, VirtualMachineDiskInfo.class);
                     if (infoInChain != null) {
@@ -3838,7 +3850,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             s_logger.info("Executing resource RebootRouterCommand: " + _gson.toJson(cmd));
         }
 
-        RebootAnswer answer = (RebootAnswer)execute((RebootCommand)cmd);
+        RebootAnswer answer = (RebootAnswer) execute((RebootCommand) cmd);
 
         if (answer.getResult()) {
             String connectResult = connect(cmd.getVmName(), cmd.getPrivateIpAddress());
@@ -4037,7 +4049,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 return new Answer(cmd, (Exception) e);
             }
             if (s_logger.isDebugEnabled()) {
-                s_logger.debug("problem" , e);
+                s_logger.debug("problem", e);
             }
             s_logger.error(e.getLocalizedMessage());
             return new Answer(cmd, false, "unknown problem: " + e.getLocalizedMessage());
@@ -4051,7 +4063,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // OfflineVmwareMigration: getVolumesFromCommand(cmd);
             Map<Integer, Long> volumeDeviceKey = getVolumesFromCommand(vmMo, cmd);
             if (s_logger.isTraceEnabled()) {
-                for (Integer diskId: volumeDeviceKey.keySet()) {
+                for (Integer diskId : volumeDeviceKey.keySet()) {
                     s_logger.trace(String.format("disk to migrate has disk id %d and volumeId %d", diskId, volumeDeviceKey.get(diskId)));
                 }
             }
@@ -4071,12 +4083,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         } catch (Exception e) {
             String msg = "change data store for VM " + vmMo.getVmName() + " failed";
             s_logger.error(msg + ": " + e.getLocalizedMessage());
-            throw new CloudRuntimeException(msg,e);
+            throw new CloudRuntimeException(msg, e);
         }
     }
 
     Answer createAnswerForCmd(VirtualMachineMO vmMo, String poolUuid, Command cmd, Map<Integer, Long> volumeDeviceKey) throws Exception {
-        List<VolumeObjectTO> volumeToList =  new ArrayList<>();
+        List<VolumeObjectTO> volumeToList = new ArrayList<>();
         VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();
         VirtualDisk[] disks = vmMo.getAllDiskDevice();
         Answer answer;
@@ -4099,7 +4111,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 newVol.setChainInfo(_gson.toJson(diskInfo));
                 volumeToList.add(newVol);
             }
-            return new MigrateVmToPoolAnswer((MigrateVmToPoolCommand)cmd, volumeToList);
+            return new MigrateVmToPoolAnswer((MigrateVmToPoolCommand) cmd, volumeToList);
         }
         return new Answer(cmd, false, null);
     }
@@ -4107,12 +4119,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     private Map<Integer, Long> getVolumesFromCommand(VirtualMachineMO vmMo, Command cmd) throws Exception {
         Map<Integer, Long> volumeDeviceKey = new HashMap<Integer, Long>();
         if (cmd instanceof MigrateVmToPoolCommand) {
-            MigrateVmToPoolCommand mcmd = (MigrateVmToPoolCommand)cmd;
+            MigrateVmToPoolCommand mcmd = (MigrateVmToPoolCommand) cmd;
             for (VolumeTO volume : mcmd.getVolumes()) {
                 addVolumeDiskmapping(vmMo, volumeDeviceKey, volume.getPath(), volume.getId());
             }
         } else if (cmd instanceof MigrateVolumeCommand) {
-            MigrateVolumeCommand mcmd = (MigrateVolumeCommand)cmd;
+            MigrateVolumeCommand mcmd = (MigrateVolumeCommand) cmd;
             addVolumeDiskmapping(vmMo, volumeDeviceKey, mcmd.getVolumePath(), mcmd.getVolumeId());
         }
         return volumeDeviceKey;
@@ -4134,7 +4146,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     private ManagedObjectReference getTargetDatastoreMOReference(String destinationPool, VmwareHypervisorHost hyperHost) {
         ManagedObjectReference morDs;
         try {
-            if(s_logger.isDebugEnabled()) {
+            if (s_logger.isDebugEnabled()) {
                 s_logger.debug(String.format("finding datastore %s", destinationPool));
             }
             morDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, destinationPool);
@@ -4262,7 +4274,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 throw new CloudRuntimeException(msg);
             }
             VmwareManager mgr = tgtHyperHost.getContext().getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
-            String srcHostApiVersion = ((HostMO)srcHyperHost).getHostAboutInfo().getApiVersion();
+            String srcHostApiVersion = ((HostMO) srcHyperHost).getHostAboutInfo().getApiVersion();
 
             // find VM through datacenter (VM is not at the target host yet)
             vmMo = srcHyperHost.findVmOnPeerHyperHost(vmName);
@@ -4449,7 +4461,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             String msg = "MigrationCommand failed due to " + VmwareHelper.getExceptionMessage(e);
             s_logger.warn(msg, e);
-            return new MigrateWithStorageAnswer(cmd, (Exception)e);
+            return new MigrateWithStorageAnswer(cmd, (Exception) e);
         } finally {
             // Cleanup datastores mounted on source host
             for (String mountedDatastore : mountedDatastoresAtSource) {
@@ -4482,15 +4494,15 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // we need to spawn a worker VM to attach the volume to and move it
             vmName = getWorkerName(getServiceContext(), cmd, 0);
 
-                // OfflineVmwareMigration: refactor for re-use
-                // OfflineVmwareMigration: 1. find data(store)
+            // OfflineVmwareMigration: refactor for re-use
+            // OfflineVmwareMigration: 1. find data(store)
             // OfflineVmwareMigration: more robust would be to find the store given the volume as it might have been moved out of band or due to error
 // example:            DatastoreMO existingVmDsMo = new DatastoreMO(dcMo.getContext(), dcMo.findDatastore(fileInDatastore.getDatastoreName()));
 
             morSourceDS = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, cmd.getSourcePool().getUuid());
             dsMo = new DatastoreMO(hyperHost.getContext(), morSourceDS);
             s_logger.info("Create worker VM " + vmName);
-                // OfflineVmwareMigration: 2. create the worker with access to the data(store)
+            // OfflineVmwareMigration: 2. create the worker with access to the data(store)
             vmMo = HypervisorHostHelper.createWorkerVM(hyperHost, dsMo, vmName);
             if (vmMo == null) {
                 // OfflineVmwareMigration: don't throw a general Exception but think of a specific one
@@ -4502,21 +4514,21 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 String vmdkFileName = path + VMDK_EXTENSION;
                 vmdkDataStorePath = VmwareStorageLayoutHelper.getLegacyDatastorePathFromVmdkFileName(dsMo, vmdkFileName);
                 if (!dsMo.fileExists(vmdkDataStorePath)) {
-                    if(s_logger.isDebugEnabled()) {
+                    if (s_logger.isDebugEnabled()) {
                         s_logger.debug(String.format("path not found (%s), trying under '%s'", vmdkFileName, path));
                     }
                     vmdkDataStorePath = VmwareStorageLayoutHelper.getVmwareDatastorePathFromVmdkFileName(dsMo, path, vmdkFileName);
                 }
                 if (!dsMo.fileExists(vmdkDataStorePath)) {
-                    if(s_logger.isDebugEnabled()) {
+                    if (s_logger.isDebugEnabled()) {
                         s_logger.debug(String.format("path not found (%s), trying under '%s'", vmdkFileName, vmName));
                     }
                     vmdkDataStorePath = VmwareStorageLayoutHelper.getVmwareDatastorePathFromVmdkFileName(dsMo, vmName, vmdkFileName);
                 }
-                if(s_logger.isDebugEnabled()) {
+                if (s_logger.isDebugEnabled()) {
                     s_logger.debug(String.format("attaching %s to %s for migration", vmdkDataStorePath, vmMo.getVmName()));
                 }
-                vmMo.attachDisk(new String[] { vmdkDataStorePath }, morSourceDS);
+                vmMo.attachDisk(new String[]{vmdkDataStorePath}, morSourceDS);
             }
 
             // OfflineVmwareMigration: 4. find the (worker-) VM
@@ -4532,7 +4544,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 VirtualDisk[] disks = vmMo.getAllDiskDevice();
                 String format = "disk %d is attached as %s";
                 for (VirtualDisk disk : disks) {
-                    s_logger.trace(String.format(format,disk.getKey(),vmMo.getVmdkFileBaseName(disk)));
+                    s_logger.trace(String.format(format, disk.getKey(), vmMo.getVmdkFileBaseName(disk)));
                 }
             }
 
@@ -4579,7 +4591,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             }
         }
         if (answer instanceof MigrateVolumeAnswer) {
-            String newPath = ((MigrateVolumeAnswer)answer).getVolumePath();
+            String newPath = ((MigrateVolumeAnswer) answer).getVolumePath();
             String vmdkFileName = newPath + VMDK_EXTENSION;
             try {
                 VmwareStorageLayoutHelper.syncVolumeToRootFolder(dsMo.getOwnerDatacenter().first(), dsMo, newPath, vmName);
@@ -4726,7 +4738,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
         VmwareManager mgr = dcMo.getContext().getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
 
-        List<ObjectContent> ocs = dcMo.getHostPropertiesOnDatacenterHostFolder(new String[] {"name", "parent"});
+        List<ObjectContent> ocs = dcMo.getHostPropertiesOnDatacenterHostFolder(new String[]{"name", "parent"});
         if (ocs != null && ocs.size() > 0) {
             for (ObjectContent oc : ocs) {
                 HostMO hostMo = new HostMO(dcMo.getContext(), oc.getObj());
@@ -4774,15 +4786,13 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
                     hostMOs.add(hostMO);
                 }
-            }
-            catch (Exception ex) {
+            } catch (Exception ex) {
                 s_logger.error(ex.getMessage(), ex);
 
                 throw new CloudRuntimeException(ex.getMessage(), ex);
             }
-        }
-        else {
-            hostMOs.add((HostMO)hyperHost);
+        } else {
+            hostMOs.add((HostMO) hyperHost);
         }
 
         handleTargets(cmd.getAdd(), cmd.getTargetTypeToRemove(), cmd.isRemoveAsync(), cmd.getTargets(), hostMOs);
@@ -4844,8 +4854,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         if (targets != null && targets.size() > 0) {
             try {
                 _storageProcessor.handleTargets(add, targetTypeToRemove, isRemoveAsync, targets, hosts);
-            }
-            catch (Exception ex) {
+            } catch (Exception ex) {
                 s_logger.warn(ex.getMessage());
             }
         }
@@ -5262,7 +5271,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 }
             }
 
-            Pair<String, Integer> portInfo = vmMo.getVncPort(mgr.getManagementPortGroupByHost((HostMO)hyperHost));
+            Pair<String, Integer> portInfo = vmMo.getVncPort(mgr.getManagementPortGroupByHost((HostMO) hyperHost));
 
             if (s_logger.isTraceEnabled()) {
                 s_logger.trace("Found vnc port info. vm: " + cmd.getName() + " host: " + portInfo.first() + ", vnc port: " + portInfo.second());
@@ -5317,7 +5326,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             VmwareHypervisorHost hyperHost = getHyperHost(context);
 
             try {
-                HostMO hostMo = (HostMO)hyperHost;
+                HostMO hostMo = (HostMO) hyperHost;
                 ClusterMO clusterMo = new ClusterMO(context, hostMo.getHyperHostCluster());
                 VmwareManager mgr = context.getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
 
@@ -5419,7 +5428,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         try {
             VmwareContext context = getServiceContext();
             VmwareManager mgr = context.getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
-            return (PrimaryStorageDownloadAnswer)mgr.getStorageManager().execute(this, cmd);
+            return (PrimaryStorageDownloadAnswer) mgr.getStorageManager().execute(this, cmd);
         } catch (Throwable e) {
             if (e instanceof RemoteException) {
                 s_logger.warn("Encounter remote exception to vCenter, invalidate VMware session context");
@@ -5512,7 +5521,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
             // Get a list of all the hosts in this cluster
             @SuppressWarnings("unchecked")
-            List<ManagedObjectReference> hosts = (List<ManagedObjectReference>)context.getVimClient().getDynamicProperty(clusterMO, "host");
+            List<ManagedObjectReference> hosts = (List<ManagedObjectReference>) context.getVimClient().getDynamicProperty(clusterMO, "host");
             if (hosts == null) {
                 return new Answer(cmd, false, "No hosts in cluster, which is pretty weird");
             }
@@ -5557,7 +5566,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         try {
             VmwareContext context = getServiceContext();
             VmwareManager mgr = context.getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
-            return (CopyVolumeAnswer)mgr.getStorageManager().execute(this, cmd);
+            return (CopyVolumeAnswer) mgr.getStorageManager().execute(this, cmd);
         } catch (Throwable e) {
             if (e instanceof RemoteException) {
                 s_logger.warn("Encounter remote exception to vCenter, invalidate VMware session context");
@@ -5611,13 +5620,13 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
                 s_logger.info("Scan hung worker VM to recycle");
 
-                int workerKey = ((HostMO)hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_WORKER);
-                int workerTagKey = ((HostMO)hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_WORKER_TAG);
+                int workerKey = ((HostMO) hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_WORKER);
+                int workerTagKey = ((HostMO) hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_WORKER_TAG);
                 String workerPropName = String.format("value[%d]", workerKey);
                 String workerTagPropName = String.format("value[%d]", workerTagKey);
 
                 // GC worker that has been running for too long
-                ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[] {"name", "config.template", workerPropName, workerTagPropName,});
+                ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[]{"name", "config.template", workerPropName, workerTagPropName,});
                 if (ocs != null) {
                     for (ObjectContent oc : ocs) {
                         List<DynamicProperty> props = oc.getPropSet();
@@ -5628,13 +5637,13 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
                             for (DynamicProperty prop : props) {
                                 if (prop.getName().equals("config.template")) {
-                                    template = (Boolean)prop.getVal();
+                                    template = (Boolean) prop.getVal();
                                 } else if (prop.getName().equals(workerPropName)) {
-                                    CustomFieldStringValue val = (CustomFieldStringValue)prop.getVal();
+                                    CustomFieldStringValue val = (CustomFieldStringValue) prop.getVal();
                                     if (val != null && val.getValue() != null && val.getValue().equalsIgnoreCase("true"))
                                         isWorker = true;
                                 } else if (prop.getName().equals(workerTagPropName)) {
-                                    CustomFieldStringValue val = (CustomFieldStringValue)prop.getVal();
+                                    CustomFieldStringValue val = (CustomFieldStringValue) prop.getVal();
                                     workerTag = val.getValue();
                                 }
                             }
@@ -5680,14 +5689,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             try {
                 VmwareHypervisorHost hyperHost = getHyperHost(context);
                 assert (hyperHost instanceof HostMO);
-                if (!((HostMO)hyperHost).isHyperHostConnected()) {
+                if (!((HostMO) hyperHost).isHyperHostConnected()) {
                     s_logger.info("Host " + hyperHost.getHyperHostName() + " is not in connected state");
                     return null;
                 }
 
-                ((HostMO)hyperHost).enableVncOnHostFirewall();
+                ((HostMO) hyperHost).enableVncOnHostFirewall();
 
-                AboutInfo aboutInfo = ((HostMO)hyperHost).getHostAboutInfo();
+                AboutInfo aboutInfo = ((HostMO) hyperHost).getHostAboutInfo();
                 hostApiVersion = aboutInfo.getApiVersion();
 
             } catch (Exception e) {
@@ -5723,7 +5732,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         try {
             VmwareHypervisorHost hyperHost = getHyperHost(context);
             if (hyperHost instanceof HostMO) {
-                HostMO hostMo = (HostMO)hyperHost;
+                HostMO hostMo = (HostMO) hyperHost;
 
                 List<Pair<ManagedObjectReference, String>> dsList = hostMo.getLocalDatastoreOnHost();
                 for (Pair<ManagedObjectReference, String> dsPair : dsList) {
@@ -5804,15 +5813,15 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             VmwareHypervisorHost hyperHost = getHyperHost(getServiceContext());
 
             if (hyperHost instanceof HostMO) {
-                HostMO host = (HostMO)hyperHost;
+                HostMO host = (HostMO) hyperHost;
                 HostStorageSystemMO hostStorageSystem = host.getHostStorageSystemMO();
 
                 for (HostHostBusAdapter hba : hostStorageSystem.getStorageDeviceInfo().getHostBusAdapter()) {
                     if (hba instanceof HostInternetScsiHba) {
-                        HostInternetScsiHba hostInternetScsiHba = (HostInternetScsiHba)hba;
+                        HostInternetScsiHba hostInternetScsiHba = (HostInternetScsiHba) hba;
 
                         if (hostInternetScsiHba.isIsSoftwareBased()) {
-                            return ((HostInternetScsiHba)hba).getIScsiName();
+                            return ((HostInternetScsiHba) hba).getIScsiName();
                         }
                     }
                 }
@@ -5837,7 +5846,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         cmd.setDom0MinMemory(0);
         cmd.setSpeed(summary.getCpuSpeed());
         cmd.setCpuSockets(summary.getCpuSockets());
-        cmd.setCpus((int)summary.getCpuCount());
+        cmd.setCpus((int) summary.getCpuCount());
         cmd.setMemory(summary.getMemoryBytes());
     }
 
@@ -5849,7 +5858,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             assert (hyperHost instanceof HostMO);
             VmwareManager mgr = hyperHost.getContext().getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
 
-            VmwareHypervisorHostNetworkSummary summary = hyperHost.getHyperHostNetworkSummary(mgr.getManagementPortGroupByHost((HostMO)hyperHost));
+            VmwareHypervisorHostNetworkSummary summary = hyperHost.getHyperHostNetworkSummary(mgr.getManagementPortGroupByHost((HostMO) hyperHost));
             if (summary == null) {
                 throw new Exception("No ESX(i) host found");
             }
@@ -5994,7 +6003,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     private HashMap<String, HostVmStateReportEntry> getHostVmStateReport() throws Exception {
         VmwareHypervisorHost hyperHost = getHyperHost(getServiceContext());
 
-        int key = ((HostMO)hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_VM_INTERNAL_NAME);
+        int key = ((HostMO) hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_VM_INTERNAL_NAME);
         if (key == 0) {
             s_logger.warn("Custom field " + CustomFieldConstants.CLOUD_VM_INTERNAL_NAME + " is not registered ?!");
         }
@@ -6002,7 +6011,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
         // CLOUD_VM_INTERNAL_NAME stores the internal CS generated vm name. This was earlier stored in name. Now, name can be either the hostname or
         // the internal CS name, but the custom field CLOUD_VM_INTERNAL_NAME always stores the internal CS name.
-        ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[] {"name", "runtime.powerState", "config.template", instanceNameCustomField});
+        ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[]{"name", "runtime.powerState", "config.template", instanceNameCustomField});
 
         HashMap<String, HostVmStateReportEntry> newStates = new HashMap<String, HostVmStateReportEntry>();
         if (ocs != null && ocs.length > 0) {
@@ -6020,12 +6029,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                                 isTemplate = true;
                             }
                         } else if (objProp.getName().equals("runtime.powerState")) {
-                            powerState = (VirtualMachinePowerState)objProp.getVal();
+                            powerState = (VirtualMachinePowerState) objProp.getVal();
                         } else if (objProp.getName().equals("name")) {
-                            name = (String)objProp.getVal();
+                            name = (String) objProp.getVal();
                         } else if (objProp.getName().contains(instanceNameCustomField)) {
                             if (objProp.getVal() != null)
-                                VMInternalCSName = ((CustomFieldStringValue)objProp.getVal()).getValue();
+                                VMInternalCSName = ((CustomFieldStringValue) objProp.getVal()).getValue();
                         } else {
                             assert (false);
                         }
@@ -6046,7 +6055,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     private HashMap<String, PowerState> getVmStates() throws Exception {
         VmwareHypervisorHost hyperHost = getHyperHost(getServiceContext());
 
-        int key = ((HostMO)hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_VM_INTERNAL_NAME);
+        int key = ((HostMO) hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_VM_INTERNAL_NAME);
         if (key == 0) {
             s_logger.warn("Custom field " + CustomFieldConstants.CLOUD_VM_INTERNAL_NAME + " is not registered ?!");
         }
@@ -6054,7 +6063,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
         // CLOUD_VM_INTERNAL_NAME stores the internal CS generated vm name. This was earlier stored in name. Now, name can be either the hostname or
         // the internal CS name, but the custom field CLOUD_VM_INTERNAL_NAME always stores the internal CS name.
-        ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[] {"name", "runtime.powerState", "config.template", instanceNameCustomField});
+        ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[]{"name", "runtime.powerState", "config.template", instanceNameCustomField});
 
         HashMap<String, PowerState> newStates = new HashMap<String, PowerState>();
         if (ocs != null && ocs.length > 0) {
@@ -6072,12 +6081,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                                 isTemplate = true;
                             }
                         } else if (objProp.getName().equals("runtime.powerState")) {
-                            powerState = (VirtualMachinePowerState)objProp.getVal();
+                            powerState = (VirtualMachinePowerState) objProp.getVal();
                         } else if (objProp.getName().equals("name")) {
-                            name = (String)objProp.getVal();
+                            name = (String) objProp.getVal();
                         } else if (objProp.getName().contains(instanceNameCustomField)) {
                             if (objProp.getVal() != null)
-                                VMInternalCSName = ((CustomFieldStringValue)objProp.getVal()).getValue();
+                                VMInternalCSName = ((CustomFieldStringValue) objProp.getVal()).getValue();
                         } else {
                             assert (false);
                         }
@@ -6138,7 +6147,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             }
         }
 
-        int key = ((HostMO)hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_VM_INTERNAL_NAME);
+        int key = ((HostMO) hyperHost).getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_VM_INTERNAL_NAME);
         if (key == 0) {
             s_logger.warn("Custom field " + CustomFieldConstants.CLOUD_VM_INTERNAL_NAME + " is not registered ?!");
         }
@@ -6151,8 +6160,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         final String memMbStr = "config.hardware.memoryMB";
         final String allocatedCpuStr = "summary.runtime.maxCpuUsage";
 
-        ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[] {
-                "name", numCpuStr, cpuUseStr, guestMemUseStr, memLimitStr, memMbStr,allocatedCpuStr, instanceNameCustomField
+        ObjectContent[] ocs = hyperHost.getVmPropertiesOnHyperHost(new String[]{
+                "name", numCpuStr, cpuUseStr, guestMemUseStr, memLimitStr, memMbStr, allocatedCpuStr, instanceNameCustomField
         });
 
         if (ocs != null && ocs.length > 0) {
@@ -6173,7 +6182,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                             vmNameOnVcenter = objProp.getVal().toString();
                         } else if (objProp.getName().contains(instanceNameCustomField)) {
                             if (objProp.getVal() != null)
-                                vmInternalCSName = ((CustomFieldStringValue)objProp.getVal()).getValue();
+                                vmInternalCSName = ((CustomFieldStringValue) objProp.getVal()).getValue();
                         } else if (objProp.getName().equals(guestMemUseStr)) {
                             guestMemusage = objProp.getVal().toString();
                         } else if (objProp.getName().equals(numCpuStr)) {
@@ -6184,12 +6193,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                             memlimit = objProp.getVal().toString();
                         } else if (objProp.getName().equals(memMbStr)) {
                             memkb = objProp.getVal().toString();
-                        } else if (objProp.getName().equals(allocatedCpuStr)){
-                            allocatedCpu  = NumberUtils.toDouble(objProp.getVal().toString());
+                        } else if (objProp.getName().equals(allocatedCpuStr)) {
+                            allocatedCpu = NumberUtils.toDouble(objProp.getVal().toString());
                         }
                     }
 
-                    maxCpuUsage = (maxCpuUsage/allocatedCpu)*100;
+                    maxCpuUsage = (maxCpuUsage / allocatedCpu) * 100;
                     if (vmInternalCSName != null) {
                         name = vmInternalCSName;
                     } else {
@@ -6276,7 +6285,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                         }
                     }
 
-                    final VmStatsEntry vmStats = new VmStatsEntry( NumberUtils.toDouble(memkb)*1024,NumberUtils.toDouble(guestMemusage)*1024,NumberUtils.toDouble(memlimit)*1024,
+                    final VmStatsEntry vmStats = new VmStatsEntry(NumberUtils.toDouble(memkb) * 1024, NumberUtils.toDouble(guestMemusage) * 1024, NumberUtils.toDouble(memlimit) * 1024,
                             maxCpuUsage, networkReadKBs, networkWriteKBs, NumberUtils.toInt(numberCPUs), "vm");
                     vmStats.setDiskReadIOs(diskReadIops);
                     vmStats.setDiskWriteIOs(diskWriteIops);
@@ -6401,7 +6410,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         HostStatsEntry entry = new HostStatsEntry();
 
         entry.setEntityType("host");
-        double cpuUtilization = ((double)(hardwareSummary.getTotalCpu() - hardwareSummary.getEffectiveCpu()) / (double)hardwareSummary.getTotalCpu() * 100);
+        double cpuUtilization = ((double) (hardwareSummary.getTotalCpu() - hardwareSummary.getEffectiveCpu()) / (double) hardwareSummary.getTotalCpu() * 100);
         entry.setCpuUtilization(cpuUtilization);
         entry.setTotalMemoryKBs(hardwareSummary.getTotalMemory() / 1024);
         entry.setFreeMemoryKBs(hardwareSummary.getEffectiveMemory() * 1024);
@@ -6435,14 +6444,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         try {
             _name = name;
 
-            _url = (String)params.get("url");
-            _username = (String)params.get("username");
-            _password = (String)params.get("password");
-            _dcId = (String)params.get("zone");
-            _pod = (String)params.get("pod");
-            _cluster = (String)params.get("cluster");
+            _url = (String) params.get("url");
+            _username = (String) params.get("username");
+            _password = (String) params.get("password");
+            _dcId = (String) params.get("zone");
+            _pod = (String) params.get("pod");
+            _cluster = (String) params.get("cluster");
 
-            _guid = (String)params.get("guid");
+            _guid = (String) params.get("guid");
             String[] tokens = _guid.split("@");
             _vCenterAddress = tokens[1];
             _morHyperHost = new ManagedObjectReference();
@@ -6450,8 +6459,8 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             _morHyperHost.setType(hostTokens[0]);
             _morHyperHost.setValue(hostTokens[1]);
 
-            _guestTrafficInfo = (VmwareTrafficLabel)params.get("guestTrafficInfo");
-            _publicTrafficInfo = (VmwareTrafficLabel)params.get("publicTrafficInfo");
+            _guestTrafficInfo = (VmwareTrafficLabel) params.get("guestTrafficInfo");
+            _publicTrafficInfo = (VmwareTrafficLabel) params.get("publicTrafficInfo");
             VmwareContext context = getServiceContext();
             VmwareManager mgr = context.getStockObject(VmwareManager.CONTEXT_STOCK_NAME);
             if (mgr == null) {
@@ -6482,14 +6491,14 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             }
 
             if (_privateNetworkVSwitchName == null) {
-                _privateNetworkVSwitchName = (String)params.get("private.network.vswitch.name");
+                _privateNetworkVSwitchName = (String) params.get("private.network.vswitch.name");
             }
 
-            String value = (String)params.get("vmware.recycle.hung.wokervm");
+            String value = (String) params.get("vmware.recycle.hung.wokervm");
             if (value != null && value.equalsIgnoreCase("true"))
                 _recycleHungWorker = true;
 
-            value = (String)params.get("vmware.root.disk.controller");
+            value = (String) params.get("vmware.root.disk.controller");
             if (value != null && value.equalsIgnoreCase("scsi"))
                 _rootDiskController = DiskControllerType.scsi;
             else if (value != null && value.equalsIgnoreCase("ide"))
@@ -6497,7 +6506,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             else
                 _rootDiskController = DiskControllerType.osdefault;
 
-            Integer intObj = (Integer)params.get("ports.per.dvportgroup");
+            Integer intObj = (Integer) params.get("ports.per.dvportgroup");
             if (intObj != null)
                 _portsPerDvPortGroup = intObj.intValue();
 
@@ -6505,25 +6514,25 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                     + _publicTrafficInfo.getVirtualSwitchType() + " : " + _publicTrafficInfo.getVirtualSwitchName() + ", guest traffic over "
                     + _guestTrafficInfo.getVirtualSwitchType() + " : " + _guestTrafficInfo.getVirtualSwitchName());
 
-            Boolean boolObj = (Boolean)params.get("vmware.create.full.clone");
+            Boolean boolObj = (Boolean) params.get("vmware.create.full.clone");
             if (boolObj != null && boolObj.booleanValue()) {
                 _fullCloneFlag = true;
             } else {
                 _fullCloneFlag = false;
             }
 
-            boolObj = (Boolean)params.get("vm.instancename.flag");
+            boolObj = (Boolean) params.get("vm.instancename.flag");
             if (boolObj != null && boolObj.booleanValue()) {
                 _instanceNameFlag = true;
             } else {
                 _instanceNameFlag = false;
             }
 
-            value = (String)params.get("scripts.timeout");
+            value = (String) params.get("scripts.timeout");
             int timeout = NumbersUtil.parseInt(value, 1440) * 1000;
 
             storageNfsVersion = NfsSecondaryStorageResource.retrieveNfsVersionFromParams(params);
-            _storageProcessor = new VmwareStorageProcessor((VmwareHostService)this, _fullCloneFlag, (VmwareStorageMount)mgr, timeout, this, _shutdownWaitMs, null,
+            _storageProcessor = new VmwareStorageProcessor((VmwareHostService) this, _fullCloneFlag, (VmwareStorageMount) mgr, timeout, this, _shutdownWaitMs, null,
                     storageNfsVersion);
             storageHandler = new VmwareStorageSubsystemCommandHandler(_storageProcessor, storageNfsVersion);
 
@@ -6717,11 +6726,12 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
     /**
      * Use data center to look for vm, instead of randomly picking up a cluster<br/>
      * (in multiple cluster environments vm could not be found if wrong cluster was chosen)
-     * @param context vmware context
+     *
+     * @param context   vmware context
      * @param hyperHost vmware hv host
-     * @param vol volume
+     * @param vol       volume
      * @return a virtualmachinemo if could be found on datacenter.
-     * @throws Exception if there is an error while finding vm
+     * @throws Exception             if there is an error while finding vm
      * @throws CloudRuntimeException if datacenter cannot be found
      */
     protected VirtualMachineMO findVmOnDatacenter(VmwareContext context, VmwareHypervisorHost hyperHost, VolumeTO vol) throws Exception {
@@ -6738,7 +6748,7 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
         String vmdkAbsFile = null;
         VirtualDeviceBackingInfo backingInfo = disk.getBacking();
         if (backingInfo instanceof VirtualDiskFlatVer2BackingInfo) {
-            VirtualDiskFlatVer2BackingInfo diskBackingInfo = (VirtualDiskFlatVer2BackingInfo)backingInfo;
+            VirtualDiskFlatVer2BackingInfo diskBackingInfo = (VirtualDiskFlatVer2BackingInfo) backingInfo;
             vmdkAbsFile = diskBackingInfo.getFileName();
         }
         return vmdkAbsFile;
@@ -6776,5 +6786,221 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             s_logger.error("Unable to locate id_rsa.cloud in your setup at " + keyFile.toString());
         }
         return keyFile;
+    }
+
+    private List<UnmanagedInstance.Disk> getUnmanageInstanceDisks(VirtualMachineMO vmMo) {
+        List<UnmanagedInstance.Disk> instanceDisks = new ArrayList<>();
+        VirtualDisk[] disks = null;
+        try {
+            disks = vmMo.getAllDiskDevice();
+        } catch (Exception e) {
+            s_logger.info("Unable to retrieve unmanaged instance disks! " + e.getMessage());
+        }
+        if (disks != null) {
+            for (VirtualDevice diskDevice : disks) {
+                try {
+                    if (diskDevice instanceof VirtualDisk) {
+                        UnmanagedInstance.Disk instanceDisk = new UnmanagedInstance.Disk();
+                        VirtualDisk disk = (VirtualDisk) diskDevice;
+                        instanceDisk.setDiskId(disk.getDiskObjectId());
+                        instanceDisk.setLabel(disk.getDeviceInfo() != null ? disk.getDeviceInfo().getLabel() : "");
+                        instanceDisk.setImagePath(getAbsoluteVmdkFile(disk));
+                        instanceDisk.setCapacity(disk.getCapacityInKB());
+                        for (VirtualDevice device : vmMo.getAllDeviceList()) {
+                            if (diskDevice.getControllerKey() == device.getKey()) {
+                                if (device instanceof VirtualIDEController) {
+                                    instanceDisk.setController(DiskControllerType.getType(device.getClass().getSimpleName()).toString());
+                                    instanceDisk.setControllerUnit(((VirtualIDEController) device).getBusNumber());
+                                } else if (device instanceof VirtualSCSIController) {
+                                    instanceDisk.setController("scsi");
+                                    instanceDisk.setControllerUnit(((VirtualSCSIController) device).getBusNumber());
+                                } else {
+                                    instanceDisk.setController(DiskControllerType.none.toString());
+                                }
+                                instanceDisk.setPosition(diskDevice.getUnitNumber());
+                                break;
+                            }
+                        }
+                        s_logger.info(vmMo.getName() + " " + disk.getDeviceInfo().getLabel() + " " + disk.getDeviceInfo().getSummary() + " " + disk.getDiskObjectId() + " " + disk.getCapacityInKB() + " " + instanceDisk.getController());
+                        instanceDisks.add(instanceDisk);
+                    }
+                } catch (Exception e) {
+                    s_logger.info("Unable to retrieve unmanaged instance disk info! " + e.getMessage());
+                }
+            }
+            Collections.sort(instanceDisks, new Comparator<UnmanagedInstance.Disk>() {
+                @Override
+                public int compare(final UnmanagedInstance.Disk disk1, final UnmanagedInstance.Disk disk2) {
+                    return extractInt(disk1) - extractInt(disk2);
+                }
+
+                int extractInt(UnmanagedInstance.Disk disk) {
+                    String num = disk.getLabel().replaceAll("\\D", "");
+                    // return 0 if no digits found
+                    return num.isEmpty() ? 0 : Integer.parseInt(num);
+                }
+            });
+        }
+        return instanceDisks;
+    }
+
+    private List<UnmanagedInstance.Nic> getUnmanageInstanceNics(VmwareHypervisorHost hyperHost, VirtualMachineMO vmMo) {
+        List<UnmanagedInstance.Nic> instanceNics = new ArrayList<>();
+        boolean guestInfoAvailable = false;
+
+        HashMap<String, String> guestNicMacIPAddressMap = new HashMap<>();
+        try {
+            GuestInfo guestInfo = vmMo.getGuestInfo();
+            VirtualMachineToolsStatus toolsStatus = guestInfo.getToolsStatus();
+            if (toolsStatus == VirtualMachineToolsStatus.TOOLS_NOT_INSTALLED) {
+                for (GuestNicInfo nicInfo: guestInfo.getNet()) {
+                    if (!nicInfo.getIpAddress().isEmpty()) {
+                        guestNicMacIPAddressMap.put(nicInfo.getMacAddress(), nicInfo.getIpAddress().get(0));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            s_logger.info("Unable to retrieve guest nics for instance VM tools! " + e.getMessage());
+        }
+        VirtualDevice[] nics = null;
+        try {
+            nics = vmMo.getNicDevices();
+        } catch (Exception e) {
+            s_logger.info("Unable to retrieve unmanaged instance nics! " + e.getMessage());
+        }
+        if (nics != null) {
+            for (VirtualDevice nic : nics) {
+                try {
+                    VirtualEthernetCard ethCardDevice = (VirtualEthernetCard) nic;
+                    s_logger.error(nic.getClass().getCanonicalName() + " " + nic.getBacking().getClass().getCanonicalName() + " " + ethCardDevice.getMacAddress());
+                    UnmanagedInstance.Nic instanceNic = new UnmanagedInstance.Nic();
+                    instanceNic.setNicId(ethCardDevice.getDeviceInfo().getLabel());
+                    instanceNic.setAdapterType(nic.getClass().getSimpleName());
+                    instanceNic.setMacAddress(ethCardDevice.getMacAddress());
+                    instanceNic.setIpAddress(guestNicMacIPAddressMap.get(instanceNic.getMacAddress()));
+                    if (ethCardDevice.getSlotInfo() != null) {
+                        instanceNic.setPciSlot(ethCardDevice.getSlotInfo().toString());
+                    }
+                    VirtualDeviceBackingInfo backing = ethCardDevice.getBacking();
+                    if (backing instanceof VirtualEthernetCardDistributedVirtualPortBackingInfo) {
+                        VirtualEthernetCardDistributedVirtualPortBackingInfo backingInfo = (VirtualEthernetCardDistributedVirtualPortBackingInfo) backing;
+                        DistributedVirtualSwitchPortConnection port = backingInfo.getPort();
+                        String portKey = port.getPortKey();
+                        String portGroupKey = port.getPortgroupKey();
+                        String dvSwitchUuid = port.getSwitchUuid();
+
+                        s_logger.debug("NIC " + nic.toString() + " is connected to dvSwitch " + dvSwitchUuid + " pg " + portGroupKey + " port " + portKey);
+
+                        ManagedObjectReference dvSwitchManager = vmMo.getContext().getVimClient().getServiceContent().getDvSwitchManager();
+                        ManagedObjectReference dvSwitch = vmMo.getContext().getVimClient().getService().queryDvsByUuid(dvSwitchManager, dvSwitchUuid);
+
+                        // Get all ports
+                        DistributedVirtualSwitchPortCriteria criteria = new DistributedVirtualSwitchPortCriteria();
+                        criteria.setInside(true);
+                        criteria.getPortgroupKey().add(portGroupKey);
+                        List<DistributedVirtualPort> dvPorts = vmMo.getContext().getVimClient().getService().fetchDVPorts(dvSwitch, criteria);
+
+                        for (DistributedVirtualPort dvPort : dvPorts) {
+                            // Find the port for this NIC by portkey
+                            if (portKey.equals(dvPort.getKey())) {
+                                VMwareDVSPortSetting settings = (VMwareDVSPortSetting) dvPort.getConfig().getSetting();
+                                VmwareDistributedVirtualSwitchVlanIdSpec vlanId = (VmwareDistributedVirtualSwitchVlanIdSpec) settings.getVlan();
+                                s_logger.trace("Found port " + dvPort.getKey() + " with vlan " + vlanId.getVlanId());
+                                if (vlanId.getVlanId() > 0 && vlanId.getVlanId() < 4095) {
+                                    instanceNic.setVlan(vlanId.getVlanId());
+                                }
+                                break;
+                            }
+                        }
+                    } else if (backing instanceof VirtualEthernetCardNetworkBackingInfo) {
+                        VirtualEthernetCardNetworkBackingInfo backingInfo = (VirtualEthernetCardNetworkBackingInfo) backing;
+                        instanceNic.setNetwork(backingInfo.getDeviceName());
+                        ManagedObjectReference mor = backingInfo.getNetwork();
+                        if (hyperHost instanceof HostMO) {
+                            HostMO hostMo = (HostMO) hyperHost;
+                            HostPortGroupSpec portGroupSpec = hostMo.getHostPortGroupSpec(backingInfo.getDeviceName());
+                            instanceNic.setVlan(portGroupSpec.getVlanId());
+                        }
+                    }
+                    instanceNics.add(instanceNic);
+                } catch (Exception e) {
+                    s_logger.info("Unable to retrieve unmanaged instance nic info! " + e.getMessage());
+                }
+            }
+            Collections.sort(instanceNics, new Comparator<UnmanagedInstance.Nic>() {
+                @Override
+                public int compare(final UnmanagedInstance.Nic nic1, final UnmanagedInstance.Nic nic2) {
+                    return extractInt(nic1) - extractInt(nic2);
+                }
+
+                int extractInt(UnmanagedInstance.Nic nic) {
+                    String num = nic.getNicId().replaceAll("\\D", "");
+                    // return 0 if no digits found
+                    return num.isEmpty() ? 0 : Integer.parseInt(num);
+                }
+            });
+        }
+        return  instanceNics;
+    }
+
+    private UnmanagedInstance getUnmanagedInstance(VmwareHypervisorHost hyperHost, VirtualMachineMO vmMo) {
+        UnmanagedInstance instance = null;
+        try {
+            instance = new UnmanagedInstance();
+            instance.setName(vmMo.getVmName());
+            instance.setCpuCores(vmMo.getConfigSummary().getNumCpu());
+            instance.setCpuCoresPerSocket(vmMo.getCoresPerSocket());
+            instance.setCpuSpeed(vmMo.getConfigSummary().getCpuReservation());
+            instance.setMemory(vmMo.getConfigSummary().getMemorySizeMB());
+            instance.setOperatingSystem(vmMo.getVmGuestInfo().getGuestFullName());
+            if (Strings.isNullOrEmpty(instance.getOperatingSystem())) {
+                instance.setOperatingSystem(vmMo.getConfigSummary().getGuestFullName());
+            }
+            instance.setPowerState(vmMo.getPowerState().toString());
+            instance.setDisks(getUnmanageInstanceDisks(vmMo));
+            instance.setNics(getUnmanageInstanceNics(hyperHost, vmMo));
+        } catch (Exception e) {
+            s_logger.info("Unable to retrieve unmanaged instance info! " + e.getMessage());
+        }
+
+        return  instance;
+    }
+
+    private Answer execute(GetUnmanagedInstancesCommand cmd) {
+        if (s_logger.isInfoEnabled()) {
+            s_logger.info("Executing resource GetUnmanagedInstancesCommand " + _gson.toJson(cmd));
+        }
+
+        VmwareContext context = getServiceContext();
+        HashMap<String, UnmanagedInstance> unmanagedInstances = new HashMap<>();
+        try {
+            VmwareHypervisorHost hyperHost = getHyperHost(context);
+
+            String vmName = cmd.getInstanceName();
+            List<VirtualMachineMO> vmMos = hyperHost.listVmsOnHyperHost(vmName);
+
+            if (vmMos != null && !vmMos.isEmpty()) {
+                for (VirtualMachineMO vmMo : vmMos) {
+                    if (vmMo != null && !vmMo.isTemplate()) {
+                        // Filter managed instances
+                        if (cmd.hasManagedInstance(vmMo.getName())) {
+                            continue;
+                        }
+                        // Filter instance if answer is requested for a particular instance name
+                        if (!Strings.isNullOrEmpty(cmd.getInstanceName()) &&
+                                        cmd.getInstanceName().equals(vmMo.getVmName())) {
+                            continue;
+                        }
+                        UnmanagedInstance instance = getUnmanagedInstance(hyperHost, vmMo);
+                        if (instance != null) {
+                            unmanagedInstances.put(instance.getName(), instance);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            s_logger.info("GetUnmanagedInstancesCommand failed due to " + VmwareHelper.getExceptionMessage(e));
+        }
+        return new GetUnmanagedInstancesAnswer(cmd, "", unmanagedInstances);
     }
 }

--- a/plugins/hypervisors/xenserver/pom.xml
+++ b/plugins/hypervisors/xenserver/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/integrations/cloudian/pom.xml
+++ b/plugins/integrations/cloudian/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/integrations/prometheus/pom.xml
+++ b/plugins/integrations/prometheus/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/metrics/pom.xml
+++ b/plugins/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/network-elements/bigswitch/pom.xml
+++ b/plugins/network-elements/bigswitch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/network-elements/brocade-vcs/pom.xml
+++ b/plugins/network-elements/brocade-vcs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <build>

--- a/plugins/network-elements/cisco-vnmc/pom.xml
+++ b/plugins/network-elements/cisco-vnmc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/network-elements/dns-notifier/pom.xml
+++ b/plugins/network-elements/dns-notifier/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>cloud-plugin-example-dns-notifier</artifactId>

--- a/plugins/network-elements/elastic-loadbalancer/pom.xml
+++ b/plugins/network-elements/elastic-loadbalancer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/network-elements/f5/pom.xml
+++ b/plugins/network-elements/f5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/network-elements/globodns/pom.xml
+++ b/plugins/network-elements/globodns/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/network-elements/internal-loadbalancer/pom.xml
+++ b/plugins/network-elements/internal-loadbalancer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/network-elements/juniper-contrail/pom.xml
+++ b/plugins/network-elements/juniper-contrail/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <repositories>

--- a/plugins/network-elements/juniper-srx/pom.xml
+++ b/plugins/network-elements/juniper-srx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/network-elements/netscaler/pom.xml
+++ b/plugins/network-elements/netscaler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/network-elements/nicira-nvp/pom.xml
+++ b/plugins/network-elements/nicira-nvp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/network-elements/opendaylight/pom.xml
+++ b/plugins/network-elements/opendaylight/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <profiles>

--- a/plugins/network-elements/ovs/pom.xml
+++ b/plugins/network-elements/ovs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/network-elements/palo-alto/pom.xml
+++ b/plugins/network-elements/palo-alto/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/network-elements/stratosphere-ssp/pom.xml
+++ b/plugins/network-elements/stratosphere-ssp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/network-elements/vxlan/pom.xml
+++ b/plugins/network-elements/vxlan/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/outofbandmanagement-drivers/ipmitool/pom.xml
+++ b/plugins/outofbandmanagement-drivers/ipmitool/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/outofbandmanagement-drivers/nested-cloudstack/pom.xml
+++ b/plugins/outofbandmanagement-drivers/nested-cloudstack/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <build>
         <plugins>

--- a/plugins/storage-allocators/random/pom.xml
+++ b/plugins/storage-allocators/random/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/image/default/pom.xml
+++ b/plugins/storage/image/default/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/image/s3/pom.xml
+++ b/plugins/storage/image/s3/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/image/sample/pom.xml
+++ b/plugins/storage/image/sample/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/image/swift/pom.xml
+++ b/plugins/storage/image/swift/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/volume/cloudbyte/pom.xml
+++ b/plugins/storage/volume/cloudbyte/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/volume/datera/pom.xml
+++ b/plugins/storage/volume/datera/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack-plugins</artifactId>
-    <version>4.13.0.0-SNAPSHOT</version>
+    <version>4.13.0.0</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <dependencies>

--- a/plugins/storage/volume/default/pom.xml
+++ b/plugins/storage/volume/default/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/volume/nexenta/pom.xml
+++ b/plugins/storage/volume/nexenta/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/volume/sample/pom.xml
+++ b/plugins/storage/volume/sample/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/storage/volume/solidfire/pom.xml
+++ b/plugins/storage/volume/solidfire/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <build>

--- a/plugins/user-authenticators/md5/pom.xml
+++ b/plugins/user-authenticators/md5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/user-authenticators/pbkdf2/pom.xml
+++ b/plugins/user-authenticators/pbkdf2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/user-authenticators/plain-text/pom.xml
+++ b/plugins/user-authenticators/plain-text/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/plugins/user-authenticators/saml2/pom.xml
+++ b/plugins/user-authenticators/saml2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/plugins/user-authenticators/sha256salted/pom.xml
+++ b/plugins/user-authenticators/sha256salted/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-plugins</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>cloudstack</artifactId>
-    <version>4.13.0.0-SNAPSHOT</version>
+    <version>4.13.0.0</version>
     <packaging>pom</packaging>
     <name>Apache CloudStack</name>
     <description>Apache CloudStack is an IaaS ("Infrastructure as a Service") cloud orchestration platform.</description>

--- a/quickcloud/pom.xml
+++ b/quickcloud/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -40,8 +40,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
-import com.cloud.storage.TemplateOVFPropertyVO;
-import com.cloud.storage.dao.TemplateOVFPropertiesDao;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.affinity.AffinityGroupService;
@@ -101,7 +99,6 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
-import com.cloud.hypervisor.kvm.dpdk.DpdkHelper;
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
@@ -186,6 +183,7 @@ import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.hypervisor.HypervisorCapabilitiesVO;
 import com.cloud.hypervisor.dao.HypervisorCapabilitiesDao;
+import com.cloud.hypervisor.kvm.dpdk.DpdkHelper;
 import com.cloud.network.IpAddressManager;
 import com.cloud.network.Network;
 import com.cloud.network.Network.IpAddresses;
@@ -243,6 +241,7 @@ import com.cloud.storage.Storage.StoragePoolType;
 import com.cloud.storage.Storage.TemplateType;
 import com.cloud.storage.StoragePool;
 import com.cloud.storage.StoragePoolStatus;
+import com.cloud.storage.TemplateOVFPropertyVO;
 import com.cloud.storage.VMTemplateStorageResourceAssoc;
 import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.VMTemplateZoneVO;
@@ -253,6 +252,7 @@ import com.cloud.storage.dao.DiskOfferingDao;
 import com.cloud.storage.dao.GuestOSCategoryDao;
 import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.storage.dao.SnapshotDao;
+import com.cloud.storage.dao.TemplateOVFPropertiesDao;
 import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.storage.dao.VMTemplateZoneDao;
 import com.cloud.storage.dao.VolumeDao;
@@ -313,6 +313,7 @@ import com.cloud.vm.snapshot.VMSnapshotManager;
 import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 import com.google.common.base.Strings;
+import com.google.gson.Gson;
 
 public class UserVmManagerImpl extends ManagerBase implements UserVmManager, VirtualMachineGuru, UserVmService, Configurable {
     private static final Logger s_logger = Logger.getLogger(UserVmManagerImpl.class);
@@ -488,6 +489,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
     private ResourceTagDao resourceTagDao;
     @Inject
     private TemplateOVFPropertiesDao templateOVFPropertiesDao;
+
+    protected Gson gson;
 
     private ScheduledExecutorService _executor = null;
     private ScheduledExecutorService _vmIpFetchExecutor = null;
@@ -3822,12 +3825,12 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         return _instance + "-" + uuidName;
     }
 
-    private UserVmVO commitUserVm(final DataCenter zone, final VirtualMachineTemplate template, final String hostName, final String displayName, final Account owner,
-            final Long diskOfferingId, final Long diskSize, final String userData, final Account caller, final Boolean isDisplayVm, final String keyboard,
-            final long accountId, final long userId, final ServiceOfferingVO offering, final boolean isIso, final String sshPublicKey, final LinkedHashMap<String, NicProfile> networkNicMap,
-            final long id, final String instanceName, final String uuidName, final HypervisorType hypervisorType, final Map<String, String> customParameters, final Map<String,
+    private UserVmVO commitUserVm(final boolean isImport, final DataCenter zone, final VirtualMachineTemplate template, final String hostName, final String displayName, final Account owner,
+                                  final Long diskOfferingId, final Long diskSize, final String userData, final Account caller, final Boolean isDisplayVm, final String keyboard,
+                                  final long accountId, final long userId, final ServiceOffering offering, final boolean isIso, final String sshPublicKey, final LinkedHashMap<String, NicProfile> networkNicMap,
+                                  final long id, final String instanceName, final String uuidName, final HypervisorType hypervisorType, final Map<String, String> customParameters, final Map<String,
             Map<Integer, String>> extraDhcpOptionMap, final Map<Long, DiskOffering> dataDiskTemplateToDiskOfferingMap,
-            Map<String, String> userVmOVFPropertiesMap) throws InsufficientCapacityException {
+                                  Map<String, String> userVmOVFPropertiesMap) throws InsufficientCapacityException {
         return Transaction.execute(new TransactionCallbackWithException<UserVmVO, InsufficientCapacityException>() {
             @Override
             public UserVmVO doInTransaction(TransactionStatus status) throws InsufficientCapacityException {
@@ -3903,7 +3906,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
                 _vmDao.persist(vm);
                 for (String key : customParameters.keySet()) {
-                    if( key.equalsIgnoreCase(VmDetailConstants.CPU_NUMBER) ||
+                    if (key.equalsIgnoreCase(VmDetailConstants.CPU_NUMBER) ||
                             key.equalsIgnoreCase(VmDetailConstants.CPU_SPEED) ||
                             key.equalsIgnoreCase(VmDetailConstants.MEMORY)) {
                         // handle double byte strings.
@@ -3937,27 +3940,28 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 }
 
                 _vmDao.saveDetails(vm);
+                if (!isImport) {
+                    s_logger.debug("Allocating in the DB for vm");
+                    DataCenterDeployment plan = new DataCenterDeployment(zone.getId());
 
-                s_logger.debug("Allocating in the DB for vm");
-                DataCenterDeployment plan = new DataCenterDeployment(zone.getId());
+                    List<String> computeTags = new ArrayList<String>();
+                    computeTags.add(offering.getHostTag());
 
-                List<String> computeTags = new ArrayList<String>();
-                computeTags.add(offering.getHostTag());
+                    List<String> rootDiskTags = new ArrayList<String>();
+                    rootDiskTags.add(offering.getTags());
 
-                List<String> rootDiskTags = new ArrayList<String>();
-                rootDiskTags.add(offering.getTags());
+                    if (isIso) {
+                        _orchSrvc.createVirtualMachineFromScratch(vm.getUuid(), Long.toString(owner.getAccountId()), vm.getIsoId().toString(), hostName, displayName,
+                                hypervisorType.name(), guestOSCategory.getName(), offering.getCpu(), offering.getSpeed(), offering.getRamSize(), diskSize, computeTags, rootDiskTags,
+                                networkNicMap, plan, extraDhcpOptionMap);
+                    } else {
+                        _orchSrvc.createVirtualMachine(vm.getUuid(), Long.toString(owner.getAccountId()), Long.toString(template.getId()), hostName, displayName, hypervisorType.name(),
+                                offering.getCpu(), offering.getSpeed(), offering.getRamSize(), diskSize, computeTags, rootDiskTags, networkNicMap, plan, rootDiskSize, extraDhcpOptionMap, dataDiskTemplateToDiskOfferingMap);
+                    }
 
-                if (isIso) {
-                    _orchSrvc.createVirtualMachineFromScratch(vm.getUuid(), Long.toString(owner.getAccountId()), vm.getIsoId().toString(), hostName, displayName,
-                            hypervisorType.name(), guestOSCategory.getName(), offering.getCpu(), offering.getSpeed(), offering.getRamSize(), diskSize, computeTags, rootDiskTags,
-                            networkNicMap, plan, extraDhcpOptionMap);
-                } else {
-                    _orchSrvc.createVirtualMachine(vm.getUuid(), Long.toString(owner.getAccountId()), Long.toString(template.getId()), hostName, displayName, hypervisorType.name(),
-                            offering.getCpu(), offering.getSpeed(), offering.getRamSize(), diskSize, computeTags, rootDiskTags, networkNicMap, plan, rootDiskSize, extraDhcpOptionMap, dataDiskTemplateToDiskOfferingMap);
-                }
-
-                if (s_logger.isDebugEnabled()) {
-                    s_logger.debug("Successfully allocated DB entry for " + vm);
+                    if (s_logger.isDebugEnabled()) {
+                        s_logger.debug("Successfully allocated DB entry for " + vm);
+                    }
                 }
                 CallContext.current().setEventDetails("Vm Id: " + vm.getUuid());
 
@@ -3974,6 +3978,20 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 return vm;
             }
         });
+    }
+
+    private UserVmVO commitUserVm(final DataCenter zone, final VirtualMachineTemplate template, final String hostName, final String displayName, final Account owner,
+            final Long diskOfferingId, final Long diskSize, final String userData, final Account caller, final Boolean isDisplayVm, final String keyboard,
+            final long accountId, final long userId, final ServiceOfferingVO offering, final boolean isIso, final String sshPublicKey, final LinkedHashMap<String, NicProfile> networkNicMap,
+            final long id, final String instanceName, final String uuidName, final HypervisorType hypervisorType, final Map<String, String> customParameters, final Map<String,
+            Map<Integer, String>> extraDhcpOptionMap, final Map<Long, DiskOffering> dataDiskTemplateToDiskOfferingMap,
+            Map<String, String> userVmOVFPropertiesMap) throws InsufficientCapacityException {
+        return commitUserVm(false, zone, template, hostName, displayName, owner,
+                diskOfferingId, diskSize, userData, caller, isDisplayVm, keyboard,
+                accountId, userId, offering, isIso, sshPublicKey, networkNicMap,
+                id, instanceName, uuidName, hypervisorType, customParameters,
+                extraDhcpOptionMap, dataDiskTemplateToDiskOfferingMap,
+                userVmOVFPropertiesMap);
     }
 
     public void validateRootDiskResize(final HypervisorType hypervisorType, Long rootDiskSize, VMTemplateVO templateVO, UserVmVO vm, final Map<String, String> customParameters) throws InvalidParameterValueException
@@ -6834,5 +6852,27 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 s_logger.error("DestroyVM remove volume - failed to delete volume " + volume.getInstanceId() + " from instance " + volume.getId());
             }
         }
+    }
+
+    @Override
+    public UserVm importVM(final DataCenter zone, final Host host, final VirtualMachineTemplate template, final String instanceName, final String displayName,
+                           final Account owner, final String userData, final Account caller, final Boolean isDisplayVm, final String keyboard,
+                           final long accountId, final long userId, final ServiceOffering serviceOffering, final DiskOffering rootDiskOffering, final String sshPublicKey,
+                           final String hostName, final HypervisorType hypervisorType, final Map<String, String> customParameters, final VirtualMachine.PowerState powerState) throws InsufficientCapacityException {
+
+
+        final long id = _vmDao.getNextInSequence(Long.class, "id");
+
+        if (hostName != null) {
+            // Check is hostName is RFC compliant
+            checkNameForRFCCompliance(hostName);
+        }
+
+        final String uuidName = _uuidMgr.generateUuid(UserVm.class, null);
+        return commitUserVm(true, zone, template, hostName, displayName, owner,
+                rootDiskOffering.getId(), null, userData, caller, isDisplayVm, keyboard,
+                accountId, userId, serviceOffering, false, sshPublicKey, null,
+                id, instanceName, uuidName, hypervisorType, customParameters,
+                null, null, null);
     }
 }

--- a/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
@@ -1,0 +1,472 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.vm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.ResponseGenerator;
+import org.apache.cloudstack.api.ResponseObject;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.command.admin.ingestion.ImportUnmanageInstanceCmd;
+import org.apache.cloudstack.api.command.admin.ingestion.ListUnmanagedInstancesCmd;
+import org.apache.cloudstack.api.response.ListResponse;
+import org.apache.cloudstack.api.response.NicResponse;
+import org.apache.cloudstack.api.response.UnmanagedInstanceDiskResponse;
+import org.apache.cloudstack.api.response.UnmanagedInstanceResponse;
+import org.apache.cloudstack.api.response.UserVmResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
+import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.utils.volume.VirtualMachineDiskInfo;
+import org.apache.log4j.Logger;
+
+import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.GetUnmanagedInstancesAnswer;
+import com.cloud.agent.api.GetUnmanagedInstancesCommand;
+import com.cloud.dc.DataCenter;
+import com.cloud.dc.dao.ClusterDao;
+import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.dc.dao.VlanDao;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.host.Host;
+import com.cloud.host.HostVO;
+import com.cloud.host.Status;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.network.Network;
+import com.cloud.network.dao.NetworkDao;
+import com.cloud.offering.DiskOffering;
+import com.cloud.offering.ServiceOffering;
+import com.cloud.org.Cluster;
+import com.cloud.resource.ResourceManager;
+import com.cloud.serializer.GsonHelper;
+import com.cloud.service.dao.ServiceOfferingDao;
+import com.cloud.storage.StoragePool;
+import com.cloud.storage.VMTemplateStoragePoolVO;
+import com.cloud.storage.Volume;
+import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.VMTemplateDao;
+import com.cloud.storage.dao.VMTemplatePoolDao;
+import com.cloud.template.VirtualMachineTemplate;
+import com.cloud.user.Account;
+import com.cloud.user.AccountService;
+import com.cloud.user.UserVO;
+import com.cloud.user.dao.UserDao;
+import com.cloud.uservm.UserVm;
+import com.cloud.utils.Pair;
+import com.cloud.utils.net.NetUtils;
+import com.cloud.vm.DiskProfile;
+import com.cloud.vm.NicProfile;
+import com.cloud.vm.UserVmService;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.dao.VMInstanceDao;
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+
+public class VmImportManagerImpl implements VmImportService {
+    private static final Logger LOGGER = Logger.getLogger(VmImportManagerImpl.class);
+
+    @Inject
+    private AgentManager agentManager;
+    @Inject
+    private DataCenterDao dataCenterDao;
+    @Inject
+    private ClusterDao clusterDao;
+    @Inject
+    private AccountService accountService;
+    @Inject
+    private UserDao userDao;
+    @Inject
+    private VMTemplateDao templateDao;
+    @Inject
+    private VMTemplatePoolDao templatePoolDao;
+    @Inject
+    private ServiceOfferingDao serviceOfferingDao;
+    @Inject
+    private DiskOfferingDao diskOfferingDao;
+    @Inject
+    private ResourceManager resourceManager;
+    @Inject
+    private UserVmService userVmService;
+    @Inject
+    public ResponseGenerator responseGenerator;
+    @Inject
+    private VolumeOrchestrationService volumeManager;
+    @Inject
+    private PrimaryDataStoreDao primaryDataStoreDao;
+    @Inject
+    private NetworkDao networkDao;
+    @Inject
+    private NetworkOrchestrationService networkOrchestrationService;
+    @Inject
+    protected VMInstanceDao _vmDao;
+    @Inject
+    protected VlanDao vlanDao;
+
+    protected Gson gson;
+
+    public VmImportManagerImpl() {
+        gson = GsonHelper.getGsonLogger();
+    }
+
+    private UnmanagedInstanceResponse createUnmanagedInstanceResponse(UnmanagedInstance instance, Cluster cluster, Host host) {
+        UnmanagedInstanceResponse response = new UnmanagedInstanceResponse();
+        response.setName(instance.getName());
+        if (cluster != null) {
+            response.setClusterId(cluster.getUuid());
+        }
+        if (host != null) {
+            response.setHostId(host.getUuid());
+        }
+        response.setPowerState(instance.getPowerState());
+        response.setCpuCores(instance.getCpuCores());
+        response.setCpuSpeed(instance.getCpuSpeed());
+        response.setCpuCoresPerSocket(instance.getCpuCoresPerSocket());
+        response.setMemory(instance.getMemory());
+        response.setOperatingSystem(instance.getOperatingSystem());
+        response.setObjectName(UnmanagedInstance.class.getSimpleName().toLowerCase());
+
+        if (instance.getDisks() != null) {
+            for (UnmanagedInstance.Disk disk : instance.getDisks()) {
+                UnmanagedInstanceDiskResponse diskResponse = new UnmanagedInstanceDiskResponse();
+                diskResponse.setDiskId(disk.getDiskId());
+                if (!Strings.isNullOrEmpty(disk.getLabel())) {
+                    diskResponse.setLabel(disk.getLabel());
+                }
+                diskResponse.setCapacity(disk.getCapacity());
+                diskResponse.setController(disk.getController());
+                diskResponse.setControllerUnit(disk.getControllerUnit());
+                diskResponse.setPosition(disk.getPosition());
+                diskResponse.setImagePath(disk.getImagePath());
+                response.addDisk(diskResponse);
+            }
+        }
+
+        if (instance.getNics() != null) {
+            for (UnmanagedInstance.Nic nic : instance.getNics()) {
+                NicResponse nicResponse = new NicResponse();
+                nicResponse.setId(nic.getNicId());
+                nicResponse.setNetworkName(nic.getNetwork());
+                nicResponse.setMacAddress(nic.getMacAddress());
+                //nicResponse.setIpaddress(nic.getIpAddress());
+                nicResponse.setVlanId(nic.getVlan());
+                response.addNic(nicResponse);
+            }
+        }
+        return response;
+    }
+
+    private List<String> getHostManagedVms(Host host) {
+        List<String> managedVms = new ArrayList<>();
+        List<VMInstanceVO> instances = _vmDao.listByHostId(host.getId());
+        for (VMInstanceVO instance : instances) {
+            managedVms.add(instance.getInstanceName());
+        }
+        instances = _vmDao.listByLastHostId(host.getId());
+        for (VMInstanceVO instance : instances) {
+            managedVms.add(instance.getInstanceName());
+        }
+        return managedVms;
+    }
+
+    private DiskProfile importDisk(UnmanagedInstance.Disk disk, VirtualMachine vm, DiskOffering diskOffering,
+                                   Volume.Type type, String name, Long diskSize, VirtualMachineTemplate template,
+                                   Account owner, Long deviceId) {
+        VirtualMachineDiskInfo diskInfo = new VirtualMachineDiskInfo();
+        diskInfo.setDiskDeviceBusName(String.format("%s%d:%d", disk.getController(), disk.getControllerUnit(), disk.getPosition()));
+        diskInfo.setDiskChain(new String[]{disk.getImagePath()});
+        String path = disk.getImagePath();
+        long poolId = 0;
+        if (vm.getHypervisorType() == Hypervisor.HypervisorType.VMware) {
+            String[] splits = path.split(" ");
+            String poolUuid = splits[0];
+            poolUuid = poolUuid.replace("[", "").replace("]", "");
+            StoragePool storagePool = null;
+            if (poolUuid.length() == 32) {
+                poolUuid = String.format("%s-%s-%s-%s-%s", poolUuid.substring(0, 8),
+                        poolUuid.substring(8, 12), poolUuid.substring(12, 16),
+                        poolUuid.substring(16, 20), poolUuid.substring(20, 32));
+                storagePool = primaryDataStoreDao.findPoolByUUID(poolUuid);
+            }
+            if (storagePool != null) {
+                poolId = storagePool.getId();
+            }
+            path = String.join(" ", Arrays.copyOfRange(splits, 1, splits.length));
+            splits = path.split("/");
+            path = splits[splits.length - 1];
+            splits = path.split("\\.");
+            path = splits[0];
+        }
+        return volumeManager.importVolume(type, name, diskOffering, diskSize,
+                diskOffering.getMinIops(), diskOffering.getMaxIops(), vm, template, owner, deviceId, poolId, path, gson.toJson(diskInfo));
+    }
+
+    private NicProfile importNic(UnmanagedInstance.Nic nic, VirtualMachine vm, Network network, String ipAddress, boolean isDefaultNic) {
+        Pair<NicProfile, Integer> result = networkOrchestrationService.importNic(nic.getMacAddress(), 0, network, isDefaultNic, vm, ipAddress);
+        if (result == null) {
+            return null;
+        }
+        return result.first();
+    }
+
+    @Override
+    public ListResponse<UnmanagedInstanceResponse> listUnmanagedInstances(ListUnmanagedInstancesCmd cmd) {
+        final Account caller = CallContext.current().getCallingAccount();
+        if (caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
+            throw new PermissionDeniedException(String.format("Cannot perform this operation, Calling account is not root admin: %s", caller.getUuid()));
+        }
+        final Long clusterId = cmd.getClusterId();
+        if (clusterId == null) {
+            throw new InvalidParameterValueException(String.format("Cluster ID cannot be null!"));
+        }
+        final Cluster cluster = clusterDao.findById(clusterId);
+        if (cluster == null) {
+            throw new InvalidParameterValueException(String.format("Cluster ID: %d cannot be found!", clusterId));
+        }
+        if (cluster.getHypervisorType() != Hypervisor.HypervisorType.VMware) {
+            throw new InvalidParameterValueException(String.format("VM ingestion is currently not supported for hypervisor: %s", cluster.getHypervisorType().toString()));
+        }
+
+        List<HostVO> hosts = resourceManager.listHostsInClusterByStatus(clusterId, Status.Up);
+
+        List<String> templatesFilterList = new ArrayList<>();
+
+        if (cluster.getHypervisorType() == Hypervisor.HypervisorType.VMware) { // Add filter for templates for VMware
+            List<VMTemplateStoragePoolVO> templates = templatePoolDao.listAll();
+            for (VMTemplateStoragePoolVO template : templates) {
+                templatesFilterList.add(template.getInstallPath());
+            }
+        }
+
+        List<UnmanagedInstanceResponse> responses = new ArrayList<>();
+        for (HostVO host : hosts) {
+            List<String> managedVms = new ArrayList<>();
+            managedVms.addAll(templatesFilterList);
+            managedVms.addAll(getHostManagedVms(host));
+
+            GetUnmanagedInstancesCommand command = new GetUnmanagedInstancesCommand();
+            command.setInstanceName(cmd.getName());
+            command.setManagedInstancesNames(managedVms);
+            Answer answer = agentManager.easySend(host.getId(), command);
+            if (answer instanceof GetUnmanagedInstancesAnswer) {
+                GetUnmanagedInstancesAnswer unmanagedInstancesAnswer = (GetUnmanagedInstancesAnswer) answer;
+                HashMap<String, UnmanagedInstance> unmanagedInstances = new HashMap<>();
+                unmanagedInstances.putAll(unmanagedInstancesAnswer.getUnmanagedInstances());
+                Set<String> keys = unmanagedInstances.keySet();
+                for (String key : keys) {
+                    responses.add(createUnmanagedInstanceResponse(unmanagedInstances.get(key), cluster, host));
+                }
+            }
+        }
+        ListResponse<UnmanagedInstanceResponse> listResponses = new ListResponse<>();
+        listResponses.setResponses(responses, responses.size());
+        return listResponses;
+    }
+
+    @Override
+    public UserVmResponse importUnmanagedInstance(ImportUnmanageInstanceCmd cmd) {
+        final Account caller = CallContext.current().getCallingAccount();
+        if (caller.getType() != Account.ACCOUNT_TYPE_ADMIN) {
+            throw new PermissionDeniedException(String.format("Cannot perform this operation, Calling account is not root admin: %s", caller.getUuid()));
+        }
+        final Long clusterId = cmd.getClusterId();
+        if (clusterId == null) {
+            throw new InvalidParameterValueException(String.format("Cluster ID cannot be null!"));
+        }
+        final Cluster cluster = clusterDao.findById(clusterId);
+        if (cluster == null) {
+            throw new InvalidParameterValueException(String.format("Cluster ID: %d cannot be found!", clusterId));
+        }
+        if (cluster.getHypervisorType() != Hypervisor.HypervisorType.VMware) {
+            throw new InvalidParameterValueException(String.format("VM ingestion is currently not supported for hypervisor: %s", cluster.getHypervisorType().toString()));
+        }
+        final DataCenter zone = dataCenterDao.findById(cluster.getDataCenterId());
+        final String instanceName = cmd.getName();
+        if (Strings.isNullOrEmpty(instanceName)) {
+            throw new InvalidParameterValueException(String.format("Instance name cannot be empty!"));
+        }
+        final Account owner = accountService.getActiveAccountById(cmd.getEntityOwnerId());
+
+        Long userId = null;
+        List<UserVO> userVOs = userDao.listByAccount(owner.getAccountId());
+        if (!userVOs.isEmpty()) {
+            userId = userVOs.get(0).getId();
+        }
+        final Long templateId = cmd.getTemplateId();
+        if (templateId == null) {
+            throw new InvalidParameterValueException(String.format("Template ID cannot be null!"));
+        }
+        final VirtualMachineTemplate template = templateDao.findById(templateId);
+        if (template == null) {
+            throw new InvalidParameterValueException(String.format("Template ID: %d cannot be found!", templateId));
+        }
+        final Long serviceOfferingId = cmd.getServiceOfferingId();
+        if (serviceOfferingId == null) {
+            throw new InvalidParameterValueException(String.format("Service offering ID cannot be null!"));
+        }
+        final ServiceOffering serviceOffering = serviceOfferingDao.findById(serviceOfferingId);
+        if (serviceOffering == null) {
+            throw new InvalidParameterValueException(String.format("Service offering ID: %d cannot be found!", serviceOfferingId));
+        }
+        final Long diskOfferingId = cmd.getDiskOfferingId();
+        if (diskOfferingId == null) {
+            throw new InvalidParameterValueException(String.format("Service offering ID cannot be null!"));
+        }
+        final DiskOffering diskOffering = diskOfferingDao.findById(diskOfferingId);
+        if (diskOffering == null) {
+            throw new InvalidParameterValueException(String.format("Disk offering ID: %d cannot be found!", diskOfferingId));
+        }
+        String displayName = cmd.getDisplayName();
+        if (Strings.isNullOrEmpty(displayName)) {
+            displayName = instanceName;
+        }
+        String hostName = cmd.getHostName();
+        if (Strings.isNullOrEmpty(hostName)) {
+            if (!NetUtils.verifyDomainNameLabel(instanceName, true)) {
+                throw new InvalidParameterValueException(String.format("Please provide hostname for the VM. VM name contains unsupported characters for it to be used as hostname"));
+            }
+            hostName = instanceName;
+        }
+        if (!NetUtils.verifyDomainNameLabel(hostName, true)) {
+            throw new InvalidParameterValueException("Invalid VM hostname. VM hostname can contain ASCII letters 'a' through 'z', the digits '0' through '9', "
+                    + "and the hyphen ('-'), must be between 1 and 63 characters long, and can't start or end with \"-\" and can't start with digit");
+        }
+
+        final Map<String, Long> nicNetworkMap = cmd.getNicNetworkList();
+        final Map<String, String> nicIpAddressMap = cmd.getNicIpAddressList();
+        final Map<String, Long> dataDiskOfferingMap = cmd.getDataDiskToDiskOfferingList();
+
+        List<HostVO> hosts = resourceManager.listHostsInClusterByStatus(clusterId, Status.Up);
+
+        UserVm userVm = null;
+
+        List<String> templatesFilterList = new ArrayList<>();
+
+        if (cluster.getHypervisorType() == Hypervisor.HypervisorType.VMware) { // Add filter for templates for VMware
+            List<VMTemplateStoragePoolVO> templates = templatePoolDao.listAll();
+            for (VMTemplateStoragePoolVO templateStoragePoolVO : templates) {
+                templatesFilterList.add(templateStoragePoolVO.getInstallPath());
+            }
+        }
+
+        for (HostVO host : hosts) {
+            List<String> managedVms = new ArrayList<>();
+            managedVms.addAll(templatesFilterList);
+            managedVms.addAll(getHostManagedVms(host));
+            GetUnmanagedInstancesCommand command = new GetUnmanagedInstancesCommand(instanceName);
+            command.setManagedInstancesNames(managedVms);
+            Answer answer = agentManager.easySend(host.getId(), command);
+            if (answer instanceof GetUnmanagedInstancesAnswer) {
+                GetUnmanagedInstancesAnswer unmanagedInstancesAnswer = (GetUnmanagedInstancesAnswer) answer;
+                HashMap<String, UnmanagedInstance> unmanagedInstances = unmanagedInstancesAnswer.getUnmanagedInstances();
+                if (unmanagedInstances != null && !unmanagedInstances.isEmpty()) {
+                    Set<String> names = unmanagedInstances.keySet();
+                    for (String name : names) {
+                        if (name.equals(instanceName)) {
+                            UnmanagedInstance unmanagedInstance = unmanagedInstances.get(name);
+                            if (unmanagedInstance.getDisks() == null || unmanagedInstance.getDisks().isEmpty()) {
+                                throw new InvalidParameterValueException(String.format("No attached disks found for the unmanaged VM: %s", name));
+                            }
+                            final UnmanagedInstance.Disk rootDisk = unmanagedInstance.getDisks().get(0);
+                            final long rootDiskSize = diskOffering.isCustomized() ? (rootDisk.getCapacity() / (1024 * 1024)) : diskOffering.getDiskSize();
+                            VirtualMachine.PowerState powerState = VirtualMachine.PowerState.PowerOff;
+                            if (unmanagedInstance.getPowerState().equalsIgnoreCase("PowerOn") ||
+                                    unmanagedInstance.getPowerState().equalsIgnoreCase("POWERED_ON")) {
+                                powerState = VirtualMachine.PowerState.PowerOn;
+                            }
+                            try {
+                                userVm = userVmService.importVM(zone, host, template, instanceName, displayName, owner,
+                                        null, caller, true, null, owner.getAccountId(), userId,
+                                        serviceOffering, diskOffering, null, hostName,
+                                        cluster.getHypervisorType(), cmd.getDetails(), powerState);
+                            } catch (InsufficientCapacityException ice) {
+                                throw new ServerApiException(ApiErrorCode.INSUFFICIENT_CAPACITY_ERROR, ice.getMessage());
+                            }
+                            if (userVm != null) {
+                                try {
+                                    importDisk(rootDisk, userVm, diskOffering, Volume.Type.ROOT, String.format("ROOT-%d", userVm.getId()), rootDiskSize, template, owner, null);
+                                    Set<String> disks = dataDiskOfferingMap.keySet();
+                                    for (String diskId : disks) {
+                                        for (UnmanagedInstance.Disk unmanagedDisk : unmanagedInstance.getDisks()) {
+                                            if (unmanagedDisk.getDiskId().equals(diskId)) {
+                                                DiskOffering offering = diskOfferingDao.findById(dataDiskOfferingMap.get(diskId));
+                                                importDisk(unmanagedDisk, userVm, diskOffering, Volume.Type.DATADISK, String.format("DATA-%d-%s", userVm.getId(), unmanagedDisk.getDiskId()), offering.isCustomized() ? (unmanagedDisk.getCapacity() / (1024 * 1024)) : offering.getDiskSize(), template, owner, null);
+                                            }
+                                        }
+                                    }
+                                } catch (Exception e) {
+                                    throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to import volumes while ingesting vm: %s. %s", instanceName, e.getMessage()));
+                                }
+
+                                try {
+                                    Set<String> nics = nicNetworkMap.keySet();
+                                    int i = 0;
+                                    for (String nicId : nics) {
+                                        Network network = networkDao.findById(nicNetworkMap.get(nicId));
+                                        for (UnmanagedInstance.Nic unmanagedNic : unmanagedInstance.getNics()) {
+                                            if (unmanagedNic.getNicId().equals(nicId) &&
+                                                    network.getBroadcastUri().toString().equals(String.format("vlan://%d", unmanagedNic.getVlan()))) {
+                                                String ipAddress = nicIpAddressMap.get(nicId);
+                                                if (Strings.isNullOrEmpty(ipAddress)) {
+                                                    ipAddress = unmanagedNic.getIpAddress();
+                                                }
+                                                importNic(unmanagedNic, userVm, network, ipAddress, i == 0);
+                                            }
+                                        }
+                                        i++;
+                                    }
+                                } catch (Exception e) {
+                                    throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to import NICs while ingesting vm: %s. %s", instanceName, e.getMessage()));
+                                }
+                            } else {
+                                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to import vm name: %s", instanceName));
+                            }
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        if (userVm == null) {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to find unmanaged vm with name: %s", instanceName));
+        }
+        UserVmResponse response = responseGenerator.createUserVmResponse(ResponseObject.ResponseView.Full, "virtualmachine", userVm).get(0);
+        return response;
+    }
+
+    @Override
+    public List<Class<?>> getCommands() {
+        final List<Class<?>> cmdList = new ArrayList<Class<?>>();
+        cmdList.add(ListUnmanagedInstancesCmd.class);
+        cmdList.add(ImportUnmanageInstanceCmd.class);
+        return cmdList;
+    }
+}

--- a/server/src/main/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
+++ b/server/src/main/resources/META-INF/cloudstack/server-compute/spring-server-compute-context.xml
@@ -35,4 +35,6 @@
         <property name="name" value="LXCGuru" />
     </bean>
 
+    <bean id="vmImportService" class="org.apache.cloudstack.vm.VmImportManagerImpl" />
+
 </beans>

--- a/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -973,4 +973,9 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     public AcquirePodIpCmdResponse allocatePodIp(Account account, String zoneId, String podId) throws ResourceAllocationException, ConcurrentOperationException {
         return null;
     }
+
+    @Override
+    public Pair<NicProfile, Integer> importNic(String macAddress, int deviceId, Network network, Boolean isDefaultNic, VirtualMachine vm, String ipAddress) {
+        return null;
+    }
 }

--- a/server/src/test/java/org/apache/cloudstack/vm/VmImportManagerImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/vm/VmImportManagerImplTest.java
@@ -1,0 +1,250 @@
+package org.apache.cloudstack.vm;
+
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.cloudstack.api.ResponseGenerator;
+import org.apache.cloudstack.api.ResponseObject;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.command.admin.ingestion.ImportUnmanageInstanceCmd;
+import org.apache.cloudstack.api.command.admin.ingestion.ListUnmanagedInstancesCmd;
+import org.apache.cloudstack.api.response.UserVmResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
+import org.apache.cloudstack.engine.orchestration.service.VolumeOrchestrationService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.Answer;
+import com.cloud.agent.api.GetUnmanagedInstancesAnswer;
+import com.cloud.agent.api.GetUnmanagedInstancesCommand;
+import com.cloud.dc.ClusterVO;
+import com.cloud.dc.DataCenter;
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.dao.ClusterDao;
+import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.host.Host;
+import com.cloud.host.HostVO;
+import com.cloud.host.Status;
+import com.cloud.hypervisor.Hypervisor;
+import com.cloud.network.Network;
+import com.cloud.network.dao.NetworkDao;
+import com.cloud.network.dao.NetworkVO;
+import com.cloud.offering.DiskOffering;
+import com.cloud.offering.ServiceOffering;
+import com.cloud.resource.ResourceManager;
+import com.cloud.service.ServiceOfferingVO;
+import com.cloud.service.dao.ServiceOfferingDao;
+import com.cloud.storage.DiskOfferingVO;
+import com.cloud.storage.VMTemplateStoragePoolVO;
+import com.cloud.storage.VMTemplateVO;
+import com.cloud.storage.Volume;
+import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.VMTemplateDao;
+import com.cloud.storage.dao.VMTemplatePoolDao;
+import com.cloud.template.VirtualMachineTemplate;
+import com.cloud.user.Account;
+import com.cloud.user.AccountService;
+import com.cloud.user.AccountVO;
+import com.cloud.user.User;
+import com.cloud.user.UserVO;
+import com.cloud.user.dao.UserDao;
+import com.cloud.uservm.UserVm;
+import com.cloud.utils.Pair;
+import com.cloud.vm.DiskProfile;
+import com.cloud.vm.NicProfile;
+import com.cloud.vm.UserVmService;
+import com.cloud.vm.UserVmVO;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.dao.VMInstanceDao;
+
+public class VmImportManagerImplTest {
+
+    @InjectMocks
+    private VmImportService vmIngestionService = new VmImportManagerImpl();
+
+    @Mock
+    private UserVmService userVmService;
+    @Mock
+    private ClusterDao clusterDao;
+    @Mock
+    private ResourceManager resourceManager;
+    @Mock
+    private VMTemplatePoolDao templatePoolDao;
+    @Mock
+    private AgentManager agentManager;
+    @Mock
+    private AccountService accountService;
+    @Mock
+    private UserDao userDao;
+    @Mock
+    private DataCenterDao dataCenterDao;
+    @Mock
+    private VMTemplateDao templateDao;
+    @Mock
+    private VMInstanceDao vmDao;
+    @Mock
+    private ServiceOfferingDao serviceOfferingDao;
+    @Mock
+    private DiskOfferingDao diskOfferingDao;
+    @Mock
+    private NetworkDao networkDao;
+    @Mock
+    private NetworkOrchestrationService networkOrchestrationService;
+    @Mock
+    private VolumeOrchestrationService volumeManager;
+    @Mock
+    public ResponseGenerator responseGenerator;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        AccountVO account = new AccountVO("admin", 1L, "", Account.ACCOUNT_TYPE_ADMIN, "uuid");
+        UserVO user = new UserVO(1, "adminuser", "password", "firstname", "lastName", "email", "timezone", UUID.randomUUID().toString(), User.Source.UNKNOWN);
+        CallContext.register(user, account);
+
+        UnmanagedInstance instance = new UnmanagedInstance();
+        instance.setName("TestInstance");
+        instance.setCpuCores(2);
+        instance.setCpuCoresPerSocket(1);
+        instance.setCpuSpeed(100);
+        instance.setMemory(1024);
+        instance.setOperatingSystem("CentOS 7");
+        List<UnmanagedInstance.Disk> instanceDisks = new ArrayList<>();
+        UnmanagedInstance.Disk instanceDisk = new UnmanagedInstance.Disk();
+        instanceDisk.setDiskId("1000-1");
+        instanceDisk.setLabel("DiskLabel");
+        instanceDisk.setImagePath("[SomeID] path/path.vmdk");
+        instanceDisk.setCapacity(5242880L);
+        instanceDisks.add(instanceDisk);
+        instance.setDisks(instanceDisks);
+        List<UnmanagedInstance.Nic> instanceNics = new ArrayList<>();
+        UnmanagedInstance.Nic instanceNic = new UnmanagedInstance.Nic();
+        instanceNic.setNicId("NIC 1");
+        instanceNic.setAdapterType("VirtualE1000E");
+        instanceNic.setMacAddress("02:00:2e:0f:00:02");
+        instanceNic.setVlan(1024);
+        instanceNics.add(instanceNic);
+        instance.setNics(instanceNics);
+        instance.setPowerState("POWERED_ON");
+
+        ClusterVO cluster = new ClusterVO(1, 1, "Cluster");
+        cluster.setHypervisorType(Hypervisor.HypervisorType.VMware.toString());
+        when(clusterDao.findById(Mockito.anyLong())).thenReturn(cluster);
+
+        List<HostVO> hosts = new ArrayList<>();
+        HostVO hostVO = Mockito.mock(HostVO.class);
+        hosts.add(hostVO);
+        when(resourceManager.listHostsInClusterByStatus(Mockito.anyLong(), Mockito.any(Status.class))).thenReturn(hosts);
+        List<VMTemplateStoragePoolVO> templates = new ArrayList<>();
+        when(templatePoolDao.listAll()).thenReturn(templates);
+        List<VMInstanceVO> vms = new ArrayList<>();
+        when(vmDao.listByHostId(Mockito.anyLong())).thenReturn(vms);
+        when(vmDao.listByLastHostId(Mockito.anyLong())).thenReturn(vms);
+        GetUnmanagedInstancesCommand cmd = Mockito.mock(GetUnmanagedInstancesCommand.class);
+        HashMap<String, UnmanagedInstance> map = new HashMap<>();
+        map.put(instance.getName(), instance);
+        Answer answer = new GetUnmanagedInstancesAnswer(cmd, "", map);
+        when(agentManager.easySend(Mockito.anyLong(), Mockito.any(GetUnmanagedInstancesCommand.class))).thenReturn(answer);
+
+        when(dataCenterDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(DataCenterVO.class));
+        when(accountService.getActiveAccountById(Mockito.anyLong())).thenReturn(Mockito.mock(Account.class));
+        List<UserVO> users = new ArrayList<>();
+        users.add(Mockito.mock(UserVO.class));
+        when(userDao.listByAccount(Mockito.anyLong())).thenReturn(users);
+        when(templateDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(VMTemplateVO.class));
+        when(serviceOfferingDao.findById(Mockito.anyLong())).thenReturn(Mockito.mock(ServiceOfferingVO.class));
+        DiskOfferingVO diskOfferingVO = Mockito.mock(DiskOfferingVO.class);
+        when(diskOfferingVO.isCustomized()).thenReturn(false);
+        when(diskOfferingDao.findById(Mockito.anyLong())).thenReturn(diskOfferingVO);
+        UserVmVO userVm = Mockito.mock(UserVmVO.class);
+        userVm.setInstanceName(instance.getName());
+        userVm.setHostName(instance.getName());
+        when(userVmService.importVM(Mockito.any(DataCenter.class), Mockito.any(Host.class), Mockito.any(VirtualMachineTemplate.class), Mockito.anyString(), Mockito.anyString(),
+                Mockito.any(Account.class), Mockito.anyString(), Mockito.any(Account.class), Mockito.anyBoolean(), Mockito.anyString(),
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.any(ServiceOffering.class), Mockito.any(DiskOffering.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.any(Hypervisor.HypervisorType.class), Mockito.anyMap(), Mockito.any(VirtualMachine.PowerState.class))).thenReturn(userVm);
+        NetworkVO networkVO = Mockito.mock(NetworkVO.class);
+        networkVO.setBroadcastUri(URI.create(String.format("vlan://%d", instanceNic.getVlan())));
+        when(networkDao.findById(Mockito.anyLong())).thenReturn(networkVO);
+        NicProfile profile = Mockito.mock(NicProfile.class);
+        Integer deviceId = 100;
+        Pair<NicProfile, Integer> pair = new Pair<NicProfile, Integer>(profile, deviceId);
+        when(networkOrchestrationService.importNic(Mockito.anyString(), Mockito.anyInt(), Mockito.any(Network.class), Mockito.anyBoolean(), Mockito.any(VirtualMachine.class), Mockito.anyString())).thenReturn(pair);
+        when(volumeManager.importVolume(Mockito.any(Volume.Type.class), Mockito.anyString(), Mockito.any(DiskOffering.class), Mockito.anyLong(),
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.any(VirtualMachine.class), Mockito.any(VirtualMachineTemplate.class),
+                Mockito.any(Account.class), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString(), Mockito.anyString())).thenReturn(Mockito.mock(DiskProfile.class));
+        List<UserVmResponse> userVmResponses = new ArrayList<>();
+        UserVmResponse userVmResponse = new UserVmResponse();
+        userVmResponse.setInstanceName(instance.getName());
+        userVmResponses.add(userVmResponse);
+        when(responseGenerator.createUserVmResponse(Mockito.any(ResponseObject.ResponseView.class), Mockito.anyString(), Mockito.any(UserVm.class))).thenReturn(userVmResponses);
+    }
+
+    @After
+    public void tearDown() {
+        CallContext.unregister();
+    }
+
+    @Test
+    public void listUnmanagedInstancesTest() {
+        ListUnmanagedInstancesCmd cmd = Mockito.mock(ListUnmanagedInstancesCmd.class);
+        vmIngestionService.listUnmanagedInstances(cmd);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void listUnmanagedInstancesInvalidHypervisorTest() {
+        ListUnmanagedInstancesCmd cmd = Mockito.mock(ListUnmanagedInstancesCmd.class);
+        ClusterVO cluster = new ClusterVO(1, 1, "Cluster");
+        cluster.setHypervisorType(Hypervisor.HypervisorType.KVM.toString());
+        when(clusterDao.findById(Mockito.anyLong())).thenReturn(cluster);
+        vmIngestionService.listUnmanagedInstances(cmd);
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void listUnmanagedInstancesInvalidCallerTest() {
+        CallContext.unregister();
+        AccountVO account = new AccountVO("user", 1L, "", Account.ACCOUNT_TYPE_NORMAL, "uuid");
+        UserVO user = new UserVO(1, "testuser", "password", "firstname", "lastName", "email", "timezone", UUID.randomUUID().toString(), User.Source.UNKNOWN);
+        CallContext.register(user, account);
+        ListUnmanagedInstancesCmd cmd = Mockito.mock(ListUnmanagedInstancesCmd.class);
+        vmIngestionService.listUnmanagedInstances(cmd);
+    }
+
+    @Test
+    public void importUnmanagedInstanceTest() {
+        ImportUnmanageInstanceCmd importUnmanageInstanceCmd = Mockito.mock(ImportUnmanageInstanceCmd.class);
+        when(importUnmanageInstanceCmd.getName()).thenReturn("TestInstance");
+        vmIngestionService.importUnmanagedInstance(importUnmanageInstanceCmd);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void importUnmanagedInstanceInvalidHostnameTest() {
+        ImportUnmanageInstanceCmd importUnmanageInstanceCmd = Mockito.mock(ImportUnmanageInstanceCmd.class);
+        when(importUnmanageInstanceCmd.getName()).thenReturn("TestInstance");
+        when(importUnmanageInstanceCmd.getName()).thenReturn("some name");
+        vmIngestionService.importUnmanagedInstance(importUnmanageInstanceCmd);
+    }
+
+    @Test(expected = ServerApiException.class)
+    public void importUnmanagedInstanceMissingInstanceTest() {
+        ImportUnmanageInstanceCmd importUnmanageInstanceCmd = Mockito.mock(ImportUnmanageInstanceCmd.class);
+        when(importUnmanageInstanceCmd.getName()).thenReturn("SomeInstance");
+        vmIngestionService.importUnmanagedInstance(importUnmanageInstanceCmd);
+    }
+}

--- a/services/console-proxy/pom.xml
+++ b/services/console-proxy/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-services</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/services/console-proxy/rdpconsole/pom.xml
+++ b/services/console-proxy/rdpconsole/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-service-console-proxy</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/console-proxy/server/pom.xml
+++ b/services/console-proxy/server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-service-console-proxy</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/services/secondary-storage/controller/pom.xml
+++ b/services/secondary-storage/controller/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-service-secondary-storage</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/services/secondary-storage/pom.xml
+++ b/services/secondary-storage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-services</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/services/secondary-storage/server/pom.xml
+++ b/services/secondary-storage/server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack-service-secondary-storage</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/systemvm/pom.xml
+++ b/systemvm/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/tools/apidoc/gen_toc.py
+++ b/tools/apidoc/gen_toc.py
@@ -192,6 +192,7 @@ known_categories = {
     'Sioc' : 'Sioc',
     'Diagnostics': 'Diagnostics',
     'Management': 'Management',
+    'UnmanagedInstance': 'Virtual Machine'
     }
 
 

--- a/tools/apidoc/pom.xml
+++ b/tools/apidoc/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-tools</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/tools/checkstyle/pom.xml
+++ b/tools/checkstyle/pom.xml
@@ -22,7 +22,7 @@
     <name>Apache CloudStack Developer Tools - Checkstyle Configuration</name>
     <groupId>org.apache.cloudstack</groupId>
     <artifactId>checkstyle</artifactId>
-    <version>4.13.0.0-SNAPSHOT</version>
+    <version>4.13.0.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tools/devcloud-kvm/pom.xml
+++ b/tools/devcloud-kvm/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-tools</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/devcloud4/pom.xml
+++ b/tools/devcloud4/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-tools</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -20,7 +20,7 @@
 FROM ubuntu:16.04
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.13.0.0-SNAPSHOT"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.13.0.0"
 
 RUN apt-get -y update && apt-get install -y \
     genisoimage \

--- a/tools/docker/Dockerfile.centos6
+++ b/tools/docker/Dockerfile.centos6
@@ -18,7 +18,7 @@
 FROM centos:6
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.13.0.0-SNAPSHOT"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.13.0.0"
 
 ENV PKG_URL=https://builds.cloudstack.org/job/package-master-rhel63/lastSuccessfulBuild/artifact/dist/rpmbuild/RPMS/x86_64
 
@@ -26,8 +26,8 @@ ENV PKG_URL=https://builds.cloudstack.org/job/package-master-rhel63/lastSuccessf
 RUN rpm -i http://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-2.1.3-1.el6.x86_64.rpm
 
 RUN yum install -y nc wget \
-    ${PKG_URL}/cloudstack-common-4.13.0.0-SNAPSHOT.el6.x86_64.rpm \
-    ${PKG_URL}/cloudstack-management-4.13.0.0-SNAPSHOT.el6.x86_64.rpm
+    ${PKG_URL}/cloudstack-common-4.13.0.0.el6.x86_64.rpm \
+    ${PKG_URL}/cloudstack-management-4.13.0.0.el6.x86_64.rpm
 
 RUN cd /etc/cloudstack/management; \
     ln -s tomcat6-nonssl.conf tomcat6.conf; \

--- a/tools/docker/Dockerfile.marvin
+++ b/tools/docker/Dockerfile.marvin
@@ -20,11 +20,11 @@
 FROM python:2
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
-LABEL Vendor="Apache.org" License="ApacheV2" Version="4.13.0.0-SNAPSHOT"
+LABEL Vendor="Apache.org" License="ApacheV2" Version="4.13.0.0"
 
 ENV WORK_DIR=/marvin
 
-ENV PKG_URL=https://builds.cloudstack.org/job/build-master-marvin/lastSuccessfulBuild/artifact/tools/marvin/dist/Marvin-4.13.0.0-SNAPSHOT.tar.gz
+ENV PKG_URL=https://builds.cloudstack.org/job/build-master-marvin/lastSuccessfulBuild/artifact/tools/marvin/dist/Marvin-4.13.0.0.tar.gz
 
 RUN apt-get update && apt-get install -y vim
 RUN pip install --upgrade paramiko nose requests

--- a/tools/marvin/pom.xml
+++ b/tools/marvin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloud-tools</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/tools/marvin/setup.py
+++ b/tools/marvin/setup.py
@@ -27,7 +27,7 @@ except ImportError:
         raise RuntimeError("python setuptools is required to build Marvin")
 
 
-VERSION = "4.13.0.0-SNAPSHOT"
+VERSION = "4.13.0.0"
 
 setup(name="Marvin",
       version=VERSION,

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/vmware-base/pom.xml
+++ b/vmware-base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.cloudstack</groupId>
         <artifactId>cloudstack</artifactId>
-        <version>4.13.0.0-SNAPSHOT</version>
+        <version>4.13.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ClusterMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/ClusterMO.java
@@ -217,6 +217,19 @@ public class ClusterMO extends BaseMO implements VmwareHypervisorHost {
     }
 
     @Override
+    public synchronized List<VirtualMachineMO> listVmsOnHyperHost(String vmName) throws Exception {
+        List<VirtualMachineMO> vms = new ArrayList<>();
+        List<ManagedObjectReference> hosts = _context.getVimClient().getDynamicProperty(_mor, "host");
+        if (hosts != null && hosts.size() > 0) {
+            for (ManagedObjectReference morHost : hosts) {
+                HostMO hostMo = new HostMO(_context, morHost);
+                vms.addAll(hostMo.listVmsOnHyperHost(vmName));
+            }
+        }
+        return vms;
+    }
+
+    @Override
     public VirtualMachineMO findVmOnHyperHost(String name) throws Exception {
 
         int key = getCustomFieldKey("VirtualMachine", CustomFieldConstants.CLOUD_VM_INTERNAL_NAME);

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HostMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/HostMO.java
@@ -497,6 +497,18 @@ public class HostMO extends BaseMO implements VmwareHypervisorHost {
     }
 
     @Override
+    public synchronized List<VirtualMachineMO> listVmsOnHyperHost(String vmName) throws Exception {
+        List<VirtualMachineMO> vms = new ArrayList<>();
+        if (vmName != null && !vmName.isEmpty()) {
+            vms.add(findVmOnHyperHost(vmName));
+        } else {
+            loadVmCache();
+            vms.addAll(_vmCache.values());
+        }
+        return vms;
+    }
+
+    @Override
     public synchronized VirtualMachineMO findVmOnHyperHost(String vmName) throws Exception {
         if (s_logger.isDebugEnabled())
             s_logger.debug("find VM " + vmName + " on host");

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VmwareHypervisorHost.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VmwareHypervisorHost.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.hypervisor.vmware.mo;
 
+import java.util.List;
+
 import com.vmware.vim25.ClusterDasConfigInfo;
 import com.vmware.vim25.ComputeResourceSummary;
 import com.vmware.vim25.ManagedObjectReference;
@@ -50,6 +52,8 @@ public interface VmwareHypervisorHost {
     boolean isHyperHostConnected() throws Exception;
 
     String getHyperHostDefaultGateway() throws Exception;
+
+    List<VirtualMachineMO> listVmsOnHyperHost(String name) throws Exception;
 
     VirtualMachineMO findVmOnHyperHost(String name) throws Exception;
 


### PR DESCRIPTION
## Description
VM ingestion feature allows CloudStack to discover, on-board, import existing VMs in an infra. The feature currently works only for VMware, with a hypervisor agnostic framework which may be extended for KVM and XenServer in future.
Two new APIs have been added, `listUnmanagedInstances` and `importUnmanagedInstance`.
### listUnmanagedInstances
API will list all unmanaged virtual machine for a give cluster. Optionally, name for an existing unmanaged virtual machine can be given to retrieve VM details.
**API request params -** 
`clusterid`(UUID of cluster)
`name`(instance name)
**Response -**
`clusterid`
`hostid`
`name`
`osdisplayname`
`memory`
`powerstate`
`cpuCoresPerSocket`
`cpunumber`
`cpuspeed`
`disk`
    - `id`
    - `capacity`
    - `controller`
    - `controllerunit`
    - `imagepath`
    - `position`
`nic`
    - `id`
    - `macaddress`
    - `networkname`
    - `vlanid`
    - `pcislot`

### importUnmanagedInstance
API will import an exisitng unmanaged virtual machine into CloudStack for a given cluster and virtual machine name. Service offering for the VM, disk offerings for volumes and networks for NICs of the VM can be mapped. Some optional parameters like projectid, domainid, hostname, details, etc can also be given. Appropritate networks, service offering and disk offerings need to be present before import and cannot be created on the fly during the API call.
**API request params -** 
`clusterid`(UUID of cluster)
`name`(instance name)
`displayname`
`hostname`
`domainid`
`projectid`
`templateid`
`serviceofferingid`
`diskofferingid`(UUID of disk offering for root disk)
`nicnetworklist`(Map for NIC ID and corresponding Network UUID)
`datadiskofferinglist`(Map for disk ID and corresponding disk offering UUID)
`details`(Map for VM details)
**Response -** 
Same response as that of `deployVirtualMachine` API

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## API sample calls:
**List**
```
> list unmanagedinstances clusterid=079a19c2-2710-4ed6-9110-027dd5e0f262 
{
  "count": 2,
  "unmanagedinstance": [
    {
      "clusterid": "079a19c2-2710-4ed6-9110-027dd5e0f262",
      "cpucorespersocket": 1,
      "cpunumber": 1,
      "cpuspeed": 0,
      "disk": [
        {
          "capacity": 2097152,
          "controller": "ide",
          "controllerunit": 0,
          "id": "51-3001",
          "imagepath": "[8aca30d6f7803420973f01cc91c1c011] test-unmanaged/test-unmanaged_64.vmdk",
          "label": "Hard disk 1",
          "position": 1
        },
        {
          "capacity": 5242880,
          "controller": "scsi",
          "controllerunit": 0,
          "id": "51-2000",
          "imagepath": "[8aca30d6f7803420973f01cc91c1c011] test-unmanaged/test-unmanaged_63.vmdk",
          "label": "Hard disk 2",
          "position": 0
        }
      ],
      "hostid": "4ab4147a-7e40-4abe-a0e2-2fac1aa6f0bf",
      "memory": 512,
      "name": "test-unmanaged",
      "nic": [
        {
          "id": "Network adapter 1",
          "macaddress": "02:00:39:7c:00:24",
          "networkname": "cloud.guest.1212.200.1-vSwitch1",
          "vlanid": 1212
        }
      ],
      "osdisplayname": "CentOS 4/5 or later (64-bit)",
      "powerstate": "POWERED_ON"
    }
  ]
}
```
**Import**
```
> import unmanagedinstance name=test-unmanaged templateid=200f3fe9-c845-11e9-b69f-1e003c0107c4 clusterid=079a19c2-2710-4ed6-9110-027dd5e0f262 diskofferingid=e9eb069f-2946-4e26-8d81-07aebba868d1 serviceofferingid=c4c5b9e8-8a4a-422d-bccc-2f1bcc166c59 datadiskofferinglist[0].disk=51-2000 datadiskofferinglist[0].diskOffering=e9eb069f-2946-4e26-8d81-07aebba868d1 displayname=NewVm nicNetworkList[0].nic="Network adapter 1" nicNetworkList[0].network=4c44312b-f009-4d33-b942-989169f3d2fc
{
  "virtualmachine": {
    "account": "admin",
    "affinitygroup": [],
    "cpunumber": 1,
    "cpuspeed": 500,
    "created": "2019-09-05T11:32:04+0000",
    "details": {},
    "diskofferingid": "e9eb069f-2946-4e26-8d81-07aebba868d1",
    "diskofferingname": "Custom",
    "displayname": "NewVm",
    "displayvm": true,
    "domain": "ROOT",
    "domainid": "20088b4d-c845-11e9-b69f-1e003c0107c4",
    "guestosid": "2015cd08-c845-11e9-b69f-1e003c0107c4",
    "haenable": false,
    "hostid": "4ab4147a-7e40-4abe-a0e2-2fac1aa6f0bf",
    "hostname": "10.2.2.144",
    "hypervisor": "VMware",
    "id": "4fda861e-e693-4227-a8aa-1b4ce90d5041",
    "instancename": "test-unmanaged",
    "isdynamicallyscalable": false,
    "memory": 512,
    "name": "test-unmanaged",
    "nic": [
      {
        "broadcasturi": "vlan://1212",
        "extradhcpoption": [],
        "id": "61952f25-7efa-4bc2-aa92-ecd38c122e65",
        "isdefault": true,
        "isolationuri": "vlan://1212",
        "macaddress": "02:00:39:7c:00:24",
        "networkid": "4c44312b-f009-4d33-b942-989169f3d2fc",
        "networkname": "lol",
        "secondaryip": [],
        "traffictype": "Guest",
        "type": "L2"
      }
    ],
    "ostypeid": "2015cd08-c845-11e9-b69f-1e003c0107c4",
    "passwordenabled": false,
    "rootdeviceid": 0,
    "rootdevicetype": "ROOT",
    "securitygroup": [],
    "serviceofferingid": "c4c5b9e8-8a4a-422d-bccc-2f1bcc166c59",
    "serviceofferingname": "Small Instance",
    "state": "Stopped",
    "tags": [],
    "templatedisplaytext": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "templateid": "200f3fe9-c845-11e9-b69f-1e003c0107c4",
    "templatename": "CentOS 5.3(64-bit) no GUI (vSphere)",
    "userid": "4dfc315c-c845-11e9-b69f-1e003c0107c4",
    "username": "admin",
    "zoneid": "db18d224-279d-4c08-aeef-0cb7030d0edb",
    "zonename": "pr3540-t341-vmware-65u2"
  }
}importUnmanagedInstance
```


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- A VMware added to running CloudStack with multiple hosts.
- A new vitrual machine deployed from VMware vCenter with multiple disks, networks in the cluster.
- At this point CloudStack does not show or control newly deployed virtual machine.
- `listUnmanagedInstances` API is executed for the cluster. It shows newly deployed VM (deployed from vCenter)
- Import API, `importUnmanagedInstance`, is executed, with appropriate service offering, network- VM NIC details and custom disk offerings for this unmanaged VM
- On successful completion of import API, UI is verified showing imported VM. `listVirtualMachines` API is called to verify showing new VM and `cloud` database is checked for containing new records in `vm_instance`, `volumes`, `nics` tables.
- Lifecycle tasks were performed on the imported VM - stop, start, reboot, migrate, attach new disk.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
