### PR TITLE
Rename max.retries setting

### DIFF
--- a/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
+++ b/server/src/main/java/com/cloud/ha/HighAvailabilityManagerImpl.java
@@ -105,10 +105,10 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
     private static final int SECONDS_TO_MILLISECONDS_FACTOR = 1000;
 
     protected static final Logger s_logger = Logger.getLogger(HighAvailabilityManagerImpl.class);
-    private ConfigKey<Integer> MaxRetries = new ConfigKey<>("Advanced", Integer.class,
-            "max.retries","5",
+    private ConfigKey<Integer> MigrationMaxRetries = new ConfigKey<>("Advanced", Integer.class,
+            "vm.ha.migration.max.retries","5",
             "Total number of attempts for trying migration of a VM.",
-            true, ConfigKey.Scope.Cluster);
+            true, ConfigKey.Scope.Global);
 
     WorkerThread[] _workers;
     boolean _stopped;
@@ -863,7 +863,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
 
         _forceHA = ForceHA.value();
         _timeToSleep = TimeToSleep.value() * SECONDS_TO_MILLISECONDS_FACTOR;
-        _maxRetries = MaxRetries.value();
+        _maxRetries = MigrationMaxRetries.value();
         _timeBetweenFailures = TimeBetweenFailures.value() * SECONDS_TO_MILLISECONDS_FACTOR;
         _timeBetweenCleanups = TimeBetweenCleanup.value();
         _stopRetryInterval = StopRetryInterval.value();
@@ -1037,7 +1037,7 @@ public class HighAvailabilityManagerImpl extends ManagerBase implements Configur
      */
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey[] {TimeBetweenCleanup, MaxRetries, TimeToSleep, TimeBetweenFailures,
+        return new ConfigKey[] {TimeBetweenCleanup, MigrationMaxRetries, TimeToSleep, TimeBetweenFailures,
             StopRetryInterval, RestartRetryInterval, MigrateRetryInterval, InvestigateRetryInterval,
             HAWorkers, ForceHA};
     }


### PR DESCRIPTION
## Description
Simply rename a global setting name to a more descriptive one:

`max.retries` to `vm.ha.migration.max.retries`

Also, as it is used in global context, have changed the scope from Cluster to Global.

This setting has been introduced before 4.14, so no need to update DB on upgrade

Setting improvement as well as #3961 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
