### PR TITLE
Fix listing management server by parameters

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/management/ListMgmtsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/management/ListMgmtsCmd.java
@@ -22,7 +22,6 @@ import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.BaseListCmd;
 import org.apache.cloudstack.api.Parameter;
-import org.apache.cloudstack.api.response.HostResponse;
 import org.apache.cloudstack.api.response.ListResponse;
 import org.apache.cloudstack.api.response.ManagementServerResponse;
 import org.apache.log4j.Logger;
@@ -38,7 +37,7 @@ public class ListMgmtsCmd extends BaseListCmd {
     //////////////// API parameters /////////////////////
     /////////////////////////////////////////////////////
 
-    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = HostResponse.class, description = "the id of the management server")
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = ManagementServerResponse.class, description = "the id of the management server")
     private Long id;
 
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "the name of the management server")

--- a/api/src/main/java/org/apache/cloudstack/management/ManagementServerHost.java
+++ b/api/src/main/java/org/apache/cloudstack/management/ManagementServerHost.java
@@ -16,14 +16,13 @@
 // under the License.
 package org.apache.cloudstack.management;
 
-public interface ManagementServerHost {
+import org.apache.cloudstack.api.Identity;
+import org.apache.cloudstack.api.InternalIdentity;
+
+public interface ManagementServerHost extends InternalIdentity, Identity {
     enum State {
         Up, Down
     }
-
-    long getId();
-
-    String getUuid();
 
     long getMsid();
 

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3835,10 +3835,10 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         Pair<List<ManagementServerHostVO>, Integer> result = listManagementServersInternal(cmd);
         List<ManagementServerResponse> hostResponses = new ArrayList<>();
 
-        for(ManagementServerHostVO host : result.first()) {
+        for (ManagementServerHostVO host : result.first()) {
             ManagementServerResponse hostResponse = createManagementServerResponse(host);
             hostResponses.add(hostResponse);
-         }
+        }
 
         response.setResponses(hostResponses);
         return response;
@@ -3850,10 +3850,10 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
 
         SearchBuilder<ManagementServerHostVO> sb = managementServerHostDao.createSearchBuilder();
         SearchCriteria<ManagementServerHostVO> sc = sb.create();
-        if(id != null) {
+        if (id != null) {
             sc.addAnd("id", SearchCriteria.Op.EQ, id);
         }
-        if(name != null) {
+        if (name != null) {
             sc.addAnd("name", SearchCriteria.Op.EQ, name);
         }
         return managementServerHostDao.searchAndCount(sc, null);

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3832,18 +3832,41 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
     @Override
     public ListResponse<ManagementServerResponse> listManagementServers(ListMgmtsCmd cmd) {
         ListResponse<ManagementServerResponse> response = new ListResponse<>();
-        List<ManagementServerResponse> result = new ArrayList<>();
-        for (ManagementServerHostVO mgmt : managementServerHostDao.listAll()) {
-            ManagementServerResponse mgmtResponse = new ManagementServerResponse();
-            mgmtResponse.setId(mgmt.getUuid());
-            mgmtResponse.setName(mgmt.getName());
-            mgmtResponse.setState(mgmt.getState());
-            mgmtResponse.setVersion(mgmt.getVersion());
-            mgmtResponse.setObjectName("managementserver");
-            result.add(mgmtResponse);
-        }
-        response.setResponses(result);
+        Pair<List<ManagementServerHostVO>, Integer> result = listManagementServersInternal(cmd);
+        List<ManagementServerResponse> hostResponses = new ArrayList<>();
+
+        for(ManagementServerHostVO host : result.first()) {
+            ManagementServerResponse hostResponse = createManagementServerResponse(host);
+            hostResponses.add(hostResponse);
+         }
+
+        response.setResponses(hostResponses);
         return response;
+    }
+
+    protected Pair<List<ManagementServerHostVO>, Integer> listManagementServersInternal(ListMgmtsCmd cmd) {
+        Long id = cmd.getId();
+        String name = cmd.getHostName();
+
+        SearchBuilder<ManagementServerHostVO> sb = managementServerHostDao.createSearchBuilder();
+        SearchCriteria<ManagementServerHostVO> sc = sb.create();
+        if(id != null) {
+            sc.addAnd("id", SearchCriteria.Op.EQ, id);
+        }
+        if(name != null) {
+            sc.addAnd("name", SearchCriteria.Op.EQ, name);
+        }
+        return managementServerHostDao.searchAndCount(sc, null);
+    }
+
+    protected ManagementServerResponse createManagementServerResponse(ManagementServerHostVO mgmt) {
+        ManagementServerResponse mgmtResponse = new ManagementServerResponse();
+        mgmtResponse.setId(mgmt.getUuid());
+        mgmtResponse.setName(mgmt.getName());
+        mgmtResponse.setState(mgmt.getState());
+        mgmtResponse.setVersion(mgmt.getVersion());
+        mgmtResponse.setObjectName("managementserver");
+        return mgmtResponse;
     }
 
     @Override


### PR DESCRIPTION
## Description
The List Management Server api returns a list of all the management servers but fails when trying to list by id or name. This ensures that it fetches the details as per the parameters passed.
Fixes: #3833

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Verified by testing the api with and without parameters

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
