### PR TITLE
server: Cannot list affinity group if there are hosts dedicated to domain

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -3626,7 +3626,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             affinityGroups.addAll(listDomainLevelAffinityGroups(scDomain, searchFilter, domainId));
         }
 
-        return new Pair<List<AffinityGroupJoinVO>, Integer>(affinityGroups, uniqueGroupsPair.second());
+        return new Pair<List<AffinityGroupJoinVO>, Integer>(affinityGroups, affinityGroups.size());
 
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR aims to fix an issue when list affinity group, which can be reproduced by steps below
(1) dedicate a host to a domain (for example ROOT)
(2) create a vm in domain if not exist
(3) stop the vm
(4) change affinity group, affinity group cannot be listed.
![image](https://user-images.githubusercontent.com/3204966/78754009-0dee1f80-7977-11ea-8708-22c21613e5f6.png)
(5) "cloudmonkey list affinitygroups" also fails.
![image](https://user-images.githubusercontent.com/3204966/78754029-16def100-7977-11ea-9023-e821938483a0.png)

This issue does not appear if there are other hosts dedicated to the account (not domain).



<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested ok.

An issue remained is that listing affinity groups by pagesize/pages does not work perfectly. it will return
(1) affinity groups to the account by pagesize/page
(2) and all domain-level affinity groups.
However, I think it is not a critical bug.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
