### PR TITLE
vpc: set traffic type of private gateway IP to Public to fix keepalived misconfiguration

### DIFF
--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/VpcGatewayDao.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/VpcGatewayDao.java
@@ -32,4 +32,6 @@ public interface VpcGatewayDao extends GenericDao<VpcGatewayVO, Long> {
     List<VpcGatewayVO> listByAclIdAndType(long aclId, VpcGateway.Type type);
 
     List<VpcGatewayVO> listByVpcId(long vpcId);
+
+    VpcGatewayVO getVpcGatewayByNetworkId(long networkId);
 }

--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/VpcGatewayDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/VpcGatewayDaoImpl.java
@@ -89,4 +89,11 @@ public class VpcGatewayDaoImpl extends GenericDaoBase<VpcGatewayVO, Long> implem
         sc.setParameters("vpcId", vpcId);
         return listBy(sc);
     }
+
+    @Override
+    public VpcGatewayVO getVpcGatewayByNetworkId(long networkId) {
+        SearchCriteria<VpcGatewayVO> sc = AllFieldsSearch.create();
+        sc.setParameters("networkid", networkId);
+        return findOneBy(sc);
+    }
 }

--- a/server/src/main/java/com/cloud/network/NetworkModelImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkModelImpl.java
@@ -94,7 +94,9 @@ import com.cloud.network.element.UserDataServiceProvider;
 import com.cloud.network.rules.FirewallRule.Purpose;
 import com.cloud.network.rules.FirewallRuleVO;
 import com.cloud.network.rules.dao.PortForwardingRulesDao;
+import com.cloud.network.vpc.VpcGatewayVO;
 import com.cloud.network.vpc.dao.PrivateIpDao;
+import com.cloud.network.vpc.dao.VpcGatewayDao;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offering.NetworkOffering.Detail;
 import com.cloud.offerings.NetworkOfferingServiceMapVO;
@@ -158,6 +160,8 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
     NicDao _nicDao = null;
     @Inject
     PodVlanMapDao _podVlanMapDao;
+    @Inject
+    VpcGatewayDao _vpcGatewayDao;
 
     private List<NetworkElement> networkElements;
 
@@ -1780,8 +1784,8 @@ public class NetworkModelImpl extends ManagerBase implements NetworkModel, Confi
 
     @Override
     public boolean isPrivateGateway(long ntwkId) {
-        Network network = getNetwork(ntwkId);
-        if (network.getTrafficType() != TrafficType.Guest || network.getNetworkOfferingId() != s_privateOfferingId.longValue()) {
+        final VpcGatewayVO gateway = _vpcGatewayDao.getVpcGatewayByNetworkId(ntwkId);
+        if (gateway == null) {
             return false;
         }
         return true;

--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -1109,7 +1109,7 @@ public class CommandSetupHelper {
     private TrafficType getNetworkTrafficType(Network network) {
         final VpcGatewayVO gateway = _vpcGatewayDao.getVpcGatewayByNetworkId(network.getId());
         if (gateway != null) {
-            s_logger.debug("network " + network.getId() + " is a vpc private gateway, set traffic type to Public");
+            s_logger.debug("network " + network.getId() + " (name: " + network.getName() + " ) is a vpc private gateway, set traffic type to Public");
             return TrafficType.Public;
         } else {
             return network.getTrafficType();

--- a/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
+++ b/server/src/main/java/com/cloud/network/router/CommandSetupHelper.java
@@ -104,7 +104,9 @@ import com.cloud.network.vpc.PrivateIpAddress;
 import com.cloud.network.vpc.StaticRouteProfile;
 import com.cloud.network.vpc.Vpc;
 import com.cloud.network.vpc.VpcGateway;
+import com.cloud.network.vpc.VpcGatewayVO;
 import com.cloud.network.vpc.dao.VpcDao;
+import com.cloud.network.vpc.dao.VpcGatewayDao;
 import com.cloud.offering.NetworkOffering;
 import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
@@ -169,6 +171,8 @@ public class CommandSetupHelper {
     private Site2SiteVpnGatewayDao _s2sVpnGatewayDao;
     @Inject
     private VpcDao _vpcDao;
+    @Inject
+    private VpcGatewayDao _vpcGatewayDao;
     @Inject
     private VlanDao _vlanDao;
     @Inject
@@ -707,7 +711,7 @@ public class CommandSetupHelper {
                 final IpAddressTO ip = new IpAddressTO(ipAddr.getAccountId(), ipAddr.getAddress().addr(), add, firstIP, sourceNat, BroadcastDomainType.fromString(ipAddr.getVlanTag()).toString(), ipAddr.getGateway(),
                         ipAddr.getNetmask(), macAddress, networkRate, ipAddr.isOneToOneNat());
 
-                ip.setTrafficType(network.getTrafficType());
+                ip.setTrafficType(getNetworkTrafficType(network));
                 ip.setNetworkName(_networkModel.getNetworkTag(router.getHypervisorType(), network));
                 ipsToSend[i++] = ip;
                 if (ipAddr.isSourceNat()) {
@@ -823,7 +827,7 @@ public class CommandSetupHelper {
                 final IpAddressTO ip = new IpAddressTO(ipAddr.getAccountId(), ipAddr.getAddress().addr(), add, firstIP, sourceNat, vlanId, vlanGateway, vlanNetmask,
                         vifMacAddress, networkRate, ipAddr.isOneToOneNat());
 
-                ip.setTrafficType(network.getTrafficType());
+                ip.setTrafficType(getNetworkTrafficType(network));
                 ip.setNetworkName(_networkModel.getNetworkTag(router.getHypervisorType(), network));
                 ipsToSend[i++] = ip;
                 /*
@@ -948,7 +952,7 @@ public class CommandSetupHelper {
                 final IpAddressTO ip = new IpAddressTO(Account.ACCOUNT_ID_SYSTEM, ipAddr.getIpAddress(), add, false, ipAddr.getSourceNat(), ipAddr.getBroadcastUri(),
                         ipAddr.getGateway(), ipAddr.getNetmask(), ipAddr.getMacAddress(), null, false);
 
-                ip.setTrafficType(network.getTrafficType());
+                ip.setTrafficType(getNetworkTrafficType(network));
                 ip.setNetworkName(_networkModel.getNetworkTag(router.getHypervisorType(), network));
                 ipsToSend[i++] = ip;
 
@@ -1100,5 +1104,15 @@ public class CommandSetupHelper {
             }
         }
         return dhcpRange;
+    }
+
+    private TrafficType getNetworkTrafficType(Network network) {
+        final VpcGatewayVO gateway = _vpcGatewayDao.getVpcGatewayByNetworkId(network.getId());
+        if (gateway != null) {
+            s_logger.debug("network " + network.getId() + " is a vpc private gateway, set traffic type to Public");
+            return TrafficType.Public;
+        } else {
+            return network.getTrafficType();
+        }
     }
 }


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

In VPC, the private gateway has traffic type as Guest not Public.
This leads to keepalived misconfiguration in VPC with redundant VRs.

There are some commits (eg 65cb22216aa1d5d6257f99d4ad84f80c319cdea9 and f4f9b3ab4ef2ef34e4d8a04c6ebfbf0784497227) for this issue, however the issue still exists in 4.13 and 4.14.

Simply setting the traffic type of ip address (of private gateway) to Public fixes the issue.

Fixes: #3402 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Before change,

In VPC master VR (redundant), IP of private gateway is added in keepalived, and gateway of private gateway is also added to ethX which is obviously wrong. 
nw_type of ethX is 'guest' in /etc/cloudstack/ips.json

```
root@r-181-VM:~# grep virtual_ipaddress /etc/keepalived/keepalived.conf -A5
    virtual_ipaddress {
        10.11.112.254/24 brd 10.11.112.255 dev eth6
        192.168.0.2/27 brd 192.168.0.31 dev eth5
        192.168.0.129/26 brd 192.168.0.191 dev eth4
        192.168.0.65/26 brd 192.168.0.127 dev eth3
    }

8: eth6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 1e:00:65:00:01:ef brd ff:ff:ff:ff:ff:ff
    inet 10.11.112.10/24 brd 10.11.112.255 scope global eth6
       valid_lft forever preferred_lft forever
    inet 10.11.112.254/24 brd 10.11.112.255 scope global secondary eth6
       valid_lft forever preferred_lft forever

  "eth6": [
    {
      "add": true,
      "broadcast": "10.11.112.255",
      "cidr": "10.11.112.10/24",
      "device": "eth6",
      "first_i_p": false,
      "gateway": "10.11.112.254",
      "netmask": "255.255.255.0",
      "network": "10.11.112.0/24",
      "new_nic": false,
      "nic_dev_id": 6,
      "nw_type": "guest",
      "one_to_one_nat": false,
      "public_ip": "10.11.112.10",
      "size": "24",
      "source_nat": false,
      "vif_mac_address": "1e:00:65:00:01:ef"
    }
  ],
```

After change, private gateway IP is not added in keepalived, gateway is not added to ethX. 
nw_type of ethX is 'public' in /etc/cloudstack/ips.json
```
root@r-187-VM:~# grep virtual_ipaddress /etc/keepalived/keepalived.conf -A5
    virtual_ipaddress {
        192.168.0.2/27 brd 192.168.0.31 dev eth5
        192.168.0.129/26 brd 192.168.0.191 dev eth4
        192.168.0.65/26 brd 192.168.0.127 dev eth3
    }


8: eth6: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 1e:00:f2:00:01:ef brd ff:ff:ff:ff:ff:ff
    inet 10.11.112.10/24 brd 10.11.112.255 scope global eth6
       valid_lft forever preferred_lft forever


  "eth6": [
    {
      "add": true,
      "broadcast": "10.11.112.255",
      "cidr": "10.11.112.10/24",
      "device": "eth6",
      "first_i_p": false,
      "gateway": "10.11.112.254",
      "netmask": "255.255.255.0",
      "network": "10.11.112.0/24",
      "new_nic": false,
      "nic_dev_id": 6,
      "nw_type": "public",
      "one_to_one_nat": false,
      "public_ip": "10.11.112.10",
      "size": "24",
      "source_nat": false,
      "vif_mac_address": "1e:00:f2:00:01:ef"
    }
  ],
```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
