### PR TITLE
server: password is not displayed when reinstall a vm or reset ssh key

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -822,6 +822,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
         if (!result) {
             throw new CloudRuntimeException("Failed to reset SSH Key for the virtual machine ");
         }
+        userVm.setPassword(password);
         return userVm;
     }
 
@@ -6503,6 +6504,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                 if (!result) {
                     throw new CloudRuntimeException("VM reset is completed but failed to reset password for the virtual machine ");
                 }
+                vm.setPassword(password);
             }
 
             if (needRestart) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

After reinstall a stopped vm or reset ssh key, the password is reset, and new password is saved in virtual router (if it is running). However we do not get any password in the api response as well as cloudstack UI.

This fixes the issue above.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
