### PR TITLE
Fix for "Impossible to edit domain settings in UI"

### DIFF
--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -1789,6 +1789,11 @@ div.list-view td.state.notsuitable-storage-migration-required span {
   overflow-x: hidden;
 }
 
+div#details-tab-settings.detail-group.ui-tabs-panel {
+  overflow: hidden;
+  overflow-x: scroll;
+}
+
 .detail-view .main-groups {
   width: 100%;
   max-height: 407px;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This pull request adds a scroll bar to the domain settings page that will allow a user to scroll to the right to change settings.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3032
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
From the UI click on domain and then navigate to the settings tab. You are now able to scroll right to change the settings.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
