### PR TITLE
Fix template registration error

### DIFF
--- a/utils/src/main/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtil.java
+++ b/utils/src/main/java/org/apache/cloudstack/utils/imagestore/ImageStoreUtil.java
@@ -58,7 +58,7 @@ public class ImageStoreUtil {
             return "";
         }
         // raw
-        if ((output.contains("x86 boot") || output.contains("DOS/MBR boot sector") || output.contains("data")) && (isCorrectExtension(uripath, "raw") || isCorrectExtension(uripath, "img"))) {
+        if ((output.contains("x86 boot") || output.contains("DOS/MBR boot sector") || output.contains("data")) && isCorrectExtension(uripath, "raw")) {
             s_logger.debug("File at path " + path + " looks like a raw image :" + output);
             return "";
         }


### PR DESCRIPTION
## Description
After forward merge from branch 4.13 template registration fails with NPE:

![image](https://user-images.githubusercontent.com/5295080/78172837-1b625180-742d-11ea-8880-c63d31227a20.png)

````
2020-04-01 17:53:54,306 INFO  [storage.template.HttpTemplateDownloader] (agentRequest-Handler-9:null) No credentials configured for host=dl.openvm.eu:80
2020-04-01 17:53:54,347 INFO  [storage.template.HttpTemplateDownloader] (pool-1-thread-4:null) Starting download from http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina-kvm.qcow2.bz2 to /mnt/SecStorage/e5b31dbe-98f0-35b5-b5d6-fe87b26cc133/template/tmpl/2/203/dnld11734576344067057786tmp_ remoteSize=20456842 , max size=53687091200
2020-04-01 17:53:56,877 INFO  [storage.template.DownloadManagerImpl] (pool-1-thread-4:null) Download Completion for jobId: ec049522-34e6-4c98-b954-aaba8443fe6f, status=IN_PROGRESS
2020-04-01 17:53:56,878 INFO  [storage.template.DownloadManagerImpl] (pool-1-thread-4:null) local: /mnt/SecStorage/e5b31dbe-98f0-35b5-b5d6-fe87b26cc133/template/tmpl/2/203/dnld11734576344067057786tmp_, bytes=1049522, error= , pct=5
2020-04-01 17:53:56,878 INFO  [storage.template.DownloadManagerImpl] (pool-1-thread-4:null) Resuming jobId: ec049522-34e6-4c98-b954-aaba8443fe6f, status=IN_PROGRESS
2020-04-01 17:53:56,879 WARN  [storage.template.HttpTemplateDownloader] (pool-1-thread-4:null) Caught exception during download null
java.lang.NullPointerException
	at org.apache.cloudstack.utils.imagestore.ImageStoreUtil.isCorrectExtension(ImageStoreUtil.java:97)
	at org.apache.cloudstack.utils.imagestore.ImageStoreUtil.checkTemplateFormat(ImageStoreUtil.java:61)
	at com.cloud.storage.template.HttpTemplateDownloader$VerifyFormat.invoke(HttpTemplateDownloader.java:523)
	at com.cloud.storage.template.HttpTemplateDownloader.copyBytes(HttpTemplateDownloader.java:245)
	at com.cloud.storage.template.HttpTemplateDownloader.download(HttpTemplateDownloader.java:209)
	at com.cloud.storage.template.HttpTemplateDownloader.runInContext(HttpTemplateDownloader.java:426)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable$1.run(ManagedContextRunnable.java:49)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext$1.call(DefaultManagedContext.java:56)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.callWithContext(DefaultManagedContext.java:103)
	at org.apache.cloudstack.managed.context.impl.DefaultManagedContext.runWithContext(DefaultManagedContext.java:53)
	at org.apache.cloudstack.managed.context.ManagedContextRunnable.run(ManagedContextRunnable.java:46)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)

````

The data structure for supported formats does not include `img` as a key, it is instead a value for key `raw`:
````
private final static Map<String, Set<String>> SUPPORTED_EXTENSIONS_BY_FORMAT =
            ImmutableMap.<String, Set<String>>builder()
                        .put("vhd", buildExtensionSet(false, "vhd"))
                        .put("vhdx", buildExtensionSet(false, "vhdx"))
                        .put("qcow2", buildExtensionSet(true, "qcow2"))
                        .put("ova", buildExtensionSet(true, "ova"))
                        .put("tar", buildExtensionSet(false, "tar"))
                        .put("raw", buildExtensionSet(false, "img", "raw"))
                        .put("vmdk", buildExtensionSet(false, "vmdk"))
                        .put("iso", buildExtensionSet(true, "iso"))
            .build();
````

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Register template -> Failure
