### PR TITLE
server: Search zone-wide storage pool when allocation algothrim is firstfitleastconsumed

### DIFF
--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -56,5 +56,5 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     float findClusterConsumption(Long clusterId, short capacityType, long computeRequested);
 
-    List<Long> orderHostsByFreeCapacity(Long clusterId, short capacityType);
+    List<Long> orderHostsByFreeCapacity(Long zoneId, Long clusterId, short capacityType);
 }

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -903,20 +903,28 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     }
 
     @Override
-    public List<Long> orderHostsByFreeCapacity(Long clusterId, short capacityTypeForOrdering){
+    public List<Long> orderHostsByFreeCapacity(Long zoneId, Long clusterId, short capacityTypeForOrdering){
          TransactionLegacy txn = TransactionLegacy.currentTxn();
          PreparedStatement pstmt = null;
          List<Long> result = new ArrayList<Long>();
          StringBuilder sql = new StringBuilder(ORDER_HOSTS_BY_FREE_CAPACITY_PART1);
-        if(clusterId != null) {
-            sql.append("AND cluster_id = ?");
-        }
-        sql.append(ORDER_HOSTS_BY_FREE_CAPACITY_PART2);
+         if (zoneId != null) {
+             sql.append(" AND data_center_id = ?");
+         }
+         if (clusterId != null) {
+             sql.append(" AND cluster_id = ?");
+         }
+         sql.append(ORDER_HOSTS_BY_FREE_CAPACITY_PART2);
          try {
              pstmt = txn.prepareAutoCloseStatement(sql.toString());
              pstmt.setShort(1, capacityTypeForOrdering);
-             if(clusterId != null) {
-                pstmt.setLong(2, clusterId);
+             int index = 2;
+             if (zoneId != null) {
+                 pstmt.setLong(index, zoneId);
+                 index ++;
+             }
+             if (clusterId != null) {
+                 pstmt.setLong(index, clusterId);
              }
 
              ResultSet rs = pstmt.executeQuery();

--- a/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
+++ b/engine/storage/src/main/java/org/apache/cloudstack/storage/allocator/AbstractStoragePoolAllocator.java
@@ -94,6 +94,7 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
 
     protected List<StoragePool> reorderPoolsByCapacity(DeploymentPlan plan,
         List<StoragePool> pools) {
+        Long zoneId = plan.getDataCenterId();
         Long clusterId = plan.getClusterId();
         short capacityType;
         if(pools != null && pools.size() != 0){
@@ -102,7 +103,7 @@ public abstract class AbstractStoragePoolAllocator extends AdapterBase implement
             return null;
         }
 
-        List<Long> poolIdsByCapacity = capacityDao.orderHostsByFreeCapacity(clusterId, capacityType);
+        List<Long> poolIdsByCapacity = capacityDao.orderHostsByFreeCapacity(zoneId, clusterId, capacityType);
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("List of pools in descending order of free capacity: "+ poolIdsByCapacity);
         }

--- a/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
+++ b/server/src/main/java/com/cloud/agent/manager/allocator/impl/FirstFitAllocator.java
@@ -345,6 +345,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
 
     // Reorder hosts in the decreasing order of free capacity.
     private List<? extends Host> reorderHostsByCapacity(DeploymentPlan plan, List<? extends Host> hosts) {
+        Long zoneId = plan.getDataCenterId();
         Long clusterId = plan.getClusterId();
         //Get capacity by which we should reorder
         String capacityTypeToOrder = _configDao.getValue(Config.HostCapacityTypeToOrderClusters.key());
@@ -352,7 +353,7 @@ public class FirstFitAllocator extends AdapterBase implements HostAllocator {
         if("RAM".equalsIgnoreCase(capacityTypeToOrder)){
             capacityType = CapacityVO.CAPACITY_TYPE_MEMORY;
         }
-        List<Long> hostIdsByFreeCapacity = _capacityDao.orderHostsByFreeCapacity(clusterId, capacityType);
+        List<Long> hostIdsByFreeCapacity = _capacityDao.orderHostsByFreeCapacity(zoneId, clusterId, capacityType);
         if (s_logger.isDebugEnabled()) {
             s_logger.debug("List of hosts in descending order of free capacity in the cluster: "+ hostIdsByFreeCapacity);
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When vm.allocation.algorithm is set to 'firstfitleastconsumed', we are unable to create vm or volume if all storage pools are zone-wide (which have cluster_id=NULL)

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

1. create zone with zone-wide storage pool
2. deploy vm successfully.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
