### PR TITLE
Update message when keys are NOT being injected

### DIFF
--- a/scripts/vm/systemvm/injectkeys.sh
+++ b/scripts/vm/systemvm/injectkeys.sh
@@ -45,7 +45,7 @@ inject_into_iso() {
   [ ! -f $isofile ] && echo "$(basename $0): Could not find systemvm iso patch file $isofile" && return 1
   bsdtar -C $MOUNTPATH -xf $isofile
   [ $? -ne 0 ] && echo "$(basename $0): Failed to extract original iso $isofile" && clean_up && return 1
-  diff -q $MOUNTPATH/authorized_keys $newpubkey &> /dev/null && clean_up && return 0
+  diff -q $MOUNTPATH/authorized_keys $newpubkey &> /dev/null && echo "New public key is the same as the one in the systemvm.iso, not injecting it, not modifying systemvm.iso" && clean_up && return 0
   backup_iso
   [ $? -ne 0 ] && echo "$(basename $0): Failed to backup original iso $isofile" && clean_up && return 1
   $SUDO cp $newpubkey $MOUNTPATH/authorized_keys

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -767,7 +767,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         command.add(systemVmIsoPath);
 
         final String result = command.execute();
-        s_logger.info("Injected new public key into systemvm iso with result : " + result);
+        s_logger.info("The script injectkeys.sh was run with result : " + result);
         if (result != null) {
             s_logger.warn("Failed to inject generated public key into systemvm iso " + result);
             throw new CloudRuntimeException("Failed to inject generated public key into systemvm iso " + result);

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -769,8 +769,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         final String result = command.execute();
         s_logger.info("The script injectkeys.sh was run with result : " + result);
         if (result != null) {
-            s_logger.warn("Failed to inject generated public key into systemvm iso " + result);
-            throw new CloudRuntimeException("Failed to inject generated public key into systemvm iso " + result);
+            s_logger.warn("The script injectkeys.sh failed to run sucessfully : " + result);
+            throw new CloudRuntimeException("The script injectkeys.sh failed to run sucessfully : " + result);
         }
     }
 

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -767,7 +767,7 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         command.add(systemVmIsoPath);
 
         final String result = command.execute();
-        s_logger.info("Injected public and private keys into systemvm iso with result : " + result);
+        s_logger.info("Injected new public key into systemvm iso with result : " + result);
         if (result != null) {
             s_logger.warn("Failed to inject generated public key into systemvm iso " + result);
             throw new CloudRuntimeException("Failed to inject generated public key into systemvm iso " + result);

--- a/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ConfigurationServerImpl.java
@@ -769,8 +769,8 @@ public class ConfigurationServerImpl extends ManagerBase implements Configuratio
         final String result = command.execute();
         s_logger.info("The script injectkeys.sh was run with result : " + result);
         if (result != null) {
-            s_logger.warn("The script injectkeys.sh failed to run sucessfully : " + result);
-            throw new CloudRuntimeException("The script injectkeys.sh failed to run sucessfully : " + result);
+            s_logger.warn("The script injectkeys.sh failed to run successfully : " + result);
+            throw new CloudRuntimeException("The script injectkeys.sh failed to run successfully : " + result);
         }
     }
 


### PR DESCRIPTION
## Description
When the injectkeys.sh script runs, if the public ssh key is the same as the authorized_keys file inside the extracted systemvm.iso - then the public ssh key files is NOT copied over and the systemvm.iso is not modified - message added to explain just that.

Also, after the injectkeys.sh is run/finished, from the Java code we currently generate a wrong message that the private key has also been injected (we don't inject it, only the public key) - and in general sometimes NOTHING is injected - so changed the messages accordingly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Restarted the mgmt server for an existing installation, injectkeys.ssh was run, and confirmed that the systemvm.iso is NOT modified, same modification date, same md5sum as before.
Message properly logged in the mgmt logs, as follows:

> 2020-01-09 22:28:08,777 DEBUG [c.c.s.ConfigurationServerImpl] (main:null) (logid:) Executing: /bin/bash /usr/share/cloudstack-common/scripts/vm/systemvm/injectkeys.sh /var/cloudstack/management/.ssh/id_rsa.pub /var/cloudstack/management/.ssh/id_rsa /usr/share/cloudstack-common/vms/systemvm.iso
2020-01-09 22:28:08,897 DEBUG [c.c.s.ConfigurationServerImpl] (main:null) (logid:) Execution is successful.
2020-01-09 22:28:08,898 DEBUG [c.c.s.ConfigurationServerImpl] (main:null) (logid:) **New public key is the same as the one in the systemvm.iso, not injecting it, not modifying systemvm.iso**
2020-01-09 22:28:08,898 INFO  [c.c.s.ConfigurationServerImpl] (main:null) (logid:) **The script injectkeys.sh was run with result** : null 