### PR TITLE
Regression Fix: Allow full response view to Admin user

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1765,6 +1765,9 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         ListResponse<VolumeResponse> response = new ListResponse<VolumeResponse>();
 
         ResponseView respView = cmd.getResponseView();
+        if (_accountMgr.isAdmin(CallContext.current().getCallingAccount().getId())) {
+            respView = ResponseView.Full;
+        }
 
         List<VolumeResponse> volumeResponses = ViewResponseHelper.createVolumeResponse(respView, result.first().toArray(new VolumeJoinVO[result.first().size()]));
 

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1765,7 +1765,8 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         ListResponse<VolumeResponse> response = new ListResponse<VolumeResponse>();
 
         ResponseView respView = cmd.getResponseView();
-        if (_accountMgr.isAdmin(CallContext.current().getCallingAccount().getId())) {
+        Account account = CallContext.current().getCallingAccount();
+        if (_accountMgr.isAdmin(account.getAccountId())) {
             respView = ResponseView.Full;
         }
 

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1765,7 +1765,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         ListResponse<VolumeResponse> response = new ListResponse<VolumeResponse>();
 
         ResponseView respView = cmd.getResponseView();
-        if (_accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())) {
+        if (_accountMgr.isAdmin(CallContext.current().getCallingAccount().getId())) {
             respView = ResponseView.Full;
         }
 

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1765,7 +1765,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
         ListResponse<VolumeResponse> response = new ListResponse<VolumeResponse>();
 
         ResponseView respView = cmd.getResponseView();
-        if (_accountMgr.isAdmin(CallContext.current().getCallingAccount().getId())) {
+        if (_accountMgr.isRootAdmin(CallContext.current().getCallingAccount().getId())) {
             respView = ResponseView.Full;
         }
 


### PR DESCRIPTION
## Description
list volumes metrics API has missing fields from list volumes API, which effects Primate UI
Addresses Issue: https://github.com/apache/cloudstack/issues/3938


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
```
list volumesmetrics (before fix): 
{
  "count": 1,
  "volume": [
    {
      "account": "admin",
      "created": "2020-03-05T19:41:59+0530",
      "deviceid": 0,
      "diskiopstotal": 0,
      "diskioread": 0,
      "diskiowrite": 0,
      "diskkbsread": 0,
      "diskkbswrite": 0,
      "displayvolume": true,
      "domain": "ROOT",
      "domainid": "968c400b-5eea-11ea-b12b-50eb7122da94",
      "id": "c4d09dc3-8864-42bd-9338-8023be187477",
      "isextractable": false,
      "name": "ROOT-3",
      "provisioningtype": "thin",
      "quiescevm": false,
      "serviceofferingdisplaytext": "Small Instance",
      "serviceofferingid": "dc716e01-07a7-4993-acd8-c0525956bd4b",
      "serviceofferingname": "Small Instance",
      "size": 2147483648,
      "sizegb": "2.00 GB",
      "state": "Ready",
      "tags": [],
      "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
      "templateid": "b0a97947-5eea-11ea-b12b-50eb7122da94",
      "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
      "type": "ROOT",
      "virtualmachineid": "81b1311f-1577-417c-b3b5-de51886423a4",
      "vmdisplayname": "test",
      "vmname": "test",
      "vmstate": "Running",
      "zoneid": "d61a905c-c058-4866-9d53-a16fffb3e4f4",
      "zonename": "Sandbox-simulator"
    }
  ]
}


list volumesmetrics (after fix):
{
  "count": 1,
  "volume": [
    {
      "account": "admin",
      "clusterid": "6642fcf8-7f8a-46e1-8642-f04efbb5f89c",
      "clustername": "C0",
      "created": "2020-03-05T19:41:59+0530",
      "deviceid": 0,
      "diskiopstotal": 0,
      "diskioread": 0,
      "diskiowrite": 0,
      "diskkbsread": 0,
      "diskkbswrite": 0,
      "displayvolume": true,
      "domain": "ROOT",
      "domainid": "968c400b-5eea-11ea-b12b-50eb7122da94",
      "hypervisor": "Simulator",
      "id": "c4d09dc3-8864-42bd-9338-8023be187477",
      "isextractable": false,
      "name": "ROOT-3",
      "path": "f31e908c-9bfd-44a0-8b77-8240d94169f5",
      "podid": "850e3d6f-2bdf-48d9-a2de-a9253b33d4b2",
      "podname": "POD0",
      "provisioningtype": "thin",
      "quiescevm": false,
      "serviceofferingdisplaytext": "Small Instance",
      "serviceofferingid": "dc716e01-07a7-4993-acd8-c0525956bd4b",
      "serviceofferingname": "Small Instance",
      "size": 2147483648,
      "sizegb": "2.00 GB",
      "state": "Ready",
      "storage": "PS1",
      "storageid": "cd360613-e1cf-3a32-b8ef-d07bad8dd92b",
      "storagetype": "Shared (ROOT)",
      "tags": [],
      "templatedisplaytext": "CentOS 5.6 (64-bit) no GUI (Simulator)",
      "templateid": "b0a97947-5eea-11ea-b12b-50eb7122da94",
      "templatename": "CentOS 5.6 (64-bit) no GUI (Simulator)",
      "type": "ROOT",
      "virtualmachineid": "81b1311f-1577-417c-b3b5-de51886423a4",
      "vmdisplayname": "test",
      "vmname": "test",
      "vmstate": "Running",
      "zoneid": "d61a905c-c058-4866-9d53-a16fffb3e4f4",
      "zonename": "Sandbox-simulator"
    }
  ]
}

```
