### PR TITLE
Change listVpcOfferings endpoint and createVpcOffering endpoint

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/vpc/UpdateVPCOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/vpc/UpdateVPCOfferingCmd.java
@@ -25,6 +25,7 @@ import org.apache.cloudstack.api.ApiErrorCode;
 import org.apache.cloudstack.api.BaseAsyncCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.ServiceOfferingResponse;
 import org.apache.cloudstack.api.response.VpcOfferingResponse;
 import org.apache.log4j.Logger;
 
@@ -71,6 +72,12 @@ public class UpdateVPCOfferingCmd extends BaseAsyncCmd {
 
     @Parameter(name = ApiConstants.SORT_KEY, type = CommandType.INTEGER, description = "sort key of the VPC offering, integer")
     private Integer sortKey;
+
+    @Parameter(name = ApiConstants.SERVICE_OFFERING_ID,
+            type = CommandType.UUID,
+            entityType = ServiceOfferingResponse.class,
+            description = "the ID of the service offering for the VPC router appliance")
+    private Long serviceOfferingId;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -154,6 +161,10 @@ public class UpdateVPCOfferingCmd extends BaseAsyncCmd {
 
     public Integer getSortKey() {
         return sortKey;
+    }
+
+    public Long getServiceOfferingId() {
+        return serviceOfferingId;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/response/VpcOfferingResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/VpcOfferingResponse.java
@@ -82,6 +82,10 @@ public class VpcOfferingResponse extends BaseResponse {
     @Param(description = "the zone name(s) this disk offering belongs to. Ignore this information as it is not currently applicable.", since = "4.13.0")
     private String zone;
 
+    @SerializedName(ApiConstants.SERVICE_OFFERING_ID)
+    @Param(description = "the service offering which was used to create vpc offering")
+    private String serviceOfferingId;
+
     public void setId(String id) {
         this.id = id;
     }
@@ -148,5 +152,9 @@ public class VpcOfferingResponse extends BaseResponse {
 
     public void setZone(String zone) {
         this.zone = zone;
+    }
+
+    public void setServiceOfferingId(String serviceOfferingId) {
+        this.serviceOfferingId = serviceOfferingId;
     }
 }

--- a/engine/schema/src/main/java/com/cloud/network/vpc/VpcOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/VpcOfferingVO.java
@@ -181,6 +181,10 @@ public class VpcOfferingVO implements VpcOffering {
         return serviceOfferingId;
     }
 
+    public void setServiceOfferingId(Long serviceOfferingId) {
+        this.serviceOfferingId = serviceOfferingId;
+    }
+
     @Override
     public boolean isSupportsDistributedRouter() {
         return supportsDistributedRouter;

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import com.cloud.resource.RollingMaintenanceManager;
+import com.cloud.service.dao.ServiceOfferingDao;
 import org.apache.cloudstack.acl.ControlledEntity;
 import org.apache.cloudstack.acl.ControlledEntity.ACLType;
 import org.apache.cloudstack.affinity.AffinityGroup;
@@ -391,6 +392,8 @@ public class ApiResponseHelper implements ResponseGenerator {
     private VMSnapshotDao vmSnapshotDao;
     @Inject
     private BackupOfferingDao backupOfferingDao;
+    @Inject
+    private ServiceOfferingDao serviceOfferingDao;
 
     @Override
     public UserResponse createUserResponse(User user) {
@@ -2887,6 +2890,8 @@ public class ApiResponseHelper implements ResponseGenerator {
             serviceResponses.add(svcRsp);
         }
         response.setServices(serviceResponses);
+        if(offering.getServiceOfferingId() != null)
+            response.setServiceOfferingId(serviceOfferingDao.findById(offering.getServiceOfferingId()).getUuid());
         return response;
     }
 

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -804,7 +804,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_VPC_OFFERING_UPDATE, eventDescription = "updating vpc offering")
     public VpcOffering updateVpcOffering(long vpcOffId, String vpcOfferingName, String displayText, String state) {
-        return updateVpcOfferingInternal(vpcOffId, vpcOfferingName, displayText, state, null, null, null);
+        return updateVpcOfferingInternal(vpcOffId, vpcOfferingName, displayText, state, null, null, null, null);
     }
 
     @Override
@@ -817,6 +817,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         final List<Long> domainIds = cmd.getDomainIds();
         final List<Long> zoneIds = cmd.getZoneIds();
         final Integer sortKey = cmd.getSortKey();
+        final Long serviceOfferingId = cmd.getServiceOfferingId();
 
         // check if valid domain
         if (CollectionUtils.isNotEmpty(domainIds)) {
@@ -835,10 +836,10 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             }
         }
 
-        return updateVpcOfferingInternal(offeringId, vpcOfferingName, displayText, state, sortKey, domainIds, zoneIds);
+        return updateVpcOfferingInternal(offeringId, vpcOfferingName, displayText, state, sortKey, domainIds, zoneIds, serviceOfferingId);
     }
 
-    private VpcOffering updateVpcOfferingInternal(long vpcOffId, String vpcOfferingName, String displayText, String state, Integer sortKey, final List<Long> domainIds, final List<Long> zoneIds) {
+    private VpcOffering updateVpcOfferingInternal(long vpcOffId, String vpcOfferingName, String displayText, String state, Integer sortKey, final List<Long> domainIds, final List<Long> zoneIds, final Long serviceOfferingId) {
         CallContext.current().setEventDetails(" Id: " + vpcOffId);
 
         // Verify input parameters
@@ -875,6 +876,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             if (displayText != null) {
                 offering.setDisplayText(displayText);
             }
+            offering.setServiceOfferingId(serviceOfferingId);
             if (state != null) {
                 boolean validState = false;
                 for (final VpcOffering.State st : VpcOffering.State.values()) {

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -4409,7 +4409,7 @@ class VpcOffering:
         self.__dict__.update(items)
 
     @classmethod
-    def create(cls, apiclient, services):
+    def create(cls, apiclient, services, serviceofferingid=None):
         """Create vpc offering"""
 
         import logging
@@ -4418,6 +4418,7 @@ class VpcOffering:
         cmd.name = "-".join([services["name"], random_gen()])
         cmd.displaytext = services["displaytext"]
         cmd.supportedServices = services["supportedservices"]
+        cmd.serviceofferingid = serviceofferingid
         if "serviceProviderList" in services:
             for service, provider in services["serviceProviderList"].items():
                 providers = provider


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Currently in cloudstack there is no way to create a VPC Offering with a selected service offering, the service offering is always null. When a VPC router is created if the service offering is null a default Service Offering is chosen.

The following changes have been added:

- listVpcOfferings endpoint will list what system service offering they were created with
- the cloudstack ui will let you pick what serviceOfferingId to use
- the cloudstack ui will let you edit the serviceOffering used by the vpcOffering

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![addVpcOffering](https://user-images.githubusercontent.com/50488048/77345749-c2fcc700-6d3d-11ea-82cb-64429e800c01.PNG)
![editOffering](https://user-images.githubusercontent.com/50488048/77345766-c85a1180-6d3d-11ea-9e93-05c2ec21da77.PNG)


## How Has This Been Tested?

Wrote a python test for testing create VPC offering with selected service offering
Steps for validation

- Create a system offering
- Create VPC Offering by specifying all supported Services and your system offering
- VPC offering should be created successfully

[results.txt](https://github.com/apache/cloudstack/files/4371015/results.txt)
[runinfo.txt](https://github.com/apache/cloudstack/files/4371016/runinfo.txt)



<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
