### PR TITLE
kvm-local-pool-trailing-slash

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
@@ -20,3 +20,6 @@
 --;
 
 DELETE FROM `cloud`.`configuration` WHERE name = 'host.maintenance.retries';
+
+-- Stop asking user (in the upgraded documentation) to remove a trailing slash for local KVM pool
+UPDATE `cloud`.`storage_pool` SET path="/var/lib/libvirt/images" WHERE path="/var/lib/libvirt/images/";


### PR DESCRIPTION
## Description
Stop asking user (in the upgrade documentation) to remove a trailing slash for local KVM pool - do it here in upgrade path - so not needed in DOC for the upgrade to 4.14 and onwards.

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
