### PR TITLE
config: add isdynamic flag in configuration response

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -187,6 +187,7 @@ public class ApiConstants {
     public static final String IP_LIMIT = "iplimit";
     public static final String IP_TOTAL = "iptotal";
     public static final String IS_CLEANUP_REQUIRED = "iscleanuprequired";
+    public static final String IS_DYNAMIC = "isdynamic";
     public static final String IS_EXTRACTABLE = "isextractable";
     public static final String IS_FEATURED = "isfeatured";
     public static final String IS_PORTABLE = "isportable";

--- a/api/src/main/java/org/apache/cloudstack/api/response/ConfigurationResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ConfigurationResponse.java
@@ -48,6 +48,10 @@ public class ConfigurationResponse extends BaseResponse {
     @Param(description = "the description of the configuration")
     private String description;
 
+    @SerializedName(ApiConstants.IS_DYNAMIC)
+    @Param(description = "true if the configuration is dynamic")
+    private boolean isDynamic;
+
     public String getCategory() {
         return category;
     }
@@ -87,4 +91,13 @@ public class ConfigurationResponse extends BaseResponse {
     public void setScope(String scope) {
         this.scope = scope;
     }
+
+    public boolean isDynamic() {
+        return isDynamic;
+    }
+
+    public void setIsDynamic(boolean isDynamic) {
+        this.isDynamic = isDynamic;
+    }
+
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -491,6 +491,7 @@ public class ApiResponseHelper implements ResponseGenerator {
         } else {
             cfgResponse.setValue(cfg.getValue());
         }
+        cfgResponse.setIsDynamic(cfg.isDynamic());
         cfgResponse.setObjectName("configuration");
 
         return cfgResponse;

--- a/ui/scripts/globalSettings.js
+++ b/ui/scripts/globalSettings.js
@@ -41,11 +41,11 @@
                                     data: data,
                                     success: function(json) {
                                         var item = json.updateconfigurationresponse.configuration;
-                                        if (item.category == "Usage")
+                                        if (item.category == "Usage" && item.isdynamic == false)
                                             cloudStack.dialog.notice({
                                                 message: _l('message.restart.mgmt.usage.server')
                                             });
-                                        else
+                                        else if (item.isdynamic == false)
                                             cloudStack.dialog.notice({
                                                 message: _l('message.restart.mgmt.server')
                                             });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Some configurations are dynamic so it does not require restart of mgt server when we change it.
Add isdynamic in configuration response, and does not pop up dialog "restart mgt server" if config is dynamic on UI.

Fixes: #3683 

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested with global configuration "xen.vm.vcpu.max", it works fine (no pop up dialog).

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
