### PR TITLE
utils: use iproute to get default network interface

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Description: A common package which contains files which are shared by several C
 
 Package: cloudstack-management
 Architecture: all
-Depends: ${python:Depends}, openjdk-8-jre-headless | java8-runtime-headless | java8-runtime | openjdk-9-jre-headless, cloudstack-common (= ${source:Version}), sudo, python-mysql.connector, libmysql-java, augeas-tools, mysql-client, adduser, bzip2, ipmitool, file, lsb-release, init-system-helpers (>= 1.14~)
+Depends: ${python:Depends}, openjdk-8-jre-headless | java8-runtime-headless | java8-runtime | openjdk-9-jre-headless, cloudstack-common (= ${source:Version}), sudo, python-mysql.connector, libmysql-java, augeas-tools, mysql-client, adduser, bzip2, ipmitool, file, iproute2, lsb-release, init-system-helpers (>= 1.14~)
 Conflicts: cloud-server, cloud-client, cloud-client-ui
 Description: CloudStack server library
  The CloudStack management server

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Description: A common package which contains files which are shared by several C
 
 Package: cloudstack-management
 Architecture: all
-Depends: ${python:Depends}, openjdk-8-jre-headless | java8-runtime-headless | java8-runtime | openjdk-9-jre-headless, cloudstack-common (= ${source:Version}), sudo, python-mysql.connector, libmysql-java, augeas-tools, mysql-client, adduser, bzip2, ipmitool, file, iproute2, lsb-release, init-system-helpers (>= 1.14~)
+Depends: ${python:Depends}, openjdk-8-jre-headless | java8-runtime-headless | java8-runtime | openjdk-9-jre-headless, cloudstack-common (= ${source:Version}), sudo, python-mysql.connector, libmysql-java, augeas-tools, mysql-client, adduser, bzip2, ipmitool, file, gawk, iproute2, lsb-release, init-system-helpers (>= 1.14~)
 Conflicts: cloud-server, cloud-client, cloud-client-ui
 Description: CloudStack server library
  The CloudStack management server

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -58,6 +58,7 @@ Requires: java-1.8.0-openjdk
 Requires: python
 Requires: python3
 Requires: bash
+Requires: gawk
 Requires: bzip2
 Requires: gzip
 Requires: unzip

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -64,6 +64,7 @@ Requires: unzip
 Requires: /sbin/mount.nfs
 Requires: openssh-clients
 Requires: nfs-utils
+Requires: iproute
 Requires: wget
 Requires: mysql
 Requires: mysql-connector-java

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -268,7 +268,7 @@ public class NetUtils {
             final String defDev = Script.runSimpleBashScript("/sbin/route -n get default 2> /dev/null | grep interface | awk '{print $2}'");
             return defDev;
         }
-        return Script.runSimpleBashScript("ip route | grep default | head -1 | grep -Po '(?<=dev )(\\S+)'");
+        return Script.runSimpleBashScript("awk '$2 == 00000000 { print $1 }' /proc/net/route");
     }
 
     public static String getLocalIPString() {

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -268,7 +268,7 @@ public class NetUtils {
             final String defDev = Script.runSimpleBashScript("/sbin/route -n get default 2> /dev/null | grep interface | awk '{print $2}'");
             return defDev;
         }
-        return Script.runSimpleBashScript("awk '$2 == 00000000 { print $1 }' /proc/net/route");
+        return Script.runSimpleBashScript("ip route show default 0.0.0.0/0 | head -1 | awk '{print $5}'");
     }
 
     public static String getLocalIPString() {

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -268,19 +268,7 @@ public class NetUtils {
             final String defDev = Script.runSimpleBashScript("/sbin/route -n get default 2> /dev/null | grep interface | awk '{print $2}'");
             return defDev;
         }
-        final String defaultRoute = Script.runSimpleBashScript("/sbin/route | grep default");
-
-        if (defaultRoute == null) {
-            return null;
-        }
-
-        final String[] defaultRouteList = defaultRoute.split("\\s+");
-
-        if (defaultRouteList.length != 8) {
-            return null;
-        }
-
-        return defaultRouteList[7];
+        return Script.runSimpleBashScript("ip route | grep default | head -1 | grep -Po '(?<=dev )(\\S+)'");
     }
 
     public static String getLocalIPString() {


### PR DESCRIPTION
This uses `ip route` than `route` without an explicit path (/bin, /sbin
etc.) to query the default network interface on the system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

Tested on Ubuntu:
> ip route | grep default | head -1 | grep -Po '(?<=dev )(\S+)'
wlp0s20f3