### PR TITLE
kvm: fix issue that network rules for secondary IPs are not applied

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -3638,7 +3638,7 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         cmd.add("network_rules_vmSecondaryIp");
         cmd.add("--vmname", vmName);
         cmd.add("--nicsecips", secIp);
-        cmd.add("--action", action);
+        cmd.add("--action=" + action);
 
         final String result = cmd.execute();
         if (result != null) {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

When I add a secondary IP to a nic on shared network in advanced zone with security groups, the network rules for new IP are not applied on KVM hypervisors.
It is because "--action -A" cannot be recognized in security_group.py after commit ac73e7e671ba107830f96b9fb534eb716956e405. changing to "--action=-A" will fix it.


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

When add a ip (ip must to be specified see https://github.com/apache/cloudstack/pull/3635) to a nic, in advanced zone with security groups, the network rules for the ip should be added on hypervisor. However it does not work in 4.13/master.

in agent.log it gives the following error
```
root@node32:~# /usr/share/cloudstack-common/scripts/vm/network/security_group.py network_rules_vmSecondaryIp --vmname i-14-54-VM --nicsecips 192.168.116.246 --action -A
usage: security_group.py [-h] [--vmname VMNAME] [--vmip VMIP] [--vmip6 VMIP6]
                         [--vmid VMID] [--vmmac VMMAC] [--vif VIF] [--sig SIG]
                         [--seq SEQ] [--rules RULES] [--brname BRNAME]
                         [--localbrname LOCALBRNAME] [--dhcpSvr DHCPSVR]
                         [--hostIp HOSTIP] [--hostMacAddr HOSTMACADDR]
                         [--nicsecips NICSECIPS] [--action ACTION]
                         [--privnic PRIVNIC] [--isFirstNic] [--check]
                         command
security_group.py: error: argument --action: expected one argument
```
The rules (ipset, iptables, ebtables) are added after this fix.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
