### PR TITLE
Vmware hypervisor : enhance Mac OS compatibility

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -29,13 +29,12 @@
 #
 #
 
+  * After testing Mac OS last versions (above 10.12) with Vmware Hypervisor,
+    it seems that this OS has some compatibility issues with default Cloudstack hardware 
+    profile (that is to say, with LSI Logic Parallel SCSI Disk Controller and E1000 Network card). 
+    To make it work, we set up a different profil for Mac OS virtual machines.
+  * One SATA Controller is now defined as default hardware profil when using 
+    Vmware VSphere Hypervisor, instead of usual 4 SCSI controllers. Also, 
+    instead of E1000 Nic Adapter, Mac OS virtual machine are now set up 
+    with E1000E network adapter by default. 
 
-example.ver.1 > example.ver.2:
-  * VirtualRouters are now deployed with the latest version of ExampleLinux
-    and wil also use a new MyFirstDHCPServer instead of dnsmasq to provide
-    faster and more robust deployment of new Instances
-
-  * ISOs are no longer supported and will be replaced by 2.88MB Floppy Drives
-    which can now be attached to Instances. This is to prevent the Secondary
-    Storage to grow to enormous sizes as Linux Distributions keep growing in
-    size while a stripped down Linux should fit on a 2.88MB floppy.

--- a/deps/install-non-oss.sh
+++ b/deps/install-non-oss.sh
@@ -18,7 +18,8 @@
 
 # From https://devcentral.f5.com
 # Version: unknown
-mvn install:install-file -Dfile=cloud-iControl.jar      -DgroupId=com.cloud.com.f5     -DartifactId=icontrol        -Dversion=1.0   -Dpackaging=jar
+mvn install:install-file -Dfile=cloud-iControl.jar -DgroupId=com.cloud.com.f5 -DartifactId=icontrol -Dversion=1.0 -Dpackaging=jar
+mvn install:install-file -Dfile=iControl-12.1.0.jar -DgroupId=com.cloud.com.f5 -DartifactId=icontrol -Dversion=12.1 -Dpackaging=jar
 
 # From Citrix
 # Version: unknown

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/guru/VMwareGuru.java
@@ -298,7 +298,7 @@ public class VMwareGuru extends HypervisorGuruBase implements HypervisorGuru, Co
         String diskDeviceType = details.get(VmDetailConstants.ROOT_DISK_CONTROLLER);
         if (userVm) {
             if (diskDeviceType == null) {
-                details.put(VmDetailConstants.ROOT_DISK_CONTROLLER, _vmwareMgr.getRootDiskController());
+               details.put(VmDetailConstants.ROOT_DISK_CONTROLLER, _vmwareMgr.getRootDiskController());
             }
         }
         String diskController = details.get(VmDetailConstants.DATA_DISK_CONTROLLER);

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -2007,6 +2007,11 @@ public class VmwareStorageProcessor implements StorageProcessor {
                     diskController = vmMo.getRecommendedDiskController(null);
                 }
 
+                String vmMoGuestId = vmMo.getGuestId();
+                if (vmMoGuestId != null && vmMoGuestId.startsWith("darwin")) {
+                    diskController = DiskControllerType.ahci.toString();
+                }
+
                 vmMo.attachDisk(new String[] { datastoreVolumePath }, morDs, diskController);
 
                 if (isManaged) {

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -408,6 +408,10 @@
                                                 id: "buslogic",
                                                 description: "buslogic"
                                             });
+                                            items.push({
+                                                id: "sata",
+                                                description: "sata"
+                                            });
                                             args.response.success({
                                                 data: items
                                             });
@@ -425,6 +429,10 @@
                                             items.push({
                                                 id: "E1000",
                                                 description: "E1000"
+                                            });
+                                            items.push({
+                                                id: "E1000E",
+                                                description: "E1000E"
                                             });
                                             items.push({
                                                 id: "PCNet32",

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/DiskControllerType.java
@@ -19,11 +19,13 @@ package com.cloud.hypervisor.vmware.mo;
 public enum DiskControllerType {
     ide,
     scsi,
+    sata,
     osdefault,
     lsilogic,
     lsisas1068,
     buslogic,
     pvscsi,
+    ahci,
     none;
     public static DiskControllerType getType(String diskController) {
         if (diskController == null || diskController.equalsIgnoreCase("osdefault")) {
@@ -43,6 +45,9 @@ public enum DiskControllerType {
         } else if (diskController.equalsIgnoreCase("vim.vm.device.VirtualBusLogicController") || diskController.equalsIgnoreCase("VirtualBusLogicController")
                 || diskController.equalsIgnoreCase(ScsiDiskControllerType.BUSLOGIC)) {
             return DiskControllerType.buslogic;
+        } else if (diskController.equalsIgnoreCase("vim.vm.device.VirtualAHCIController") || diskController.equalsIgnoreCase("VirtualAHCIController")
+                || diskController.equalsIgnoreCase(SataDiskControllerType.AHCI)) {
+            return DiskControllerType.ahci;
         } else {
             return DiskControllerType.none;
         }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/SataDiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/SataDiskControllerType.java
@@ -1,0 +1,5 @@
+package com.cloud.hypervisor.vmware.mo;
+
+public interface SataDiskControllerType {
+    public final static String AHCI = "ahci";
+}

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/SataDiskControllerType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/SataDiskControllerType.java
@@ -1,3 +1,19 @@
+//Licensed to the Apache Software Foundation (ASF) under one
+//or more contributor license agreements.  See the NOTICE file
+//distributed with this work for additional information
+//regarding copyright ownership.  The ASF licenses this file
+//to you under the Apache License, Version 2.0 (the
+//"License"); you may not use this file except in compliance
+//with the License.  You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing,
+//software distributed under the License is distributed on an
+//"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//KIND, either express or implied.  See the License for the
+//specific language governing permissions and limitations
+//under the License.
 package com.cloud.hypervisor.vmware.mo;
 
 public interface SataDiskControllerType {

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualEthernetCardType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualEthernetCardType.java
@@ -17,5 +17,5 @@
 package com.cloud.hypervisor.vmware.mo;
 
 public enum VirtualEthernetCardType {
-    E1000, PCNet32, Vmxnet2, Vmxnet3
+    E1000, PCNet32, Vmxnet2, Vmxnet3, E1000E
 }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VmdkAdapterType.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VmdkAdapterType.java
@@ -20,6 +20,7 @@ public enum VmdkAdapterType {
     ide,
     lsilogic,
     buslogic,
+    ahci,
     none;
 
     public static VmdkAdapterType getAdapterType(DiskControllerType diskControllerType) {
@@ -29,6 +30,8 @@ public enum VmdkAdapterType {
             return VmdkAdapterType.buslogic;
         } else if (diskControllerType == DiskControllerType.lsilogic || diskControllerType == DiskControllerType.pvscsi || diskControllerType == DiskControllerType.lsisas1068) {
             return VmdkAdapterType.lsilogic;
+        } else if (diskControllerType == DiskControllerType.ahci) {
+            return VmdkAdapterType.ahci;
         } else {
             return VmdkAdapterType.none;
         }
@@ -41,6 +44,8 @@ public enum VmdkAdapterType {
             return VmdkAdapterType.lsilogic;
         } else if (vmdkAdapterType.equalsIgnoreCase("buslogic")) {
             return VmdkAdapterType.buslogic;
+        } else if (vmdkAdapterType.equalsIgnoreCase("ahci")) {
+            return VmdkAdapterType.ahci;
         } else {
             return VmdkAdapterType.none;
         }

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/util/VmwareHelper.java
@@ -64,6 +64,7 @@ import com.vmware.vim25.VirtualDiskRawDiskMappingVer1BackingInfo;
 import com.vmware.vim25.VirtualDiskSparseVer1BackingInfo;
 import com.vmware.vim25.VirtualDiskSparseVer2BackingInfo;
 import com.vmware.vim25.VirtualE1000;
+import com.vmware.vim25.VirtualE1000E;
 import com.vmware.vim25.VirtualEthernetCard;
 import com.vmware.vim25.VirtualEthernetCardDistributedVirtualPortBackingInfo;
 import com.vmware.vim25.VirtualEthernetCardNetworkBackingInfo;
@@ -89,6 +90,7 @@ public class VmwareHelper {
     private static final Logger s_logger = Logger.getLogger(VmwareHelper.class);
 
     public static final int MAX_SCSI_CONTROLLER_COUNT = 4;
+    public static final int MAX_SATA_CONTROLLER_COUNT = 4;
     public static final int MAX_IDE_CONTROLLER_COUNT = 2;
     public static final int MAX_ALLOWED_DEVICES_IDE_CONTROLLER = 2;
     public static final int MAX_ALLOWED_DEVICES_SCSI_CONTROLLER = 15;
@@ -115,6 +117,10 @@ public class VmwareHelper {
                 nic = new VirtualE1000();
                 break;
 
+            case E1000E:
+                nic = new VirtualE1000E();
+                break;
+
             case PCNet32:
                 nic = new VirtualPCNet32();
                 break;
@@ -130,6 +136,7 @@ public class VmwareHelper {
             default:
                 assert (false);
                 nic = new VirtualE1000();
+
         }
         return nic;
     }

--- a/vmware-base/src/test/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMOTest.java
+++ b/vmware-base/src/test/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMOTest.java
@@ -20,9 +20,11 @@ package com.cloud.hypervisor.vmware.mo;
 import com.cloud.hypervisor.vmware.util.VmwareClient;
 import com.cloud.hypervisor.vmware.util.VmwareContext;
 import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.VirtualAHCIController;
 import com.vmware.vim25.VirtualDevice;
 import com.vmware.vim25.VirtualLsiLogicController;
 import com.vmware.vim25.VirtualLsiLogicSASController;
+import com.vmware.vim25.VirtualSATAController;
 import com.vmware.vim25.VirtualSCSIController;
 import com.vmware.vim25.VirtualSCSISharing;
 import org.junit.After;
@@ -43,6 +45,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
+
 public class VirtualMachineMOTest {
 
     @Mock
@@ -68,6 +71,20 @@ public class VirtualMachineMOTest {
         catch (Exception ex) {
 
         }
+        return deviceList;
+    }
+
+    private List<VirtualDevice> getVirtualSataDeviceList(Class<?> cls) {
+
+        List<VirtualDevice> deviceList = new ArrayList<>();
+        try {
+
+            VirtualSATAController sataController = (VirtualSATAController)cls.newInstance();
+            sataController.setBusNumber(0);
+            sataController.setKey(0);
+            deviceList.add(sataController);
+        }
+        catch (Exception ex) {}
         return deviceList;
     }
 
@@ -111,6 +128,30 @@ public class VirtualMachineMOTest {
         try {
             when(client.getDynamicProperty(any(ManagedObjectReference.class), any(String.class))).thenReturn(getVirtualScSiDeviceList(VirtualLsiLogicController.class));
             vmMo.ensureLsiLogicDeviceControllers(1, 0);
+        }
+        catch (Exception e) {
+            fail("Received exception when success expected: " + e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void testEnsureSataDeviceController() {
+        try {
+            when(client.getDynamicProperty(any(ManagedObjectReference.class), any(String.class))).thenReturn(getVirtualSataDeviceList(VirtualAHCIController.class));
+            vmMo.ensureSataDeviceController();
+        }
+        catch (Exception e) {
+            fail("Received exception when success expected: " + e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void testEnsureAhciDeviceControllers() {
+        try {
+            when(client.getDynamicProperty(any(ManagedObjectReference.class), any(String.class))).thenReturn(getVirtualSataDeviceList(VirtualAHCIController.class));
+            vmMo.ensureAhciDeviceControllers(1, 0);
         }
         catch (Exception e) {
             fail("Received exception when success expected: " + e.getMessage());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Actually, by default, Cloudstack uses **LSI Logic Parallel** Disk controllers and **E1000** network adapter. Since Mac OS seems to present some compatibility issues (above 10.12) with this default hardware profile, we now set up by default only **one SATA Disk controller** and **E1000E** network adapter (which are compatibles with last versions of Mac OS).

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
Few tests have been made to ensure that we are manipulating SATA Controllers mainly (in VirtualMachineMOTest.java). Also, direct debugging of UI Client (cloud-client-uI-4.11.3.0.jar).
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
