### PR TITLE
systemvm: for ip route show command don't use the throw command

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsRoute.py
@@ -79,7 +79,7 @@ class CsRoute:
         found = False
         search = cmd
         if "throw" in search:
-            search = "type " + search
+            search = search.replace("throw", "")
         for i in CsHelper.execute("ip route show " + search):
             found = True
         if not found and method == "add":


### PR DESCRIPTION
While searching for existing route, don't use the throw keyword when
using the cmd with `ip route show`. This fixes unnecessary ERROR messages in the VR cloud.log and issue of re-adding an already added routing rule (which may throw RTLINK file already exists error).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)