### PR TITLE
Fixed null pointer and deployment issue on Xenserver with L2 Guest network with configDrive

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1052,7 +1052,6 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 } catch (final AffinityConflictException e2) {
                     s_logger.warn("Unable to create deployment, affinity rules associted to the VM conflict", e2);
                     throw new CloudRuntimeException("Unable to create deployment, affinity rules associted to the VM conflict");
-
                 }
 
                 if (dest == null) {

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -205,6 +205,8 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
 
     private final static String VM_NAME_ISO_SUFFIX = "-ISO";
 
+    private final static String VM_FILE_ISO_SUFFIX = ".iso";
+
     private static final XenServerConnectionPool ConnPool = XenServerConnectionPool.getInstance();
     // static min values for guests on xenserver
     private static final long mem_128m = 134217728L;
@@ -5538,7 +5540,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             SR sr = getSRByNameLabel(conn, vmName + VM_NAME_ISO_SUFFIX);
             //Here you will find only two vdis with the <vmname>.iso.
             //one is from source host and second from dest host
-            Set<VDI> vdis = VDI.getByNameLabel(conn, vmName + ".iso");
+            Set<VDI> vdis = VDI.getByNameLabel(conn, vmName + VM_FILE_ISO_SUFFIX);
             if (vdis.isEmpty()) {
                 s_logger.debug("Could not find config drive ISO: " + vmName);
                 return false;

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -5544,7 +5544,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             s_logger.debug("Attaching config drive iso device for the VM " + vmName + " In host " + ipAddr);
             Set<VM> vms = VM.getByNameLabel(conn, vmName);
 
-            SR sr = getSRByNameLabel(conn, _configDriveSRName + ipAddr);
+            SR sr = getSRByNameLabel(conn, vmName + "-ISO");
             //Here you will find only two vdis with the <vmname>.iso.
             //one is from source host and second from dest host
             Set<VDI> vdis = VDI.getByNameLabel(conn, vmName + ".iso");

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -201,6 +201,8 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
 
     private final static int BASE_TO_CONVERT_BYTES_INTO_KILOBYTES = 1024;
 
+    private final static int USER_DEVICE_START_ID = 3;
+
     private static final XenServerConnectionPool ConnPool = XenServerConnectionPool.getInstance();
     // static min values for guests on xenserver
     private static final long mem_128m = 134217728L;
@@ -1156,7 +1158,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         if (volume.getType() == Volume.Type.ISO) {
             vbdr.mode = Types.VbdMode.RO;
             vbdr.type = Types.VbdType.CD;
-            vbdr.userdevice = String.valueOf(3 + isoCount);
+            vbdr.userdevice = String.valueOf(USER_DEVICE_START_ID + isoCount);
         } else {
             vbdr.mode = Types.VbdMode.RW;
             vbdr.type = Types.VbdType.DISK;

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -3870,7 +3870,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         return getVDIbyUuid(conn, volumePath);
     }
 
-    protected VDI mount(final Connection conn, final String vmName, final DiskTO volume) throws XmlRpcException, XenAPIException {
+    public VDI mount(final Connection conn, final String vmName, final DiskTO volume) throws XmlRpcException, XenAPIException {
         final DataTO data = volume.getData();
         final Volume.Type type = volume.getType();
         if (type == Volume.Type.ISO) {
@@ -3913,7 +3913,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             } catch (final URISyntaxException e) {
                 throw new CloudRuntimeException("Incorrect uri " + mountpoint, e);
             }
-            final SR isoSr = createIsoSRbyURI(conn, uri, vmName, false);
+            final SR isoSr = createIsoSRbyURI(conn, uri, vmName, true);
 
             final String isoname = isoPath.substring(index + 1);
 
@@ -4099,17 +4099,6 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             throw new CloudRuntimeException("There are " + (vms == null ? "0" : vms.size()) + " VMs named " + vmName);
         }
         final VM vm = vms.iterator().next();
-
-        if (vmDataList != null) {
-            // create SR
-            SR sr = createLocalIsoSR(conn, _configDriveSRName + getHost().getIp());
-
-            // 1. create vm data files
-            createVmdataFiles(vmName, vmDataList, configDriveLabel);
-
-            // 2. copy config drive iso to host
-            copyConfigDriveIsoToHost(conn, sr, vmName);
-        }
 
         final Set<VBD> vbds = vm.getVBDs(conn);
         for (final VBD vbd : vbds) {
@@ -5451,7 +5440,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
     public SR createLocalIsoSR(final Connection conn, final String srName) throws XenAPIException, XmlRpcException {
 
         // if config drive sr already exists then return
-        SR sr = getSRByNameLabelandHost(conn, _configDriveSRName + _host.getIp());
+        SR sr = getSRByNameLabelandHost(conn, srName);
 
         if (sr != null) {
             s_logger.debug("Config drive SR already exist, returing it");

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -1120,7 +1120,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         throw new CloudRuntimeException(errMsg);
     }
 
-    public VBD createVbd(final Connection conn, final DiskTO volume, final String vmName, final VM vm, final BootloaderType bootLoaderType, VDI vdi) throws XmlRpcException, XenAPIException {
+    public VBD createVbd(final Connection conn, final DiskTO volume, final String vmName, final VM vm, final BootloaderType bootLoaderType, VDI vdi, int isoCount) throws XmlRpcException, XenAPIException {
         final Volume.Type type = volume.getType();
 
         if (vdi == null) {
@@ -1156,7 +1156,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
         if (volume.getType() == Volume.Type.ISO) {
             vbdr.mode = Types.VbdMode.RO;
             vbdr.type = Types.VbdType.CD;
-            vbdr.userdevice = "3";
+            vbdr.userdevice = String.valueOf(3 + isoCount);
         } else {
             vbdr.mode = Types.VbdMode.RW;
             vbdr.type = Types.VbdType.DISK;
@@ -3882,7 +3882,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
 
             // corer case, xenserver pv driver iso
             final String templateName = iso.getName();
-            if (templateName.startsWith("xs-tools")) {
+            if (templateName != null && templateName.startsWith("xs-tools")) {
                 try {
                     final String actualTemplateName = getActualIsoTemplate(conn);
                     final Set<VDI> vdis = VDI.getByNameLabel(conn, actualTemplateName);

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/CitrixResourceBase.java
@@ -203,6 +203,8 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
 
     private final static int USER_DEVICE_START_ID = 3;
 
+    private final static String VM_NAME_ISO_SUFFIX = "-ISO";
+
     private static final XenServerConnectionPool ConnPool = XenServerConnectionPool.getInstance();
     // static min values for guests on xenserver
     private static final long mem_128m = 134217728L;
@@ -5533,7 +5535,7 @@ public abstract class CitrixResourceBase implements ServerResource, HypervisorRe
             s_logger.debug("Attaching config drive iso device for the VM " + vmName + " In host " + ipAddr);
             Set<VM> vms = VM.getByNameLabel(conn, vmName);
 
-            SR sr = getSRByNameLabel(conn, vmName + "-ISO");
+            SR sr = getSRByNameLabel(conn, vmName + VM_NAME_ISO_SUFFIX);
             //Here you will find only two vdis with the <vmname>.iso.
             //one is from source host and second from dest host
             Set<VDI> vdis = VDI.getByNameLabel(conn, vmName + ".iso");

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixMigrateCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixMigrateCommandWrapper.java
@@ -91,7 +91,8 @@ public class CitrixMigrateCommandWrapper extends CommandWrapper<MigrateCommand, 
 
             // The iso can be attached to vm only once the vm is (present in the host) migrated.
             // Attach the config drive iso device to VM
-            if (!citrixResourceBase.attachConfigDriveToMigratedVm(conn, vmName, dstHostIpAddr)) {
+            VM vm = vms.iterator().next();
+            if (!citrixResourceBase.attachConfigDriveIsoToVm(conn, vm)) {
                 s_logger.debug("Config drive ISO attach failed after migration for vm "+vmName);
             }
 

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
@@ -98,39 +98,8 @@ public final class CitrixStartCommandWrapper extends CommandWrapper<StartCommand
             if (vmSpec.getType() != VirtualMachine.Type.User) {
                 citrixResourceBase.createPatchVbd(conn, vmName, vm);
             }
-            // put cdrom at the first place in the list
-            List<DiskTO> disks = new ArrayList<DiskTO>(vmSpec.getDisks().length);
-            int index = 0;
-            for (final DiskTO disk : vmSpec.getDisks()) {
-                if (Volume.Type.ISO.equals(disk.getType())) {
-                    disks.add(0, disk);
-                } else {
-                    disks.add(index, disk);
-                }
-                index++;
-            }
 
-            int isoCount = 0;
-
-            for (DiskTO disk : disks) {
-                final VDI newVdi = citrixResourceBase.prepareManagedDisk(conn, disk, vmSpec.getId(), vmSpec.getName());
-
-                if (newVdi != null) {
-                    final Map<String, String> data = new HashMap<>();
-
-                    final String path = newVdi.getUuid(conn);
-
-                    data.put(StartAnswer.PATH, path);
-                    data.put(StartAnswer.IMAGE_FORMAT, Storage.ImageFormat.VHD.toString());
-
-                    iqnToData.put(disk.getDetails().get(DiskTO.IQN), data);
-                }
-                citrixResourceBase.createVbd(conn, disk, vmName, vm, vmSpec.getBootloader(), newVdi, isoCount);
-
-                if (disk.getType() == Volume.Type.ISO) {
-                    isoCount++;
-                }
-            }
+            prepareDisks(vmSpec, citrixResourceBase, conn, iqnToData, vmName, vm);
 
             for (final NicTO nic : vmSpec.getNics()) {
                 citrixResourceBase.createVif(conn, vmName, vm, vmSpec, nic);
@@ -230,6 +199,37 @@ public final class CitrixStartCommandWrapper extends CommandWrapper<StartCommand
                 s_logger.debug("2. The VM " + vmName + " is in " + state + " state.");
             } else {
                 s_logger.debug("The VM is in stopped state, detected problem during startup : " + vmName);
+            }
+        }
+    }
+
+    private void prepareDisks(VirtualMachineTO vmSpec, CitrixResourceBase citrixResourceBase, Connection conn,
+                              Map<String, Map<String, String>> iqnToData, String vmName, VM vm) throws Exception {
+        // put cdrom at the first place in the list
+        List<DiskTO> disks = new ArrayList<DiskTO>(vmSpec.getDisks().length);
+        int index = 0;
+        for (final DiskTO disk : vmSpec.getDisks()) {
+            if (Volume.Type.ISO.equals(disk.getType())) {
+                disks.add(0, disk);
+            } else {
+                disks.add(index, disk);
+            }
+            index++;
+        }
+        int isoCount = 0;
+        for (DiskTO disk : disks) {
+            final VDI newVdi = citrixResourceBase.prepareManagedDisk(conn, disk, vmSpec.getId(), vmSpec.getName());
+            if (newVdi != null) {
+                final Map<String, String> data = new HashMap<>();
+                final String path = newVdi.getUuid(conn);
+                data.put(StartAnswer.PATH, path);
+                data.put(StartAnswer.IMAGE_FORMAT, Storage.ImageFormat.VHD.toString());
+                iqnToData.put(disk.getDetails().get(DiskTO.IQN), data);
+            }
+            citrixResourceBase.createVbd(conn, disk, vmName, vm, vmSpec.getBootloader(), newVdi, isoCount);
+
+            if (disk.getType() == Volume.Type.ISO) {
+                isoCount++;
             }
         }
     }

--- a/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
+++ b/plugins/hypervisors/xenserver/src/main/java/com/cloud/hypervisor/xenserver/resource/wrapper/xenbase/CitrixStartCommandWrapper.java
@@ -110,6 +110,8 @@ public final class CitrixStartCommandWrapper extends CommandWrapper<StartCommand
                 index++;
             }
 
+            int isoCount = 0;
+
             for (DiskTO disk : disks) {
                 final VDI newVdi = citrixResourceBase.prepareManagedDisk(conn, disk, vmSpec.getId(), vmSpec.getName());
 
@@ -123,8 +125,11 @@ public final class CitrixStartCommandWrapper extends CommandWrapper<StartCommand
 
                     iqnToData.put(disk.getDetails().get(DiskTO.IQN), data);
                 }
+                citrixResourceBase.createVbd(conn, disk, vmName, vm, vmSpec.getBootloader(), newVdi, isoCount);
 
-                citrixResourceBase.createVbd(conn, disk, vmName, vm, vmSpec.getBootloader(), newVdi);
+                if (disk.getType() == Volume.Type.ISO) {
+                    isoCount++;
+                }
             }
 
             for (final NicTO nic : vmSpec.getNics()) {

--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -305,18 +305,16 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
 
     @Override
     public boolean prepareMigration(NicProfile nic, Network network, VirtualMachineProfile vm, DeployDestination dest, ReservationContext context) {
-        if (nic.isDefaultNic() && _networkModel.getUserDataUpdateProvider(network).getProvider().equals(Provider.ConfigDrive)) {
+        if (_networkModel.getUserDataUpdateProvider(network).getProvider().equals(Provider.ConfigDrive)) {
             LOG.trace(String.format("[prepareMigration] for vm: %s", vm.getInstanceName()));
-            final DataStore dataStore = findDataStore(vm, dest);
-
             try {
-                addConfigDriveDisk(vm, dataStore);
-            } catch (ResourceUnavailableException e) {
+                addPasswordAndUserdata(network, nic, vm, dest, context);
+            } catch (InsufficientCapacityException | ResourceUnavailableException e) {
                 LOG.error("Failed to add config disk drive due to: ", e);
+                return false;
             }
-            return false;
         }
-        else return  true;
+        return  true;
     }
 
     @Override
@@ -478,7 +476,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         return true;
     }
 
-    private void addConfigDriveDisk(final VirtualMachineProfile profile, final DataStore dataStore) throws ResourceUnavailableException {
+    public static void addConfigDriveDisk(final VirtualMachineProfile profile, final DataStore dataStore) throws ResourceUnavailableException {
         boolean isoAvailable = false;
         final String isoPath = ConfigDrive.createConfigDrivePath(profile.getInstanceName());
         for (DiskTO dataTo : profile.getDisks()) {

--- a/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
+++ b/server/src/main/java/com/cloud/network/element/ConfigDriveNetworkElement.java
@@ -476,7 +476,7 @@ public class ConfigDriveNetworkElement extends AdapterBase implements NetworkEle
         return true;
     }
 
-    public static void addConfigDriveDisk(final VirtualMachineProfile profile, final DataStore dataStore) throws ResourceUnavailableException {
+    private void addConfigDriveDisk(final VirtualMachineProfile profile, final DataStore dataStore) throws ResourceUnavailableException {
         boolean isoAvailable = false;
         final String isoPath = ConfigDrive.createConfigDrivePath(profile.getInstanceName());
         for (DiskTO dataTo : profile.getDisks()) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes an issue where an instance fails to deploy due to a null pointer when using an L2 Guest Network with DefaultL2NetworkOfferingConfigDrive on Xenserver. It also fixes migrating an instance to another host.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This has been tested by: 
- Creating an L2 Guest network, using DefaultL2NetworkOfferingConfigDrive as the network offering. 
- Deploying an instance using the L2 Guest network created.
- Migrating the instance away from the host and back


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
