### PR TITLE
Load Average for KVM

### DIFF
--- a/api/src/main/java/com/cloud/host/HostStats.java
+++ b/api/src/main/java/com/cloud/host/HostStats.java
@@ -35,6 +35,6 @@ public interface HostStats {
 
     public HostStats getHostStats();
 
-    // public double getAverageLoad();
+    public double getLoadAverage();
     // public double getXapiMemoryUsageKBs();
 }

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -71,6 +71,7 @@ public class ApiConstants {
     public static final String COMPONENT = "component";
     public static final String CPU_NUMBER = "cpunumber";
     public static final String CPU_SPEED = "cpuspeed";
+    public static final String CPU_LOAD_AVERAGE = "cpuloadaverage";
     public static final String CREATED = "created";
     public static final String CTX_ACCOUNT_ID = "ctxaccountid";
     public static final String CTX_DETAILS = "ctxDetails";

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -116,7 +116,7 @@ public class HostResponse extends BaseResponse {
 
     @SerializedName("averageload")
     @Param(description = "the cpu average load on the host")
-    private Long averageLoad;
+    private Double averageLoad;
 
     @SerializedName("networkkbsread")
     @Param(description = "the incoming network traffic on the host")
@@ -337,7 +337,7 @@ public class HostResponse extends BaseResponse {
         this.cpuUsed = cpuUsed;
     }
 
-    public void setAverageLoad(Long averageLoad) {
+    public void setCpuAverageLoad(Double averageLoad) {
         this.averageLoad = averageLoad;
     }
 
@@ -570,7 +570,7 @@ public class HostResponse extends BaseResponse {
         return cpuUsed;
     }
 
-    public Long getAverageLoad() {
+    public Double getAverageLoad() {
         return averageLoad;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -114,9 +114,9 @@ public class HostResponse extends BaseResponse {
     @Param(description = "the amount of the host's CPU after applying the cpu.overprovisioning.factor ")
     private String cpuWithOverprovisioning;
 
-    @SerializedName("cpuloadaverage ")
+    @SerializedName("cpuloadaverage")
     @Param(description = "the cpu average load on the host")
-    private Double cpuloadaverage ;
+    private Double cpuloadaverage;
 
     @SerializedName("networkkbsread")
     @Param(description = "the incoming network traffic on the host")

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -114,7 +114,7 @@ public class HostResponse extends BaseResponse {
     @Param(description = "the amount of the host's CPU after applying the cpu.overprovisioning.factor ")
     private String cpuWithOverprovisioning;
 
-    @SerializedName("cpuloadaverage")
+    @SerializedName(ApiConstants.CPU_LOAD_AVERAGE)
     @Param(description = "the cpu average load on the host")
     private Double cpuloadaverage;
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/HostResponse.java
@@ -114,9 +114,9 @@ public class HostResponse extends BaseResponse {
     @Param(description = "the amount of the host's CPU after applying the cpu.overprovisioning.factor ")
     private String cpuWithOverprovisioning;
 
-    @SerializedName("averageload")
+    @SerializedName("cpuloadaverage ")
     @Param(description = "the cpu average load on the host")
-    private Double averageLoad;
+    private Double cpuloadaverage ;
 
     @SerializedName("networkkbsread")
     @Param(description = "the incoming network traffic on the host")
@@ -338,7 +338,7 @@ public class HostResponse extends BaseResponse {
     }
 
     public void setCpuAverageLoad(Double averageLoad) {
-        this.averageLoad = averageLoad;
+        this.cpuloadaverage = averageLoad;
     }
 
     public void setNetworkKbsRead(Long networkKbsRead) {
@@ -571,7 +571,7 @@ public class HostResponse extends BaseResponse {
     }
 
     public Double getAverageLoad() {
-        return averageLoad;
+        return cpuloadaverage;
     }
 
     public Long getNetworkKbsRead() {

--- a/core/src/main/java/com/cloud/agent/api/GetHostStatsAnswer.java
+++ b/core/src/main/java/com/cloud/agent/api/GetHostStatsAnswer.java
@@ -70,6 +70,11 @@ public class GetHostStatsAnswer extends Answer implements HostStats {
     }
 
     @Override
+    public double getLoadAverage() {
+        return hostStats.getLoadAverage();
+    }
+
+    @Override
     public double getNetworkReadKBs() {
         return hostStats.getNetworkReadKBs();
     }

--- a/core/src/main/java/com/cloud/agent/api/HostStatsEntry.java
+++ b/core/src/main/java/com/cloud/agent/api/HostStatsEntry.java
@@ -28,6 +28,7 @@ public class HostStatsEntry implements HostStats {
     HostVO hostVo;
     String entityType;
     double cpuUtilization;
+    double averageLoad;
     double networkReadKBs;
     double networkWriteKBs;
     double totalMemoryKBs;
@@ -45,6 +46,7 @@ public class HostStatsEntry implements HostStats {
         this.networkWriteKBs = networkWriteKBs;
         this.totalMemoryKBs = totalMemoryKBs;
         this.freeMemoryKBs = freeMemoryKBs;
+        this.averageLoad = averageLoad;
     }
 
     @Override
@@ -99,6 +101,15 @@ public class HostStatsEntry implements HostStats {
 
     public void setCpuUtilization(double cpuUtilization) {
         this.cpuUtilization = cpuUtilization;
+    }
+
+    @Override
+    public double getLoadAverage() {
+        return this.averageLoad;
+    }
+
+    public void setAverageLoad(double cpuAvgLoad) {
+        this.averageLoad = cpuAvgLoad;
     }
 
     @Override

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetHostStatsCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtGetHostStatsCommandWrapper.java
@@ -42,10 +42,11 @@ public final class LibvirtGetHostStatsCommandWrapper extends CommandWrapper<GetH
         MemStat memStat = libvirtComputingResource.getMemStat();
 
         final double cpuUtil = cpuStat.getCpuUsedPercent();
+        final double loadAvg = cpuStat.getCpuLoadAverage();
 
         final Pair<Double, Double> nicStats = libvirtComputingResource.getNicStats(libvirtComputingResource.getPublicBridgeName());
 
-        final HostStatsEntry hostStats = new HostStatsEntry(command.getHostId(), cpuUtil, nicStats.first() / 1024, nicStats.second() / 1024, "host", memStat.getTotal() / 1024, memStat.getAvailable() / 1024, 0, 0);
+        final HostStatsEntry hostStats = new HostStatsEntry(command.getHostId(), cpuUtil, nicStats.first() / 1024, nicStats.second() / 1024, "host", memStat.getTotal() / 1024, memStat.getAvailable() / 1024, 0, loadAvg);
         return new GetHostStatsAnswer(command, hostStats);
     }
 }

--- a/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/CPUStat.java
+++ b/plugins/hypervisors/kvm/src/main/java/org/apache/cloudstack/utils/linux/CPUStat.java
@@ -30,6 +30,7 @@ public class CPUStat {
     private UptimeStats _lastStats;
     private final String _sysfsCpuDir = "/sys/devices/system/cpu";
     private final String _uptimeFile = "/proc/uptime";
+    private final String _loadavgFile = "/proc/loadavg";
 
     class UptimeStats {
         public Double upTime = 0d;
@@ -78,6 +79,17 @@ public class CPUStat {
 
     public Integer getCores() {
         return _cores;
+    }
+
+    public Double getCpuLoadAverage() {
+        File f = new File(_loadavgFile);
+        String[] load = {"0.0"};
+        try (Scanner scanner = new Scanner(f,"UTF-8");) {
+            load = scanner.useDelimiter("\\Z").next().split("\\s+");
+        } catch (FileNotFoundException ex) {
+            s_logger.warn("File " + _uptimeFile + " not found:" + ex.toString());
+        }
+        return Double.parseDouble(load[0]);
     }
 
     public Double getCpuUsedPercent() {

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/metrics/MetricsServiceImpl.java
@@ -279,6 +279,7 @@ public class MetricsServiceImpl extends ComponentLifecycleBase implements Metric
             metricsResponse.setCpuTotal(hostResponse.getCpuNumber(), hostResponse.getCpuSpeed(), cpuOvercommitRatio);
             metricsResponse.setCpuUsed(hostResponse.getCpuUsed(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
             metricsResponse.setCpuAllocated(hostResponse.getCpuAllocated(), hostResponse.getCpuNumber(), hostResponse.getCpuSpeed());
+            metricsResponse.setLoadAverage(hostResponse.getAverageLoad());
             metricsResponse.setMemTotal(hostResponse.getMemoryTotal(), memoryOvercommitRatio);
             metricsResponse.setMemAllocated(hostResponse.getMemoryAllocated());
             metricsResponse.setMemUsed(hostResponse.getMemoryUsed());

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
@@ -43,6 +43,10 @@ public class HostMetricsResponse extends HostResponse {
     @Param(description = "the total cpu allocated in Ghz")
     private String cpuAllocated;
 
+    @SerializedName("loadAverage")
+    @Param(description = "the average cpu load the last minute")
+    private String loadAverage;
+
     @SerializedName("memorytotalgb")
     @Param(description = "the total cpu capacity in GiB")
     private String memTotal;
@@ -114,6 +118,12 @@ public class HostMetricsResponse extends HostResponse {
     public void setCpuUsed(final String cpuUsed, final Integer cpuNumber, final Long cpuSpeed) {
         if (cpuUsed != null && cpuNumber != null && cpuSpeed != null) {
             this.cpuUsed = String.format("%.2f Ghz", Double.valueOf(cpuUsed.replace("%", "")) * cpuNumber * cpuSpeed / (100.0 * 1000.0));
+        }
+    }
+
+    public void setLoadAverage(final Double loadAverage) {
+        if (loadAverage != null) {
+            this.loadAverage = String.format("%.2f", loadAverage);
         }
     }
 

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
@@ -43,7 +43,7 @@ public class HostMetricsResponse extends HostResponse {
     @Param(description = "the total cpu allocated in Ghz")
     private String cpuAllocated;
 
-    @SerializedName("loadAverage")
+    @SerializedName("cpuloadaverage")
     @Param(description = "the average cpu load the last minute")
     private String loadAverage;
 

--- a/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
+++ b/plugins/metrics/src/main/java/org/apache/cloudstack/response/HostMetricsResponse.java
@@ -45,7 +45,7 @@ public class HostMetricsResponse extends HostResponse {
 
     @SerializedName("cpuloadaverage")
     @Param(description = "the average cpu load the last minute")
-    private String loadAverage;
+    private Double loadAverage;
 
     @SerializedName("memorytotalgb")
     @Param(description = "the total cpu capacity in GiB")
@@ -123,7 +123,7 @@ public class HostMetricsResponse extends HostResponse {
 
     public void setLoadAverage(final Double loadAverage) {
         if (loadAverage != null) {
-            this.loadAverage = String.format("%.2f", loadAverage);
+            this.loadAverage = loadAverage;
         }
     }
 

--- a/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/HostJoinDaoImpl.java
@@ -194,6 +194,7 @@ public class HostJoinDaoImpl extends GenericDaoBase<HostJoinVO, Long> implements
                     float cpuUtil = (float)hostStats.getCpuUtilization();
                     cpuUsed = decimalFormat.format(cpuUtil) + "%";
                     hostResponse.setCpuUsed(cpuUsed);
+                    hostResponse.setCpuAverageLoad(hostStats.getLoadAverage());
                     hostResponse.setMemoryUsed((new Double(hostStats.getUsedMemory())).longValue());
                     hostResponse.setNetworkKbsRead((new Double(hostStats.getNetworkReadKBs())).longValue());
                     hostResponse.setNetworkKbsWrite((new Double(hostStats.getNetworkWriteKBs())).longValue());


### PR DESCRIPTION
## Description
This adds the **load average for the kvm hypervisor**. The average Load already seems to be available for Xen.

In the _listHosts_ the [averageload](https://cloudstack.apache.org/api/apidocs-4.13/apis/listHosts.html) is already present. In _listHostMetrics_ it appears as "cpuloadaverage".

It adds the 1-min load average from /proc/loadavg to the
_listHosts
listHostsMetrics_
API calls.

![image](https://user-images.githubusercontent.com/33484272/70162276-ab7dcd80-16bd-11ea-8543-bd91c2837832.png)

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Built and tested in kvm cluster.
Tested manually via API calls
