### PR TITLE
vrouter: Save PlaceHolder nic for VR if network does not have source nat

### DIFF
--- a/api/src/main/java/com/cloud/vm/NicProfile.java
+++ b/api/src/main/java/com/cloud/vm/NicProfile.java
@@ -423,6 +423,7 @@ public class NicProfile implements InternalIdentity, Serializable {
                 .append(iPv4Address)
                 .append("-")
                 .append(broadcastUri)
+                .append("]")
                 .toString();
     }
 }

--- a/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/NetworkServiceImpl.java
@@ -2438,6 +2438,9 @@ public class NetworkServiceImpl extends ManagerBase implements NetworkService, C
                                         // log assign usage events for new offering
                                         List<NicVO> nics = _nicDao.listByNetworkId(networkId);
                                         for (NicVO nic : nics) {
+                                            if (nic.getReservationStrategy() == Nic.ReservationStrategy.PlaceHolder) {
+                                                continue;
+                                            }
                                             long vmId = nic.getInstanceId();
                                             VMInstanceVO vm = _vmDao.findById(vmId);
                                             if (vm == null) {

--- a/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -75,6 +75,7 @@ import com.cloud.utils.db.TransactionCallbackNoReturn;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils;
+import com.cloud.vm.Nic;
 import com.cloud.vm.Nic.ReservationStrategy;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.ReservationContext;
@@ -372,15 +373,25 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
 
                 if (isGateway) {
                     guestIp = network.getGateway();
-                } else if (vm.getVirtualMachine().getType() == VirtualMachine.Type.DomainRouter) {
-                    guestIp = _ipAddrMgr.acquireGuestIpAddressByPlacement(network, nic.getRequestedIPv4());
                 } else {
-                    guestIp = _ipAddrMgr.acquireGuestIpAddress(network, nic.getRequestedIPv4());
-                }
-
-                if (!isGateway && guestIp == null && network.getGuestType() != GuestType.L2 && !_networkModel.listNetworkOfferingServices(network.getNetworkOfferingId()).isEmpty()) {
-                    throw new InsufficientVirtualNetworkCapacityException("Unable to acquire Guest IP" + " address for network " + network, DataCenter.class,
-                            dc.getId());
+                    if (network.getGuestType() != GuestType.L2 && vm.getType() == VirtualMachine.Type.DomainRouter) {
+                        Nic placeholderNic = _networkModel.getPlaceholderNicForRouter(network, null);
+                        if (placeholderNic != null) {
+                            s_logger.debug("Nic got an ip address " + placeholderNic.getIPv4Address() + " stored in placeholder nic for the network " + network);
+                            guestIp = placeholderNic.getIPv4Address();
+                        }
+                    }
+                    if (guestIp == null) {
+                        if (vm.getVirtualMachine().getType() == VirtualMachine.Type.DomainRouter) {
+                            guestIp = _ipAddrMgr.acquireGuestIpAddressByPlacement(network, nic.getRequestedIPv4());
+                        } else {
+                            guestIp = _ipAddrMgr.acquireGuestIpAddress(network, nic.getRequestedIPv4());
+                        }
+                    }
+                    if (guestIp == null && network.getGuestType() != GuestType.L2 && !_networkModel.listNetworkOfferingServices(network.getNetworkOfferingId()).isEmpty()) {
+                        throw new InsufficientVirtualNetworkCapacityException("Unable to acquire Guest IP" + " address for network " + network, DataCenter.class,
+                                dc.getId());
+                    }
                 }
 
                 nic.setIPv4Address(guestIp);

--- a/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/NetworkHelperImpl.java
@@ -710,8 +710,8 @@ public class NetworkHelperImpl implements NetworkHelper {
         if (guestNetwork != null) {
             s_logger.debug("Adding nic for Virtual Router in Guest network " + guestNetwork);
             String defaultNetworkStartIp = null, defaultNetworkStartIpv6 = null;
+            final Nic placeholder = _networkModel.getPlaceholderNicForRouter(guestNetwork, routerDeploymentDefinition.getPodId());
             if (!routerDeploymentDefinition.isPublicNetwork()) {
-                final Nic placeholder = _networkModel.getPlaceholderNicForRouter(guestNetwork, routerDeploymentDefinition.getPodId());
                 if (guestNetwork.getCidr() != null) {
                     if (placeholder != null && placeholder.getIPv4Address() != null) {
                         s_logger.debug("Requesting ipv4 address " + placeholder.getIPv4Address() + " stored in placeholder nic for the network "
@@ -744,6 +744,9 @@ public class NetworkHelperImpl implements NetworkHelper {
                         }
                     }
                 }
+            } else if (placeholder != null) {
+                // Remove placeholder nic if router has public network
+                _nicDao.remove(placeholder.getId());
             }
 
             final NicProfile gatewayNic = new NicProfile(defaultNetworkStartIp, defaultNetworkStartIpv6);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR aims to fix the issue below

1. Create a network offering for isolated network, services: Dns/Dhcp/Userdata, and enable it
2. create a isolated network with the new offering
3. create a vm
4. check the guest IP of virtual router, 
5. restart network with cleanup
6. check the guest IP of new virtual router
7. The IP in step4 and step6 should be the same, but they are different actually.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested with steps above, the IPs are same in step 7.
change network to another offering with public ip, the placeholder ip is removed from database.

tested with shared networks and L2 network as well.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
