### PR TITLE
With basic zone and VMware hypervisor, VR fails to start

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -200,7 +200,6 @@ import com.cloud.agent.resource.virtualnetwork.VRScripts;
 import com.cloud.agent.resource.virtualnetwork.VirtualRouterDeployer;
 import com.cloud.agent.resource.virtualnetwork.VirtualRoutingResource;
 import com.cloud.configuration.Resource.ResourceType;
-import com.cloud.dc.DataCenter.NetworkType;
 import com.cloud.dc.Vlan;
 import com.cloud.exception.CloudException;
 import com.cloud.exception.InternalErrorException;
@@ -6411,16 +6410,6 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
 
     private static String getRouterSshControlIp(NetworkElementCommand cmd) {
         String routerIp = cmd.getAccessDetail(NetworkElementCommand.ROUTER_IP);
-        String routerGuestIp = cmd.getAccessDetail(NetworkElementCommand.ROUTER_GUEST_IP);
-        String zoneNetworkType = cmd.getAccessDetail(NetworkElementCommand.ZONE_NETWORK_TYPE);
-
-        if (routerGuestIp != null && zoneNetworkType != null && NetworkType.valueOf(zoneNetworkType) == NetworkType.Basic) {
-            if (s_logger.isDebugEnabled())
-                s_logger.debug("In Basic zone mode, use router's guest IP for SSH control. guest IP : " + routerGuestIp);
-
-            return routerGuestIp;
-        }
-
         if (s_logger.isDebugEnabled())
             s_logger.debug("Use router's private IP for SSH control. IP : " + routerIp);
         return routerIp;

--- a/server/src/main/java/com/cloud/network/guru/ControlNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/ControlNetworkGuru.java
@@ -138,22 +138,11 @@ public class ControlNetworkGuru extends PodBasedNetworkGuru implements NetworkGu
         // we have to get management/private ip for the control nic for vmware/hyperv due ssh issues.
         HypervisorType hType = vm.getHypervisorType();
         if (((hType == HypervisorType.VMware) || (hType == HypervisorType.Hyperv)) && isRouterVm(vm)) {
-            if (dest.getDataCenter().getNetworkType() != NetworkType.Basic) {
-                super.reserve(nic, config, vm, dest, context);
+            super.reserve(nic, config, vm, dest, context);
 
-                String mac = _networkMgr.getNextAvailableMacAddressInNetwork(config.getId());
-                nic.setMacAddress(mac);
-                return;
-            } else {
-                // in basic mode and in VMware case, control network will be shared with guest network
-                String mac = _networkMgr.getNextAvailableMacAddressInNetwork(config.getId());
-                nic.setMacAddress(mac);
-                nic.setIPv4Address("0.0.0.0");
-                nic.setIPv4Netmask("0.0.0.0");
-                nic.setFormat(AddressFormat.Ip4);
-                nic.setIPv4Gateway("0.0.0.0");
-                return;
-            }
+            String mac = _networkMgr.getNextAvailableMacAddressInNetwork(config.getId());
+            nic.setMacAddress(mac);
+            return;
         }
 
         String ip = _dcDao.allocateLinkLocalIpAddress(dest.getDataCenter().getId(), dest.getPod().getId(), nic.getId(), context.getReservationId());

--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -1401,7 +1401,11 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
 
                     if (dc.getNetworkType() == NetworkType.Basic) {
                         // ask domR to setup SSH on guest network
-                        buf.append(" sshonguest=true");
+                        if (profile.getHypervisorType() == HypervisorType.VMware) {
+                            buf.append(" sshonguest=false");
+                        } else {
+                            buf.append(" sshonguest=true");
+                        }
                     }
 
                 }
@@ -1760,19 +1764,9 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
         final DomainRouterVO router = _routerDao.findById(profile.getId());
         final DataCenterVO dcVo = _dcDao.findById(router.getDataCenterId());
         NicProfile controlNic = null;
-        if (profile.getHypervisorType() == HypervisorType.VMware && dcVo.getNetworkType() == NetworkType.Basic) {
-            // TODO this is a ugly to test hypervisor type here
-            // for basic network mode, we will use the guest NIC for control NIC
-            for (final NicProfile nic : profile.getNics()) {
-                if (nic.getTrafficType() == TrafficType.Guest && nic.getIPv4Address() != null) {
-                    controlNic = nic;
-                }
-            }
-        } else {
-            for (final NicProfile nic : profile.getNics()) {
-                if (nic.getTrafficType() == TrafficType.Control && nic.getIPv4Address() != null) {
-                    controlNic = nic;
-                }
+        for (final NicProfile nic : profile.getNics()) {
+            if (nic.getTrafficType() == TrafficType.Control && nic.getIPv4Address() != null) {
+                controlNic = nic;
             }
         }
         return controlNic;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
    With basic zone and VMware hypervisor, VR fails to start since eth1 is getting empty instead of a private IP.

Boot Args for VM[DomainRouter|r-4-VM]:  template=domP name=r-4-VM eth0ip=10.3.0.89 eth0mask=255.255.224.0 gateway=10.3.31.254 domain=cs1cloud.internal cidrsize=19 dhcprange=10.3.0.1 eth1ip=0.0.0.0 eth1mask=0.0.0.0 mgmtcidr=10.2.0.0/16 localgw=10.2.254.254 sshonguest=true type=dhcpsrvr disable_rp_filter=true extra_pubnics=2 dns1=8.8.8.8 

    Though VMware does not support security groups, but in a basic zone with VMware and no isolation VMs should be able to deploy.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3031

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
1. Created a VMware basic zone
2. Created a VM and Virtual router
3. VR is in running state with private IP assigned to it
4. VM deployment is also successful


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
