### PR TITLE
Bring back vm.suspend during deleting VM snapshot

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1006,9 +1006,10 @@ public class KVMStorageProcessor implements StorageProcessor {
                     if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot()) {
                         final DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
                         try {
+                            s_logger.info(String.format("Suspending VM '%s' to delete snapshot,", vm.getName()));
                             vm.suspend();
                         } catch (final LibvirtException e) {
-                            s_logger.debug("Failed to suspend the VM: " + e);
+                            s_logger.error("Failed to suspend the VM", e);
                             throw e;
                         }
                         snap.delete(0);

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1010,7 +1010,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                         } catch (final LibvirtException e) {
                             s_logger.debug("Failed to suspend the VM: " + e);
                             throw e;
-                        }                      
+                        }
                         snap.delete(0);
 
                         /*

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1005,6 +1005,12 @@ public class KVMStorageProcessor implements StorageProcessor {
                             primaryStore.getUuid());
                     if (state == DomainInfo.DomainState.VIR_DOMAIN_RUNNING && !primaryStorage.isExternalSnapshot()) {
                         final DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
+                        try {
+                            vm.suspend();
+                        } catch(final Exception e) {
+                            s_logger.debug("Failed to suspend the VM: " + e);
+                            throw e;
+                        }                      
                         snap.delete(0);
 
                         /*

--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/storage/KVMStorageProcessor.java
@@ -1007,7 +1007,7 @@ public class KVMStorageProcessor implements StorageProcessor {
                         final DomainSnapshot snap = vm.snapshotLookupByName(snapshotName);
                         try {
                             vm.suspend();
-                        } catch(final Exception e) {
+                        } catch (final LibvirtException e) {
                             s_logger.debug("Failed to suspend the VM: " + e);
                             throw e;
                         }                      


### PR DESCRIPTION
Original commit, merged to 4.11.3, got mysteriously missing when merging branch 4.11 to 4.12 on the very same day that original PR was merged - so bringing back the same "suspend the VM before the KVM VM snapshot is deleted" code (we already have "resume if it's suspended, after VM snap deletion is finished"

I'm talking about the PR #3194 (the commit itself is there, but NOT the content/code - possibly a wrongly resolved merge conflicts etc)

/cc @weizhouapache  (you approved the original PR) and @rhtyd (you also approved the original PR)