### PR TITLE
Fixed default text missing from network selection on instance wizard

### DIFF
--- a/ui/scripts/ui-custom/instanceWizard.js
+++ b/ui/scripts/ui-custom/instanceWizard.js
@@ -330,9 +330,8 @@
                                             .attr('checked', false);
                                     }
                                 })
-                                .after(
-                                    $('<div>').addClass('name').html(options.secondary.desc)
-                                )
+                            ).append(
+                                $('<div>').addClass('name').html(options.secondary.desc)
                             ).appendTo($select);
                         }
                     });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the missing "Default" display issue on the instance wizard when selecting a network.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3633 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![default](https://user-images.githubusercontent.com/49917670/73828979-de058d00-480a-11ea-8bb5-ae4ee2aa66d4.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested from the UI. First make sure that there are some available networks. 
From the create instance wizard, complete all the steps until the network page. The text next to the radio button will read "Default".

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
