### PR TITLE
Bug fix: De-associate IP address if enabling static nat fails

### DIFF
--- a/server/src/main/java/com/cloud/network/rules/RulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/rules/RulesManagerImpl.java
@@ -500,6 +500,7 @@ public class RulesManagerImpl extends ManagerBase implements RulesManager, Rules
                         s_logger.debug("The ip is not associated with the VPC network id=" + networkId + ", so assigning");
                         try {
                             ipAddress = _ipAddrMgr.associateIPToGuestNetwork(ipId, networkId, false);
+                            performedIpAssoc = true;
                         } catch (Exception ex) {
                             s_logger.warn("Failed to associate ip id=" + ipId + " to VPC network id=" + networkId + " as " + "a part of enable static nat");
                             return false;


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
Associating static NAT on IP to VM fails even though the IP is not allocated.
When we try enable static NAT on second IP address to the same VM, the operation fails but the IP address is still allocated in the db and it can't be used to enable static NAT on different VM.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Steps to reproduce the issue

(1) create a vpc (vpc-001) and a vpc tier (vpc-001-001)

(2) create a vm (vm-001-001) in vpc-001-001

(3) acquire a public ip (ip-1) and enable static nat to vm-001-001,
operation succeeds.

(4) acquire a second public ip (ip-2) and enable static nat to the same vm vm-001-001.
The operation fails but the ip is still assigned to vpc tier vpc-001-001.
Note down the ip address and the id of it.

(5) create another vpc vpc-002, vpc tier vpc-001-002, and vm (vm-001-002) in the second tier

(6) enable static NAT on second IP ip-2  to vm-001-002.

Expected Result:

Enabling static NAT on second IP to vm vm-001-002 should be success

Actual result:
Operation fails as the IP is still allocated to first vpc/tier


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
