### PR TITLE
Update schema-41310to41400.sql

### DIFF
--- a/engine/schema/src/main/resources/META-INF/db/schema-41310to41400.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41310to41400.sql
@@ -21,7 +21,7 @@
 
 -- Update the description to indicate this only works with KVM + Ceph 
 -- (not implemented properly atm for KVM+NFS/local, and it accidentaly works with XS + NFS. Not applicable for VMware)
-UPDATE `cloud`.`configuration` SET `description`='Indicates whether to always backup primary storage snapshot to secondary storage. Applicable for KVM + Ceph only.' WHERE  `name`='snapshot.backup.to.secondary';
+UPDATE `cloud`.`configuration` SET `description`='Indicates whether to always backup primary storage snapshot to secondary storage. Keeping snapshots only on Primary storage is applicable for KVM + Ceph only.' WHERE  `name`='snapshot.backup.to.secondary';
 
 -- KVM: enable storage data motion on KVM hypervisor_capabilities
 UPDATE `cloud`.`hypervisor_capabilities` SET `storage_motion_supported` = 1 WHERE `hypervisor_capabilities`.`hypervisor_type` = 'KVM';

--- a/engine/schema/src/main/resources/META-INF/db/schema-41310to41400.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41310to41400.sql
@@ -21,7 +21,7 @@
 
 -- Update the description to indicate this only works with KVM + Ceph 
 -- (not implemented properly atm for KVM+NFS/local, and it accidentaly works with XS + NFS. Not applicable for VMware)
-UPDATE `cloud`.`configuration` SET `description`='Indicates whether to always backup primary storage snapshot to secondary storage. KVM + Ceph only.' WHERE  `name`='snapshot.backup.to.secondary';
+UPDATE `cloud`.`configuration` SET `description`='Indicates whether to always backup primary storage snapshot to secondary storage. Applicable for KVM + Ceph only.' WHERE  `name`='snapshot.backup.to.secondary';
 
 -- KVM: enable storage data motion on KVM hypervisor_capabilities
 UPDATE `cloud`.`hypervisor_capabilities` SET `storage_motion_supported` = 1 WHERE `hypervisor_capabilities`.`hypervisor_type` = 'KVM';

--- a/engine/schema/src/main/resources/META-INF/db/schema-41310to41400.sql
+++ b/engine/schema/src/main/resources/META-INF/db/schema-41310to41400.sql
@@ -19,6 +19,10 @@
 -- Schema upgrade from 4.13.1.0 to 4.14.0.0
 --;
 
+-- Update the description to indicate this only works with KVM + Ceph 
+-- (not implemented properly atm for KVM+NFS/local, and it accidentaly works with XS + NFS. Not applicable for VMware)
+UPDATE `cloud`.`configuration` SET `description`='Indicates whether to always backup primary storage snapshot to secondary storage. KVM + Ceph only.' WHERE  `name`='snapshot.backup.to.secondary';
+
 -- KVM: enable storage data motion on KVM hypervisor_capabilities
 UPDATE `cloud`.`hypervisor_capabilities` SET `storage_motion_supported` = 1 WHERE `hypervisor_capabilities`.`hypervisor_type` = 'KVM';
 

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManager.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManager.java
@@ -57,7 +57,7 @@ public interface SnapshotManager extends Configurable {
             "Time in seconds between retries in backing up snapshot to secondary", false, ConfigKey.Scope.Global, null);
 
     public static final ConfigKey<Boolean> BackupSnapshotAfterTakingSnapshot = new ConfigKey<Boolean>(Boolean.class, "snapshot.backup.to.secondary",  "Snapshots", "true",
-            "Indicates whether to always backup primary storage snapshot to secondary storage. Applicable for KVM + Ceph only.", false, ConfigKey.Scope.Global, null);
+            "Indicates whether to always backup primary storage snapshot to secondary storage. Keeping snapshots only on Primary storage is applicable for KVM + Ceph only.", false, ConfigKey.Scope.Global, null);
 
     void deletePoliciesForVolume(Long volumeId);
 

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManager.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManager.java
@@ -57,7 +57,7 @@ public interface SnapshotManager extends Configurable {
             "Time in seconds between retries in backing up snapshot to secondary", false, ConfigKey.Scope.Global, null);
 
     public static final ConfigKey<Boolean> BackupSnapshotAfterTakingSnapshot = new ConfigKey<Boolean>(Boolean.class, "snapshot.backup.to.secondary",  "Snapshots", "true",
-            "Indicates whether to always backup primary storage snapshot to secondary storage", false, ConfigKey.Scope.Global, null);
+            "Indicates whether to always backup primary storage snapshot to secondary storage. Applicable for KVM + Ceph only.", false, ConfigKey.Scope.Global, null);
 
     void deletePoliciesForVolume(Long volumeId);
 


### PR DESCRIPTION
Keeping the snapshot on Primary storage only, was originally implemented for KVM+Ceph specifically as it seems, since it's seriously broken for KVM+NFS/local in 4.11+ (and not applicable/doesn't affects VMware at all, while it accidentally works for XS+NFS as they share the same "strategy")

Thus update the desc so that KVM users don't find themselves scratching their head.
We would want to fix/implement this in 4.15 (?) since when using qcow2 the snaps can be kept "attached" to it, the same way they are now attached/part of the rbd image (Ceph)

ping @GabrielBrascher @wido @weizhouapache 

cc @nathanejohnson (you guys implemented this, right?) 