### PR TITLE
Handle port forward rule check for vpc and non vpc Isolated networks

### DIFF
--- a/systemvm/debian/root/health_checks/iptables_check.py
+++ b/systemvm/debian/root/health_checks/iptables_check.py
@@ -36,8 +36,7 @@ def main():
         srcPortText = "--dport " + formatPort(portForward["sourcePortStart"], portForward["sourcePortEnd"], ":")
         dstText = destIp + ":" + formatPort(portForward["destPortStart"], portForward["destPortEnd"], "-")
         for algo in [["PREROUTING", "--to-destination"],
-                     ["OUTPUT", "--to-destination"],
-                     ["POSTROUTING", "--to-source"]]:
+                     ["OUTPUT", "--to-destination"]]:
             entriesExpected.append([algo[0], srcIpText, srcPortText, algo[1] + " " + dstText])
 
         fetchIpTableEntriesCmd = "iptables-save | grep " + destIp


### PR DESCRIPTION
## Description
Port forwarding rules not checked properly on Isolated networks (non-VPC)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


## How Has This Been Tested?
Created Isolated network and added port forward rules for the Instance created in that network
Create an Instance in a tier of a VPC network and  ran the health check from UI and cmk with performfreshchecks as true
All tests passed for both the routers
