### PR TITLE
[Work in progress - do not merge] Replace builtin CentOS 5.x with 8.0 templates

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
@@ -19,6 +19,6 @@
 -- Schema upgrade cleanup from 4.13.0.0 to 4.14.0.0
 --;
 
-# Delete an ancient template added in 2.2, which was set as removed in 4.5. For sake of cleanup and easier overview of builtin templates.
-# This DOES assume one is not running any VMs from this template!
+-- Delete an ancient template added in 2.2, which was set as removed in 4.5. For sake of cleanup and easier overview of builtin templates.
+-- This DOES assume one is not running any VMs from this template!
 DELETE FROM `cloud`.`vm_template` WHERE `id`=2 AND `unique_name`="centos53-x86_64" AND `name`="CentOS 5.3(64-bit) no GUI (XenServer)";

--- a/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
@@ -19,3 +19,5 @@
 -- Schema upgrade cleanup from 4.13.0.0 to 4.14.0.0
 --;
 
+# Delete an ancient template added in 2.2, which was set as removed in 4.5. For sake of cleanup and easier overview of builtin templates
+DELETE FROM `cloud`.`vm_template` WHERE `id`=2 AND `unique_name`="centos53-x86_64" AND `name`="CentOS 5.3(64-bit) no GUI (XenServer)";

--- a/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
@@ -19,5 +19,6 @@
 -- Schema upgrade cleanup from 4.13.0.0 to 4.14.0.0
 --;
 
-# Delete an ancient template added in 2.2, which was set as removed in 4.5. For sake of cleanup and easier overview of builtin templates
+# Delete an ancient template added in 2.2, which was set as removed in 4.5. For sake of cleanup and easier overview of builtin templates.
+# This DOES assume one is not running any VMs from this template!
 DELETE FROM `cloud`.`vm_template` WHERE `id`=2 AND `unique_name`="centos53-x86_64" AND `name`="CentOS 5.3(64-bit) no GUI (XenServer)";

--- a/setup/db/templates.sql
+++ b/setup/db/templates.sql
@@ -34,16 +34,18 @@ INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created,
     VALUES (2, UUID(), 'centos53-x86_64', 'CentOS 5.3(64-bit) no GUI (XenServer)', 1, now(), now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/templates/builtin/f59f18fb-ae94-4f97-afd2-f84755767aca.vhd.bz2', 'b63d854a9560c013142567bbae8d98cf', 0, 'CentOS 5.3(64-bit) no GUI (XenServer)', 'VHD', 12, 1, 1, 'XenServer', 1);
 
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, display_text, enable_password, format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
-    VALUES (4, UUID(), 'centos55-x86_64', 'CentOS 5.5(64-bit) no GUI (KVM)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/2.2.0/eec2209b-9875-3c8d-92be-c001bd8a0faf.qcow2.bz2', 'ed0e788280ff2912ea40f7f91ca7a249', 'CentOS 5.5(64-bit) no GUI (KVM)', 0, 'QCOW2', 112, 1, 1, 'KVM', 1);
+    VALUES (4, UUID(), 'default-tmpl-centos8.0-kvm', 'CentOS 8.0(64-bit) no GUI (KVM)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.qcow2.bz2', '80da87ecc67d1e4fcf90079873241619', 'CentOS 8.0(64-bit) no GUI (KVM)', 0, 'QCOW2', 274, 1, 1, 'KVM', 1);
 
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text,  format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
-    VALUES (5, UUID(), 'centos56-x86_64-xen', 'CentOS 5.6(64-bit) no GUI (XenServer)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/templates/builtin/centos56-x86_64.vhd.bz2', '905cec879afd9c9d22ecc8036131a180', 0, 'CentOS 5.6(64-bit) no GUI (XenServer)', 'VHD', 142, 1, 1, 'XenServer', 1);
+    VALUES (5, UUID(), 'default-tmpl-centos7.2-xen', 'CentOS 7.2(64-bit) no GUI (XenServer)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.vhd.bz2', '9a2726a0d7680fb15a24af874f2a26e8', 0, 'CentOS 7.2(64-bit) no GUI (XenServer)', 'VHD', 274, 1, 1, 'XenServer', 1);
 
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text,  format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
     VALUES (6, UUID(), 'centos64-x64', 'CentOS 6.4(64-bit) GUI (Hyperv)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.3/centos6_4_64bit.vhd.bz2', 'eef6b9940ea3ed01221d963d4a012d0a', 0, 'CentOS 6.4 (64-bit) GUI (Hyperv)', 'VHD', 182, 1, 1, 'Hyperv', 1);
 
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text,  format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
-    VALUES (7, UUID(), 'centos53-x64', 'CentOS 5.3(64-bit) no GUI (vSphere)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/2.2.0/CentOS5.3-x86_64.ova', 'f6f881b7f2292948d8494db837fe0f47', 0, 'CentOS 5.3(64-bit) no GUI (vSphere)', 'OVA', 12, 1, 1, 'VMware', 1);
+    VALUES (7, UUID(), 'default-tmpl-centos8.0-vmware', 'CentOS 8.0(64-bit) no GUI (vSphere)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.ova', '85168c007c6ab85c516274cdf23eda48', 0, 'CentOS 8.0(64-bit) no GUI (vSphere)', 'OVA', 274, 1, 1, 'VMware', 1);
+INSERT INTO `cloud`.`vm_template_details` (`id`, `template_id`, `name`, `value`, `display`) VALUES (1, 7, 'nicAdapter', 'Vmxnet3', 1);
+INSERT INTO `cloud`.`vm_template_details` (`id`, `template_id`, `name`, `value`, `display`) VALUES (2, 7, 'rootDiskController', 'pvscsi', 1);
 
 INSERT INTO `cloud`.`guest_os_category` (id, uuid, name) VALUES (1, UUID(), 'CentOS');
 INSERT INTO `cloud`.`guest_os_category` (id, uuid, name) VALUES (2, UUID(), 'Debian');

--- a/setup/db/templates.sql
+++ b/setup/db/templates.sql
@@ -30,9 +30,6 @@ INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created,
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text, format, guest_os_id, featured, cross_zones, hypervisor_type)
     VALUES (9, UUID(), 'routing-9', 'SystemVM Template (HyperV)', 0, now(), 'SYSTEM', 0, 64, 1, 'http://download.cloudstack.org/systemvm/4.6/systemvm64template-4.6.0-hyperv.vhd.zip', '53e24bddfa56ea3139ed37af4b519013', 0, 'SystemVM Template (HyperV)', 'VHD', 15, 0, 1, 'Hyperv' );
 
-INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, removed, type, hvm, bits, account_id, url, checksum, enable_password, display_text,  format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
-    VALUES (2, UUID(), 'centos53-x86_64', 'CentOS 5.3(64-bit) no GUI (XenServer)', 1, now(), now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/templates/builtin/f59f18fb-ae94-4f97-afd2-f84755767aca.vhd.bz2', 'b63d854a9560c013142567bbae8d98cf', 0, 'CentOS 5.3(64-bit) no GUI (XenServer)', 'VHD', 12, 1, 1, 'XenServer', 1);
-
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, display_text, enable_password, format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
     VALUES (4, UUID(), 'default-tmpl-centos8.0-kvm', 'CentOS 8.0(64-bit) no GUI (KVM)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.qcow2.bz2', '80da87ecc67d1e4fcf90079873241619', 'CentOS 8.0(64-bit) no GUI (KVM)', 0, 'QCOW2', 274, 1, 1, 'KVM', 1);
 

--- a/setup/db/templates.sql
+++ b/setup/db/templates.sql
@@ -37,7 +37,7 @@ INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created,
     VALUES (4, UUID(), 'default-tmpl-centos8.0-kvm', 'CentOS 8.0(64-bit) no GUI (KVM)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.qcow2.bz2', '80da87ecc67d1e4fcf90079873241619', 'CentOS 8.0(64-bit) no GUI (KVM)', 0, 'QCOW2', 274, 1, 1, 'KVM', 1);
 
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text,  format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
-    VALUES (5, UUID(), 'default-tmpl-centos7.2-xen', 'CentOS 7.2(64-bit) no GUI (XenServer)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.vhd.bz2', '9a2726a0d7680fb15a24af874f2a26e8', 0, 'CentOS 7.2(64-bit) no GUI (XenServer)', 'VHD', 274, 1, 1, 'XenServer', 1);
+    VALUES (5, UUID(), 'default-tmpl-centos8.0-xen', 'CentOS 8.0(64-bit) no GUI (XenServer)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.vhd.bz2', '440acfd548a7391b26559c4763377118', 0, 'CentOS 8.0(64-bit) no GUI (XenServer)', 'VHD', 274, 1, 1, 'XenServer', 1);
 
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text,  format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
     VALUES (6, UUID(), 'centos64-x64', 'CentOS 6.4(64-bit) GUI (Hyperv)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.3/centos6_4_64bit.vhd.bz2', 'eef6b9940ea3ed01221d963d4a012d0a', 0, 'CentOS 6.4 (64-bit) GUI (Hyperv)', 'VHD', 182, 1, 1, 'Hyperv', 1);

--- a/setup/db/templates.sql
+++ b/setup/db/templates.sql
@@ -41,8 +41,8 @@ INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created,
 
 INSERT INTO `cloud`.`vm_template` (id, uuid, unique_name, name, public, created, type, hvm, bits, account_id, url, checksum, enable_password, display_text,  format, guest_os_id, featured, cross_zones, hypervisor_type, extractable)
     VALUES (7, UUID(), 'default-tmpl-centos8.0-vmware', 'CentOS 8.0(64-bit) no GUI (vSphere)', 1, now(), 'BUILTIN', 0, 64, 1, 'http://download.cloudstack.org/releases/4.14/default-tmpl-centos8.0.ova', '85168c007c6ab85c516274cdf23eda48', 0, 'CentOS 8.0(64-bit) no GUI (vSphere)', 'OVA', 274, 1, 1, 'VMware', 1);
-INSERT INTO `cloud`.`vm_template_details` (`id`, `template_id`, `name`, `value`, `display`) VALUES (1, 7, 'nicAdapter', 'Vmxnet3', 1);
-INSERT INTO `cloud`.`vm_template_details` (`id`, `template_id`, `name`, `value`, `display`) VALUES (2, 7, 'rootDiskController', 'pvscsi', 1);
+INSERT INTO `cloud`.`vm_template_details` (`id`, `template_id`, `name`, `value`) VALUES (1, 7, 'nicAdapter', 'Vmxnet3');
+INSERT INTO `cloud`.`vm_template_details` (`id`, `template_id`, `name`, `value`) VALUES (2, 7, 'rootDiskController', 'pvscsi');
 
 INSERT INTO `cloud`.`guest_os_category` (id, uuid, name) VALUES (1, UUID(), 'CentOS');
 INSERT INTO `cloud`.`guest_os_category` (id, uuid, name) VALUES (2, UUID(), 'Debian');


### PR DESCRIPTION
## Description

New default/bultin templates for major hypervisors:

- CentOS 8.0 (VMware/KVM/XenServer) 
- Minimal install with "standard" / "core" groupinstall (a.k.a. additional network tools - ifconfig, route, etc.)
- nano, iftop, iotop, htop, bash-completion, traceroute
- ssh running, systemctl stop/disable firewalld, SELinux disabled
- disabled "predictive" interface names (net.ifnames=0 added to kernel boot line)
- stripped UUID/MAC from eth0 network config file
- VMware: opensource variant "open-vm-tools" installed - recommended by VMware (instead of using the one from ESXi hosts); both vmw_pvscsi and vmxnet3 drivers present and details added to vm_template_table to spin VMs with those devices
- XenServer: XenServer Tools 6.5sp1 installed (xs-tools confirmed as running, considering this is CentOS8 which the xs-tools installation script was not aware of)
- KVM: no special configuration, VirtIO present by default

## Types of changes
- [ x] Enhancement (improves an existing feature and functionality)


## Screenshots (if appropriate):

## How Has This Been Tested?
Templates were deployed on ACS install with old versions of hypervisors: VMware 5.5, XenServer 6.5sp1 fully patched up to patch 1066 and CentOS 7.3 (3 clusters, mixed env) and verified to work on those versions of hypervisors.

Yet to be tested against VMware 6.0/6.5/6.7, XenServer 7.0, 7.1, 7.x and Ubuntu 16/18, CentOS 7.6 maybe - but if it works on older ones than any newer hypervisor should be no problem.

## Comment:
- The only concern is that XenServer 6.5 must have all the patches installed (confirmed that patch XS65ESP1066 is needed) - otherwise, CentOS 8 (actually, anything newer than CentOS 7.2) will not boot successfully.
