### PR TITLE
Increase DHCP lease time to infinite

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -160,10 +160,14 @@ class CsDhcp(CsDataBag):
 
     def add(self, entry):
         self.add_host(entry['ipv4_address'], entry['host_name'])
-        # Lease time is effectively infinite (36000+ days) since we fully control VM lifecycle via CloudStack
+        # Lease time set to effectively infinite (36000+ days) since we properly control all DHCP/DNS config via CloudStack.
         # Infinite time helps avoid some edge cases which could cause DHCPNAK being sent to VMs since
-        # (RHEL) system lose routes when they receive DHCPNAK
-        # When VM is expunged, it's lease and DHCP/DNS config is properly removed from related files in VR
+        # (RHEL) system lose routes when they receive DHCPNAK.
+        # When VM is expunged, its active lease and DHCP/DNS config is properly removed from related files in VR,
+        # so the infinite duration of lease does not cause any issues or garbage.
+        # There will be soon a PR which also regenerates the /var/lib/misc/dnsmasq.leases (active lease DB file)
+        # in the new VR (when restarting network with cleanup), which will help around RHEL edge cases (described above)
+        # for the VMs who are already running in productions systems with 30d lease time.
         lease = randint(870000, 870010)
 
         if entry['default_entry']:

--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -160,9 +160,11 @@ class CsDhcp(CsDataBag):
 
     def add(self, entry):
         self.add_host(entry['ipv4_address'], entry['host_name'])
-        # lease time boils down to once a month
-        # with a splay of 60 hours to prevent storms
-        lease = randint(700, 760)
+        # Lease time is effectively infinite (36000+ days) since we fully control VM lifecycle via CloudStack
+        # Infinite time helps avoid some edge cases which could cause DHCPNAK being sent to VMs since
+        # (RHEL) system lose routes when they receive DHCPNAK
+        # When VM is expunged, it's lease and DHCP/DNS config is properly removed from related files in VR
+        lease = randint(870000, 870010)
 
         if entry['default_entry']:
             self.cloud.add("%s,%s,%s,%sh" % (entry['mac_address'],


### PR DESCRIPTION
Lease time set to effectively infinite (36000+ days) since we fully control VM lifecycle via CloudStack.
Infinite time helps avoid some edge cases which could cause DHCPNAK being sent to VMs since
(RHEL) system lose routes when they receive DHCPNAK.
When VM is expunged, its active lease and DHCP/DNS config is properly removed (#3627 and #3608) from related files in VR, so the infinite duration of lease does not cause any issues or garbage.
There will be soon a PR which also regenerates the /var/lib/misc/dnsmasq.leases (active lease DB file) in the new VR (when restarting network with cleanup), which will help around RHEL edge cases (described above) for the VMs who are already running in productions systems with 30d lease time.


## Types of changes
- [x] Enhancement (improves an existing feature and functionality)


