### PR TITLE
kvm: Logrotate should not touch agent.log

### DIFF
--- a/agent/conf/cloudstack-agent.logrotate.in
+++ b/agent/conf/cloudstack-agent.logrotate.in
@@ -15,12 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-@AGENTLOG@
-/var/log/cloudstack/agent/security_group.log
-{
+/var/log/cloudstack/agent/security_group.log /var/log/cloudstack/agent/resizevolume.log {
     copytruncate
     daily
     rotate 5
     compress
     missingok
+    size 10M
 }


### PR DESCRIPTION
Logrotate should only touch security_group.log and resizevolume.log
as the agent.log is already rotated by log4j inside the Agent.

Having two systems trying to rotate agent.log leads to all kinds of
issues like having binary (compressed) data in the middle of a plain-text
log file.

Signed-off-by: Wido den Hollander <wido@widodh.nl>
