### PR TITLE
travis: use https based maven repo mirror

### DIFF
--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -89,7 +89,7 @@ echo "<settings>
   <mirrors>
     <mirror>
       <id>Central</id>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <mirrorOf>central</mirrorOf>
       <!-- United States, St. Louis-->
     </mirror>


### PR DESCRIPTION
Travis has been failing lately as it requires that repositories use
https:// URLs.

Reference:
https://blog.sonatype.com/central-repository-moving-to-https

Without this fix all PRs are blocked from testing for 4.11+ branches.