### PR TITLE
Reduce nonsence value for capacity.skipcounting.hours

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41300to41400.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41300to41400.sql
@@ -19,6 +19,11 @@
 -- Schema upgrade from 4.13.0.0 to 4.14.0.0
 --;
 
+-- Don't reserve capacities for stopped VMs by default as this influences normal capacity checks when doing i.e. rolling host maintenance, etc.
+-- One is free to increase this to a high value in case it's needed in his environment, otherwise makes no sense in most environments,
+-- as new VM can't be started on an empty host which was consumed previously by many VMS which are now stopped
+UPDATE `cloud`.`configuration` SET `default_value`='10' WHERE  `name`='capacity.skipcounting.hours';
+
 -- KVM: enable storage data motion on KVM hypervisor_capabilities
 UPDATE `cloud`.`hypervisor_capabilities` SET `storage_motion_supported` = 1 WHERE `hypervisor_capabilities`.`hypervisor_type` = 'KVM';
 


### PR DESCRIPTION
When doing rapid host maintenance one after the other, and when previously stopping a huge number of VMs on a single host (i.e. all VMs on that host are stopped) - no new VMs can be started on this empty host since those VMs' capacities are reserved for 3600sec - so when doing maintenance of another host, VMs can't be migrated to this empty host.

Not sure who and why has this setting default value to such high value (1h) (doesn't make sense)
Not to mention the name of the setting is wrong, should be "capacity.skipcounting.second"

Another PR to rename this setting is most welcome @nvazquez @DaanHoogland @weizhouapache 
