### PR TITLE
IoT/ARM64 support: allow cloudstack-agent on Raspberry Pi 4 (armv8) to use kvm acceleration

### DIFF
--- a/agent/conf/agent.properties
+++ b/agent/conf/agent.properties
@@ -146,6 +146,12 @@ hypervisor.type=kvm
 # on,run virsh capabilities for more details.
 # guest.cpu.model=
 #
+# This param will set the CPU architecture for the domain override what
+# the management server would send
+# In case of arm64 (aarch64), this will change the machine type to 'virt' and
+# adds a SCSI and a USB controller in the domain xml.
+# guest.cpu.arch=x86_64|aarch64
+#
 # This param will require CPU features on the <cpu> section
 # guest.cpu.features=vmx vme
 #

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtCapXMLParser.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtCapXMLParser.java
@@ -80,7 +80,8 @@ public class LibvirtCapXMLParser extends LibvirtXMLParser {
             }
         } else if (qName.equalsIgnoreCase("arch")) {
             for (int i = 0; i < attributes.getLength(); i++) {
-                if (attributes.getQName(i).equalsIgnoreCase("name") && attributes.getValue(i).equalsIgnoreCase("x86_64")) {
+                if (attributes.getQName(i).equalsIgnoreCase("name") &&
+                        (attributes.getValue(i).equalsIgnoreCase("x86_64") || attributes.getValue(i).equalsIgnoreCase("aarch64"))) {
                     _archTypex8664 = true;
                 }
             }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -125,7 +125,7 @@ public class LibvirtVMDef {
                     guestDef.append(" machine='" + _machine + "'");
                 }
                 guestDef.append(">hvm</type>\n");
-                if (_arch.equals("aarch64")) {
+                if (_arch != null && _arch.equals("aarch64")) {
                     guestDef.append("<loader readonly='yes' type='pflash'>/usr/share/AAVMF/AAVMF_CODE.fd</loader>\n");
                 }
                 if (!_bootdevs.isEmpty()) {
@@ -133,7 +133,7 @@ public class LibvirtVMDef {
                         guestDef.append("<boot dev='" + bo + "'/>\n");
                     }
                 }
-                if (!_arch.equals("aarch64")) {
+                if (_arch == null || !_arch.equals("aarch64")) {
                     guestDef.append("<smbios mode='sysinfo'/>\n");
                 }
                 guestDef.append("</os>\n");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDef.java
@@ -125,12 +125,17 @@ public class LibvirtVMDef {
                     guestDef.append(" machine='" + _machine + "'");
                 }
                 guestDef.append(">hvm</type>\n");
+                if (_arch.equals("aarch64")) {
+                    guestDef.append("<loader readonly='yes' type='pflash'>/usr/share/AAVMF/AAVMF_CODE.fd</loader>\n");
+                }
                 if (!_bootdevs.isEmpty()) {
                     for (BootOrder bo : _bootdevs) {
                         guestDef.append("<boot dev='" + bo + "'/>\n");
                     }
                 }
-                guestDef.append("<smbios mode='sysinfo'/>\n");
+                if (!_arch.equals("aarch64")) {
+                    guestDef.append("<smbios mode='sysinfo'/>\n");
+                }
                 guestDef.append("</os>\n");
                 return guestDef.toString();
             } else if (_type == GuestType.LXC) {
@@ -780,6 +785,10 @@ public class LibvirtVMDef {
 
         public DiskBus getBusType() {
             return _bus;
+        }
+
+        public void setBusType(DiskBus busType) {
+            _bus = busType;
         }
 
         public DiskFmtType getDiskFormatType() {
@@ -1619,6 +1628,37 @@ public class LibvirtVMDef {
             if (this.queues > 0) {
                 scsiBuilder.append(String.format("<driver queues='%d'/>\n", this.queues));
             }
+            scsiBuilder.append("</controller>\n");
+            return scsiBuilder.toString();
+        }
+    }
+
+    public static class USBDef {
+        private short index = 0;
+        private int domain = 0;
+        private int bus = 0;
+        private int slot = 9;
+        private int function = 0;
+
+        public USBDef(short index, int domain, int bus, int slot, int function) {
+            this.index = index;
+            this.domain = domain;
+            this.bus = bus;
+            this.slot = slot;
+            this.function = function;
+        }
+
+        public USBDef() {
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder scsiBuilder = new StringBuilder();
+
+            scsiBuilder.append(String.format("<controller type='usb' index='%d' model='qemu-xhci'>\n", this.index));
+            scsiBuilder.append("<alias name='usb'/>");
+            scsiBuilder.append(String.format("<address type='pci' domain='0x%04X' bus='0x%02X' slot='0x%02X' function='0x%01X'/>\n",
+                    this.domain, this.bus, this.slot, this.function ) );
             scsiBuilder.append("</controller>\n");
             return scsiBuilder.toString();
         }

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -243,6 +243,7 @@ public class LibvirtComputingResourceTest {
 
         final VirtualMachineTO to = new VirtualMachineTO(id, name, VirtualMachine.Type.User, cpus, speed, minRam, maxRam, BootloaderType.HVM, os, false, false, vncPassword);
         to.setVncAddr(vncAddr);
+        to.setArch("x86_64");
         to.setUuid("b0f0a72d-7efb-3cad-a8ff-70ebf30b3af9");
 
         final LibvirtVMDef vm = lcr.createVMFromSpec(to);
@@ -275,6 +276,7 @@ public class LibvirtComputingResourceTest {
 
         final VirtualMachineTO to = new VirtualMachineTO(id, name, VirtualMachine.Type.User, cpus, minSpeed, maxSpeed, minRam, maxRam, BootloaderType.HVM, os, false, false, vncPassword);
         to.setVncAddr(vncAddr);
+        to.setArch("x86_64");
         to.setUuid("b0f0a72d-7efb-3cad-a8ff-70ebf30b3af9");
 
         final LibvirtVMDef vm = lcr.createVMFromSpec(to);
@@ -344,6 +346,7 @@ public class LibvirtComputingResourceTest {
         final VirtualMachineTO to =
                 new VirtualMachineTO(id, name, VirtualMachine.Type.User, cpus, minSpeed, maxSpeed, minRam, maxRam, BootloaderType.HVM, os, false, false, vncPassword);
         to.setVncAddr(vncAddr);
+        to.setArch("x86_64");
         to.setUuid("b0f0a72d-7efb-3cad-a8ff-70ebf30b3af9");
 
         final LibvirtVMDef vm = lcr.createVMFromSpec(to);

--- a/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
+++ b/server/src/main/java/com/cloud/hypervisor/kvm/discoverer/LibvirtServerDiscoverer.java
@@ -251,7 +251,7 @@ public abstract class LibvirtServerDiscoverer extends DiscovererBase implements 
                 throw new DiscoveredWithErrorException("Authentication error");
             }
 
-            if (!SSHCmdHelper.sshExecuteCmd(sshConnection, "lsmod|grep kvm")) {
+            if (!SSHCmdHelper.sshExecuteCmd(sshConnection, "ls /dev/kvm")) {
                 s_logger.debug("It's not a KVM enabled machine");
                 return null;
             }


### PR DESCRIPTION
KVM is supported on arm64 Linux (https://www.linux-kvm.org/page/Processor_support#ARM:). For a small (IoT) platform such as the new Raspberry Pi 4 that uses armv8 processor (cortex-a72) it's possible to run Linux host with `/dev/kvm` accleration.

This PR is from a fun weekend project where:
- I set up a Raspberry Pi 4 - 4GB RAM model with 4 CPU cores @ 1.5Ghz, 128GB SD samsung evo plus card
- Installed Ubuntu 19.10 raspi3 base image: http://cdimage.ubuntu.com/releases/19.10/release/ubuntu-19.10-preinstalled-server-arm64+raspi3.img.xz
- Build a custom Linux 5.3 kernel with KVM enabled, deb here: http://dl.rohityadav.cloud/cloudstack-rpi/kernel-19.10/ and install the linux-image and linux-module
- Then install/setup CloudStack on it (fix some issues around jna, by manually installing newer libjna-java to /usr/share/cloudstack-agent/lib)
- Since the host processor is not x86_64, I had to build a new arm64 (or aarch64) systemvmtemplate: http://dl.rohityadav.cloud/cloudstack-rpi/systemvmtemplate/

I could finally get a 4.13 CloudStack + Adv zone/networking to run on it and deployed a KVM based Ubuntu 19.10 environment and NFS storage. Deployed a test vm with isolated network, VR works as expected. Console proxy works as well, for this tested against arm64 openstack Debian 9/10 templates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

![Screenshot from 2019-10-18 16-55-23](https://user-images.githubusercontent.com/95203/67157162-0c3b8b80-f346-11e9-9e00-b1460b676477.png)
![Screenshot from 2019-10-18 17-20-49](https://user-images.githubusercontent.com/95203/67157163-0cd42200-f346-11e9-98ca-97e5a63a04a7.png)
![Screenshot from 2019-10-20 01-43-43](https://user-images.githubusercontent.com/95203/67157164-0d6cb880-f346-11e9-9cae-d7f94f410062.png)