### PR TITLE
Start all (instead of Disconnected) Site-to-Site VPN connections when VPC VR starts

### DIFF
--- a/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -154,6 +154,8 @@ public class NetworkHelperImpl implements NetworkHelper {
     protected IpAddressManager _ipAddrMgr;
     @Inject
     ConfigurationDao _configDao;
+    @Inject
+    VpcVirtualNetworkApplianceManager _vpcRouterMgr;
 
     protected final Map<HypervisorType, ConfigKey<String>> hypervisorsMap = new HashMap<>();
 
@@ -288,7 +290,7 @@ public class NetworkHelperImpl implements NetworkHelper {
         // only after router start successfully
         final Long vpcId = router.getVpcId();
         if (vpcId != null) {
-            _s2sVpnMgr.reconnectDisconnectedVpnByVpc(vpcId);
+            _vpcRouterMgr.startSite2SiteVpn(_routerDao.findById(router.getId()));
         }
         return _routerDao.findById(router.getId());
     }

--- a/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManager.java
+++ b/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManager.java
@@ -74,4 +74,11 @@ public interface VpcVirtualNetworkApplianceManager extends VirtualNetworkApplian
      * @throws ResourceUnavailableException
      */
     boolean stopRemoteAccessVpn(RemoteAccessVpn vpn, VirtualRouter router) throws ResourceUnavailableException;
+
+    /**
+     * @param router
+     * @return
+     * @throws ResourceUnavailableException
+     */
+    boolean startSite2SiteVpn(DomainRouterVO router) throws ResourceUnavailableException;
 }

--- a/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -66,6 +66,7 @@ import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.MonitoringServiceVO;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.dao.RemoteAccessVpnVO;
+import com.cloud.network.dao.Site2SiteVpnConnectionVO;
 import com.cloud.network.vpc.NetworkACLItemDao;
 import com.cloud.network.vpc.NetworkACLItemVO;
 import com.cloud.network.vpc.NetworkACLManager;
@@ -654,6 +655,17 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
         }
 
         return applySite2SiteVpn(true, router, conn);
+    }
+
+    @Override
+    public boolean startSite2SiteVpn(DomainRouterVO router) throws ResourceUnavailableException {
+        boolean result = true;
+        List<Site2SiteVpnConnectionVO> conns = _s2sVpnMgr.getConnectionsForRouter(router);
+        for (Site2SiteVpnConnectionVO conn : conns) {
+            result = result && startSite2SiteVpn(conn, router);
+        }
+
+        return result;
     }
 
     @Override

--- a/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
+++ b/server/src/test/java/com/cloud/vpc/MockVpcVirtualNetworkApplianceManager.java
@@ -274,4 +274,10 @@ public class MockVpcVirtualNetworkApplianceManager extends ManagerBase implement
         // TODO Auto-generated method stub
         return false;
     }
+
+    @Override
+    public boolean startSite2SiteVpn(DomainRouterVO router) throws ResourceUnavailableException {
+        // TODO Auto-generated method stub
+        return false;
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When we restart the VPC after destroying the master VR, the backup VR
becomes the master and the site to site connections are not in
the connected state. The passive VPN connection will be in the connected
state but the active VPN connection will be in a disconnected state

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Steps to reproduce the issue

1 . Create two VPC's. Configure VPN customer gateway and VPN connection. The steps are clearly explained in [here](https://docs.cloudstack.apache.org/projects/cloudstack-administration/en/4.8/networking/site_to_site_vpn.html#site-to-site-vpn-connection-between-vpc-networks)
2 . Once everything is setup properly make sure that the VPN state is "Connected" in both VPC.
3 . Now navigate to "Infrastructure" → "Virtual Routers"
4 . Search for the routers which belong to one of the VPC created above
5 . Now stop the Backup router and eventually destroy it. It is important that you stop/destroy the Backup router and not the Master router
6 . Now navigate to "Networks" → Select "VPC" in the select view drop down menu and select the VPC for which the virtual router has been destroyed.
7 . Now restart the VPC without cleanup. This will create a new backup VR.
8 . Once the backup vr is created, stop/destroy the master router. The steps are similar to destroying the backup router
9 . Again navigate to Networks → vpc and restart the VPC without cleanup. The initial backup router will become the master and a new backup router will be created
10 . Now check the status of the VPN connection


Expected result:

Both the active and passive VPN connections should be in "Connected" state.


Actual result:

Passive VPN was in Connected state and the active VPN was in Disconnected state
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
