### PR TITLE
server: double check host capacity when start/migrate a vm

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2349,6 +2349,17 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             _networkMgr.rollbackNicForMigration(vmSrc, profile);
             s_logger.info("Migration cancelled because " + e1.getMessage());
             throw new ConcurrentOperationException("Migration cancelled because " + e1.getMessage());
+        } catch (final CloudRuntimeException e2) {
+            _networkMgr.rollbackNicForMigration(vmSrc, profile);
+            s_logger.info("Migration cancelled because " + e2.getMessage());
+            work.setStep(Step.Done);
+            _workDao.update(work.getId(), work);
+            try {
+                stateTransitTo(vm, Event.OperationFailed, srcHostId);
+            } catch (final NoTransitionException e3) {
+                s_logger.warn(e3.getMessage());
+            }
+            throw new CloudRuntimeException("Migration cancelled because " + e2.getMessage());
         }
 
         boolean migrated = false;

--- a/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
@@ -172,6 +172,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         final ServiceOfferingVO svo = _offeringsDao.findById(vm.getId(), vm.getServiceOfferingId());
         CapacityVO capacityCpu = _capacityDao.findByHostIdType(hostId, Capacity.CAPACITY_TYPE_CPU);
         CapacityVO capacityMemory = _capacityDao.findByHostIdType(hostId, Capacity.CAPACITY_TYPE_MEMORY);
+        CapacityVO capacityCpuCore = _capacityDao.findByHostIdType(hostId, Capacity.CAPACITY_TYPE_CPU_CORE);
         Long clusterId = null;
         if (hostId != null) {
             HostVO host = _hostDao.findById(hostId);
@@ -182,7 +183,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
             clusterId = host.getClusterId();
         }
-        if (capacityCpu == null || capacityMemory == null || svo == null) {
+        if (capacityCpu == null || capacityMemory == null || svo == null || capacityCpuCore == null) {
             return false;
         }
 
@@ -190,20 +191,26 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
             final Long clusterIdFinal = clusterId;
             final long capacityCpuId = capacityCpu.getId();
             final long capacityMemoryId = capacityMemory.getId();
+            final long capacityCpuCoreId = capacityCpuCore.getId();
+
             Transaction.execute(new TransactionCallbackNoReturn() {
                 @Override
                 public void doInTransactionWithoutResult(TransactionStatus status) {
                     CapacityVO capacityCpu = _capacityDao.lockRow(capacityCpuId, true);
                     CapacityVO capacityMemory = _capacityDao.lockRow(capacityMemoryId, true);
+                    CapacityVO capacityCpuCore = _capacityDao.lockRow(capacityCpuCoreId, true);
 
                     long usedCpu = capacityCpu.getUsedCapacity();
                     long usedMem = capacityMemory.getUsedCapacity();
+                    long usedCpuCore = capacityCpuCore.getUsedCapacity();
                     long reservedCpu = capacityCpu.getReservedCapacity();
                     long reservedMem = capacityMemory.getReservedCapacity();
+                    long reservedCpuCore = capacityCpuCore.getReservedCapacity();
                     long actualTotalCpu = capacityCpu.getTotalCapacity();
                     float cpuOvercommitRatio = Float.parseFloat(_clusterDetailsDao.findDetail(clusterIdFinal, "cpuOvercommitRatio").getValue());
                     float memoryOvercommitRatio = Float.parseFloat(_clusterDetailsDao.findDetail(clusterIdFinal, "memoryOvercommitRatio").getValue());
                     int vmCPU = svo.getCpu() * svo.getSpeed();
+                    int vmCPUCore = svo.getCpu();
                     long vmMem = svo.getRamSize() * 1024L * 1024L;
                     long actualTotalMem = capacityMemory.getTotalCapacity();
                     long totalMem = (long)(actualTotalMem * memoryOvercommitRatio);
@@ -221,6 +228,9 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                         if (usedMem >= vmMem) {
                             capacityMemory.setUsedCapacity(usedMem - vmMem);
                         }
+                        if (usedCpuCore >= vmCPUCore) {
+                            capacityCpuCore.setUsedCapacity(usedCpuCore - vmCPUCore);
+                        }
 
                         if (moveToReservered) {
                             if (reservedCpu + vmCPU <= totalCpu) {
@@ -229,6 +239,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                             if (reservedMem + vmMem <= totalMem) {
                                 capacityMemory.setReservedCapacity(reservedMem + vmMem);
                             }
+                            capacityCpuCore.setReservedCapacity(reservedCpuCore + vmCPUCore);
                         }
                     } else {
                         if (reservedCpu >= vmCPU) {
@@ -236,6 +247,9 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                         }
                         if (reservedMem >= vmMem) {
                             capacityMemory.setReservedCapacity(reservedMem - vmMem);
+                        }
+                        if (reservedCpuCore >= vmCPUCore) {
+                            capacityCpuCore.setReservedCapacity(reservedCpuCore - vmCPUCore);
                         }
                     }
 
@@ -249,6 +263,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
                     _capacityDao.update(capacityCpu.getId(), capacityCpu);
                     _capacityDao.update(capacityMemory.getId(), capacityMemory);
+                    _capacityDao.update(capacityCpuCore.getId(), capacityCpuCore);
                 }
             });
 
@@ -273,28 +288,34 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
         CapacityVO capacityCpu = _capacityDao.findByHostIdType(hostId, Capacity.CAPACITY_TYPE_CPU);
         CapacityVO capacityMem = _capacityDao.findByHostIdType(hostId, Capacity.CAPACITY_TYPE_MEMORY);
+        CapacityVO capacityCpuCore = _capacityDao.findByHostIdType(hostId, Capacity.CAPACITY_TYPE_CPU_CORE);
 
-        if (capacityCpu == null || capacityMem == null || svo == null) {
+        if (capacityCpu == null || capacityMem == null || svo == null || capacityCpuCore == null) {
             return;
         }
 
         final int cpu = svo.getCpu() * svo.getSpeed();
+        final int cpucore = svo.getCpu();
         final long ram = svo.getRamSize() * 1024L * 1024L;
 
         try {
             final long capacityCpuId = capacityCpu.getId();
             final long capacityMemId = capacityMem.getId();
+            final long capacityCpuCoreId = capacityCpuCore.getId();
 
             Transaction.execute(new TransactionCallbackNoReturn() {
                 @Override
                 public void doInTransactionWithoutResult(TransactionStatus status) {
                     CapacityVO capacityCpu = _capacityDao.lockRow(capacityCpuId, true);
                     CapacityVO capacityMem = _capacityDao.lockRow(capacityMemId, true);
+                    CapacityVO capacityCpuCore = _capacityDao.lockRow(capacityCpuCoreId, true);
 
                     long usedCpu = capacityCpu.getUsedCapacity();
                     long usedMem = capacityMem.getUsedCapacity();
+                    long usedCpuCore = capacityCpuCore.getUsedCapacity();
                     long reservedCpu = capacityCpu.getReservedCapacity();
                     long reservedMem = capacityMem.getReservedCapacity();
+                    long reservedCpuCore = capacityCpuCore.getReservedCapacity();
                     long actualTotalCpu = capacityCpu.getTotalCapacity();
                     long actualTotalMem = capacityMem.getTotalCapacity();
                     long totalCpu = (long)(actualTotalCpu * cpuOvercommitRatio);
@@ -313,6 +334,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                     }
                     capacityCpu.setUsedCapacity(usedCpu + cpu);
                     capacityMem.setUsedCapacity(usedMem + ram);
+                    capacityCpuCore.setUsedCapacity(usedCpuCore + cpucore);
 
                     if (fromLastHost) {
                         /* alloc from reserved */
@@ -324,6 +346,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
                         if (reservedCpu >= cpu && reservedMem >= ram) {
                             capacityCpu.setReservedCapacity(reservedCpu - cpu);
                             capacityMem.setReservedCapacity(reservedMem - ram);
+                            capacityCpuCore.setReservedCapacity(reservedCpuCore - cpucore);
                         }
                     } else {
                         /* alloc from free resource */
@@ -345,6 +368,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
 
                     _capacityDao.update(capacityCpu.getId(), capacityCpu);
                     _capacityDao.update(capacityMem.getId(), capacityMem);
+                    _capacityDao.update(capacityCpuCore.getId(), capacityCpuCore);
                 }
             });
         } catch (Exception e) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When start a vm or migrate a vm (away from a host in host maintenance), cloudstack will check capacity of all hosts and choose one. If there are hundreds of hosts on the platform, it will take some seconds. When cloudstack choose a host and start/migrate vm to it, the resource consumption of the host might have been changed. This normally happens when we start/migrate multiple vms.
It would be better to double check the host capacity when start vm on a host.

This PR includes the fix for cpucore capacity when start/migrate a vm.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

start multiple vms on a host
put a host to maintenance so multiple vms will be migrated at same time
check the resource count of cpucore, all looks good.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
