### PR TITLE
create Volume Access Groups per cluster instead of CloudStack-RandomUUID()

### DIFF
--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
@@ -171,7 +171,7 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
 
             SolidFireUtil.SolidFireConnection sfConnection = SolidFireUtil.getSolidFireConnection(storagePoolId, storagePoolDetailsDao);
 
-            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolumeId, hosts);
+            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolumeId, hosts, clusterId);
 
             return true;
         }

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/driver/SolidFirePrimaryDataStoreDriver.java
@@ -169,9 +169,11 @@ public class SolidFirePrimaryDataStoreDriver implements PrimaryDataStoreDriver {
         try {
             List<HostVO> hosts = hostDao.findByClusterId(clusterId);
 
+            String clusterUuId = clusterDao.findById(clusterId).getUuid();
+
             SolidFireUtil.SolidFireConnection sfConnection = SolidFireUtil.getSolidFireConnection(storagePoolId, storagePoolDetailsDao);
 
-            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolumeId, hosts, clusterId);
+            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolumeId, hosts, clusterUuId);
 
             return true;
         }

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/SolidFireSharedPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/SolidFireSharedPrimaryDataStoreLifeCycle.java
@@ -285,7 +285,9 @@ public class SolidFireSharedPrimaryDataStoreLifeCycle implements PrimaryDataStor
             // place the newly created volume in the Volume Access Group
             List<HostVO> hosts = hostDao.findByClusterId(clusterId);
 
-            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolume.getId(), hosts, clusterId);
+            String clusterUuId = clusterDao.findById(clusterId).getUuid();
+
+            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolume.getId(), hosts, clusterUuId);
 
             SolidFireUtil.SolidFireAccount sfAccount = sfCreateVolume.getAccount();
             Account csAccount = CallContext.current().getCallingAccount();

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/SolidFireSharedPrimaryDataStoreLifeCycle.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/lifecycle/SolidFireSharedPrimaryDataStoreLifeCycle.java
@@ -285,7 +285,7 @@ public class SolidFireSharedPrimaryDataStoreLifeCycle implements PrimaryDataStor
             // place the newly created volume in the Volume Access Group
             List<HostVO> hosts = hostDao.findByClusterId(clusterId);
 
-            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolume.getId(), hosts);
+            SolidFireUtil.placeVolumeInVolumeAccessGroups(sfConnection, sfVolume.getId(), hosts, clusterId);
 
             SolidFireUtil.SolidFireAccount sfAccount = sfCreateVolume.getAccount();
             Account csAccount = CallContext.current().getCallingAccount();

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -393,7 +393,7 @@ public class SolidFireUtil {
             }
         }
         else {
-            List<ClusterVO> clustersInZone = clusterDao.listByZoneId(storagePoolVO.getDataCenterId());
+            List<ClusterVO> clustersInZone = clusterDao.listClustersByDcId(storagePoolVO.getDataCenterId());
 
             if (clustersInZone != null) {
                 for (ClusterVO clusterInZone : clustersInZone) {

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -497,7 +497,7 @@ public class SolidFireUtil {
                         if (sfVag != null) {
                             placeVolumeIdsInVag(sfConnection, sfVags, sfVag, hostVO, hostDao);
                         } else {
-                            handleVagForHost(sfConnection, sfVags, hostVO, hostDao);
+                            handleVagForHost(sfConnection, sfVags, hostVO, hostDao, clusterDao);
                         }
                     }
                 }
@@ -513,13 +513,13 @@ public class SolidFireUtil {
     // creating a new VAG won't exceed 4 VAGs for the computer cluster).
     // If none of the hosts in the cluster are in a VAG, then leave this host out of a VAG.
     // Place applicable volume IDs in VAG, if need be (account of volume starts with SF_CS_ACCOUNT_PREFIX).
-    private static void handleVagForHost(SolidFireUtil.SolidFireConnection sfConnection, List<SolidFireUtil.SolidFireVag> sfVags, Host host, HostDao hostDao) {
+    private static void handleVagForHost(SolidFireUtil.SolidFireConnection sfConnection, List<SolidFireUtil.SolidFireVag> sfVags, Host host, HostDao hostDao, ClusterDao clusterDao) {
         List<HostVO> hostVOs = hostDao.findByClusterId(host.getClusterId());
 
         if (hostVOs != null) {
             int numVags = 0;
 
-            String clusterUuId = hostDao.findById(host.getClusterId()).getUuid();
+            String clusterUuId = clusterDao.findById(host.getClusterId()).getUuid();
             SolidFireVag sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterUuId)).findFirst().orElse(null);
             if (sfVagMatchingClusterId != null && sfVagMatchingClusterId.getInitiators().length < MAX_NUM_INITIATORS_PER_VAG) {
                 addInitiatorsToSolidFireVag(sfConnection, sfVagMatchingClusterId.getId(), new String[]{host.getStorageUrl()});

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -713,17 +713,18 @@ public class SolidFireUtil {
 
             //Check if cluster VAG exists
             SolidFireVag sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterUuId)).findFirst().orElse(null);
-            // Create cluster VAG if doesnt exist
-            if (sfVagMatchingClusterId == null) {
 
+            if (sfVagMatchingClusterId == null) {
+                // Create cluster VAG if doesnt exist
                 LOGGER.info("Creating volume access group CloudStack-"+clusterUuId);
                 SolidFireUtil.createVag(sfConnection, "CloudStack-"+clusterUuId, sfVagToIqnsMap.get(null).toArray(new String[0]), new long[] { sfVolumeId });
 
-                //update null entry in vag to IQN Map
-                sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterUuId)).findFirst().orElse(null);
-                sfVagToIqnsMap.put(sfVagMatchingClusterId,sfVagToIqnsMap.get(null));
-                sfVagToIqnsMap.remove(null);
             }
+
+            //update null entry in vag to IQN Map
+            sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterUuId)).findFirst().orElse(null);
+            sfVagToIqnsMap.put(sfVagMatchingClusterId,sfVagToIqnsMap.get(null));
+            sfVagToIqnsMap.remove(null);
         }
 
 

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -550,8 +550,9 @@ public class SolidFireUtil {
                                 throw new CloudRuntimeException(errMsg);
                             }
 
-                            addInitiatorsToSolidFireVag(sfConnection, sfVag.getId(), new String[] { host.getStorageUrl() });
-
+                            if(!isInitiatorInSfVag(host.getStorageUrl(),sfVag)) {
+                                addInitiatorsToSolidFireVag(sfConnection, sfVag.getId(), new String[]{host.getStorageUrl()});
+                            }
                             return;
                         }
                     }

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -556,7 +556,7 @@ public class SolidFireUtil {
                 throw new CloudRuntimeException("Can support at most four volume access groups per compute cluster (==)");
             }
 
-            // if MAX_NUM_INITIATORS_PER_VAG is reached create new random VAG
+            // if MAX_NUM_INITIATORS_PER_VAG is not yet reached but numVags is > 0 create new random VAG
             if (numVags > 0) {
                 if (!hostSupports_iScsi(host)) {
                     String errMsg = "Host with ID " + host.getId() + " does not support iSCSI.";
@@ -721,9 +721,9 @@ public class SolidFireUtil {
                 SolidFireUtil.createVag(sfConnection, "CloudStack-" + clusterId, IQNsInCluster.toArray(new String[0]), new long[] { sfVolumeId });
             }
 
-            //refresh sf VAG list and rebuild sfVagToIqnsMap (should no longer have null entry)
-            sfVags = SolidFireUtil.getAllVags(sfConnection);
-            sfVagToIqnsMap = buildVagtoIQNMap(hosts, sfVags);
+            //update null entry in vag to IQN Map
+            sfVagToIqnsMap.put(sfVagMatchingClusterId,sfVagToIqnsMap.get(null));
+            sfVagToIqnsMap.remove(null);
         }
 
         // throw exception if more than 4 VAGs

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -718,11 +718,11 @@ public class SolidFireUtil {
                 // Create cluster VAG if doesnt exist
                 LOGGER.info("Creating volume access group CloudStack-"+clusterUuId);
                 SolidFireUtil.createVag(sfConnection, "CloudStack-"+clusterUuId, sfVagToIqnsMap.get(null).toArray(new String[0]), new long[] { sfVolumeId });
-
+                sfVags = SolidFireUtil.getAllVags(sfConnection);
+                sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterUuId)).findFirst().orElse(null);
             }
 
             //update null entry in vag to IQN Map
-            sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterUuId)).findFirst().orElse(null);
             sfVagToIqnsMap.put(sfVagMatchingClusterId,sfVagToIqnsMap.get(null));
             sfVagToIqnsMap.remove(null);
         }

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -719,6 +719,8 @@ public class SolidFireUtil {
                     IQNsInCluster.add(iqn);
                 }
                 SolidFireUtil.createVag(sfConnection, "CloudStack-" + clusterId, IQNsInCluster.toArray(new String[0]), new long[] { sfVolumeId });
+                sfVags = SolidFireUtil.getAllVags(sfConnection);
+                sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterId)).findFirst().orElse(null);
             }
 
             //update null entry in vag to IQN Map

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -1290,13 +1290,13 @@ public class SolidFireUtil {
         private final long _id;
         private final String[] _initiators;
         private final long[] _volumeIds;
-        private final String _name;
+        private final String _vagName;
 
         SolidFireVag(long id, String[] initiators, long[] volumeIds, String name) {
             _id = id;
             _initiators = initiators;
             _volumeIds = volumeIds;
-            _name = name;
+            _vagName = name;
         }
 
         public long getId() {
@@ -1311,7 +1311,7 @@ public class SolidFireUtil {
             return _volumeIds;
         }
 
-        public String getName() { return _name; }
+        public String getName() { return _vagName; }
 
         @Override
         public int hashCode() {

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -708,12 +708,12 @@ public class SolidFireUtil {
             throw new CloudRuntimeException("A SolidFire volume can be in at most four volume access groups simultaneously.");
         }
         if (sfVagToIqnsMap.containsKey(null)) {
-            sfVagToIqnsMap = updateNullKeyInsfVagToIqnsMap(sfVagToIqnsMap, sfVags, sfConnection, clusterUuId, sfVolumeId);
+            sfVagToIqnsMap = updateNullKeyInSfVagToIqnsMap(sfVagToIqnsMap, sfVags, sfConnection, clusterUuId, sfVolumeId);
         }
-        addVoulumestoVagIfNotPresent(sfVagToIqnsMap.keySet(), sfVolumeId, sfConnection);
+        addVolumestoVagIfNotPresent(sfVagToIqnsMap.keySet(), sfVolumeId, sfConnection);
     }
 
-    private static Map<SolidFireUtil.SolidFireVag, List<String>> updateNullKeyInsfVagToIqnsMap(Map<SolidFireUtil.SolidFireVag,List<String>> sfVagToIqnsMap, List <SolidFireUtil.SolidFireVag> sfVags, SolidFireConnection sfConnection, String clusterUuId, long sfVolumeId){
+    private static Map<SolidFireUtil.SolidFireVag, List<String>> updateNullKeyInSfVagToIqnsMap(Map<SolidFireUtil.SolidFireVag,List<String>> sfVagToIqnsMap, List <SolidFireUtil.SolidFireVag> sfVags, SolidFireConnection sfConnection, String clusterUuId, long sfVolumeId){
         SolidFireUtil.SolidFireVag sfVagMatchingClusterId = createClusterVagIfDoesntExist(sfVags, sfConnection, clusterUuId, sfVagToIqnsMap, sfVolumeId);
         sfVagToIqnsMap.put(sfVagMatchingClusterId, sfVagToIqnsMap.get(null));
         sfVagToIqnsMap.remove(null);
@@ -732,7 +732,7 @@ public class SolidFireUtil {
         }
     }
 
-    private static void addVoulumestoVagIfNotPresent(Set<SolidFireUtil.SolidFireVag> sfVagSet, long sfVolumeId, SolidFireConnection sfConnection){
+    private static void addVolumestoVagIfNotPresent(Set<SolidFireUtil.SolidFireVag> sfVagSet, long sfVolumeId, SolidFireConnection sfConnection){
         for (SolidFireUtil.SolidFireVag sfVag : sfVagSet) {
             if (sfVag != null) {
                 if (!SolidFireUtil.isVolumeIdInSfVag(sfVolumeId, sfVag)) {

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -700,7 +700,7 @@ public class SolidFireUtil {
         SolidFireUtil.SolidFireVag sfVagMatchingClusterId;
         for (SolidFireUtil.SolidFireVag sfVag : sfVags) {
 
-            if(sfVag.getName() == "CloudStack-"+clusterId){
+            if(sfVag.getName().equals("CloudStack-"+clusterId)){
                 clusterVagExists = true;
                 sfVagMatchingClusterId = sfVag;
             }

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -556,6 +556,7 @@ public class SolidFireUtil {
                 throw new CloudRuntimeException("Can support at most four volume access groups per compute cluster (==)");
             }
 
+            // if MAX_NUM_INITIATORS_PER_VAG is reached create new random VAG
             if (numVags > 0) {
                 if (!hostSupports_iScsi(host)) {
                     String errMsg = "Host with ID " + host.getId() + " does not support iSCSI.";
@@ -728,7 +729,8 @@ public class SolidFireUtil {
                 SolidFireUtil.createVag(sfConnection, "CloudStack-" + clusterId, IQNsInCluster.toArray(new String[0]), new long[] { sfVolumeId });
             }
 
-            //rebuild (should no longer have null entry)
+            //refresh sf VAG list and rebuild sfVagToIqnsMap (should no longer have null entry)
+            sfVags = SolidFireUtil.getAllVags(sfConnection);
             sfVagToIqnsMap = buildVagtoIQNMap(hosts, sfVags);
         }
 
@@ -744,7 +746,7 @@ public class SolidFireUtil {
                     SolidFireUtil.addVolumeIdsToSolidFireVag(sfConnection, sfVag.getId(), new Long[] { sfVolumeId });
                 }
             }
-            // if no VAGs associated with hosts or IQNs create a vag with random uuid
+            // if no VAGs associated with hosts or IQNs create a vag with random uuid (should not happen)
             else {
                 List<String> iqnsNotInVag = sfVagToIqnsMap.get(null);
 

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -703,7 +703,7 @@ public class SolidFireUtil {
 
             //Check if cluster VAG exists
             Boolean clusterVagExists = false;
-            SolidFireUtil.SolidFireVag sfVagMatchingClusterId;
+            SolidFireUtil.SolidFireVag sfVagMatchingClusterId = sfVags.get(0);
             for (SolidFireUtil.SolidFireVag sfVag : sfVags) {
 
                 if(sfVag.getName().equals("CloudStack-"+clusterId)){
@@ -720,7 +720,7 @@ public class SolidFireUtil {
             } else {
                 // Create cluster VAG
                 LOGGER.info("Creating volume access group CloudStack-"+clusterId);
-                List<String> IQNsInCluster = new List<String>;
+                List<String> IQNsInCluster = new ArrayList<>();
                 for (HostVO hostVO : hosts) {
                     String iqn = hostVO.getStorageUrl();
                     IQNsInCluster.add(iqn);

--- a/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
+++ b/plugins/storage/volume/solidfire/src/main/java/org/apache/cloudstack/storage/datastore/util/SolidFireUtil.java
@@ -703,17 +703,9 @@ public class SolidFireUtil {
         if (sfVagToIqnsMap.containsKey(null)) {
 
             //Check if cluster VAG exists
-            Boolean clusterVagExists = false;
-            SolidFireUtil.SolidFireVag sfVagMatchingClusterId = sfVags.get(0);
-            for (SolidFireUtil.SolidFireVag sfVag : sfVags) {
-
-                if(sfVag.getName().equals("CloudStack-"+clusterId)){
-                    clusterVagExists = true;
-                    sfVagMatchingClusterId = sfVag;
-                }
-            }
+            SolidFireVag sfVagMatchingClusterId = sfVags.stream().filter(vag -> vag.getName().equals("CloudStack-"+clusterId)).findFirst().orElse(null);
             //Use existing cluster VAG
-            if (clusterVagExists) {
+            if (sfVagMatchingClusterId != null) {
                 LOGGER.info("Using existing volume access group CloudStack-"+clusterId);
                 if (!SolidFireUtil.isVolumeIdInSfVag(sfVolumeId, sfVagMatchingClusterId)) {
                     SolidFireUtil.addVolumeIdsToSolidFireVag(sfConnection, sfVagMatchingClusterId.getId(), new Long[] { sfVolumeId });


### PR DESCRIPTION
## Description
Previously, volume access groups were assigned with the convention Cloudstack-RandomUUID. This change proposes that that we use Cloudstack-clusterUuId instead.

The problem addressed by this PR is that under some conditions multiple volume access groups with random uuids are created. This is illustrated in the screenshot below:
![image](https://user-images.githubusercontent.com/45833770/73491211-14ab5580-437c-11ea-9518-c2f335e11833.png)
One of the scenarios in which this occurs is when upgrades are done to the hypervisor hosts by removing, re-provisioning them and re-adding them.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

### Scenario where new random volume access groups are created

Steps to reproduce in test environment with two hosts:

1. - Create VMs
2. - Remove all hosts
3. - Re-Add hosts
4. - Start VMs

_Outcome before applying this patch:_
A new volume access group is created with the convention CloudStack-RandomUUID
_After applying this patch:_
If an existing volume access group with the naming convention CloudStack-clusterUuId exists, it will be used otherwise a volume access group with this naming convention will be created.

### Backward Compatibility test

1. - initial scenario old code, two hosts, volume access group name with random-uuid
2. - switch to new code
3. - remove one host
4. - re-add host

_Outcome before applying this patch:_
no new volume access group created, existing volume access group with random-uuid is used.
_After applying this patch:_
no new volume access group created, existing volume access group with random-uuid is used.

A scenario with one host in the new group and one in the old does not occur for the above tests

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
