### PR TITLE
Jdk11 auto select on upgrade

### DIFF
--- a/debian/cloudstack-agent.postinst
+++ b/debian/cloudstack-agent.postinst
@@ -53,6 +53,13 @@ case "$1" in
         fi
         cp -a /usr/share/cloudstack-agent/lib/libvirtqemuhook /etc/libvirt/hooks/qemu
 
+        # Check and switch to Java 11
+        JDK11_NAME=$(update-java-alternatives --list | grep 11 | head -1 |  grep -Eo '^[^ ]+')
+        if [ -z ${JDK11_NAME} ]; then
+          echo "Setting default JAVA to ${JDK11_NAME}"
+          update-java-alternatives -s ${JDK11_NAME} > /dev/null
+        fi
+
         ;;
 esac
 

--- a/debian/cloudstack-agent.postinst
+++ b/debian/cloudstack-agent.postinst
@@ -55,9 +55,9 @@ case "$1" in
 
         # Check and switch to Java 11
         JDK11_NAME=$(update-java-alternatives --list | grep 11 | head -1 |  grep -Eo '^[^ ]+')
-        if [ -z ${JDK11_NAME} ]; then
+        if [ -n ${JDK11_NAME} ]; then
           echo "Setting default JAVA to ${JDK11_NAME}"
-          update-java-alternatives -s ${JDK11_NAME} > /dev/null
+          update-java-alternatives --jre-headless -s ${JDK11_NAME} > /dev/null
         fi
 
         ;;

--- a/debian/cloudstack-management.postinst
+++ b/debian/cloudstack-management.postinst
@@ -63,6 +63,13 @@ if [ "$1" = configure ]; then
     grep -s -q "db.cloud.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS} || sed -i -e "\$adb.cloud.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS}
     grep -s -q "db.usage.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS} || sed -i -e "\$adb.usage.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS}
     grep -s -q "db.simulator.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS} || sed -i -e "\$adb.simulator.driver=jdbc:mysql" ${CONFDIR}/${DBPROPS}
+
+    # Check and switch to Java 11
+    JDK11_NAME=$(update-java-alternatives --list | grep 11 | head -1 |  grep -Eo '^[^ ]+')
+    if [ -z ${JDK11_NAME} ]; then
+      echo "Setting default JAVA to ${JDK11_NAME}"
+      update-java-alternatives -s ${JDK11_NAME} > /dev/null
+    fi
 fi
 
 #DEBHELPER#

--- a/debian/cloudstack-management.postinst
+++ b/debian/cloudstack-management.postinst
@@ -66,9 +66,9 @@ if [ "$1" = configure ]; then
 
     # Check and switch to Java 11
     JDK11_NAME=$(update-java-alternatives --list | grep 11 | head -1 |  grep -Eo '^[^ ]+')
-    if [ -z ${JDK11_NAME} ]; then
+    if [ -n ${JDK11_NAME} ]; then
       echo "Setting default JAVA to ${JDK11_NAME}"
-      update-java-alternatives -s ${JDK11_NAME} > /dev/null
+      update-java-alternatives --jre-headless -s ${JDK11_NAME} > /dev/null
     fi
 fi
 

--- a/debian/cloudstack-usage.postinst
+++ b/debian/cloudstack-usage.postinst
@@ -38,6 +38,14 @@ case "$1" in
             rm -f /etc/cloudstack/usage/key
             ln -s /etc/cloudstack/management/key /etc/cloudstack/usage/key
         fi
+
+        # Check and switch to Java 11
+        JDK11_NAME=$(update-java-alternatives --list | grep 11 | head -1 |  grep -Eo '^[^ ]+')
+        if [ -z ${JDK11_NAME} ]; then
+          echo "Setting default JAVA to ${JDK11_NAME}"
+          update-java-alternatives -s ${JDK11_NAME} > /dev/null
+        fi
+
         ;;
 esac
 

--- a/debian/cloudstack-usage.postinst
+++ b/debian/cloudstack-usage.postinst
@@ -41,9 +41,9 @@ case "$1" in
 
         # Check and switch to Java 11
         JDK11_NAME=$(update-java-alternatives --list | grep 11 | head -1 |  grep -Eo '^[^ ]+')
-        if [ -z ${JDK11_NAME} ]; then
+        if [ -n ${JDK11_NAME} ]; then
           echo "Setting default JAVA to ${JDK11_NAME}"
-          update-java-alternatives -s ${JDK11_NAME} > /dev/null
+          update-java-alternatives --jre-headless -s ${JDK11_NAME} > /dev/null
         fi
 
         ;;

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -403,7 +403,7 @@ chown -R cloud:cloud /var/log/cloudstack/management
 systemctl daemon-reload
 
 JAVA11_NAME=$(alternatives --display java | grep 'family java-11' | grep -Eo '^[^ ]+')
-if [ -z $JDK11_NAME ]; then
+if [ -n $JDK11_NAME ]; then
   echo "Setting default Java to $JDK11_NAME"
   alternatives --set java $JDK11_NAME
 fi
@@ -446,7 +446,7 @@ fi
 systemctl daemon-reload
 
 JAVA11_NAME=$(alternatives --display java | grep 'family java-11' | grep -Eo '^[^ ]+')
-if [ -z $JDK11_NAME ]; then
+if [ -n $JDK11_NAME ]; then
   echo "Setting default Java to $JDK11_NAME"
   alternatives --set java $JDK11_NAME
 fi
@@ -480,7 +480,7 @@ if [ ! -f "%{_sysconfdir}/%{name}/usage/key" ]; then
 fi
 
 JAVA11_NAME=$(alternatives --display java | grep 'family java-11' | grep -Eo '^[^ ]+')
-if [ -z $JDK11_NAME ]; then
+if [ -n $JDK11_NAME ]; then
   echo "Setting default Java to $JDK11_NAME"
   alternatives --set java $JDK11_NAME
 fi

--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -402,6 +402,12 @@ chown -R cloud:cloud /var/log/cloudstack/management
 
 systemctl daemon-reload
 
+JAVA11_NAME=$(alternatives --display java | grep 'family java-11' | grep -Eo '^[^ ]+')
+if [ -z $JDK11_NAME ]; then
+  echo "Setting default Java to $JDK11_NAME"
+  alternatives --set java $JDK11_NAME
+fi
+
 %preun agent
 /sbin/service cloudstack-agent stop || true
 if [ "$1" == "0" ] ; then
@@ -439,6 +445,12 @@ fi
 
 systemctl daemon-reload
 
+JAVA11_NAME=$(alternatives --display java | grep 'family java-11' | grep -Eo '^[^ ]+')
+if [ -z $JDK11_NAME ]; then
+  echo "Setting default Java to $JDK11_NAME"
+  alternatives --set java $JDK11_NAME
+fi
+
 %pre usage
 id cloud > /dev/null 2>&1 || /usr/sbin/useradd -M -c "CloudStack unprivileged user" \
      -r -s /bin/sh -d %{_localstatedir}/cloudstack/management cloud|| true
@@ -465,6 +477,12 @@ fi
 
 if [ ! -f "%{_sysconfdir}/%{name}/usage/key" ]; then
     ln -s %{_sysconfdir}/%{name}/management/key %{_sysconfdir}/%{name}/usage/key
+fi
+
+JAVA11_NAME=$(alternatives --display java | grep 'family java-11' | grep -Eo '^[^ ]+')
+if [ -z $JDK11_NAME ]; then
+  echo "Setting default Java to $JDK11_NAME"
+  alternatives --set java $JDK11_NAME
 fi
 
 %post marvin


### PR DESCRIPTION
## Description

On install or upgrade, in the post-installation/configure, the packages can check and update the default java to JDK11. On most systems, the java is set to `auto` or the best/latest version available, but for in-place upgrades, users may miss reading the release notes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)