### PR TITLE
maven: configure toolchains based on ASF infra jdk names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1006,6 +1006,27 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-toolchains-plugin</artifactId>
+                  <version>1.1</version>
+                  <executions>
+                    <execution>
+                      <goals>
+                        <goal>toolchain</goal>
+                      </goals>
+                    </execution>
+                  </executions>
+                  <configuration>
+                    <!-- https://github.com/apache/infrastructure-puppet/blob/deployment/modules/build_slaves/files/toolchains.xml -->
+                    <toolchains>
+                      <jdk>
+                        <version>${cs.jdk.version}</version>
+                        <vendor>oracle</vendor>
+                      </jdk>
+                    </toolchains>
+                  </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${cs.jar-plugin.version}</version>


### PR DESCRIPTION
This adds toolchain configuration for CloudStack to use specific
toolchain for building per ASF infra's configured toolchain.
Reference: https://issues.apache.org/jira/browse/INFRA-19817

Signed-off-by: Rohit Yadav <rohit.yadav@shapeblue.com>