### PR TITLE
VR: Send VM password to all Running VRs in network/vpc

### DIFF
--- a/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
@@ -707,6 +707,11 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
         for (final VirtualRouter router : routers) {
             if (router.getState() == State.Running) {
                 final boolean result = networkTopology.savePasswordToRouter(network, nic, uservm, router);
+                if (!result) {
+                    s_logger.error("Unable to save password for VM " + vm.getInstanceName() +
+                            " on router " + router.getInstanceName());
+                    return false;
+                }
                 isVrRunning = true;
                 savePasswordResult = savePasswordResult && result;
             }

--- a/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
+++ b/server/src/main/java/com/cloud/network/element/VirtualRouterElement.java
@@ -702,18 +702,27 @@ NetworkMigrationResponder, AggregatedCommandExecutor, RedundantResource, DnsServ
 
         // If any router is running then send save password command otherwise
         // save the password in DB
+        boolean savePasswordResult = true;
+        boolean isVrRunning = false;
         for (final VirtualRouter router : routers) {
             if (router.getState() == State.Running) {
                 final boolean result = networkTopology.savePasswordToRouter(network, nic, uservm, router);
-                if (result) {
-                    // Explicit password reset, while VM hasn't generated a password yet.
-                    final UserVmVO userVmVO = _userVmDao.findById(vm.getId());
-                    userVmVO.setUpdateParameters(false);
-                    _userVmDao.update(userVmVO.getId(), userVmVO);
-                }
-                return result;
+                isVrRunning = true;
+                savePasswordResult = savePasswordResult && result;
             }
         }
+
+        // return the result only if one of the vr is running
+        if (isVrRunning) {
+            if (savePasswordResult) {
+                // Explicit password reset, while VM hasn't generated a password yet.
+                final UserVmVO userVmVO = _userVmDao.findById(vm.getId());
+                userVmVO.setUpdateParameters(false);
+                _userVmDao.update(userVmVO.getId(), userVmVO);
+            }
+            return savePasswordResult;
+        }
+
         final String password = (String) uservm.getParameter(VirtualMachineProfile.Param.VmPassword);
         final String password_encrypted = DBEncryptionUtil.encrypt(password);
         final UserVmVO userVmVO = _userVmDao.findById(vm.getId());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Currently, the cloudstack sends VM password only to the first
router in the network even if its the backup and return the result.

In some cases the first router will be back up and the second will be master.
Since password server is not running in backup, when the user resets the password,
it is sent to the first router which can be backup.
In that case, the new password is not stored in the password server and users cant log in with a new password.

This change ensures that we send the password to both the routers instead
of the first router so that a new password is stored in the master router.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1 . Create and isolated network with redundant VR and a VM in it.
2 . Note down the password of the newly created and try to ssh to it from VR
3 . Ssh works with the existing password.
4 . Now reboot the master VR so that it will become BACKUP and the BACKUP will become MASTER
5 . Now stop the VM and reset it's password.
6 . Try to login to VM using the new password


Expected Result:

Ssh should work with new password


Actual result:

Ssh wont work
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
