### PR TITLE
Avoid duplicate alerts when router state changes

### DIFF
--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1075,7 +1075,9 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             for (final DomainRouterVO router : routers) {
                 final List<Long> routerGuestNtwkIds = _routerDao.getRouterNetworks(router.getId());
 
-                for (final Long routerGuestNtwkId : routerGuestNtwkIds) {
+                final Long vpcId = router.getVpcId();
+                if (vpcId != null || routerGuestNtwkIds.size() > 0) {
+                    Long routerGuestNtwkId = vpcId != null ? vpcId : routerGuestNtwkIds.get(0);
                     if (router.getRedundantState() == RedundantState.MASTER) {
                         if (networkRouterMaps.containsKey(routerGuestNtwkId)) {
                             final DomainRouterVO dupRouter = networkRouterMaps.get(routerGuestNtwkId);
@@ -1084,7 +1086,6 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                             final String context = "Virtual router (name: " + router.getHostName() + ", id: " + router.getId() + " and router (name: " + dupRouter.getHostName()
                                     + ", id: " + router.getId() + ") are both in MASTER state! If the problem persist, restart both of routers. ";
                             _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_DOMAIN_ROUTER, router.getDataCenterId(), router.getPodIdToDeployIn(), title, context);
-                            _alertMgr.sendAlert(AlertManager.AlertType.ALERT_TYPE_DOMAIN_ROUTER, dupRouter.getDataCenterId(), dupRouter.getPodIdToDeployIn(), title, context);
                             s_logger.warn(context);
                         } else {
                             networkRouterMaps.put(routerGuestNtwkId, router);
@@ -1168,8 +1169,14 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
 
                 updateSite2SiteVpnConnectionState(routers);
 
-                List<NetworkVO> networks = _networkDao.listVpcNetworks();
-                s_logger.debug("Found " + networks.size() + " VPC networks to update Redundant State. ");
+                List<NetworkVO> networks = new ArrayList<>();
+                for (Vpc vpc : _vpcDao.listAll()) {
+                    List<NetworkVO> vpcNetworks = _networkDao.listByVpc(vpc.getId());
+                    if (vpcNetworks.size() > 0) {
+                        networks.add(vpcNetworks.get(0));
+                    }
+                }
+                s_logger.debug("Found " + networks.size() + " VPC's to update Redundant State. ");
                 pushToUpdateQueue(networks);
 
                 networks = _networkDao.listRedundantNetworks();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When both router of VPC are in MASTER state
then multiple alerts are sent equal to the number of tiers in the VPC.
If the VPC has 3 tiers then 6 alerts will be sent. This is not good
if VPC has more than 10 networks in it.

Instead of checking the router status for all the tiers in the VPC,
just check the status of rotuer for one tier in a VPC so that
multiple deplicate alerts can be avoided

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

Alerts Dashboard when both routers are in MASTER state in VPC

![Screenshot 2020-02-20 at 15 00 20](https://user-images.githubusercontent.com/10645273/74940840-59159880-53f2-11ea-8eb1-fbb66c8df7e3.png)



After the fix, when both routers are in master state


![Screenshot 2020-02-20 at 15 09 16](https://user-images.githubusercontent.com/10645273/74941249-01c3f800-53f3-11ea-90ba-c9052de89443.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1 . Create a VPC with redundant VR's and multiple tiers in it
2. Change the state of the BACKUP VR to MASTER.
3 . You will see multiple alerts in the Cloudstack dashboard

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
