### PR TITLE
Restarting all networks that needs a restart in a VPC

### DIFF
--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1747,13 +1747,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 return true;
             }
 
-            // Restart all networks in this VPC that needs a restart
-            List<? extends Network> networks = _ntwkModel.listNetworksByVpc(vpcId);
-            for (Network network: networks){
-                if (network.isRestartRequired()){
-                    _ntwkMgr.restartNetwork(network.getId(), callerAccount, callerUser, cleanUp);
-                }
-            }
+            restartVPCNetworks(vpcId, callerAccount, callerUser, cleanUp);
 
             s_logger.debug("Starting VPC " + vpc + " as a part of VPC restart process without cleanup");
             if (!startVpc(vpcId, false)) {
@@ -1768,6 +1762,15 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
             final VpcVO vo = _vpcDao.findById(vpcId);
             vo.setRestartRequired(restartRequired);
             _vpcDao.update(vpc.getId(), vo);
+        }
+    }
+
+    private void restartVPCNetworks(long vpcId, Account callerAccount, User callerUser, boolean cleanUp) throws InsufficientCapacityException, ResourceUnavailableException {
+        List<? extends Network> networks = _ntwkModel.listNetworksByVpc(vpcId);
+        for (Network network: networks) {
+            if (network.isRestartRequired()) {
+                _ntwkMgr.restartNetwork(network.getId(), callerAccount, callerUser, cleanUp);
+            }
         }
     }
 

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1747,6 +1747,14 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 return true;
             }
 
+            // Restart all networks in this VPC that needs a restart
+            List<? extends Network> networks = _ntwkModel.listNetworksByVpc(vpcId);
+            for (Network network: networks){
+                if (network.isRestartRequired()){
+                    _ntwkMgr.restartNetwork(network.getId(), callerAccount, callerUser, cleanUp);
+                }
+            }
+
             s_logger.debug("Starting VPC " + vpc + " as a part of VPC restart process without cleanup");
             if (!startVpc(vpcId, false)) {
                 s_logger.warn("Failed to start vpc as a part of VPC " + vpc + " restart process");


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When a VPC is restarted, the networks in the VPC is not restarted, this PR will add the logic to restart the networks in the VPC that needs a restart when the VPC is restarted.
<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes: #3816 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This was tested by manually setting the needs restart flag in the db in the networks table and then restarting the VPC.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
