### PR TITLE
[4.16] systemvm: configurable root disk size based on new systemvm template definition

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -440,7 +440,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         final VirtualMachineProfileImpl vmProfile = new VirtualMachineProfileImpl(vmFinal, template, serviceOffering, null, null);
 
         Long rootDiskSize = rootDiskOfferingInfo.getSize();
-        if (vm.getType().isUsedBySystem() && SystemVmRootDiskSize.value() != null) {
+        if (vm.getType().isUsedBySystem() && SystemVmRootDiskSize.value() != null &&  SystemVmRootDiskSize.value() > 0L) {
             rootDiskSize = SystemVmRootDiskSize.value();
         }
         final Long rootDiskSizeFinal = rootDiskSize;

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -387,6 +387,10 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
     static final ConfigKey<Boolean> HaVmRestartHostUp = new ConfigKey<Boolean>("Advanced", Boolean.class, "ha.vm.restart.hostup", "true",
             "If an out-of-band stop of a VM is detected and its host is up, then power on the VM", true);
 
+    static final ConfigKey<Long> SystemVmRootDiskSize = new ConfigKey<Long>("Advanced",
+            Long.class, "systemvm.root.disk.size", "-1",
+            "root size (in GB) of systemvm and virtual routers", true);
+
     ScheduledExecutorService _executor = null;
 
     private long _nodeId;
@@ -435,6 +439,12 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         final VirtualMachineProfileImpl vmProfile = new VirtualMachineProfileImpl(vmFinal, template, serviceOffering, null, null);
 
+        Long rootDiskSize = rootDiskOfferingInfo.getSize();
+        if (vm.getType().isUsedBySystem() && SystemVmRootDiskSize.value() != null) {
+            rootDiskSize = SystemVmRootDiskSize.value();
+        }
+        final Long rootDiskSizeFinal = rootDiskSize;
+
         Transaction.execute(new TransactionCallbackWithExceptionNoReturn<InsufficientCapacityException>() {
             @Override
             public void doInTransactionWithoutResult(final TransactionStatus status) throws InsufficientCapacityException {
@@ -460,7 +470,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 } else if (template.getFormat() == ImageFormat.BAREMETAL) {
                     // Do nothing
                 } else {
-                    volumeMgr.allocateTemplatedVolumes(Type.ROOT, "ROOT-" + vmFinal.getId(), rootDiskOfferingInfo.getDiskOffering(), rootDiskOfferingInfo.getSize(),
+                    volumeMgr.allocateTemplatedVolumes(Type.ROOT, "ROOT-" + vmFinal.getId(), rootDiskOfferingInfo.getDiskOffering(), rootDiskSizeFinal,
                             rootDiskOfferingInfo.getMinIops(), rootDiskOfferingInfo.getMaxIops(), template, vmFinal, owner);
                 }
 
@@ -4520,7 +4530,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
             VmOpLockStateRetry,
             VmOpWaitInterval, ExecuteInSequence, VmJobCheckInterval, VmJobTimeout, VmJobStateReportInterval, VmConfigDriveLabel, VmConfigDriveOnPrimaryPool, HaVmRestartHostUp,
             ResoureCountRunningVMsonly, AllowExposeHypervisorHostname, AllowExposeHypervisorHostnameAccountLevel,
-            VmServiceOfferingMaxCPUCores, VmServiceOfferingMaxRAMSize };
+            VmServiceOfferingMaxCPUCores, VmServiceOfferingMaxRAMSize, SystemVmRootDiskSize };
     }
 
     public List<StoragePoolAllocator> getStoragePoolAllocators() {

--- a/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
+++ b/systemvm/debian/opt/cloud/bin/setup/cloud-early-config
@@ -89,6 +89,23 @@ start() {
   rm -f /root/.rnd
   echo "" > /root/.ssh/known_hosts
 
+  local root_dev=
+  if [ -e /dev/xvda ]; then
+       root_dev=/dev/xvda
+  elif [ -e /dev/vda ]; then
+       root_dev=/dev/vda
+  elif [ -e /dev/hda ]; then
+       root_dev=/dev/hda
+  elif [ -e /dev/sda ]; then
+       root_dev=/dev/sda
+  fi
+
+  if [ ! -z $root_dev ] && [ `which growpart` ];then
+    growpart $root_dev 2
+    growpart $root_dev 6
+    resize2fs ${root_dev}6
+  fi
+
   patch
   sync
   /opt/cloud/bin/setup/bootstrap.sh

--- a/tools/appliance/systemvmtemplate/http/preseed.cfg
+++ b/tools/appliance/systemvmtemplate/http/preseed.cfg
@@ -62,13 +62,13 @@ d-i partman-auto/expert_recipe string                         \
                       use_filesystem{ } filesystem{ ext2 }    \
                       mountpoint{ /boot }                     \
               .                                               \
+              256 1000 256 linux-swap                         \
+                      method{ swap } format{ }                \
+              .                                               \
               2240 40 2500 ext4                               \
                       method{ format } format{ }              \
                       use_filesystem{ } filesystem{ ext4 }    \
                       mountpoint{ / }                         \
-              .                                               \
-              256 1000 256 linux-swap                         \
-                      method{ swap } format{ }                \
               .
 
 d-i partman-md/confirm boolean true

--- a/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
+++ b/tools/appliance/systemvmtemplate/scripts/install_systemvm_packages.sh
@@ -70,7 +70,7 @@ function install_packages() {
     radvd \
     sharutils genisoimage aria2 \
     strongswan libcharon-extra-plugins libstrongswan-extra-plugins strongswan-charon strongswan-starter \
-    virt-what open-vm-tools qemu-guest-agent hyperv-daemons
+    virt-what open-vm-tools qemu-guest-agent hyperv-daemons cloud-guest-utils
 
   apt-get -y autoremove --purge
   apt-get clean


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The official systemvm template has very few free spaces, it would be better to make the disk size configuration.

Main changes in systemvm template
(1) remove /var and /tmp partitions
(2) move / partition to the last.
(3) install cloud-guest-utils to support "growpart"
(4) install haproxy 1.8 from stretch-backports instead of haproxy 1.7

other changes
(3) add global setting systemvm.root.disk.size
(4) when systemvm starts,  allocate all free spaces on disk to  the extend partition, root partition (/dev/vda6) and file system.

This applies on all systemvms (cpvm,ssvm,virtual routers, etc)

This fixes #3455 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. build new systemvm template
2. register new systemvm template
3. change type from "USER" to "SYSTEM"
4. change global setting systemvm.root.disk.size to 3GB
5. destroy ssvm or cpvm
6. new ssvm/cpvm will have 3GB disk (default 1.5GB) and 2.5 GB free space (default 1GB) on filesystem.

old VR
```
root@r-269-VM:~# df
Filesystem     1K-blocks    Used Available Use% Mounted on
udev              103748       0    103748   0% /dev
tmpfs              47352   23480     23872  50% /run
/dev/vda5        2086316 1209892    860040  59% /
tmpfs             118372       0    118372   0% /dev/shm
tmpfs               5120       0      5120   0% /run/lock
tmpfs             118372       0    118372   0% /sys/fs/cgroup
/dev/vda1          93207   46230     46977  50% /boot
tmpfs              23672       0     23672   0% /run/user/0
```

new VR
```
root@r-270-VM:~# df
Filesystem     1K-blocks   Used Available Use% Mounted on
udev              103688      0    103688   0% /dev
tmpfs              47352   5556     41796  12% /run
/dev/vda6        2687084 970912   1699788  37% /
tmpfs             118372      0    118372   0% /dev/shm
tmpfs               5120      0      5120   0% /run/lock
tmpfs             118372      0    118372   0% /sys/fs/cgroup
/dev/vda1          93207  46361     46846  50% /boot
tmpfs              23672      0     23672   0% /run/user/0
```

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
