### PR TITLE
Add missing HA config keys

### DIFF
--- a/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
@@ -16,18 +16,36 @@
 // under the License.
 package com.cloud.ha;
 
-import java.util.List;
+import static java.lang.String.valueOf;
 
 import com.cloud.deploy.DeploymentPlanner;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
 import com.cloud.utils.component.Manager;
 import com.cloud.vm.VMInstanceVO;
+import org.apache.cloudstack.framework.config.ConfigKey;
+
+import java.util.List;
 
 /**
  * HighAvailabilityManager checks to make sure the VMs are running fine.
  */
 public interface HighAvailabilityManager extends Manager {
+
+    ConfigKey<Integer> TimeBetweenCleanup = new ConfigKey<>("Advanced", Integer.class,
+        "time.between.cleanup", valueOf(3600 * 24), "Time in milliseconds to wait before the cleanup thread runs.",
+        false, null);
+
+    ConfigKey<Integer> MaxRetries = new ConfigKey<>("Advanced", Integer.class, "max.retries",
+        valueOf(5), "Number of times to retry start.", false, null);
+
+    ConfigKey<Integer> TimeToSleep = new ConfigKey<>("Advanced", Integer.class, "time.to.sleep",
+        valueOf(60 * 1000), "Time in seconds to sleep if no work items are found.", false, null);
+
+    ConfigKey<Integer> TimeBetweenFailures = new ConfigKey<>("Advanced", Integer.class,
+        "time.between.failures", valueOf(3600 * 1000), "Time in milliseconds before try to cleanup all the VMs"
+        + " which are registered for the HA event that were successful and are now ready to be purged.", false, null);
+
     public enum WorkType {
         Migration,  // Migrating VMs off of a host.
         Stop,       // Stops a VM for storage pool migration purposes.  This should be obsolete now.

--- a/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
@@ -33,17 +33,17 @@ import java.util.List;
 public interface HighAvailabilityManager extends Manager {
 
     ConfigKey<Integer> TimeBetweenCleanup = new ConfigKey<>("Advanced", Integer.class,
-        "time.between.cleanup", valueOf(3600 * 24), "Time in milliseconds to wait before the cleanup thread runs.",
+        "time.between.cleanup", valueOf(3600 * 24), "Time in seconds to wait before the cleanup thread runs.",
         false, null);
 
     ConfigKey<Integer> MaxRetries = new ConfigKey<>("Advanced", Integer.class, "max.retries",
         valueOf(5), "Number of times to retry start.", false, null);
 
     ConfigKey<Integer> TimeToSleep = new ConfigKey<>("Advanced", Integer.class, "time.to.sleep",
-        valueOf(60 * 1000), "Time in seconds to sleep if no work items are found.", false, null);
+        valueOf(60), "Time in seconds to sleep if no work items are found.", false, null);
 
     ConfigKey<Integer> TimeBetweenFailures = new ConfigKey<>("Advanced", Integer.class,
-        "time.between.failures", valueOf(3600 * 1000), "Time in milliseconds before try to cleanup all the VMs"
+        "time.between.failures", valueOf(3600), "Time in seconds before try to cleanup all the VMs"
         + " which are registered for the HA event that were successful and are now ready to be purged.", false, null);
 
     public enum WorkType {

--- a/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
@@ -16,8 +16,6 @@
 // under the License.
 package com.cloud.ha;
 
-import static java.lang.String.valueOf;
-
 import com.cloud.deploy.DeploymentPlanner;
 import com.cloud.host.HostVO;
 import com.cloud.host.Status;
@@ -33,17 +31,17 @@ import java.util.List;
 public interface HighAvailabilityManager extends Manager {
 
     ConfigKey<Long> TimeBetweenCleanup = new ConfigKey<>("Advanced", Long.class,
-        "time.between.cleanup", valueOf(3600 * 24), "Time in seconds to wait before the cleanup thread runs.",
+        "time.between.cleanup", "86400", "Time in seconds to wait before the cleanup thread runs.",
         false, null);
 
     ConfigKey<Integer> MaxRetries = new ConfigKey<>("Advanced", Integer.class, "max.retries",
-        valueOf(5), "Number of times to retry start.", false, null);
+        "5", "Number of times to retry start.", false, null);
 
     ConfigKey<Long> TimeToSleep = new ConfigKey<>("Advanced", Long.class, "time.to.sleep",
-        valueOf(60), "Time in seconds to sleep if no work items are found.", false, null);
+        "60", "Time in seconds to sleep if no work items are found.", false, null);
 
     ConfigKey<Long> TimeBetweenFailures = new ConfigKey<>("Advanced", Long.class,
-        "time.between.failures", valueOf(3600), "Time in seconds before try to cleanup all the VMs"
+        "time.between.failures", "3600", "Time in seconds before try to cleanup all the VMs"
         + " which are registered for the HA event that were successful and are now ready to be purged.", false, null);
 
     public enum WorkType {

--- a/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
+++ b/engine/components-api/src/main/java/com/cloud/ha/HighAvailabilityManager.java
@@ -32,17 +32,17 @@ import java.util.List;
  */
 public interface HighAvailabilityManager extends Manager {
 
-    ConfigKey<Integer> TimeBetweenCleanup = new ConfigKey<>("Advanced", Integer.class,
+    ConfigKey<Long> TimeBetweenCleanup = new ConfigKey<>("Advanced", Long.class,
         "time.between.cleanup", valueOf(3600 * 24), "Time in seconds to wait before the cleanup thread runs.",
         false, null);
 
     ConfigKey<Integer> MaxRetries = new ConfigKey<>("Advanced", Integer.class, "max.retries",
         valueOf(5), "Number of times to retry start.", false, null);
 
-    ConfigKey<Integer> TimeToSleep = new ConfigKey<>("Advanced", Integer.class, "time.to.sleep",
+    ConfigKey<Long> TimeToSleep = new ConfigKey<>("Advanced", Long.class, "time.to.sleep",
         valueOf(60), "Time in seconds to sleep if no work items are found.", false, null);
 
-    ConfigKey<Integer> TimeBetweenFailures = new ConfigKey<>("Advanced", Integer.class,
+    ConfigKey<Long> TimeBetweenFailures = new ConfigKey<>("Advanced", Long.class,
         "time.between.failures", valueOf(3600), "Time in seconds before try to cleanup all the VMs"
         + " which are registered for the HA event that were successful and are now ready to be purged.", false, null);
 

--- a/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -16,6 +16,8 @@
 // under the License.
 package com.cloud.ha;
 
+import static java.lang.Long.parseLong;
+
 import com.cloud.agent.AgentManager;
 import com.cloud.alert.AlertManager;
 import com.cloud.cluster.ClusterManagerListener;
@@ -846,16 +848,16 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
         _forceHA = Boolean.parseBoolean(value);
 
         value = params.get(TimeToSleep.key());
-        _timeToSleep = (long)NumbersUtil.parseInt(value, 60) * 1000;
+        _timeToSleep = NumbersUtil.parseLong(value, parseLong(TimeToSleep.defaultValue())) * 1000;
 
         value = params.get(MaxRetries.key());
         _maxRetries = NumbersUtil.parseInt(value, 5);
 
         value = params.get(TimeBetweenFailures.key());
-        _timeBetweenFailures = NumbersUtil.parseLong(value, 3600) * 1000;
+        _timeBetweenFailures = NumbersUtil.parseLong(value, parseLong(TimeBetweenFailures.defaultValue())) * 1000;
 
         value = params.get(TimeBetweenCleanup.key());
-        _timeBetweenCleanups = NumbersUtil.parseLong(value, 3600 * 24);
+        _timeBetweenCleanups = NumbersUtil.parseLong(value, parseLong(TimeBetweenCleanup.defaultValue()));
 
         value = params.get("stop.retry.interval");
         _stopRetryInterval = NumbersUtil.parseInt(value, 10 * 60);

--- a/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -104,7 +104,7 @@ import javax.naming.ConfigurationException;
  **/
 public class HighAvailabilityManagerImpl extends ManagerBase implements Configurable, HighAvailabilityManager, ClusterManagerListener {
 
-    private static final int MILLISECONDS_TO_SECONDS_FACTOR = 1000;
+    private static final int SECONDS_TO_MILLISECONDS_FACTOR = 1000;
     private static final int STOP_RETRY_INTERVAL_SECONDS = 600;
     private static final int RESTART_RETRY_INTERVAL_SECONDS = 600;
     private static final int INVESTIGATE_RETRY_INTERVAL_SECONDS = 60;
@@ -851,17 +851,13 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
         value = params.get("force.ha");
         _forceHA = Boolean.parseBoolean(value);
 
-        value = params.get(TimeToSleep.key());
-        _timeToSleep = NumbersUtil.parseLong(value, TimeToSleep.value()) * MILLISECONDS_TO_SECONDS_FACTOR;
+        _timeToSleep = TimeToSleep.value() * SECONDS_TO_MILLISECONDS_FACTOR;
 
-        value = params.get(MaxRetries.key());
-        _maxRetries = NumbersUtil.parseInt(value, MaxRetries.value());
+        _maxRetries = MaxRetries.value();
 
-        value = params.get(TimeBetweenFailures.key());
-        _timeBetweenFailures = NumbersUtil.parseLong(value, TimeBetweenFailures.value()) * MILLISECONDS_TO_SECONDS_FACTOR;
+        _timeBetweenFailures = TimeBetweenFailures.value() * SECONDS_TO_MILLISECONDS_FACTOR;
 
-        value = params.get(TimeBetweenCleanup.key());
-        _timeBetweenCleanups = NumbersUtil.parseLong(value, TimeBetweenCleanup.value());
+        _timeBetweenCleanups = TimeBetweenCleanup.value();
 
         value = params.get("stop.retry.interval");
         _stopRetryInterval = NumbersUtil.parseInt(value, STOP_RETRY_INTERVAL_SECONDS);

--- a/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.ha;
 
+import static java.lang.Integer.parseInt;
 import static java.lang.Long.parseLong;
 
 import com.cloud.agent.AgentManager;
@@ -851,7 +852,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
         _timeToSleep = NumbersUtil.parseLong(value, parseLong(TimeToSleep.defaultValue())) * 1000;
 
         value = params.get(MaxRetries.key());
-        _maxRetries = NumbersUtil.parseInt(value, 5);
+        _maxRetries = NumbersUtil.parseInt(value, parseInt(MaxRetries.defaultValue()));
 
         value = params.get(TimeBetweenFailures.key());
         _timeBetweenFailures = NumbersUtil.parseLong(value, parseLong(TimeBetweenFailures.defaultValue())) * 1000;

--- a/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -16,9 +16,6 @@
 // under the License.
 package com.cloud.ha;
 
-import static java.lang.Integer.parseInt;
-import static java.lang.Long.parseLong;
-
 import com.cloud.agent.AgentManager;
 import com.cloud.alert.AlertManager;
 import com.cloud.cluster.ClusterManagerListener;
@@ -106,6 +103,12 @@ import javax.naming.ConfigurationException;
  *         before retrying the stop | seconds | 120 || * }
  **/
 public class HighAvailabilityManagerImpl extends ManagerBase implements Configurable, HighAvailabilityManager, ClusterManagerListener {
+
+    private static final int MILLISECONDS_TO_SECONDS_FACTOR = 1000;
+    private static final int STOP_RETRY_INTERVAL_SECONDS = 600;
+    private static final int RESTART_RETRY_INTERVAL_SECONDS = 600;
+    private static final int INVESTIGATE_RETRY_INTERVAL_SECONDS = 60;
+    private static final int MIGRATE_RETRY_INTERVAL_SECONDS = 120;
 
     protected static final Logger s_logger = Logger.getLogger(HighAvailabilityManagerImpl.class);
     WorkerThread[] _workers;
@@ -849,28 +852,28 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
         _forceHA = Boolean.parseBoolean(value);
 
         value = params.get(TimeToSleep.key());
-        _timeToSleep = NumbersUtil.parseLong(value, parseLong(TimeToSleep.defaultValue())) * 1000;
+        _timeToSleep = NumbersUtil.parseLong(value, TimeToSleep.value()) * MILLISECONDS_TO_SECONDS_FACTOR;
 
         value = params.get(MaxRetries.key());
-        _maxRetries = NumbersUtil.parseInt(value, parseInt(MaxRetries.defaultValue()));
+        _maxRetries = NumbersUtil.parseInt(value, MaxRetries.value());
 
         value = params.get(TimeBetweenFailures.key());
-        _timeBetweenFailures = NumbersUtil.parseLong(value, parseLong(TimeBetweenFailures.defaultValue())) * 1000;
+        _timeBetweenFailures = NumbersUtil.parseLong(value, TimeBetweenFailures.value()) * MILLISECONDS_TO_SECONDS_FACTOR;
 
         value = params.get(TimeBetweenCleanup.key());
-        _timeBetweenCleanups = NumbersUtil.parseLong(value, parseLong(TimeBetweenCleanup.defaultValue()));
+        _timeBetweenCleanups = NumbersUtil.parseLong(value, TimeBetweenCleanup.value());
 
         value = params.get("stop.retry.interval");
-        _stopRetryInterval = NumbersUtil.parseInt(value, 10 * 60);
+        _stopRetryInterval = NumbersUtil.parseInt(value, STOP_RETRY_INTERVAL_SECONDS);
 
         value = params.get("restart.retry.interval");
-        _restartRetryInterval = NumbersUtil.parseInt(value, 10 * 60);
+        _restartRetryInterval = NumbersUtil.parseInt(value, RESTART_RETRY_INTERVAL_SECONDS);
 
         value = params.get("investigate.retry.interval");
-        _investigateRetryInterval = NumbersUtil.parseInt(value, 1 * 60);
+        _investigateRetryInterval = NumbersUtil.parseInt(value, INVESTIGATE_RETRY_INTERVAL_SECONDS);
 
         value = params.get("migrate.retry.interval");
-        _migrateRetryInterval = NumbersUtil.parseInt(value, 2 * 60);
+        _migrateRetryInterval = NumbersUtil.parseInt(value, MIGRATE_RETRY_INTERVAL_SECONDS);
 
         _instance = params.get("instance");
         if (_instance == null) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This pull request adds the missing configuration keys for the High Availability service for virtual machines. (https://cwiki.apache.org/confluence/display/CLOUDSTACK/High+Availability+Developer%27s+Guide)

**Added keys (missing in the global configuration):**
time.between.cleanup
max.retries
time.to.sleep
time.between.failures

**Rename keys in the confluence document:**
ha.retry.wait -> restart.retry.interval
stop.retry.wait -> stop.retry.interval
workers -> ha.workers

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
We tested it in production in our KVM environment.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
