### PR TITLE
fixed inconsistency of IP on VR when VR is destroyed and recrea…

### DIFF
--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2299,6 +2299,9 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
                         ipv6 = _ipv6Dao.findByNetworkIdAndIp(network.getId(), nic.getIPv6Address());
                     }
                     //return nic only when its ip address belong to the pod range (for the Basic zone case)
+                    if (vlans.isEmpty()) {
+                        return nic;
+                    }
                     for (Vlan vlan : vlans) {
                         if (ip != null && ip.getVlanId() == vlan.getId()) {
                             return nic;

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2298,7 +2298,7 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
                     } else {
                         ipv6 = _ipv6Dao.findByNetworkIdAndIp(network.getId(), nic.getIPv6Address());
                     }
-                    
+
                     if (vlans.isEmpty()) {
                         return nic;
                     }

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -2298,10 +2298,11 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
                     } else {
                         ipv6 = _ipv6Dao.findByNetworkIdAndIp(network.getId(), nic.getIPv6Address());
                     }
-                    //return nic only when its ip address belong to the pod range (for the Basic zone case)
+                    
                     if (vlans.isEmpty()) {
                         return nic;
                     }
+                    //return nic only when its ip address belong to the pod range (for the Basic zone case)
                     for (Vlan vlan : vlans) {
                         if (ip != null && ip.getVlanId() == vlan.getId()) {
                             return nic;


### PR DESCRIPTION
## Description
This address the issue mentioned in #3787  - Guest IP address of Shared Network VR is not persistent when VR is destroyed/recreated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
- Created a shared network
- Created a VM in the shared network
- destroyed the Virtual router 
- stopped and restarted the instance 
- the VR created will have the same Guest IP as it had previously

