### PR TITLE
Ignore site to site vpn status check on internallbvm

### DIFF
--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -840,6 +840,10 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     @DB
     protected void updateSite2SiteVpnConnectionState(final List<DomainRouterVO> routers) {
         for (final DomainRouterVO router : routers) {
+            if (router.getRole() == Role.INTERNAL_LB_VM) {
+                continue;
+            }
+
             final List<Site2SiteVpnConnectionVO> conns = _s2sVpnMgr.getConnectionsForRouter(router);
             if (conns == null || conns.isEmpty()) {
                 continue;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When the state of the site to site vpn changes, the check
is done on all the virtual routers including the internal
load balancing vm as well. It is not needed to check the
state for internal load balancing vm

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Steps to reprodcue the issue

1 . Create two VPC's. Configure VPN customer gateway and VPN connection. The steps are clearly explained [here](https://docs.cloudstack.apache.org/projects/cloudstack-administration/en/4.8/networking/site_to_site_vpn.html#site-to-site-vpn-connection-between-vpc-networks)
2 . Now navigate to networks section in main cloudstack ui. In the drop down menu select VPC. Click configure on one of the VPC
3 . Click on "Create Network" and create a tier with "DefaultisolatedNetworkOfferingForVPCNetworksWithInternalLB" network offering
4 . Once the tier is created click on "Internal LB" tab.
5 . In the right side, click on "Add Internal LB" button
6 . Enter the input according to your needs and press OK
7 . Once the Internal LB is created, click on it and select the "Assigned VM's" tab.
8 . Click on "Assign VM's" button and select the VM's which are present in this tier. If none are present then create vm's.
9 . This will create a new type of router "internallb" which can be listed using the cloudmonkey command "list internalloadbalancervms" whose name starts with b-
10 . Change the state of any VPN connection in this VPC and observe the logs for the keyword "Site-to-site Vpn Connection to <VPN gw name> on router b-<>-VM"

Expected result:

A log mesasge mentioned in the step 10 will be displayed in /var/log/cloudstack/management/management-server.log


Actual result:

The above log should not be displayed.
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
