### PR TITLE
[FIX] Rethrow takeVMSnapshot() exception

### DIFF
--- a/server/src/main/java/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/snapshot/VMSnapshotManagerImpl.java
@@ -515,7 +515,7 @@ public class VMSnapshotManagerImpl extends MutualExclusiveIdsManagerBase impleme
             return snapshot;
         } catch (Exception e) {
             s_logger.debug("Failed to create vm snapshot: " + vmSnapshotId, e);
-            return null;
+            throw new CloudRuntimeException("Failed to create vm snapshot: " + vmSnapshotId, e);
         }
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This patch changes the behaviour of `VMSnapshotManagerImpl.orchestrateCreateVMSnapshot(Long vmId, Long vmSnapshotId, Boolean quiescevm)` to rethrow the exception when `takeVMSnapshot()` fails, instead of returning null.

If null is returned, this will lead to a NullPointerException in `VMSnapshotManagerImpl.orchestrateCreateVMSnapshot(VmWorkCreateVMSnapshot work)` in the `snapshot.getId()` call, and causes an incomplete snapshot entry to remain in the database.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3518

See there for more details.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This change has not been tested yet.

At this point, it is unknown if it will cause unexpected side effects.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
