### PR TITLE
ui: fix for truncated name for project accounts

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -8188,8 +8188,11 @@ div.container div.panel div#details-tab-addloadBalancer.detail-group div.loadBal
   display: block;
   float: left;
   max-width: 90%;
-  text-overflow: ellipsis;
   overflow: hidden;
+  word-break: break-all;
+  word-wrap: break-word;
+  text-indent: 0;
+  margin-left: 10px;
 }
 
 .multi-edit .data .data-body .data-item table tbody tr td.name {


### PR DESCRIPTION
Fixes truncated name for accounts in project details UI
Existing behaviour,
![Screenshot from 2020-01-02 17-27-06](https://user-images.githubusercontent.com/153340/71666344-70d38780-2d86-11ea-85a2-33626f57d2b5.png)
While Accounts page table showed the complete name,
![Screenshot from 2020-01-02 17-37-24](https://user-images.githubusercontent.com/153340/71666397-a1b3bc80-2d86-11ea-9594-274a0188ced5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
UI after changes,
![Screenshot from 2020-01-02 17-32-46](https://user-images.githubusercontent.com/153340/71666361-7e890d00-2d86-11ea-94bc-e2265356e511.png)


## How Has This Been Tested?
UI


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
