### PR TITLE
vr: fix password server run with empty gateway in isolated network with RVRs

### DIFF
--- a/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/debian/opt/cloud/bin/cs/CsAddress.py
@@ -583,9 +583,9 @@ class CsIP:
                         CsPasswdSvc(self.address['public_ip']).stop()
                 elif cmdline.is_master():
                     if method == "add":
-                        CsPasswdSvc(self.address['gateway'] + "," + self.address['public_ip']).start()
+                        CsPasswdSvc(self.get_gateway() + "," + self.address['public_ip']).start()
                     elif method == "delete":
-                        CsPasswdSvc(self.address['gateway'] + "," + self.address['public_ip']).stop()
+                        CsPasswdSvc(self.get_gateway() + "," + self.address['public_ip']).stop()
 
         if self.get_type() == "public" and self.config.is_vpc() and method == "add":
             if self.address["source_nat"]:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
This is regression issue of #3898 

The password server in isolated network with RVRs run with wrong parameter
```
root@r-1083-VM:~# ps -ef|grep pass
root      1070     1  0 20:58 ?        00:00:01 python /opt/cloud/bin/passwd_server_ip.py ,192.168.10.84
```
it is because the gateway is "" for eth0 in /etc/cloudstack/ips.json.

This does not impact vpc with redundant VRs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

restart network with cleanup, the new VR seems ok
```
root@r-1085-VM:~# ps -ef|grep pass
root      5468     1  0 21:37 ?        00:00:00 python /opt/cloud/bin/passwd_server_ip.py 192.168.0.1,192.168.0.28
```

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
