### PR TITLE
kvm: Fix router migration issue when router has control/public nics onother physical network than guest

### DIFF
--- a/agent/bindir/libvirtqemuhook.in
+++ b/agent/bindir/libvirtqemuhook.in
@@ -65,11 +65,15 @@ def handleMigrateBegin():
             bridge = source.getAttribute("bridge")
             if isOldStyleBridge(bridge):
                 vlanId = bridge.replace("cloudVirBr", "")
+                phyDev = getGuestNetworkDevice()
             elif isNewStyleBridge(bridge):
                 vlanId = re.sub(r"br(\w+)-", "", bridge)
+                phyDev = re.sub(r"-(\d+)$", "" , re.sub(r"^br", "" ,bridge))
+                netlib = networkConfig()
+                if not netlib.isNetworkDev(phyDev):
+                    phyDev = getGuestNetworkDevice()
             else:
                 continue
-            phyDev = getGuestNetworkDevice()
             newBrName = "br" + phyDev + "-" + vlanId
             source.setAttribute("bridge", newBrName)
         print(domain.toxml())


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

In VM migration on KVM, libvirt qemu hook script will change the bridge name to bridges for guest networks. It works for user vm. However for virtual router, it has nics on control network and public network. If control/public use different physical networks than guest network, virtual router cannot be migrated.

Fixes: #2783 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

We have more than 1 physical networks and faced same issue before.
We have this change to fix the issue in old cloudstack versions. 
I did not test in latest master or 4.13 but I believe it should work as well.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
