### PR TITLE
Incorrect param name caused global setting test to fail

### DIFF
--- a/test/integration/smoke/test_global_settings.py
+++ b/test/integration/smoke/test_global_settings.py
@@ -48,7 +48,7 @@ class TestUpdateConfigWithScope(cloudstackTestCase):
         self.debug("updated the parameter %s with value %s"%(updateConfigurationResponse.name, updateConfigurationResponse.value))
 
         listConfigurationsCmd = listConfigurations.listConfigurationsCmd()
-        listConfigurationsCmd.cfgName = updateConfigurationResponse.name
+        listConfigurationsCmd.name = updateConfigurationResponse.name
         listConfigurationsCmd.scopename = "zone"
         listConfigurationsCmd.scopeid = 1
         listConfigurationsResponse = self.apiClient.listConfigurations(listConfigurationsCmd)


### PR DESCRIPTION
Causes failure in travis. The incorrect param was returning no value back and causing test to fail.

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Ran the Marvin test locally on CentOS based monkeybox env and verified test failed without change and succeeded with change.
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
