### PR TITLE
Fixed create template from snapshot never returning

### DIFF
--- a/ui/scripts/sharedFunctions.js
+++ b/ui/scripts/sharedFunctions.js
@@ -2988,7 +2988,7 @@ cloudStack.createTemplateFromSnapshotMethod = function (){
                                 return {}; //nothing in this snapshot needs to be updated
                             },
                             getActionFilter: function() {
-                                return snapshotActionfilter;
+                                return cloudStack.actionFilter.snapshotActionfilter;
                             }
                         }
                     });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->
When creating a template from a snapshot, the notification is not updated after the task is completed. 

This PR fixes the issue.

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3711 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This has been tested by creating a template from a volume snapshot from the UI

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
