### PR TITLE
Added zone check for attach iso

### DIFF
--- a/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
+++ b/server/src/main/java/com/cloud/template/TemplateManagerImpl.java
@@ -1187,6 +1187,12 @@ public class TemplateManagerImpl extends ManagerBase implements TemplateManager,
             throw new InvalidParameterValueException("Unable to find an ISO with id " + isoId);
         }
 
+        long dcId = vm.getDataCenterId();
+        VMTemplateZoneVO exists = _tmpltZoneDao.findByZoneTemplate(dcId, isoId);
+        if (null == exists) {
+            throw new InvalidParameterValueException("ISO is not available in the zone the VM is in.");
+        }
+
         // check permissions
         // check if caller has access to VM and ISO
         // and also check if the VM's owner has access to the ISO.


### PR DESCRIPTION
## Description
This fix adds a check if the iso belongs to the zone the virtual machine is in
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3588

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This was tested using cloudmonkey using the attach iso command.
A Cloudstack installation with 2 zones is required. 
I created an instance in the first zone and then uploaded an iso to the second zone.
When trying to attach the iso to the virtual machine in the first zone this error message is returned:

(localcloud) 🐱 > attach iso virtualmachineid=e1b6b77b-df84-4d5e-998a-d7283e5f4f21 id=326c0c96-db4f-4e01-924e-2eac50e0420e 
{
  "accountid": "4c71abb8-1a54-11ea-a067-000c29a1fe4f",
  "cmd": "org.apache.cloudstack.api.command.admin.iso.AttachIsoCmdByAdmin",
  "completed": "2019-12-09T12:02:43+0200",
  "created": "2019-12-09T12:02:43+0200",
  "jobid": "971ce126-7d8c-4ea0-ba3f-5cbbcdbf750f",
  "jobprocstatus": 0,
  "jobresult": {
    "errorcode": 431,
    "errortext": "ISO is not available in the zone the VM is in."
  },
  "jobresultcode": 530,
  "jobresulttype": "object",
  "jobstatus": 2,
  "userid": "4c71db6e-1a54-11ea-a067-000c29a1fe4f"
}
🙈 Error: async API failed for job 971ce126-7d8c-4ea0-ba3f-5cbbcdbf750f

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
