### PR TITLE
Clean up inactive iscsi sessions when VMs get moved due to crashes

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -48,6 +48,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import com.cloud.hypervisor.kvm.dpdk.DpdkHelper;
 import com.cloud.resource.RequestWrapper;
+import com.cloud.hypervisor.kvm.storage.IscsiStorageCleanupMonitor;
 import org.apache.cloudstack.storage.to.PrimaryDataStoreTO;
 import org.apache.cloudstack.storage.to.TemplateObjectTO;
 import org.apache.cloudstack.storage.to.VolumeObjectTO;
@@ -1085,6 +1086,10 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         final KVMStorageProcessor storageProcessor = new KVMStorageProcessor(_storagePoolMgr, this);
         storageProcessor.configure(name, params);
         storageHandler = new StorageSubsystemCommandHandlerBase(storageProcessor);
+
+        IscsiStorageCleanupMonitor isciCleanupMonitor = new IscsiStorageCleanupMonitor();
+        final Thread cleanupMonitor = new Thread(isciCleanupMonitor);
+        cleanupMonitor.start();
 
         return true;
     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiStorageCleanupMonitor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiStorageCleanupMonitor.java
@@ -1,0 +1,128 @@
+package com.cloud.hypervisor.kvm.storage;
+
+import com.cloud.hypervisor.kvm.resource.LibvirtConnection;
+import com.cloud.hypervisor.kvm.resource.LibvirtDomainXMLParser;
+import com.cloud.hypervisor.kvm.resource.LibvirtVMDef;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.log4j.Logger;
+import org.libvirt.Connect;
+import org.libvirt.Domain;
+import org.libvirt.LibvirtException;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class IscsiStorageCleanupMonitor implements Runnable{
+    private static final Logger s_logger = Logger.getLogger(IscsiStorageCleanupMonitor.class);
+    private static final int CLEANUP_INTERVAL_SEC = 60; // check every X seconds
+    private static final String ISCSI_PATH_PREFIX = "/dev/disk/by-path";
+    private static final String KEYWORD_ISCSI = "iscsi";
+    private static final String KEYWORD_IQN = "iqn";
+
+    private IscsiAdmStorageAdaptor iscsiStorageAdaptor;
+
+    private Map<String, Boolean> diskStatusMap;
+
+    public IscsiStorageCleanupMonitor() {
+        diskStatusMap = new HashMap<>();
+        s_logger.debug("Initialize cleanup thread");
+        iscsiStorageAdaptor = new IscsiAdmStorageAdaptor();
+    }
+
+
+    private class Monitor extends ManagedContextRunnable {
+
+        @Override
+        protected void runInContext() {
+            Connect conn = null;
+            try {
+                conn = LibvirtConnection.getConnection();
+
+                //populate all the iscsi disks currently attached to this host
+                diskStatusMap.clear();
+                File[] iscsiVolumes = new File(ISCSI_PATH_PREFIX).listFiles();
+
+                if (iscsiVolumes == null || iscsiVolumes.length == 0) {
+                    s_logger.debug("No iscsi sessions found for cleanup");
+                    return;
+                }
+
+                for( File v : iscsiVolumes) {
+                    if (isIscsiDisk(v.getAbsolutePath())) {
+                        s_logger.debug("found iscsi disk by cleanup thread, marking inactive:" + v.getAbsolutePath());
+                        diskStatusMap.put(v.getAbsolutePath(), false);
+                    }
+                }
+
+                // check if they belong to any VM
+                int[] domains = conn.listDomains();
+                s_logger.debug(String.format(" ********* FOUND %d DOMAINS ************", domains.length));
+                for (int domId : domains) {
+                    Domain dm = conn.domainLookupByID(domId);
+                    final String domXml = dm.getXMLDesc(0);
+                    final LibvirtDomainXMLParser parser = new LibvirtDomainXMLParser();
+                    parser.parseDomainXML(domXml);
+                    List<LibvirtVMDef.DiskDef> disks = parser.getDisks();
+
+                    //check the volume map. If an entry exists change the status to True
+                    for (final LibvirtVMDef.DiskDef disk : disks) {
+                        if (diskStatusMap.containsKey(disk.getDiskPath())) {
+                            diskStatusMap.put(disk.getDiskPath(), true);
+                            s_logger.debug("active disk found by cleanup thread" + disk.getDiskPath());
+                        }
+                    }
+                }
+
+                // the ones where the state is false, they are stale. They may be
+                // removed we go through each volume which is false, check iscsiadm,
+                // if the volume still exisits, logout of that volume and remove it from the map
+
+                // XXX: It is possible that someone had manually added an iSCSI volume.
+                // we would not be able to detect that
+                for (String diskPath : diskStatusMap.keySet()) {
+                    if (!diskStatusMap.get(diskPath)) {
+                        if (Files.exists(Paths.get(diskPath))) {
+                            try {
+                                s_logger.info("Cleaning up disk " + diskPath);
+                                iscsiStorageAdaptor.disconnectPhysicalDiskByPath(diskPath);
+                            } catch (Exception e) {
+                                s_logger.warn("[ignored] Error cleaning up " + diskPath, e);
+                            }
+                        }
+                        diskStatusMap.remove(diskPath);
+                    }
+                }
+
+            } catch (LibvirtException e) {
+                s_logger.warn("[ignored] Error tryong to cleanup ", e);
+            }
+        }
+
+        private boolean isIscsiDisk(String path) {
+            return path.startsWith(ISCSI_PATH_PREFIX) && path.contains(KEYWORD_ISCSI) && path.contains(KEYWORD_IQN);
+        }
+    }
+
+    @Override
+    public void run() {
+        while(true) {
+            try {
+                Thread.sleep(CLEANUP_INTERVAL_SEC * 1000);
+            } catch (InterruptedException e) {
+                s_logger.debug("[ignored] interupted between heartbeats.");
+            }
+
+            Thread monitorThread = new Thread(new Monitor());
+            monitorThread.start();
+            try {
+                monitorThread.join();
+            } catch (InterruptedException e) {
+                s_logger.debug("[ignored] interupted joining monitor.");
+            }
+        }
+    }
+}

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiStorageCleanupMonitor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiStorageCleanupMonitor.java
@@ -60,7 +60,7 @@ public class IscsiStorageCleanupMonitor implements Runnable{
 
                 // check if they belong to any VM
                 int[] domains = conn.listDomains();
-                s_logger.debug(String.format(" ********* FOUND %d DOMAINS ************", domains.length));
+                s_logger.debug(String.format("found %d domains", domains.length));
                 for (int domId : domains) {
                     Domain dm = conn.domainLookupByID(domId);
                     final String domXml = dm.getXMLDesc(0);
@@ -93,12 +93,11 @@ public class IscsiStorageCleanupMonitor implements Runnable{
                                 s_logger.warn("[ignored] Error cleaning up " + diskPath, e);
                             }
                         }
-                        diskStatusMap.remove(diskPath);
                     }
                 }
 
             } catch (LibvirtException e) {
-                s_logger.warn("[ignored] Error tryong to cleanup ", e);
+                s_logger.warn("[ignored] Error trying to cleanup ", e);
             }
         }
 

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiStorageCleanupMonitor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/IscsiStorageCleanupMonitor.java
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package com.cloud.hypervisor.kvm.storage;
 
 import com.cloud.hypervisor.kvm.resource.LibvirtConnection;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Previously, iscsi sessions would not be cleaned up on KVM when

* vms are crashed or rebooted on another host
* a hypervisor host crashed and ha enabled vms

This leads to to long boot times from the hypervisor host and session overloading of the netapp solidfire nodes. Each node can have a maximum of 700 iSCSI sessions. The iSCSI Daemon on the hypervisor host holds iSCSI sessions that are not cleaned up. The iSCSI Daemon tried to reconnect every time resulting in holding the unused sessions. Only a logout of the iSCSI daemon to the volume will solve the problem. This changes adds a kvm.storage.IscsiStorageCleanupMonitor class that scans for and cleans up inactive iscsi sessions.

steps to reproduce:

1. check there are a vm is running and sessions to Netapp Solidfire are there ```ìscsiadm -m session -P 0```
2. crash the kvm host (e.g. power off, be sure there are running vms on it) or destroy a virtual machine (```virsh destroy vmname```)
3. look with ```ìscsiadm -m session -P 0``` and you will see sessions they should not be there

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested by observing that inactive iscsi sessions are cleaned up when VMs are removed.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
