### PR TITLE
UI: Hide cpuspeed for custom constrained offering

### DIFF
--- a/ui/scripts/instances.js
+++ b/ui/scripts/instances.js
@@ -2196,7 +2196,11 @@
                                                 return;
 
                                             if (selectedServiceofferingObj.iscustomized == true) {
-                                                $form.find('.form-item[rel=cpuSpeed]').css('display', 'inline-block');
+                                                if (selectedServiceofferingObj.cpuspeed) {
+                                                    $form.find('.form-item[rel=cpuSpeed]').hide();
+                                                } else {
+                                                    $form.find('.form-item[rel=cpuSpeed]').css('display', 'inline-block');
+                                                }
                                                 $form.find('.form-item[rel=cpuNumber]').css('display', 'inline-block');
                                                 $form.find('.form-item[rel=memory]').css('display', 'inline-block');
                                             } else {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

For customer constrained offering, the cpu speed is fixed. 
Therefore the 'CpuSpeed' field should be hidden for customer constrained offering when change vm offering on UI. 
It is visible only for unconstrained offering.

This is regression issue of #3245 
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
