### PR TITLE
Fixed private gateway can't be deleted

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/CreateStaticRouteCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/CreateStaticRouteCmd.java
@@ -109,7 +109,7 @@ public class CreateStaticRouteCmd extends BaseAsyncCreateCmd {
             routeResponse.setResponseName(getCommandName());
         } finally {
             if (!success || route == null) {
-                _vpcService.revokeStaticRoute(getEntityId());
+                _entityMgr.remove(StaticRoute.class, getEntityId());
                 throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to create static route");
             }
         }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
@@ -48,6 +48,9 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
     @Parameter(name = ApiConstants.GATEWAY_ID, type = CommandType.UUID, entityType = PrivateGatewayResponse.class, description = "list static routes by gateway id")
     private Long gatewayId;
 
+    @Parameter(name = ApiConstants.STATE, type = CommandType.STRING, description = "list static routes by state")
+    private String state;
+
     public Long getId() {
         return id;
     }
@@ -58,6 +61,10 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
 
     public Long getGatewayId() {
         return gatewayId;
+    }
+
+    public String getState() {
+        return state;
     }
 
     /////////////////////////////////////////////////////

--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDao.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDao.java
@@ -30,7 +30,7 @@ public interface StaticRouteDao extends GenericDao<StaticRouteVO, Long> {
 
     List<StaticRouteVO> listByVpcId(long vpcId);
 
-    List<StaticRouteVO> listByGatewayId(long vpcId);
+    List<StaticRouteVO> listByGatewayId(long gatewayId);
 
     long countRoutesByGateway(long gatewayId);
 

--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDao.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDao.java
@@ -30,6 +30,8 @@ public interface StaticRouteDao extends GenericDao<StaticRouteVO, Long> {
 
     List<StaticRouteVO> listByVpcId(long vpcId);
 
+    List<StaticRouteVO> listByGatewayId(long vpcId);
+
     long countRoutesByGateway(long gatewayId);
 
 }

--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDaoImpl.java
@@ -62,6 +62,7 @@ public class StaticRouteDaoImpl extends GenericDaoBase<StaticRouteVO, Long> impl
         RoutesByGatewayCount = createSearchBuilder(Long.class);
         RoutesByGatewayCount.select(null, Func.COUNT, RoutesByGatewayCount.entity().getId());
         RoutesByGatewayCount.and("gatewayId", RoutesByGatewayCount.entity().getVpcGatewayId(), Op.EQ);
+        RoutesByGatewayCount.and("state", RoutesByGatewayCount.entity().getState(), Op.EQ);
         RoutesByGatewayCount.done();
     }
 
@@ -92,9 +93,17 @@ public class StaticRouteDaoImpl extends GenericDaoBase<StaticRouteVO, Long> impl
     }
 
     @Override
+    public List<StaticRouteVO> listByGatewayId(long gatewayId) {
+        SearchCriteria<StaticRouteVO> sc = AllFieldsSearch.create();
+        sc.setParameters("gatewayId", gatewayId);
+        return listBy(sc);
+    }
+
+    @Override
     public long countRoutesByGateway(long gatewayId) {
         SearchCriteria<Long> sc = RoutesByGatewayCount.create();
         sc.setParameters("gatewayId", gatewayId);
+        sc.setParameters("state", "Active");
         return customSearch(sc, null).get(0);
     }
 

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2016,13 +2016,23 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 }
             }
 
-            // 2) Delete private gateway from the DB
+            // 2) Clean up any remaining routes
+            cleanUpRoutesByGatewayId(gatewayId);
+
+            // 3) Delete private gateway from the DB
             return deletePrivateGatewayFromTheDB(gateway);
 
         } finally {
             if (gatewayVO != null) {
                 _vpcGatewayDao.releaseFromLockTable(gatewayId);
             }
+        }
+    }
+
+    private void cleanUpRoutesByGatewayId(long gatewayId){
+        List<StaticRouteVO> routes = _staticRouteDao.listByGatewayId(gatewayId);
+        for (StaticRouteVO route: routes){
+            _staticRouteDao.remove(route.getId());
         }
     }
 
@@ -2318,6 +2328,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         final List<Long> permittedAccounts = new ArrayList<Long>();
         final Map<String, String> tags = cmd.getTags();
         final Long projectId = cmd.getProjectId();
+        final String state = cmd.getState();
 
         final Ternary<Long, Boolean, ListProjectResourcesCriteria> domainIdRecursiveListProject = new Ternary<Long, Boolean, ListProjectResourcesCriteria>(domainId, isRecursive,
                 null);
@@ -2333,6 +2344,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
         sb.and("vpcId", sb.entity().getVpcId(), SearchCriteria.Op.EQ);
         sb.and("vpcGatewayId", sb.entity().getVpcGatewayId(), SearchCriteria.Op.EQ);
+        sb.and("state", sb.entity().getState(), SearchCriteria.Op.EQ);
 
         if (tags != null && !tags.isEmpty()) {
             final SearchBuilder<ResourceTagVO> tagSearch = _resourceTagDao.createSearchBuilder();
@@ -2358,6 +2370,10 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
         if (gatewayId != null) {
             sc.addAnd("vpcGatewayId", Op.EQ, gatewayId);
+        }
+
+        if (state != null) {
+            sc.addAnd("state", Op.EQ, state);
         }
 
         if (tags != null && !tags.isEmpty()) {

--- a/ui/scripts/vpc.js
+++ b/ui/scripts/vpc.js
@@ -2652,7 +2652,8 @@
                                                     url: createURL('listStaticRoutes'),
                                                     data: {
                                                         gatewayid: args.context.vpcGateways[0].id,
-                                                        listAll: true
+                                                        listAll: true,
+                                                        state: "Active"
                                                     },
                                                     success: function(json) {
                                                         var items = json.liststaticroutesresponse.staticroute;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When the static route service is not available on the VPC and a static route is created, the static route is created in a revoked state.

Currently, the UI doesn't distinguish between active or revoked static routes.

This PR adds the missing state filter to the list routes command and only lists active routes in the UI.
It also ignores revoked routes when the private gateway is being removed but clears out the inactive routes before the gateway is removed.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->
Fixes #2908 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This has been tested by creating a VPC with no services, adding a private gateway, adding a static route and deleting the gateway.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
