### PR TITLE
Fix network rules issue if default egress policy is Allow

### DIFF
--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1812,10 +1812,8 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
         // Fetch firewall Egress rules.
         if (_networkModel.isProviderSupportServiceInNetwork(guestNetworkId, Service.Firewall, provider)) {
             firewallRulesEgress.addAll(_rulesDao.listByNetworkPurposeTrafficType(guestNetworkId, Purpose.Firewall, FirewallRule.TrafficType.Egress));
-            if (firewallRulesEgress.isEmpty()) {
-                //create egress default rule for VR
-                createDefaultEgressFirewallRule(firewallRulesEgress, guestNetworkId);
-            }
+            //create egress default rule for VR
+            createDefaultEgressFirewallRule(firewallRulesEgress, guestNetworkId);
         }
 
         // Re-apply firewall Egress rules


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
When the network service offering of a network is changed from
"defualt deny" to "default allow", the ping from VM to outside
world is stopped even after adding egress rule.

If the default policy is allow then the ping should never stop
working

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Steps to reproduce the issue

1 . Create a network offering with static nat enabled and default policy as "DENY"
2 . Create a vm in it and try to ping 8.8.8.8 from the vm
3 . Ping will fail
4. Now add an ICMP egress rule with code -1
5. Try to ping 8.8.8.8 from vm and this time ping will work
6. Add or remove any other egress rule and the ping should still work
7. Now create a new network offering with static nat enable and default egress policy as "ALLOW"
8. Change the network offering of the above created network to the newly created network offering
9. Now ssh to vm and try to ping 8.8.8.8
10. Ping wont work because of the existing ICMP egress rule.
11. Now remove the ICMP egress rule and try to ping 8.8.8.8 from VM
12. The ping still DOES NOT work


Expected result:

The ping should work at step 12 since default egress policy is ALLOW

Actual result:

The ping doesn't work even though the default egress policy is ALLOW


Now apply the patch and try to reproduce steps 1 to 12
Ping from VM to 8.8.8.8 will work at step 12.


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
