### PR TITLE
Unable to deploy VMs via UI in advanced networks with SG and IPv6 cidr

### DIFF
--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -594,9 +594,6 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
             if (!hasFreeIps) {
                 return false;
             }
-            if (network.getIp6Gateway() != null) {
-                hasFreeIps = areThereIPv6AddressAvailableInNetwork(network.getId());
-            }
         } else {
             if (network.getCidr() == null) {
                 s_logger.debug("Network - " + network.getId() +  " has NULL CIDR.");


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When deploying a VM via UI, networks that have all the following characteristics are not listed on the wizard:
- advanced networking with security groups
- traffic type of "Guest"
- guest type of "Shared"
- IPv6 CIDR not null

This PR fixes it by removing the verification that counts the IPs from UserIpv6AddressVO in order to check if it can use the network for deploying new VMs in UI [1]. Table "user_ipv6_address" (UserIpv6AddressVO) is empty and will always be as it is a legacy code/table, not used in any IP 
allocation flow. Therefore, the removed verification should be removed.

[1] com.cloud.network.NetworkModelImpl.canUseForDeploy(Network)

This PR fixes #3570

### Why it happens

The Javascript code adds the parameter `canusefordeploy=true` on the API call when the network is an advanced network with security groups. With that, the endpoint (management server) expects "canUseForDeploy" to be _true_; however, the returned value is false due to not finding IPv6 addresses available in the network, which makes the UI to not list those networks.

**#3569 IPv6 code cleanup:** several PRs will be created in the near future aiming a complete cleanup on IPv6 code in order to avoid such mistakes to repeat

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases