### PR TITLE
fix Volume migration across pools sometimes loses volume

### DIFF
--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -348,8 +348,10 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
             // directly to s3
             ImageStoreEntity imageStore = (ImageStoreEntity)dataStoreMgr.getImageStoreWithFreeCapacity(destScope.getScopeId());
             if (imageStore == null || !imageStore.getProtocol().equalsIgnoreCase("nfs") && !imageStore.getProtocol().equalsIgnoreCase("cifs")) {
-                s_logger.debug("can't find a nfs (or cifs) image store to satisfy the need for a staging store");
-                return null;
+                //s_logger.debug("can't find a nfs (or cifs) image store to satisfy the need for a staging store");
+                String errMsg = "can't find a nfs (or cifs) image store to satisfy the need for a staging store";
+                Answer answer = new Answer(null, false, errMsg);
+                return answer;
             }
 
             DataObject objOnImageStore = imageStore.create(srcData);
@@ -485,9 +487,6 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
 
             if (answer != null && !answer.getResult()) {
                 errMsg = answer.getDetails();
-            }
-            if (answer == null) {
-                errMsg = "answer is null, set to error for CopyCommandResult";
             }
         } catch (Exception e) {
             s_logger.debug("copy failed", e);

--- a/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
+++ b/engine/storage/datamotion/src/main/java/org/apache/cloudstack/storage/motion/AncientDataMotionStrategy.java
@@ -486,6 +486,9 @@ public class AncientDataMotionStrategy implements DataMotionStrategy {
             if (answer != null && !answer.getResult()) {
                 errMsg = answer.getDetails();
             }
+            if (answer == null) {
+                errMsg = "answer is null, set to error for CopyCommandResult";
+            }
         } catch (Exception e) {
             s_logger.debug("copy failed", e);
             errMsg = e.toString();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When secondary storage usage is> 90%, VOLUME migration across primary storage will cause the migration to fail and lose VOLUME
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
Fixes: #3958
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
