### PR TITLE
Remove rolling-maintenance service from debian rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -141,7 +141,7 @@ override_dh_auto_install:
 	cp -r test/integration/* $(DESTDIR)/usr/share/$(PACKAGE)-integration-tests/
 
 override_dh_systemd_enable:
-	dh_systemd_enable -pcloudstack-management -pcloudstack-agent -pcloudstack-usage -pcloudstack-rolling-maintenance@
+	dh_systemd_enable -pcloudstack-management -pcloudstack-agent -pcloudstack-usage
 
 override_dh_strip_nondeterminism:
 	# Disable dh_strip_nondeterminism to speed up the build


### PR DESCRIPTION
## Description
The cloudstack-rolling-maintenance service fails on ubuntu while packaging.

Fixes: #3981 

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
````
~/cloudstack/packaging# ./build-deb.sh
````
