### PR TITLE
reload dnsmasq instead of restart when adding new rules

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsDhcp.py
@@ -69,7 +69,7 @@ class CsDhcp(CsDataBag):
 
         if not self.cl.is_redundant() or self.cl.is_master():
             if restart_dnsmasq:
-                CsHelper.service("dnsmasq", "restart")
+                CsHelper.service("dnsmasq", "reload")
             else:
                 CsHelper.start_if_stopped("dnsmasq")
                 CsHelper.service("dnsmasq", "reload")


### PR DESCRIPTION

Fixes #3613 
Optimistic fix, to be tested.

## Description
<!--- Describe your changes in detail -->
Reload dnsmasq when new dhcp rules are added, don't restart.
Avoids "downtime" as observed by VR monitoring scripst in environemnts with lot's of VMs being started/stopped/created in parallel, etc.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

To be tested.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
