### PR TITLE
ui: fix migrate host form no host popup

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -2004,14 +2004,10 @@
                                                         args.response.success({
                                                             data: items
                                                         });
-                                                    } else if(args.page == 1) {
+                                                    } else {
                                                         args.response.success({
                                                             data: null
                                                         });
-                                                    } else {
-                                                         cloudStack.dialog.notice({
-                                                             message: _l('message.no.more.hosts.available')
-                                                         });
                                                     }
                                                 }
                                             });


### PR DESCRIPTION
## Description
This PR changes behaviour for VM migrate host form where currently it shows a popup on scrolling to the end of the list saying `No more hosts are available for migration`. Popup has been removed to avoid confusion cleaner user experience.

Popup,
![thumbnail_image002](https://user-images.githubusercontent.com/153340/68752770-e4c89d80-0629-11ea-8f4e-17ea8445e712.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
From UI
https://screencast-o-matic.com/watch/cqXIjtUDzF


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
