### PR TITLE
ui: fix merge issue that causes VR duplicates

### DIFF
--- a/ui/scripts/system.js
+++ b/ui/scripts/system.js
@@ -9996,7 +9996,7 @@
                                             }
 
                                             $.ajax({
-                                                url: createURL("listRouters&listAll=true&page=" + args.page + "&pagesize=" + pageSize + array1.join("") + "&projectid=-1"),
+                                                url: createURL("listRouters&page=" + args.page + "&pagesize=" + pageSize + array1.join("") + "&projectid=-1"),
                                                 data: data2,
                                                 async: false,
                                                 success: function (json) {


### PR DESCRIPTION
This fixes issue from merging 4d8a2da133b74f2de9ecc599eebafdfc68e6fa60
on master/4.14-snapshot which causes duplicate VRs to show up.

Fixes #3926 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)