### PR TITLE
Fix VR creation issue while creating VM on shared network using PVLAN

### DIFF
--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -2083,6 +2083,12 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             }
         }
 
+        if (result) {
+            for (Network guestNetwork : guestNetworks) {
+                _routerDao.addRouterToGuestNetwork(router, guestNetwork);
+            }
+        }
+
         return result;
     }
 

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -2057,6 +2057,11 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
         // Get guest networks info
         final List<Network> guestNetworks = new ArrayList<Network>();
 
+        final GetDomRVersionAnswer versionAnswer = (GetDomRVersionAnswer) cmds.getAnswer("getDomRVersion");
+        router.setTemplateVersion(versionAnswer.getTemplateVersion());
+        router.setScriptsVersion(versionAnswer.getScriptsVersion());
+        _routerDao.persist(router, guestNetworks);
+
         final List<? extends Nic> routerNics = _nicDao.listByVmId(profile.getId());
         for (final Nic nic : routerNics) {
             final Network network = _networkModel.getNetwork(nic.getNetworkId());
@@ -2076,12 +2081,6 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                     }
                 }
             }
-        }
-        if (result) {
-            final GetDomRVersionAnswer versionAnswer = (GetDomRVersionAnswer) cmds.getAnswer("getDomRVersion");
-            router.setTemplateVersion(versionAnswer.getTemplateVersion());
-            router.setScriptsVersion(versionAnswer.getScriptsVersion());
-            _routerDao.persist(router, guestNetworks);
         }
 
         return result;


### PR DESCRIPTION
## Description
Fix VR creation issue when deploying VM on shared network using PVLAN.
Tested on KVM + Open vSwitch host

Error:
````
2019-10-28 13:37:19,217 DEBUG [c.c.a.t.Request] (Work-Job-Executor-3:ctx-522095d0 job-29/job-30 ctx-22bff2f0) (logid:6771277e) Seq 1-4072942913003192458: Received:  { Ans: , MgmtId: 32988167473142, via: 1(ref-trl-218-k-m7-nvazquez-kvm1), Ver: v1, Flags: 10, { StartAnswer, CheckSshAnswer, GetDomRVersionAnswer, NetworkUsageAnswer, Answer, Answer, Answer } }
2019-10-28 13:37:19,224 DEBUG [o.a.c.n.t.AdvancedNetworkTopology] (Work-Job-Executor-3:ctx-522095d0 job-29/job-30 ctx-22bff2f0) (logid:6771277e) SETUP DHCP PVLAN RULES
2019-10-28 13:37:19,228 DEBUG [c.c.n.r.NetworkHelperImpl] (Work-Job-Executor-3:ctx-522095d0 job-29/job-30 ctx-22bff2f0) (logid:6771277e) Router requires upgrade. Unable to send command to router:4, router template version : null, minimal required version : 4.10.0
2019-10-28 13:37:19,229 WARN  [o.a.c.n.t.AdvancedNetworkVisitor] (Work-Job-Executor-3:ctx-522095d0 job-29/job-30 ctx-22bff2f0) (logid:6771277e) Timed Out
com.cloud.exception.ResourceUnavailableException: Resource [VirtualRouter:4] is unreachable: Unable to send command. Router requires upgrade
	at com.cloud.network.router.NetworkHelperImpl.sendCommandsToRouter(NetworkHelperImpl.java:175)
	at org.apache.cloudstack.network.topology.AdvancedNetworkVisitor.visit(AdvancedNetworkVisitor.java:185)
	at com.cloud.network.rules.DhcpPvlanRules.accept(DhcpPvlanRules.java:61)
	at org.apache.cloudstack.network.topology.AdvancedNetworkTopology.setupDhcpForPvlan(AdvancedNetworkTopology.java:131)
	at com.cloud.network.router.VirtualNetworkApplianceManagerImpl.finalizeStart(VirtualNetworkApplianceManagerImpl.java:2073)
	at com.cloud.vm.VirtualMachineManagerImpl.orchestrateStart(VirtualMachineManagerImpl.java:1146)
````

Proposed fix:
- Move the VR template version insert into `domain_router` table before iterating through the VR nics to setup PVLAN

Workaround:
- Disable the global setting: `router.version.check`

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
KVM + Open vSwitch bridging

- Create a Shared network providing:
   - Primary VLAN ID
   - Secondary VLAN ID
- Deploy user VM on network

Before this fix: Observe that VR creation fails -> user VM creation fails
After this fix: Successful VM deployment