### PR TITLE
fix issue #3590 'Revert Ceph/RBD Snapshot'

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRevertSnapshotCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRevertSnapshotCommandWrapper.java
@@ -86,14 +86,16 @@ public final class LibvirtRevertSnapshotCommandWrapper extends CommandWrapper<Re
                 rados.connect();
 
                 String[] rbdPoolAndVolumeAndSnapshot = snapshotRelPath.split("/");
+                int snapshotIndex = rbdPoolAndVolumeAndSnapshot.length - 1;
+                String rbdSnapshotId = rbdPoolAndVolumeAndSnapshot[snapshotIndex];
 
                 IoCTX io = rados.ioCtxCreate(primaryPool.getSourceDir());
                 Rbd rbd = new Rbd(io);
-                RbdImage image = rbd.open(rbdPoolAndVolumeAndSnapshot[1]);
 
-                s_logger.debug(String.format("Attempting to rollback RBD snapshot [name:%s], [pool:%s], [volumeid:%s], [snapshotid:%s]", snapshot.getName(),
-                        rbdPoolAndVolumeAndSnapshot[0], rbdPoolAndVolumeAndSnapshot[1], rbdPoolAndVolumeAndSnapshot[2]));
-                image.snapRollBack(rbdPoolAndVolumeAndSnapshot[2]);
+                s_logger.debug(String.format("Attempting to rollback RBD snapshot [name:%s], [volumeid:%s], [snapshotid:%s]", snapshot.getName(), volumePath, rbdSnapshotId));
+
+                RbdImage image = rbd.open(volumePath);
+                image.snapRollBack(rbdSnapshotId);
 
                 rbd.close(image);
                 rados.ioCtxDestroy(io);


### PR DESCRIPTION
## Description
Fixes issue #3590 by using the last element on the array from the snapshot "path" String for retrieving the snapshot id. Additionally, it uses the `volumePath` as the volume id which should always be the correct value. The error raised on issue #3590 was related to the wrong use of variable "path" where in some cases had a different set of substrings.

The proposed change has been tested and evaluated. The values used for openning the RBD connection and executing the rollback were stable on the tests. Runned rollback on multiple snapshots and could start the VM with the content matching the ROOT reverted snapshot.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)