### PR TITLE
Validate disk offering IOPS normal and maximum read/write values

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -400,17 +400,19 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     public static final ConfigKey<Boolean> SystemVMUseLocalStorage = new ConfigKey<Boolean>(Boolean.class, "system.vm.use.local.storage", "Advanced", "false",
             "Indicates whether to use local storage pools or shared storage pools for system VMs.", false, ConfigKey.Scope.Zone, null);
 
-    public static ConfigKey<Long> iopsMaximumRateLength = new ConfigKey<Long>(Long.class, "iops.maximum.rate.length", "Advanced", "0",
-            "Sets the maximum IOPS read/write length (seconds) accepted; thus, preventing irrealistic values for a disk offering (e.g. hours or days of burst IOPS)."
-                    + " The default value is 0 (zero) and allows any IOPS maximum rate length."
-                    + " Example: iops.maximum.rate.length = 3600 sets the maximum IOPS length accepted for a disk offering as 3600 seconds (60 minutes).",
-            false, ConfigKey.Scope.Global, null);
+    public final static ConfigKey<Long> BYTES_MAX_READ_LENGTH= new ConfigKey<Long>(Long.class, "vm.disk.bytes.maximum.read.length", "Advanced", "0",
+            "Maximum Bytes read burst duration (seconds). If '0' (zero) then does not check for maximum burst length.", true, ConfigKey.Scope.Global, null);
+    public final static ConfigKey<Long> BYTES_MAX_WRITE_LENGTH = new ConfigKey<Long>(Long.class, "vm.disk.bytes.maximum.write.length", "Advanced", "0",
+            "Maximum Bytes write burst duration (seconds). If '0' (zero) then does not check for maximum burst length.", true, ConfigKey.Scope.Global, null);
+    public final static ConfigKey<Long> IOPS_MAX_READ_LENGTH = new ConfigKey<Long>(Long.class, "vm.disk.iops.maximum.read.length", "Advanced", "0",
+            "Maximum IOPS read burst duration (seconds). If '0' (zero) then does not check for maximum burst length.", true, ConfigKey.Scope.Global, null);
+    public final static ConfigKey<Long> IOPS_MAX_WRITE_LENGTH = new ConfigKey<Long>(Long.class, "vm.disk.iops.maximum.write.length", "Advanced", "0",
+            "Maximum IOPS write burst duration (seconds). If '0' (zero) then does not check for maximum burst length.", true, ConfigKey.Scope.Global, null);
 
-    public static ConfigKey<Long> iopsMaximumBytes = new ConfigKey<Long>(Long.class, "iops.maximum.rate.length", "Advanced", "0",
-            "Sets the maximum rate length (bytes) accepted; thus, preventing irrealistic values for a disk offering (e.g. Petabytes)."
-                    + " The default value is 0 (zero) and allows any IOPS maximum bytes rate."
-                    + " Example: iops.maximum.rate.length = 3600 sets the maximum IOPS length accepted for a disk offering as 3600 seconds (60 minutes).",
-            false, ConfigKey.Scope.Global, null);
+    private static final String IOPS_READ_RATE = "IOPS Read";
+    private static final String IOPS_WRITE_RATE = "IOPS Write";
+    private static final String BYTES_READ_RATE = "Bytes Read";
+    private static final String BYTES_WRITE_RATE = "Bytes Write";
 
     private static final String DefaultForSystemVmsForPodIpRange = "0";
     private static final String DefaultVlanForPodIpRange = Vlan.UNTAGGED.toString();
@@ -3008,7 +3010,12 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final Long iopsWriteRateMaxLength = cmd.getIopsWriteRateMaxLength();
         final Integer hypervisorSnapshotReserve = cmd.getHypervisorSnapshotReserve();
 
-        valildateIopsRateOfferings(iopsReadRate, iopsReadRateMax, iopsReadRateMaxLength, iopsWriteRate, iopsWriteRateMax, iopsWriteRateMaxLength);
+        validateMaxRateEqualsOrGreater(iopsReadRate, iopsReadRateMax, IOPS_READ_RATE);
+        validateMaxRateEqualsOrGreater(iopsWriteRate, iopsWriteRateMax, IOPS_WRITE_RATE);
+        validateMaxRateEqualsOrGreater(bytesReadRate, bytesReadRateMax, BYTES_READ_RATE);
+        validateMaxRateEqualsOrGreater(bytesWriteRate, bytesWriteRateMax, BYTES_WRITE_RATE);
+
+        validateMaximumIopsAndBytesLength(iopsReadRateMaxLength, iopsWriteRateMaxLength, bytesReadRateMaxLength, bytesWriteRateMaxLength);
 
         final Long userId = CallContext.current().getCallingUserId();
         return createDiskOffering(userId, domainIds, zoneIds, name, description, provisioningType, numGibibytes, tags, isCustomized,
@@ -3019,60 +3026,52 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     }
 
     /**
-     * Validates IOPS read and write rate offerings. It throws InvalidParameterValueException in case of one of the following cases is not respected: </br>
+     * Validates rate offerings, being flexible about which rate is being validated (e.g. read/write Bytes, read/write IOPS).</br>
+     * It throws InvalidParameterValueException if normal rate is greater than maximum rate
+     */
+    protected void validateMaxRateEqualsOrGreater(Long normalRate, Long maxRate, String rateType) {
+        if (normalRate != null && maxRate != null && maxRate < normalRate) {
+            throw new InvalidParameterValueException(
+                    String.format("%s rate (%d) cannot be greater than %s maximum rate (%d)", rateType, normalRate, rateType, maxRate));
+        }
+    }
+
+    /**
+     *  Throws InvalidParameterValueException if At least one of the VM disk Bytes/IOPS Read/Write length are smaller than the respective disk offering max length.</br>
+     *  It will ignore verification in case of default values (zero):
      * <ul>
-     *  <li>IOPS write rate cannot be greater than IOPS write maximum rate</li>
-     *  <li>IOPS read rate cannot be greater than IOPS read maximum rate</li>
-     *  <li>IOPS read rate max length (seconds) must be greater than zero</li>
-     *  <li>IOPS write rate max length (seconds) must be greater than zero</li>
-     *  <li>If iops.maximum.rate.length is not 0 (zero), blank or null, IOPS write/read maximum rate length (seconds) cannot be bigger than thevalue from iops.maximum.rate.length</li>
+     *  <li>vm.disk.bytes.maximum.read.length = 0</li>
+     *  <li>vm.disk.bytes.maximum.write.length = 0</li>
+     *  <li>vm.disk.iops.maximum.read.length = 0</li>
+     *  <li>vm.disk.iops.maximum.write.length = 0</li>
      * </ul>
      */
-    protected void valildateIopsRateOfferings(final Long iopsReadRate, final Long iopsReadRateMax, final Long iopsReadRateMaxLength, final Long iopsWriteRate,
-            final Long iopsWriteRateMax, final Long iopsWriteRateMaxLength) {
-        if (iopsWriteRateMax != null && iopsWriteRate != null && iopsWriteRateMax < iopsWriteRate) {
-            throw new InvalidParameterValueException(
-                    String.format("IOPS write rate (rate: %d) cannot be greater than IOPS write maximum rate (maximum rate: %d)", iopsWriteRate, iopsWriteRateMax));
-        }
-
-        if (iopsReadRateMax != null && iopsReadRate != null && iopsReadRateMax < iopsReadRate) {
-            throw new InvalidParameterValueException(
-                    String.format("IOPS read rate (rate: %d) cannot be greater than IOPS read maximum rate (maximum rate: %d)", iopsReadRate, iopsReadRateMax));
-        }
-
-        if (iopsReadRateMaxLength != null && iopsReadRateMaxLength <= 0) {
-            throw new InvalidParameterValueException(String.format("IOPS read rate max length (max length: %d seconds) must be greater than zero", iopsReadRateMaxLength));
-        }
-
-        if (iopsWriteRateMaxLength != null && iopsWriteRateMaxLength <= 0) {
-            throw new InvalidParameterValueException(String.format("IOPS write rate max length (max length: %d seconds) must be greater than zero", iopsWriteRateMaxLength));
-        }
-
-        verifyMaximumLength(iopsReadRateMaxLength, iopsWriteRateMaxLength);
-        verifyMaximumBytesRate(iopsReadRateMax, iopsReadRateMaxLength, iopsWriteRateMax, iopsWriteRateMaxLength);
-    }
-
-    private void verifyMaximumBytesRate(final Long iopsReadRateMax, final Long iopsReadRateMaxLength, final Long iopsWriteRateMax, final Long iopsWriteRateMaxLength) {
-        if (iopsMaximumBytes.value() != null && !iopsMaximumBytes.value().equals(0L)) {
-            if (iopsReadRateMax != null && iopsReadRateMax > iopsMaximumBytes.value()) {
-                throw new InvalidParameterValueException(String.format("IOPS read max rate (%d bytes) cannot be greater than iops.maximum.rate.length (%d bytes)", iopsReadRateMaxLength, iopsMaximumBytes.value()));
-            }
-            if (iopsWriteRateMax != null && iopsWriteRateMax > iopsMaximumBytes.value()) {
-                throw new InvalidParameterValueException(String.format("IOPS write max length (%d bytes) cannot be greater than sane.iops.maximum.rate.length (%d bytes)", iopsWriteRateMaxLength, iopsMaximumBytes.value()));
+    protected void validateMaximumIopsAndBytesLength(final Long iopsReadRateMaxLength, final Long iopsWriteRateMaxLength, Long bytesReadRateMaxLength, Long bytesWriteRateMaxLength) {
+        if (IOPS_MAX_READ_LENGTH.value() != null && IOPS_MAX_READ_LENGTH.value() != 0l) {
+            if (iopsReadRateMaxLength != null && iopsReadRateMaxLength > IOPS_MAX_READ_LENGTH.value()) {
+                throw new InvalidParameterValueException(String.format("IOPS read max length (%d seconds) cannot be greater than vm.disk.iops.maximum.read.length (%d seconds)",
+                        iopsReadRateMaxLength, IOPS_MAX_READ_LENGTH.value()));
             }
         }
-    }
 
-    private void verifyMaximumLength(final Long iopsReadRateMaxLength, final Long iopsWriteRateMaxLength) {
-        if (iopsMaximumRateLength.value() != null && !iopsMaximumRateLength.value().equals(0L)) {
-            if (iopsReadRateMaxLength != null && iopsReadRateMaxLength > iopsMaximumRateLength.value()) {
-                throw new InvalidParameterValueException(String.format("IOPS read max length (%d seconds) cannot be greater than iops.maximum.rate.length (%d seconds)",
-                        iopsReadRateMaxLength, iopsMaximumRateLength.value()));
+        if (IOPS_MAX_WRITE_LENGTH.value() != null && IOPS_MAX_WRITE_LENGTH.value() != 0l) {
+            if (iopsWriteRateMaxLength != null && iopsWriteRateMaxLength > IOPS_MAX_WRITE_LENGTH.value()) {
+                throw new InvalidParameterValueException(String.format("IOPS write max length (%d seconds) cannot be greater than vm.disk.iops.maximum.write.length (%d seconds)",
+                        iopsWriteRateMaxLength, IOPS_MAX_WRITE_LENGTH.value()));
             }
+        }
 
-            if (iopsWriteRateMaxLength != null && iopsWriteRateMaxLength > iopsMaximumRateLength.value()) {
-                throw new InvalidParameterValueException(String.format("IOPS write max length (%d seconds) cannot be greater than sane.iops.maximum.rate.length (%d seconds)",
-                        iopsWriteRateMaxLength, iopsMaximumRateLength.value()));
+        if (BYTES_MAX_READ_LENGTH.value() != null && BYTES_MAX_READ_LENGTH.value() != 0l) {
+            if (bytesReadRateMaxLength != null && bytesReadRateMaxLength > BYTES_MAX_READ_LENGTH.value()) {
+                throw new InvalidParameterValueException(String.format("Bytes read max length (%d seconds) cannot be greater than vm.disk.bytes.maximum.read.length (%d seconds)",
+                        bytesReadRateMaxLength, BYTES_MAX_READ_LENGTH.value()));
+            }
+        }
+
+        if (BYTES_MAX_WRITE_LENGTH.value() != null && BYTES_MAX_WRITE_LENGTH.value() != 0l) {
+            if (bytesReadRateMaxLength != null && bytesReadRateMaxLength > BYTES_MAX_WRITE_LENGTH.value()) {
+                throw new InvalidParameterValueException(String.format("Bytes write max length (%d seconds) cannot be greater than vm.disk.bytes.maximum.write.length (%d seconds)",
+                        bytesReadRateMaxLength, BYTES_MAX_WRITE_LENGTH.value()));
             }
         }
     }
@@ -6354,6 +6353,6 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {SystemVMUseLocalStorage, iopsMaximumRateLength};
+        return new ConfigKey<?>[] {SystemVMUseLocalStorage, IOPS_MAX_READ_LENGTH, IOPS_MAX_WRITE_LENGTH, BYTES_MAX_READ_LENGTH, BYTES_MAX_WRITE_LENGTH};
     }
 }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3069,9 +3069,9 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         if (BYTES_MAX_WRITE_LENGTH.value() != null && BYTES_MAX_WRITE_LENGTH.value() != 0l) {
-            if (bytesReadRateMaxLength != null && bytesReadRateMaxLength > BYTES_MAX_WRITE_LENGTH.value()) {
+            if (bytesWriteRateMaxLength != null && bytesWriteRateMaxLength > BYTES_MAX_WRITE_LENGTH.value()) {
                 throw new InvalidParameterValueException(String.format("Bytes write max length (%d seconds) cannot be greater than vm.disk.bytes.maximum.write.length (%d seconds)",
-                        bytesReadRateMaxLength, BYTES_MAX_WRITE_LENGTH.value()));
+                        bytesWriteRateMaxLength, BYTES_MAX_WRITE_LENGTH.value()));
             }
         }
     }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -3019,36 +3019,37 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
      *  <li>IOPS read rate cannot be greater than IOPS read maximum rate</li>
      *  <li>IOPS read rate max length (seconds) must be greater than zero</li>
      *  <li>IOPS write rate max length (seconds) must be greater than zero</li>
+     *  <li>If iops.maximum.rate.length is not 0 (zero), blank or null, IOPS write/read maximum rate length (seconds) cannot be bigger than thevalue from iops.maximum.rate.length</li>
      * </ul>
      */
     protected void valildateIopsRateOfferings(final Long iopsReadRate, final Long iopsReadRateMax, final Long iopsReadRateMaxLength, final Long iopsWriteRate,
             final Long iopsWriteRateMax, final Long iopsWriteRateMaxLength) {
         if (iopsWriteRateMax != null && iopsWriteRate != null && iopsWriteRateMax < iopsWriteRate) {
             throw new InvalidParameterValueException(
-                    String.format("IOPS write rate (rate: %s) cannot be greater than IOPS write maximum rate (maximum rate: %s)", iopsWriteRate, iopsWriteRateMax));
+                    String.format("IOPS write rate (rate: %d) cannot be greater than IOPS write maximum rate (maximum rate: %d)", iopsWriteRate, iopsWriteRateMax));
         }
 
         if (iopsReadRateMax != null && iopsReadRate != null && iopsReadRateMax < iopsReadRate) {
             throw new InvalidParameterValueException(
-                    String.format("IOPS read rate (rate: %s) cannot be greater than IOPS read maximum rate (maximum rate: %s)", iopsReadRate, iopsReadRateMax));
+                    String.format("IOPS read rate (rate: %d) cannot be greater than IOPS read maximum rate (maximum rate: %d)", iopsReadRate, iopsReadRateMax));
         }
 
         if (iopsReadRateMaxLength != null && iopsReadRateMaxLength <= 0) {
-            throw new InvalidParameterValueException(String.format("IOPS read rate max length (max length: %s seconds) must be greater than zero", iopsReadRateMaxLength));
+            throw new InvalidParameterValueException(String.format("IOPS read rate max length (max length: %d seconds) must be greater than zero", iopsReadRateMaxLength));
         }
 
         if (iopsWriteRateMaxLength != null && iopsWriteRateMaxLength <= 0) {
-            throw new InvalidParameterValueException(String.format("IOPS write rate max length (max length: %s seconds) must be greater than zero", iopsWriteRateMaxLength));
+            throw new InvalidParameterValueException(String.format("IOPS write rate max length (max length: %d seconds) must be greater than zero", iopsWriteRateMaxLength));
         }
 
         if (iopsMaximumRateLength.value() != null && !iopsMaximumRateLength.value().equals(0L)) {
             if (iopsReadRateMaxLength != null && iopsReadRateMaxLength > iopsMaximumRateLength.value()) {
-                throw new InvalidParameterValueException(String.format("IOPS read max length (%s seconds) cannot be greater than iops.maximum.rate.length (%s seconds)",
+                throw new InvalidParameterValueException(String.format("IOPS read max length (%d seconds) cannot be greater than iops.maximum.rate.length (%ds seconds)",
                         iopsReadRateMaxLength, iopsMaximumRateLength.value()));
             }
 
             if (iopsWriteRateMaxLength != null && iopsWriteRateMaxLength > iopsMaximumRateLength.value()) {
-                throw new InvalidParameterValueException(String.format("IOPS write max length (%s seconds) cannot be greater than sane.iops.maximum.rate.length (%s seconds)",
+                throw new InvalidParameterValueException(String.format("IOPS write max length (%d seconds) cannot be greater than sane.iops.maximum.rate.length (%d seconds)",
                         iopsWriteRateMaxLength, iopsMaximumRateLength.value()));
             }
         }

--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
@@ -19,11 +19,11 @@ package com.cloud.configuration;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -44,7 +44,6 @@ import org.apache.cloudstack.api.command.user.network.ListNetworkOfferingsCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
-import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
@@ -57,7 +56,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
 
 import com.cloud.api.query.dao.NetworkOfferingJoinDao;
 import com.cloud.api.query.vo.NetworkOfferingJoinVO;
@@ -168,7 +166,7 @@ public class ConfigurationManagerTest {
 
     VlanVO vlan = new VlanVO(Vlan.VlanType.VirtualNetwork, "vlantag", "vlangateway", "vlannetmask", 1L, "iprange", 1L, 1L, null, null, null);
 
-    private static final String MAXIMUM_LENGTH_ALLOWED = "3600";
+    private static final String MAXIMUM_DURATION_ALLOWED = "3600";
 
     @Mock
     Network network;
@@ -907,100 +905,37 @@ public class ConfigurationManagerTest {
     }
 
     @Test
-    public void valildateIopsRateOfferingsTestAllGood() {
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 1, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 1L, 1L, 2L, 3L);
+    public void validateMaxRateEqualsOrGreaterTestAllGood() {
+        configurationMgr.validateMaxRateEqualsOrGreater(1l, 2l, "IOPS Read");
     }
 
     @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsRateOfferingsTestIopsReadGreaterThanMax() {
-        //iopsReadRate = 3, iopsReadRateMax = 2, iopsReadRateMaxLength = 1, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
-        configurationMgr.valildateIopsRateOfferings(3L, 2L, 1L, 1L, 2L, 3L);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsRateOfferingsTestIopsReadLengthZero() {
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 0, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 0L, 1L, 2L, 3L);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsRateOfferingsTestIopsReadLengthNegative() {
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = -1, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, -1L, 1L, 2L, 3L);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsWriteOfferingsTestIopsWriteLengthZero() {
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 0
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 0L);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsRateOfferingsTestIopsWriteLengthNegative() {
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = -1
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, -1L);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsRateOfferingsTestIopsWriteGreaterThanMax() {
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 3, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 4
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 3L, 2L, 4L);
+    public void validateMaxRateEqualsOrGreaterTestNormalRateGreaterThanMax() {
+        configurationMgr.validateMaxRateEqualsOrGreater(3l, 2l, "IOPS Read");
     }
 
     @Test
-    public void valildateIopsRateOfferingsTestAllnull() {
-        configurationMgr.valildateIopsRateOfferings(null, null, null, null, null, null);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsWriteOfferingsTestIopsWriteLengthGreaterThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 9999, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 9999L, 1L, 2L, 3L);
+    public void validateMaxRateNull() {
+        configurationMgr.validateMaxRateEqualsOrGreater(3l, null, "IOPS Read");
     }
 
     @Test
-    public void valildateIopsWriteOfferingsTestIopsWriteLengthSmallerThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3599, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3599L, 1L, 2L, 3L);
+    public void validateNormalRateNull() {
+        configurationMgr.validateMaxRateEqualsOrGreater(null, 3l, "IOPS Read");
     }
 
     @Test
-    public void valildateIopsWriteOfferingsTestIopsWriteLengthEqualsThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3600L, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3600L, 1L, 2L, 3L);
-    }
-
-    @Test(expected = InvalidParameterValueException.class)
-    public void valildateIopsWriteOfferingsTestIopsReadLengthGreaterThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3601L);
+    public void validateAllNull() {
+        configurationMgr.validateMaxRateEqualsOrGreater(null, 3l, "IOPS Read");
     }
 
     @Test
-    public void valildateIopsWriteOfferingsTestIopsReadLengthSmallerThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3599L);
+    public void validateMaximumIopsAndBytesLengthTestAllNull() {
+        configurationMgr.validateMaximumIopsAndBytesLength(null, null, null, null);
     }
 
     @Test
-    public void valildateIopsWriteOfferingsTestIopsReadLengthEqualsThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
-        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
-        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3600L);
+    public void validateMaximumIopsAndBytesLengthTestDefaultLengthConfigs() {
+        configurationMgr.validateMaximumIopsAndBytesLength(36000l, 36000l, 36000l, 36000l);
     }
-
-    private void staticPowerMockConfigKeyParameter(String configValue) {
-        PowerMockito.mockStatic(ConfigurationManagerImpl.class);
-        ConfigurationManagerImpl.iopsMaximumRateLength = new ConfigKey<Long>(Long.class, "sane.iops.maximum.rate.length", "Advanced", configValue,
-                "Indicates the maximum IOPS read/write length (seconds) accepted to prevent irrealistigs values for a disk offering. Default (0) allows any IOPS maximum rate length."
-                        + " Example: sane.iops.maximum.rate.length = 3600 sets the maximum IOPS length accepted for a disk offering is of 3600 seconds (60 minutes).",
-                false, ConfigKey.Scope.Global, null);
-    }
-
 }

--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
@@ -168,7 +168,7 @@ public class ConfigurationManagerTest {
 
     VlanVO vlan = new VlanVO(Vlan.VlanType.VirtualNetwork, "vlantag", "vlangateway", "vlannetmask", 1L, "iprange", 1L, 1L, null, null, null);
 
-    private static final String MAXIMUM_IOPS_ALLOWED = "3600";
+    private static final String MAXIMUM_LENGTH_ALLOWED = "3600";
 
     @Mock
     Network network;
@@ -553,8 +553,10 @@ public class ConfigurationManagerTest {
         try {
             configurationMgr.validateStaticNatServiceCapablities(staticNatServiceCapabilityMap);
         } catch (InvalidParameterValueException e) {
-            Assert.assertTrue(e.getMessage(), e.getMessage()
-                    .contains("Capability " + Capability.AssociatePublicIP.getName() + " can only be set when capability " + Capability.ElasticIp.getName() + " is true"));
+            Assert.assertTrue(
+                    e.getMessage(),
+                    e.getMessage().contains(
+                        "Capability " + Capability.AssociatePublicIP.getName() + " can only be set when capability " + Capability.ElasticIp.getName() + " is true"));
             caught = true;
         }
         Assert.assertTrue("should not be accepted", caught);
@@ -832,7 +834,7 @@ public class ConfigurationManagerTest {
         try {
             configurationMgr.hasSameSubnet(true, "10.0.0.1", "255.255.0.0", "10.0.0.2", "255.255.255.0", "10.0.0.2", "10.0.0.10", false, null, null, null, null, null);
             Assert.fail();
-        } catch (InvalidParameterValueException e) {
+        } catch (InvalidParameterValueException e){
             Assert.assertEquals(e.getMessage(), "The subnet you are trying to add is a subset of the existing subnet having gateway 10.0.0.1 and netmask 255.255.0.0");
         }
         try {
@@ -848,43 +850,35 @@ public class ConfigurationManagerTest {
         Network ipV6Network = mock(Network.class);
         when(ipV6Network.getIp6Gateway()).thenReturn("2001:db8:0:f101::1");
         when(ipV6Network.getIp6Cidr()).thenReturn("2001:db8:0:f101::0/64");
-        doThrow(new InvalidParameterValueException("Exception from Mock: startIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel)
-                .checkIp6Parameters("2001:db9:0:f101::2", "2001:db9:0:f101::a", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
-        doThrow(new InvalidParameterValueException("Exception from Mock: endIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel)
-                .checkIp6Parameters("2001:db8:0:f101::a", "2001:db9:0:f101::2", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
-        doThrow(new InvalidParameterValueException("ip6Gateway and ip6Cidr should be defined when startIPv6/endIPv6 are passed in")).when(configurationMgr._networkModel)
-                .checkIp6Parameters(Mockito.anyString(), Mockito.anyString(), Mockito.isNull(String.class), Mockito.isNull(String.class));
+        doThrow(new InvalidParameterValueException("Exception from Mock: startIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel).checkIp6Parameters("2001:db9:0:f101::2", "2001:db9:0:f101::a", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
+        doThrow(new InvalidParameterValueException("Exception from Mock: endIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel).checkIp6Parameters("2001:db8:0:f101::a", "2001:db9:0:f101::2", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
+        doThrow(new InvalidParameterValueException("ip6Gateway and ip6Cidr should be defined when startIPv6/endIPv6 are passed in")).when(configurationMgr._networkModel).checkIp6Parameters(Mockito.anyString(), Mockito.anyString(), Mockito.isNull(String.class), Mockito.isNull(String.class));
 
-        configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2", "2001:db8:0:f101::a",
-                ipV6Network);
+        configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2", "2001:db8:0:f101::a", ipV6Network);
         Assert.assertTrue(result);
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::2", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2",
-                    "2001:db8:0:f101::a", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::2", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2", "2001:db8:0:f101::a", ipV6Network);
             Assert.fail();
-        } catch (InvalidParameterValueException e) {
+        } catch (InvalidParameterValueException e){
             Assert.assertEquals(e.getMessage(), "The input gateway 2001:db8:0:f101::2 is not same as network gateway 2001:db8:0:f101::1");
         }
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/63", "2001:db8:0:f101::2",
-                    "2001:db8:0:f101::a", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/63", "2001:db8:0:f101::2", "2001:db8:0:f101::a", ipV6Network);
             Assert.fail();
-        } catch (InvalidParameterValueException e) {
+        } catch (InvalidParameterValueException e){
             Assert.assertEquals(e.getMessage(), "The input cidr 2001:db8:0:f101::0/63 is not same as network cidr 2001:db8:0:f101::0/64");
         }
 
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db9:0:f101::2",
-                    "2001:db9:0:f101::a", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db9:0:f101::2", "2001:db9:0:f101::a", ipV6Network);
             Assert.fail();
         } catch (InvalidParameterValueException e) {
             Assert.assertEquals(e.getMessage(), "Exception from Mock: startIPv6 is not in ip6cidr indicated network!");
         }
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::a",
-                    "2001:db9:0:f101::2", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::a", "2001:db9:0:f101::2", ipV6Network);
             Assert.fail();
-        } catch (InvalidParameterValueException e) {
+        } catch(InvalidParameterValueException e) {
             Assert.assertEquals(e.getMessage(), "Exception from Mock: endIPv6 is not in ip6cidr indicated network!");
         }
 
@@ -961,42 +955,42 @@ public class ConfigurationManagerTest {
 
     @Test(expected = InvalidParameterValueException.class)
     public void valildateIopsWriteOfferingsTestIopsWriteLengthGreaterThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
         //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 9999, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
         configurationMgr.valildateIopsRateOfferings(1L, 2L, 9999L, 1L, 2L, 3L);
     }
 
     @Test
     public void valildateIopsWriteOfferingsTestIopsWriteLengthSmallerThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
         //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3599, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
         configurationMgr.valildateIopsRateOfferings(1L, 2L, 3599L, 1L, 2L, 3L);
     }
 
     @Test
     public void valildateIopsWriteOfferingsTestIopsWriteLengthEqualsThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
         //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3600L, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
         configurationMgr.valildateIopsRateOfferings(1L, 2L, 3600L, 1L, 2L, 3L);
     }
 
     @Test(expected = InvalidParameterValueException.class)
     public void valildateIopsWriteOfferingsTestIopsReadLengthGreaterThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
         //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
         configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3601L);
     }
 
     @Test
     public void valildateIopsWriteOfferingsTestIopsReadLengthSmallerThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
         //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
         configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3599L);
     }
 
     @Test
     public void valildateIopsWriteOfferingsTestIopsReadLengthEqualsThanMaxAllowed() throws Exception {
-        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        staticPowerMockConfigKeyParameter(MAXIMUM_LENGTH_ALLOWED);
         //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
         configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3600L);
     }

--- a/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
+++ b/server/src/test/java/com/cloud/configuration/ConfigurationManagerTest.java
@@ -44,6 +44,7 @@ import org.apache.cloudstack.api.command.user.network.ListNetworkOfferingsCmd;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
+import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
 import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
@@ -56,6 +57,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
 
 import com.cloud.api.query.dao.NetworkOfferingJoinDao;
 import com.cloud.api.query.vo.NetworkOfferingJoinVO;
@@ -165,6 +167,8 @@ public class ConfigurationManagerTest {
     ConfigurationDao _configDao;
 
     VlanVO vlan = new VlanVO(Vlan.VlanType.VirtualNetwork, "vlantag", "vlangateway", "vlannetmask", 1L, "iprange", 1L, 1L, null, null, null);
+
+    private static final String MAXIMUM_IOPS_ALLOWED = "3600";
 
     @Mock
     Network network;
@@ -280,9 +284,8 @@ public class ConfigurationManagerTest {
 
         when(configurationMgr._accountVlanMapDao.listAccountVlanMapsByAccount(anyLong())).thenReturn(null);
 
-        DataCenterVO dc =
-            new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null, true,
-                true, null, null);
+        DataCenterVO dc = new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null,
+                true, true, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
         List<IPAddressVO> ipAddressList = new ArrayList<IPAddressVO>();
@@ -324,9 +327,8 @@ public class ConfigurationManagerTest {
         accountVlanMaps.add(accountVlanMap);
         when(configurationMgr._accountVlanMapDao.listAccountVlanMapsByVlan(anyLong())).thenReturn(accountVlanMaps);
 
-        DataCenterVO dc =
-            new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null, true,
-                true, null, null);
+        DataCenterVO dc = new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null,
+                true, true, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
         List<IPAddressVO> ipAddressList = new ArrayList<IPAddressVO>();
@@ -351,8 +353,7 @@ public class ConfigurationManagerTest {
         when(configurationMgr._accountVlanMapDao.listAccountVlanMapsByVlan(anyLong())).thenReturn(null);
 
         // public ip range belongs to zone of type basic
-        DataCenterVO dc =
-            new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Basic, null, null, true,
+        DataCenterVO dc = new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Basic, null, null, true,
                 true, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
@@ -377,9 +378,8 @@ public class ConfigurationManagerTest {
 
         when(configurationMgr._accountVlanMapDao.listAccountVlanMapsByAccount(anyLong())).thenReturn(null);
 
-        DataCenterVO dc =
-            new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null, true,
-                true, null, null);
+        DataCenterVO dc = new DataCenterVO(UUID.randomUUID().toString(), "test", "8.8.8.8", null, "10.0.0.1", null, "10.0.0.1/24", null, null, NetworkType.Advanced, null, null,
+                true, true, null, null);
         when(configurationMgr._zoneDao.findById(anyLong())).thenReturn(dc);
 
         // one of the ip addresses of the range is allocated to different account
@@ -489,11 +489,7 @@ public class ConfigurationManagerTest {
     public void searchForNetworkOfferingsTest() {
         NetworkOfferingJoinVO forVpcOfferingJoinVO = new NetworkOfferingJoinVO();
         forVpcOfferingJoinVO.setForVpc(true);
-        List<NetworkOfferingJoinVO> offerings = Arrays.asList(
-                new NetworkOfferingJoinVO(),
-                new NetworkOfferingJoinVO(),
-                forVpcOfferingJoinVO
-        );
+        List<NetworkOfferingJoinVO> offerings = Arrays.asList(new NetworkOfferingJoinVO(), new NetworkOfferingJoinVO(), forVpcOfferingJoinVO);
 
         Mockito.when(networkOfferingJoinDao.createSearchCriteria()).thenReturn(Mockito.mock(SearchCriteria.class));
         Mockito.when(networkOfferingJoinDao.search(Mockito.any(SearchCriteria.class), Mockito.any(Filter.class))).thenReturn(offerings);
@@ -557,10 +553,8 @@ public class ConfigurationManagerTest {
         try {
             configurationMgr.validateStaticNatServiceCapablities(staticNatServiceCapabilityMap);
         } catch (InvalidParameterValueException e) {
-            Assert.assertTrue(
-                e.getMessage(),
-                e.getMessage().contains(
-                    "Capability " + Capability.AssociatePublicIP.getName() + " can only be set when capability " + Capability.ElasticIp.getName() + " is true"));
+            Assert.assertTrue(e.getMessage(), e.getMessage()
+                    .contains("Capability " + Capability.AssociatePublicIP.getName() + " can only be set when capability " + Capability.ElasticIp.getName() + " is true"));
             caught = true;
         }
         Assert.assertTrue("should not be accepted", caught);
@@ -838,7 +832,7 @@ public class ConfigurationManagerTest {
         try {
             configurationMgr.hasSameSubnet(true, "10.0.0.1", "255.255.0.0", "10.0.0.2", "255.255.255.0", "10.0.0.2", "10.0.0.10", false, null, null, null, null, null);
             Assert.fail();
-        } catch (InvalidParameterValueException e){
+        } catch (InvalidParameterValueException e) {
             Assert.assertEquals(e.getMessage(), "The subnet you are trying to add is a subset of the existing subnet having gateway 10.0.0.1 and netmask 255.255.0.0");
         }
         try {
@@ -854,36 +848,43 @@ public class ConfigurationManagerTest {
         Network ipV6Network = mock(Network.class);
         when(ipV6Network.getIp6Gateway()).thenReturn("2001:db8:0:f101::1");
         when(ipV6Network.getIp6Cidr()).thenReturn("2001:db8:0:f101::0/64");
-        doThrow(new InvalidParameterValueException("Exception from Mock: startIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel).checkIp6Parameters("2001:db9:0:f101::2", "2001:db9:0:f101::a", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
-        doThrow(new InvalidParameterValueException("Exception from Mock: endIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel).checkIp6Parameters("2001:db8:0:f101::a", "2001:db9:0:f101::2", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
-        doThrow(new InvalidParameterValueException("ip6Gateway and ip6Cidr should be defined when startIPv6/endIPv6 are passed in")).when(configurationMgr._networkModel).checkIp6Parameters(Mockito.anyString(), Mockito.anyString(), Mockito.isNull(String.class), Mockito.isNull(String.class));
+        doThrow(new InvalidParameterValueException("Exception from Mock: startIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel)
+                .checkIp6Parameters("2001:db9:0:f101::2", "2001:db9:0:f101::a", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
+        doThrow(new InvalidParameterValueException("Exception from Mock: endIPv6 is not in ip6cidr indicated network!")).when(configurationMgr._networkModel)
+                .checkIp6Parameters("2001:db8:0:f101::a", "2001:db9:0:f101::2", "2001:db8:0:f101::1", "2001:db8:0:f101::0/64");
+        doThrow(new InvalidParameterValueException("ip6Gateway and ip6Cidr should be defined when startIPv6/endIPv6 are passed in")).when(configurationMgr._networkModel)
+                .checkIp6Parameters(Mockito.anyString(), Mockito.anyString(), Mockito.isNull(String.class), Mockito.isNull(String.class));
 
-
-        configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2", "2001:db8:0:f101::a", ipV6Network);
+        configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2", "2001:db8:0:f101::a",
+                ipV6Network);
         Assert.assertTrue(result);
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::2", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2", "2001:db8:0:f101::a", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::2", "2001:db8:0:f101::0/64", "2001:db8:0:f101::2",
+                    "2001:db8:0:f101::a", ipV6Network);
             Assert.fail();
-        } catch (InvalidParameterValueException e){
+        } catch (InvalidParameterValueException e) {
             Assert.assertEquals(e.getMessage(), "The input gateway 2001:db8:0:f101::2 is not same as network gateway 2001:db8:0:f101::1");
         }
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/63", "2001:db8:0:f101::2", "2001:db8:0:f101::a", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/63", "2001:db8:0:f101::2",
+                    "2001:db8:0:f101::a", ipV6Network);
             Assert.fail();
-        } catch (InvalidParameterValueException e){
+        } catch (InvalidParameterValueException e) {
             Assert.assertEquals(e.getMessage(), "The input cidr 2001:db8:0:f101::0/63 is not same as network cidr 2001:db8:0:f101::0/64");
         }
 
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db9:0:f101::2", "2001:db9:0:f101::a", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db9:0:f101::2",
+                    "2001:db9:0:f101::a", ipV6Network);
             Assert.fail();
         } catch (InvalidParameterValueException e) {
             Assert.assertEquals(e.getMessage(), "Exception from Mock: startIPv6 is not in ip6cidr indicated network!");
         }
         try {
-            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::a", "2001:db9:0:f101::2", ipV6Network);
+            configurationMgr.hasSameSubnet(false, null, null, null, null, null, null, true, "2001:db8:0:f101::1", "2001:db8:0:f101::0/64", "2001:db8:0:f101::a",
+                    "2001:db9:0:f101::2", ipV6Network);
             Assert.fail();
-        } catch(InvalidParameterValueException e){
+        } catch (InvalidParameterValueException e) {
             Assert.assertEquals(e.getMessage(), "Exception from Mock: endIPv6 is not in ip6cidr indicated network!");
         }
 
@@ -910,4 +911,102 @@ public class ConfigurationManagerTest {
     public void testGetVlanNumberFromUriUntagged() {
         Assert.assertEquals("untagged", configurationMgr.getVlanNumberFromUri("vlan://untagged"));
     }
+
+    @Test
+    public void valildateIopsRateOfferingsTestAllGood() {
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 1, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 1L, 1L, 2L, 3L);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsRateOfferingsTestIopsReadGreaterThanMax() {
+        //iopsReadRate = 3, iopsReadRateMax = 2, iopsReadRateMaxLength = 1, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
+        configurationMgr.valildateIopsRateOfferings(3L, 2L, 1L, 1L, 2L, 3L);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsRateOfferingsTestIopsReadLengthZero() {
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 0, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 0L, 1L, 2L, 3L);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsRateOfferingsTestIopsReadLengthNegative() {
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = -1, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, -1L, 1L, 2L, 3L);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsWriteOfferingsTestIopsWriteLengthZero() {
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 0
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 0L);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsRateOfferingsTestIopsWriteLengthNegative() {
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = -1
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, -1L);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsRateOfferingsTestIopsWriteGreaterThanMax() {
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 3, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 4
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 3L, 2L, 4L);
+    }
+
+    @Test
+    public void valildateIopsRateOfferingsTestAllnull() {
+        configurationMgr.valildateIopsRateOfferings(null, null, null, null, null, null);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsWriteOfferingsTestIopsWriteLengthGreaterThanMaxAllowed() throws Exception {
+        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 9999, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 9999L, 1L, 2L, 3L);
+    }
+
+    @Test
+    public void valildateIopsWriteOfferingsTestIopsWriteLengthSmallerThanMaxAllowed() throws Exception {
+        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3599, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3599L, 1L, 2L, 3L);
+    }
+
+    @Test
+    public void valildateIopsWriteOfferingsTestIopsWriteLengthEqualsThanMaxAllowed() throws Exception {
+        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3600L, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3600L, 1L, 2L, 3L);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void valildateIopsWriteOfferingsTestIopsReadLengthGreaterThanMaxAllowed() throws Exception {
+        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3601L);
+    }
+
+    @Test
+    public void valildateIopsWriteOfferingsTestIopsReadLengthSmallerThanMaxAllowed() throws Exception {
+        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3599L);
+    }
+
+    @Test
+    public void valildateIopsWriteOfferingsTestIopsReadLengthEqualsThanMaxAllowed() throws Exception {
+        staticPowerMockConfigKeyParameter(MAXIMUM_IOPS_ALLOWED);
+        //iopsReadRate = 1, iopsReadRateMax = 2, iopsReadRateMaxLength = 3, iopsWriteRate = 1, iopsWriteRateMax = 2, iopsWriteRateMaxLength = 3, saneIopsMaximumLength=3600
+        configurationMgr.valildateIopsRateOfferings(1L, 2L, 3L, 1L, 2L, 3600L);
+    }
+
+    private void staticPowerMockConfigKeyParameter(String configValue) {
+        PowerMockito.mockStatic(ConfigurationManagerImpl.class);
+        ConfigurationManagerImpl.iopsMaximumRateLength = new ConfigKey<Long>(Long.class, "sane.iops.maximum.rate.length", "Advanced", configValue,
+                "Indicates the maximum IOPS read/write length (seconds) accepted to prevent irrealistigs values for a disk offering. Default (0) allows any IOPS maximum rate length."
+                        + " Example: sane.iops.maximum.rate.length = 3600 sets the maximum IOPS length accepted for a disk offering is of 3600 seconds (60 minutes).",
+                false, ConfigKey.Scope.Global, null);
+    }
+
 }


### PR DESCRIPTION
## Description

When creating a new disk offering ('createDiskOffering' command on API) one can set _normal_ IOPS (write/read) higher than the maximum, breaking the logics on the disk offerings. Additionally, one can (by mistake) put irrealistic values for the bursting length. Example if adding few zeros by mistake and configuring **360000** seconds, which turns out to be a bursting length of **100** hours.

This PR adds verifications ensuring that either Bytes or IOPS bursts cannot be greater than a configured value of the following global settings variables.

```
vm.disk.bytes.maximum.read.length
vm.disk.bytes.maximum.write.length
vm.disk.iops.maximum.read.length
vm.disk.iops.maximum.write.length
```

The default value is 0 (zero), allows any IOPS maximum rate length; thus keeping backward compatibility and not affecting any environment configuration after upgrades.

# Example:
One can set the 'vm.disk.bytes.maximum.read.length' to '3600' (seconds); once the parameter is updated on the management server it will not be possible to create disk offerings with IOPS length higher than 3600 seconds (60 minutes).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)g