### PR TITLE
VR: incorporate OOB start checks to properly HA the VR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ env:
              smoke/test_ssvm
              smoke/test_staticroles
              smoke/test_templates
+             smoke/test_update_security_group
              smoke/test_usage
              smoke/test_usage_events"
 

--- a/api/src/main/java/com/cloud/event/EventTypes.java
+++ b/api/src/main/java/com/cloud/event/EventTypes.java
@@ -327,6 +327,7 @@ public class EventTypes {
     public static final String EVENT_SECURITY_GROUP_DELETE = "SG.DELETE";
     public static final String EVENT_SECURITY_GROUP_ASSIGN = "SG.ASSIGN";
     public static final String EVENT_SECURITY_GROUP_REMOVE = "SG.REMOVE";
+    public static final String EVENT_SECURITY_GROUP_UPDATE = "SG.UPDATE";
 
     // Host
     public static final String EVENT_HOST_RECONNECT = "HOST.RECONNECT";

--- a/api/src/main/java/com/cloud/network/NetworkService.java
+++ b/api/src/main/java/com/cloud/network/NetworkService.java
@@ -180,7 +180,7 @@ public interface NetworkService {
      * @throws ResourceAllocationException
      */
     Network createPrivateNetwork(String networkName, String displayText, long physicalNetworkId, String broadcastUri, String startIp, String endIP, String gateway,
-        String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId) throws ResourceAllocationException, ConcurrentOperationException,
+        String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId, Boolean bypassVlanOverlapCheck) throws ResourceAllocationException, ConcurrentOperationException,
         InsufficientCapacityException;
 
     /**

--- a/api/src/main/java/com/cloud/network/security/SecurityGroupService.java
+++ b/api/src/main/java/com/cloud/network/security/SecurityGroupService.java
@@ -18,16 +18,17 @@ package com.cloud.network.security;
 
 import java.util.List;
 
+import com.cloud.exception.InvalidParameterValueException;
+import com.cloud.exception.PermissionDeniedException;
+import com.cloud.exception.ResourceInUseException;
+
 import org.apache.cloudstack.api.command.user.securitygroup.AuthorizeSecurityGroupEgressCmd;
 import org.apache.cloudstack.api.command.user.securitygroup.AuthorizeSecurityGroupIngressCmd;
 import org.apache.cloudstack.api.command.user.securitygroup.CreateSecurityGroupCmd;
 import org.apache.cloudstack.api.command.user.securitygroup.DeleteSecurityGroupCmd;
 import org.apache.cloudstack.api.command.user.securitygroup.RevokeSecurityGroupEgressCmd;
 import org.apache.cloudstack.api.command.user.securitygroup.RevokeSecurityGroupIngressCmd;
-
-import com.cloud.exception.InvalidParameterValueException;
-import com.cloud.exception.PermissionDeniedException;
-import com.cloud.exception.ResourceInUseException;
+import org.apache.cloudstack.api.command.user.securitygroup.UpdateSecurityGroupCmd;
 
 public interface SecurityGroupService {
     /**
@@ -42,6 +43,8 @@ public interface SecurityGroupService {
     boolean revokeSecurityGroupEgress(RevokeSecurityGroupEgressCmd cmd);
 
     boolean deleteSecurityGroup(DeleteSecurityGroupCmd cmd) throws ResourceInUseException;
+
+    SecurityGroup updateSecurityGroup(UpdateSecurityGroupCmd cmd);
 
     public List<? extends SecurityRule> authorizeSecurityGroupIngress(AuthorizeSecurityGroupIngressCmd cmd);
 

--- a/api/src/main/java/com/cloud/network/vpc/VpcService.java
+++ b/api/src/main/java/com/cloud/network/vpc/VpcService.java
@@ -166,7 +166,7 @@ public interface VpcService {
      * @throws ResourceAllocationException
      */
     public PrivateGateway createVpcPrivateGateway(long vpcId, Long physicalNetworkId, String vlan, String ipAddress, String gateway, String netmask, long gatewayOwnerId,
-            Long networkOfferingId, Boolean isSoruceNat, Long aclId) throws ResourceAllocationException, ConcurrentOperationException, InsufficientCapacityException;
+            Long networkOfferingId, Boolean isSoruceNat, Long aclId, Boolean bypassVlanOverlapCheck) throws ResourceAllocationException, ConcurrentOperationException, InsufficientCapacityException;
 
     /**
      * Applies VPC private gateway on the backend, so it becomes functional

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vpc/CreatePrivateGatewayCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vpc/CreatePrivateGatewayCmd.java
@@ -92,6 +92,9 @@ public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
     @Parameter(name = ApiConstants.ACL_ID, type = CommandType.UUID, entityType = NetworkACLResponse.class, required = false, description = "the ID of the network ACL")
     private Long aclId;
 
+    @Parameter(name=ApiConstants.BYPASS_VLAN_OVERLAP_CHECK, type=CommandType.BOOLEAN, description="when true bypasses VLAN id/range overlap check during private gateway creation")
+    private Boolean bypassVlanOverlapCheck;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -135,6 +138,13 @@ public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
         return aclId;
     }
 
+    public Boolean getBypassVlanOverlapCheck() {
+        if (bypassVlanOverlapCheck != null) {
+            return bypassVlanOverlapCheck;
+        }
+        return false;
+    }
+
     /////////////////////////////////////////////////////
     /////////////// API Implementation///////////////////
     /////////////////////////////////////////////////////
@@ -149,7 +159,7 @@ public class CreatePrivateGatewayCmd extends BaseAsyncCreateCmd {
         try {
             result =
                 _vpcService.createVpcPrivateGateway(getVpcId(), getPhysicalNetworkId(), getBroadcastUri(), getStartIp(), getGateway(), getNetmask(), getEntityOwnerId(),
-                    getNetworkOfferingId(), getIsSourceNat(), getAclId());
+                    getNetworkOfferingId(), getIsSourceNat(), getAclId(), getBypassVlanOverlapCheck());
         } catch (InsufficientCapacityException ex) {
             s_logger.info(ex);
             s_logger.trace(ex);

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/securitygroup/UpdateSecurityGroupCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/securitygroup/UpdateSecurityGroupCmd.java
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.user.securitygroup;
+
+import org.apache.log4j.Logger;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.acl.SecurityChecker.AccessType;
+import org.apache.cloudstack.api.ACL;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.BaseCustomIdCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.SecurityGroupResponse;
+
+import com.cloud.network.security.SecurityGroup;
+import com.cloud.user.Account;
+
+@APICommand(name = UpdateSecurityGroupCmd.APINAME, description = "Updates a security group", responseObject = SecurityGroupResponse.class, entityType = {SecurityGroup.class},
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false,
+        since = "4.14.0.0",
+        authorized = {RoleType.Admin})
+public class UpdateSecurityGroupCmd extends BaseCustomIdCmd {
+    public static final String APINAME = "updateSecurityGroup";
+    public static final Logger s_logger = Logger.getLogger(UpdateSecurityGroupCmd.class.getName());
+    private static final String s_name = "updatesecuritygroupresponse";
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @ACL(accessType = AccessType.OperateEntry)
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, required=true, description="The ID of the security group.", entityType=SecurityGroupResponse.class)
+    private Long id;
+
+    @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "The new name of the security group.")
+    private String name;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+    @Override
+    public String getCommandName() {
+        return s_name;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        SecurityGroup securityGroup = _entityMgr.findById(SecurityGroup.class, getId());
+        if (securityGroup != null) {
+            return securityGroup.getAccountId();
+        }
+
+        return Account.ACCOUNT_ID_SYSTEM; // no account info given, parent this command to SYSTEM so ERROR events are tracked
+    }
+
+    @Override
+    public void execute() {
+        SecurityGroup result = _securityGroupService.updateSecurityGroup(this);
+        if (result != null) {
+            SecurityGroupResponse response = _responseGenerator.createSecurityGroupResponse(result);
+            response.setResponseName(getCommandName());
+            setResponseObject(response);
+        } else {
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to update security group");
+        }
+    }
+
+    @Override
+    public void checkUuid() {
+        if (getCustomId() != null) {
+            _uuidMgr.checkUuid(getCustomId(), SecurityGroup.class);
+        }
+    }
+
+}

--- a/core/src/main/java/com/cloud/agent/api/RebootCommand.java
+++ b/core/src/main/java/com/cloud/agent/api/RebootCommand.java
@@ -19,8 +19,11 @@
 
 package com.cloud.agent.api;
 
+import com.cloud.agent.api.to.VirtualMachineTO;
+
 public class RebootCommand extends Command {
     String vmName;
+    VirtualMachineTO vm;
     protected boolean executeInSequence = false;
 
     protected RebootCommand() {
@@ -33,6 +36,14 @@ public class RebootCommand extends Command {
 
     public String getVmName() {
         return this.vmName;
+    }
+
+    public void setVirtualMachine(VirtualMachineTO vm) {
+        this.vm = vm;
+    }
+
+    public VirtualMachineTO getVirtualMachine() {
+        return vm;
     }
 
     @Override

--- a/core/src/main/java/com/cloud/agent/api/SecurityGroupRulesCmd.java
+++ b/core/src/main/java/com/cloud/agent/api/SecurityGroupRulesCmd.java
@@ -30,12 +30,13 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.log4j.Logger;
 
 import com.cloud.agent.api.LogLevel.Log4jLevel;
+import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.utils.net.NetUtils;
 
 public class SecurityGroupRulesCmd extends Command {
     private static final String CIDR_LENGTH_SEPARATOR = "/";
-    private static final char RULE_TARGET_SEPARATOR = ',';
-    private static final char RULE_COMMAND_SEPARATOR = ';';
+    public static final char RULE_TARGET_SEPARATOR = ',';
+    public static final char RULE_COMMAND_SEPARATOR = ';';
     protected static final String EGRESS_RULE = "E:";
     protected static final String INGRESS_RULE = "I:";
     private static final Logger LOGGER = Logger.getLogger(SecurityGroupRulesCmd.class);
@@ -51,6 +52,7 @@ public class SecurityGroupRulesCmd extends Command {
     private List<IpPortAndProto> ingressRuleSet;
     private List<IpPortAndProto> egressRuleSet;
     private final List<String> secIps;
+    private VirtualMachineTO vmTO;
 
     public static class IpPortAndProto {
         private final String proto;
@@ -250,6 +252,14 @@ public class SecurityGroupRulesCmd extends Command {
 
     public Long getVmId() {
         return vmId;
+    }
+
+    public void setVmTO(VirtualMachineTO vmTO) {
+        this.vmTO = vmTO;
+    }
+
+    public VirtualMachineTO getVmTO() {
+        return vmTO;
     }
 
     /**

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/NetworkOrchestrationService.java
@@ -178,6 +178,8 @@ public interface NetworkOrchestrationService {
 
     boolean destroyNetwork(long networkId, ReservationContext context, boolean forced);
 
+    Network createPrivateNetwork(long networkOfferingId, String name, String displayText, String gateway, String cidr, String vlanId, boolean bypassVlanOverlapCheck, Account owner, PhysicalNetwork pNtwk, Long vpcId) throws ConcurrentOperationException, InsufficientCapacityException, ResourceAllocationException;
+
     Network createGuestNetwork(long networkOfferingId, String name, String displayText, String gateway, String cidr, String vlanId, boolean bypassVlanOverlapCheck, String networkDomain, Account owner,
                                Long domainId, PhysicalNetwork physicalNetwork, long zoneId, ACLType aclType, Boolean subdomainAccess, Long vpcId, String ip6Gateway, String ip6Cidr,
                                Boolean displayNetworkEnabled, String isolatedPvlan, Network.PVlanType isolatedPvlanType, String externalId) throws ConcurrentOperationException, InsufficientCapacityException, ResourceAllocationException;

--- a/engine/components-api/src/main/java/com/cloud/agent/AgentManager.java
+++ b/engine/components-api/src/main/java/com/cloud/agent/AgentManager.java
@@ -152,4 +152,6 @@ public interface AgentManager {
     void notifyMonitorsOfHostAboutToBeRemoved(long hostId);
 
     void notifyMonitorsOfRemovedHost(long hostId, long clusterId);
+
+    void propagateChangeToAgents();
 }

--- a/engine/components-api/src/main/java/com/cloud/network/security/SecurityGroupManager.java
+++ b/engine/components-api/src/main/java/com/cloud/network/security/SecurityGroupManager.java
@@ -53,4 +53,6 @@ public interface SecurityGroupManager {
     SecurityGroup getSecurityGroup(String name, long accountId);
 
     boolean isVmMappedToDefaultSecurityGroup(long vmId);
+
+    void scheduleRulesetUpdateToHosts(List<Long> affectedVms, boolean updateSeqno, Long delayMs);
 }

--- a/engine/schema/src/main/java/com/cloud/network/dao/NetworkDao.java
+++ b/engine/schema/src/main/java/com/cloud/network/dao/NetworkDao.java
@@ -105,7 +105,7 @@ public interface NetworkDao extends GenericDao<NetworkVO, Long>, StateDao<State,
 
     List<NetworkVO> listByVpc(long vpcId);
 
-    NetworkVO getPrivateNetwork(String broadcastUri, String cidr, long accountId, long zoneId, Long networkOfferingId);
+    NetworkVO getPrivateNetwork(String broadcastUri, String cidr, long accountId, long zoneId, Long networkOfferingId, Long vpcId);
 
     long countVpcNetworks(long vpcId);
 

--- a/engine/schema/src/main/java/com/cloud/network/security/SecurityGroupVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/security/SecurityGroupVO.java
@@ -70,6 +70,10 @@ public class SecurityGroupVO implements SecurityGroup {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     @Override
     public String getDescription() {
         return description;

--- a/engine/schema/src/main/java/com/cloud/vm/dao/NicDao.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/NicDao.java
@@ -50,6 +50,8 @@ public interface NicDao extends GenericDao<NicVO, Long> {
 
     NicVO findDefaultNicForVM(long instanceId);
 
+    NicVO findFirstNicForVM(long instanceId);
+
     /**
      * @param networkId
      * @param instanceId

--- a/engine/schema/src/main/java/com/cloud/vm/dao/NicDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/vm/dao/NicDaoImpl.java
@@ -69,6 +69,7 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         AllFieldsSearch.and("strategy", AllFieldsSearch.entity().getReservationStrategy(), Op.EQ);
         AllFieldsSearch.and("reserverName",AllFieldsSearch.entity().getReserver(),Op.EQ);
         AllFieldsSearch.and("macAddress", AllFieldsSearch.entity().getMacAddress(), Op.EQ);
+        AllFieldsSearch.and("deviceid", AllFieldsSearch.entity().getDeviceId(), Op.EQ);
         AllFieldsSearch.done();
 
         IpSearch = createSearchBuilder(String.class);
@@ -219,6 +220,14 @@ public class NicDaoImpl extends GenericDaoBase<NicVO, Long> implements NicDao {
         SearchCriteria<NicVO> sc = AllFieldsSearch.create();
         sc.setParameters("instance", instanceId);
         sc.setParameters("isDefault", 1);
+        return findOneBy(sc);
+    }
+
+    @Override
+    public NicVO findFirstNicForVM(long instanceId) {
+        SearchCriteria<NicVO> sc = AllFieldsSearch.create();
+        sc.setParameters("instance", instanceId);
+        sc.setParameters("deviceid", 0);
         return findOneBy(sc);
     }
 

--- a/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41300to41400-cleanup.sql
@@ -23,3 +23,6 @@ DELETE FROM `cloud`.`configuration` WHERE name = 'host.maintenance.retries';
 
 -- Stop asking user (in the upgraded documentation) to remove a trailing slash for local KVM pool
 UPDATE `cloud`.`storage_pool` SET path="/var/lib/libvirt/images" WHERE path="/var/lib/libvirt/images/";
+
+-- remove (one of) duplicate unique indexes from Region table
+ALTER TABLE `region` DROP INDEX `id_3`;

--- a/framework/agent-lb/src/main/java/org/apache/cloudstack/agent/lb/IndirectAgentLB.java
+++ b/framework/agent-lb/src/main/java/org/apache/cloudstack/agent/lb/IndirectAgentLB.java
@@ -50,4 +50,7 @@ public interface IndirectAgentLB {
      * @return returns interval in seconds
      */
     Long getLBPreferredHostCheckInterval(Long clusterId);
+
+    void propagateMSListToAgents();
+
 }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -103,6 +103,7 @@ import com.cloud.agent.api.to.IpAddressTO;
 import com.cloud.agent.api.to.NfsTO;
 import com.cloud.agent.api.to.NicTO;
 import com.cloud.agent.api.to.VirtualMachineTO;
+import com.cloud.agent.dao.impl.PropertiesStorage;
 import com.cloud.agent.resource.virtualnetwork.VRScripts;
 import com.cloud.agent.resource.virtualnetwork.VirtualRouterDeployer;
 import com.cloud.agent.resource.virtualnetwork.VirtualRoutingResource;
@@ -1098,6 +1099,24 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
         IscsiStorageCleanupMonitor isciCleanupMonitor = new IscsiStorageCleanupMonitor();
         final Thread cleanupMonitor = new Thread(isciCleanupMonitor);
         cleanupMonitor.start();
+
+        return true;
+    }
+
+    public boolean configureHostParams(final Map<String, String> params) {
+        final File file = PropertiesUtil.findConfigFile("agent.properties");
+        if (file == null) {
+            s_logger.error("Unable to find the file agent.properties");
+            return false;
+        }
+        // Save configurations in agent.properties
+        PropertiesStorage storage = new PropertiesStorage();
+        storage.configure("Storage", new HashMap<String, Object>());
+        if (params.get("router.aggregation.command.each.timeout") != null) {
+            String value = (String)params.get("router.aggregation.command.each.timeout");
+            Integer intValue = NumbersUtil.parseInt(value, 600);
+            storage.persist("router.aggregation.command.each.timeout", String.valueOf(intValue));
+        }
 
         return true;
     }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtNetworkRulesVmSecondaryIpCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtNetworkRulesVmSecondaryIpCommandWrapper.java
@@ -41,7 +41,7 @@ public final class LibvirtNetworkRulesVmSecondaryIpCommandWrapper extends Comman
             final LibvirtUtilitiesHelper libvirtUtilitiesHelper = libvirtComputingResource.getLibvirtUtilitiesHelper();
 
             final Connect conn = libvirtUtilitiesHelper.getConnectionByVmName(command.getVmName());
-            result = libvirtComputingResource.configureNetworkRulesVMSecondaryIP(conn, command.getVmName(), command.getVmSecIp(), command.getAction());
+            result = libvirtComputingResource.configureNetworkRulesVMSecondaryIP(conn, command.getVmName(), command.getVmMac(), command.getVmSecIp(), command.getAction());
         } catch (final LibvirtException e) {
             s_logger.debug("Could not configure VM secondary IP! => " + e.getLocalizedMessage());
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRebootCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRebootCommandWrapper.java
@@ -26,6 +26,7 @@ import org.libvirt.LibvirtException;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.RebootAnswer;
 import com.cloud.agent.api.RebootCommand;
+import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
 import com.cloud.resource.CommandWrapper;
 import com.cloud.resource.ResourceWrapper;
@@ -38,6 +39,7 @@ public final class LibvirtRebootCommandWrapper extends CommandWrapper<RebootComm
     @Override
     public Answer execute(final RebootCommand command, final LibvirtComputingResource libvirtComputingResource) {
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = libvirtComputingResource.getLibvirtUtilitiesHelper();
+        final VirtualMachineTO vmSpec = command.getVirtualMachine();
 
         try {
             final Connect conn = libvirtUtilitiesHelper.getConnectionByVmName(command.getVmName());
@@ -49,7 +51,9 @@ public final class LibvirtRebootCommandWrapper extends CommandWrapper<RebootComm
                 } catch (final LibvirtException e) {
                     s_logger.trace("Ignoring libvirt error.", e);
                 }
-                libvirtComputingResource.getRuleLogsForVms();
+                if (vmSpec != null) {
+                    libvirtComputingResource.applyDefaultNetworkRules(conn, vmSpec, false);
+                }
                 return new RebootAnswer(command, null, vncPort);
             } else {
                 return new RebootAnswer(command, result, false);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtSecurityGroupRulesCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtSecurityGroupRulesCommandWrapper.java
@@ -28,6 +28,7 @@ import org.libvirt.LibvirtException;
 import com.cloud.agent.api.Answer;
 import com.cloud.agent.api.SecurityGroupRuleAnswer;
 import com.cloud.agent.api.SecurityGroupRulesCmd;
+import com.cloud.agent.api.to.VirtualMachineTO;
 import com.cloud.hypervisor.kvm.resource.LibvirtComputingResource;
 import com.cloud.hypervisor.kvm.resource.LibvirtVMDef.InterfaceDef;
 import com.cloud.resource.CommandWrapper;
@@ -50,6 +51,12 @@ public final class LibvirtSecurityGroupRulesCommandWrapper extends CommandWrappe
 
             vif = nics.get(0).getDevName();
             brname = nics.get(0).getBrName();
+
+            final VirtualMachineTO vm = command.getVmTO();
+            if (!libvirtComputingResource.applyDefaultNetworkRules(conn, vm, true)) {
+                s_logger.warn("Failed to program default network rules for vm " + command.getVmName());
+                return new SecurityGroupRuleAnswer(command, false, "programming default network rules failed");
+            }
         } catch (final LibvirtException e) {
             return new SecurityGroupRuleAnswer(command, false, e.toString());
         }

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtSetHostParamsCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtSetHostParamsCommandWrapper.java
@@ -35,6 +35,7 @@ public final class LibvirtSetHostParamsCommandWrapper extends CommandWrapper<Set
 
         final Map<String, String> params = command.getParams();
         boolean success = libvirtComputingResource.getVirtRouterResource().configureHostParams(params);
+        success = success && libvirtComputingResource.configureHostParams(params);
 
         if (!success) {
             return new Answer(command, false, "Failed to set host parameters");

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtUnPlugNicCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtUnPlugNicCommandWrapper.java
@@ -55,6 +55,9 @@ public final class LibvirtUnPlugNicCommandWrapper extends CommandWrapper<UnPlugN
 
             for (final InterfaceDef pluggedNic : pluggedNics) {
                 if (pluggedNic.getMacAddress().equalsIgnoreCase(nic.getMac())) {
+                    if (nic.isSecurityGroupEnabled()) {
+                        libvirtComputingResource.destroyNetworkRulesForNic(conn, vmName, nic);
+                    }
                     vm.detachDevice(pluggedNic.toString());
                     // We don't know which "traffic type" is associated with
                     // each interface at this point, so inform all vif drivers

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -2413,7 +2413,7 @@ public class LibvirtComputingResourceTest {
         } catch (final LibvirtException e) {
             fail(e.getMessage());
         }
-        when(libvirtComputingResource.configureNetworkRulesVMSecondaryIP(conn, command.getVmName(), command.getVmSecIp(), command.getAction())).thenReturn(true);
+        when(libvirtComputingResource.configureNetworkRulesVMSecondaryIP(conn, command.getVmName(), command.getVmMac(), command.getVmSecIp(), command.getAction())).thenReturn(true);
 
         final LibvirtRequestWrapper wrapper = LibvirtRequestWrapper.getInstance();
         assertNotNull(wrapper);
@@ -2427,7 +2427,7 @@ public class LibvirtComputingResourceTest {
             fail(e.getMessage());
         }
         verify(libvirtComputingResource, times(1)).getLibvirtUtilitiesHelper();
-        verify(libvirtComputingResource, times(1)).configureNetworkRulesVMSecondaryIP(conn, command.getVmName(), command.getVmSecIp(), command.getAction());
+        verify(libvirtComputingResource, times(1)).configureNetworkRulesVMSecondaryIP(conn, command.getVmName(), command.getVmMac(), command.getVmSecIp(), command.getAction());
     }
 
     @SuppressWarnings("unchecked")
@@ -3021,6 +3021,8 @@ public class LibvirtComputingResourceTest {
         cidrs.add("0.0.0.0/0");
 
         final SecurityGroupRulesCmd command = new SecurityGroupRulesCmd(guestIp, guestIp6, guestMac, vmName, vmId, signature, seqNum, ingressRuleSet, egressRuleSet, secIps);
+        final VirtualMachineTO vm = Mockito.mock(VirtualMachineTO.class);
+        command.setVmTO(vm);
 
         final LibvirtUtilitiesHelper libvirtUtilitiesHelper = Mockito.mock(LibvirtUtilitiesHelper.class);
         final Connect conn = Mockito.mock(Connect.class);
@@ -3053,6 +3055,7 @@ public class LibvirtComputingResourceTest {
         when(egressRuleSet[0].getEndPort()).thenReturn(22);
         when(egressRuleSet[0].getAllowedCidrs()).thenReturn(cidrs);
 
+        when(libvirtComputingResource.applyDefaultNetworkRules(conn, vm, true)).thenReturn(true);
         when(libvirtComputingResource.addNetworkRules(command.getVmName(), Long.toString(command.getVmId()), command.getGuestIp(), command.getGuestIp6(), command.getSignature(),
                 Long.toString(command.getSeqNum()), command.getGuestMac(), command.stringifyRules(), vif, brname, command.getSecIpsString())).thenReturn(true);
 

--- a/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
+++ b/server/src/main/java/com/cloud/hypervisor/KVMGuru.java
@@ -132,7 +132,7 @@ public class KVMGuru extends HypervisorGuruBase implements HypervisorGuru {
             guestOsMapping = _guestOsHypervisorDao.findByOsIdAndHypervisor(guestOS.getId(), getHypervisorType().toString(), host.getHypervisorVersion());
         }
         if (guestOsMapping == null || host == null) {
-            to.setPlatformEmulator("Other");
+            to.setPlatformEmulator(guestOS.getDisplayName() == null ? "Other" : guestOS.getDisplayName());
         } else {
             to.setPlatformEmulator(guestOsMapping.getGuestOsName());
         }

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -885,6 +885,10 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     @DB
     protected void updateSite2SiteVpnConnectionState(final List<DomainRouterVO> routers) {
         for (final DomainRouterVO router : routers) {
+            if (router.getRole() == Role.INTERNAL_LB_VM) {
+                continue;
+            }
+
             final List<Site2SiteVpnConnectionVO> conns = _s2sVpnMgr.getConnectionsForRouter(router);
             if (conns == null || conns.isEmpty()) {
                 continue;

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -2448,10 +2448,8 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
         // Fetch firewall Egress rules.
         if (_networkModel.isProviderSupportServiceInNetwork(guestNetworkId, Service.Firewall, provider)) {
             firewallRulesEgress.addAll(_rulesDao.listByNetworkPurposeTrafficType(guestNetworkId, Purpose.Firewall, FirewallRule.TrafficType.Egress));
-            if (firewallRulesEgress.isEmpty()) {
-                //create egress default rule for VR
-                createDefaultEgressFirewallRule(firewallRulesEgress, guestNetworkId);
-            }
+            //create egress default rule for VR
+            createDefaultEgressFirewallRule(firewallRulesEgress, guestNetworkId);
         }
 
         // Re-apply firewall Egress rules

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -379,6 +379,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     private ScheduledExecutorService _checkExecutor;
     private ScheduledExecutorService _networkStatsUpdateExecutor;
     private ExecutorService _rvrStatusUpdateExecutor;
+    private ExecutorService _routerOobStartExecutor;
 
     private BlockingQueue<Long> _vrUpdateQueue;
 
@@ -539,6 +540,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
         _executor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("RouterMonitor"));
         _checkExecutor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("RouterStatusMonitor"));
         _networkStatsUpdateExecutor = Executors.newScheduledThreadPool(1, new NamedThreadFactory("NetworkStatsUpdater"));
+        _routerOobStartExecutor = Executors.newCachedThreadPool(new NamedThreadFactory("CheckRouterAfterOobStartExecutor"));
 
         VirtualMachine.State.getStateMachine().registerListener(this);
 
@@ -3269,7 +3271,12 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                 event == VirtualMachine.Event.FollowAgentPowerOnReport &&
                 newState == VirtualMachine.State.Running &&
                 isOutOfBandMigrated(opaque)) {
-            s_logger.debug("Virtual router " + vo.getInstanceName() + " is powered-on out-of-band");
+            // Since vRouter appears to be powered-on OOB, make sure we can talk to router
+            // If we can't talk to it, we need to reboot it to get it managed correctly
+            // This is needed for example when a host agent goes down and comes back up,
+            // we would have done a failed HA event on the router and end up having our controlIP out-of-sync
+            s_logger.info("Virtual router " + vo.getInstanceName() + " is powered-on out-of-band, checking if can send CheckRouterCommand to router");
+            _routerOobStartExecutor.execute(new CheckRouterAfterOobStart(vo.getId()));
         }
 
         return true;
@@ -3297,6 +3304,42 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
             }
         }
         return false;
+    }
+
+    protected class CheckRouterAfterOobStart extends ManagedContextRunnable {
+
+        long _routerId;
+
+        public CheckRouterAfterOobStart(final long routerId) {
+            _routerId = routerId;
+        }
+
+        @Override
+        protected void runInContext() {
+            // Since vRouter appears to be powered-on OOB, make sure we can talk to router
+            // If we can't talk to it, we need to reboot it to get it managed correctly
+            // This is needed for example when a host agent goes down and comes back up,
+            // we would have done a failed HA event on the router and end up having our controlIP out-of-sync
+            final DomainRouterVO router = _routerDao.findById(_routerId);
+            final CheckRouterCommand command = new CheckRouterCommand();
+            final String routerDesc = router.getInstanceName() + " (ID:" + _routerId + ")";
+
+            command.setAccessDetail(NetworkElementCommand.ROUTER_IP, _routerControlHelper.getRouterControlIp(_routerId));
+            command.setAccessDetail(NetworkElementCommand.ROUTER_NAME, router.getInstanceName());
+            command.setWait(30);
+            final Answer answer = _agentMgr.easySend(router.getHostId(), command);
+            if (answer instanceof CheckRouterAnswer && answer.getResult()) {
+                s_logger.info("Successfully able to send CheckRouterCommand to " + routerDesc + " after out-of-band power-on");
+            }
+            else {
+                s_logger.warn("Unable to send CheckRouterCommand to " + routerDesc + ", rebooting router ");
+                try {
+                    rebootRouter(_routerId, true);
+                } catch (final Exception e) {
+                    s_logger.error("Error while rebooting router " + routerDesc, e);
+                }
+            }
+        }
     }
 
     protected boolean aggregationExecution(final AggregationControlCommand.Action action, final Network network, final List<DomainRouterVO> routers)

--- a/server/src/main/java/com/cloud/network/security/SecurityGroupManagerImpl2.java
+++ b/server/src/main/java/com/cloud/network/security/SecurityGroupManagerImpl2.java
@@ -177,16 +177,17 @@ public class SecurityGroupManagerImpl2 extends SecurityGroupManagerImpl {
             Map<PortAndProto, Set<String>> egressRules = generateRulesForVM(userVmId, SecurityRuleType.EgressRule);
             Long agentId = vm.getHostId();
             if (agentId != null) {
-                String privateIp = vm.getPrivateIpAddress();
-                NicVO nic = _nicDao.findByIp4AddressAndVmId(privateIp, vm.getId());
+                NicVO nic = _nicDao.findFirstNicForVM(vm.getId());
                 List<String> nicSecIps = null;
                 if (nic != null) {
                     if (nic.getSecondaryIp()) {
                         nicSecIps = _nicSecIpDao.getSecondaryIpAddressesForNic(nic.getId());
                     }
+                } else {
+                    return;
                 }
                 SecurityGroupRulesCmd cmd =
-                    generateRulesetCmd(vm.getInstanceName(), vm.getPrivateIpAddress(), nic.getIPv6Address(), vm.getPrivateMacAddress(), vm.getId(), null, work.getLogsequenceNumber(),
+                    generateRulesetCmd(vm.getInstanceName(), nic.getIPv4Address(), nic.getIPv6Address(), vm.getPrivateMacAddress(), vm.getId(), null, work.getLogsequenceNumber(),
                         ingressRules, egressRules, nicSecIps);
                 cmd.setMsId(_serverId);
                 if (s_logger.isDebugEnabled()) {

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1805,7 +1805,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @DB
     @ActionEvent(eventType = EventTypes.EVENT_PRIVATE_GATEWAY_CREATE, eventDescription = "creating VPC private gateway", create = true)
     public PrivateGateway createVpcPrivateGateway(final long vpcId, Long physicalNetworkId, final String broadcastUri, final String ipAddress, final String gateway,
-            final String netmask, final long gatewayOwnerId, final Long networkOfferingId, final Boolean isSourceNat, final Long aclId) throws ResourceAllocationException,
+            final String netmask, final long gatewayOwnerId, final Long networkOfferingId, final Boolean isSourceNat, final Long aclId, final Boolean bypassVlanOverlapCheck) throws ResourceAllocationException,
             ConcurrentOperationException, InsufficientCapacityException {
 
         // Validate parameters
@@ -1846,7 +1846,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                     Network privateNtwk = null;
                     if (BroadcastDomainType.getSchemeValue(BroadcastDomainType.fromString(broadcastUri)) == BroadcastDomainType.Lswitch) {
                         final String cidr = NetUtils.ipAndNetMaskToCidr(gateway, netmask);
-                        privateNtwk = _ntwkDao.getPrivateNetwork(broadcastUri, cidr, gatewayOwnerId, dcId, networkOfferingId);
+                        privateNtwk = _ntwkDao.getPrivateNetwork(broadcastUri, cidr, gatewayOwnerId, dcId, networkOfferingId, vpcId);
                         // if the dcid is different we get no network so next we
                         // try to create it
                     }
@@ -1854,7 +1854,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                         s_logger.info("creating new network for vpc " + vpc + " using broadcast uri: " + broadcastUri);
                         final String networkName = "vpc-" + vpc.getName() + "-privateNetwork";
                         privateNtwk = _ntwkSvc.createPrivateNetwork(networkName, networkName, physicalNetworkIdFinal, broadcastUri, ipAddress, null, gateway, netmask,
-                                gatewayOwnerId, vpcId, isSourceNat, networkOfferingId);
+                                gatewayOwnerId, vpcId, isSourceNat, networkOfferingId, bypassVlanOverlapCheck);
                     } else { // create the nic/ip as createPrivateNetwork
                         // doesn''t do that work for us now
                         s_logger.info("found and using existing network for vpc " + vpc + ": " + broadcastUri);

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -425,6 +425,7 @@ import org.apache.cloudstack.api.command.user.securitygroup.DeleteSecurityGroupC
 import org.apache.cloudstack.api.command.user.securitygroup.ListSecurityGroupsCmd;
 import org.apache.cloudstack.api.command.user.securitygroup.RevokeSecurityGroupEgressCmd;
 import org.apache.cloudstack.api.command.user.securitygroup.RevokeSecurityGroupIngressCmd;
+import org.apache.cloudstack.api.command.user.securitygroup.UpdateSecurityGroupCmd;
 import org.apache.cloudstack.api.command.user.snapshot.ArchiveSnapshotCmd;
 import org.apache.cloudstack.api.command.user.snapshot.CreateSnapshotCmd;
 import org.apache.cloudstack.api.command.user.snapshot.CreateSnapshotFromVMSnapshotCmd;
@@ -2895,6 +2896,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(ListSecurityGroupsCmd.class);
         cmdList.add(RevokeSecurityGroupEgressCmd.class);
         cmdList.add(RevokeSecurityGroupIngressCmd.class);
+        cmdList.add(UpdateSecurityGroupCmd.class);
         cmdList.add(CreateSnapshotCmd.class);
         cmdList.add(CreateSnapshotFromVMSnapshotCmd.class);
         cmdList.add(DeleteSnapshotCmd.class);

--- a/server/src/main/java/com/cloud/server/StatsCollector.java
+++ b/server/src/main/java/com/cloud/server/StatsCollector.java
@@ -928,13 +928,7 @@ public class StatsCollector extends ManagerBase implements ComponentMethodInterc
                     List<VolumeVO> volumes = _volsDao.findByPoolId(pool.getId(), null);
                     List<String> volumeLocators = new ArrayList<String>();
                     for (VolumeVO volume : volumes) {
-                        if (volume.getFormat() == ImageFormat.QCOW2) {
-                            if (pool.isManaged()) {
-                                volumeLocators.add(volume.getPath());
-                            } else {
-                                volumeLocators.add(volume.getUuid());
-                            }
-                        } else if (volume.getFormat() == ImageFormat.VHD) {
+                        if (volume.getFormat() == ImageFormat.QCOW2 || volume.getFormat() == ImageFormat.VHD) {
                             volumeLocators.add(volume.getPath());
                         } else if (volume.getFormat() == ImageFormat.OVA) {
                             volumeLocators.add(volume.getChainInfo());

--- a/server/src/test/java/com/cloud/network/CreatePrivateNetworkTest.java
+++ b/server/src/test/java/com/cloud/network/CreatePrivateNetworkTest.java
@@ -116,7 +116,7 @@ public class CreatePrivateNetworkTest {
         DataCenterVO dc = new DataCenterVO(1L, "hut", "op de hei", null, null, null, null, "10.1.1.0/24", "unreal.net", 1L, NetworkType.Advanced, null, null);
         when(networkService._dcDao.lockRow(anyLong(), anyBoolean())).thenReturn(dc);
 
-        when(networkService._networksDao.getPrivateNetwork(anyString(), anyString(), eq(1L), eq(1L), anyLong())).thenReturn(null);
+        when(networkService._networksDao.getPrivateNetwork(anyString(), anyString(), eq(1L), eq(1L), anyLong(), anyLong())).thenReturn(null);
 
         Network net =
             new NetworkVO(1L, TrafficType.Guest, Mode.None, BroadcastDomainType.Vlan, 1L, 1L, 1L, 1L, "bla", "fake", "eet.net", GuestType.Isolated, 1L, 1L,
@@ -124,6 +124,8 @@ public class CreatePrivateNetworkTest {
         when(networkService._networkMgr.createGuestNetwork(eq(ntwkOff.getId()), eq("bla"), eq("fake"), eq("10.1.1.1"), eq("10.1.1.0/24"), nullable(String.class), nullable(Boolean.class), nullable(String.class),
                         eq(account), nullable(Long.class), eq(physicalNetwork), eq(physicalNetwork.getDataCenterId()), eq(ACLType.Account), nullable(Boolean.class), eq(1L), nullable(String.class), nullable(String.class),
                         nullable(Boolean.class), nullable(String.class), nullable(Network.PVlanType.class), nullable(String.class))).thenReturn(net);
+        when(
+            networkService._networkMgr.createPrivateNetwork(eq(ntwkOff.getId()), eq("bla"), eq("fake"), eq("10.1.1.1"), eq("10.1.1.0/24"), anyString(), anyBoolean(), eq(account), eq(physicalNetwork), eq(1L))).thenReturn(net);
 
         when(networkService._privateIpDao.findByIpAndSourceNetworkId(net.getId(), "10.1.1.2")).thenReturn(null);
         when(networkService._privateIpDao.findByIpAndSourceNetworkIdAndVpcId(eq(1L), anyString(), eq(1L))).thenReturn(null);
@@ -137,21 +139,21 @@ public class CreatePrivateNetworkTest {
         /* Network nw; */
         try {
             /* nw = */
-            networkService.createPrivateNetwork("bla", "fake", 1L, "vlan:1", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, true, 1L);
+            networkService.createPrivateNetwork("bla", "fake", 1L, "vlan:1", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, true, 1L, false);
             /* nw = */
-            networkService.createPrivateNetwork("bla", "fake", 1L, "lswitch:3", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, false, 1L);
+            networkService.createPrivateNetwork("bla", "fake", 1L, "lswitch:3", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1L, 1L, false, 1L, false);
             boolean invalid = false;
             boolean unsupported = false;
             try {
                 /* nw = */
-                networkService.createPrivateNetwork("bla", "fake", 1, "bla:2", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, true, 1L);
+                networkService.createPrivateNetwork("bla", "fake", 1, "bla:2", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, true, 1L, false);
             } catch (CloudRuntimeException e) {
                 Assert.assertEquals("unexpected parameter exception", "string 'bla:2' has an unknown BroadcastDomainType.", e.getMessage());
                 invalid = true;
             }
             try {
                 /* nw = */
-                networkService.createPrivateNetwork("bla", "fake", 1, "mido://4", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, false, 1L);
+                networkService.createPrivateNetwork("bla", "fake", 1, "mido://4", "10.1.1.2", null, "10.1.1.1", "255.255.255.0", 1, 1L, false, 1L, false);
             } catch (InvalidParameterValueException e) {
                 Assert.assertEquals("unexpected parameter exception", "unsupported type of broadcastUri specified: mido://4", e.getMessage());
                 unsupported = true;

--- a/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockNetworkManagerImpl.java
@@ -506,7 +506,7 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
      */
     @Override
     public Network createPrivateNetwork(String networkName, String displayText, long physicalNetworkId, String vlan, String startIp, String endIP, String gateway,
-        String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId) throws ResourceAllocationException, ConcurrentOperationException,
+        String netmask, long networkOwnerId, Long vpcId, Boolean sourceNat, Long networkOfferingId, Boolean bypassVlanOverlapCheck) throws ResourceAllocationException, ConcurrentOperationException,
         InsufficientCapacityException {
         // TODO Auto-generated method stub
         return null;
@@ -633,6 +633,11 @@ public class MockNetworkManagerImpl extends ManagerBase implements NetworkOrches
     public boolean destroyNetwork(long networkId, ReservationContext context, boolean forced) {
         // TODO Auto-generated method stub
         return false;
+    }
+
+    public Network createPrivateNetwork(final long networkOfferingId, final String name, final String displayText, final String gateway, final String cidr, final String vlanId, final boolean bypassVlanOverlapCheck, final Account owner, final PhysicalNetwork pNtwk, final Long vpcId) throws ConcurrentOperationException, InsufficientCapacityException, ResourceAllocationException {
+        // TODO Auto-generated method stub
+        return null;
     }
 
     /* (non-Javadoc)

--- a/server/src/test/java/com/cloud/vpc/dao/MockNetworkDaoImpl.java
+++ b/server/src/test/java/com/cloud/vpc/dao/MockNetworkDaoImpl.java
@@ -192,7 +192,7 @@ public class MockNetworkDaoImpl extends GenericDaoBase<NetworkVO, Long> implemen
     }
 
     @Override
-    public NetworkVO getPrivateNetwork(final String broadcastUri, final String cidr, final long accountId, final long zoneId, final Long netofferid) {
+    public NetworkVO getPrivateNetwork(final String broadcastUri, final String cidr, final long accountId, final long zoneId, final Long netofferid, final Long vpcId) {
         return null;
     }
 

--- a/server/src/test/java/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/agent/lb/IndirectAgentLBServiceImplTest.java
@@ -95,7 +95,6 @@ public class IndirectAgentLBServiceImplTest {
             id++;
         }
         addField(agentMSLB, "hostDao", hostDao);
-        addField(agentMSLB, "messageBus", messageBus);
         addField(agentMSLB, "agentManager", agentManager);
 
         when(hostDao.listAll()).thenReturn(Arrays.asList(host4, host2, host1, host3));

--- a/server/src/test/resources/createNetworkOffering.xml
+++ b/server/src/test/resources/createNetworkOffering.xml
@@ -58,4 +58,5 @@
     <bean id="DiskOfferingDetailsDaoImpl" class="org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDaoImpl" />
     <bean id="networkOfferingJoinDaoImpl" class="com.cloud.api.query.dao.NetworkOfferingJoinDaoImpl" />
     <bean id="networkOfferingDetailsDaoImpl" class="com.cloud.offerings.dao.NetworkOfferingDetailsDaoImpl" />
+    <bean id="indirectAgentLBImpl" class="org.apache.cloudstack.agent.lb.IndirectAgentLBServiceImpl" />
 </beans>

--- a/test/integration/component/test_multiple_nic_support.py
+++ b/test/integration/component/test_multiple_nic_support.py
@@ -1,0 +1,629 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+""" tests for supporting multiple NIC's in advanced zone with security groups in cloudstack 4.14.0.0
+
+"""
+# Import Local Modules
+from nose.plugins.attrib import attr
+from marvin.cloudstackTestCase import cloudstackTestCase, unittest
+from marvin.sshClient import SshClient
+from marvin.lib.utils import (validateList,
+                              cleanup_resources,
+                              get_host_credentials,
+                              get_process_status,
+                              execute_command_in_host,
+                              random_gen)
+from marvin.lib.base import (PhysicalNetwork,
+                             Account,
+                             Host,
+                             TrafficType,
+                             Domain,
+                             Network,
+                             NetworkOffering,
+                             VirtualMachine,
+                             ServiceOffering,
+                             Zone,
+                             NIC,
+                             SecurityGroup)
+from marvin.lib.common import (get_domain,
+                               get_zone,
+                               get_template,
+                               list_virtual_machines,
+                               list_routers,
+                               list_hosts,
+                               get_free_vlan)
+from marvin.codes import (PASS, FAILED)
+import logging
+import random
+import time
+
+class TestMulipleNicSupport(cloudstackTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.testClient = super(
+            TestMulipleNicSupport,
+            cls).getClsTestClient()
+        cls.apiclient = cls.testClient.getApiClient()
+        cls.testdata = cls.testClient.getParsedTestDataConfig()
+        cls.services = cls.testClient.getParsedTestDataConfig()
+        zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
+        cls.zone = Zone(zone.__dict__)
+        cls._cleanup = []
+
+        if str(cls.zone.securitygroupsenabled) != "True":
+            sys.exit(1)
+
+        cls.logger = logging.getLogger("TestMulipleNicSupport")
+        cls.stream_handler = logging.StreamHandler()
+        cls.logger.setLevel(logging.DEBUG)
+        cls.logger.addHandler(cls.stream_handler)
+
+        # Get Domain and templates
+        cls.domain = get_domain(cls.apiclient)
+        cls.services['mode'] = cls.zone.networktype
+
+        cls.template = get_template(cls.apiclient, cls.zone.id, hypervisor="KVM")
+        if cls.template == FAILED:
+            sys.exit(1)
+
+        # Create new domain, account, network and VM
+        cls.user_domain = Domain.create(
+            cls.apiclient,
+            services=cls.testdata["acl"]["domain2"],
+            parentdomainid=cls.domain.id)
+
+        # Create account
+        cls.account1 = Account.create(
+            cls.apiclient,
+            cls.testdata["acl"]["accountD2"],
+            admin=True,
+            domainid=cls.user_domain.id
+        )
+
+        # Create small service offering
+        cls.service_offering = ServiceOffering.create(
+            cls.apiclient,
+            cls.testdata["service_offerings"]["small"]
+        )
+
+        cls._cleanup.append(cls.service_offering)
+        cls.services["network"]["zoneid"] = cls.zone.id
+        cls.network_offering = NetworkOffering.create(
+            cls.apiclient,
+            cls.services["network_offering"],
+        )
+        # Enable Network offering
+        cls.network_offering.update(cls.apiclient, state='Enabled')
+
+        cls._cleanup.append(cls.network_offering)
+        cls.testdata["virtual_machine"]["zoneid"] = cls.zone.id
+        cls.testdata["virtual_machine"]["template"] = cls.template.id
+
+        if cls.zone.securitygroupsenabled:
+            # Enable networking for reaching to VM thorugh SSH
+            security_group = SecurityGroup.create(
+                cls.apiclient,
+                cls.testdata["security_group"],
+                account=cls.account1.name,
+                domainid=cls.account1.domainid
+            )
+
+            # Authorize Security group to SSH to VM
+            ingress_rule = security_group.authorize(
+                cls.apiclient,
+                cls.testdata["ingress_rule"],
+                account=cls.account1.name,
+                domainid=cls.account1.domainid
+            )
+
+            # Authorize Security group to SSH to VM
+            ingress_rule2 = security_group.authorize(
+                cls.apiclient,
+                cls.testdata["ingress_rule_ICMP"],
+                account=cls.account1.name,
+                domainid=cls.account1.domainid
+            )
+
+        cls.testdata["shared_network_offering_sg"]["specifyVlan"] = 'True'
+        cls.testdata["shared_network_offering_sg"]["specifyIpRanges"] = 'True'
+        cls.shared_network_offering = NetworkOffering.create(
+            cls.apiclient,
+            cls.testdata["shared_network_offering_sg"],
+            conservemode=False
+        )
+
+        NetworkOffering.update(
+            cls.shared_network_offering,
+            cls.apiclient,
+            id=cls.shared_network_offering.id,
+            state="enabled"
+        )
+
+        physical_network, vlan = get_free_vlan(cls.apiclient, cls.zone.id)
+        cls.testdata["shared_network_sg"]["physicalnetworkid"] = physical_network.id
+
+        random_subnet_number = random.randrange(90, 99)
+        cls.testdata["shared_network_sg"]["name"] = "Shared-Network-SG-Test-vlan" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["displaytext"] = "Shared-Network-SG-Test-vlan" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["vlan"] = "vlan://" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["startip"] = "192.168." + str(random_subnet_number) + ".240"
+        cls.testdata["shared_network_sg"]["endip"] = "192.168." + str(random_subnet_number) + ".250"
+        cls.testdata["shared_network_sg"]["gateway"] = "192.168." + str(random_subnet_number) + ".254"
+        cls.network1 = Network.create(
+            cls.apiclient,
+            cls.testdata["shared_network_sg"],
+            networkofferingid=cls.shared_network_offering.id,
+            zoneid=cls.zone.id,
+            accountid=cls.account1.name,
+            domainid=cls.account1.domainid
+        )
+
+        random_subnet_number = random.randrange(100, 110)
+        cls.testdata["shared_network_sg"]["name"] = "Shared-Network-SG-Test-vlan" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["displaytext"] = "Shared-Network-SG-Test-vlan" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["vlan"] = "vlan://" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["startip"] = "192.168." + str(random_subnet_number) + ".240"
+        cls.testdata["shared_network_sg"]["endip"] = "192.168." + str(random_subnet_number) + ".250"
+        cls.testdata["shared_network_sg"]["gateway"] = "192.168." + str(random_subnet_number) + ".254"
+        cls.network2 = Network.create(
+            cls.apiclient,
+            cls.testdata["shared_network_sg"],
+            networkofferingid=cls.shared_network_offering.id,
+            zoneid=cls.zone.id,
+            accountid=cls.account1.name,
+            domainid=cls.account1.domainid
+        )
+
+        random_subnet_number = random.randrange(111, 120)
+        cls.testdata["shared_network_sg"]["name"] = "Shared-Network-SG-Test-vlan" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["displaytext"] = "Shared-Network-SG-Test-vlan" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["vlan"] = "vlan://" + str(random_subnet_number)
+        cls.testdata["shared_network_sg"]["startip"] = "192.168." + str(random_subnet_number) + ".240"
+        cls.testdata["shared_network_sg"]["endip"] = "192.168." + str(random_subnet_number) + ".250"
+        cls.testdata["shared_network_sg"]["gateway"] = "192.168." + str(random_subnet_number) + ".254"
+        cls.network3 = Network.create(
+            cls.apiclient,
+            cls.testdata["shared_network_sg"],
+            networkofferingid=cls.shared_network_offering.id,
+            zoneid=cls.zone.id,
+            accountid=cls.account1.name,
+            domainid=cls.account1.domainid
+        )
+
+        try:
+            cls.virtual_machine1 = VirtualMachine.create(
+                cls.apiclient,
+                cls.testdata["virtual_machine"],
+                accountid=cls.account1.name,
+                domainid=cls.account1.domainid,
+                serviceofferingid=cls.service_offering.id,
+                templateid=cls.template.id,
+                securitygroupids=[security_group.id],
+                networkids=cls.network1.id
+            )
+            for nic in cls.virtual_machine1.nic:
+                if nic.isdefault:
+                    cls.virtual_machine1.ssh_ip = nic.ipaddress
+                    cls.virtual_machine1.default_network_id = nic.networkid
+                    break
+        except Exception as e:
+            cls.fail("Exception while deploying virtual machine: %s" % e)
+
+        try:
+            cls.virtual_machine2 = VirtualMachine.create(
+                cls.apiclient,
+                cls.testdata["virtual_machine"],
+                accountid=cls.account1.name,
+                domainid=cls.account1.domainid,
+                serviceofferingid=cls.service_offering.id,
+                templateid=cls.template.id,
+                securitygroupids=[security_group.id],
+                networkids=[str(cls.network1.id), str(cls.network2.id)]
+            )
+            for nic in cls.virtual_machine2.nic:
+                if nic.isdefault:
+                    cls.virtual_machine2.ssh_ip = nic.ipaddress
+                    cls.virtual_machine2.default_network_id = nic.networkid
+                    break
+        except Exception as e:
+            cls.fail("Exception while deploying virtual machine: %s" % e)
+
+        cls._cleanup.append(cls.virtual_machine1)
+        cls._cleanup.append(cls.virtual_machine2)
+        cls._cleanup.append(cls.network1)
+        cls._cleanup.append(cls.network2)
+        cls._cleanup.append(cls.network3)
+        cls._cleanup.append(cls.shared_network_offering)
+        if cls.zone.securitygroupsenabled:
+            cls._cleanup.append(security_group)
+        cls._cleanup.append(cls.account1)
+        cls._cleanup.append(cls.user_domain)
+
+    @classmethod
+    def tearDownClass(self):
+        try:
+            cleanup_resources(self.apiclient, self._cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.cleanup = []
+        return
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def verify_network_rules(self, vm_id):
+        virtual_machine = VirtualMachine.list(
+             self.apiclient,
+             id=vm_id
+        )
+        vm = virtual_machine[0]
+        hosts = list_hosts(
+            self.apiclient,
+            id=vm.hostid
+        )
+        host = hosts[0]
+        if host.hypervisor.lower() not in "kvm":
+            return
+        host.user, host.password = get_host_credentials(self.config, host.ipaddress)
+        for nic in vm.nic:
+            secips = ""
+            if len(nic.secondaryip) > 0:
+                for secip in nic.secondaryip:
+                    secips += secip.ipaddress + ";"
+            command="/usr/share/cloudstack-common/scripts/vm/network/security_group.py verify_network_rules --vmname %s --vmip %s --vmmac %s --nicsecips '%s'" % (vm.instancename, nic.ipaddress, nic.macaddress, secips)
+            self.logger.debug("Executing command '%s' in host %s" % (command, host.ipaddress))
+            result=execute_command_in_host(host.ipaddress, 22,
+                host.user,
+                host.password,
+                command)
+            if len(result) > 0:
+                self.fail("The iptables/ebtables rules for nic %s on vm %s on host %s are not correct" %(nic.ipaddress, vm.instancename, host.name))
+
+    @attr(tags=["adeancedsg"], required_hardware="false")
+    def test_01_create_vm_with_multiple_nics(self):
+        """Create Vm with multiple NIC's
+
+            Steps:
+            # 1. Create more than 1 isolated or shared network
+            # 2. Create a vm and select more than 1 network while deploying
+            # 3. Vm is deployed successfully with 1 nic from each network
+            # 4. All the vm's should be pingable
+        :return:
+        """
+        virtual_machine = VirtualMachine.list(
+             self.apiclient,
+             id=self.virtual_machine2.id
+        )
+        self.assertEqual(
+            len(virtual_machine), 1,
+            "Virtual Machine create with 2 NIC's failed")
+
+        nicIdInVm = virtual_machine[0].nic[0]
+        self.assertIsNotNone(nicIdInVm, "NIC 1 not found in Virtual Machine")
+
+        nicIdInVm = virtual_machine[0].nic[1]
+        self.assertIsNotNone(nicIdInVm, "NIC 2 not found in Virtual Machine")
+
+        self.verify_network_rules(self.virtual_machine2.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_02_add_nic_to_vm(self):
+        """Create VM with single NIC and then add additional NIC
+
+            Steps:
+            # 1. Create a VM by selecting one default NIC
+            # 2. Create few more isolated or shared networks
+            # 3. Add extra NIC's to the vm from the newly created networks
+            # 4. The deployed VM should have extra nic's added in the above
+            #    step without any fail
+            # 5. The IP's of the extra NIC's should be pingable
+        :return:
+        """
+        self.virtual_machine1.add_nic(self.apiclient, self.network2.id)
+
+        virtual_machine = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine1.id
+        )
+
+        nicIdInVm = virtual_machine[0].nic[1]
+        self.assertIsNotNone(nicIdInVm, "Second NIC not found")
+
+        self.verify_network_rules(self.virtual_machine1.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_03_add_ip_to_default_nic(self):
+        """ Add secondary IP's to the VM
+
+            Steps:
+            # 1. Create a VM with more than 1 NIC
+            # 2) Navigate to Instances->NIC->Edit Secondary IP's
+            # ->Aquire new Secondary IP"
+            # 3) Add as many secondary Ip as possible to the VM
+            # 4) Configure the secondary IP's by referring to "Configure
+            # the secondary IP's" in the "Action Item" section
+        :return:
+        """
+        ipaddress = NIC.addIp(
+            self.apiclient,
+            id=self.virtual_machine2.nic[0].id
+        )
+
+        self.assertIsNotNone(
+            ipaddress,
+            "Unable to add secondary IP to the default NIC")
+
+        self.verify_network_rules(self.virtual_machine2.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_04_add_ip_to_remaining_nics(self):
+        """ Add secondary IP's to remaining NIC's
+
+            Steps:
+            # 1) Create a VM with more than 1 NIC
+            # 2)Navigate to Instances-NIC's->Edit Secondary IP's
+            # ->Acquire new Secondary IP
+            # 3) Add secondary IP to all the NIC's of the VM
+            # 4) Confiugre the secondary IP's by referring to "Configure the
+            # secondary IP's" in the "Action Item" section
+        :return:
+        """
+
+        self.virtual_machine1.add_nic(self.apiclient, self.network3.id)
+
+        vms = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine1.id
+        )
+
+        self.assertIsNotNone(
+            vms[0].nic[2],
+            "Third NIC is not added successfully to the VM")
+
+        vms1_nic1_id = vms[0].nic[1]['id']
+        vms1_nic2_id = vms[0].nic[2]['id']
+
+        ipaddress21 = NIC.addIp(
+            self.apiclient,
+            id=vms1_nic1_id
+        )
+
+        ipaddress22 = NIC.addIp(
+            self.apiclient,
+            id=vms1_nic1_id
+        )
+
+        self.assertIsNotNone(
+            ipaddress21,
+            "Unable to add first secondary IP to the second nic")
+        self.assertIsNotNone(
+            ipaddress22,
+            "Unable to add second secondary IP to second NIC")
+
+        ipaddress31 = NIC.addIp(
+            self.apiclient,
+            id=vms1_nic2_id
+        )
+
+        ipaddress32 = NIC.addIp(
+            self.apiclient,
+            id=vms1_nic2_id
+        )
+
+        self.assertIsNotNone(
+            ipaddress31,
+            "Unable to add first secondary IP to third NIC")
+        self.assertIsNotNone(
+            ipaddress32,
+            "Unable to add second secondary IP to third NIC")
+
+        self.verify_network_rules(self.virtual_machine1.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_05_stop_start_vm_with_multiple_nic(self):
+        """ Stop and Start a VM with Multple NIC
+
+            Steps:
+            # 1) Create a Vm with multiple NIC's
+            # 2) Configure secondary IP's on the VM
+            # 3) Try to stop/start the VM
+            # 4) Ping the IP's of the vm
+            # 5) Remove Secondary IP from one of the NIC
+        :return:
+        """
+        ipaddress1 = NIC.addIp(
+            self.apiclient,
+            id=self.virtual_machine2.nic[0].id
+        )
+
+        ipaddress2 = NIC.addIp(
+            self.apiclient,
+            id=self.virtual_machine2.nic[1].id
+        )
+        # Stop the VM with multiple NIC's
+        self.virtual_machine2.stop(self.apiclient)
+
+        virtual_machine = VirtualMachine.list(
+             self.apiclient,
+             id=self.virtual_machine2.id
+        )
+
+        self.assertEqual(
+            virtual_machine[0]['state'], 'Stopped',
+            "Could not stop the VM with multiple NIC's")
+
+        if virtual_machine[0]['state'] == 'Stopped':
+            # If stopped then try to start the VM
+            self.virtual_machine2.start(self.apiclient)
+            virtual_machine = VirtualMachine.list(
+                self.apiclient,
+                id=self.virtual_machine2.id
+            )
+            self.assertEqual(
+                virtual_machine[0]['state'], 'Running',
+                "Could not start the VM with multiple NIC's")
+
+        self.verify_network_rules(self.virtual_machine2.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_06_migrate_vm_with_multiple_nic(self):
+        """ Migrate a VM with Multple NIC
+
+            Steps:
+            # 1) Create a Vm with multiple NIC's
+            # 2) Configure secondary IP's on the VM
+            # 3) Try to stop/start the VM
+            # 4) Ping the IP's of the vm
+        :return:
+        """
+        # Skipping adding Secondary IP to NIC since its already
+        # done in the previous test cases
+
+        virtual_machine = VirtualMachine.list(
+             self.apiclient,
+             id=self.virtual_machine1.id
+        )
+        old_host_id = virtual_machine[0]['hostid']
+
+        try:
+            hosts = Host.list(
+                self.apiclient,
+                virtualmachineid=self.virtual_machine1.id,
+                listall=True)
+            self.assertEqual(
+                validateList(hosts)[0],
+                PASS,
+                "hosts list validation failed")
+
+            # Get a host which is not already assigned to VM
+            for host in hosts:
+                if host.id == old_host_id:
+                    continue
+                else:
+                    host_id = host.id
+                    break
+
+            self.virtual_machine1.migrate(self.apiclient, host_id)
+        except Exception as e:
+            self.fail("Exception occured: %s" % e)
+
+        # List the vm again
+        virtual_machine = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine1.id)
+
+        new_host_id = virtual_machine[0]['hostid']
+
+        self.assertNotEqual(
+            old_host_id, new_host_id,
+            "Migration of VM to new host failed"
+        )
+
+        self.verify_network_rules(self.virtual_machine1.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_07_remove_secondary_ip_from_nic(self):
+        """ Remove secondary IP from any NIC
+            Steps:
+            # 1) Navigate to Instances
+            # 2) Select any vm
+            # 3) NIC's ->Edit secondary IP's->Release IP
+            # 4) The secondary IP should be successfully removed
+        """
+        virtual_machine = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine2.id)
+
+        # Check which NIC is having secondary IP
+        secondary_ips = virtual_machine[0].nic[1].secondaryip
+
+        for secondary_ip in secondary_ips:
+            NIC.removeIp(self.apiclient, ipaddressid=secondary_ip['id'])
+
+        virtual_machine = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine2.id
+        )
+
+        self.assertFalse(
+            virtual_machine[0].nic[1].secondaryip,
+            'Failed to remove secondary IP')
+
+        self.verify_network_rules(self.virtual_machine2.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_08_remove_nic_from_vm(self):
+        """ Remove NIC from VM
+            Steps:
+            # 1) Navigate to Instances->select any vm->NIC's->NIC 2
+            # ->Click on "X" button to remove the second NIC
+            # 2) Remove other NIC's as well from the VM
+            # 3) All the NIC's should be successfully removed from the VM
+        :return:
+        """
+        virtual_machine = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine2.id)
+
+        for nic in virtual_machine[0].nic:
+            if nic.isdefault:
+                continue
+            self.virtual_machine2.remove_nic(self.apiclient, nic.id)
+
+        virtual_machine = VirtualMachine.list(
+            self.apiclient,
+            id=self.virtual_machine2.id)
+
+        self.assertEqual(
+            len(virtual_machine[0].nic), 1,
+            "Failed to remove all the nics from the virtual machine")
+
+        self.verify_network_rules(self.virtual_machine2.id)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_09_reboot_vm_with_multiple_nic(self):
+        """ Reboot a VM with Multple NIC
+
+            Steps:
+            # 1) Create a Vm with multiple NIC's
+            # 2) Configure secondary IP's on the VM
+            # 3) Try to reboot the VM
+            # 4) Ping the IP's of the vm
+        :return:
+        """
+        # Skipping adding Secondary IP to NIC since its already
+        # done in the previous test cases
+
+        virtual_machine = VirtualMachine.list(
+             self.apiclient,
+             id=self.virtual_machine1.id
+        )
+        try:
+            self.virtual_machine1.reboot(self.apiclient)
+        except Exception as e:
+            self.fail("Exception occured: %s" % e)
+
+        self.verify_network_rules(self.virtual_machine1.id)
+

--- a/test/integration/smoke/test_privategw_acl.py
+++ b/test/integration/smoke/test_privategw_acl.py
@@ -639,6 +639,7 @@ class TestPrivateGwACL(cloudstackTestCase):
         createPrivateGatewayCmd.netmask = "255.255.255.0"
         createPrivateGatewayCmd.ipaddress = ip_address
         createPrivateGatewayCmd.vlan = vlan
+        createPrivateGatewayCmd.bypassvlanoverlapcheck = "true"
         createPrivateGatewayCmd.vpcid = vpc.id
         createPrivateGatewayCmd.sourcenatsupported = "false"
         createPrivateGatewayCmd.aclid = aclId

--- a/test/integration/smoke/test_update_security_group.py
+++ b/test/integration/smoke/test_update_security_group.py
@@ -1,0 +1,312 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Tests for updating security group name
+"""
+
+# Import Local Modules
+from nose.plugins.attrib import attr
+from marvin.cloudstackTestCase import cloudstackTestCase, unittest
+from marvin.cloudstackAPI import updateSecurityGroup, createSecurityGroup
+from marvin.sshClient import SshClient
+from marvin.lib.utils import (validateList,
+                              cleanup_resources,
+                              random_gen)
+from marvin.lib.base import (PhysicalNetwork,
+                             Account,
+                             Host,
+                             TrafficType,
+                             Domain,
+                             Network,
+                             NetworkOffering,
+                             VirtualMachine,
+                             ServiceOffering,
+                             Zone,
+                             SecurityGroup)
+from marvin.lib.common import (get_domain,
+                               get_zone,
+                               get_template,
+                               list_virtual_machines,
+                               list_routers,
+                               list_hosts,
+                               get_free_vlan)
+from marvin.codes import (PASS, FAIL)
+import logging
+import random
+import time
+
+class TestUpdateSecurityGroup(cloudstackTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.testClient = super(
+            TestUpdateSecurityGroup,
+            cls).getClsTestClient()
+        cls.apiclient = cls.testClient.getApiClient()
+        cls.testdata = cls.testClient.getParsedTestDataConfig()
+        cls.services = cls.testClient.getParsedTestDataConfig()
+
+        zone = get_zone(cls.apiclient, cls.testClient.getZoneForTests())
+        cls.zone = Zone(zone.__dict__)
+        cls.template = get_template(cls.apiclient, cls.zone.id)
+        cls._cleanup = []
+
+        if str(cls.zone.securitygroupsenabled) != "True":
+            sys.exit(1)
+
+        cls.logger = logging.getLogger("TestUpdateSecurityGroup")
+        cls.stream_handler = logging.StreamHandler()
+        cls.logger.setLevel(logging.DEBUG)
+        cls.logger.addHandler(cls.stream_handler)
+
+        # Get Zone, Domain and templates
+        cls.domain = get_domain(cls.apiclient)
+        testClient = super(TestUpdateSecurityGroup, cls).getClsTestClient()
+        cls.zone = get_zone(cls.apiclient, testClient.getZoneForTests())
+        cls.services['mode'] = cls.zone.networktype
+
+        # Create new domain, account, network and VM
+        cls.user_domain = Domain.create(
+            cls.apiclient,
+            services=cls.testdata["acl"]["domain2"],
+            parentdomainid=cls.domain.id)
+
+        # Create account
+        cls.account = Account.create(
+            cls.apiclient,
+            cls.testdata["acl"]["accountD2"],
+            admin=True,
+            domainid=cls.user_domain.id
+        )
+
+        cls._cleanup.append(cls.account)
+        cls._cleanup.append(cls.user_domain)
+
+    @classmethod
+    def tearDownClass(self):
+        try:
+            cleanup_resources(self.apiclient, self._cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    def setUp(self):
+        self.apiclient = self.testClient.getApiClient()
+        self.cleanup = []
+        return
+
+    def tearDown(self):
+        try:
+            cleanup_resources(self.apiclient, self.cleanup)
+        except Exception as e:
+            raise Exception("Warning: Exception during cleanup : %s" % e)
+        return
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_01_create_security_group(self):
+        # Validate the following:
+        #
+        # 1. Create a new security group
+        # 2. Update the security group with new name
+        # 3. List the security group with new name as the keyword
+        # 4. Make sure that the response is not empty
+
+        security_group = SecurityGroup.create(
+            self.apiclient,
+            self.testdata["security_group"],
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.debug("Created security group with ID: %s" % security_group.id)
+
+        initial_secgroup_name = security_group.name
+        new_secgroup_name = "testing-update-security-group"
+
+        cmd = updateSecurityGroup.updateSecurityGroupCmd()
+        cmd.id = security_group.id
+        cmd.name = new_secgroup_name
+        self.apiclient.updateSecurityGroup(cmd)
+
+        new_security_group = SecurityGroup.list(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            keyword=new_secgroup_name
+        )
+        self.assertNotEqual(
+            len(new_security_group),
+            0,
+            "Update security group failed"
+        )
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_02_duplicate_security_group_name(self):
+        # Validate the following
+        #
+        # 1. Create a security groups with name "test"
+        # 2. Try to create another security group with name "test"
+        # 3. Creation of second security group should fail
+
+        security_group_name = "test"
+        security_group = SecurityGroup.create(
+            self.apiclient,
+            {"name": security_group_name},
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.debug("Created security group with name: %s" % security_group.name)
+
+        security_group_list = SecurityGroup.list(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            keyword=security_group.name
+        )
+        self.assertNotEqual(
+            len(security_group_list),
+            0,
+            "Creating security group failed"
+        )
+
+        # Need to use createSecurituGroupCmd since SecurityGroup.create
+        # adds random string to security group name
+        with self.assertRaises(Exception):
+            cmd = createSecurityGroup.createSecurityGroupCmd()
+            cmd.name = security_group.name
+            cmd.account = self.account.name
+            cmd.domainid = self.account.domainid
+            self.apiclient.createSecurityGroup(cmd)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_03_update_security_group_with_existing_name(self):
+        # Validate the following
+        #
+        # 1. Create a security groups with name "test"
+        # 2. Create another security group
+        # 3. Try to update the second security group to update its name to "test"
+        # 4. Update security group should fail
+
+        # Create security group
+        security_group = SecurityGroup.create(
+            self.apiclient,
+            self.testdata["security_group"],
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.debug("Created security group with ID: %s" % security_group.id)
+        security_group_name = security_group.name
+
+        # Make sure its created
+        security_group_list = SecurityGroup.list(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            keyword=security_group_name
+        )
+        self.assertNotEqual(
+            len(security_group_list),
+            0,
+            "Creating security group failed"
+        )
+
+        # Create another security group
+        second_security_group = SecurityGroup.create(
+            self.apiclient,
+            self.testdata["security_group"],
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.debug("Created security group with ID: %s" % second_security_group.id)
+
+        # Make sure its created
+        security_group_list = SecurityGroup.list(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            keyword=second_security_group.name
+        )
+        self.assertNotEqual(
+            len(security_group_list),
+            0,
+            "Creating security group failed"
+        )
+
+        # Update the security group
+        with self.assertRaises(Exception):
+            cmd = updateSecurityGroup.updateSecurityGroupCmd()
+            cmd.id = second_security_group.id
+            cmd.name = security_group_name
+            self.apiclient.updateSecurityGroup(cmd)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_04_update_security_group_with_empty_name(self):
+        # Validate the following
+        #
+        # 1. Create a security group
+        # 2. Update the security group to an empty name
+        # 3. Update security group should fail
+
+        # Create security group
+        security_group = SecurityGroup.create(
+            self.apiclient,
+            self.testdata["security_group"],
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.debug("Created security group with ID: %s" % security_group.id)
+
+        # Make sure its created
+        security_group_list = SecurityGroup.list(
+            self.apiclient,
+            account=self.account.name,
+            domainid=self.account.domainid,
+            keyword=security_group.name
+        )
+        self.assertNotEqual(
+            len(security_group_list),
+            0,
+            "Creating security group failed"
+        )
+
+        # Update the security group
+        with self.assertRaises(Exception):
+            cmd = updateSecurityGroup.updateSecurityGroupCmd()
+            cmd.id = security_group.id
+            cmd.name = ""
+            self.apiclient.updateSecurityGroup(cmd)
+
+    @attr(tags=["advancedsg"], required_hardware="false")
+    def test_05_rename_security_group(self):
+        # Validate the following
+        #
+        # 1. Create a security group
+        # 2. Update the security group and change its name to "default"
+        # 3. Exception should be thrown as "default" name cant be used
+
+        security_group = SecurityGroup.create(
+            self.apiclient,
+            self.testdata["security_group"],
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+        self.debug("Created security group with ID: %s" % security_group.id)
+
+        with self.assertRaises(Exception):
+            cmd = updateSecurityGroup.updateSecurityGroupCmd()
+            cmd.id = security_group.id
+            cmd.name = "default"
+            self.apiclient.updateSecurityGroup(cmd)

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -3030,7 +3030,7 @@ class Network:
                networkofferingid=None, projectid=None,
                subdomainaccess=None, zoneid=None,
                gateway=None, netmask=None, vpcid=None, aclid=None, vlan=None,
-               externalid=None):
+               externalid=None, bypassvlanoverlapcheck=None):
         """Create Network for account"""
         cmd = createNetwork.createNetworkCmd()
         cmd.name = services["name"]
@@ -3084,6 +3084,8 @@ class Network:
             cmd.aclid = aclid
         if externalid:
             cmd.externalid = externalid
+        if bypassvlanoverlapcheck:
+            cmd.bypassvlanoverlapcheck = bypassvlanoverlapcheck
         return Network(apiclient.createNetwork(cmd).__dict__)
 
     def delete(self, apiclient):
@@ -4540,7 +4542,7 @@ class PrivateGateway:
 
     @classmethod
     def create(cls, apiclient, gateway, ipaddress, netmask, vlan, vpcid,
-               physicalnetworkid=None, aclid=None):
+               physicalnetworkid=None, aclid=None, bypassvlanoverlapcheck=None):
         """Create private gateway"""
 
         cmd = createPrivateGateway.createPrivateGatewayCmd()
@@ -4553,6 +4555,8 @@ class PrivateGateway:
             cmd.physicalnetworkid = physicalnetworkid
         if aclid:
             cmd.aclid = aclid
+        if bypassvlanoverlapcheck:
+            cmd.bypassvlanoverlapcheck = bypassvlanoverlapcheck
 
         return PrivateGateway(apiclient.createPrivateGateway(cmd).__dict__)
 

--- a/tools/marvin/marvin/lib/utils.py
+++ b/tools/marvin/marvin/lib/utils.py
@@ -62,13 +62,15 @@ def _configure_timeout(hypervisor):
     return timeout
 
 
-def _execute_ssh_command(hostip, port, username, password, ssh_command):
+def _execute_ssh_command(hostip, port, username, password, ssh_command, timeout=5):
     #SSH to the machine
     ssh = SshClient(hostip, port, username, password)
     # Ensure the SSH login is successful
     while True:
         res = ssh.execute(ssh_command)
-        if "Connection refused".lower() in res[0].lower():
+        if len(res) == 0:
+            return res
+        elif "Connection refused".lower() in res[0].lower():
             pass
         elif res[0] != "Host key verification failed.":
             break
@@ -228,6 +230,10 @@ def get_host_credentials(config, hostip):
                         raise Exception("Unresolvable host %s error is %s" % (hostip, e))
     raise KeyError("Please provide the marvin configuration file with credentials to your hosts")
 
+def execute_command_in_host(hostip, port, username, password, command, hypervisor=None):
+    timeout = _configure_timeout(hypervisor)
+    result = _execute_ssh_command(hostip, port, username, password, command)
+    return result
 
 def get_process_status(hostip, port, username, password, linklocalip, command, hypervisor=None):
     """Double hop and returns a command execution result"""

--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -3354,6 +3354,16 @@
                                 label: 'label.description'
                             }
                         }],
+                        viewAll: {
+                            path: 'network.securityGroups',
+                            attachTo: 'id',
+                            label: 'label.security.groups',
+                            title: function(args) {
+                                var title = _l('label.security.groups');
+
+                                return title;
+                            }
+                        },
                         dataProvider: function(args) {
                             // args.response.success({data: args.context.instances[0].securitygroup});
                             $.ajax({

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -361,6 +361,7 @@
                 args.context.item.state != 'Destroyed' &&
                 args.context.item.name != 'default') {
                 allowedActions.push('remove');
+                allowedActions.push('edit');
             }
 
             return allowedActions;
@@ -4523,7 +4524,11 @@
                                 title: 'label.details',
                                 fields: [{
                                     name: {
-                                        label: 'label.name'
+                                        label: 'label.name',
+                                        isEditable: true,
+                                        validation: {
+                                            required: true
+                                        }
                                     }
                                 }, {
                                     id: {
@@ -5075,6 +5080,30 @@
                         },
 
                         actions: {
+                            edit: {
+                                label: 'label.edit',
+                                action: function(args) {
+                                    var data = {
+                                        id: args.context.securityGroups[0].id
+                                    };
+                                    if (args.data.name != args.context.securityGroups[0].name) {
+                                        $.extend(data, {
+                                            name: args.data.name
+                                        });
+                                    };
+                                    $.ajax({
+                                        url: createURL('updateSecurityGroup'),
+                                        data: data,
+                                        success: function(json) {
+                                            var item = json.updatesecuritygroupresponse.securitygroup;
+                                            args.response.success({
+                                                data: item
+                                            });
+                                        }
+                                    });
+                                }
+                            },
+
                             remove: {
                                 label: 'label.action.delete.security.group',
                                 messages: {

--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -4504,6 +4504,14 @@
                         var data = {};
                         listViewDataProvider(args, data);
 
+                        if (args.context != null) {
+                            if ("securityGroups" in args.context) {
+                                $.extend(data, {
+                                    id: args.context.securityGroups[0].id
+                                });
+                            }
+                        }
+
                         $.ajax({
                             url: createURL('listSecurityGroups'),
                             data: data,

--- a/ui/scripts/ui-custom/instanceWizard.js
+++ b/ui/scripts/ui-custom/instanceWizard.js
@@ -1516,14 +1516,29 @@
 
                                 if (advSGFilter == 0) { //when total number of selected sg networks is 0, then 'Select Security Group' is skipped, go to step 6 directly
                                     showStep(6);
-                                } else { //when total number of selected sg networks > 0
+                                } else if (advSGFilter > 0) { //when total number of selected sg networks > 0
                                     if ($activeStep.find('input[type=checkbox]:checked').length > 1) { //when total number of selected networks > 1
                                         cloudStack.dialog.notice({
                                             message: "Can't create a vm with multiple networks one of which is Security Group enabled"
                                         });
                                         return false;
                                     }
+                                } else if (advSGFilter == -1) { // vm with multiple IPs is supported in KVM
+                                    var $selectNetwork = $activeStep.find('input[type=checkbox]:checked');
+                                    var myNetworkIps = [];
+                                    $selectNetwork.each(function() {
+                                        var $specifyIp = $(this).parent().find('.specify-ip input[type=text]');
+                                        myNetworkIps.push($specifyIp.val() == -1 ? null : $specifyIp.val());
+                                    });
+                                    $activeStep.closest('form').data('my-network-ips', myNetworkIps);
+                                    $selectNetwork.each(function() {
+                                        if ($(this).parent().find('input[type=radio]').is(':checked')) {
+                                            $activeStep.closest('form').data('defaultNetwork', $(this).val());
+                                            return;
+                                        }
+                                    })
                                 }
+
                             }
                         }
 

--- a/ui/scripts/vpc.js
+++ b/ui/scripts/vpc.js
@@ -2055,6 +2055,10 @@
                             },
                             docID: 'helpVPCGatewayVLAN'
                         },
+                        bypassVlanOverlapCheck: {
+                            label: 'label.bypass.vlan.overlap.check',
+                            isBoolean: true
+                        },
                         ipaddress: {
                             label: 'label.ip.address',
                             validation: {
@@ -2124,6 +2128,9 @@
                     } else
                         array1.push("&sourcenatsupported=false");
 
+                    if (args.$form.find('.form-item[rel=bypassVlanOverlapCheck]').css("display") != "none") {
+                        array1.push("&bypassVlanOverlapCheck=" + encodeURIComponent((args.data.bypassVlanOverlapCheck == "on")));
+                    }
 
                     $.ajax({
                         url: createURL('createPrivateGateway' + array1.join("")),
@@ -2233,6 +2240,10 @@
                                             },
                                             docID: 'helpVPCGatewayVLAN'
                                         },
+                                        bypassVlanOverlapCheck: {
+                                            label: 'label.bypass.vlan.overlap.check',
+                                            isBoolean: true
+                                        },
                                         ipaddress: {
                                             label: 'label.ip.address',
                                             validation: {
@@ -2307,6 +2318,9 @@
                                     } else
                                         array1.push("&sourcenatsupported=false");
 
+                                    if (args.$form.find('.form-item[rel=bypassVlanOverlapCheck]').css("display") != "none") {
+                                        array1.push("&bypassVlanOverlapCheck=" + encodeURIComponent((args.data.bypassVlanOverlapCheck == "on")));
+                                    }
 
                                     $.ajax({
                                         url: createURL('createPrivateGateway' + array1.join("")),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The file VirtualNetworkApplianceManagerImpl.java is edited for a related VM HA problem. When a Host is determined to be DOWN, CloudStack attempts to VM HA any affected routers. The problem is, when the host is determined to be down, by code referenced above, the host may not actually be DOWN. On KVM for example, the host is considered DOWN if the agent is stopped on the KVM host for too long. In that case, the VMs could still be running just fine... However when we think the host is DOWN, VM HA runs on the router and as part of that it unallocates/cleans-up the router and it's 169.x.x.x control IP is unallocated. Then after it cleans it up, it tries to power on the router on another host, and as part of that it allocates a NEW 169.x.x.x control IP and writes that to the DB. However, since the router isn't actually down (we just think the host is down) the VM HA fails as the vRouter is currently still running on the problem host.

Next, in this example, when the host agent is back online again, it sends a power report to the mgmt servers, and the management servers think the router was powered-on OOB. However, the GUI will not show a control IP for the vRouter, and the DB will have the NEW control IP it tried to allocated during the failed VM HA event. Thus, leaving us unable to communicate with the vRouter.

This PR does a simple check that we can still communicate with the vRouter after any OOB power-on occurs. If we can, then we have the correct control IP in the DB and we're good - so we do nothing. If we can't communicate with the vRouter after the OOB power-on, we do a reboot of the vRouter to fix it.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
I ran this sql statement to simulate an OOB power on by making CloudStack believe the router is down, but the host then sending a power report stating it is running:
`
-- id = 157 is the row id of the virtual router in the table
update vm_instance set state='Stopped',power_state='PowerReportMissing',host_id=NULL where id=157;
`
I then observed that the router got marked as OOB started, and was considered healthy, and no further action was taken.

I then ran the sql statement above again, to make cloudstack believe the router is down, and then connected to the router via cloudstack-ssh and took it to run level 1 via 'init 1' to effectively make it so that it cannot be connected to.

I then observed that the router was restarted by cloudstack, and verified the logs on the management server


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
