### PR TITLE
vr: add missing rule for port forwarding rule in vpc

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -793,6 +793,12 @@ class CsForwardingRules(CsDataBag):
 
         return None
 
+    def getGuestIpByIp(self, ipa):
+        for interface in self.config.address().get_interfaces():
+            if interface.ip_in_subnet(ipa):
+                return interface.get_ip()
+        return None
+
     def getDeviceByIp(self, ipa):
         for interface in self.config.address().get_interfaces():
             if interface.ip_in_subnet(ipa):
@@ -930,8 +936,20 @@ class CsForwardingRules(CsDataBag):
         if not rule["internal_ports"] == "any":
             fw_output_rule += ":" + self.portsToString(rule["internal_ports"], "-")
 
+        fw_postrout_rule2 = "-j SNAT --to-source %s -A POSTROUTING -s %s -d %s/32 -o %s -p %s -m %s --dport %s" % \
+              (
+                self.getGuestIpByIp(rule['internal_ip']),
+                self.getNetworkByIp(rule['internal_ip']),
+                rule['internal_ip'],
+                self.getDeviceByIp(rule['internal_ip']),
+                rule['protocol'],
+                rule['protocol'],
+                self.portsToString(rule['internal_ports'], ':')
+              )
+
         self.fw.append(["nat", "", fw_prerout_rule])
         self.fw.append(["nat", "", fw_postrout_rule])
+        self.fw.append(["nat", "", fw_postrout_rule2])
         self.fw.append(["nat", "", fw_output_rule])
 
     def processStaticNatRule(self, rule):

--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -937,7 +937,7 @@ class CsForwardingRules(CsDataBag):
             fw_output_rule += ":" + self.portsToString(rule["internal_ports"], "-")
 
         fw_postrout_rule2 = "-j SNAT --to-source %s -A POSTROUTING -s %s -d %s/32 -o %s -p %s -m %s --dport %s" % \
-              (
+            (
                 self.getGuestIpByIp(rule['internal_ip']),
                 self.getNetworkByIp(rule['internal_ip']),
                 rule['internal_ip'],
@@ -945,7 +945,7 @@ class CsForwardingRules(CsDataBag):
                 rule['protocol'],
                 rule['protocol'],
                 self.portsToString(rule['internal_ports'], ':')
-              )
+            )
 
         self.fw.append(["nat", "", fw_prerout_rule])
         self.fw.append(["nat", "", fw_postrout_rule])


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When create a port forwarding rule to a vm in vpc, we cannot access the port forwarding rule from inside the vm.

Steps to reproduce
(1) create a port forwarding rule in VPC, public ip X.X.X.X to vm Y.Y.Y.Y port 22
(2) ssh to vm, or login vm console
(3) in vm, ssh X.X.X.X does not work.

Fixes: #3763

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

with this change, the public Ip is reachable from inside vm in step (3) above.
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
