### PR TITLE
Improvement on build time and new quality profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -777,46 +777,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${cs.jacoco-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.openclover</groupId>
-                <artifactId>clover-maven-plugin</artifactId>
-                <version>${cs.clover-maven-plugin.version}</version>
-                <configuration>
-                    <flushPolicy>threaded</flushPolicy>
-                    <flushInterval>100</flushInterval>
-                    <targetPercentage>0%</targetPercentage>
-                    <generateHtml>true</generateHtml>
-                    <generateXml>true</generateXml>
-                    <generateHistorical>true</generateHistorical>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>main</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>instrument</goal>
-                            <goal>aggregate</goal>
-                            <goal>check</goal>
-                            <goal>log</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>site</id>
-                        <phase>pre-site</phase>
-                        <goals>
-                            <goal>instrument</goal>
-                            <goal>aggregate</goal>
-                            <!-- We save a history point in order to have data to generate a historical report -->
-                            <goal>save-history</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1223,26 +1183,6 @@
                     <version>${cs.failsafe-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${cs.jacoco-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>prepare-coverage-agent</id>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>produce-coverage-reports</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${cs.site-plugin.version}</version>
@@ -1282,19 +1222,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>${cs.resources-plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${cs.jacoco-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <!-- select non-aggregate reports -->
-                            <report>report</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
             </plugin>
         </plugins>
     </reporting>
@@ -1346,6 +1273,97 @@
             <modules>
                 <module>vmware-base</module>
             </modules>
+        </profile>
+        <profile>
+            <id>quality</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${cs.jacoco-plugin.version}</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.openclover</groupId>
+                        <artifactId>clover-maven-plugin</artifactId>
+                        <version>${cs.clover-maven-plugin.version}</version>
+                        <configuration>
+                            <flushPolicy>threaded</flushPolicy>
+                            <flushInterval>100</flushInterval>
+                            <targetPercentage>0%</targetPercentage>
+                            <generateHtml>true</generateHtml>
+                            <generateXml>true</generateXml>
+                            <generateHistorical>true</generateHistorical>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>main</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>instrument</goal>
+                                    <goal>aggregate</goal>
+                                    <goal>check</goal>
+                                    <goal>log</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>site</id>
+                                <phase>pre-site</phase>
+                                <goals>
+                                    <goal>instrument</goal>
+                                    <goal>aggregate</goal>
+                                    <!-- We save a history point in order to have data to generate a historical report -->
+                                    <goal>save-history</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <version>${cs.jacoco-plugin.version}</version>
+                            <executions>
+                                <execution>
+                                    <id>prepare-coverage-agent</id>
+                                    <goals>
+                                        <goal>prepare-agent</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>produce-coverage-reports</id>
+                                    <phase>test</phase>
+                                    <goals>
+                                        <goal>report</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${cs.jacoco-plugin.version}</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <!-- select non-aggregate reports -->
+                                    <report>report</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
         </profile>
         <profile>
             <id>disablecheckstyle</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1046,22 +1046,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>${cs.owasp.dependency-checker-plugin.version}</version>
-                    <configuration>
-                        <skipProvidedScope>true</skipProvidedScope>
-                        <skipRuntimeScope>true</skipRuntimeScope>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${cs.compiler-plugin.version}</version>
@@ -1174,7 +1158,7 @@
                     <version>${cs.surefire-plugin.version}</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
-                        <argLine>@{argLine} -Djava.security.egd=file:/dev/./urandom -noverify</argLine>
+                        <argLine>-Djava.security.egd=file:/dev/./urandom -noverify</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1192,18 +1176,6 @@
     </build>
     <reporting>
         <plugins>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>${cs.owasp.dependency-checker-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>aggregate</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
@@ -1325,6 +1297,22 @@
                 <pluginManagement>
                     <plugins>
                         <plugin>
+                            <groupId>org.owasp</groupId>
+                            <artifactId>dependency-check-maven</artifactId>
+                            <version>${cs.owasp.dependency-checker-plugin.version}</version>
+                            <configuration>
+                                <skipProvidedScope>true</skipProvidedScope>
+                                <skipRuntimeScope>true</skipRuntimeScope>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
                             <groupId>org.jacoco</groupId>
                             <artifactId>jacoco-maven-plugin</artifactId>
                             <version>${cs.jacoco-plugin.version}</version>
@@ -1349,6 +1337,18 @@
             </build>
             <reporting>
                 <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${cs.owasp.dependency-checker-plugin.version}</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>aggregate</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
## Description
Since PR #3956 has been merged the build time has increased drastically due to the quality tools added.

This PR simply removes these tools from the default build execution and adds a new profile with name: `quality` to enable these tools.

To enable this new profile, simply append: `-P quality` to the maven build command

As a result, the default build time increases significantly, as shown in the 'How has this been tested' section

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?

Tested on Ubuntu 19.10 laptop, 8x1.8Ghz CPU - 16GB RAM
openjdk version "11.0.6" 2020-01-14
Apache Maven 3.6.1

Default build:

````
$ mvn clean install -Dnoredist -P developer,systemvm -DskipTests -T4

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  06:21 min (Wall Clock)
[INFO] Finished at: 2020-04-05T01:16:18-03:00
[INFO] ------------------------------------------------------------------------
````

Enabling quality tools (x2+ slower):
````
mvn clean install -Dnoredist -P developer,systemvm,quality -U -DskipTests -T4

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  16:25 min (Wall Clock)
[INFO] Finished at: 2020-04-05T01:42:07-03:00
[INFO] ------------------------------------------------------------------------
````