### PR TITLE
kvm/security_group: Make Security Group Python 3 compatible

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,13 @@ Section: libs
 Priority: extra
 Maintainer: Wido den Hollander <wido@widodh.nl>
 Build-Depends: debhelper (>= 9), openjdk-8-jdk | java8-sdk | java8-jdk | openjdk-9-jdk, genisoimage,
- python-mysql.connector, maven (>= 3) | maven3, python (>= 2.7), lsb-release, dh-systemd, python-setuptools
+ python-mysql.connector, maven (>= 3) | maven3, python (>= 2.7), python3 (>= 3), lsb-release, dh-systemd, python-setuptools
 Standards-Version: 3.8.1
 Homepage: http://www.cloudstack.org/
 
 Package: cloudstack-common
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, genisoimage, nfs-common, python-netaddr
+Depends: ${misc:Depends}, ${python:Depends}, genisoimage, nfs-common
 Conflicts: cloud-scripts, cloud-utils, cloud-system-iso, cloud-console-proxy, cloud-daemonize, cloud-deps, cloud-python, cloud-setup
 Description: A common package which contains files which are shared by several CloudStack packages
 
@@ -22,7 +22,7 @@ Description: CloudStack server library
 
 Package: cloudstack-agent
 Architecture: all
-Depends: ${python:Depends}, openjdk-8-jre-headless | java8-runtime-headless | java8-runtime | openjdk-9-jre-headless, cloudstack-common (= ${source:Version}), lsb-base (>= 9), openssh-client, qemu-kvm (>= 2.5), libvirt-bin (>= 1.3) | libvirt-daemon-system (>= 3.0), uuid-runtime, iproute2, ebtables, vlan, ipset, python-libvirt, ethtool, iptables, lsb-release, aria2
+Depends: ${python:Depends}, openjdk-8-jre-headless | java8-runtime-headless | java8-runtime | openjdk-9-jre-headless, cloudstack-common (= ${source:Version}), lsb-base (>= 9), openssh-client, qemu-kvm (>= 2.5), libvirt-bin (>= 1.3) | libvirt-daemon-system (>= 3.0), uuid-runtime, iproute2, ebtables, vlan, ipset, python3-libvirt, ethtool, iptables, lsb-release, aria2
 Recommends: init-system-helpers
 Conflicts: cloud-agent, cloud-agent-libs, cloud-agent-deps, cloud-agent-scripts
 Description: CloudStack agent

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -55,6 +55,7 @@ intelligent IaaS cloud implementation.
 Summary:   CloudStack management server UI
 Requires: java-1.8.0-openjdk
 Requires: python
+Requires: python3
 Requires: bash
 Requires: bzip2
 Requires: gzip
@@ -82,6 +83,7 @@ management, and intelligence in CloudStack.
 %package common
 Summary: Apache CloudStack common files and scripts
 Requires: python
+Requires: python3
 Requires: python-argparse
 Requires: python-netaddr
 Group:   System Environment/Libraries


### PR DESCRIPTION
This script only runs on the KVM Hypervisors and these all support
Python 3.

As Python 2 is deprecated at the end of 2019 we need to fix these
scripts to work under Python 3.

CentOS 7, 8 and Ubuntu 16.04 and 18.04 all have Python 3 installed
by default.

Ubuntu 20.04 will no longer have Python 2 installed and therefor
this script needs to be modified to work with Python 3.

Signed-off-by: Wido den Hollander <wido@widodh.nl>