### PR TITLE
server: fix checking disk offering access for snapshot volume

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -673,8 +673,6 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 zoneId = snapshotCheck.getDataCenterId();
             }
 
-            _configMgr.checkDiskOfferingAccess(null, diskOffering, _dcDao.findById(zoneId));
-
             if (diskOffering == null) { // Pure snapshot is being used to create volume.
                 diskOfferingId = snapshotCheck.getDiskOfferingId();
                 diskOffering = _diskOfferingDao.findById(diskOfferingId);
@@ -688,6 +686,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                             size / (1024 * 1024 * 1024), snapshotCheck.getSize() / (1024 * 1024 * 1024)));
                 }
             }
+
+            _configMgr.checkDiskOfferingAccess(null, diskOffering, _dcDao.findById(zoneId));
 
             // check snapshot permissions
             _accountMgr.checkAccess(caller, null, true, snapshotCheck);


### PR DESCRIPTION
Fixes #3783
As reported in the issue, creating volumes from pure snapshot fails with NPE. This is due to order of calls where disk offering access is checked before checking disk offering value. This PR fixes the same.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
