### PR TITLE
Fix Policy Based Routing for private gateway static routes

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -931,10 +931,10 @@ class CsForwardingRules(CsDataBag):
 
         self.fw.append(["mangle", "front",
                         "-A PREROUTING -s %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
-                        rule["internal_ip"]])
+                        rule["public_ip"]])
         self.fw.append(["mangle", "front",
                         "-A PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
-                        (rule["internal_ip"], hex(100 + int(device[len("eth"):])))])
+                        (rule["public_ip"], hex(100 + int(device[len("eth"):])))])
         self.fw.append(["nat", "front",
                         "-A PREROUTING -d %s/32 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])
         self.fw.append(["nat", "front",

--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -930,10 +930,10 @@ class CsForwardingRules(CsDataBag):
             raise Exception("Ip address %s has no device in the ips databag" % rule["public_ip"])
 
         self.fw.append(["mangle", "front",
-                        "-A PREROUTING -s %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
+                        "-A PREROUTING -d %s/32 -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" %
                         rule["public_ip"]])
         self.fw.append(["mangle", "front",
-                        "-A PREROUTING -s %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
+                        "-A PREROUTING -d %s/32 -m state --state NEW -j MARK --set-xmark %s/0xffffffff" %
                         (rule["public_ip"], hex(100 + int(device[len("eth"):])))])
         self.fw.append(["nat", "front",
                         "-A PREROUTING -d %s/32 -j DNAT --to-destination %s" % (rule["public_ip"], rule["internal_ip"])])


### PR DESCRIPTION
## Description

We noticed that VMs that are target of a static nat cannot use private gateways.

Investigation showed that these VMs behave differently than all other VMs in a VPC because their whole traffic gets marked and is only allowed to leave through the public ip provided by the static nat.

Could be related to: https://github.com/apache/cloudstack/pull/3366
Maybe @richardlawley @rhtyd can contribute if this is an unwanted side-effect.

To not break anything we propose a solution that does only mark the nat portion of the traffic and allow the VM use the private gateway like normal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
We built and manually tested this to check if function is restored and nothing else breaks.
