### PR TITLE
FIX: prevent empty sshkey name.

### DIFF
--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -3711,6 +3711,11 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final SSHKeysHelper keys = new SSHKeysHelper(sshKeyLength.value());
 
         final String name = cmd.getName();
+        
+        if (StringUtils.isBlank(name)) {
+            throw new InvalidParameterValueException("Please specify a valid name for the key pair. The key name can't be empty");
+        }
+        
         final String publicKey = keys.getPublicKey();
         final String fingerprint = keys.getPublicKeyFingerPrint();
         final String privateKey = keys.getPrivateKey();

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -3701,6 +3701,12 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         final Long domainId = cmd.getDomainId();
         final Long projectId = cmd.getProjectId();
 
+        final String name = cmd.getName();
+
+        if (StringUtils.isBlank(name)) {
+            throw new InvalidParameterValueException("Please specify a valid name for the key pair. The key name can't be empty");
+        }
+
         final Account owner = _accountMgr.finalizeOwner(caller, accountName, domainId, projectId);
 
         final SSHKeyPairVO s = _sshKeyPairDao.findByName(owner.getAccountId(), owner.getDomainId(), cmd.getName());
@@ -3709,13 +3715,6 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         }
 
         final SSHKeysHelper keys = new SSHKeysHelper(sshKeyLength.value());
-
-        final String name = cmd.getName();
-        
-        if (StringUtils.isBlank(name)) {
-            throw new InvalidParameterValueException("Please specify a valid name for the key pair. The key name can't be empty");
-        }
-        
         final String publicKey = keys.getPublicKey();
         final String fingerprint = keys.getPublicKeyFingerPrint();
         final String privateKey = keys.getPrivateKey();


### PR DESCRIPTION
## Description
It is a small bug fix preventing ssh key name to be empty.


Items | FIX CloudStack API allows SSHKeyPair name to be empty
-- | --
Steps | create a sshkeypair with empty name `cloudmonkey create sshkeypair name=`
Expected Results | operation should fail
Actual results | sshkey pair is created successfully


## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## How Has This Been Tested?
Created a small Cloudstack environment with three hypervisor and one management server. Try to create sshKey with empty name via cloudmonkey.

