### PR TITLE
kvm: Use 'ip' instead of 'brctl'

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/BridgeVifDriver.java
@@ -273,12 +273,12 @@ public class BridgeVifDriver extends VifDriverBase {
 
     @Override
     public void attach(LibvirtVMDef.InterfaceDef iface) {
-        Script.runSimpleBashScript("brctl addif " + iface.getBrName() + " " + iface.getDevName());
+        Script.runSimpleBashScript("ip link set " + iface.getDevName() + " master " +  iface.getBrName());
     }
 
     @Override
     public void detach(LibvirtVMDef.InterfaceDef iface) {
-        Script.runSimpleBashScript("test -d /sys/class/net/" + iface.getBrName() + "/brif/" + iface.getDevName() + " && brctl delif " + iface.getBrName() + " " + iface.getDevName());
+        Script.runSimpleBashScript("test -d /sys/class/net/" + iface.getBrName() + "/brif/" + iface.getDevName() + " && ip link set " + iface.getDevName() + " nomaster");
     }
 
     private String generateVnetBrName(String pifName, String vnetId) {

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/IvsVifDriver.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/IvsVifDriver.java
@@ -282,7 +282,7 @@ public class IvsVifDriver extends VifDriverBase {
     public void createControlNetwork(String privBrName) {
         deleteExitingLinkLocalRouteTable(privBrName);
         if (!isBridgeExists(privBrName)) {
-            Script.runSimpleBashScript("brctl addbr " + privBrName + "; ip link set " + privBrName + " up");
+            Script.runSimpleBashScript("ip link add " + privBrName + " type bridge; ip link set " + privBrName + " up");
             Script.runSimpleBashScript("ip address add " + NetUtils.getLinkLocalAddressFromCIDR(_controlCidr) + " dev " + privBrName, _timeout);
         }
     }

--- a/scripts/vm/network/vnet/modifyvlan.sh
+++ b/scripts/vm/network/vnet/modifyvlan.sh
@@ -52,7 +52,8 @@ addVlan() {
 	
 	if [ ! -d /sys/class/net/$vlanBr ]
 	then
-		brctl addbr $vlanBr > /dev/null
+		ip link add name $vlanBr type bridge
+		ip link set $vlanBr up
 	
 		if [ $? -gt 0 ]
 		then
@@ -62,15 +63,13 @@ addVlan() {
 				return 2
 			fi
 		fi
-
-		brctl setfd $vlanBr 0
 	fi
 	
 	#pif is eslaved into vlanBr?
 	ls /sys/class/net/$vlanBr/brif/ |grep -w "$vlanDev" > /dev/null 
 	if [ $? -gt 0 ]
 	then
-		brctl addif $vlanBr $vlanDev > /dev/null
+		ip link set $vlanDev master $vlanBr
 		if [ $? -gt 0 ]
 		then
 			ls /sys/class/net/$vlanBr/brif/ |grep -w "$vlanDev" > /dev/null 
@@ -108,7 +107,7 @@ deleteVlan() {
 		return 1
 	fi
 	
-	brctl delbr $vlanBr
+	ip link delete $vlanBr type bridge
 	
 	if [ $? -gt 0 ]
 	then


### PR DESCRIPTION
The command 'brctl' is deprecated and should no longer be used.

iproute2 supports all the features we need and therefor we should use
this instead of the old commands.

Feature wise this does not change anything. It just makes the code more
robust towards the future.

Signed-off-by: Wido den Hollander <wido@widodh.nl>