### PR TITLE
Usage event to store zone id while uploading template and volume

### DIFF
--- a/server/src/main/java/com/cloud/storage/ImageStoreUploadMonitorImpl.java
+++ b/server/src/main/java/com/cloud/storage/ImageStoreUploadMonitorImpl.java
@@ -55,6 +55,8 @@ import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.StartupCommand;
 import com.cloud.alert.AlertManager;
+import com.cloud.api.query.dao.TemplateJoinDao;
+import com.cloud.api.query.vo.TemplateJoinVO;
 import com.cloud.configuration.Resource;
 import com.cloud.event.EventTypes;
 import com.cloud.event.UsageEventUtils;
@@ -111,6 +113,8 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
     private TemplateDataFactory templateFactory;
     @Inject
     private TemplateService templateService;
+    @Inject
+    private TemplateJoinDao templateJoinDao;
 
     private long _nodeId;
     private ScheduledExecutorService _executor = null;
@@ -322,7 +326,7 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
 
                             // publish usage events
                             UsageEventUtils.publishUsageEvent(EventTypes.EVENT_VOLUME_UPLOAD, tmpVolume.getAccountId(),
-                                    tmpVolumeDataStore.getDataStoreId(), tmpVolume.getId(), tmpVolume.getName(),
+                                    tmpVolume.getDataCenterId(), tmpVolume.getId(), tmpVolume.getName(),
                                     null, null, tmpVolumeDataStore.getPhysicalSize(), tmpVolumeDataStore.getSize(),
                                     Volume.class.getName(), tmpVolume.getUuid());
 
@@ -425,7 +429,9 @@ public class ImageStoreUploadMonitorImpl extends ManagerBase implements ImageSto
                             if (tmpTemplate.getFormat() == Storage.ImageFormat.ISO) {
                                 etype = EventTypes.EVENT_ISO_CREATE;
                             }
-                            UsageEventUtils.publishUsageEvent(etype, tmpTemplate.getAccountId(), tmpTemplateDataStore.getDataStoreId(), tmpTemplate.getId(), tmpTemplate.getName(), null, null,
+                            TemplateJoinVO vo = templateJoinDao.findById(tmpTemplate.getId());
+                            assert (vo != null) : "Couldn't find the template view for given template ID";
+                            UsageEventUtils.publishUsageEvent(etype, tmpTemplate.getAccountId(), vo.getDataCenterId(), tmpTemplate.getId(), tmpTemplate.getName(), null, null,
                                     tmpTemplateDataStore.getPhysicalSize(), tmpTemplateDataStore.getSize(), VirtualMachineTemplate.class.getName(), tmpTemplate.getUuid());
 
                             if (s_logger.isDebugEnabled()) {


### PR DESCRIPTION
## Description
After a local template is uploaded via browser, the generated usage event with type = "TEMPLATE.CREATE" is persisted with the data store ID instead of the zone ID on the zone_id column. The fix will refactor the upload monitor logic, as after the upload completes, it sets the datastore ID on the zone ID column for the created "TEMPLATE.CREATE" usage event. This refactor will query the DB for the data store and will set its associated zone ID in the usage field.
The fix produces the same behaviour as when registering a template from URL.
FIx is also for uploading VOLUME from local/via browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

