### PR TITLE
Bug fix : set restart_required to 0 after restarting network

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -2936,7 +2936,8 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
     @Override
     public boolean restartNetwork(final Long networkId, final Account callerAccount, final User callerUser, final boolean cleanup) throws ConcurrentOperationException, ResourceUnavailableException,
     InsufficientCapacityException {
-
+        boolean status = true;
+        boolean restartRequired = false;
         final NetworkVO network = _networksDao.findById(networkId);
 
         s_logger.debug("Restarting network " + networkId + "...");
@@ -2947,16 +2948,17 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
         if (cleanup) {
             if (!rollingRestartRouters(network, offering, dest, context)) {
-                setRestartRequired(network, true);
-                return false;
+                status = false;
+                restartRequired = true;
             }
-            return true;
+            setRestartRequired(network, restartRequired);
+            return status;
         }
 
         s_logger.debug("Implementing the network " + network + " elements and resources as a part of network restart without cleanup");
         try {
             implementNetworkElementsAndResources(dest, context, network, offering);
-            setRestartRequired(network, true);
+            setRestartRequired(network, false);
             return true;
         } catch (final Exception ex) {
             s_logger.warn("Failed to implement network " + network + " elements and resources as a part of network restart due to ", ex);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
After restarting the network with or without cleanup option, the ```restart_required``` field in ```networks``` table should be reset to 0

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
1 . Check if the ```restart_required``` field in the ```networks``` table is 1 or not. If not you can set it to 1
2 . Restart the network with or without cleanup option.
3 . The ```restart_required``` field in the ```networks``` table should be reset to 0 once the network restarts successfully.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
