### PR TITLE
Prevent NullPointer on a network with removed IP ranges/"VLANs"

### DIFF
--- a/engine/schema/src/main/java/com/cloud/dc/dao/VlanDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/VlanDaoImpl.java
@@ -168,7 +168,7 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
         List<VlanVO> result = new ArrayList<VlanVO>();
         for (PodVlanMapVO pvmvo : vlanMaps) {
             VlanVO vlanByPodId = findById(pvmvo.getVlanDbId());
-            if (vlanByPodId != null && vlanByPodId.getRemoved() == null) {
+            if (vlanByPodId != null) {
                 result.add(vlanByPodId);
             }
         }
@@ -318,12 +318,6 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
         }
 
         return null;
-//        String ipAddress = _ipAddressDao.assignIpAddress(accountId, domainId, vlan.getId(), false).getAddress();
-//        if (ipAddress == null) {
-//            return null;
-//        }
-//        return new Pair<String, VlanVO>(ipAddress, vlan);
-
     }
 
     @Override

--- a/engine/schema/src/main/java/com/cloud/dc/dao/VlanDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/VlanDaoImpl.java
@@ -167,7 +167,10 @@ public class VlanDaoImpl extends GenericDaoBase<VlanVO, Long> implements VlanDao
         List<PodVlanMapVO> vlanMaps = _podVlanMapDao.listPodVlanMapsByPod(podId);
         List<VlanVO> result = new ArrayList<VlanVO>();
         for (PodVlanMapVO pvmvo : vlanMaps) {
-            result.add(findById(pvmvo.getVlanDbId()));
+            VlanVO vlanByPodId = findById(pvmvo.getVlanDbId());
+            if (vlanByPodId != null && vlanByPodId.getRemoved() == null) {
+                result.add(vlanByPodId);
+            }
         }
         return result;
     }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -266,7 +266,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @Inject
     DomainVlanMapDao _domainVlanMapDao;
     @Inject
-    PodVlanMapDao _podVlanMapDao;
+    PodVlanMapDao podVlanMapDao;
     @Inject
     DataCenterDao _zoneDao;
     @Inject
@@ -3949,7 +3949,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 } else if (podId != null) {
                     // This VLAN is pod-wide, so create a PodVlanMapVO entry
                     final PodVlanMapVO podVlanMapVO = new PodVlanMapVO(podId, vlan.getId());
-                    _podVlanMapDao.persist(podVlanMapVO);
+                    podVlanMapDao.persist(podVlanMapVO);
                 }
                 return vlan;
             }
@@ -4045,7 +4045,17 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) {
                 _publicIpAddressDao.deletePublicIPRange(vlanDbId);
+                s_logger.debug(String.format("Delete Public IP Range (from user_ip_address, where vlan_db_d=%s)", vlanDbId));
+
                 _vlanDao.remove(vlanDbId);
+                s_logger.debug(String.format("Mark vlan as Remove vlan (vlan_db_id=%s)", vlanDbId));
+
+                SearchBuilder<PodVlanMapVO> sb = podVlanMapDao.createSearchBuilder();
+                sb.and("vlan_db_id", sb.entity().getVlanDbId(), SearchCriteria.Op.EQ);
+                SearchCriteria<PodVlanMapVO> sc = sb.create();
+                sc.setParameters("vlan_db_id", vlanDbId);
+                podVlanMapDao.remove(sc);
+                s_logger.debug(String.format("Delete vlan_db_id=%s in pod_vlan_map", vlanDbId));
             }
         });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When a network IP range is removed, the "vlan" stays mapped on `pod_vlan_map`; therefore, the method that lists the VLANs by pod id will return null VLANS.

This PR adds proper verifications to avoid null pointer exception when deploying VRs on a pod with removed VLANs. The exception was caused on [getPlaceholderNicForRouter](https://github.com/apache/cloudstack/blob/3c2af55d81dbfaf17a3bf0b6247ecd830df12996/server/src/main/java/com/cloud/network/NetworkModelImpl.java#L2306)

```
java.lang.NullPointerException
        at com.cloud.network.NetworkModelImpl.getPlaceholderNicForRouter(NetworkModelImpl.java:2306)
```
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
