### PR TITLE
Alert on certain host status transitions

### DIFF
--- a/api/src/main/java/com/cloud/host/Status.java
+++ b/api/src/main/java/com/cloud/host/Status.java
@@ -97,6 +97,9 @@ public enum Status {
     public Status getNextStatus(Event e) throws NoTransitionException {
         return s_fsm.getNextState(this, e);
     }
+    public boolean getTransitionAlertFlag(Event e) throws NoTransitionException {
+        return s_fsm.getTransitionAlertFlag(this, e);
+    }
 
     public Status[] getFromStates(Event e) {
         List<Status> from = s_fsm.getFromStates(this, e);
@@ -119,31 +122,31 @@ public enum Status {
     static {
         s_fsm.addTransition(null, Event.AgentConnected, Status.Connecting);
         s_fsm.addTransition(Status.Creating, Event.AgentConnected, Status.Connecting);
-        s_fsm.addTransition(Status.Creating, Event.Error, Status.Error);
+        s_fsm.addTransition(Status.Creating, Event.Error, Status.Error, true);
         s_fsm.addTransition(Status.Connecting, Event.AgentConnected, Status.Connecting);
-        s_fsm.addTransition(Status.Connecting, Event.Ready, Status.Up);
-        s_fsm.addTransition(Status.Connecting, Event.PingTimeout, Status.Alert);
-        s_fsm.addTransition(Status.Connecting, Event.ShutdownRequested, Status.Disconnected);
-        s_fsm.addTransition(Status.Connecting, Event.HostDown, Status.Down);
+        s_fsm.addTransition(Status.Connecting, Event.Ready, Status.Up, true);
+        s_fsm.addTransition(Status.Connecting, Event.PingTimeout, Status.Alert, true);
+        s_fsm.addTransition(Status.Connecting, Event.ShutdownRequested, Status.Disconnected, true);
+        s_fsm.addTransition(Status.Connecting, Event.HostDown, Status.Down, true);
         s_fsm.addTransition(Status.Connecting, Event.Ping, Status.Connecting);
-        s_fsm.addTransition(Status.Connecting, Event.ManagementServerDown, Status.Disconnected);
-        s_fsm.addTransition(Status.Connecting, Event.AgentDisconnected, Status.Alert);
-        s_fsm.addTransition(Status.Up, Event.PingTimeout, Status.Alert);
-        s_fsm.addTransition(Status.Up, Event.AgentDisconnected, Status.Alert);
-        s_fsm.addTransition(Status.Up, Event.ShutdownRequested, Status.Disconnected);
-        s_fsm.addTransition(Status.Up, Event.HostDown, Status.Down);
+        s_fsm.addTransition(Status.Connecting, Event.ManagementServerDown, Status.Disconnected, true);
+        s_fsm.addTransition(Status.Connecting, Event.AgentDisconnected, Status.Alert, true);
+        s_fsm.addTransition(Status.Up, Event.PingTimeout, Status.Alert, true);
+        s_fsm.addTransition(Status.Up, Event.AgentDisconnected, Status.Alert, true);
+        s_fsm.addTransition(Status.Up, Event.ShutdownRequested, Status.Disconnected, true);
+        s_fsm.addTransition(Status.Up, Event.HostDown, Status.Down, true);
         s_fsm.addTransition(Status.Up, Event.Ping, Status.Up);
         s_fsm.addTransition(Status.Up, Event.AgentConnected, Status.Connecting);
-        s_fsm.addTransition(Status.Up, Event.ManagementServerDown, Status.Disconnected);
+        s_fsm.addTransition(Status.Up, Event.ManagementServerDown, Status.Disconnected, true);
         s_fsm.addTransition(Status.Up, Event.StartAgentRebalance, Status.Rebalancing);
-        s_fsm.addTransition(Status.Up, Event.Remove, Status.Removed);
-        s_fsm.addTransition(Status.Disconnected, Event.PingTimeout, Status.Alert);
+        s_fsm.addTransition(Status.Up, Event.Remove, Status.Removed, true);
+        s_fsm.addTransition(Status.Disconnected, Event.PingTimeout, Status.Alert, true);
         s_fsm.addTransition(Status.Disconnected, Event.AgentConnected, Status.Connecting);
-        s_fsm.addTransition(Status.Disconnected, Event.Ping, Status.Up);
-        s_fsm.addTransition(Status.Disconnected, Event.HostDown, Status.Down);
+        s_fsm.addTransition(Status.Disconnected, Event.Ping, Status.Up, true);
+        s_fsm.addTransition(Status.Disconnected, Event.HostDown, Status.Down, true);
         s_fsm.addTransition(Status.Disconnected, Event.ManagementServerDown, Status.Disconnected);
-        s_fsm.addTransition(Status.Disconnected, Event.WaitedTooLong, Status.Alert);
-        s_fsm.addTransition(Status.Disconnected, Event.Remove, Status.Removed);
+        s_fsm.addTransition(Status.Disconnected, Event.WaitedTooLong, Status.Alert, true);
+        s_fsm.addTransition(Status.Disconnected, Event.Remove, Status.Removed, true);
         s_fsm.addTransition(Status.Disconnected, Event.AgentDisconnected, Status.Disconnected);
         s_fsm.addTransition(Status.Down, Event.AgentConnected, Status.Connecting);
         s_fsm.addTransition(Status.Down, Event.Remove, Status.Removed);
@@ -151,13 +154,13 @@ public enum Status {
         s_fsm.addTransition(Status.Down, Event.AgentDisconnected, Status.Down);
         s_fsm.addTransition(Status.Down, Event.PingTimeout, Status.Down);
         s_fsm.addTransition(Status.Down, Event.HostDown, Status.Down);
-        s_fsm.addTransition(Status.Alert, Event.AgentConnected, Status.Connecting);
-        s_fsm.addTransition(Status.Alert, Event.Ping, Status.Up);
+        s_fsm.addTransition(Status.Alert, Event.AgentConnected, Status.Connecting, true);
+        s_fsm.addTransition(Status.Alert, Event.Ping, Status.Up, true);
         s_fsm.addTransition(Status.Alert, Event.Remove, Status.Removed);
         s_fsm.addTransition(Status.Alert, Event.ManagementServerDown, Status.Alert);
         s_fsm.addTransition(Status.Alert, Event.AgentDisconnected, Status.Alert);
-        s_fsm.addTransition(Status.Alert, Event.ShutdownRequested, Status.Disconnected);
-        s_fsm.addTransition(Status.Alert, Event.HostDown, Status.Down);
+        s_fsm.addTransition(Status.Alert, Event.ShutdownRequested, Status.Disconnected, true);
+        s_fsm.addTransition(Status.Alert, Event.HostDown, Status.Down, true);
         s_fsm.addTransition(Status.Rebalancing, Event.RebalanceFailed, Status.Disconnected);
         s_fsm.addTransition(Status.Rebalancing, Event.RebalanceCompleted, Status.Connecting);
         s_fsm.addTransition(Status.Rebalancing, Event.ManagementServerDown, Status.Disconnected);

--- a/utils/src/main/java/com/cloud/utils/fsm/StateMachine2.java
+++ b/utils/src/main/java/com/cloud/utils/fsm/StateMachine2.java
@@ -50,7 +50,11 @@ public class StateMachine2<S, E, V extends StateObject<S>> {
     }
 
     public void addTransition(S currentState, E event, S toState) {
-      addTransition(new Transition<S, E>(currentState, event, toState, null));
+      addTransition(currentState, event, toState, false);
+    }
+
+    public void addTransition(S currentState, E event, S toState, boolean alertFlag) {
+      addTransition(new Transition<S, E>(currentState, event, toState, null, alertFlag));
     }
 
     @SafeVarargs
@@ -92,6 +96,10 @@ public class StateMachine2<S, E, V extends StateObject<S>> {
 
     public S getNextState(S s, E e) throws NoTransitionException {
         return getTransition(s, e).getToState();
+    }
+
+    public boolean getTransitionAlertFlag(S s, E e) throws NoTransitionException {
+        return getTransition(s, e).getAlertFlag();
     }
 
     public Transition<S, E> getTransition(S s, E e) throws NoTransitionException {
@@ -171,15 +179,22 @@ public class StateMachine2<S, E, V extends StateObject<S>> {
 
       private List<Impact> impacts;
 
+      private boolean alertFlag;
+
       public static enum Impact {
         USAGE
       }
 
       public Transition(S currentState, E event, S toState, List<Impact> impacts) {
+        this(currentState, event, toState, impacts, false);
+      }
+
+      public Transition(S currentState, E event, S toState, List<Impact> impacts, boolean alertFlag) {
         this.currentState = currentState;
         this.event = event;
         this.toState = toState;
         this.impacts = impacts;
+        this.alertFlag = alertFlag;
       }
 
       public S getCurrentState() {
@@ -199,6 +214,10 @@ public class StateMachine2<S, E, V extends StateObject<S>> {
           return false;
         }
         return impacts.contains(impact);
+      }
+
+      public boolean getAlertFlag() {
+        return alertFlag;
       }
 
       @Override


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add ability to create alert for host status transitions, such as from Alert->Up or Up->Disconnected, etc.  Right now some transitions may alert, but we wanted to know about any major host status transition.  

We also created a ConfigKey (alert.on.host.transiton) that defaults to the current behavior of not alerting on transitions.  But, by changing the setting to True, we are alerted if there are host transitions.  Which we find helpful - especially as once in a great while we'll have a host transition out of an Up status to something else.  But we never get an alert that it transitioned back to Up (even if it happened 1 second later)....

The ConfigKey works in conjunction with a flag set on the FSM's transitions.  If the TransitionAlertFlag for a particular transition is set to True AND the ConfigKey is set to True then the alert will be raised.

Let me know if 4.13 is OK or if you prefer a different branch instead of 4.13.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Our environment has it set to True, but it defaults to False.
![image](https://user-images.githubusercontent.com/17735593/75086251-b9423280-54f7-11ea-8898-0de7ebe03692.png)
![image](https://user-images.githubusercontent.com/17735593/75086270-e0006900-54f7-11ea-8270-2883e8c46569.png)

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Tested putting hosts through various states.  Made sure we received the emails and the Alerts appear in the UI.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
