### PR TITLE
Fix simulator docker db deploy issue (apache#3397)

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -22,6 +22,8 @@ FROM ubuntu:16.04
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
 LABEL Vendor="Apache.org" License="ApacheV2" Version="4.13.1.0-SNAPSHOT"
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get -y update && apt-get install -y \
     genisoimage \
     libffi-dev \
@@ -37,18 +39,12 @@ RUN apt-get -y update && apt-get install -y \
     python-mysql.connector \
     supervisor
 
-RUN echo 'mysql-server mysql-server/root_password password root' |  debconf-set-selections; \
-    echo 'mysql-server mysql-server/root_password_again password root' |  debconf-set-selections;
-
 RUN apt-get install -qqy mysql-server && \
     apt-get clean all && \
     mkdir /var/run/mysqld; \
     chown mysql /var/run/mysqld
 
 RUN echo '''sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"''' >> /etc/mysql/mysql.conf.d/mysqld.cnf
-RUN (/usr/bin/mysqld_safe &); sleep 5; mysqladmin -u root -proot password ''
-
-#RUN pip install --allow-external mysql-connector-python mysql-connector-python
 
 COPY tools/docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY . ./root
@@ -56,12 +52,15 @@ WORKDIR /root
 
 RUN mvn -Pdeveloper -Dsimulator -DskipTests clean install
 
-RUN (/usr/bin/mysqld_safe &); \
+RUN find /var/lib/mysql -type f -exec touch {} \; && \
+    (/usr/bin/mysqld_safe &) && \
     sleep 5; \
     mvn -Pdeveloper -pl developer -Ddeploydb; \
     mvn -Pdeveloper -pl developer -Ddeploydb-simulator; \
     MARVIN_FILE=`find /root/tools/marvin/dist/ -name "Marvin*.tar.gz"`; \
     pip install $MARVIN_FILE
+
+VOLUME /var/lib/mysql
 
 EXPOSE 8080 8096
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
As the latest docker image in dockerhub is built from master branch, I thought it would be correct to open PR into a master branch (and not to release, if inacceptable, please suggest the correct one).

Fixes: #3397

The latest cloudstack/simulator image is not working causing issue #3397. 
The build was incomplete as mysql 5.7 is failing to start during docker build, thus DB is not deployed.
The command `find /var/lib/mysql -type f -exec touch {} \;` is a workaround for the issue which causes mysqld 5.7 to crash after start.
Putting VOLUME instruction before starting mysql also solves this problem but does not allow any other changes to the folder during build.

There are other also options that might be discussed:
1. Setting `VOLUME /var/lib/mysql` instruction in Dockerfile and importing the db during each container run (the start of the container will take longer).
2. Try to download and install mysql v5.5 from archives during docker build (not included in ubuntu repository, limited to 5.5)

Other ideas/input will be much appreciated.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Successfully built/run docker image/container according to the documentation.
```
docker build -f Dockerfile -t cloudstack/simulator ../..
docker run --name simulator -p 8080:8080 -d cloudstack/simulator
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
