### PR TITLE
Enable Direct Download for System VMs

### DIFF
--- a/agent/src/main/java/com/cloud/agent/direct/download/HttpDirectTemplateDownloader.java
+++ b/agent/src/main/java/com/cloud/agent/direct/download/HttpDirectTemplateDownloader.java
@@ -19,22 +19,23 @@
 
 package com.cloud.agent.direct.download;
 
-import com.cloud.utils.exception.CloudRuntimeException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import com.cloud.utils.exception.CloudRuntimeException;
 
 public class HttpDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
 
@@ -44,10 +45,10 @@ public class HttpDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
     protected GetMethod request;
     protected Map<String, String> reqHeaders = new HashMap<>();
 
-    public HttpDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers) {
+    public HttpDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
         super(url, destPoolPath, templateId, checksum);
-        s_httpClientManager.getParams().setConnectionTimeout(5000);
-        s_httpClientManager.getParams().setSoTimeout(5000);
+        s_httpClientManager.getParams().setConnectionTimeout(connectTimeout);
+        s_httpClientManager.getParams().setSoTimeout(soTimeout);
         client = new HttpClient(s_httpClientManager);
         request = createRequest(url, headers);
         String downloadDir = getDirectDownloadTempPath(templateId);

--- a/agent/src/main/java/com/cloud/agent/direct/download/HttpDirectTemplateDownloader.java
+++ b/agent/src/main/java/com/cloud/agent/direct/download/HttpDirectTemplateDownloader.java
@@ -45,10 +45,10 @@ public class HttpDirectTemplateDownloader extends DirectTemplateDownloaderImpl {
     protected GetMethod request;
     protected Map<String, String> reqHeaders = new HashMap<>();
 
-    public HttpDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
+    public HttpDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers, Integer connectTimeout, Integer soTimeout) {
         super(url, destPoolPath, templateId, checksum);
-        s_httpClientManager.getParams().setConnectionTimeout(connectTimeout);
-        s_httpClientManager.getParams().setSoTimeout(soTimeout);
+        s_httpClientManager.getParams().setConnectionTimeout(connectTimeout == null ? 5000 : connectTimeout);
+        s_httpClientManager.getParams().setSoTimeout(soTimeout == null ? 5000 : soTimeout);
         client = new HttpClient(s_httpClientManager);
         request = createRequest(url, headers);
         String downloadDir = getDirectDownloadTempPath(templateId);

--- a/agent/src/main/java/com/cloud/agent/direct/download/HttpsDirectTemplateDownloader.java
+++ b/agent/src/main/java/com/cloud/agent/direct/download/HttpsDirectTemplateDownloader.java
@@ -55,7 +55,7 @@ public class HttpsDirectTemplateDownloader extends HttpDirectTemplateDownloader 
     private CloseableHttpClient httpsClient;
     private HttpUriRequest req;
 
-    public HttpsDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout, int connectionRequestTimeout) {
+    public HttpsDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers, Integer connectTimeout, Integer soTimeout, Integer connectionRequestTimeout) {
         super(url, templateId, destPoolPath, checksum, headers, connectTimeout, soTimeout);
         SSLContext sslcontext = null;
         try {
@@ -65,9 +65,9 @@ public class HttpsDirectTemplateDownloader extends HttpDirectTemplateDownloader 
         }
         SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(sslcontext, SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
         RequestConfig config = RequestConfig.custom()
-                .setConnectTimeout(connectTimeout)
-                .setConnectionRequestTimeout(connectionRequestTimeout)
-                .setSocketTimeout(soTimeout).build();
+                .setConnectTimeout(connectTimeout == null ? 5000 : connectTimeout)
+                .setConnectionRequestTimeout(connectionRequestTimeout == null ? 5000 : connectionRequestTimeout)
+                .setSocketTimeout(soTimeout == null ? 5000 : soTimeout).build();
         httpsClient = HttpClients.custom().setSSLSocketFactory(factory).setDefaultRequestConfig(config).build();
         createUriRequest(url, headers);
     }

--- a/agent/src/main/java/com/cloud/agent/direct/download/HttpsDirectTemplateDownloader.java
+++ b/agent/src/main/java/com/cloud/agent/direct/download/HttpsDirectTemplateDownloader.java
@@ -19,13 +19,26 @@
 
 package com.cloud.agent.direct.download;
 
-import com.cloud.utils.exception.CloudRuntimeException;
-import com.cloud.utils.script.Script;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.commons.collections.MapUtils;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -34,27 +47,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
 
-import javax.net.ssl.SSLContext;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.FileOutputStream;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.util.Map;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.utils.script.Script;
 
 public class HttpsDirectTemplateDownloader extends HttpDirectTemplateDownloader {
 
     private CloseableHttpClient httpsClient;
     private HttpUriRequest req;
 
-    public HttpsDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers) {
-        super(url, templateId, destPoolPath, checksum, headers);
+    public HttpsDirectTemplateDownloader(String url, Long templateId, String destPoolPath, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout, int connectionRequestTimeout) {
+        super(url, templateId, destPoolPath, checksum, headers, connectTimeout, soTimeout);
         SSLContext sslcontext = null;
         try {
             sslcontext = getSSLContext();
@@ -63,9 +65,9 @@ public class HttpsDirectTemplateDownloader extends HttpDirectTemplateDownloader 
         }
         SSLConnectionSocketFactory factory = new SSLConnectionSocketFactory(sslcontext, SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
         RequestConfig config = RequestConfig.custom()
-                .setConnectTimeout(5000)
-                .setConnectionRequestTimeout(5000)
-                .setSocketTimeout(5000).build();
+                .setConnectTimeout(connectTimeout)
+                .setConnectionRequestTimeout(connectionRequestTimeout)
+                .setSocketTimeout(soTimeout).build();
         httpsClient = HttpClients.custom().setSSLSocketFactory(factory).setDefaultRequestConfig(config).build();
         createUriRequest(url, headers);
     }

--- a/agent/src/main/java/com/cloud/agent/direct/download/MetalinkDirectTemplateDownloader.java
+++ b/agent/src/main/java/com/cloud/agent/direct/download/MetalinkDirectTemplateDownloader.java
@@ -18,16 +18,17 @@
 //
 package com.cloud.agent.direct.download;
 
-import com.cloud.utils.UriUtils;
-import com.cloud.utils.exception.CloudRuntimeException;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
-
 import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+
+import com.cloud.utils.UriUtils;
+import com.cloud.utils.exception.CloudRuntimeException;
 
 public class MetalinkDirectTemplateDownloader extends HttpDirectTemplateDownloader {
 
@@ -37,8 +38,8 @@ public class MetalinkDirectTemplateDownloader extends HttpDirectTemplateDownload
     private Random random = new Random();
     private static final Logger s_logger = Logger.getLogger(MetalinkDirectTemplateDownloader.class.getName());
 
-    public MetalinkDirectTemplateDownloader(String url, String destPoolPath, Long templateId, String checksum, Map<String, String> headers) {
-        super(url, templateId, destPoolPath, checksum, headers);
+    public MetalinkDirectTemplateDownloader(String url, String destPoolPath, Long templateId, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
+        super(url, templateId, destPoolPath, checksum, headers, connectTimeout, soTimeout);
         metalinkUrl = url;
         metalinkUrls = UriUtils.getMetalinkUrls(metalinkUrl);
         metalinkChecksums = UriUtils.getMetalinkChecksums(metalinkUrl);

--- a/agent/src/main/java/com/cloud/agent/direct/download/MetalinkDirectTemplateDownloader.java
+++ b/agent/src/main/java/com/cloud/agent/direct/download/MetalinkDirectTemplateDownloader.java
@@ -38,7 +38,7 @@ public class MetalinkDirectTemplateDownloader extends HttpDirectTemplateDownload
     private Random random = new Random();
     private static final Logger s_logger = Logger.getLogger(MetalinkDirectTemplateDownloader.class.getName());
 
-    public MetalinkDirectTemplateDownloader(String url, String destPoolPath, Long templateId, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
+    public MetalinkDirectTemplateDownloader(String url, String destPoolPath, Long templateId, String checksum, Map<String, String> headers, Integer connectTimeout, Integer soTimeout) {
         super(url, templateId, destPoolPath, checksum, headers, connectTimeout, soTimeout);
         metalinkUrl = url;
         metalinkUrls = UriUtils.getMetalinkUrls(metalinkUrl);

--- a/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
+++ b/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
@@ -17,12 +17,17 @@
 
 package org.apache.cloudstack.direct.download;
 
-import com.cloud.utils.component.PluggableService;
 import org.apache.cloudstack.framework.agent.direct.download.DirectDownloadService;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.framework.config.Configurable;
 
+import com.cloud.utils.component.PluggableService;
+
 public interface DirectDownloadManager extends DirectDownloadService, PluggableService, Configurable {
+
+    static final int DEFAULT_DIRECT_DOWNLOAD_CONNECT_TIMEOUT = 5000;
+    static final int DEFAULT_DIRECT_DOWNLOAD_SOCKET_TIMEOUT = 5000;
+    static final int DEFAULT_DIRECT_DOWNLOAD_CONNECTION_REQUEST_TIMEOUT = 5000;
 
     ConfigKey<Long> DirectDownloadCertificateUploadInterval = new ConfigKey<>("Advanced", Long.class,
             "direct.download.certificate.background.task.interval",
@@ -31,6 +36,24 @@ public interface DirectDownloadManager extends DirectDownloadService, PluggableS
                     "missing uploaded certificates for direct download." +
                     "Only certificates which have not been revoked from hosts are uploaded",
             false);
+
+    static final ConfigKey<Integer> DirectDownloadConnectTimeout = new ConfigKey<Integer>("Advanced", Integer.class,
+            "direct.download.connect.timeout",
+            String.valueOf(DEFAULT_DIRECT_DOWNLOAD_CONNECT_TIMEOUT),
+            "Connection establishment timeout in milliseconds for direct download",
+            true);
+
+    static final ConfigKey<Integer> DirectDownloadSocketTimeout = new ConfigKey<Integer>("Advanced", Integer.class,
+            "direct.download.socket.timeout",
+            String.valueOf(DEFAULT_DIRECT_DOWNLOAD_SOCKET_TIMEOUT),
+            "Socket timeout (SO_TIMEOUT) in milliseconds for direct download",
+            true);
+
+    static final ConfigKey<Integer> DirectDownloadConnectionRequestTimeout = new ConfigKey<Integer>("Advanced", Integer.class,
+            "direct.download.connection.request.timeout",
+            String.valueOf(DEFAULT_DIRECT_DOWNLOAD_CONNECTION_REQUEST_TIMEOUT),
+            "Requesting a connection from connection manager timeout in milliseconds for direct download",
+            true);
 
     /**
      * Revoke direct download certificate with alias 'alias' from hosts of hypervisor type 'hypervisor'

--- a/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
+++ b/api/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManager.java
@@ -49,7 +49,7 @@ public interface DirectDownloadManager extends DirectDownloadService, PluggableS
             "Socket timeout (SO_TIMEOUT) in milliseconds for direct download",
             true);
 
-    static final ConfigKey<Integer> DirectDownloadConnectionRequestTimeout = new ConfigKey<Integer>("Advanced", Integer.class,
+    static final ConfigKey<Integer> DirectDownloadConnectionRequestTimeout = new ConfigKey<Integer>("Hidden", Integer.class,
             "direct.download.connection.request.timeout",
             String.valueOf(DEFAULT_DIRECT_DOWNLOAD_CONNECTION_REQUEST_TIMEOUT),
             "Requesting a connection from connection manager timeout in milliseconds for direct download",

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/DirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/DirectDownloadCommand.java
@@ -35,16 +35,19 @@ public abstract class DirectDownloadCommand extends StorageSubSystemCommand {
     private PrimaryDataStoreTO destPool;
     private String checksum;
     private Map<String, String> headers;
-    private int connectTimeout;
-    private int soTimeout;
-    private int connectionRequestTimeout;
+    private Integer connectTimeout;
+    private Integer soTimeout;
+    private Integer connectionRequestTimeout;
 
-    protected DirectDownloadCommand (final String url, final Long templateId, final PrimaryDataStoreTO destPool, final String checksum, final Map<String, String> headers) {
+    protected DirectDownloadCommand (final String url, final Long templateId, final PrimaryDataStoreTO destPool, final String checksum, final Map<String, String> headers, final Integer connectTimeout, final Integer soTimeout, final Integer connectionRequestTimeout) {
         this.url = url;
         this.templateId = templateId;
         this.destPool = destPool;
         this.checksum = checksum;
         this.headers = headers;
+        this.connectTimeout = connectTimeout;
+        this.soTimeout = soTimeout;
+        this.connectionRequestTimeout = connectionRequestTimeout;
     }
 
     public String getUrl() {
@@ -67,27 +70,27 @@ public abstract class DirectDownloadCommand extends StorageSubSystemCommand {
         return headers;
     }
 
-    public int getConnectTimeout() {
+    public Integer getConnectTimeout() {
         return connectTimeout;
     }
 
-    public void setConnectTimeout(int connectTimeout) {
+    public void setConnectTimeout(Integer connectTimeout) {
         this.connectTimeout = connectTimeout;
     }
 
-    public int getSoTimeout() {
+    public Integer getSoTimeout() {
         return soTimeout;
     }
 
-    public void setSoTimeout(int soTimeout) {
+    public void setSoTimeout(Integer soTimeout) {
         this.soTimeout = soTimeout;
     }
 
-    public int getConnectionRequestTimeout() {
+    public Integer getConnectionRequestTimeout() {
         return connectionRequestTimeout;
     }
 
-    public void setConnectionRequestTimeout(int connectionRequestTimeout) {
+    public void setConnectionRequestTimeout(Integer connectionRequestTimeout) {
         this.connectionRequestTimeout = connectionRequestTimeout;
     }
 

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/DirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/DirectDownloadCommand.java
@@ -19,10 +19,10 @@
 
 package org.apache.cloudstack.agent.directdownload;
 
+import java.util.Map;
+
 import org.apache.cloudstack.storage.command.StorageSubSystemCommand;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-
-import java.util.Map;
 
 public abstract class DirectDownloadCommand extends StorageSubSystemCommand {
 
@@ -35,6 +35,9 @@ public abstract class DirectDownloadCommand extends StorageSubSystemCommand {
     private PrimaryDataStoreTO destPool;
     private String checksum;
     private Map<String, String> headers;
+    private int connectTimeout;
+    private int soTimeout;
+    private int connectionRequestTimeout;
 
     protected DirectDownloadCommand (final String url, final Long templateId, final PrimaryDataStoreTO destPool, final String checksum, final Map<String, String> headers) {
         this.url = url;
@@ -62,6 +65,30 @@ public abstract class DirectDownloadCommand extends StorageSubSystemCommand {
 
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getSoTimeout() {
+        return soTimeout;
+    }
+
+    public void setSoTimeout(int soTimeout) {
+        this.soTimeout = soTimeout;
+    }
+
+    public int getConnectionRequestTimeout() {
+        return connectionRequestTimeout;
+    }
+
+    public void setConnectionRequestTimeout(int connectionRequestTimeout) {
+        this.connectionRequestTimeout = connectionRequestTimeout;
     }
 
     @Override

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpDirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpDirectDownloadCommand.java
@@ -18,14 +18,16 @@
  */
 package org.apache.cloudstack.agent.directdownload;
 
-import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-
 import java.util.Map;
+
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 
 public class HttpDirectDownloadCommand extends DirectDownloadCommand {
 
-    public HttpDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers) {
+    public HttpDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
         super(url, templateId, destPool, checksum, headers);
+        setConnectTimeout(connectTimeout);
+        setSoTimeout(soTimeout);
     }
 
 }

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpDirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpDirectDownloadCommand.java
@@ -25,9 +25,7 @@ import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 public class HttpDirectDownloadCommand extends DirectDownloadCommand {
 
     public HttpDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
-        super(url, templateId, destPool, checksum, headers);
-        setConnectTimeout(connectTimeout);
-        setSoTimeout(soTimeout);
+        super(url, templateId, destPool, checksum, headers, connectTimeout, soTimeout, null);
     }
 
 }

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpsDirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpsDirectDownloadCommand.java
@@ -19,13 +19,16 @@
 
 package org.apache.cloudstack.agent.directdownload;
 
-import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-
 import java.util.Map;
+
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 
 public class HttpsDirectDownloadCommand extends DirectDownloadCommand {
 
-    public HttpsDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers) {
+    public HttpsDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout, int connectionRequestTimeout) {
         super(url, templateId, destPool, checksum, headers);
+        setConnectTimeout(connectTimeout);
+        setSoTimeout(soTimeout);
+        setConnectionRequestTimeout(connectionRequestTimeout);
     }
 }

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpsDirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/HttpsDirectDownloadCommand.java
@@ -26,9 +26,6 @@ import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 public class HttpsDirectDownloadCommand extends DirectDownloadCommand {
 
     public HttpsDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout, int connectionRequestTimeout) {
-        super(url, templateId, destPool, checksum, headers);
-        setConnectTimeout(connectTimeout);
-        setSoTimeout(soTimeout);
-        setConnectionRequestTimeout(connectionRequestTimeout);
+        super(url, templateId, destPool, checksum, headers, connectTimeout, soTimeout, connectionRequestTimeout);
     }
 }

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/MetalinkDirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/MetalinkDirectDownloadCommand.java
@@ -25,9 +25,7 @@ import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 public class MetalinkDirectDownloadCommand extends DirectDownloadCommand {
 
     public MetalinkDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
-        super(url, templateId, destPool, checksum, headers);
-        setConnectTimeout(connectTimeout);
-        setSoTimeout(soTimeout);
+        super(url, templateId, destPool, checksum, headers, connectTimeout, soTimeout, null);
     }
 
 }

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/MetalinkDirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/MetalinkDirectDownloadCommand.java
@@ -18,14 +18,16 @@
 //
 package org.apache.cloudstack.agent.directdownload;
 
-import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-
 import java.util.Map;
+
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 
 public class MetalinkDirectDownloadCommand extends DirectDownloadCommand {
 
-    public MetalinkDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers) {
+    public MetalinkDirectDownloadCommand(String url, Long templateId, PrimaryDataStoreTO destPool, String checksum, Map<String, String> headers, int connectTimeout, int soTimeout) {
         super(url, templateId, destPool, checksum, headers);
+        setConnectTimeout(connectTimeout);
+        setSoTimeout(soTimeout);
     }
 
 }

--- a/core/src/main/java/org/apache/cloudstack/agent/directdownload/NfsDirectDownloadCommand.java
+++ b/core/src/main/java/org/apache/cloudstack/agent/directdownload/NfsDirectDownloadCommand.java
@@ -18,14 +18,14 @@
 //
 package org.apache.cloudstack.agent.directdownload;
 
-import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-
 import java.util.Map;
+
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 
 public class NfsDirectDownloadCommand extends DirectDownloadCommand {
 
     public NfsDirectDownloadCommand(final String url, final Long templateId, final PrimaryDataStoreTO destPool, final String checksum, final Map<String, String> headers) {
-        super(url, templateId, destPool, checksum, headers);
+        super(url, templateId, destPool, checksum, headers, null, null, null);
     }
 
 }

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/TemplateService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/TemplateService.java
@@ -71,5 +71,7 @@ public interface TemplateService {
 
     void associateCrosszoneTemplatesToZone(long dcId);
 
+    void dissociateTemplatesFromZone(long zoneId);
+
     AsyncCallFuture<TemplateApiResult> createDatadiskTemplateAsync(TemplateInfo parentTemplate, TemplateInfo dataDiskTemplate, String path, String diskId, long fileSize, boolean bootable);
 }

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/TemplateService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/subsystem/api/storage/TemplateService.java
@@ -71,7 +71,5 @@ public interface TemplateService {
 
     void associateCrosszoneTemplatesToZone(long dcId);
 
-    void dissociateTemplatesFromZone(long zoneId);
-
     AsyncCallFuture<TemplateApiResult> createDatadiskTemplateAsync(TemplateInfo parentTemplate, TemplateInfo dataDiskTemplate, String path, String diskId, long fileSize, boolean bootable);
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateDaoImpl.java
@@ -345,7 +345,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
         readySystemTemplateSearch.and("state", readySystemTemplateSearch.entity().getState(), SearchCriteria.Op.EQ);
         readySystemTemplateSearch.and("templateType", readySystemTemplateSearch.entity().getTemplateType(), SearchCriteria.Op.EQ);
         SearchBuilder<TemplateDataStoreVO> templateDownloadSearch = _templateDataStoreDao.createSearchBuilder();
-        templateDownloadSearch.and("downloadState", templateDownloadSearch.entity().getDownloadState(), SearchCriteria.Op.EQ);
+        templateDownloadSearch.and("downloadState", templateDownloadSearch.entity().getDownloadState(), SearchCriteria.Op.IN);
         readySystemTemplateSearch.join("vmTemplateJoinTemplateStoreRef", templateDownloadSearch, templateDownloadSearch.entity().getTemplateId(),
             readySystemTemplateSearch.entity().getId(), JoinBuilder.JoinType.INNER);
         SearchBuilder<HostVO> hostHyperSearch2 = _hostDao.createSearchBuilder();
@@ -860,7 +860,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
         sc.setParameters("state", VirtualMachineTemplate.State.Active);
         sc.setJoinParameters("tmplHyper", "type", Host.Type.Routing);
         sc.setJoinParameters("tmplHyper", "zoneId", zoneId);
-        sc.setJoinParameters("vmTemplateJoinTemplateStoreRef", "downloadState", VMTemplateStorageResourceAssoc.Status.DOWNLOADED);
+        sc.setJoinParameters("vmTemplateJoinTemplateStoreRef", "downloadState", (Object) new VMTemplateStorageResourceAssoc.Status[] {VMTemplateStorageResourceAssoc.Status.DOWNLOADED, VMTemplateStorageResourceAssoc.Status.BYPASSED});
 
         // order by descending order of id
         List<VMTemplateVO> tmplts = listBy(sc, new Filter(VMTemplateVO.class, "id", false, null, null));

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateDaoImpl.java
@@ -860,7 +860,7 @@ public class VMTemplateDaoImpl extends GenericDaoBase<VMTemplateVO, Long> implem
         sc.setParameters("state", VirtualMachineTemplate.State.Active);
         sc.setJoinParameters("tmplHyper", "type", Host.Type.Routing);
         sc.setJoinParameters("tmplHyper", "zoneId", zoneId);
-        sc.setJoinParameters("vmTemplateJoinTemplateStoreRef", "downloadState", (Object) new VMTemplateStorageResourceAssoc.Status[] {VMTemplateStorageResourceAssoc.Status.DOWNLOADED, VMTemplateStorageResourceAssoc.Status.BYPASSED});
+        sc.setJoinParameters("vmTemplateJoinTemplateStoreRef", "downloadState", new VMTemplateStorageResourceAssoc.Status[] {VMTemplateStorageResourceAssoc.Status.DOWNLOADED, VMTemplateStorageResourceAssoc.Status.BYPASSED});
 
         // order by descending order of id
         List<VMTemplateVO> tmplts = listBy(sc, new Filter(VMTemplateVO.class, "id", false, null, null));

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateZoneDao.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateZoneDao.java
@@ -22,14 +22,15 @@ import com.cloud.storage.VMTemplateZoneVO;
 import com.cloud.utils.db.GenericDao;
 
 public interface VMTemplateZoneDao extends GenericDao<VMTemplateZoneVO, Long> {
-    public List<VMTemplateZoneVO> listByZoneId(long id);
+    List<VMTemplateZoneVO> listByZoneId(long id);
 
-    public List<VMTemplateZoneVO> listByTemplateId(long templateId);
+    List<VMTemplateZoneVO> listByTemplateId(long templateId);
 
-    public VMTemplateZoneVO findByZoneTemplate(long zoneId, long templateId);
+    VMTemplateZoneVO findByZoneTemplate(long zoneId, long templateId);
 
-    public List<VMTemplateZoneVO> listByZoneTemplate(Long zoneId, long templateId);
+    List<VMTemplateZoneVO> listByZoneTemplate(Long zoneId, long templateId);
 
-    public void deletePrimaryRecordsForTemplate(long templateId);
+    void deletePrimaryRecordsForTemplate(long templateId);
 
+    void deleteByZoneId(long zoneId);
 }

--- a/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateZoneDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/storage/dao/VMTemplateZoneDaoImpl.java
@@ -93,4 +93,13 @@ public class VMTemplateZoneDaoImpl extends GenericDaoBase<VMTemplateZoneVO, Long
         txn.commit();
     }
 
+    @Override
+    public void deleteByZoneId(long zoneId) {
+        SearchCriteria<VMTemplateZoneVO> sc = ZoneSearch.create();
+        sc.setParameters("zone_id", zoneId);
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        txn.start();
+        remove(sc);
+        txn.commit();
+    }
 }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -1201,19 +1201,17 @@ public class TemplateServiceImpl implements TemplateService {
         for (VMTemplateVO tmplt : rtngTmplts) {
             TemplateDataStoreVO tmpltStore = _vmTemplateStoreDao.findByStoreTemplate(storeId, tmplt.getId());
             if (tmpltStore == null) {
-                if (tmplt.isDirectDownload()) {
-                    TemplateDataStoreVO directDownloadEntry = _vmTemplateStoreDao.createTemplateDirectDownloadEntry(tmplt.getId(), tmplt.getSize());
-                    _vmTemplateStoreDao.persist(directDownloadEntry);
-                } else {
-                    tmpltStore =
-                            new TemplateDataStoreVO(storeId, tmplt.getId(), new Date(), 100, Status.DOWNLOADED, null, null, null,
-                                    TemplateConstants.DEFAULT_SYSTEM_VM_TEMPLATE_PATH + tmplt.getId() + '/', tmplt.getUrl());
-                    tmpltStore.setSize(0L);
-                    tmpltStore.setPhysicalSize(0); // no size information for
-                    // pre-seeded system vm templates
-                    tmpltStore.setDataStoreRole(store.getRole());
-                    _vmTemplateStoreDao.persist(tmpltStore);
+                if (_vmTemplateStoreDao.isTemplateMarkedForDirectDownload(tmplt.getId())) {
+                    continue;
                 }
+                tmpltStore =
+                        new TemplateDataStoreVO(storeId, tmplt.getId(), new Date(), 100, Status.DOWNLOADED, null, null, null,
+                                TemplateConstants.DEFAULT_SYSTEM_VM_TEMPLATE_PATH + tmplt.getId() + '/', tmplt.getUrl());
+                tmpltStore.setSize(0L);
+                tmpltStore.setPhysicalSize(0); // no size information for
+                // pre-seeded system vm templates
+                tmpltStore.setDataStoreRole(store.getRole());
+                _vmTemplateStoreDao.persist(tmpltStore);
             }
         }
     }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -629,6 +629,15 @@ public class TemplateServiceImpl implements TemplateService {
         }
     }
 
+    // mark template_zone_ref entries as removed for zone
+    @Override
+    public void dissociateTemplatesFromZone(long zoneId) {
+        List<VMTemplateZoneVO> zoneTemplates = _vmTemplateZoneDao.listByZoneId(zoneId);
+        for (VMTemplateZoneVO zoneTemplate : zoneTemplates) {
+            _vmTemplateZoneDao.remove(zoneTemplate.getId());
+        }
+    }
+
     protected Void createTemplateAsyncCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, TemplateApiResult> callback,
                                                TemplateOpContext<TemplateApiResult> context) {
         TemplateInfo template = context.template;

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -264,13 +264,13 @@ public class TemplateServiceImpl implements TemplateService {
             List<VMTemplateVO> defaultBuiltin = _templateDao.listDefaultBuiltinTemplates();
 
             for (VMTemplateVO rtngTmplt : rtngTmplts) {
-                if (rtngTmplt.getHypervisorType() == hostHyper) {
+                if (rtngTmplt.getHypervisorType() == hostHyper && !rtngTmplt.isDirectDownload()) {
                     toBeDownloaded.add(rtngTmplt);
                 }
             }
 
             for (VMTemplateVO builtinTmplt : defaultBuiltin) {
-                if (builtinTmplt.getHypervisorType() == hostHyper) {
+                if (builtinTmplt.getHypervisorType() == hostHyper && !builtinTmplt.isDirectDownload()) {
                     toBeDownloaded.add(builtinTmplt);
                 }
             }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -1201,14 +1201,19 @@ public class TemplateServiceImpl implements TemplateService {
         for (VMTemplateVO tmplt : rtngTmplts) {
             TemplateDataStoreVO tmpltStore = _vmTemplateStoreDao.findByStoreTemplate(storeId, tmplt.getId());
             if (tmpltStore == null) {
-                tmpltStore =
-                        new TemplateDataStoreVO(storeId, tmplt.getId(), new Date(), 100, Status.DOWNLOADED, null, null, null,
-                                TemplateConstants.DEFAULT_SYSTEM_VM_TEMPLATE_PATH + tmplt.getId() + '/', tmplt.getUrl());
-                tmpltStore.setSize(0L);
-                tmpltStore.setPhysicalSize(0); // no size information for
-                // pre-seeded system vm templates
-                tmpltStore.setDataStoreRole(store.getRole());
-                _vmTemplateStoreDao.persist(tmpltStore);
+                if (tmplt.isDirectDownload()) {
+                    TemplateDataStoreVO directDownloadEntry = _vmTemplateStoreDao.createTemplateDirectDownloadEntry(tmplt.getId(), tmplt.getSize());
+                    _vmTemplateStoreDao.persist(directDownloadEntry);
+                } else {
+                    tmpltStore =
+                            new TemplateDataStoreVO(storeId, tmplt.getId(), new Date(), 100, Status.DOWNLOADED, null, null, null,
+                                    TemplateConstants.DEFAULT_SYSTEM_VM_TEMPLATE_PATH + tmplt.getId() + '/', tmplt.getUrl());
+                    tmpltStore.setSize(0L);
+                    tmpltStore.setPhysicalSize(0); // no size information for
+                    // pre-seeded system vm templates
+                    tmpltStore.setDataStoreRole(store.getRole());
+                    _vmTemplateStoreDao.persist(tmpltStore);
+                }
             }
         }
     }

--- a/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
+++ b/engine/storage/image/src/main/java/org/apache/cloudstack/storage/image/TemplateServiceImpl.java
@@ -629,15 +629,6 @@ public class TemplateServiceImpl implements TemplateService {
         }
     }
 
-    // mark template_zone_ref entries as removed for zone
-    @Override
-    public void dissociateTemplatesFromZone(long zoneId) {
-        List<VMTemplateZoneVO> zoneTemplates = _vmTemplateZoneDao.listByZoneId(zoneId);
-        for (VMTemplateZoneVO zoneTemplate : zoneTemplates) {
-            _vmTemplateZoneDao.remove(zoneTemplate.getId());
-        }
-    }
-
     protected Void createTemplateAsyncCallBack(AsyncCallbackDispatcher<TemplateServiceImpl, TemplateApiResult> callback,
                                                TemplateOpContext<TemplateApiResult> context) {
         TemplateInfo template = context.template;

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1678,13 +1678,13 @@ public class KVMStorageProcessor implements StorageProcessor {
      */
     private DirectTemplateDownloader getDirectTemplateDownloaderFromCommand(DirectDownloadCommand cmd, KVMStoragePool destPool) {
         if (cmd instanceof HttpDirectDownloadCommand) {
-            return new HttpDirectTemplateDownloader(cmd.getUrl(), cmd.getTemplateId(), destPool.getLocalPath(), cmd.getChecksum(), cmd.getHeaders());
+            return new HttpDirectTemplateDownloader(cmd.getUrl(), cmd.getTemplateId(), destPool.getLocalPath(), cmd.getChecksum(), cmd.getHeaders(), cmd.getConnectTimeout(), cmd.getSoTimeout());
         } else if (cmd instanceof HttpsDirectDownloadCommand) {
-            return new HttpsDirectTemplateDownloader(cmd.getUrl(), cmd.getTemplateId(), destPool.getLocalPath(), cmd.getChecksum(), cmd.getHeaders());
+            return new HttpsDirectTemplateDownloader(cmd.getUrl(), cmd.getTemplateId(), destPool.getLocalPath(), cmd.getChecksum(), cmd.getHeaders(), cmd.getConnectTimeout(), cmd.getSoTimeout(), cmd.getConnectionRequestTimeout());
         } else if (cmd instanceof NfsDirectDownloadCommand) {
             return new NfsDirectTemplateDownloader(cmd.getUrl(), destPool.getLocalPath(), cmd.getTemplateId(), cmd.getChecksum());
         } else if (cmd instanceof MetalinkDirectDownloadCommand) {
-            return new MetalinkDirectTemplateDownloader(cmd.getUrl(), destPool.getLocalPath(), cmd.getTemplateId(), cmd.getChecksum(), cmd.getHeaders());
+            return new MetalinkDirectTemplateDownloader(cmd.getUrl(), destPool.getLocalPath(), cmd.getTemplateId(), cmd.getChecksum(), cmd.getHeaders(), cmd.getConnectTimeout(), cmd.getSoTimeout());
         } else {
             throw new IllegalArgumentException("Unsupported protocol, please provide HTTP(S), NFS or a metalink");
         }

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -16,6 +16,93 @@
 // under the License.
 package com.cloud.configuration;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+
+import org.apache.cloudstack.acl.SecurityChecker;
+import org.apache.cloudstack.affinity.AffinityGroup;
+import org.apache.cloudstack.affinity.AffinityGroupService;
+import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.command.admin.config.UpdateCfgCmd;
+import org.apache.cloudstack.api.command.admin.network.CreateManagementNetworkIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.network.CreateNetworkOfferingCmd;
+import org.apache.cloudstack.api.command.admin.network.DeleteManagementNetworkIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.network.DeleteNetworkOfferingCmd;
+import org.apache.cloudstack.api.command.admin.network.UpdateNetworkOfferingCmd;
+import org.apache.cloudstack.api.command.admin.offering.CreateDiskOfferingCmd;
+import org.apache.cloudstack.api.command.admin.offering.CreateServiceOfferingCmd;
+import org.apache.cloudstack.api.command.admin.offering.DeleteDiskOfferingCmd;
+import org.apache.cloudstack.api.command.admin.offering.DeleteServiceOfferingCmd;
+import org.apache.cloudstack.api.command.admin.offering.UpdateDiskOfferingCmd;
+import org.apache.cloudstack.api.command.admin.offering.UpdateServiceOfferingCmd;
+import org.apache.cloudstack.api.command.admin.pod.DeletePodCmd;
+import org.apache.cloudstack.api.command.admin.pod.UpdatePodCmd;
+import org.apache.cloudstack.api.command.admin.region.CreatePortableIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.region.DeletePortableIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.region.ListPortableIpRangesCmd;
+import org.apache.cloudstack.api.command.admin.vlan.CreateVlanIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.vlan.DedicatePublicIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.vlan.DeleteVlanIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.vlan.ReleasePublicIpRangeCmd;
+import org.apache.cloudstack.api.command.admin.zone.CreateZoneCmd;
+import org.apache.cloudstack.api.command.admin.zone.DeleteZoneCmd;
+import org.apache.cloudstack.api.command.admin.zone.UpdateZoneCmd;
+import org.apache.cloudstack.api.command.user.network.ListNetworkOfferingsCmd;
+import org.apache.cloudstack.config.Configuration;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
+import org.apache.cloudstack.engine.subsystem.api.storage.TemplateService;
+import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
+import org.apache.cloudstack.framework.config.ConfigDepot;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
+import org.apache.cloudstack.framework.messagebus.MessageBus;
+import org.apache.cloudstack.framework.messagebus.PublishScope;
+import org.apache.cloudstack.region.PortableIp;
+import org.apache.cloudstack.region.PortableIpDao;
+import org.apache.cloudstack.region.PortableIpRange;
+import org.apache.cloudstack.region.PortableIpRangeDao;
+import org.apache.cloudstack.region.PortableIpRangeVO;
+import org.apache.cloudstack.region.PortableIpVO;
+import org.apache.cloudstack.region.Region;
+import org.apache.cloudstack.region.RegionVO;
+import org.apache.cloudstack.region.dao.RegionDao;
+import org.apache.cloudstack.resourcedetail.DiskOfferingDetailVO;
+import org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDao;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDao;
+import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.log4j.Logger;
+
 import com.cloud.alert.AlertManager;
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.dao.NetworkOfferingJoinDao;
@@ -157,91 +244,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
-import org.apache.cloudstack.acl.SecurityChecker;
-import org.apache.cloudstack.affinity.AffinityGroup;
-import org.apache.cloudstack.affinity.AffinityGroupService;
-import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
-import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.command.admin.config.UpdateCfgCmd;
-import org.apache.cloudstack.api.command.admin.network.CreateManagementNetworkIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.network.CreateNetworkOfferingCmd;
-import org.apache.cloudstack.api.command.admin.network.DeleteManagementNetworkIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.network.DeleteNetworkOfferingCmd;
-import org.apache.cloudstack.api.command.admin.network.UpdateNetworkOfferingCmd;
-import org.apache.cloudstack.api.command.admin.offering.CreateDiskOfferingCmd;
-import org.apache.cloudstack.api.command.admin.offering.CreateServiceOfferingCmd;
-import org.apache.cloudstack.api.command.admin.offering.DeleteDiskOfferingCmd;
-import org.apache.cloudstack.api.command.admin.offering.DeleteServiceOfferingCmd;
-import org.apache.cloudstack.api.command.admin.offering.UpdateDiskOfferingCmd;
-import org.apache.cloudstack.api.command.admin.offering.UpdateServiceOfferingCmd;
-import org.apache.cloudstack.api.command.admin.pod.DeletePodCmd;
-import org.apache.cloudstack.api.command.admin.pod.UpdatePodCmd;
-import org.apache.cloudstack.api.command.admin.region.CreatePortableIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.region.DeletePortableIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.region.ListPortableIpRangesCmd;
-import org.apache.cloudstack.api.command.admin.vlan.CreateVlanIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.vlan.DedicatePublicIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.vlan.DeleteVlanIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.vlan.ReleasePublicIpRangeCmd;
-import org.apache.cloudstack.api.command.admin.zone.CreateZoneCmd;
-import org.apache.cloudstack.api.command.admin.zone.DeleteZoneCmd;
-import org.apache.cloudstack.api.command.admin.zone.UpdateZoneCmd;
-import org.apache.cloudstack.api.command.user.network.ListNetworkOfferingsCmd;
-import org.apache.cloudstack.config.Configuration;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
-import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
-import org.apache.cloudstack.framework.config.ConfigDepot;
-import org.apache.cloudstack.framework.config.ConfigKey;
-import org.apache.cloudstack.framework.config.Configurable;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
-import org.apache.cloudstack.framework.messagebus.MessageBus;
-import org.apache.cloudstack.framework.messagebus.PublishScope;
-import org.apache.cloudstack.region.PortableIp;
-import org.apache.cloudstack.region.PortableIpDao;
-import org.apache.cloudstack.region.PortableIpRange;
-import org.apache.cloudstack.region.PortableIpRangeDao;
-import org.apache.cloudstack.region.PortableIpRangeVO;
-import org.apache.cloudstack.region.PortableIpVO;
-import org.apache.cloudstack.region.Region;
-import org.apache.cloudstack.region.RegionVO;
-import org.apache.cloudstack.region.dao.RegionDao;
-import org.apache.cloudstack.resourcedetail.DiskOfferingDetailVO;
-import org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDao;
-import org.apache.cloudstack.storage.datastore.db.ImageStoreDao;
-import org.apache.cloudstack.storage.datastore.db.ImageStoreDetailsDao;
-import org.apache.cloudstack.storage.datastore.db.ImageStoreVO;
-import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
-import org.apache.cloudstack.storage.datastore.db.StoragePoolDetailsDao;
-import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
-import org.apache.log4j.Logger;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
 
 public class ConfigurationManagerImpl extends ManagerBase implements ConfigurationManager, ConfigurationService, Configurable {
     public static final Logger s_logger = Logger.getLogger(ConfigurationManagerImpl.class);
@@ -372,6 +374,8 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     ImageStoreDetailsDao _imageStoreDetailsDao;
     @Inject
     MessageBus messageBus;
+    @Inject
+    private TemplateService templateService;
 
 
     // FIXME - why don't we have interface for DataCenterLinkLocalIpAddressDao?
@@ -1806,6 +1810,9 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 for (final VlanVO vlan : vlans) {
                     _vlanDao.remove(vlan.getId());
                 }
+
+                // delete template refs for this zone
+                templateService.dissociateTemplatesFromZone(zoneId);
 
                 final boolean success = _zoneDao.remove(zoneId);
 

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -1838,12 +1838,11 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                     _vlanDao.remove(vlan.getId());
                 }
 
-                // delete template refs for this zone
-                templateZoneDao.deleteByZoneId(zoneId);
-
                 final boolean success = _zoneDao.remove(zoneId);
 
                 if (success) {
+                    // delete template refs for this zone
+                    templateZoneDao.deleteByZoneId(zoneId);
                     // delete all capacity records for the zone
                     _capacityDao.removeBy(null, zoneId, null, null, null);
                     // remove from dedicated resources

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -73,7 +73,6 @@ import org.apache.cloudstack.config.Configuration;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
-import org.apache.cloudstack.engine.subsystem.api.storage.TemplateService;
 import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
 import org.apache.cloudstack.framework.config.ConfigDepot;
 import org.apache.cloudstack.framework.config.ConfigKey;
@@ -204,6 +203,7 @@ import com.cloud.storage.DiskOfferingVO;
 import com.cloud.storage.Storage.ProvisioningType;
 import com.cloud.storage.StorageManager;
 import com.cloud.storage.dao.DiskOfferingDao;
+import com.cloud.storage.dao.VMTemplateZoneDao;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.test.IPRangeConfig;
 import com.cloud.user.Account;
@@ -375,7 +375,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     @Inject
     MessageBus messageBus;
     @Inject
-    private TemplateService templateService;
+    private VMTemplateZoneDao templateZoneDao;
 
 
     // FIXME - why don't we have interface for DataCenterLinkLocalIpAddressDao?
@@ -1812,7 +1812,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
                 }
 
                 // delete template refs for this zone
-                templateService.dissociateTemplatesFromZone(zoneId);
+                templateZoneDao.deleteByZoneId(zoneId);
 
                 final boolean success = _zoneDao.remove(zoneId);
 

--- a/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
+++ b/server/src/main/java/com/cloud/consoleproxy/ConsoleProxyManagerImpl.java
@@ -100,6 +100,7 @@ import com.cloud.resource.ServerResource;
 import com.cloud.resource.UnableDeleteHostException;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
+import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.Storage;
 import com.cloud.storage.StoragePoolStatus;
 import com.cloud.storage.VMTemplateStorageResourceAssoc.Status;
@@ -1011,7 +1012,12 @@ public class ConsoleProxyManagerImpl extends ManagerBase implements ConsoleProxy
                 }
                 return false;
             }
-            TemplateDataStoreVO templateHostRef = _vmTemplateStoreDao.findByTemplateZoneDownloadStatus(template.getId(), dataCenterId, Status.DOWNLOADED);
+            TemplateDataStoreVO templateHostRef = null;
+            if (template.isDirectDownload()) {
+                templateHostRef = _vmTemplateStoreDao.findByTemplate(template.getId(), DataStoreRole.Image);
+            } else {
+                templateHostRef = _vmTemplateStoreDao.findByTemplateZoneDownloadStatus(template.getId(), dataCenterId, Status.DOWNLOADED);
+            }
 
             if (templateHostRef != null) {
                 boolean useLocalStorage = false;

--- a/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
@@ -325,30 +325,9 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
      */
     private DirectDownloadCommand getDirectDownloadCommandFromProtocol(DownloadProtocol protocol, String url, Long templateId, PrimaryDataStoreTO destPool,
                                                                        String checksum, Map<String, String> httpHeaders) {
-        int connectTimeout = DEFAULT_DIRECT_DOWNLOAD_CONNECT_TIMEOUT;
-        int soTimeout = DEFAULT_DIRECT_DOWNLOAD_SOCKET_TIMEOUT;
-        int connectionRequestTimeout = DEFAULT_DIRECT_DOWNLOAD_CONNECTION_REQUEST_TIMEOUT;
-        if (DownloadProtocol.HTTP.equals(protocol) ||
-                DownloadProtocol.HTTPS.equals(protocol) ||
-                DownloadProtocol.METALINK.equals(protocol)) {
-            try {
-                connectTimeout = Integer.parseInt(configDao.getValue(DirectDownloadConnectTimeout.key()));
-            } catch (NumberFormatException nfe) {
-                s_logger.warn(String.format("Unable to retrieve configuration: %s value", DirectDownloadConnectTimeout.key()), nfe);
-            }
-            try {
-                soTimeout = Integer.parseInt(configDao.getValue(DirectDownloadSocketTimeout.key()));
-            } catch (NumberFormatException nfe) {
-                s_logger.warn(String.format("Unable to retrieve configuration: %s value", DirectDownloadSocketTimeout.key()), nfe);
-            }
-        }
-        if (DownloadProtocol.HTTPS.equals(protocol)) {
-            try {
-                connectionRequestTimeout = Integer.parseInt(configDao.getValue(DirectDownloadConnectionRequestTimeout.key()));
-            } catch (NumberFormatException nfe) {
-                s_logger.warn(String.format("Unable to retrieve configuration: %s value", DirectDownloadConnectionRequestTimeout.key()), nfe);
-            }
-        }
+        int connectTimeout = DirectDownloadConnectTimeout.value();
+        int soTimeout = DirectDownloadSocketTimeout.value();
+        int connectionRequestTimeout = DirectDownloadConnectionRequestTimeout.value();
         if (protocol.equals(DownloadProtocol.HTTP)) {
             return new HttpDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders, connectTimeout, soTimeout);
         } else if (protocol.equals(DownloadProtocol.HTTPS)) {

--- a/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/direct/download/DirectDownloadManagerImpl.java
@@ -20,6 +20,53 @@ package org.apache.cloudstack.direct.download;
 
 import static com.cloud.storage.Storage.ImageFormat;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+
+import org.apache.cloudstack.agent.directdownload.DirectDownloadAnswer;
+import org.apache.cloudstack.agent.directdownload.DirectDownloadCommand;
+import org.apache.cloudstack.agent.directdownload.DirectDownloadCommand.DownloadProtocol;
+import org.apache.cloudstack.agent.directdownload.HttpDirectDownloadCommand;
+import org.apache.cloudstack.agent.directdownload.HttpsDirectDownloadCommand;
+import org.apache.cloudstack.agent.directdownload.MetalinkDirectDownloadCommand;
+import org.apache.cloudstack.agent.directdownload.NfsDirectDownloadCommand;
+import org.apache.cloudstack.agent.directdownload.RevokeDirectDownloadCertificateCommand;
+import org.apache.cloudstack.agent.directdownload.SetupDirectDownloadCertificateCommand;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
+import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
+import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStore;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.cloudstack.poll.BackgroundPollManager;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
 import com.cloud.agent.AgentManager;
 import com.cloud.agent.api.Answer;
 import com.cloud.dc.DataCenterVO;
@@ -43,52 +90,8 @@ import com.cloud.storage.dao.VMTemplatePoolDao;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.concurrency.NamedThreadFactory;
 import com.cloud.utils.exception.CloudRuntimeException;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateExpiredException;
-import java.security.cert.CertificateNotYetValidException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-
 import com.cloud.utils.security.CertificateHelper;
-import org.apache.cloudstack.agent.directdownload.DirectDownloadCommand;
-import org.apache.cloudstack.agent.directdownload.DirectDownloadAnswer;
-import org.apache.cloudstack.agent.directdownload.DirectDownloadCommand.DownloadProtocol;
-import org.apache.cloudstack.agent.directdownload.HttpDirectDownloadCommand;
-import org.apache.cloudstack.agent.directdownload.MetalinkDirectDownloadCommand;
-import org.apache.cloudstack.agent.directdownload.NfsDirectDownloadCommand;
-import org.apache.cloudstack.agent.directdownload.HttpsDirectDownloadCommand;
-import org.apache.cloudstack.agent.directdownload.RevokeDirectDownloadCertificateCommand;
-import org.apache.cloudstack.agent.directdownload.SetupDirectDownloadCertificateCommand;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
-import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
-import org.apache.cloudstack.engine.subsystem.api.storage.PrimaryDataStore;
-import org.apache.cloudstack.framework.config.ConfigKey;
-import org.apache.cloudstack.managed.context.ManagedContextRunnable;
-import org.apache.cloudstack.poll.BackgroundPollManager;
-import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
-import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
-import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
-import org.apache.log4j.Logger;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+
 import sun.security.x509.X509CertImpl;
 
 public class DirectDownloadManagerImpl extends ManagerBase implements DirectDownloadManager {
@@ -119,6 +122,8 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
     private BackgroundPollManager backgroundPollManager;
     @Inject
     private DataCenterDao dataCenterDao;
+    @Inject
+    private ConfigurationDao configDao;
 
     protected ScheduledExecutorService executorService;
 
@@ -320,14 +325,38 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
      */
     private DirectDownloadCommand getDirectDownloadCommandFromProtocol(DownloadProtocol protocol, String url, Long templateId, PrimaryDataStoreTO destPool,
                                                                        String checksum, Map<String, String> httpHeaders) {
+        int connectTimeout = DEFAULT_DIRECT_DOWNLOAD_CONNECT_TIMEOUT;
+        int soTimeout = DEFAULT_DIRECT_DOWNLOAD_SOCKET_TIMEOUT;
+        int connectionRequestTimeout = DEFAULT_DIRECT_DOWNLOAD_CONNECTION_REQUEST_TIMEOUT;
+        if (DownloadProtocol.HTTP.equals(protocol) ||
+                DownloadProtocol.HTTPS.equals(protocol) ||
+                DownloadProtocol.METALINK.equals(protocol)) {
+            try {
+                connectTimeout = Integer.parseInt(configDao.getValue(DirectDownloadConnectTimeout.key()));
+            } catch (NumberFormatException nfe) {
+                s_logger.warn(String.format("Unable to retrieve configuration: %s value", DirectDownloadConnectTimeout.key()), nfe);
+            }
+            try {
+                soTimeout = Integer.parseInt(configDao.getValue(DirectDownloadSocketTimeout.key()));
+            } catch (NumberFormatException nfe) {
+                s_logger.warn(String.format("Unable to retrieve configuration: %s value", DirectDownloadSocketTimeout.key()), nfe);
+            }
+        }
+        if (DownloadProtocol.HTTPS.equals(protocol)) {
+            try {
+                connectionRequestTimeout = Integer.parseInt(configDao.getValue(DirectDownloadConnectionRequestTimeout.key()));
+            } catch (NumberFormatException nfe) {
+                s_logger.warn(String.format("Unable to retrieve configuration: %s value", DirectDownloadConnectionRequestTimeout.key()), nfe);
+            }
+        }
         if (protocol.equals(DownloadProtocol.HTTP)) {
-            return new HttpDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders);
+            return new HttpDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders, connectTimeout, soTimeout);
         } else if (protocol.equals(DownloadProtocol.HTTPS)) {
-            return new HttpsDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders);
+            return new HttpsDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders, connectTimeout, soTimeout, connectionRequestTimeout);
         } else if (protocol.equals(DownloadProtocol.NFS)) {
             return new NfsDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders);
         } else if (protocol.equals(DownloadProtocol.METALINK)) {
-            return new MetalinkDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders);
+            return new MetalinkDirectDownloadCommand(url, templateId, destPool, checksum, httpHeaders, connectTimeout, soTimeout);
         } else {
             return null;
         }
@@ -549,7 +578,10 @@ public class DirectDownloadManagerImpl extends ManagerBase implements DirectDown
     @Override
     public ConfigKey<?>[] getConfigKeys() {
         return new ConfigKey<?>[]{
-                DirectDownloadCertificateUploadInterval
+                DirectDownloadCertificateUploadInterval,
+                DirectDownloadConnectTimeout,
+                DirectDownloadSocketTimeout,
+                DirectDownloadConnectionRequestTimeout
         };
     }
 

--- a/server/src/test/resources/createNetworkOffering.xml
+++ b/server/src/test/resources/createNetworkOffering.xml
@@ -58,5 +58,5 @@
     <bean id="DiskOfferingDetailsDaoImpl" class="org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDaoImpl" />
     <bean id="networkOfferingJoinDaoImpl" class="com.cloud.api.query.dao.NetworkOfferingJoinDaoImpl" />
     <bean id="networkOfferingDetailsDaoImpl" class="com.cloud.offerings.dao.NetworkOfferingDetailsDaoImpl" />
-    <bean id="templateServiceImpl" class="org.apache.cloudstack.storage.image.TemplateServiceImpl" />
+    <bean id="vMTemplateZoneDaoImpl" class="com.cloud.storage.dao.VMTemplateZoneDaoImpl" />
 </beans>

--- a/server/src/test/resources/createNetworkOffering.xml
+++ b/server/src/test/resources/createNetworkOffering.xml
@@ -58,4 +58,5 @@
     <bean id="DiskOfferingDetailsDaoImpl" class="org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDaoImpl" />
     <bean id="networkOfferingJoinDaoImpl" class="com.cloud.api.query.dao.NetworkOfferingJoinDaoImpl" />
     <bean id="networkOfferingDetailsDaoImpl" class="com.cloud.offerings.dao.NetworkOfferingDetailsDaoImpl" />
+    <bean id="templateServiceImpl" class="org.apache.cloudstack.storage.image.TemplateServiceImpl" />
 </beans>

--- a/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
+++ b/services/secondary-storage/controller/src/main/java/org/apache/cloudstack/secondarystorage/SecondaryStorageManagerImpl.java
@@ -828,8 +828,7 @@ public class SecondaryStorageManagerImpl extends ManagerBase implements Secondar
                 return false;
             }
 
-            DataStore store = templateMgr.getImageStore(dataCenterId, template.getId());
-            if (store == null) {
+            if (!template.isDirectDownload() && templateMgr.getImageStore(dataCenterId, template.getId()) == null) {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("No secondary storage available in zone " + dataCenterId + ", wait until it is ready to launch secondary storage vm");
                 }


### PR DESCRIPTION
## Description
As of now provisioning of System VMs with direct download enabled template was not supported. Even after setting such templates as SYSTEM template, while provisioning SSVM and CPVM the server would return an error message like,

> System vm template is not ready at data center 1, wait until it is ready to launch secondary storage vm

This behaviour has been changed and it allows the server to provision SSVM and CPVM even with direct download system templates.
Additionally, changes have been made to make different timeouts for direct download functionality configurable using global settings. Following global configurations have been added for this,
`direct.download.connect.timeout` - Connection establishment timeout in milliseconds for direct download
`direct.download.socket.timeout` - Socket timeout (SO_TIMEOUT) in milliseconds for direct download
`direct.download.connection.request.timeout` - Requesting a connection from connection manager timeout in milliseconds for direct download

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
New global settings,
![Screenshot from 2020-02-13 14-21-14](https://user-images.githubusercontent.com/153340/74417098-2d336980-4e6c-11ea-8242-cc06ea28638d.png)


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Admin registers a direct download private USER or ROUTING type template,

```
> register template url=http://staging.yadav.xyz/systemvmtemplate/4.14/systemvmtemplate-4.14.0-kvm.qcow2.bz2 name=NewTemplate displaytext=NewTemplate zoneids=94ecae8c-923a-4f32-9d32-4067a99e76e2 format=QCOW2 isextractable=false passwordEnabled=false isdynamicallyscalable=false ostypeid=528a9a3d-4e13-11ea-8448-1e006e01076c hypervisor=KVM ispublic=false requireshvm=true isfeatured=false isrouting=true details[0].rootDiskController=osdefault directdownload=true
{
  "count": 1,
  "template": [
    {
      "account": "admin",
      "bits": 0,
      "created": "2020-02-13T09:02:45+0000",
      "crossZones": false,
      "details": {
        "rootDiskController": "osdefault"
      },
      "directdownload": true,
      "displaytext": "NewTemplate",
      "domain": "ROOT",
      "domainid": "527d6f21-4e13-11ea-8448-1e006e01076c",
      "format": "QCOW2",
      "hypervisor": "KVM",
      "id": "4cdf991c-4ed8-46f5-be3b-9810c9fce17d",
      "isdynamicallyscalable": false,
      "isextractable": false,
      "isfeatured": false,
      "ispublic": false,
      "isready": true,
      "name": "NewTemplate",
      "ostypeid": "528a9a3d-4e13-11ea-8448-1e006e01076c",
      "ostypename": "Debian GNU/Linux 5.0 (64-bit)",
      "passwordenabled": false,
      "requireshvm": true,
      "size": 328521792,
      "sshkeyenabled": false,
      "status": "Bypassed Secondary Storage",
      "tags": [],
      "templatetype": "ROUTING",
      "zoneid": "94ecae8c-923a-4f32-9d32-4067a99e76e2",
      "zonename": "pr3731-t985-kvm-centos7"
    }
  ]
}

```

For testing databse is updated manually to make newly added template to the SYSTEM type template. This can be done using upgrade script during upgrade,
```
MariaDB [cloud]> update vm_template set type='SYSTEM' where uuid='4cdf991c-4ed8-46f5-be3b-9810c9fce17d';
Query OK, 0 rows affected (0.00 sec)
Rows matched: 1  Changed: 0  Warnings: 0

MariaDB [cloud]> select * from vm_template where uuid='4cdf991c-4ed8-46f5-be3b-9810c9fce17d'\G;
*************************** 1. row ***************************
                  id: 207
         unique_name: 207-2-b5793aa9-d8d1-33bd-b1c5-d144f98a6719
                name: NewTemplate
                uuid: 4cdf991c-4ed8-46f5-be3b-9810c9fce17d
              public: 0
            featured: 0
                type: SYSTEM
                 hvm: 1
                bits: 64
                 url: http://staging.yadav.xyz/systemvmtemplate/4.14/systemvmtemplate-4.14.0-kvm.qcow2.bz2
              format: QCOW2
             created: 2020-02-13 09:02:45
             removed: NULL
          account_id: 2
            checksum: NULL
        display_text: NewTemplate
     enable_password: 0
       enable_sshkey: 0
         guest_os_id: 15
            bootable: 1
         prepopulate: 0
         cross_zones: 0
         extractable: 0
     hypervisor_type: KVM
  source_template_id: NULL
        template_tag: NULL
            sort_key: 0
                size: 328521792
               state: Active
        update_count: 0
             updated: NULL
dynamically_scalable: 0
  parent_template_id: NULL
     direct_download: 1
1 row in set (0.00 sec)
```
Existing SSVM and CPVM are destroyed for testing new template and server can provision new VMs with newly added template.
New VMs get created,
![Screenshot from 2020-02-13 14-34-16](https://user-images.githubusercontent.com/153340/74418171-f9594380-4e6d-11ea-9279-420f393dc571.png)
Database values for template_id verified in vm_instance,
MariaDB [cloud]> select id,name,vm_template_id from vm_instance where removed IS NULL\G;
```
*************************** 1. row ***************************
            id: 5
          name: VM-17980201-ff14-48c5-ba8a-d90e1be13490
vm_template_id: 4
*************************** 2. row ***************************
            id: 6
          name: r-6-VM
vm_template_id: 203
*************************** 3. row ***************************
            id: 12
          name: s-12-VM
vm_template_id: 207
*************************** 4. row ***************************
            id: 13
          name: v-13-VM
vm_template_id: 207
4 rows in set (0.00 sec)
```

To check direct download template for VR `router.template.*` global config is updated and VR is recreated or new network is created.
```
> list routers filter=id,name
{
  "count": 1,
  "router": [
    {
      "id": "e003704c-c98e-4e84-9a6d-8bfeb45b10cb",
      "name": "r-15-VM"
    }
  ]
}

```
Verified in DB,
```
MariaDB [cloud]> select id,name,vm_template_id from vm_instance where uuid='e003704c-c98e-4e84-9a6d-8bfeb45b10cb'\G;
*************************** 1. row ***************************
            id: 15
          name: r-15-VM
vm_template_id: 207
1 row in set (0.00 sec)
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
