### PR TITLE
server: use host record related to a ssvm/cpvm

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/SystemVmResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SystemVmResponse.java
@@ -154,9 +154,9 @@ public class SystemVmResponse extends BaseResponse {
     @Param(description = "public vlan range")
     private List<String> publicVlan;
 
-    @SerializedName("lastpinged")
-    @Param(description = "the date and time the host was last pinged", since = "4.13.1")
-    private Date lastPinged;
+    @SerializedName("disconnected")
+    @Param(description = "the last disconnected date of host", since = "4.13.1")
+    private Date disconnectedOn;
 
     @SerializedName("version")
     @Param(description = "the systemvm agent version", since = "4.13.1")
@@ -403,12 +403,12 @@ public class SystemVmResponse extends BaseResponse {
         this.publicVlan = publicVlan;
     }
 
-    public Date getLastPinged() {
-        return lastPinged;
+    public Date getDisconnectedOn() {
+        return disconnectedOn;
     }
 
-    public void setLastPinged(Date lastPinged) {
-        this.lastPinged = lastPinged;
+    public void setDisconnectedOn(Date disconnectedOn) {
+        this.disconnectedOn = disconnectedOn;
     }
 
     public String getVersion() {

--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -1039,6 +1039,10 @@ public class ApiDBUtils {
         return s_hostDao.findByIdIncludingRemoved(hostId);
     }
 
+    public static HostVO findHostByTypeNameAndZoneId(Long zoneId, String name, Host.Type type) {
+        return s_hostDao.findByTypeNameAndZoneId(zoneId, name, type);
+    }
+
     public static IPAddressVO findIpAddressById(long addressId) {
         return s_ipAddressDao.findById(addressId);
     }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -1375,9 +1375,16 @@ public class ApiResponseHelper implements ResponseGenerator {
                     vmResponse.setHostId(host.getUuid());
                     vmResponse.setHostName(host.getName());
                     vmResponse.setHypervisor(host.getHypervisorType().toString());
-                    vmResponse.setAgentState(host.getStatus());
-                    vmResponse.setLastPinged(new Date(host.getLastPinged()));
-                    vmResponse.setVersion(host.getVersion());
+                }
+            }
+
+            if (vm.getType() == Type.SecondaryStorageVm || vm.getType() == Type.ConsoleProxy) {
+                Host systemVmHost = ApiDBUtils.findHostByTypeNameAndZoneId(vm.getDataCenterId(), vm.getHostName(),
+                        Type.SecondaryStorageVm.equals(vm.getType()) ? Host.Type.SecondaryStorageVM : Host.Type.ConsoleProxy);
+                if (systemVmHost != null) {
+                    vmResponse.setAgentState(systemVmHost.getStatus());
+                    vmResponse.setDisconnectedOn(systemVmHost.getDisconnectedOn());
+                    vmResponse.setVersion(systemVmHost.getVersion());
                 }
             }
 


### PR DESCRIPTION
This implements the systemvm list API response creator to find and use
the host record for a ssvm/cpvm to get the agent status and other
details like last disconnected date and agent version.

Fixes #3875

Signed-off-by: Rohit Yadav <rohit.yadav@shapeblue.com>

## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
