### PR TITLE
maven: configure toolchains based on ASF infra jdk names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
         <cs.compiler-plugin.version>3.8.1</cs.compiler-plugin.version>
         <cs.dependency-plugin.version>3.1.1</cs.dependency-plugin.version>
         <cs.failsafe-plugin.version>2.22.2</cs.failsafe-plugin.version>
-        <cs.findbugs-plugin.version>3.0.5</cs.findbugs-plugin.version>
+        <cs.spotbugs.version>3.1.12</cs.spotbugs.version>
+        <cs.spotbugs-maven-plugin.version>3.1.12.2</cs.spotbugs-maven-plugin.version>
         <cs.jar-plugin.version>3.2.0</cs.jar-plugin.version>
         <cs.pmd-plugin.version>3.12.0</cs.pmd-plugin.version>
         <cs.project-info-plugin.version>3.0.0</cs.project-info-plugin.version>
@@ -722,11 +723,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${cs.spotbugs-maven-plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>cloudstack-findbugs</id>
+                        <id>cloudstack-spotbugs</id>
                         <phase>none</phase>
                         <goals>
                             <goal>check</goal>
@@ -1082,9 +1084,9 @@
                     <version>${cs.dependency-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>${cs.findbugs-plugin.version}</version>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${cs.spotbugs-maven-plugin.version}</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.cloudstack</groupId>
@@ -1102,7 +1104,7 @@
                     </configuration>
                     <executions>
                         <execution>
-                            <id>cloudstack-findbugs</id>
+                            <id>cloudstack-spotbugs</id>
                             <goals>
                                 <goal>check</goal>
                             </goals>
@@ -1176,9 +1178,9 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${cs.findbugs-plugin.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${cs.spotbugs-maven-plugin.version}</version>
                 <configuration>
                     <threshold>Low</threshold><!-- High|Normal|Low|Exp|Ignore -->
                     <effort>Default</effort><!-- Min|Default|Max -->
@@ -1296,11 +1298,11 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>cloudstack-findbugs</id>
+                                <id>cloudstack-spotbugs</id>
                                 <phase>process-classes</phase>
                                 <inherited>true</inherited>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -747,6 +747,10 @@
                 <configuration>
                     <flushPolicy>threaded</flushPolicy>
                     <flushInterval>100</flushInterval>
+                    <targetPercentage>0%</targetPercentage>
+                    <generateHtml>true</generateHtml>
+                    <generateXml>true</generateXml>
+                    <generateHistorical>true</generateHistorical>
                 </configuration>
                 <executions>
                     <execution>
@@ -767,7 +771,6 @@
                             <goal>aggregate</goal>
                             <!-- We save a history point in order to have data to generate a historical report -->
                             <goal>save-history</goal>
-
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
         <cs.spotbugs-maven-plugin.version>3.1.12.2</cs.spotbugs-maven-plugin.version>
         <cs.jar-plugin.version>3.2.0</cs.jar-plugin.version>
         <cs.pmd-plugin.version>3.12.0</cs.pmd-plugin.version>
-        <cs.project-info-plugin.version>3.0.0</cs.project-info-plugin.version>
         <cs.release-plugin.version>2.5.3</cs.release-plugin.version>
         <cs.resources-plugin.version>3.1.0</cs.resources-plugin.version>
         <cs.site-plugin.version>3.8.2</cs.site-plugin.version>
@@ -136,7 +135,7 @@
         <cs.jasypt.version>1.9.3</cs.jasypt.version>
         <cs.java-ipv6.version>0.17</cs.java-ipv6.version>
         <cs.javassist.version>3.26.0-GA</cs.javassist.version>
-        <cs.javadoc.version>3.1.1</cs.javadoc.version>
+        <cs.maven-javadoc-plugin.version>3.1.1</cs.maven-javadoc-plugin.version>
         <cs.javax.annotation.version>1.3.2</cs.javax.annotation.version>
         <cs.jaxb.version>2.3.0</cs.jaxb.version>
         <cs.jaxws.version>2.3.2</cs.jaxws.version>
@@ -176,7 +175,6 @@
     <distributionManagement>
         <site>
             <id>apache.cloudstack.site</id>
-            <url>${site.deploy.url}</url>
         </site>
     </distributionManagement>
 
@@ -1172,6 +1170,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${cs.site-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -1190,16 +1193,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${cs.javadoc.version}</version>
+                <version>${cs.maven-javadoc-plugin.version}</version>
                 <configuration>
                     <minmemory>128m</minmemory>
                     <maxmemory>1g</maxmemory>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${cs.project-info-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1021,6 +1021,27 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-toolchains-plugin</artifactId>
+                  <version>1.1</version>
+                  <executions>
+                    <execution>
+                      <goals>
+                        <goal>toolchain</goal>
+                      </goals>
+                    </execution>
+                  </executions>
+                  <configuration>
+                    <!-- https://github.com/apache/infrastructure-puppet/blob/deployment/modules/build_slaves/files/toolchains.xml -->
+                    <toolchains>
+                      <jdk>
+                        <version>${cs.jdk.version}</version>
+                        <vendor>oracle</vendor>
+                      </jdk>
+                    </toolchains>
+                  </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${cs.jar-plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <cs.antrun-plugin.version>1.8</cs.antrun-plugin.version>
         <cs.builder-helper-plugin.version>3.0.0</cs.builder-helper-plugin.version>
         <cs.checkstyle-plugin.version>3.1.0</cs.checkstyle-plugin.version>
-        <cs.cobertura-plugin.version>2.7</cs.cobertura-plugin.version>
+        <cs.jacoco-plugin.version>0.8.3</cs.jacoco-plugin.version>
         <cs.compiler-plugin.version>3.8.1</cs.compiler-plugin.version>
         <cs.dependency-plugin.version>3.1.1</cs.dependency-plugin.version>
         <cs.failsafe-plugin.version>2.22.2</cs.failsafe-plugin.version>
@@ -734,6 +734,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${cs.jacoco-plugin.version}</version>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1078,16 +1083,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <configuration>
-                        <formats>
-                            <format>html</format>
-                            <format>xml</format>
-                        </formats>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>${cs.findbugs-plugin.version}</version>
                     <dependencies>
@@ -1147,13 +1142,33 @@
                     <version>${cs.surefire-plugin.version}</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
-                        <argLine>-Djava.security.egd=file:/dev/./urandom -noverify</argLine>
+                        <argLine>@{argLine} -Djava.security.egd=file:/dev/./urandom -noverify</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${cs.failsafe-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${cs.jacoco-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-coverage-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>produce-coverage-reports</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -1185,11 +1200,6 @@
                 <version>${cs.project-info-plugin.version}</version>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${cs.cobertura-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>${cs.site-plugin.version}</version>
@@ -1198,6 +1208,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>${cs.resources-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${cs.jacoco-plugin.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <!-- select non-aggregate reports -->
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>
@@ -1272,10 +1295,6 @@
             <id>enablefindbugs</id>
             <build>
                 <plugins>
-<!--                     <plugin> -->
-<!--                         <groupId>org.apache.maven.plugins</groupId> -->
-<!--                         <artifactId>maven-pmd-plugin</artifactId> -->
-<!--                     </plugin> -->
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <cs.resources-plugin.version>3.1.0</cs.resources-plugin.version>
         <cs.site-plugin.version>3.8.2</cs.site-plugin.version>
         <cs.surefire-plugin.version>2.22.2</cs.surefire-plugin.version>
+        <cs.clover-maven-plugin.version>4.4.1</cs.clover-maven-plugin.version>
 
         <!-- Logging versions -->
         <cs.log4j.version>1.2.17</cs.log4j.version>
@@ -739,6 +740,38 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${cs.jacoco-plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.openclover</groupId>
+                <artifactId>clover-maven-plugin</artifactId>
+                <version>${cs.clover-maven-plugin.version}</version>
+                <configuration>
+                    <flushPolicy>threaded</flushPolicy>
+                    <flushInterval>100</flushInterval>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>main</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>instrument</goal>
+                            <goal>aggregate</goal>
+                            <goal>check</goal>
+                            <goal>log</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>site</id>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>instrument</goal>
+                            <goal>aggregate</goal>
+                            <!-- We save a history point in order to have data to generate a historical report -->
+                            <goal>save-history</goal>
+
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1305,6 +1338,15 @@
                                 <inherited>true</inherited>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.openclover</groupId>
+                        <artifactId>clover-maven-plugin</artifactId>
+                        <version>${cs.clover-maven-plugin.version}</version>
+                        <configuration>
+                            <generateHistorical>true</generateHistorical>
+                            <generateHtml>true</generateHtml>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/tools/checkstyle/pom.xml
+++ b/tools/checkstyle/pom.xml
@@ -36,6 +36,11 @@
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.8.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.openclover</groupId>
+                <artifactId>clover-maven-plugin</artifactId>
+                <version>4.4.1</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/tools/checkstyle/pom.xml
+++ b/tools/checkstyle/pom.xml
@@ -28,4 +28,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.8.2</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This adds toolchain configuration for CloudStack to use specific
toolchain for building per ASF infra's configured toolchain.
Reference: https://issues.apache.org/jira/browse/INFRA-19817