### PR TITLE
security_group.py: fix NameError: name 'd' is not defined

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -101,8 +101,8 @@ def virshlist(states):
 
     conn = get_libvirt_connection()
 
-    alldomains = [d for domain in map(conn.lookupByID, conn.listDomainsID())]
-    alldomains += [d for domain in map(conn.lookupByName, conn.listDefinedDomains())]
+    alldomains = [domain for domain in map(conn.lookupByID, conn.listDomainsID())]
+    alldomains += [domain for domain in map(conn.lookupByName, conn.listDefinedDomains())]
 
     domains = []
     for domain in alldomains:


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

in agent.log on a host running with cloudstack 4.14.0.0-SNAPSHOT, it gives error
```
Traceback (most recent call last):
  File "/usr/share/cloudstack-common/scripts/vm/network/security_group.py", line 1272, in <module>
    get_rule_logs_for_vms()
  File "/usr/share/cloudstack-common/scripts/vm/network/security_group.py", line 758, in get_rule_logs_for_vms
    vms = virshlist(state)
  File "/usr/share/cloudstack-common/scripts/vm/network/security_group.py", line 104, in virshlist
    alldomains = [d for domain in map(conn.lookupByID, conn.listDomainsID())]
  File "/usr/share/cloudstack-common/scripts/vm/network/security_group.py", line 104, in <listcomp>
    alldomains = [d for domain in map(conn.lookupByID, conn.listDomainsID())]
NameError: name 'd' is not defined
```
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
