### PR TITLE
set TCP as default protocol in lb list

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -3441,21 +3441,21 @@
                                                 isEditable: true,
                                                 select: function(args) {
                                                     var data = [{
-                                                            id: 'ssl',
-                                                            name: 'ssl',
-                                                            description: _l('label.lb.protocol.ssl')
-                                                        }, {
                                                             id: 'tcp',
                                                             name: 'tcp',
                                                             description: _l('label.lb.protocol.tcp')
+                                                        }, {
+                                                            id: 'udp',
+                                                            name: 'udp',
+                                                            description: _l('label.lb.protocol.udp')
                                                         }, {
                                                             id: 'tcp-proxy',
                                                             name: 'tcp-proxy',
                                                             description: _l('label.lb.protocol.tcp.proxy')
                                                         }, {
-                                                            id: 'udp',
-                                                            name: 'udp',
-                                                            description: _l('label.lb.protocol.udp')
+                                                            id: 'ssl',
+                                                            name: 'ssl',
+                                                            description: _l('label.lb.protocol.ssl')
                                                         }];
                                                     if (typeof args.context != 'undefined') {
                                                         var lbProtocols = getLBProtocols(args.context.networks[0]);


### PR DESCRIPTION
## Description
Instead of "SSL" being set as a default LB protocol when configuring a LB rule, set TCP as the default one - move SSL to the bottom of the list.

Reason: SSL is supported only with NetScaller and should not even be there if VPC is not using NetScaller for LB services... so stop offering it as the default protocol and confusing VPC VR (i.e. non-NesScaller) users

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Old setup:
![image](https://user-images.githubusercontent.com/45762285/72685903-d47fe380-3aee-11ea-8805-885f0d48550c.png)


New setup:
![image](https://user-images.githubusercontent.com/45762285/72685889-bc0fc900-3aee-11ea-8745-9a660deed581.png)

