### PR TITLE
Snapshot deletion issues

### DIFF
--- a/engine/storage/integration-test/src/test/resources/fakeDriverTestContext.xml
+++ b/engine/storage/integration-test/src/test/resources/fakeDriverTestContext.xml
@@ -49,7 +49,7 @@
     <bean id="dataStoreProviderManagerImpl" class="org.apache.cloudstack.storage.datastore.provider.DataStoreProviderManagerImpl" />
     <bean id="storageCacheManagerImpl" class="org.apache.cloudstack.storage.cache.manager.StorageCacheManagerImpl"  />
     <bean id="storageCacheRandomAllocator" class="org.apache.cloudstack.storage.cache.allocator.StorageCacheRandomAllocator" />
-    <bean id="xenserverSnapshotStrategy" class="org.apache.cloudstack.storage.snapshot.XenserverSnapshotStrategy" />
+    <bean id="defaultSnapshotStrategy" class="org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy" />
     <bean id="bAREMETAL" class="org.apache.cloudstack.storage.image.format.BAREMETAL" />
     <bean id="dataMotionServiceImpl" class="org.apache.cloudstack.storage.motion.DataMotionServiceImpl" />
     <bean id="dataObjectManagerImpl" class="org.apache.cloudstack.storage.datastore.DataObjectManagerImpl" />

--- a/engine/storage/integration-test/src/test/resources/storageContext.xml
+++ b/engine/storage/integration-test/src/test/resources/storageContext.xml
@@ -50,7 +50,7 @@
   <bean id="ancientDataMotionStrategy" class="org.apache.cloudstack.storage.motion.AncientDataMotionStrategy" />
   <bean id="storageCacheManagerImpl" class="org.apache.cloudstack.storage.cache.manager.StorageCacheManagerImpl"  />
   <bean id="storageCacheRandomAllocator" class="org.apache.cloudstack.storage.cache.allocator.StorageCacheRandomAllocator" />
-  <bean id="xenserverSnapshotStrategy" class="org.apache.cloudstack.storage.snapshot.XenserverSnapshotStrategy" />
+  <bean id="defaultSnapshotStrategy" class="org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy" />
   <bean id="bAREMETAL" class="org.apache.cloudstack.storage.image.format.BAREMETAL" />
   <bean id="dataMotionServiceImpl" class="org.apache.cloudstack.storage.motion.DataMotionServiceImpl" />
   <bean id="dataObjectManagerImpl" class="org.apache.cloudstack.storage.datastore.DataObjectManagerImpl" />

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -290,7 +290,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
         if (snapshotVO != null && snapshotVO.getState() == Snapshot.State.Destroyed) {
             deletedOnPrimary = deleteSnapshotOnPrimary(snapshotId, snapshotOnPrimaryInfo);
         } else {
-            // This is to handle snapshots which are created only on primary when snapshot.backup.to.secondary is set to false. 
+            // This is to handle snapshots which are created only on primary when snapshot.backup.to.secondary is set to false.
             SnapshotObject obj = (SnapshotObject) snapshotOnPrimaryInfo;
             try {
                 obj.processEvent(Snapshot.Event.DestroyRequested);

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -288,10 +288,12 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
             // This may occur for instance when they are created only on primary because
             // snapshot.backup.to.secondary was set to false.
             if (snapshotOnPrimaryInfo == null) {
-                s_logger.debug("Snapshot id:" + snapshotId + " not found on primary storage, skipping snapshot deletion on primary and marking it destroyed");
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug(String.format("Snapshot (id: %d) not found on primary storage, skipping snapshot deletion on primary and marking it destroyed", snapshotId));
+                }
                 snapshotVO.setState(Snapshot.State.Destroyed);
                 snapshotDao.update(snapshotId, snapshotVO);
-                return true;
+                deletedOnPrimary = true;
             } else {
                 SnapshotObject obj = (SnapshotObject) snapshotOnPrimaryInfo;
                 try {
@@ -365,15 +367,21 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
     private boolean deleteSnapshotOnPrimary(Long snapshotId, SnapshotInfo snapshotOnPrimaryInfo) {
         SnapshotDataStoreVO snapshotOnPrimary = snapshotStoreDao.findBySnapshot(snapshotId, DataStoreRole.Primary);
         if (isSnapshotOnPrimaryStorage(snapshotId)) {
-            s_logger.debug("Snapshot reference is found on primary storage for snapshot id:" + snapshotId + ", performing snapshot deletion on primary");
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(String.format("Snapshot reference is found on primary storage for snapshot id: %d, performing snapshot deletion on primary", snapshotId));
+            }
             if (snapshotSvr.deleteSnapshot(snapshotOnPrimaryInfo)) {
                 snapshotOnPrimary.setState(State.Destroyed);
                 snapshotStoreDao.update(snapshotOnPrimary.getId(), snapshotOnPrimary);
-                s_logger.debug("Successfully deleted snapshot id:" + snapshotId + " on primary storage");
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug(String.format("Successfully deleted snapshot id: %d on primary storage", snapshotId));
+                }
                 return true;
             }
         } else {
-            s_logger.debug("Snapshot reference is not found on primary storage for snapshot id:" + snapshotId + ", skipping snapshot deletion on primary");
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(String.format("Snapshot reference is not found on primary storage for snapshot id: %d, skipping snapshot deletion on primary", snapshotId));
+            }
             return true;
         }
         return false;

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -308,7 +308,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
         Boolean deletedOnSecondary = false;
         SnapshotInfo snapshotOnImage = snapshotDataFactory.getSnapshot(snapshotId, DataStoreRole.Image);
         if (snapshotOnImage == null) {
-            s_logger.debug(String.format("Can't find snapshot [snapshot id: %d] on backup storage", snapshotId));
+            s_logger.debug(String.format("Can't find snapshot [snapshot id: %d] on secondary storage", snapshotId));
         } else {
             SnapshotObject obj = (SnapshotObject)snapshotOnImage;
             try {

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -267,6 +267,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
         boolean deletedOnSecondary = false;
         if (snapshotOnImage == null) {
             s_logger.debug(String.format("Can't find snapshot [snapshot id: %d] on backup storage", snapshotId));
+            snapshotDao.remove(snapshotId);
         } else {
             SnapshotObject obj = (SnapshotObject)snapshotOnImage;
             try {
@@ -326,7 +327,6 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
         if (isSnapshotOnPrimaryStorage(snapshotId) && snapshotSvr.deleteSnapshot(snapshotOnPrimaryInfo)) {
             snapshotOnPrimary.setState(State.Destroyed);
             snapshotStoreDao.update(snapshotOnPrimary.getId(), snapshotOnPrimary);
-            snapshotDao.remove(snapshotId);
             return true;
         }
         return false;

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -305,7 +305,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
     }
 
     private Boolean deleteOnSecondaryIfNeeded(Long snapshotId) {
-        Boolean deletedOnSecondary = false;
+        Boolean deletedOnSecondary = null;
         SnapshotInfo snapshotOnImage = snapshotDataFactory.getSnapshot(snapshotId, DataStoreRole.Image);
         if (snapshotOnImage == null) {
             s_logger.debug(String.format("Can't find snapshot [snapshot id: %d] on secondary storage", snapshotId));

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -270,7 +270,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
         } else {
             s_logger.debug(String.format("The snapshot (id: %d) could not be found/deleted on primary storage.", snapshotId));
         }
-        if (null == deletedOnSecondary && deletedOnSecondary) {
+        if (null != deletedOnSecondary && deletedOnSecondary) {
             s_logger.debug(String.format("Successfully deleted snapshot (id: %d) on secondary storage.", snapshotId));
         }
         return (deletedOnSecondary != null) && deletedOnSecondary || deletedOnPrimary;

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
 import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine.Event;
@@ -70,7 +69,6 @@ import com.cloud.utils.db.DB;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.NoTransitionException;
 
-@Component
 public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
     private static final Logger s_logger = Logger.getLogger(DefaultSnapshotStrategy.class);
 

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -340,8 +340,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
         if (snapshotOnPrimary != null) {
             long volumeId = snapshotOnPrimary.getVolumeId();
             VolumeVO volumeVO = volumeDao.findById(volumeId);
-            boolean isVolumeOnPrimary = volumeVO != null && volumeVO.getRemoved() == null;
-            return isVolumeOnPrimary;
+            return volumeVO != null && volumeVO.getRemoved() == null;
         }
         return false;
     }

--- a/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
+++ b/engine/storage/snapshot/src/main/java/org/apache/cloudstack/storage/snapshot/DefaultSnapshotStrategy.java
@@ -270,7 +270,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
         } else {
             SnapshotObject obj = (SnapshotObject)snapshotOnImage;
             try {
-                deletedOnSecondary = deleteSnapshotOnSecundaryStorage(snapshotId, snapshotOnImage, obj);
+                deletedOnSecondary = deleteSnapshotOnSecondaryStorage(snapshotId, snapshotOnImage, obj);
                 if (!deletedOnSecondary) {
                     s_logger.debug(
                             String.format("Failed to find/delete snapshot (id: %d) on secondary storage. Still necessary to check and delete snapshot on primary storage.",
@@ -297,7 +297,7 @@ public class DefaultSnapshotStrategy extends SnapshotStrategyBase {
      * Deletes the snapshot on secondary storage.
      * It can return false when the snapshot was stored on primary storage and not backed up on secondary; therefore, the snapshot should also be deleted on primary storage even when this method returns false.
      */
-    private boolean deleteSnapshotOnSecundaryStorage(Long snapshotId, SnapshotInfo snapshotOnImage, SnapshotObject obj) throws NoTransitionException {
+    private boolean deleteSnapshotOnSecondaryStorage(Long snapshotId, SnapshotInfo snapshotOnImage, SnapshotObject obj) throws NoTransitionException {
         obj.processEvent(Snapshot.Event.DestroyRequested);
         List<VolumeDetailVO> volumesFromSnapshot;
         volumesFromSnapshot = _volumeDetailsDaoImpl.findDetails("SNAPSHOT_ID", String.valueOf(snapshotId), null);

--- a/engine/storage/snapshot/src/main/resources/META-INF/cloudstack/storage/spring-engine-storage-snapshot-storage-context.xml
+++ b/engine/storage/snapshot/src/main/resources/META-INF/cloudstack/storage/spring-engine-storage-snapshot-storage-context.xml
@@ -27,8 +27,8 @@
                       http://www.springframework.org/schema/context/spring-context.xsd"
                       >
 
-    <bean id="xenserverSnapshotStrategy"
-        class="org.apache.cloudstack.storage.snapshot.XenserverSnapshotStrategy" />
+    <bean id="defaultSnapshotStrategy"
+        class="org.apache.cloudstack.storage.snapshot.DefaultSnapshotStrategy" />
 
     <bean id="storageSystemSnapshotStrategy"
         class="org.apache.cloudstack.storage.snapshot.StorageSystemSnapshotStrategy" />

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -127,6 +127,14 @@ public class KVMStorageProcessor implements StorageProcessor {
     private String _createTmplPath;
     private String _manageSnapshotPath;
     private int _cmdsTimeout;
+    
+    private static final String MANAGE_SNAPSTHOT_CREATE = "-c";
+    private static final String MANAGE_SNAPSTHOT_DESTROY = "-d";
+    private static final String NAME = "-n";
+    private static final String CEPH_MON_HOST = "mon_host";
+    private static final String CEPH_AUTH_KEY = "key";
+    private static final String CEPH_CLIENT_MOUNT_TIMEOUT = "client_mount_timeout";
+    private static final String CEPH_DEFAULT_MOUNT_TIMEOUT = "30";
 
     public KVMStorageProcessor(final KVMStoragePoolManager storagePoolMgr, final LibvirtComputingResource resource) {
         this.storagePoolMgr = storagePoolMgr;
@@ -563,7 +571,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 final Script command = new Script(_createTmplPath, wait, s_logger);
                 command.add("-f", disk.getPath());
                 command.add("-t", tmpltPath);
-                command.add("-n", templateName + ".qcow2");
+                command.add(NAME, templateName + ".qcow2");
 
                 final String result = command.execute();
 
@@ -949,7 +957,7 @@ public class KVMStorageProcessor implements StorageProcessor {
             } else {
                 final Script command = new Script(_manageSnapshotPath, cmd.getWaitInMillSeconds(), s_logger);
                 command.add("-b", snapshotDisk.getPath());
-                command.add("-n", snapshotName);
+                command.add(NAME, snapshotName);
                 command.add("-p", snapshotDestPath);
                 if (isCreatedFromVmSnapshot) {
                     descName = UUID.randomUUID().toString();
@@ -1010,14 +1018,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                         }
                     } else {
                         if (primaryPool.getType() != StoragePoolType.RBD) {
-                            final Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
-                            command.add("-d", snapshotDisk.getPath());
-                            command.add("-n", snapshotName);
-                            final String result = command.execute();
-                            if (result != null) {
-                                s_logger.debug("Failed to delete snapshot on primary: " + result);
-                                // return new CopyCmdAnswer("Failed to backup snapshot: " + result);
-                            }
+                            deleteSnapshotViaManageSnapshotScript(snapshotName, snapshotDisk);
                         }
                     }
                 } catch (final Exception ex) {
@@ -1032,6 +1033,16 @@ public class KVMStorageProcessor implements StorageProcessor {
             } catch (final Exception ex) {
                 s_logger.debug("Failed to delete secondary storage", ex);
             }
+        }
+    }
+
+    private void deleteSnapshotViaManageSnapshotScript(final String snapshotName, KVMPhysicalDisk snapshotDisk) {
+        final Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
+        command.add(MANAGE_SNAPSTHOT_DESTROY, snapshotDisk.getPath());
+        command.add(NAME, snapshotName);
+        final String result = command.execute();
+        if (result != null) {
+            s_logger.debug("Failed to delete snapshot on primary: " + result);
         }
     }
 
@@ -1489,12 +1500,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                  */
                 if (primaryPool.getType() == StoragePoolType.RBD) {
                     try {
-                        final Rados r = new Rados(primaryPool.getAuthUserName());
-                        r.confSet("mon_host", primaryPool.getSourceHost() + ":" + primaryPool.getSourcePort());
-                        r.confSet("key", primaryPool.getAuthSecret());
-                        r.confSet("client_mount_timeout", "30");
-                        r.connect();
-                        s_logger.debug("Succesfully connected to Ceph cluster at " + r.confGet("mon_host"));
+                        Rados r = radosConnect(primaryPool);
 
                         final IoCTX io = r.ioCtxCreate(primaryPool.getSourceDir());
                         final Rbd rbd = new Rbd(io);
@@ -1511,8 +1517,8 @@ public class KVMStorageProcessor implements StorageProcessor {
                 } else {
                     /* VM is not running, create a snapshot by ourself */
                     final Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
-                    command.add("-c", disk.getPath());
-                    command.add("-n", snapshotName);
+                    command.add(MANAGE_SNAPSTHOT_CREATE, disk.getPath());
+                    command.add(NAME, snapshotName);
                     final String result = command.execute();
                     if (result != null) {
                         s_logger.debug("Failed to manage snapshot: " + result);
@@ -1531,6 +1537,16 @@ public class KVMStorageProcessor implements StorageProcessor {
         }
     }
 
+    private Rados radosConnect(final KVMStoragePool primaryPool) throws RadosException {
+        Rados r = new Rados(primaryPool.getAuthUserName());
+        r.confSet(CEPH_MON_HOST, primaryPool.getSourceHost() + ":" + primaryPool.getSourcePort());
+        r.confSet(CEPH_AUTH_KEY, primaryPool.getAuthSecret());
+        r.confSet(CEPH_CLIENT_MOUNT_TIMEOUT, CEPH_DEFAULT_MOUNT_TIMEOUT);
+        r.connect();
+        s_logger.debug("Succesfully connected to Ceph cluster at " + r.confGet(CEPH_MON_HOST));
+        return r;
+    }
+    
     @Override
     public Answer deleteVolume(final DeleteCommand cmd) {
         final VolumeObjectTO vol = (VolumeObjectTO)cmd.getData();
@@ -1619,12 +1635,7 @@ public class KVMStorageProcessor implements StorageProcessor {
             String snapshotName = snapshotFullPath.substring(snapshotFullPath.lastIndexOf("/") + 1);
             snap_full_name = disk.getName() + "@" + snapshotName;
             if (primaryPool.getType() == StoragePoolType.RBD) {
-                Rados r = new Rados(primaryPool.getAuthUserName());
-                r.confSet("mon_host", primaryPool.getSourceHost() + ":" + primaryPool.getSourcePort());
-                r.confSet("key", primaryPool.getAuthSecret());
-                r.confSet("client_mount_timeout", "30");
-                r.connect();
-                s_logger.debug("Succesfully connected to Ceph cluster at " + r.confGet("mon_host"));
+                Rados r = radosConnect(primaryPool);
                 IoCTX io = r.ioCtxCreate(primaryPool.getSourceDir());
                 Rbd rbd = new Rbd(io);
                 RbdImage image = rbd.open(disk.getName());
@@ -1644,6 +1655,9 @@ public class KVMStorageProcessor implements StorageProcessor {
                     rbd.close(image);
                     r.ioCtxDestroy(io);
                 }
+            } else if (primaryPool.getType() == StoragePoolType.NetworkFilesystem) {
+                s_logger.info(String.format("Attempting to remove snapshot on primary storage (id=%s, snapshot=%s, storage type=%s)", snapshotTO.getId(), snap_full_name, primaryPool.getType()));
+                deleteSnapshotViaManageSnapshotScript(snapshotName, disk);
             } else {
                 s_logger.warn("Operation not implemented for storage pool type of " + primaryPool.getType().toString());
                 throw new InternalErrorException("Operation not implemented for storage pool type of " + primaryPool.getType().toString());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -127,7 +127,7 @@ public class KVMStorageProcessor implements StorageProcessor {
     private String _createTmplPath;
     private String _manageSnapshotPath;
     private int _cmdsTimeout;
-    
+
     private static final String MANAGE_SNAPSTHOT_CREATE = "-c";
     private static final String MANAGE_SNAPSTHOT_DESTROY = "-d";
     private static final String NAME = "-n";
@@ -1546,7 +1546,7 @@ public class KVMStorageProcessor implements StorageProcessor {
         s_logger.debug("Succesfully connected to Ceph cluster at " + r.confGet(CEPH_MON_HOST));
         return r;
     }
-    
+
     @Override
     public Answer deleteVolume(final DeleteCommand cmd) {
         final VolumeObjectTO vol = (VolumeObjectTO)cmd.getData();

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1656,7 +1656,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                     r.ioCtxDestroy(io);
                 }
             } else if (primaryPool.getType() == StoragePoolType.NetworkFilesystem) {
-                s_logger.info(String.format("Attempting to remove snapshot on primary storage (id=%s, snapshot=%s, storage type=%s)", snapshotTO.getId(), snap_full_name, primaryPool.getType()));
+                s_logger.info(String.format("Attempting to remove snapshot (id=%s, name=%s, path=%s, storage type=%s) on primary storage", snapshotTO.getId(), snapshotTO.getName(), snapshotTO.getPath(), primaryPool.getType()));
                 deleteSnapshotViaManageSnapshotScript(snapshotName, disk);
             } else {
                 s_logger.warn("Operation not implemented for storage pool type of " + primaryPool.getType().toString());

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -128,9 +128,9 @@ public class KVMStorageProcessor implements StorageProcessor {
     private String _manageSnapshotPath;
     private int _cmdsTimeout;
 
-    private static final String MANAGE_SNAPSTHOT_CREATE = "-c";
-    private static final String MANAGE_SNAPSTHOT_DESTROY = "-d";
-    private static final String NAME = "-n";
+    private static final String MANAGE_SNAPSTHOT_CREATE_OPTION = "-c";
+    private static final String MANAGE_SNAPSTHOT_DESTROY_OPTION = "-d";
+    private static final String NAME_OPTION = "-n";
     private static final String CEPH_MON_HOST = "mon_host";
     private static final String CEPH_AUTH_KEY = "key";
     private static final String CEPH_CLIENT_MOUNT_TIMEOUT = "client_mount_timeout";
@@ -571,7 +571,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                 final Script command = new Script(_createTmplPath, wait, s_logger);
                 command.add("-f", disk.getPath());
                 command.add("-t", tmpltPath);
-                command.add(NAME, templateName + ".qcow2");
+                command.add(NAME_OPTION, templateName + ".qcow2");
 
                 final String result = command.execute();
 
@@ -957,7 +957,7 @@ public class KVMStorageProcessor implements StorageProcessor {
             } else {
                 final Script command = new Script(_manageSnapshotPath, cmd.getWaitInMillSeconds(), s_logger);
                 command.add("-b", snapshotDisk.getPath());
-                command.add(NAME, snapshotName);
+                command.add(NAME_OPTION, snapshotName);
                 command.add("-p", snapshotDestPath);
                 if (isCreatedFromVmSnapshot) {
                     descName = UUID.randomUUID().toString();
@@ -1038,8 +1038,8 @@ public class KVMStorageProcessor implements StorageProcessor {
 
     private void deleteSnapshotViaManageSnapshotScript(final String snapshotName, KVMPhysicalDisk snapshotDisk) {
         final Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
-        command.add(MANAGE_SNAPSTHOT_DESTROY, snapshotDisk.getPath());
-        command.add(NAME, snapshotName);
+        command.add(MANAGE_SNAPSTHOT_DESTROY_OPTION, snapshotDisk.getPath());
+        command.add(NAME_OPTION, snapshotName);
         final String result = command.execute();
         if (result != null) {
             s_logger.debug("Failed to delete snapshot on primary: " + result);
@@ -1517,8 +1517,8 @@ public class KVMStorageProcessor implements StorageProcessor {
                 } else {
                     /* VM is not running, create a snapshot by ourself */
                     final Script command = new Script(_manageSnapshotPath, _cmdsTimeout, s_logger);
-                    command.add(MANAGE_SNAPSTHOT_CREATE, disk.getPath());
-                    command.add(NAME, snapshotName);
+                    command.add(MANAGE_SNAPSTHOT_CREATE_OPTION, disk.getPath());
+                    command.add(NAME_OPTION, snapshotName);
                     final String result = command.execute();
                     if (result != null) {
                         s_logger.debug("Failed to manage snapshot: " + result);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
_copy of PR #3649 on a joint account for easier cooperation._

Tested both cases:
- Snapshot backed up on Secondary - manual and scheduled
- Snapshot stored only on primary storage (works with KVM + Ceph only)

**Note**: @GabrielBrascher changed the name of the strategy from _XenserverSnapshotStrategy_ to _DefaultSnapshotStrategy_ due to the fact that the "Xenserver" strategy handles also Ceph, KVM, and do return `StrategyPriority.DEFAULT` in any case except _REVERT_.

```
    @Override
    public StrategyPriority canHandle(Snapshot snapshot, SnapshotOperation op) {
        if (SnapshotOperation.REVERT.equals(op)) {
            long volumeId = snapshot.getVolumeId();
            VolumeVO volumeVO = volumeDao.findById(volumeId);

            if (volumeVO != null && ImageFormat.QCOW2.equals(volumeVO.getFormat())) {
                return StrategyPriority.DEFAULT;
            }
            return StrategyPriority.CANT_HANDLE;
        }
        return StrategyPriority.DEFAULT;
    }
```

Fixes: #3646

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


## WHAT HAS BEEN FIXED / WORKs FINE:

- VMware, KVM - no garbage on Secondary/Primary store (snapshot.backup.to.secondary=TRUE)👍 
-- snapshot.backup.to.secondary=FALSE - works (by design) only with KVM+Ceph - no garbage on Secondary/Primary storage 👍 
---  snapshot.backup.to.secondary=FALSE  does NOT work (by design) with other hypervisors/storage combo - so don't bother trying 😄 
- ad-hoc single XenServer volume snapshot (i.e.NOT consecutive snaps/scheduled snaps 👎 )

## WHAT HAS NOT BEEN FIXED (tracked via #4018 ):

- **Major**: XenServer consecutive/scheduled volume snapshots, since having parent/child relation _(vs. VMware and KVM where consecutive/scheduled snaps are NOT chained (no parent/child relation))_ - continues to be broken - i.e. one can continue to create/use XS volume snaps, but they are not removed properly on Primary and Secondary storage and thus leave garbage all over the place - eventually, there might happen the "Snapshot chain too long" error from Xen (see #4018 for the possible workaround/fix and a bit more explanation on how it works atm) 👎 👎 👎 
- **Minor**: VMware and KVM PRIMARY references (role_type=primary) are NOT removed from the snapshot_store_ref table - minor garbage, but to be fixed eventually 👎 
