### PR TITLE
vrouter: reload keepalived instead of restart and fix password server issues when add/remove vpc tier

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -61,7 +61,7 @@ class CsPassword(CsDataBag):
         server_ip = None
         guest_ip = None
         for interface in self.config.address().get_interfaces():
-            if interface.ip_in_subnet(vm_ip):
+            if interface.ip_in_subnet(vm_ip) and interface.is_added():
                 if self.config.cl.is_redundant():
                     server_ip = interface.get_gateway()
                     guest_ip = interface.get_ip()

--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -581,6 +581,11 @@ class CsIP:
                         CsPasswdSvc(self.address['public_ip']).start()
                     elif method == "delete":
                         CsPasswdSvc(self.address['public_ip']).stop()
+                elif cmdline.is_master():
+                    if method == "add":
+                        CsPasswdSvc(self.address['gateway'] + "," + self.address['public_ip']).start()
+                    elif method == "delete":
+                        CsPasswdSvc(self.address['gateway'] + "," + self.address['public_ip']).stop()
 
         if self.get_type() == "public" and self.config.is_vpc() and method == "add":
             if self.address["source_nat"]:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This fixes few issues below
(1) when add/remove a vpc tier, the keepalived is restarted on both master and backup VRs, which causes some seconds donwtime of vpc.
(2) when remove a vpc tier, the password server is not stopped.
(3) vpc tier is shutdown because no vm is running for 20 minutes, if we start a vm in the vpc tier, it will be implemented. however the guest ip in VPC VRs will be changed , and password server is still running with old guest ip in VRs.


<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
