### PR TITLE
Fixed root volume resize from ui

### DIFF
--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -1575,7 +1575,7 @@
                                     if (newDiskOffering != null && newDiskOffering.length > 0) {
                                         array1.push("&diskofferingid=" + encodeURIComponent(newDiskOffering));
                                     }
-                                    if ((args.context.volumes[0].type == "ROOT" || selectedDiskOfferingObj.iscustomized == true) {
+                                    if (args.context.volumes[0].type == "ROOT" || selectedDiskOfferingObj.iscustomized == true) {
                                         cloudStack.addNewSizeToCommandUrlParameterArrayIfItIsNotNullAndHigherThanZero(array1, args.data.newsize);
                                     }
 

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -1575,7 +1575,7 @@
                                     if (newDiskOffering != null && newDiskOffering.length > 0) {
                                         array1.push("&diskofferingid=" + encodeURIComponent(newDiskOffering));
                                     }
-                                    if (selectedDiskOfferingObj != null && selectedDiskOfferingObj.iscustomized == true) {
+                                    if (selectedDiskOfferingObj == null || selectedDiskOfferingObj.iscustomized == true) {
                                         cloudStack.addNewSizeToCommandUrlParameterArrayIfItIsNotNullAndHigherThanZero(array1, args.data.newsize);
                                     }
 
@@ -1593,12 +1593,10 @@
                                     if (maxIops != null && maxIops.length > 0) {
                                         array1.push("&maxiops=" + encodeURIComponent(maxIops));
                                     }
-                                    //if original disk size  > new disk size
-                                    if (args.context.volumes[0].type == "ROOT"){
-                                        if (args.context.volumes[0].size > (args.data.newsize * (1024 * 1024 * 1024))) {
-                                            return args.response.error('message.volume.root.shrink.disk.size');
-                                        }
-                                        array1.push("&size="+args.data.newsize);
+                                    //if original disk size > new disk size
+                                    if (args.context.volumes[0].type == "ROOT" &&
+                                        args.context.volumes[0].size > (args.data.newsize * (1024 * 1024 * 1024))) {
+                                        return args.response.error('message.volume.root.shrink.disk.size');
                                     }
 
                                     $.ajax({

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -1594,11 +1594,12 @@
                                         array1.push("&maxiops=" + encodeURIComponent(maxIops));
                                     }
                                     //if original disk size  > new disk size
-                                    if ((args.context.volumes[0].type == "ROOT")
-                                    && (args.context.volumes[0].size > (newSize * (1024 * 1024 * 1024)))) {
-                                        return args.response.error('message.volume.root.shrink.disk.size');
+                                    if (args.context.volumes[0].type == "ROOT"){
+                                        if (args.context.volumes[0].size > (args.data.newsize * (1024 * 1024 * 1024))) {
+                                            return args.response.error('message.volume.root.shrink.disk.size');
+                                        }
+                                        array1.push("&size="+args.data.newsize);
                                     }
-
 
                                     $.ajax({
                                         url: createURL("resizeVolume&id=" + args.context.volumes[0].id + array1.join("")),

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -1575,13 +1575,13 @@
                                     if (newDiskOffering != null && newDiskOffering.length > 0) {
                                         array1.push("&diskofferingid=" + encodeURIComponent(newDiskOffering));
                                     }
-                                    if (selectedDiskOfferingObj.iscustomized == true) {
+                                    if (selectedDiskOfferingObj != null && selectedDiskOfferingObj.iscustomized == true) {
                                         cloudStack.addNewSizeToCommandUrlParameterArrayIfItIsNotNullAndHigherThanZero(array1, args.data.newsize);
                                     }
 
                                     var minIops;
                                     var maxIops
-                                    if (selectedDiskOfferingObj.iscustomizediops == true) {
+                                    if (selectedDiskOfferingObj != null && selectedDiskOfferingObj.iscustomizediops == true) {
                                         minIops = args.data.minIops;
                                         maxIops = args.data.maxIops;
                                     }

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -1575,7 +1575,7 @@
                                     if (newDiskOffering != null && newDiskOffering.length > 0) {
                                         array1.push("&diskofferingid=" + encodeURIComponent(newDiskOffering));
                                     }
-                                    if (selectedDiskOfferingObj == null || selectedDiskOfferingObj.iscustomized == true) {
+                                    if ((args.context.volumes[0].type == "ROOT" || selectedDiskOfferingObj.iscustomized == true) {
                                         cloudStack.addNewSizeToCommandUrlParameterArrayIfItIsNotNullAndHigherThanZero(array1, args.data.newsize);
                                     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes the volume resize action for a root volume from the UI.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3860 #3874
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![volume resize](https://user-images.githubusercontent.com/49917670/74026699-60c74d00-49af-11ea-83e4-f4a20a491717.png)
## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested by creating an instance and resizing the root volume. The root volume size is then verified in storage metrics.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
