### PR TITLE
server: fix database exception while searching network offerings

### DIFF
--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -5352,7 +5352,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final Object keyword = cmd.getKeyword();
 
         if (keyword != null) {
-            final SearchCriteria<NetworkOfferingVO> ssc = _networkOfferingDao.createSearchCriteria();
+            final SearchCriteria<NetworkOfferingJoinVO> ssc = networkOfferingJoinDao.createSearchCriteria();
             ssc.addOr("displayText", SearchCriteria.Op.LIKE, "%" + keyword + "%");
             ssc.addOr("name", SearchCriteria.Op.LIKE, "%" + keyword + "%");
 


### PR DESCRIPTION
This fixes db exception when network offering is searched. Found during Primate testing: https://github.com/apache/cloudstack-primate/issues/186

![image](https://user-images.githubusercontent.com/12384665/75169161-c007ba00-5730-11ea-9d37-c5850ca2eb7c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)