### PR TITLE
Allow IMG extension for QCOW2 format

### DIFF
--- a/utils/src/main/java/com/cloud/utils/UriUtils.java
+++ b/utils/src/main/java/com/cloud/utils/UriUtils.java
@@ -512,7 +512,7 @@ public class UriUtils {
             ImmutableMap.<String, Set<String>>builder()
                         .put("vhd", buildExtensionSet(false, "vhd"))
                         .put("vhdx", buildExtensionSet(false, "vhdx"))
-                        .put("qcow2", buildExtensionSet(true, "qcow2"))
+                        .put("qcow2", buildExtensionSet(true, "qcow2", "img"))
                         .put("ova", buildExtensionSet(true, "ova"))
                         .put("tar", buildExtensionSet(false, "tar"))
                         .put("raw", buildExtensionSet(false, "img", "raw"))

--- a/utils/src/test/java/com/cloud/utils/UriUtilsParametrizedTest.java
+++ b/utils/src/test/java/com/cloud/utils/UriUtilsParametrizedTest.java
@@ -102,7 +102,10 @@ public class UriUtilsParametrizedTest {
             final String realFormat = format;
 
             for (String extension : FORMATS) {
-                final boolean expectSuccess = format.equals(extension.replace("img", "raw"));
+                boolean expectSuccess = format.equals(extension.replace("img", "raw"));
+                if (format.equals("qcow2") && extension.equals("img")) {
+                    expectSuccess = true;
+                }
 
                 for (String commpressionFormat : COMMPRESSION_FORMATS) {
                     final String url = validBaseUri + extension + commpressionFormat;


### PR DESCRIPTION
## Description
Attempts to register QCOW2 template with .img extension fails fast:
![image](https://user-images.githubusercontent.com/5295080/78420699-e110d400-7627-11ea-88e7-6332fd88a66d.png)

This fix allows registering a QCOW2 template with .img extension

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
Register templates: https://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64.img, http://dl.openvm.eu/cloudstack/macchinina/x86_64/macchinina.img with format = QCOW2
