### PR TITLE
kvm: Enable virtio drivers based on guest os display name

### DIFF
--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -132,7 +132,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
             guestOsMapping = _guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), getHypervisorType().toString(), host.getHypervisorVersion());
         }
         if (guestOsMapping == null || host == null) {
-            to.setPlatformEmulator("Other");
+            to.setPlatformEmulator(guestOS.getDisplayName());
         } else {
             to.setPlatformEmulator(guestOsMapping.getGuestOsName());
         }

--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -132,7 +132,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
             guestOsMapping = _guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), getHypervisorType().toString(), host.getHypervisorVersion());
         }
         if (guestOsMapping == null || host == null) {
-            to.setPlatformEmulator(guestOS.getDisplayName());
+            to.setPlatformEmulator(guestOS.getDisplayName() == null ? "unknown" : guestOS.getDisplayName());
         } else {
             to.setPlatformEmulator(guestOsMapping.getGuestOsName());
         }

--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -132,7 +132,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
             guestOsMapping = _guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), getHypervisorType().toString(), host.getHypervisorVersion());
         }
         if (guestOsMapping == null || host == null) {
-            to.setPlatformEmulator(guestOS.getDisplayName() == null ? "unknown" : guestOS.getDisplayName());
+            to.setPlatformEmulator(guestOS.getDisplayName() == null ? "Other" : guestOS.getDisplayName());
         } else {
             to.setPlatformEmulator(guestOsMapping.getGuestOsName());
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When we add new guest os, sometimes we missed the records in guest_os_hypervisor. 
However, the guest disk model (virtio/ide) is determined by record in the table.
It causes the issue that some new guest os(eg Debian 8/9) uses e1000 instead of virtio nic, and ide disk instead of virtio disk.

To fix the issue permanantly, pass the guest os name in guest_os if the record for kvm is not found in guest_os_hypervisor.

Related commit:7ac9f00eeeb4cd37ec39efeba066e799b581b1a0
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
