### PR TITLE
Updated 3 error messages to replace the word 'matches' with 'match'

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
@@ -428,13 +428,13 @@ public class VmImportManagerImpl implements VmImportService {
             serviceOffering = serviceOfferingDao.getComputeOffering(serviceOffering, parameters);
         } else {
             if (!cpu.equals(serviceOffering.getCpu()) && !instance.getPowerState().equals(UnmanagedInstanceTO.PowerState.PowerOff)) {
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %d CPU cores does not matches VM CPU cores %d  and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getCpu(), cpu, instance.getPowerState()));
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %d CPU cores does not match VM CPU cores %d  and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getCpu(), cpu, instance.getPowerState()));
             }
             if (!memory.equals(serviceOffering.getRamSize()) && !instance.getPowerState().equals(UnmanagedInstanceTO.PowerState.PowerOff)) {
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %dMB memory does not matches VM memory %dMB and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getRamSize(), memory, instance.getPowerState()));
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %dMB memory does not match VM memory %dMB and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getRamSize(), memory, instance.getPowerState()));
             }
             if (cpuSpeed != null && cpuSpeed > 0 && !cpuSpeed.equals(serviceOffering.getSpeed()) && !instance.getPowerState().equals(UnmanagedInstanceTO.PowerState.PowerOff)) {
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %dMHz CPU speed does not matches VM CPU speed %dMHz and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getSpeed(), cpuSpeed, instance.getPowerState()));
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %dMHz CPU speed does not match VM CPU speed %dMHz and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getSpeed(), cpuSpeed, instance.getPowerState()));
             }
         }
         resourceLimitService.checkResourceLimit(owner, Resource.ResourceType.cpu, new Long(serviceOffering.getCpu()));

--- a/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java
@@ -428,7 +428,7 @@ public class VmImportManagerImpl implements VmImportService {
             serviceOffering = serviceOfferingDao.getComputeOffering(serviceOffering, parameters);
         } else {
             if (!cpu.equals(serviceOffering.getCpu()) && !instance.getPowerState().equals(UnmanagedInstanceTO.PowerState.PowerOff)) {
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %d CPU cores does not match VM CPU cores %d  and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getCpu(), cpu, instance.getPowerState()));
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %d CPU cores do not match VM CPU cores %d and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getCpu(), cpu, instance.getPowerState()));
             }
             if (!memory.equals(serviceOffering.getRamSize()) && !instance.getPowerState().equals(UnmanagedInstanceTO.PowerState.PowerOff)) {
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Service offering (%s) %dMB memory does not match VM memory %dMB and VM is not in powered off state (Power state: %s)", serviceOffering.getUuid(), serviceOffering.getRamSize(), memory, instance.getPowerState()));


### PR DESCRIPTION
## Description
I provided a fix for the error reported in issue # 3642
Details of the error can be found at: 
    https://github.com/apache/cloudstack/issues/3642

**Root cause of the problem:**
The incorrect error messages were found in the lines 431, 434 and 437 of the file - 
    server/src/main/java/org/apache/cloudstack/vm/VmImportManagerImpl.java

_**Line # 431:**_
        ` throw new ServerApiException ... CPU cores does not matches ... `

_**Line # 434:**_
        ` throw new ServerApiException ... memory does not matches ...`

_**Line # 437:**_
         `throw new ServerApiException ... CPU speed does not matches ...`

**Changes done to fix the problem:**

I replaced the word 'matches' with 'match' inside the 3 error messages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
I compiled the code after the changes and tested whether the error messages with the updated text are shown for these 3 scenarios of Server API exceptions:
1. CPU cores not matching
2. Memory not matching
3. CPU speed not matching

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
