### PR TITLE
[WIP DO NOT MERGE] KVM dynamic VM scaling

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2105,6 +2105,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         }
         final int vcpus = vmTO.getCpus();
         grd.setVcpuNum(vcpus);
+        final KVMHostInfo info = new KVMHostInfo(_dom0MinMem, _dom0OvercommitMem);
+        grd.setMaxVcpu(info.getCpus());
         vm.addComp(grd);
 
         if (!extraConfig.containsKey(DpdkHelper.DPDK_NUMA)) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -286,6 +286,8 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     private final Map <String, String> _pifs = new HashMap<String, String>();
     private final Map<String, VmStats> _vmStats = new ConcurrentHashMap<String, VmStats>();
 
+    protected KVMHostInfo info;
+
     protected static final HashMap<DomainState, PowerState> s_powerStatesTable;
     static {
         s_powerStatesTable = new HashMap<DomainState, PowerState>();
@@ -2096,16 +2098,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
 
         final GuestResourceDef grd = new GuestResourceDef();
 
-        if (vmTO.getMinRam() != vmTO.getMaxRam() && !_noMemBalloon) {
+        if (/*vmTO.getMinRam() != vmTO.getMaxRam() && */!_noMemBalloon) {
             grd.setMemBalloning(true);
-            grd.setCurrentMem(vmTO.getMinRam() / 1024);
-            grd.setMemorySize(vmTO.getMaxRam() / 1024);
-        } else {
-            grd.setMemorySize(vmTO.getMaxRam() / 1024);
         }
+        grd.setCurrentMem(vmTO.getMaxRam() / 1024);
+        //grd.setMemorySize(info.getTotalMemory());
+        grd.setMemorySize(4 * 1024 * 1024);
         final int vcpus = vmTO.getCpus();
         grd.setVcpuNum(vcpus);
-        final KVMHostInfo info = new KVMHostInfo(_dom0MinMem, _dom0OvercommitMem);
         grd.setMaxVcpu(info.getCpus());
         vm.addComp(grd);
 
@@ -2710,7 +2710,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
     @Override
     public StartupCommand[] initialize() {
 
-        final KVMHostInfo info = new KVMHostInfo(_dom0MinMem, _dom0OvercommitMem);
+        info = new KVMHostInfo(_dom0MinMem, _dom0OvercommitMem);
 
         String capabilities = String.join(",", info.getCapabilities());
         if (dpdkSupport) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -152,6 +152,7 @@ public class LibvirtVMDef {
         private String _memBacking;
         private int _vcpu = -1;
         private boolean _memBalloning = false;
+        private int maxVcpu = -1;
 
         public void setMemorySize(long mem) {
             _mem = mem;
@@ -173,6 +174,10 @@ public class LibvirtVMDef {
             _memBalloning = turnon;
         }
 
+        public void setMaxVcpu(int maxVcpu) {
+            this.maxVcpu = maxVcpu;
+        }
+
         @Override
         public String toString() {
             StringBuilder resBuidler = new StringBuilder();
@@ -188,8 +193,8 @@ public class LibvirtVMDef {
             } else {
                 resBuidler.append("<devices>\n" + "<memballoon model='none'/>\n" + "</devices>\n");
             }
-            if (_vcpu != -1) {
-                resBuidler.append("<vcpu>" + _vcpu + "</vcpu>\n");
+            if (_vcpu != -1 && maxVcpu != -1) {
+                resBuidler.append("<vcpu current='" +_vcpu + "'>" + maxVcpu + "</vcpu>\n");
             }
             return resBuidler.toString();
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
@@ -42,6 +42,7 @@ public class LibvirtScaleVmCommandWrapper extends CommandWrapper<ScaleVmCommand,
             Connect conn = libvirtUtilitiesHelper.getConnection();
             Domain dm = serverResource.getDomain(conn, vmName);
             dm.setVcpus(command.getCpus());
+            dm.setMemory(command.getMaxRam());
             return new ScaleVmAnswer(command, true, "OK");
         } catch (LibvirtException e) {
             s_logger.error(e.getMessage());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
@@ -1,0 +1,52 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package com.cloud.hypervisor.kvm.resource.wrapper;
+
+import com.cloud.agent.api.ScaleVmAnswer;
+import com.cloud.agent.api.ScaleVmCommand;
+import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
+import com.cloud.resource.CommandWrapper;
+import com.cloud.resource.ResourceWrapper;
+import org.apache.log4j.Logger;
+import org.libvirt.Connect;
+import org.libvirt.Domain;
+import org.libvirt.LibvirtException;
+
+@ResourceWrapper(handles =  ScaleVmCommand.class)
+public class LibvirtScaleVmCommandWrapper extends CommandWrapper<ScaleVmCommand, ScaleVmAnswer, LibvirtComputingResource> {
+
+    private static final Logger s_logger = Logger.getLogger(LibvirtScaleVmCommandWrapper.class);
+
+    @Override
+    public ScaleVmAnswer execute(ScaleVmCommand command, LibvirtComputingResource serverResource) {
+        String vmName = command.getVmName();
+        s_logger.debug("Trying to scale VM " + vmName + " CPUs to " + command.getCpus());
+        try {
+            final LibvirtUtilitiesHelper libvirtUtilitiesHelper = serverResource.getLibvirtUtilitiesHelper();
+            Connect conn = libvirtUtilitiesHelper.getConnection();
+            Domain dm = serverResource.getDomain(conn, vmName);
+            dm.setVcpus(command.getCpus());
+            return new ScaleVmAnswer(command, true, "OK");
+        } catch (LibvirtException e) {
+            s_logger.error(e.getMessage());
+            return new ScaleVmAnswer(command, false, e.getMessage());
+        }
+    }
+
+}

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtScaleVmCommandWrapper.java
@@ -36,17 +36,19 @@ public class LibvirtScaleVmCommandWrapper extends CommandWrapper<ScaleVmCommand,
     @Override
     public ScaleVmAnswer execute(ScaleVmCommand command, LibvirtComputingResource serverResource) {
         String vmName = command.getVmName();
-        s_logger.debug("Trying to scale VM " + vmName + " CPUs to " + command.getCpus());
+        long memory = command.getMaxRam();
+        int cpus = command.getCpus();
+        s_logger.debug("Trying to scale VM " + vmName + " to number CPUs: " + cpus + " and memory: " + memory);
         try {
             final LibvirtUtilitiesHelper libvirtUtilitiesHelper = serverResource.getLibvirtUtilitiesHelper();
             Connect conn = libvirtUtilitiesHelper.getConnection();
             Domain dm = serverResource.getDomain(conn, vmName);
             dm.setVcpus(command.getCpus());
-            dm.setMemory(command.getMaxRam());
-            return new ScaleVmAnswer(command, true, "OK");
+            dm.setMemory(command.getMaxRam() / 1024);
+            return new ScaleVmAnswer(command, true, "VM " + vmName + " scaled successfully");
         } catch (LibvirtException e) {
             s_logger.error(e.getMessage());
-            return new ScaleVmAnswer(command, false, e.getMessage());
+            return new ScaleVmAnswer(command, false, "VM " + vmName + " scale failed: " + e.getMessage());
         }
     }
 

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -44,6 +44,7 @@ import javax.xml.xpath.XPathFactory;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.UnsupportedAnswer;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.CpuTuneDef;
+import org.apache.cloudstack.utils.linux.KVMHostInfo;
 import org.apache.commons.lang.SystemUtils;
 import org.joda.time.Duration;
 import org.junit.Assert;
@@ -199,6 +200,8 @@ public class LibvirtComputingResourceTest {
     VirtualMachineTO vmTO;
     @Mock
     LibvirtVMDef vmDef;
+    @Mock
+    KVMHostInfo info;
 
     String hyperVisorType = "kvm";
     Random random = new Random();
@@ -245,6 +248,9 @@ public class LibvirtComputingResourceTest {
         to.setVncAddr(vncAddr);
         to.setUuid("b0f0a72d-7efb-3cad-a8ff-70ebf30b3af9");
 
+        lcr.info = info;
+        Mockito.when(info.getCpus()).thenReturn(cpus);
+
         final LibvirtVMDef vm = lcr.createVMFromSpec(to);
         vm.setHvsType(hyperVisorType);
 
@@ -277,6 +283,9 @@ public class LibvirtComputingResourceTest {
         to.setVncAddr(vncAddr);
         to.setUuid("b0f0a72d-7efb-3cad-a8ff-70ebf30b3af9");
 
+        lcr.info = info;
+        Mockito.when(info.getCpus()).thenReturn(cpus);
+
         final LibvirtVMDef vm = lcr.createVMFromSpec(to);
         vm.setHvsType(hyperVisorType);
 
@@ -308,6 +317,9 @@ public class LibvirtComputingResourceTest {
         final VirtualMachineTO to = new VirtualMachineTO(id, name, VirtualMachine.Type.User, cpus, minSpeed, maxSpeed, minRam, maxRam, BootloaderType.HVM, os, false, false, vncPassword);
         to.setVncAddr(vncAddr);
         to.setUuid("b0f0a72d-7efb-3cad-a8ff-70ebf30b3af9");
+
+        lcr.info = info;
+        Mockito.when(info.getCpus()).thenReturn(cpus);
 
         final LibvirtVMDef vm = lcr.createVMFromSpec(to);
         vm.setHvsType(hyperVisorType);
@@ -345,6 +357,9 @@ public class LibvirtComputingResourceTest {
                 new VirtualMachineTO(id, name, VirtualMachine.Type.User, cpus, minSpeed, maxSpeed, minRam, maxRam, BootloaderType.HVM, os, false, false, vncPassword);
         to.setVncAddr(vncAddr);
         to.setUuid("b0f0a72d-7efb-3cad-a8ff-70ebf30b3af9");
+
+        lcr.info = info;
+        Mockito.when(info.getCpus()).thenReturn(cpus);
 
         final LibvirtVMDef vm = lcr.createVMFromSpec(to);
         vm.setHvsType(hyperVisorType);

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -1726,7 +1726,8 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         Account caller = CallContext.current().getCallingAccount();
         VMInstanceVO vmInstance = _vmInstanceDao.findById(vmId);
-        if (vmInstance.getHypervisorType() != HypervisorType.XenServer && vmInstance.getHypervisorType() != HypervisorType.VMware && vmInstance.getHypervisorType() != HypervisorType.Simulator) {
+        if (vmInstance.getHypervisorType() != HypervisorType.XenServer && vmInstance.getHypervisorType() != HypervisorType.VMware &&
+                vmInstance.getHypervisorType() != HypervisorType.Simulator && vmInstance.getHypervisorType() != HypervisorType.KVM) {
             s_logger.info("Scaling the VM dynamically is not supported for VMs running on Hypervisor "+vmInstance.getHypervisorType());
             throw new InvalidParameterValueException("Scaling the VM dynamically is not supported for VMs running on Hypervisor "+vmInstance.getHypervisorType());
         }

--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -3655,7 +3655,7 @@
             allowedActions.push("reinstall");
 
             //when userVm is running, scaleUp is not supported for KVM, LXC
-            if (jsonObj.hypervisor != 'KVM' && jsonObj.hypervisor != 'LXC') {
+            if (jsonObj.hypervisor != 'LXC') {
                 allowedActions.push("scaleUp");
             }
 


### PR DESCRIPTION
## Description
Allow dynamic VM scaling for KVM

Fixes: #3594 

Changes:
- When deploying VM, the VM vCPU max number is set to the host CPU number. This allows virsh to set vCPU numbers and avoid the error:
````
invalid argument: requested vcpus is greater than max allowable vcpus for the live domain: N > M
```` 

## Types of changes
- [x] Enhancement (improves an existing feature and functionality)

## Screenshots (if appropriate):

## How Has This Been Tested?
