### PR TITLE
server: fix issue while list ssh keypairs by keyword

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -3747,8 +3747,10 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         if (keyword != null) {
-            sc.addOr("name", SearchCriteria.Op.LIKE, "%" + keyword + "%");
-            sc.addOr("fingerprint", SearchCriteria.Op.LIKE, "%" + keyword + "%");
+            final SearchCriteria<SSHKeyPairVO> ssc = _sshKeyPairDao.createSearchCriteria();
+            ssc.addOr("name", SearchCriteria.Op.LIKE, "%" + keyword + "%");
+            ssc.addOr("fingerprint", SearchCriteria.Op.LIKE, "%" + keyword + "%");
+            sc.addAnd("name", SearchCriteria.Op.SC, ssc);
         }
 
         final Pair<List<SSHKeyPairVO>, Integer> result = _sshKeyPairDao.searchAndCount(sc, searchFilter);


### PR DESCRIPTION
## Description

in 4.13, list sshkeypairs with keyword will ignore the search by name if name is specifed.
Fixes an issue in #3098 

for example,
```
(local) > list sshkeypairs name=wei keyword=wei filter=name
{
  "count": 3,
  "sshkeypair": [
    {
      "name": "wei3"
    },
    {
      "name": "wei2"
    },
    {
      "name": "wei"
    }
  ]
}
```

with this patch ,it gives correct result.

```
(local) > list sshkeypairs name=wei keyword=wei filter=name
{
  "count": 1,
  "sshkeypair": [
    {
      "name": "wei"
    }
  ]
}
```
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
