### PR TITLE
Fixed volume stats

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -3722,7 +3722,15 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                                 VirtualMachineMO vmMo = dcMo.findVm(file.getDir());
                                 Pair<VirtualDisk, String> vds = vmMo.getDiskDevice(file.getFileName(), true);
                                 long virtualsize = vds.first().getCapacityInKB() * 1024;
-                                long physicalsize = primaryStorageDatastoreMo.fileDiskSize(file.getPath());
+                                long physicalsize = 0L;
+                                VirtualMachineFileLayoutEx fileLayout = vmMo.getFileLayout();
+                                List<VirtualMachineFileLayoutExFileInfo> files = fileLayout.getFile();
+                                for(VirtualMachineFileLayoutExFileInfo fileInfo: files){
+                                    if (fileInfo.getName().contains("ROOT")){
+                                        physicalsize += fileInfo.getSize();
+                                    }
+                                }
+
                                 if (statEntry.containsKey(chainInfo)) {
                                     VolumeStatsEntry vse = statEntry.get(chainInfo);
                                     if (vse != null) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fixes a bug where the volume statistics for the physical size is incorrect
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3416 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This was tested by verifying that the vmdk file size in vcenter corresponds to the physical volume size in the ui of the management server. Please note that vcenter displays kilobytes where 
Cloudstack management server displays kibibytes on linux.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
