### PR TITLE
vrouter: remove a POSTROUTING rule for port forwarding in VPC router

### DIFF
--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -939,7 +939,6 @@ class CsForwardingRules(CsDataBag):
             )
 
         self.fw.append(["nat", "", fw_prerout_rule])
-        self.fw.append(["nat", "", fw_postrout_rule])
         self.fw.append(["nat", "", fw_postrout_rule2])
         self.fw.append(["nat", "", fw_output_rule])
 

--- a/systemvm/debian/opt/cloud/bin/configure.py
+++ b/systemvm/debian/opt/cloud/bin/configure.py
@@ -918,15 +918,6 @@ class CsForwardingRules(CsDataBag):
         if not rule["internal_ports"] == "any":
             fw_prerout_rule += ":" + self.portsToString(rule["internal_ports"], "-")
 
-        fw_postrout_rule = "-A POSTROUTING -d %s/32 " % rule["public_ip"]
-        if not rule["protocol"] == "any":
-            fw_postrout_rule += " -m %s -p %s" % (rule["protocol"], rule["protocol"])
-        if not rule["public_ports"] == "any":
-            fw_postrout_rule += " --dport %s" % self.portsToString(rule["public_ports"], ":")
-        fw_postrout_rule += " -j SNAT --to-source %s" % rule["internal_ip"]
-        if not rule["internal_ports"] == "any":
-            fw_postrout_rule += ":" + self.portsToString(rule["internal_ports"], "-")
-
         fw_output_rule = "-A OUTPUT -d %s/32" % rule["public_ip"]
         if not rule["protocol"] == "any":
             fw_output_rule += " -m %s -p %s" % (rule["protocol"], rule["protocol"])

--- a/systemvm/debian/root/health_checks/iptables_check.py
+++ b/systemvm/debian/root/health_checks/iptables_check.py
@@ -36,8 +36,7 @@ def main():
         srcPortText = "--dport " + formatPort(portForward["sourcePortStart"], portForward["sourcePortEnd"], ":")
         dstText = destIp + ":" + formatPort(portForward["destPortStart"], portForward["destPortEnd"], "-")
         for algo in [["PREROUTING", "--to-destination"],
-                     ["OUTPUT", "--to-destination"],
-                     ["POSTROUTING", "--to-source"]]:
+                     ["OUTPUT", "--to-destination"]]:
             entriesExpected.append([algo[0], srcIpText, srcPortText, algo[1] + " " + dstText])
 
         fetchIpTableEntriesCmd = "iptables-save | grep " + destIp


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

As discussed in https://github.com/apache/cloudstack/pull/3937#issuecomment-595459008
a rule for port forwarding in VPC router might not be needed.

This fixes the failed result of health check for network VRs.
<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
