### PR TITLE
vrouter: reload haproxy when cfg file is updated

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsLoadBalancer.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsLoadBalancer.py
@@ -45,7 +45,7 @@ class CsLoadBalancer(CsDataBag):
         if not file2.compare(file1):
             CsHelper.copy(HAPROXY_CONF_T, HAPROXY_CONF_P)
 
-            proc = CsProcess(['/var/run/haproxy.pid'])
+            proc = CsProcess(['/run/haproxy.pid'])
             if not proc.find():
                 logging.debug("CsLoadBalancer:: will restart HAproxy!")
                 CsHelper.service("haproxy", "restart")


### PR DESCRIPTION
since 4.11.3, haproxy is always restarted when add/delete a lb rule.
When haproxy is started, the processes are
```
root@r-854-VM:~# ps aux |grep haproxy
root     22272  0.0  0.2   4036   668 ?        Ss   07:52   0:00 /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
haproxy  22274  0.0  2.3  38444  5856 ?        S    07:52   0:00 /usr/sbin/haproxy-master
haproxy  22275  0.0  0.3  38444   880 ?        Ss   07:52   0:00 /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
```
When haproxy is reload, the processes are
```
root@r-854-VM:~# ps aux |grep haproxy
root     22272  0.0  0.2   4168   632 ?        Ss   07:52   0:00 /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
haproxy  22283  0.0  2.3  38444  5884 ?        S    07:53   0:00 /usr/sbin/haproxy-master
haproxy  22286  0.0  0.3  38444   880 ?        Ss   07:53   0:00 /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds -sf 22275
```

We need to change the pid file from /var/run/haproxy.pid to /run/haproxy.pid, so the haproxy will be reloaded instead of restarted.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

add/delete a lb rule, haproxy is reloaded
```
root@r-854-VM:~# tailf /var/log/cloud.log |grep haproxy


2019-11-28 14:34:36,353  CsFile.py commit:66 Wrote edited file /etc/haproxy/haproxy.cfg.new
2019-11-28 14:34:36,356  CsHelper.py copy:266 Copied /etc/haproxy/haproxy.cfg.new to /etc/haproxy/haproxy.cfg
2019-11-28 14:34:36,376  CsHelper.py execute:188 Executing: systemctl reload haproxy
2019-11-28 14:34:36,414  CsHelper.py service:227 Service haproxy reload
2019-11-28 14:34:50,419  CsFile.py commit:66 Wrote edited file /etc/haproxy/haproxy.cfg.new
2019-11-28 14:34:50,422  CsHelper.py copy:266 Copied /etc/haproxy/haproxy.cfg.new to /etc/haproxy/haproxy.cfg
2019-11-28 14:34:50,445  CsHelper.py execute:188 Executing: systemctl reload haproxy
2019-11-28 14:34:50,519  CsHelper.py service:227 Service haproxy reload
2019-11-28 14:35:39,684  CsFile.py commit:66 Wrote edited file /etc/haproxy/haproxy.cfg.new
2019-11-28 14:35:39,687  CsHelper.py copy:266 Copied /etc/haproxy/haproxy.cfg.new to /etc/haproxy/haproxy.cfg
2019-11-28 14:35:39,707  CsHelper.py execute:188 Executing: systemctl reload haproxy
2019-11-28 14:35:39,744  CsHelper.py service:227 Service haproxy reload
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
