### PR TITLE
Handle Ceph/RBD snapshot delete

### DIFF
--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategy.java
@@ -56,9 +56,18 @@ public class CephSnapshotStrategy extends StorageSystemSnapshotStrategy {
             return StrategyPriority.CANT_HANDLE;
         }
 
-        if (SnapshotOperation.REVERT.equals(op) && isSnapshotStoredOnRbdStoragePool(snapshot)) {
+        if (!isSnapshotStoredOnRbdStoragePool(snapshot)) {
+            return StrategyPriority.CANT_HANDLE;
+        }
+
+        if (SnapshotOperation.REVERT.equals(op)) {
             return StrategyPriority.HIGHEST;
         }
+
+        if (SnapshotOperation.DELETE.equals(op)) {
+            return StrategyPriority.HIGHEST;
+        }
+
         return StrategyPriority.CANT_HANDLE;
     }
 

--- a/engine/storage/snapshot/src/test/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategyTest.java
+++ b/engine/storage/snapshot/src/test/java/org/apache/cloudstack/storage/snapshot/CephSnapshotStrategyTest.java
@@ -87,6 +87,8 @@ public class CephSnapshotStrategyTest {
             StrategyPriority strategyPriority = cephSnapshotStrategy.canHandle(snapshot, snapshotOps[i]);
             if (snapshotOps[i] == SnapshotOperation.REVERT && isSnapshotStoredOnRbdStoragePool) {
                 Assert.assertEquals(StrategyPriority.HIGHEST, strategyPriority);
+            } else if (snapshotOps[i] == SnapshotOperation.DELETE && isSnapshotStoredOnRbdStoragePool) {
+                Assert.assertEquals(StrategyPriority.HIGHEST, strategyPriority);
             } else {
                 Assert.assertEquals(StrategyPriority.CANT_HANDLE, strategyPriority);
             }

--- a/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
+++ b/plugins/storage/volume/default/src/main/java/org/apache/cloudstack/storage/datastore/driver/CloudStackPrimaryDataStoreDriverImpl.java
@@ -82,7 +82,7 @@ public class CloudStackPrimaryDataStoreDriverImpl implements PrimaryDataStoreDri
     @Override
     public Map<String, String> getCapabilities() {
         Map<String, String> caps = new HashMap<String, String>();
-        caps.put(DataStoreCapabilities.VOLUME_SNAPSHOT_QUIESCEVM.toString(), "false");
+        caps.put(DataStoreCapabilities.VOLUME_SNAPSHOT_QUIESCEVM.toString(), Boolean.FALSE.toString());
         return caps;
     }
 


### PR DESCRIPTION
## Description

When deleting volume snapshots, only records in the database are deleted, and snapshots are not deleted on the main storage.

Fixes: #3586

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Configuration:
```
snapshot.backup.to.secondary =false
kvm.snapshot.enabled =true
```
1. Create snapshots stored on Ceph/RBD primary storage.
2. Delete and assert that it has been removed on the RBD pool.

I was able to reproduce the issue #3586. After applying the packages with this fix, snapshots were properly removed from DB and deleted from the RBD storage pool.